### PR TITLE
Adding missing function to documentation

### DIFF
--- a/doc/src/activation.rst
+++ b/doc/src/activation.rst
@@ -10,6 +10,13 @@ miopenActivationMode_t
 
 .. doxygenenum::  miopenActivationMode_t
 
+
+miopenCreateActivationDescriptor
+--------------------------------
+
+.. doxygenfunction::  miopenCreateActivationDescriptor
+
+
 miopenSetActivationDescriptor
 -----------------------------
 


### PR DESCRIPTION
The function `miopenCreateActivationDescriptor` was missing in the documentation.