### PR TITLE
Improved error checking during db creation

### DIFF
--- a/src/include/miopen/kern_db.hpp
+++ b/src/include/miopen/kern_db.hpp
@@ -50,6 +50,10 @@ struct KernelConfig
     std::string kernel_name;
     std::string kernel_args;
     std::string kernel_blob;
+    static std::vector<std::string> FieldNames()
+    {
+        return {"kernel_name", "kernel_args", "kernel_blob"};
+    }
     static std::string CreateQuery()
     {
         std::ostringstream ss;

--- a/src/include/miopen/sqlite_db.hpp
+++ b/src/include/miopen/sqlite_db.hpp
@@ -243,9 +243,9 @@ class SQLiteBase
             MIOPEN_VALIDATE_LOCK(lock);
             SQLExec(sql_cfg_fds, cfg_res);
         }
-        std::vector<std::string> cfg_fds;
-        for(auto& row : cfg_res)
-            cfg_fds.push_back(row["name"]);
+        std::vector<std::string> cfg_fds(cfg_res.size());
+        std::transform(
+            cfg_res.begin(), cfg_res.end(), cfg_fds.begin(), [](auto row) { return row["name"]; });
         // search in the golden vector
         bool AllFound = true;
         for(auto& goldenName : goldenList)
@@ -253,7 +253,9 @@ class SQLiteBase
             if(std::find(cfg_fds.begin(), cfg_fds.end(), goldenName) == cfg_fds.end())
             {
                 AllFound = false;
-                MIOPEN_LOG_I2("Field " + goldenName + " not found in table: " + tableName);
+                std::ostringstream ss;
+                ss << "Field " << goldenName << " not found in table: " << tableName;
+                MIOPEN_LOG_I2(ss.str());
                 // break; Not breaking to enable logging of all missing fields.
             }
         }

--- a/src/kern_db.cpp
+++ b/src/kern_db.cpp
@@ -41,6 +41,17 @@ KernDb::KernDb(const std::string& filename_,
             MIOPEN_THROW(miopenStatusInternalError);
         MIOPEN_LOG_I2("Database created successfully");
     }
+    if(!dbInvalid)
+    {
+        if(!CheckTableColumns(KernelConfig::table_name(), KernelConfig::FieldNames()))
+        {
+            MIOPEN_LOG_W("Invalid fields in table: " + KernelConfig::table_name() +
+                         " disabling access to " + filename);
+            dbInvalid = true;
+        }
+    }
+    else
+        MIOPEN_LOG_I(filename + " database invalid");
 }
 
 } // namespace miopen

--- a/src/kern_db.cpp
+++ b/src/kern_db.cpp
@@ -45,8 +45,10 @@ KernDb::KernDb(const std::string& filename_,
     {
         if(!CheckTableColumns(KernelConfig::table_name(), KernelConfig::FieldNames()))
         {
-            MIOPEN_LOG_W("Invalid fields in table: " + KernelConfig::table_name() +
-                         " disabling access to " + filename);
+            std::ostringstream ss;
+            ss << "Invalid fields in table: " << KernelConfig::table_name()
+               << " disabling access to " << filename;
+            MIOPEN_LOG_W(ss.str());
             dbInvalid = true;
         }
     }

--- a/src/sqlite_db.cpp
+++ b/src/sqlite_db.cpp
@@ -105,8 +105,10 @@ SQLitePerfDb::SQLitePerfDb(const std::string& filename_,
     {
         if(!CheckTableColumns(prob_desc.table_name(), prob_desc.FieldNames()))
         {
-            MIOPEN_LOG_W("Invalid fields in table: " + prob_desc.table_name() +
-                         " disabling access to " + filename);
+            std::ostringstream ss;
+            ss << "Invalid fields in table: " << prob_desc.table_name() << " disabling access to "
+               << filename;
+            MIOPEN_LOG_W(ss.str());
             dbInvalid = true;
         }
         if(!CheckTableColumns("perf_db", {"solver", "config", "arch", "num_cu", "params"}))

--- a/src/sqlite_db.cpp
+++ b/src/sqlite_db.cpp
@@ -56,13 +56,13 @@ SQLitePerfDb::SQLitePerfDb(const std::string& filename_,
                            const std::size_t num_cu_)
     : SQLiteBase(filename_, is_system, arch_, num_cu_)
 {
+    ProblemDescription prob_desc{conv::Direction::Forward};
+    prob_desc.in_data_type      = miopenFloat;
+    prob_desc.out_data_type     = miopenFloat;
+    prob_desc.weights_data_type = miopenFloat;
     if(!is_system)
     {
         SQLRes_t res;
-        ProblemDescription prob_desc{conv::Direction::Forward};
-        prob_desc.in_data_type          = miopenFloat;
-        prob_desc.out_data_type         = miopenFloat;
-        prob_desc.weights_data_type     = miopenFloat;
         const std::string create_config = prob_desc.CreateQuery();
         // clang-format off
         const std::string create_perfdb_sql =
@@ -100,5 +100,22 @@ SQLitePerfDb::SQLitePerfDb(const std::string& filename_,
             MIOPEN_LOG_I2("Database created successfully");
         }
     }
+    // Check fields for the tables
+    if(!dbInvalid)
+    {
+        if(!CheckTableColumns(prob_desc.table_name(), prob_desc.FieldNames()))
+        {
+            MIOPEN_LOG_W("Invalid fields in table: " + prob_desc.table_name() +
+                         " disabling access to " + filename);
+            dbInvalid = true;
+        }
+        if(!CheckTableColumns("perf_db", {"solver", "config", "arch", "num_cu", "params"}))
+        {
+            MIOPEN_LOG_W("Invalid fields in table: perf_db disabling access to " + filename);
+            dbInvalid = true;
+        }
+    }
+    else
+        MIOPEN_LOG_I(filename + " database invalid");
 }
 } // namespace miopen

--- a/src/sqlite_db.cpp
+++ b/src/sqlite_db.cpp
@@ -103,11 +103,11 @@ SQLitePerfDb::SQLitePerfDb(const std::string& filename_,
     // Check fields for the tables
     if(!dbInvalid)
     {
-        if(!CheckTableColumns(prob_desc.table_name(), prob_desc.FieldNames()))
+        if(!CheckTableColumns(ProblemDescription::table_name(), prob_desc.FieldNames()))
         {
             std::ostringstream ss;
-            ss << "Invalid fields in table: " << prob_desc.table_name() << " disabling access to "
-               << filename;
+            ss << "Invalid fields in table: " << ProblemDescription::table_name()
+               << " disabling access to " << filename;
             MIOPEN_LOG_W(ss.str());
             dbInvalid = true;
         }


### PR DESCRIPTION
This PR improves the handling schema variation in Perf Db. Previously, we only checked the absence or presence of tables in the database. This PR adds the capability to inspect the columns of the tables ( if they exist in the database) and report any mismatch. If a mismatch is found, a warning is issued reporting the missing columns and access to the invalid database is disabled.

This PR does not result in any functionality or performance changes.