### PR TITLE
Remove Co-located lock files

### DIFF
--- a/src/include/miopen/sqlite_db.hpp
+++ b/src/include/miopen/sqlite_db.hpp
@@ -160,8 +160,7 @@ class SQLiteBase
         : filename(filename_),
           arch(arch_),
           num_cu(num_cu_),
-          lock_file(LockFile::Get(is_system ? LockFilePath(filename_).c_str()
-                                            : (filename_ + ".lock").c_str()))
+          lock_file(LockFile::Get(LockFilePath(filename_).c_str()))
     {
         MIOPEN_LOG_I2("Initializing " << (is_system ? "system" : "user") << " database file "
                                       << filename);


### PR DESCRIPTION
This PR removes co-located files which are causing issue with permission, and restores the old behavior.

The rationale for this change was to share the directory with multiple dockers running MIOpen. However, we see many lock file creation failures in logs, furthermore if the user config directory is not present the lock file creation fails. 

Since, we are getting rid of this mechanism for SQLite pdb in a subsequent PR, it doesn't make sense to keep this and create issues. 