### PR TITLE
Merge Fast/Hybrid Find modes into develop

### DIFF
--- a/driver/conv_driver.hpp
+++ b/driver/conv_driver.hpp
@@ -97,8 +97,10 @@ struct AutoMiopenWarmupMode
     {
         debug_logging_quiet_prev          = miopen::debug::LoggingQuiet;
         debug_find_enforce_disable_prev   = miopen::debug::FindEnforceDisable;
+        debug_find_mode_disable_prev      = miopen::debug::FindModeDisable;
         miopen::debug::LoggingQuiet       = true;
         miopen::debug::FindEnforceDisable = true;
+        miopen::debug::FindModeDisable    = true;
     }
     AutoMiopenWarmupMode(const AutoMiopenWarmupMode&) = delete;
     AutoMiopenWarmupMode(AutoMiopenWarmupMode&&)      = delete;
@@ -108,11 +110,13 @@ struct AutoMiopenWarmupMode
     {
         miopen::debug::LoggingQuiet       = debug_logging_quiet_prev;
         miopen::debug::FindEnforceDisable = debug_find_enforce_disable_prev;
+        miopen::debug::FindModeDisable    = debug_find_mode_disable_prev;
     }
 
     private:
     bool debug_logging_quiet_prev;
     bool debug_find_enforce_disable_prev;
+    bool debug_find_mode_disable_prev;
 };
 
 template <typename T>

--- a/driver/dropout_driver.hpp
+++ b/driver/dropout_driver.hpp
@@ -30,7 +30,7 @@
 #include "driver.hpp"
 #include "timer.hpp"
 #include "dropout_gpu_emulator.hpp"
-#include <../src/include/miopen/dropout.hpp>
+#include <miopen/dropout.hpp>
 #include <../test/verify.hpp>
 #include <algorithm>
 #include <cstdlib>

--- a/src/include/miopen/find_controls.hpp
+++ b/src/include/miopen/find_controls.hpp
@@ -34,10 +34,15 @@ namespace miopen {
 
 namespace debug {
 
-/// Disable observation of FIND_ENFORCE env.vars for debugging/testing purposes.
+/// Disable MIOPEN_FIND_ENFORCE. Intended for debugging/testing purposes.
 /// Currently used during warm-up phase in MIOpenDriver.
 /// WARNING: This switch is not intended for use in multi-threaded applications.
 extern bool FindEnforceDisable;
+
+/// Disable MIOPEN_FIND_MODE. Intended for debugging/testing purposes.
+/// Currently used during warm-up phase in MIOpenDriver.
+/// WARNING: This switch is not intended for use in multi-threaded applications.
+extern bool FindModeDisable;
 
 } // namespace debug
 
@@ -112,6 +117,29 @@ class FindEnforce
 };
 
 solver::Id GetEnvFindOnlySolver();
+
+class FindMode
+{
+    public:
+    enum class Values
+    {
+        Begin_ = 1, // 0 is returned for non-numeric env.vars.
+        Normal = Begin_,
+        Fast,
+        Hybrid,
+        End_,
+        Default_ = Normal,
+    };
+
+    private:
+    Values value;
+
+    public:
+    FindMode();
+    bool IsFast() const { return value == Values::Fast && !debug::FindModeDisable; }
+    bool IsHybrid() const { return value == Values::Hybrid && !debug::FindModeDisable; }
+    friend std::ostream& operator<<(std::ostream&, const FindMode&);
+};
 
 } // namespace miopen
 

--- a/src/include/miopen/handle.hpp
+++ b/src/include/miopen/handle.hpp
@@ -208,11 +208,10 @@ struct Handle : miopenHandle
     void RegisterInvoker(const Invoker& invoker,
                          const NetworkConfig& config,
                          solver::Id solver,
-                         const boost::optional<AlgorithmName>& algo = boost::none)
+                         const AlgorithmName& algo)
     {
         invokers.Register({config, solver.ToString()}, invoker);
-        if(algo)
-            invokers.SetAsFound1_0(config, *algo, solver.ToString());
+        invokers.SetAsFound1_0(config, algo, solver.ToString());
     }
 
     boost::optional<const Invoker&>

--- a/src/ocl/convolutionocl.cpp
+++ b/src/ocl/convolutionocl.cpp
@@ -34,6 +34,7 @@
 #include <miopen/env.hpp>
 #include <miopen/find_db.hpp>
 #include <miopen/finddb_kernel_cache_key.hpp>
+#include <miopen/find_controls.hpp>
 #include <miopen/float_equal.hpp>
 #include <miopen/invoker.hpp>
 #include <miopen/kernel.hpp>
@@ -492,16 +493,12 @@ static void DirConvFindCore(Handle& handle,
                             size_t workSpaceSize,
                             const ConvolutionDescriptor& conv,
                             bool exhaustiveSearch,
-                            DbRecord& record)
+                            DbRecord& record,
+                            const ConvolutionContext& ctx,
+                            bool use_winograd_only)
 {
     AutoEnableProfiling enableProfiling{handle};
-
     ValidateGroupCount(xDesc, wDesc, conv);
-
-    auto ctx = ConvolutionContext{xDesc, wDesc, yDesc, conv, conv::Direction::Forward};
-    ctx.SetStream(&handle);
-    ctx.DetectRocm();
-    const auto use_winograd_only = conv.IsWinograd3x3SupportedAndFast(ctx);
 
 #if MIOPEN_USE_GEMM
     if(!use_winograd_only && !miopen::IsDisabled(MIOPEN_DEBUG_CONV_GEMM{}) &&
@@ -831,9 +828,6 @@ static void DirConvFindCore(Handle& handle,
 
     // Winograd algo
     {
-        ConvolutionUserBuffers bufs(workSpace, workSpaceSize);
-        bufs.SetFwd(x, w, y);
-        ctx.SetBufs(bufs);
         const auto all = conv.FindWinogradSolutions(ctx);
         PrecompileSolutions(handle, all);
         const auto algorithm_name = AlgorithmName{"miopenConvolutionFwdAlgoWinograd"};
@@ -1036,8 +1030,48 @@ void ConvolutionDescriptor::FindConvFwdAlgorithm(Handle& handle,
 
     const ProblemDescription problem(xDesc, wDesc, yDesc, *this, conv::Direction::Forward);
 
-    std::vector<PerfField> perf_db =
-        UserFindDbRecord::TryLoad(handle, problem, [&](DbRecord& record) {
+    auto ctx = ConvolutionContext{problem};
+    ctx.SetStream(&handle);
+    ctx.DetectRocm();
+    ConvolutionUserBuffers bufs(workSpace, workSpaceSize);
+    bufs.SetFwd(x, w, y);
+    ctx.SetBufs(bufs);
+    const bool use_winograd_only = IsWinograd3x3SupportedAndFast(ctx);
+
+    std::vector<PerfField> perf_db;
+
+    const miopen::FindMode fm;
+    /// \section ffind_special_cases
+    /// Fast Find mode: Let's allow known fast-to-build special cases
+    /// (this is only Winograd 3x3 so far) to override switching to Immediate mode.
+    /// This minimizes performance drop in Fast Find mode at for free.
+    /// Otherwise we can hit Immediate mode fallback (which is just GEMM
+    /// right now) in many cases. -- atamazov 21 Nov 2019.
+    ///
+    /// \todo Revise this (and similar cases) when Immediate mode
+    /// will be better elaborated.
+    bool use_immediate_solution = false;
+    miopenConvSolution_t sol;
+    if((fm.IsFast() || fm.IsHybrid()) && !use_winograd_only)
+    {
+        size_t count;
+        GetForwardSolutions(handle, wDesc, xDesc, yDesc, 1, &count, &sol);
+        use_immediate_solution = (count > 0) && !(fm.IsHybrid() && sol.time < 0);
+        // In Hybrid Find mode, we use Normal Find instead of Immediate fallback kernels.
+    }
+
+    if(use_immediate_solution)
+    {
+        CompileForwardSolution(handle, wDesc, xDesc, yDesc, sol.solution_id);
+        /// It is possible to measure actual execution time and return it to the caller.
+        /// \todo Consider if we need (and want to spend time) for this.
+        const auto id = solver::Id(sol.solution_id);
+        perf_db.push_back(
+            {id.GetAlgo(conv::Direction::Forward), id.ToString(), sol.time, sol.workspace_size});
+    }
+    else
+    {
+        perf_db = UserFindDbRecord::TryLoad(handle, problem, [&](DbRecord& record) {
             DirConvFindCore(handle,
                             xDesc,
                             x,
@@ -1049,8 +1083,11 @@ void ConvolutionDescriptor::FindConvFwdAlgorithm(Handle& handle,
                             workSpaceSize,
                             *this,
                             exhaustiveSearch,
-                            record);
+                            record,
+                            ctx,
+                            use_winograd_only);
         });
+    }
 
     if(perf_db.empty())
         MIOPEN_THROW("Fwd Convolution cannot be executed due to incorrect params");
@@ -2249,7 +2286,8 @@ static std::vector<KernelInvoke> CompileSolver(Handle& handle,
 static Invoker PrepareInvoker(Handle& handle,
                               ConvolutionContext& ctx,
                               const NetworkConfig& config,
-                              solver::Id solver_id)
+                              solver::Id solver_id,
+                              conv::Direction dir)
 {
     ctx.DetectRocm();
     ctx.SetupFloats();
@@ -2260,17 +2298,20 @@ static Invoker PrepareInvoker(Handle& handle,
     const auto invoker =
         handle.PrepareInvoker(*solution.invoker_factory, solution.construction_params);
 
-    handle.RegisterInvoker(invoker, config, solver_id);
+    handle.RegisterInvoker(invoker, config, solver_id, AlgorithmName(solver_id.GetAlgo(dir)));
     return invoker;
 }
 
-static Invoker LoadOrPrepareInvoker(Handle& handle, ConvolutionContext& ctx, solver::Id solver_id)
+static Invoker LoadOrPrepareInvoker(Handle& handle,
+                                    ConvolutionContext& ctx,
+                                    solver::Id solver_id,
+                                    conv::Direction dir)
 {
     const auto config = ctx.BuildConfKey();
     auto invoker      = handle.GetInvoker(config, solver_id);
     if(invoker)
         return *invoker;
-    return PrepareInvoker(handle, ctx, config, solver_id);
+    return PrepareInvoker(handle, ctx, config, solver_id, dir);
 }
 
 static bool CheckInvokerSupport(const solver::Id solver_id, conv::Direction dir)
@@ -2290,7 +2331,7 @@ static void CompileSolution(Handle& handle,
 
     if(CheckInvokerSupport(solver_id, dir))
     {
-        LoadOrPrepareInvoker(handle, ctx, solver_id);
+        LoadOrPrepareInvoker(handle, ctx, solver_id, dir);
         return;
     }
 
@@ -2371,7 +2412,8 @@ void ConvolutionDescriptor::ConvolutionForwardImmediate(Handle& handle,
 
         if(CheckInvokerSupport(solver_id, conv::Direction::Forward))
         {
-            const auto invoker    = LoadOrPrepareInvoker(handle, ctx, solver_id);
+            const auto invoker =
+                LoadOrPrepareInvoker(handle, ctx, solver_id, conv::Direction::Forward);
             const auto invoke_ctx = conv::DataInvokeParams{tensors, workSpace, workSpaceSize};
             invoker(handle, invoke_ctx);
             return;
@@ -2484,9 +2526,31 @@ void ConvolutionDescriptor::FindConvBwdDataAlgorithm(Handle& handle,
         return IsWinograd3x3SupportedAndFast(ctx);
     }();
 
-    // < algorith_name, <time, workspace_size> >
-    std::vector<PerfField> perf_db =
-        UserFindDbRecord::TryLoad(handle, problem, [&](DbRecord& record) {
+    std::vector<PerfField> perf_db;
+
+    const miopen::FindMode fm;
+    /// \ref ffind_special_cases
+    bool use_immediate_solution = false;
+    miopenConvSolution_t imm_sol;
+    if((fm.IsFast() || fm.IsHybrid()) && !use_winograd_only)
+    {
+        size_t count;
+        GetBackwardSolutions(handle, dyDesc, wDesc, dxDesc, 1, &count, &imm_sol);
+        use_immediate_solution = (count > 0) && !(fm.IsHybrid() && imm_sol.time < 0);
+    }
+
+    if(use_immediate_solution)
+    {
+        CompileBackwardSolution(handle, dyDesc, wDesc, dxDesc, imm_sol.solution_id);
+        const auto id = solver::Id(imm_sol.solution_id);
+        perf_db.push_back({id.GetAlgo(conv::Direction::BackwardData),
+                           id.ToString(),
+                           imm_sol.time,
+                           imm_sol.workspace_size});
+    }
+    else
+    {
+        perf_db = UserFindDbRecord::TryLoad(handle, problem, [&](DbRecord& record) {
             const auto network_config = problem.BuildConfKey();
             const auto invoke_ctx     = conv::DataInvokeParams{
                 {dyDesc, dy, wDesc, w, dxDesc, dx}, workSpace, workSpaceSize};
@@ -2832,6 +2896,7 @@ void ConvolutionDescriptor::FindConvBwdDataAlgorithm(Handle& handle,
             }
 #endif
         });
+    }
 
     if(perf_db.empty())
         MIOPEN_THROW(miopenStatusUnknownError, "Backward Data Algo cannot be executed");
@@ -3514,7 +3579,8 @@ void ConvolutionDescriptor::ConvolutionBackwardImmediate(Handle& handle,
 
         if(CheckInvokerSupport(solver_id, conv::Direction::BackwardData))
         {
-            const auto invoker    = LoadOrPrepareInvoker(handle, ctx, solver_id);
+            const auto invoker =
+                LoadOrPrepareInvoker(handle, ctx, solver_id, conv::Direction::BackwardData);
             const auto invoke_ctx = conv::DataInvokeParams{tensors, workSpace, workSpaceSize};
             invoker(handle, invoke_ctx);
             return;
@@ -3890,185 +3956,206 @@ void ConvolutionDescriptor::FindConvBwdWeightsAlgorithm(Handle& handle,
     auto problem =
         ProblemDescription{xDesc, dwDesc, dyDesc, *this, conv::Direction::BackwardWeights};
 
-    // < algorith_name, <time, workspace_size> >
-    auto perf_db = UserFindDbRecord::TryLoad(handle, problem, [&](DbRecord& record) {
+    std::vector<PerfField> perf_db;
+    const miopen::FindMode fm;
+    bool use_immediate_solution = false;
+    miopenConvSolution_t imm_sol;
+    if(fm.IsFast() || fm.IsHybrid())
+    {
+        size_t count;
+        GetWrwSolutions(handle, dyDesc, xDesc, dwDesc, 1, &count, &imm_sol);
+        use_immediate_solution = (count > 0) && !(fm.IsHybrid() && imm_sol.time < 0);
+    }
 
+    if(use_immediate_solution)
+    {
+        CompileWrwSolution(handle, dyDesc, xDesc, dwDesc, imm_sol.solution_id);
+        const auto id = solver::Id(imm_sol.solution_id);
+        perf_db.push_back({id.GetAlgo(conv::Direction::BackwardWeights),
+                           id.ToString(),
+                           imm_sol.time,
+                           imm_sol.workspace_size});
+    }
+    else
+    {
+        perf_db = UserFindDbRecord::TryLoad(handle, problem, [&](DbRecord& record) {
 #if MIOPEN_USE_GEMM
-        if(!miopen::IsDisabled(MIOPEN_DEBUG_CONV_GEMM{}) &&
-           !(IsAnyBufferBF16(xDesc, dyDesc, dwDesc) && !IsUseRocBlas))
-        {
-            const bool time_precision = (!IsDisabled(MIOPEN_CONV_PRECISE_ROCBLAS_TIMING{}));
-
-            ValidateGroupCount(xDesc, dwDesc, *this);
-
-            std::size_t in_n, in_c;
-            std::tie(in_n, in_c) = tie_pick<0, 1>()(xDesc.GetLengths());
-
-            auto in_spatial =
-                boost::adaptors::slice(xDesc.GetLengths(), 2, 2 + GetSpatialDimension());
-            auto wei_spatial =
-                boost::adaptors::slice(dwDesc.GetLengths(), 2, 2 + GetSpatialDimension());
-            auto out_spatial =
-                boost::adaptors::slice(dyDesc.GetLengths(), 2, 2 + GetSpatialDimension());
-
-            size_t workspace_req =
-                BackwardWeightsGetWorkSpaceSizeGEMM(dyDesc, dwDesc) * group_count;
-
-            float time_gemm = 0;
-
-            // if not 1x1
-            if((miopen::any_of(wei_spatial, [](auto v) { return v != 1; }) ||
-                miopen::any_of(GetConvPads(), [](auto v) { return v != 0; }) ||
-                miopen::any_of(GetConvStrides(), [](auto v) { return v != 1; })) &&
-               (workSpace != nullptr && workSpaceSize >= workspace_req))
+            if(!miopen::IsDisabled(MIOPEN_DEBUG_CONV_GEMM{}) &&
+               !(IsAnyBufferBF16(xDesc, dyDesc, dwDesc) && !IsUseRocBlas))
             {
-                if(group_count > 1)
+                const bool time_precision = (!IsDisabled(MIOPEN_CONV_PRECISE_ROCBLAS_TIMING{}));
+
+                ValidateGroupCount(xDesc, dwDesc, *this);
+
+                std::size_t in_n, in_c;
+                std::tie(in_n, in_c) = tie_pick<0, 1>()(xDesc.GetLengths());
+
+                auto in_spatial =
+                    boost::adaptors::slice(xDesc.GetLengths(), 2, 2 + GetSpatialDimension());
+                auto wei_spatial =
+                    boost::adaptors::slice(dwDesc.GetLengths(), 2, 2 + GetSpatialDimension());
+                auto out_spatial =
+                    boost::adaptors::slice(dyDesc.GetLengths(), 2, 2 + GetSpatialDimension());
+
+                size_t workspace_req =
+                    BackwardWeightsGetWorkSpaceSizeGEMM(dyDesc, dwDesc) * group_count;
+
+                float time_gemm = 0;
+
+                // if not 1x1
+                if((miopen::any_of(wei_spatial, [](auto v) { return v != 1; }) ||
+                    miopen::any_of(GetConvPads(), [](auto v) { return v != 0; }) ||
+                    miopen::any_of(GetConvStrides(), [](auto v) { return v != 1; })) &&
+                   (workSpace != nullptr && workSpaceSize >= workspace_req))
                 {
-                    MIOPEN_LOG_FUNCTION("groupconv, non 1x1");
+                    if(group_count > 1)
+                    {
+                        MIOPEN_LOG_FUNCTION("groupconv, non 1x1");
+                    }
+                    else
+                    {
+                        MIOPEN_LOG_FUNCTION("convolution, non 1x1");
+                    }
+                    float time_im2col = 0;
+                    int in_offset     = 0;
+                    time_im2col       = Im2ColGPU(handle,
+                                            GetSpatialDimension(),
+                                            x,
+                                            in_offset,
+                                            in_c,
+                                            in_spatial,
+                                            wei_spatial,
+                                            out_spatial,
+                                            GetConvPads(),
+                                            GetConvStrides(),
+                                            GetConvDilations(),
+                                            workSpace,
+                                            dyDesc.GetType());
+
+                    // dw = dy * transpose(Im2Col(x))
+                    GemmDescriptor gemm_desc =
+                        group_count > 1 ? CreateGemmDescriptorGroupConvBwdWeight(
+                                              dyDesc, xDesc, dwDesc, group_count)
+                                        : CreateGemmDescriptorConvBwdWeight(dyDesc, xDesc, dwDesc);
+
+                    auto kcache_key = FindDbKCacheKey{};
+
+                    miopenStatus_t gemm_status = CallGemmTimeMeasure(
+                        handle,
+                        gemm_desc,
+                        dy,
+                        0,
+                        workSpace,
+                        0,
+                        dw,
+                        0,
+                        &kcache_key,
+                        time_precision,
+                        group_count > 1 ? callGemmStridedBatched : callGemm,
+                        group_count > 1 ? GemmBackend_t::rocblas : GemmBackend_t::miopengemm);
+
+                    time_gemm = in_n * (time_im2col + handle.GetKernelTime());
+
+                    if(gemm_status == miopenStatusSuccess)
+                        record.SetValues("miopenConvolutionBwdWeightsAlgoGEMM",
+                                         FindDbData{
+                                             "gemm", time_gemm, workspace_req, kcache_key,
+                                         });
                 }
-                else
+                // 1x1 does not require im2col or workspace
+                else if(miopen::any_of(wei_spatial, [](auto v) { return v == 1; }) &&
+                        miopen::any_of(GetConvPads(), [](auto v) { return v == 0; }) &&
+                        miopen::any_of(GetConvStrides(), [](auto v) { return v == 1; }))
                 {
-                    MIOPEN_LOG_FUNCTION("convolution, non 1x1");
+                    if(group_count > 1)
+                    {
+                        MIOPEN_LOG_FUNCTION("groupconv, 1x1");
+                    }
+                    else
+                    {
+                        MIOPEN_LOG_FUNCTION("convolution, 1x1");
+                    }
+
+                    // dw = sum_over_batch(dy[i] * transpose(x[i])), i is batch id
+                    GemmDescriptor gemm_desc =
+                        group_count > 1 ? CreateGemmDescriptorGroupConvBwdWeight(
+                                              dyDesc, xDesc, dwDesc, group_count)
+                                        : CreateGemmStridedBatchedDescriptorConv1x1BwdWeight(
+                                              dyDesc, xDesc, dwDesc);
+
+                    auto kcache_key = FindDbKCacheKey{};
+
+                    miopenStatus_t gemm_status = CallGemmTimeMeasure(
+                        handle,
+                        gemm_desc,
+                        dy,
+                        0,
+                        x,
+                        0,
+                        dw,
+                        0,
+                        &kcache_key,
+                        time_precision,
+                        group_count > 1 ? callGemmStridedBatched : callGemmStridedBatchedSequential,
+                        group_count > 1 ? GemmBackend_t::rocblas : GemmBackend_t::miopengemm);
+
+                    time_gemm = handle.GetKernelTime();
+                    if(group_count > 1)
+                        time_gemm *= in_n;
+
+                    if(gemm_status == miopenStatusSuccess)
+                        record.SetValues("miopenConvolutionBwdWeightsAlgoGEMM",
+                                         FindDbData{
+                                             "gemm", time_gemm, 0, kcache_key,
+                                         });
                 }
-                float time_im2col = 0;
-                int in_offset     = 0;
-                time_im2col       = Im2ColGPU(handle,
-                                        GetSpatialDimension(),
-                                        x,
-                                        in_offset,
-                                        in_c,
-                                        in_spatial,
-                                        wei_spatial,
-                                        out_spatial,
-                                        GetConvPads(),
-                                        GetConvStrides(),
-                                        GetConvDilations(),
-                                        workSpace,
-                                        dyDesc.GetType());
-
-                // dw = dy * transpose(Im2Col(x))
-                GemmDescriptor gemm_desc =
-                    group_count > 1
-                        ? CreateGemmDescriptorGroupConvBwdWeight(dyDesc, xDesc, dwDesc, group_count)
-                        : CreateGemmDescriptorConvBwdWeight(dyDesc, xDesc, dwDesc);
-
-                auto kcache_key = FindDbKCacheKey{};
-
-                miopenStatus_t gemm_status = CallGemmTimeMeasure(
-                    handle,
-                    gemm_desc,
-                    dy,
-                    0,
-                    workSpace,
-                    0,
-                    dw,
-                    0,
-                    &kcache_key,
-                    time_precision,
-                    group_count > 1 ? callGemmStridedBatched : callGemm,
-                    group_count > 1 ? GemmBackend_t::rocblas : GemmBackend_t::miopengemm);
-
-                time_gemm = in_n * (time_im2col + handle.GetKernelTime());
-
-                if(gemm_status == miopenStatusSuccess)
-                    record.SetValues("miopenConvolutionBwdWeightsAlgoGEMM",
-                                     FindDbData{
-                                         "gemm", time_gemm, workspace_req, kcache_key,
-                                     });
             }
-            // 1x1 does not require im2col or workspace
-            else if(miopen::any_of(wei_spatial, [](auto v) { return v == 1; }) &&
-                    miopen::any_of(GetConvPads(), [](auto v) { return v == 0; }) &&
-                    miopen::any_of(GetConvStrides(), [](auto v) { return v == 1; }))
-            {
-                if(group_count > 1)
-                {
-                    MIOPEN_LOG_FUNCTION("groupconv, 1x1");
-                }
-                else
-                {
-                    MIOPEN_LOG_FUNCTION("convolution, 1x1");
-                }
-
-                // dw = sum_over_batch(dy[i] * transpose(x[i])), i is batch id
-                GemmDescriptor gemm_desc =
-                    group_count > 1
-                        ? CreateGemmDescriptorGroupConvBwdWeight(dyDesc, xDesc, dwDesc, group_count)
-                        : CreateGemmStridedBatchedDescriptorConv1x1BwdWeight(dyDesc, xDesc, dwDesc);
-
-                auto kcache_key = FindDbKCacheKey{};
-
-                miopenStatus_t gemm_status = CallGemmTimeMeasure(
-                    handle,
-                    gemm_desc,
-                    dy,
-                    0,
-                    x,
-                    0,
-                    dw,
-                    0,
-                    &kcache_key,
-                    time_precision,
-                    group_count > 1 ? callGemmStridedBatched : callGemmStridedBatchedSequential,
-                    group_count > 1 ? GemmBackend_t::rocblas : GemmBackend_t::miopengemm);
-
-                time_gemm = handle.GetKernelTime();
-                if(group_count > 1)
-                    time_gemm *= in_n;
-
-                if(gemm_status == miopenStatusSuccess)
-                    record.SetValues("miopenConvolutionBwdWeightsAlgoGEMM",
-                                     FindDbData{
-                                         "gemm", time_gemm, 0, kcache_key,
-                                     });
-            }
-        }
 #endif
-        ConvolutionUserBuffers bufs(workSpace, workSpaceSize);
-        bufs.SetWrW(x, dw, dy);
-        auto ctx =
-            ConvolutionContext{xDesc, dwDesc, dyDesc, *this, conv::Direction::BackwardWeights};
-        ctx.do_search = exhaustiveSearch;
-        ctx.SetStream(&handle);
-        ctx.SetBufs(bufs);
-        ctx.SetupFloats();
-        ctx.DetectRocm();
-        const auto network_config = ctx.BuildConfKey();
-        const auto invoke_ctx =
-            conv::WrWInvokeParams{{dyDesc, dy, xDesc, x, dwDesc, dw}, workSpace, workSpaceSize};
-        // direct convolution
-        if(!miopen::IsDisabled(MIOPEN_DEBUG_CONV_DIRECT{}))
-        {
-            const auto all            = FindAllBwdWrW2DSolutions(ctx);
-            const auto algorithm_name = AlgorithmName{"miopenConvolutionBwdWeightsAlgoDirect"};
-            EvaluateInvokers(handle, all, algorithm_name, network_config, invoke_ctx, record);
-        }
-
-        try
-        {
-            const auto all = miopen::IsDisabled(MIOPEN_DEBUG_CONV_WINOGRAD{})
-                                 ? std::vector<miopen::solver::ConvSolution>()
-                                 : FindWinogradWrWAllSolutions(ctx);
-
-            float elapsed = 0.0f;
-            if(!all.empty())
+            ConvolutionUserBuffers bufs(workSpace, workSpaceSize);
+            bufs.SetWrW(x, dw, dy);
+            auto ctx =
+                ConvolutionContext{xDesc, dwDesc, dyDesc, *this, conv::Direction::BackwardWeights};
+            ctx.do_search = exhaustiveSearch;
+            ctx.SetStream(&handle);
+            ctx.SetBufs(bufs);
+            ctx.SetupFloats();
+            ctx.DetectRocm();
+            const auto network_config = ctx.BuildConfKey();
+            const auto invoke_ctx =
+                conv::WrWInvokeParams{{dyDesc, dy, xDesc, x, dwDesc, dw}, workSpace, workSpaceSize};
+            // direct convolution
+            if(!miopen::IsDisabled(MIOPEN_DEBUG_CONV_DIRECT{}))
             {
-                float best = std::numeric_limits<float>::max();
-                miopen::solver::ConvSolution selected{miopenStatusUnknownError};
-                for(const auto& sol : all)
-                {
-                    elapsed = 0.0f;
-                    std::vector<KernelInvoke> kernels;
+                const auto all            = FindAllBwdWrW2DSolutions(ctx);
+                const auto algorithm_name = AlgorithmName{"miopenConvolutionBwdWeightsAlgoDirect"};
+                EvaluateInvokers(handle, all, algorithm_name, network_config, invoke_ctx, record);
+            }
 
-                    AddKernels(handle,
-                               "miopenConvolutionBwdWeightsAlgoWinograd",
-                               network_config,
-                               sol,
-                               &kernels);
-                    auto tensors = ConvWrwTensors{dyDesc, dy, xDesc, x, dwDesc, dw};
-                    if(workSpaceSize < sol.workspce_sz)
-                        continue;
-                    // clang-format off
+            try
+            {
+                const auto all = miopen::IsDisabled(MIOPEN_DEBUG_CONV_WINOGRAD{})
+                                     ? std::vector<miopen::solver::ConvSolution>()
+                                     : FindWinogradWrWAllSolutions(ctx);
+
+                float elapsed = 0.0f;
+                if(!all.empty())
+                {
+                    float best = std::numeric_limits<float>::max();
+                    miopen::solver::ConvSolution selected{miopenStatusUnknownError};
+                    for(const auto& sol : all)
+                    {
+                        elapsed = 0.0f;
+                        std::vector<KernelInvoke> kernels;
+
+                        AddKernels(handle,
+                                   "miopenConvolutionBwdWeightsAlgoWinograd",
+                                   network_config,
+                                   sol,
+                                   &kernels);
+                        auto tensors = ConvWrwTensors{dyDesc, dy, xDesc, x, dwDesc, dw};
+                        if(workSpaceSize < sol.workspce_sz)
+                            continue;
+                        // clang-format off
                     if(sol.solver_id == SolverDbId(miopen::solver::ConvWinograd3x3MultipassWrW<3, 2>()))
                         EvaluateWinograd3x3MultipassWrW<3,2>(
                             handle, ctx, tensors, workSpace, kernels, GetConvPads()[0], GetConvPads()[1],&elapsed);
@@ -4110,84 +4197,84 @@ void ConvolutionDescriptor::FindConvBwdWeightsAlgorithm(Handle& handle,
                             handle, ctx, tensors, workSpace, kernels, GetConvPads()[0], GetConvPads()[1],&elapsed);
 
                     else // clang-format on
-                    {    // single pass
-                        int unused                       = 0;
-                        using dataType                   = float;
-                        static const int F_FLIP_K_C      = 1 << 2;
-                        static const int F_NKC_STRIDES   = 1 << 9;
-                        static const int F_GROUP_STRIDES = 1 << 10;
-                        int reserved                     = 0;
-                        int* reserved_ptr                = nullptr;
-                        int pad_H                        = GetConvPads()[0];
-                        int pad_W                        = GetConvPads()[1];
-                        // clang-format off
-                        int N, C, H, W, K, n_groups, out_H, out_W, R, S;
-                        // clang-format on
-                        if(kernels[0].GetName().rfind("miopenSp3AsmConv_group_20_5_23_M", 0) == 0)
-                        {
-                            GetCompiledInParameters(ctx,
-                                                    &C,
-                                                    &K,
-                                                    &R,
-                                                    &S,
-                                                    &N,
-                                                    &n_groups,
-                                                    &H,
-                                                    &W,
-                                                    &out_H,
-                                                    &out_W,
-                                                    &unused,
-                                                    &unused);
-                            // GetCompiledInParameters(
-                            // ctx, &N, &C, &H, &W, &K, &n_groups, &out_H, &out_W, &R, &S, &pad_H,
-                            // &pad_W);
-                            int flags      = F_NKC_STRIDES + F_GROUP_STRIDES;
-                            auto group_cnt = ctx.group_counts;
-                            N              = N / group_cnt;
-                            K              = K / group_cnt;
-
-                            BuffInfo d_buf(
-                                GetGroupConvLayout(
-                                    GetSwappedNCLayout(GetMemLayout_t(ctx.in_layout)), true),
-                                N,
-                                C,
-                                H,
-                                W,
-                                1,
-                                group_cnt,
-                                GetTypeSize(ctx.in_data_type)),
-                                o_buf(
-                                    GetGroupConvLayout(
-                                        GetSwappedNCLayout(GetMemLayout_t(ctx.out_layout)), false),
-                                    N,
-                                    K,
-                                    out_H,
-                                    out_W,
-                                    1,
-                                    group_cnt,
-                                    GetTypeSize(ctx.out_data_type)),
-                                f_buf(
-                                    GetGroupConvLayout(GetSwappedNCLayout(MemLayout_t::NCHW), true),
-                                    K,
-                                    C,
-                                    R,
-                                    S,
-                                    1,
-                                    group_cnt,
-                                    GetTypeSize(ctx.weights_data_type));
-
-                            if(GetKernelLocalWorkDim(kernels[0], 0) != 0)
-                                n_groups = solver::ConvBinWinogradRxSf2x3::GetNGroups(
-                                    ctx.group_counts,
-                                    GetKernelGlobalWorkDim(kernels[0], 0) /
-                                        GetKernelLocalWorkDim(kernels[0], 0));
-                            else
-                                n_groups = solver::ConvBinWinogradRxSf2x3::GetNGroups(
-                                    ctx.group_counts,
-                                    GetKernelGlobalWorkDim(kernels[0], 0) /
-                                        512); // For OCL runtime. Issue #1724
-
+                        {    // single pass
+                            int unused                       = 0;
+                            using dataType                   = float;
+                            static const int F_FLIP_K_C      = 1 << 2;
+                            static const int F_NKC_STRIDES   = 1 << 9;
+                            static const int F_GROUP_STRIDES = 1 << 10;
+                            int reserved                     = 0;
+                            int* reserved_ptr                = nullptr;
+                            int pad_H                        = GetConvPads()[0];
+                            int pad_W                        = GetConvPads()[1];
                             // clang-format off
+                        int N, C, H, W, K, n_groups, out_H, out_W, R, S;
+                            // clang-format on
+                            if(kernels[0].GetName().rfind("miopenSp3AsmConv_group_20_5_23_M", 0) ==
+                               0)
+                            {
+                                GetCompiledInParameters(ctx,
+                                                        &C,
+                                                        &K,
+                                                        &R,
+                                                        &S,
+                                                        &N,
+                                                        &n_groups,
+                                                        &H,
+                                                        &W,
+                                                        &out_H,
+                                                        &out_W,
+                                                        &unused,
+                                                        &unused);
+                                // GetCompiledInParameters(ctx, &N, &C, &H, &W, &K, &n_groups,
+                                // &out_H, &out_W, &R, &S, &pad_H, &pad_W);
+                                int flags      = F_NKC_STRIDES + F_GROUP_STRIDES;
+                                auto group_cnt = ctx.group_counts;
+                                N              = N / group_cnt;
+                                K              = K / group_cnt;
+
+                                BuffInfo d_buf(
+                                    GetGroupConvLayout(
+                                        GetSwappedNCLayout(GetMemLayout_t(ctx.in_layout)), true),
+                                    N,
+                                    C,
+                                    H,
+                                    W,
+                                    1,
+                                    group_cnt,
+                                    GetTypeSize(ctx.in_data_type)),
+                                    o_buf(GetGroupConvLayout(
+                                              GetSwappedNCLayout(GetMemLayout_t(ctx.out_layout)),
+                                              false),
+                                          N,
+                                          K,
+                                          out_H,
+                                          out_W,
+                                          1,
+                                          group_cnt,
+                                          GetTypeSize(ctx.out_data_type)),
+                                    f_buf(GetGroupConvLayout(GetSwappedNCLayout(MemLayout_t::NCHW),
+                                                             true),
+                                          K,
+                                          C,
+                                          R,
+                                          S,
+                                          1,
+                                          group_cnt,
+                                          GetTypeSize(ctx.weights_data_type));
+
+                                if(GetKernelLocalWorkDim(kernels[0], 0) != 0)
+                                    n_groups = solver::ConvBinWinogradRxSf2x3::GetNGroups(
+                                        ctx.group_counts,
+                                        GetKernelGlobalWorkDim(kernels[0], 0) /
+                                            GetKernelLocalWorkDim(kernels[0], 0));
+                                else
+                                    n_groups = solver::ConvBinWinogradRxSf2x3::GetNGroups(
+                                        ctx.group_counts,
+                                        GetKernelGlobalWorkDim(kernels[0], 0) /
+                                            512); // For OCL runtime. Issue #1724
+
+                                // clang-format off
                             MIOPEN_LOG_I2(" N=" << N << " G=" << group_cnt << " C=" << C << " H=" << H << " W=" << W << " K=" << K
                                 << " n_groups=" << n_groups << " flags=" << flags << " R=" << R << " S=" << S
                                 << " pad_H=" << pad_H << " pad_W=" << pad_W << " out_H=" << out_H << " out_W=" << out_W
@@ -4199,102 +4286,180 @@ void ConvolutionDescriptor::FindConvBwdWeightsAlgorithm(Handle& handle,
                                 << " o_buf.byte_stride.h="  << o_buf.byte_stride.h <<  " o_buf.byte_stride.w=" << o_buf.byte_stride.w
                                 << " d_buf.byte_stride.g=" << d_buf.byte_stride.g  << " o_buf.byte_stride.g="  << o_buf.byte_stride.g
                                 << " f_buf.byte_stride.g=" << f_buf.byte_stride.g); // clang-format on
-                            MIOPEN_LOG_I2(" ctx.batch_sz=" << ctx.batch_sz << "ctx.n_inputs="
-                                                           << ctx.n_inputs);
-                            elapsed = 0;
-
-                            kernels[0](N,
-                                       C,
-                                       H,
-                                       W,
-                                       K,
-                                       n_groups,
-                                       flags,
-                                       reserved,
-                                       x,
-                                       dy,
-                                       dw,
-                                       reserved_ptr, // Unused return_addr.
-                                       R,
-                                       S,
-                                       pad_H, // Like Fwd wino.
-                                       pad_W,
-                                       out_H,
-                                       out_W,
-                                       reserved_ptr, // Unused bias_addr.
-                                       reserved,     // Unused relu_alpha.
-                                       d_buf.byte_stride.nk,
-                                       d_buf.byte_stride.c,
-                                       d_buf.byte_stride.h,
-                                       d_buf.byte_stride.w,
-                                       f_buf.byte_stride.nk,
-                                       f_buf.byte_stride.c,
-                                       f_buf.byte_stride.h,
-                                       f_buf.byte_stride.w,
-                                       o_buf.byte_stride.nk,
-                                       o_buf.byte_stride.c,
-                                       o_buf.byte_stride.h,
-                                       o_buf.byte_stride.w,
-                                       group_cnt,
-                                       d_buf.byte_stride.g,
-                                       f_buf.byte_stride.g,
-                                       o_buf.byte_stride.g);
-                            elapsed = handle.GetKernelTime();
-                        }
-                        else // miopenSp3AsmConvRxSf3x2 and other
-                        {
-                            // clang-format off
+                                MIOPEN_LOG_I2(" ctx.batch_sz=" << ctx.batch_sz << "ctx.n_inputs="
+                                                               << ctx.n_inputs);
+                                kernels[0](N,
+                                           C,
+                                           H,
+                                           W,
+                                           K,
+                                           n_groups,
+                                           flags,
+                                           reserved,
+                                           x,
+                                           dy,
+                                           dw,
+                                           reserved_ptr, // Unused return_addr.
+                                           R,
+                                           S,
+                                           pad_H, // Like Fwd wino.
+                                           pad_W,
+                                           out_H,
+                                           out_W,
+                                           reserved_ptr, // Unused bias_addr.
+                                           reserved,     // Unused relu_alpha.
+                                           d_buf.byte_stride.nk,
+                                           d_buf.byte_stride.c,
+                                           d_buf.byte_stride.h,
+                                           d_buf.byte_stride.w,
+                                           f_buf.byte_stride.nk,
+                                           f_buf.byte_stride.c,
+                                           f_buf.byte_stride.h,
+                                           f_buf.byte_stride.w,
+                                           o_buf.byte_stride.nk,
+                                           o_buf.byte_stride.c,
+                                           o_buf.byte_stride.h,
+                                           o_buf.byte_stride.w,
+                                           group_cnt,
+                                           d_buf.byte_stride.g,
+                                           f_buf.byte_stride.g,
+                                           o_buf.byte_stride.g);
+                                elapsed = handle.GetKernelTime();
+                            }
+                            else // miopenSp3AsmConvRxSf3x2 and other
+                            {
+                                // clang-format off
                             GetCompiledInParameters(ctx, &N,&K,&out_H,&out_W,
                                 &C,&n_groups,&H,&W,&R,&S,&unused,&unused);
-                            // clang-format on
-                            int flags      = F_FLIP_K_C + F_NKC_STRIDES;
-                            int d_N_stride = H * W * static_cast<int>(sizeof(dataType));
-                            int d_C_stride = C * d_N_stride;
-                            int f_K_stride = out_H * out_W * static_cast<int>(sizeof(dataType));
-                            int f_C_stride = K * f_K_stride;
-                            int o_N_stride = R * S * static_cast<int>(sizeof(dataType));
-                            int o_K_stride = C * o_N_stride;
+                                // clang-format on
+                                int flags      = F_FLIP_K_C + F_NKC_STRIDES;
+                                int d_N_stride = H * W * static_cast<int>(sizeof(dataType));
+                                int d_C_stride = C * d_N_stride;
+                                int f_K_stride = out_H * out_W * static_cast<int>(sizeof(dataType));
+                                int f_C_stride = K * f_K_stride;
+                                int o_N_stride = R * S * static_cast<int>(sizeof(dataType));
+                                int o_K_stride = C * o_N_stride;
 
-                            // clang-format off
+                                // clang-format off
                             MIOPEN_LOG_I2(" N=" << N << " C=" << C << " H=" << H << " W=" << W << " K=" << K
                                 << " n_groups=" << n_groups << " flags=" << flags << " R=" << R << " S=" << S
                                 << " pad_H=" << pad_H << " pad_W=" << pad_W << " out_H=" << out_H << " out_W=" << out_W
                                 << " d_N_stride=" << d_N_stride << " d_C_stride=" << d_C_stride
                                 << " f_K_stride=" << f_K_stride << " f_C_stride=" << f_C_stride
                                 << " o_N_stride=" << o_N_stride << " o_K_stride=" << o_K_stride); // clang-format on
-                            elapsed = 0;
 
-                            kernels[0](C,
-                                       N,
-                                       H,
-                                       W,
-                                       K,
-                                       n_groups,
-                                       flags,
-                                       reserved,
-                                       x,
-                                       dy,
-                                       dw,
-                                       reserved_ptr, // Unused return_addr.
-                                       out_H,
-                                       out_W,
-                                       pad_H, // Like Fwd wino.
-                                       pad_W,
-                                       R,
-                                       S,
-                                       reserved_ptr, // Unused bias_addr.
-                                       reserved,     // Unused relu_alpha.
-                                       d_N_stride,
-                                       d_C_stride,
-                                       f_K_stride,
-                                       f_C_stride,
-                                       o_N_stride,
-                                       o_K_stride);
-                            elapsed = handle.GetKernelTime();
+                                kernels[0](C,
+                                           N,
+                                           H,
+                                           W,
+                                           K,
+                                           n_groups,
+                                           flags,
+                                           reserved,
+                                           x,
+                                           dy,
+                                           dw,
+                                           reserved_ptr, // Unused return_addr.
+                                           out_H,
+                                           out_W,
+                                           pad_H, // Like Fwd wino.
+                                           pad_W,
+                                           R,
+                                           S,
+                                           reserved_ptr, // Unused bias_addr.
+                                           reserved,     // Unused relu_alpha.
+                                           d_N_stride,
+                                           d_C_stride,
+                                           f_K_stride,
+                                           f_C_stride,
+                                           o_N_stride,
+                                           o_K_stride);
+                                elapsed = handle.GetKernelTime();
+                            }
+                        } ////single pass end
+                        MIOPEN_LOG_I(sol << ": " << elapsed << (elapsed < best ? " < " : " >= ")
+                                         << best);
+                        if(elapsed < best)
+                        {
+                            best     = elapsed;
+                            selected = sol;
                         }
-                    } ////single pass end
+                    }
+                    if(selected.Succeeded())
+                    {
+                        const std::string algorithm_name =
+                            "miopenConvolutionBwdWeightsAlgoWinograd";
+                        AddKernels(handle, algorithm_name, network_config, selected, nullptr);
+                        MIOPEN_LOG_I("Selected: " << selected << ": " << best << ", workspce_sz = "
+                                                  << selected.workspce_sz);
+                        record.SetValues(algorithm_name,
+                                         FindDbData{
+                                             selected.solver_id,
+                                             best,
+                                             selected.workspce_sz,
+                                             {algorithm_name, network_config},
+                                         });
+                    }
+                }
+            }
+            catch(const miopen::Exception& ex)
+            {
+                MIOPEN_LOG_WE("Find Winograd WrW failed:" << ex.what());
+            }
+
+            // Implicit GEMM
+            if(!miopen::IsDisabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM{}))
+            {
+                const auto all = FindImplicitGemmWrWAllSolutions(ctx);
+                float best     = std::numeric_limits<float>::max();
+                miopen::solver::ConvSolution selected{miopenStatusUnknownError};
+                const auto algo_name = "miopenConvolutionBwdWeightsAlgoImplicitGEMM";
+                float elapsed        = 0.0f;
+                for(const auto& sol : all)
+                {
+                    std::vector<KernelInvoke> kernels;
+                    AddKernels(handle, algo_name, network_config, sol, &kernels);
+                    if(!kernels.empty())
+                    {
+                        auto kernel = kernels[0];
+
+                        // For fp16/bfp16 backward data case, do zero init, bwd data with fp32
+                        // output and cast (convert) from fp32 to fp16/bfp16.
+                        // clang-format off
+                        if((dwDesc.GetType() == miopenHalf || dwDesc.GetType() == miopenBFloat16) &&
+                           (kernel.GetName() == "gridwise_convolution_implicit_gemm_v4r4_gen_xdlops_nchw_kcyx_nkhw_lds_double_buffer" ||
+                            kernel.GetName() == "gridwise_convolution_implicit_gemm_v4r4_gen_xdlops_gnchw_gkcyx_gnkhw_lds_double_buffer"))
+                        // clang-format on
+                        {
+                            float zero = 0.f;
+                            TensorDescriptor workSpaceDesc(
+                                miopenFloat, dwDesc.GetLengths(), dwDesc.GetStrides());
+                            SetTensor(handle, workSpaceDesc, workSpace, &zero);
+                            elapsed = handle.GetKernelTime();
+
+                            kernel(x, dy, workSpace);
+                            elapsed += handle.GetKernelTime();
+
+                            CastTensor(
+                                handle, &lowp_quant, workSpaceDesc, workSpace, dwDesc, dw, 0, 0);
+                            elapsed += handle.GetKernelTime();
+                        }
+                        else
+                        {
+                            // This kernel may accumulate results into input tensor, therefore need
+                            // to set zero.
+                            float zero = 0.f;
+                            SetTensor(handle, dwDesc, dw, &zero);
+                            elapsed = handle.GetKernelTime();
+
+                            kernel(x, dy, dw);
+                            elapsed += handle.GetKernelTime();
+                        }
+                    }
+
                     MIOPEN_LOG_I(sol << ": " << elapsed << (elapsed < best ? " < " : " >= ")
                                      << best);
+
                     if(elapsed < best)
                     {
                         best     = elapsed;
@@ -4303,95 +4468,18 @@ void ConvolutionDescriptor::FindConvBwdWeightsAlgorithm(Handle& handle,
                 }
                 if(selected.Succeeded())
                 {
-                    const std::string algorithm_name = "miopenConvolutionBwdWeightsAlgoWinograd";
-                    AddKernels(handle, algorithm_name, network_config, selected, nullptr);
+                    AddKernels(handle, algo_name, network_config, selected, nullptr);
                     MIOPEN_LOG_I("Selected: " << selected << ": " << best << ", workspce_sz = "
                                               << selected.workspce_sz);
-                    record.SetValues(algorithm_name,
-                                     FindDbData{
-                                         selected.solver_id,
-                                         best,
-                                         selected.workspce_sz,
-                                         {algorithm_name, network_config},
-                                     });
+                    record.SetValues(algo_name,
+                                     FindDbData{selected.solver_id,
+                                                best,
+                                                selected.workspce_sz,
+                                                {algo_name, network_config}});
                 }
             }
-        }
-        catch(const miopen::Exception& ex)
-        {
-            MIOPEN_LOG_WE("Find Winograd WrW failed:" << ex.what());
-        }
-
-        // Implicit GEMM
-        if(!miopen::IsDisabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM{}))
-        {
-            const auto all = FindImplicitGemmWrWAllSolutions(ctx);
-            float best     = std::numeric_limits<float>::max();
-            miopen::solver::ConvSolution selected{miopenStatusUnknownError};
-            const auto algo_name = "miopenConvolutionBwdWeightsAlgoImplicitGEMM";
-            float elapsed        = 0.0f;
-            for(const auto& sol : all)
-            {
-                std::vector<KernelInvoke> kernels;
-                AddKernels(handle, algo_name, network_config, sol, &kernels);
-                if(!kernels.empty())
-                {
-                    auto kernel = kernels[0];
-
-                    // For fp16/bfp16 backward data case, do zero init, bwd data with fp32 output
-                    // and cast from fp32 to fp16/bfp16
-                    // clang-format off
-                    if((dwDesc.GetType() == miopenHalf || dwDesc.GetType() == miopenBFloat16) &&
-                       (kernel.GetName() == "gridwise_convolution_implicit_gemm_v4r4_gen_xdlops_nchw_kcyx_nkhw_lds_double_buffer" ||
-                        kernel.GetName() == "gridwise_convolution_implicit_gemm_v4r4_gen_xdlops_gnchw_gkcyx_gnkhw_lds_double_buffer"))
-                    // clang-format on
-                    {
-                        float zero = 0.f;
-                        TensorDescriptor workSpaceDesc(
-                            miopenFloat, dwDesc.GetLengths(), dwDesc.GetStrides());
-                        SetTensor(handle, workSpaceDesc, workSpace, &zero);
-                        elapsed = handle.GetKernelTime();
-
-                        kernel(x, dy, workSpace);
-                        elapsed += handle.GetKernelTime();
-
-                        CastTensor(handle, &lowp_quant, workSpaceDesc, workSpace, dwDesc, dw, 0, 0);
-                        elapsed += handle.GetKernelTime();
-                    }
-                    else
-                    {
-                        // this kernel may accumulate results into input tensor, therefore need to
-                        // set zero
-                        float zero = 0.f;
-                        SetTensor(handle, dwDesc, dw, &zero);
-                        elapsed = handle.GetKernelTime();
-
-                        kernel(x, dy, dw);
-                        elapsed += handle.GetKernelTime();
-                    }
-                }
-
-                MIOPEN_LOG_I(sol << ": " << elapsed << (elapsed < best ? " < " : " >= ") << best);
-
-                if(elapsed < best)
-                {
-                    best     = elapsed;
-                    selected = sol;
-                }
-            }
-            if(selected.Succeeded())
-            {
-                AddKernels(handle, algo_name, network_config, selected, nullptr);
-                MIOPEN_LOG_I("Selected: " << selected << ": " << best << ", workspce_sz = "
-                                          << selected.workspce_sz);
-                record.SetValues(algo_name,
-                                 FindDbData{selected.solver_id,
-                                            best,
-                                            selected.workspce_sz,
-                                            {algo_name, network_config}});
-            }
-        }
-    });
+        });
+    }
 
     if(perf_db.empty())
         MIOPEN_THROW("Bwd Weights Convolution cannot be executed due to incorrect params");
@@ -5093,7 +5181,8 @@ void ConvolutionDescriptor::ConvolutionWrwImmediate(Handle& handle,
 
         if(CheckInvokerSupport(solver_id, conv::Direction::BackwardWeights))
         {
-            const auto invoker    = LoadOrPrepareInvoker(handle, ctx, solver_id);
+            const auto invoker =
+                LoadOrPrepareInvoker(handle, ctx, solver_id, conv::Direction::BackwardWeights);
             const auto invoke_ctx = conv::WrWInvokeParams{tensors, workSpace, workSpaceSize};
             invoker(handle, invoke_ctx);
             return;


### PR DESCRIPTION
Moved from https://github.com/AMDComputeLibraries/MLOpen/pull/2200

- Added Fast Find mode (A.1 in https://github.com/AMDComputeLibraries/MLOpen/issue/2208)
- Added Hybrid Find mode (A.2 in https://github.com/AMDComputeLibraries/MLOpen/issue/2208)
- Controlled by the `MIOPEN_FIND_MODE` with syntax checks, numeric and symbolic values (case-insensitive) etc. Valid values:
  - `NORMAL` or `1` or empty (undefined variable)
  - `FAST` or `2`
  - `HYBRID` or `3`
- ___TODO___ User documentation.
- ___TODO___ Make Hybrid mode the default (for Release non-DEV builds).
- ___TODO___ Merge user-find-db caching feature. Otherwise the wall time may suffer when the user-find-db becomes really big (usually it grows as the time passes).
- [Side product] Improved logging in Fwd/Bwd GWSS.

:bulb: The change is small, like `+298 -58`. Hide whitespace changes when reviewing. 

## Correctness & performance testing vs baseline

- 93 popular FP32, FP16, BF16 configs
- OpenCL and HIP backends
- Find and Immediate modes

:green_apple: No regressions.

## Performance testing of new modes vs normal Find

The tables below represent average results across some set of popular configs, all directions. Raw data is available upon request. 

I recommend first looking at https://github.com/AMDComputeLibraries/MLOpen/issues/2208#issuecomment-551854075 for detailed interpretation.

### 93 popular FP32 configs

No. | Mode | Binary cache | Hit find-db | Aux Wall Time | Conv Wall Time | Total Wall Time | Acceleration | GPU perf drop
-- | -- | -- | -- | -- | -- | -- | -- | --
1 | Find | Empty | n/a | 2139254 | 184 | 2139438 | 1.00 | 0%
2 | Find | Full | n/a | 95638 | 175 | 95813 | 22.33 | 0%
3 | Fast Find | Empty | No (Fallback) | 1983 | 6527 | 8510 | 251.40 | 55%
4 | Fast Find | Empty | Yes | 167584 | 1349 | 168933 | 12.66 | 1%
5 | Fast Find | Full | Yes | 20807 | 187 | 20994 | 101.91 | 1%
6 | Hybrid Find | Empty | No (find-db regen) | 2131788 | 181 | 2131969 | 1.00 | 0%
7 | Hybrid Find | Empty | Yes | 167992 | 1349 | 169341 | 12.63 | 1%
8 | Hybrid Find | Full | Yes | 18925 | 187 | 19112 | 111.94 | 1%
9 | Hybrid Find | Full | Yes (regenerated) | 18229 | 187 | 18416 | 116.18 | 1%

### 93 popular FP16 configs

No. | Mode | Binary cache | Hit find-db | Aux Wall Time | Conv Wall Time | Total Wall Time | Acceleration | GPU perf drop
-- | -- | -- | -- | -- | -- | -- | -- | --
1 | Find | Empty | n/a | 2533388 | 197 | 2533585 | 1.00 | 0%
2 | Find | Full | n/a | 59687 | 190 | 59877 | 42.31 | 0%
3 | Fast Find | Empty | No (Fallback) | 89 | 7921 | 8010 | 316.30 | 72%
4 | Fast Find | Empty | Yes | 120664 | 1137 | 121801 | 20.80 | 2%
5 | Fast Find | Full | Yes | 25750 | 202 | 25952 | 97.63 | 2%
6 | Hybrid Find | Empty | No (find-db regen) | 2524226 | 201 | 2524427 | 1.00 | 0%
7 | Hybrid Find | Empty | Yes | 120069 | 1135 | 121204 | 20.90 | 2%
8 | Hybrid Find | Full | Yes | 16302 | 203 | 16505 | 153.50 | 3%
9 | Hybrid Find | Full | Yes (regenerated) | 22567 | 201 | 22768 | 111.28 | 2%

### Notes (apply to both tables)
- No.1 is what we have _right now_ after installation.
- No.2 is like what we can have if all kernels reside in the persistent kernel (binary) cache.
  - Note that this mode requires ___all kernels___ _needed for Find_ to reside in the binary cache.
- No.3 is Fast Find (on Immediate mode) when we miss find-db so Immediate mode Fallback is used.
  - FP32 only: GPU performance is better than "pure" Immediate mode Fallback, because Fast/Hybrid Find leverages Winograd3x3 when it is known to be the fastest.
- No.4 is Fast Find (on Immediate mode) where all configs hit find-db, but binary cache is empty.
- No.5 is Fast Find (on Immediate mode) where all configs hit find-db, and all the needed kernels reside in the binary cache (e.g. pre-compiled or pre-installed).
- No.6 is Hybrid Find when we miss find-db so Find mode is run.
- No.7 is Hybrid Find when we hit find-db, binary cache is empty. Results match No.4.
- No.8 is Hybrid Find when we hit find-db, binary cache is full. Results match No.5.
- No.9 is Hybrid Find is like we re-run the same configs after No.6, so find-db and binary cache are updated and we hit both. The results are similar to No.8.

### Preconditions
- Installable HIP build have been tested (`BUILD_DEV=Off`, Release).
- Persistent Kernel Cache (a.k.a. Binary Cache): `Empty` is state just after normal installation. `Full` means that all required kernels reside in the cache.
- `Aux Wall Time`, `Conv Wall Time` - as reported by the MIOpenDriver (with `-w 2`). `Total Wall` is a sum of these; its value is can be considered as a measure of the ___startup latency___.
## List of development commits

* fast-find-on-immediate(01) Fwd GWSS
* fast-find-on-immediate(03) Fwd Find: partially implemented (TODO building kernels)
* fast-find-on-immediate(04) Fwd Find: all implemented (building kernels done).
* fast-find-on-immediate(11) Bwd Find: all implemented. Refactor comments.
* fast-find-on-immediate(13) WrW Find: implemented. Logging in GWSS. Style & comments. Format.
* fast-find-on-immediate(14) Fix ConvolutionAlgoToDirectionalString()
* fast-find-on-immediate(18) Immediate mode: Add algorithm to InvokerCache to ensure interop with Find 1.0.
* fast-find-on-immediate(19) [driver] include path fix in dropout
* fast-find-on-immediate(21) Fix merge errors. Make algo mandatory in RegisterInvoker().
* hybrid-find(01) MIOPEN_FAST_FIND -> MIOPEN_FIND_MODE with syntax checks, symbolic values etc.
* hybrid-find(02) Improve logging in Fwd and Bwd GWSS.
* hybrid-find(03) Hybrid Find dummy.
* hybrid-find(04) Implemented for Forward
* hybrid-find(05) Implemented for Backward
* hybrid-find(06) Implemented for WrW
* hybrid-find(10) driver: disable Fast/Hybrid Find during warmup.