### PR TITLE
[NFC] Removed redundant `@struct` from miopen.h

### DIFF
--- a/doc/src/convolution.rst
+++ b/doc/src/convolution.rst
@@ -30,6 +30,11 @@ miopenConvAlgoPerf_t
 
 .. doxygenstruct::  miopenConvAlgoPerf_t
 
+miopenConvSolution_t
+--------------------
+
+.. doxygenstruct::  miopenConvSolution_t
+
 miopenCreateConvolutionDescriptor
 ---------------------------------
 

--- a/include/miopen/miopen.h
+++ b/include/miopen/miopen.h
@@ -885,9 +885,7 @@ typedef enum {
     miopenConvolutionAlgoStaticCompiledGEMM = 6, /*!< Static Compiled GEMM convolutions */
 } miopenConvAlgorithm_t;
 
-/*! @struct miopenConvAlgoPerf_t
-
- * @brief Perf struct for forward, backward filter, or backward data algorithms
+/*! @brief Perf struct for forward, backward filter, or backward data algorithms
  *
  * Contains the union to hold the selected convolution algorithm for forward, or backwards layers,
  * and also contains the time it took to run the algorithm and the workspace required to run the
@@ -907,10 +905,8 @@ typedef struct
     size_t memory; /*!< Workspace required to run the selected algorithm represented in the union */
 } miopenConvAlgoPerf_t;
 
-/*! @struct miopenConvSolution_t
-
- * @brief Performance struct for forward, backward filter, or backward data algorithms in immediate
- mode
+/*! @brief Performance struct for forward, backward filter, or backward data algorithms in
+ * immediate mode
  *
  * Contains an integer identifying the solution and the algorithm for the solution,
  * as well as the runtime, workspace size and a boolean flag indicating whether the returned

--- a/include/miopen/miopen.h
+++ b/include/miopen/miopen.h
@@ -876,6 +876,9 @@ typedef enum {
     miopenConvolutionBwdDataAlgoImplicitGEMM = 5, /*!< Implicit GEMM convolutions, fp32 only */
 } miopenConvBwdDataAlgorithm_t;
 
+/*! @enum miopenConvAlgorithm_t
+ * Top-level convolutional algorithm mode
+ */
 typedef enum {
     miopenConvolutionAlgoGEMM         = 0, /*!< GEMM variant */
     miopenConvolutionAlgoDirect       = 1, /*!< Direct convolutions */
@@ -901,14 +904,16 @@ typedef struct
         miopenConvBwdDataAlgorithm_t
             bwd_data_algo; /*!< Back propagation on data convolution algorithm enum selection */
     };
+
     float time;    /*!< Time to exectued the selected algorithm represented in the union */
     size_t memory; /*!< Workspace required to run the selected algorithm represented in the union */
+
 } miopenConvAlgoPerf_t;
 
 /*! @brief Performance struct for forward, backward filter, or backward data algorithms in
  * immediate mode
  *
- * Contains an integer identifying the solution and the algorithm for the solution,
+ * Contains a 64-bit integer identifying the solution and the algorithm for the solution,
  * as well as the runtime, workspace size and a boolean flag indicating whether the returned
  * solution is a heuristic or resulting from an actual run
  *
@@ -917,11 +922,12 @@ typedef struct
 {
     float time; /*!< Represents the approximate time required to execute this solution on the GPU,
                      in milliseconds. This value may either be based on an acutal kernel run or an
-                     esitmate based on a heuristic.*/
+                     estimate based on a heuristic.*/
     size_t workspace_size; /*!< Workspace required to run the selected algorithm represented in the
                               union */
     uint64_t solution_id;  /*!< Identifier for the returned solution */
     miopenConvAlgorithm_t algorithm; /*!< The algorithm used to compute the solution */
+
 } miopenConvSolution_t;
 
 /*! @brief Query the maximum number of solutions applicable for the given input/output and weights


### PR DESCRIPTION
Removed redundant `@struct` that lead to annoying warnings due to issue in the compiler (moving comment blocks after definitions resolve the problem but that is not what we want).

Ubuntu 18.04.1 LTS, vanilla rocm-dkms 3.3-19.