### PR TITLE
Change workgroup launch pattern for fp16 fwd

### DIFF
--- a/src/kernels/composable_kernel/include/kernel_algorithm/gridwise_convolution_backward_data_implicit_gemm_v1r1_xdlops_fp16_bfp16_gnchw_gkcyx_gnkhw.hpp
+++ b/src/kernels/composable_kernel/include/kernel_algorithm/gridwise_convolution_backward_data_implicit_gemm_v1r1_xdlops_fp16_bfp16_gnchw_gkcyx_gnkhw.hpp
@@ -186,7 +186,8 @@ struct GridwiseConvolutionBackwardDataImplicitGemm_v1r1_xdlops_fp16_bfp16_gnchw_
                 2,
                 GemmBBlockCopySrcDataPerRead_GemmN,
                 GemmBBlockCopyDstDataPerWrite_GemmKPACK,
-                in_memory_op>{};
+                in_memory_op,
+                MBlock1NBlock0>{};
 
         gridwise_gemm.Run(p_wei_global, p_out_global, p_in_global);
     }

--- a/src/kernels/composable_kernel/include/kernel_algorithm/gridwise_convolution_backward_data_implicit_gemm_v1r1_xdlops_fp16_bfp16_nchw_kcyx_nkhw.hpp
+++ b/src/kernels/composable_kernel/include/kernel_algorithm/gridwise_convolution_backward_data_implicit_gemm_v1r1_xdlops_fp16_bfp16_nchw_kcyx_nkhw.hpp
@@ -172,7 +172,8 @@ struct GridwiseConvolutionBackwardDataImplicitGemm_v1r1_xdlops_f16_bfp16_nchw_kc
             1,
             GemmBBlockCopySrcDataPerRead_GemmN,
             GemmBBlockCopyDstDataPerWrite_GemmKPACK,
-            in_memory_op>{};
+            in_memory_op,
+            MBlock1NBlock0>{};
 
         gridwise_gemm.Run(p_wei_global, p_out_global, p_in_global);
     }

--- a/src/kernels/composable_kernel/include/kernel_algorithm/gridwise_convolution_implicit_gemm_v4r4_gen_xdlops_fp16_bfp16_fwd_nchw_kcyx_nkhw_lds_double_buffer.hpp
+++ b/src/kernels/composable_kernel/include/kernel_algorithm/gridwise_convolution_implicit_gemm_v4r4_gen_xdlops_fp16_bfp16_fwd_nchw_kcyx_nkhw_lds_double_buffer.hpp
@@ -93,7 +93,8 @@ template <index_t GridSize,
           class GemmBBlockCopyDstAccessOrder,
           index_t GemmBBlockCopySrcDataPerRead_GemmN,
           index_t GemmBBlockCopyDstDataPerWrite_GemmKPACK,
-          ImplicitGemmDirection conv_dir>
+          ImplicitGemmDirection conv_dir,
+          WorkgroupScheduleOrder WorkgroupSchdOrder>
 struct
     GridwiseConvolutionImplicitGemm_v4r4_gen_xdlops_fp16_bfp16_fwd_nchw_kcyx_nkhw_lds_double_buffer
 {
@@ -260,7 +261,8 @@ struct
                 2, // N dimension
                 GemmBBlockCopySrcDataPerRead_GemmN,
                 GemmBBlockCopyDstDataPerWrite_GemmKPACK,
-                CGlobalMemoryDataOperation>{};
+                CGlobalMemoryDataOperation,
+                WorkgroupSchdOrder>{};
 
         gridwise_gemm.Run(p_wei_global, p_in_global, p_out_global);
     }

--- a/src/kernels/composable_kernel/include/kernel_algorithm/gridwise_convolution_implicit_gemm_v4r4_gen_xdlops_fp16_bfp16_gnchw_gkcyx_gnkhw_lds_double_buffer.hpp
+++ b/src/kernels/composable_kernel/include/kernel_algorithm/gridwise_convolution_implicit_gemm_v4r4_gen_xdlops_fp16_bfp16_gnchw_gkcyx_gnkhw_lds_double_buffer.hpp
@@ -337,7 +337,8 @@ struct
                 2,
                 GemmBBlockCopySrcDataPerRead_GemmN,
                 GemmBBlockCopyDstDataPerWrite_GemmKPACK,
-                CGlobalMemoryDataOperation>{};
+                CGlobalMemoryDataOperation,
+                MBlock1NBlock0>{};
 
         gridwise_batched_gemm.Run(p_wei_global, p_in_global, p_out_global);
     }

--- a/src/kernels/composable_kernel/include/kernel_algorithm/gridwise_convolution_implicit_gemm_v4r4_gen_xdlops_fp16_bfp16_wrw_nchw_kcyx_nkhw_lds_double_buffer.hpp
+++ b/src/kernels/composable_kernel/include/kernel_algorithm/gridwise_convolution_implicit_gemm_v4r4_gen_xdlops_fp16_bfp16_wrw_nchw_kcyx_nkhw_lds_double_buffer.hpp
@@ -248,7 +248,8 @@ struct
                 2, // N dimension
                 GemmBBlockCopySrcDataPerRead_GemmN,
                 GemmBBlockCopyDstDataPerWrite_GemmKPACK,
-                CGlobalMemoryDataOperation>{};
+                CGlobalMemoryDataOperation,
+                MBlock1NBlock0>{};
 
         gridwise_gemm.Run(p_wei_global, p_in_global, p_out_global);
     }

--- a/src/kernels/composable_kernel/include/tensor_operation/gridwise_gemm_xdlops_fp16_bfp16.hpp
+++ b/src/kernels/composable_kernel/include/tensor_operation/gridwise_gemm_xdlops_fp16_bfp16.hpp
@@ -11,6 +11,39 @@
 
 namespace ck {
 
+template <index_t Gi,
+          index_t MBlockWork,
+          index_t NBlockWork,
+          WorkgroupScheduleOrder WorkgroupSchdOrder>
+struct make_batch_block_work_sequence;
+
+template <index_t Gi, index_t MBlockWork, index_t NBlockWork>
+struct make_batch_block_work_sequence<Gi, MBlockWork, NBlockWork, MBlock1NBlock0>
+{
+    __device__ constexpr auto get() { return Sequence<Gi, MBlockWork, NBlockWork>{}; }
+};
+
+template <index_t Gi, index_t MBlockWork, index_t NBlockWork>
+struct make_batch_block_work_sequence<Gi, MBlockWork, NBlockWork, NBlock1MBlock0>
+{
+    __device__ constexpr auto get() { return Sequence<Gi, NBlockWork, MBlockWork>{}; }
+};
+
+template <index_t MBlockWork, index_t NBlockWork, WorkgroupScheduleOrder WorkgroupSchdOrder>
+struct make_block_work_sequence;
+
+template <index_t MBlockWork, index_t NBlockWork>
+struct make_block_work_sequence<MBlockWork, NBlockWork, MBlock1NBlock0>
+{
+    __device__ constexpr auto get() { return Sequence<MBlockWork, NBlockWork>{}; }
+};
+
+template <index_t MBlockWork, index_t NBlockWork>
+struct make_block_work_sequence<MBlockWork, NBlockWork, NBlock1MBlock0>
+{
+    __device__ constexpr auto get() { return Sequence<NBlockWork, MBlockWork>{}; }
+};
+
 template <index_t GridSize,
           index_t BlockSize,
           class ABFloat,
@@ -42,7 +75,8 @@ template <index_t GridSize,
           index_t BBlockCopySrcVectorReadDim,
           index_t BBlockCopySrcDataPerRead,
           index_t BBlockCopyDstDataPerWrite_KPACK,
-          InMemoryDataOperation OutputMemOp>
+          InMemoryDataOperation OutputMemOp,
+          WorkgroupScheduleOrder WorkgroupSchdOrder>
 struct GridwiseGemmTransposedANormalBNormalCXdlopsFp16Bfp16_v1
 {
     __device__ void Run(const ABFloat* const __restrict__ p_a_global,
@@ -70,13 +104,18 @@ struct GridwiseGemmTransposedANormalBNormalCXdlopsFp16Bfp16_v1
         constexpr index_t MWaves = MPerBlock / MPerWave;
         constexpr index_t NWaves = NPerBlock / NPerWave;
 
-        constexpr auto block_work_desc =
-            make_cluster_descriptor(Sequence<MBlockWork, NBlockWork>{});
+        constexpr auto block_work_sequence =
+            make_block_work_sequence<MBlockWork, NBlockWork, WorkgroupSchdOrder>{}.get();
+        constexpr auto block_work_desc = make_cluster_descriptor(block_work_sequence);
 
         const auto block_work_id = block_work_desc.CalculateClusterIndex(get_block_1d_id());
 
-        const index_t k_block_data_on_global = block_work_id[0] * MPerBlock;
-        const index_t b_block_data_on_global = block_work_id[1] * NPerBlock;
+        const index_t k_block_data_on_global = (WorkgroupSchdOrder == MBlock1NBlock0)
+                                                   ? (block_work_id[0] * MPerBlock)
+                                                   : (block_work_id[1] * MPerBlock);
+        const index_t b_block_data_on_global = (WorkgroupSchdOrder == MBlock1NBlock0)
+                                                   ? (block_work_id[1] * NPerBlock)
+                                                   : (block_work_id[0] * NPerBlock);
 
         //   LDS mem
         constexpr index_t max_align = math::lcm(BBlockCopyDstDataPerWrite_KPACK,
@@ -380,7 +419,8 @@ template <index_t GridSize,
           index_t BBlockCopySrcVectorReadDim,
           index_t BBlockCopySrcDataPerRead,
           index_t BBlockCopyDstDataPerWrite_KPACK,
-          InMemoryDataOperation OutputMemOp>
+          InMemoryDataOperation OutputMemOp,
+          WorkgroupScheduleOrder WorkgroupSchdOrder>
 struct GridwiseBatchedGemmTransposedANormalBNormalCXdlopsFp16Bfp16_v1
 {
     __device__ void Run(const ABFloat* const __restrict__ p_a_global,
@@ -412,14 +452,19 @@ struct GridwiseBatchedGemmTransposedANormalBNormalCXdlopsFp16Bfp16_v1
         constexpr index_t MWaves = MPerBlock / MPerWave;
         constexpr index_t NWaves = NPerBlock / NPerWave;
 
-        constexpr auto block_work_desc =
-            make_cluster_descriptor(Sequence<Gi, MBlockWork, NBlockWork>{});
+        constexpr auto block_work_sequence =
+            make_batch_block_work_sequence<Gi, MBlockWork, NBlockWork, WorkgroupSchdOrder>{}.get();
+        constexpr auto block_work_desc = make_cluster_descriptor(block_work_sequence);
 
         const auto block_work_id = block_work_desc.CalculateClusterIndex(get_block_1d_id());
 
         const index_t group_id               = block_work_id[0];
-        const index_t m_block_data_on_global = block_work_id[1] * MPerBlock;
-        const index_t n_block_data_on_global = block_work_id[2] * NPerBlock;
+        const index_t m_block_data_on_global = (WorkgroupSchdOrder == MBlock1NBlock0)
+                                                   ? (block_work_id[1] * MPerBlock)
+                                                   : (block_work_id[2] * MPerBlock);
+        const index_t n_block_data_on_global = (WorkgroupSchdOrder == MBlock1NBlock0)
+                                                   ? (block_work_id[2] * NPerBlock)
+                                                   : (block_work_id[1] * NPerBlock);
 
         //   LDS mem
         constexpr index_t max_align = math::lcm(BBlockCopyDstDataPerWrite_KPACK,

--- a/src/kernels/composable_kernel/include/utility/config.hpp
+++ b/src/kernels/composable_kernel/include/utility/config.hpp
@@ -73,6 +73,12 @@ enum InMemoryDataOperation
     AtomicAdd
 };
 
+enum WorkgroupScheduleOrder
+{
+    MBlock1NBlock0,
+    NBlock1MBlock0
+};
+
 #if CK_UNSIGNED_INDEX_TYPE
 using index_t = uint32_t;
 #else

--- a/src/kernels/composable_kernel/src/kernel_wrapper/gridwise_convolution_implicit_gemm_v4r4_gen_xdlops_nchw_kcyx_nkhw_lds_double_buffer.cpp
+++ b/src/kernels/composable_kernel/src/kernel_wrapper/gridwise_convolution_implicit_gemm_v4r4_gen_xdlops_nchw_kcyx_nkhw_lds_double_buffer.cpp
@@ -275,6 +275,14 @@ extern "C" __global__
 #elif(MIOPEN_USE_FP16 || MIOPEN_USE_BFP16) && CK_PARAM_PROBLEM_DIRECTION != 2
     // Forward data doesn't use any atomic add so output blob remains of the same type
     // as input blob
+
+    constexpr auto wkgrp_schd_order =
+#if MIOPEN_USE_FP16
+        NBlock1MBlock0;
+#else
+        MBlock1NBlock0;
+#endif // MIOPEN_USE_FP16
+
     constexpr auto gridwise_conv =
         GridwiseConvolutionImplicitGemm_v4r4_gen_xdlops_fp16_bfp16_fwd_nchw_kcyx_nkhw_lds_double_buffer<
             GridSize,
@@ -312,7 +320,8 @@ extern "C" __global__
             GemmBBlockCopyDstAccessOrder,
             GemmBBlockCopySrcDataPerRead_GemmN,
             GemmBBlockCopyDstDataPerWrite_GemmKPACK,
-            dir>{};
+            dir,
+            wkgrp_schd_order>{};
     gridwise_conv.Run(p_in_global, p_wei_global, p_out_global);
 #else
     static_assert(false, "wrong! Only fp32, fp16 and bfp16 are supported.");


### PR DESCRIPTION
On fp16 fwd pass, the rocprof metrics reported that our fetch size was much larger than fp32 and memory unit was busy. To reduce fetch size, we want to hit more L2. Changing workgroup scheduler has helped us hit more L2 as depicted in 2nd rocprof metrics.

MIOpenDriver convfp16 -n 64 -c 1024  -H 14 -W 14 -k 1024 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -g 1 -w 1 -t 1 -F 1

dispatch[0], gpu-id(0), queue-id(4), queue-index(0), tid(31056), grd(200704), wgr(256), lds(0), scr(0), vgpr(96), sgpr(48), fbar(0), sig(0x7f8483b7da80), kernel-name("gridwise_convolution_implicit_gemm_v4r4_gen_xdlops_nchw_kcyx_nkhw_lds_double_buffer.kd")
  SQ_WAVES (3136)
  FETCH_SIZE (192237)
  MemUnitBusy (80)
  MemUnitStalled (2)
  SQ_LDS_BANK_CONFLICT (16056320)
  LDSBankConflict (22)
  ALUStalledByLDS (0)
  L2CacheHit (57)

After workgroup scheduler change, 

dispatch[0], gpu-id(0), queue-id(4), queue-index(0), tid(30324), grd(200704), wgr(256), lds(0), scr(0), vgpr(96), sgpr(48), fbar(0), sig(0x7f04ddc7da80), kernel-name("gridwise_convolution_implicit_gemm_v4r4_gen_xdlops_nchw_kcyx_nkhw_lds_double_buffer.kd")
  SQ_WAVES (3136)
  FETCH_SIZE (34778)
  MemUnitBusy (75)
  MemUnitStalled (3)
  SQ_LDS_BANK_CONFLICT (16056320)
  LDSBankConflict (25)
  ALUStalledByLDS (0)
  L2CacheHit (88)

We are seeing upto 10% gain in kernel time for fp16 fwd resnext101 configs.