### PR TITLE
Handle SQLITE_BUSY during object cleanup

### DIFF
--- a/src/include/miopen/sqlite_db.hpp
+++ b/src/include/miopen/sqlite_db.hpp
@@ -143,7 +143,15 @@ template <typename Derived>
 class SQLiteBase
 {
     protected:
-    using sqlite3_ptr      = MIOPEN_MANAGE_PTR(sqlite3*, sqlite3_close);
+    struct SQLiteCloser
+    {
+        void operator()(sqlite3* ptr)
+        {
+            std::string filename(sqlite3_db_filename(ptr, "main"));
+            SQLiteBase::SQLRety([&]() { return sqlite3_close(ptr); }, filename);
+        }
+    };
+    using sqlite3_ptr      = std::unique_ptr<sqlite3, SQLiteCloser>;
     using exclusive_lock   = boost::unique_lock<LockFile>;
     using shared_lock      = boost::shared_lock<LockFile>;
     using sqlite3_stmt_ptr = MIOPEN_MANAGE_PTR(sqlite3_stmt*, sqlite3_finalize);
@@ -257,6 +265,12 @@ class SQLiteBase
 
     template <class F>
     inline int SQLRety(F f) const
+    {
+        return SQLiteBase::SQLRety(f, filename);
+    }
+
+    template <class F>
+    static inline int SQLRety(F f, std::string filename)
     {
         auto timeout_end = std::chrono::high_resolution_clock::now() +
                            std::chrono::seconds(30); // TODO: make configurable

--- a/src/include/miopen/sqlite_db.hpp
+++ b/src/include/miopen/sqlite_db.hpp
@@ -147,8 +147,8 @@ class SQLiteBase
     {
         void operator()(sqlite3* ptr)
         {
-            std::string filename(sqlite3_db_filename(ptr, "main"));
-            SQLiteBase::SQLRety([&]() { return sqlite3_close(ptr); }, filename);
+            std::string filename_(sqlite3_db_filename(ptr, "main"));
+            SQLiteBase::SQLRety([&]() { return sqlite3_close(ptr); }, filename_);
         }
     };
     using sqlite3_ptr      = std::unique_ptr<sqlite3, SQLiteCloser>;


### PR DESCRIPTION
During the cleanup of the Perf DB SQLite object it is possible that the database may be busy writing previous transactions and return busy. 

This PR addresses this case by reusing the appropriate logic already present in the database class.