### PR TITLE
Change kpack extraction for fp16 bfp16 group conv fwd

### DIFF
--- a/src/kernels/composable_kernel/include/kernel_algorithm/gridwise_convolution_implicit_gemm_v4r4_gen_xdlops_fp16_bfp16_fwd_gnchw_gkcyx_gnkhw_lds_double_buffer.hpp
+++ b/src/kernels/composable_kernel/include/kernel_algorithm/gridwise_convolution_implicit_gemm_v4r4_gen_xdlops_fp16_bfp16_fwd_gnchw_gkcyx_gnkhw_lds_double_buffer.hpp
@@ -160,7 +160,7 @@ struct
 
         // weight tensor
         //   global mem
-	//
+        //
         constexpr auto wei_g_k_epack_c_y_x_global_desc = transform_tensor_descriptor(
             unfold_tensor_descriptor(wei_g_k_c_y_x_global_desc, I3, I4),
             make_tuple(PassThrough<G>{},
@@ -170,14 +170,15 @@ struct
             make_tuple(Sequence<0>{}, Sequence<1>{}, Sequence<2>{}, Sequence<3>{}),
             make_tuple(Sequence<0>{}, Sequence<1>{}, Sequence<2, 3>{}, Sequence<4>{}));
 
-        constexpr auto wei_gemmg_gemmk_gemmm_gemmkpack_global_desc_tmp = transform_tensor_descriptor(
-            wei_g_k_epack_c_y_x_global_desc,
-            make_tuple(PassThrough<G>{},
-                       Merge<Sequence<nonVectorizedC, Y * X>>{},
-                       PassThrough<K>{},
-                       PassThrough<GemmKPACK>{}),
-            make_tuple(Sequence<0>{}, Sequence<3, 4>{}, Sequence<1>{}, Sequence<2>{}),
-            make_tuple(Sequence<0>{}, Sequence<1>{}, Sequence<2>{}, Sequence<3>{}));
+        constexpr auto wei_gemmg_gemmk_gemmm_gemmkpack_global_desc_tmp =
+            transform_tensor_descriptor(
+                wei_g_k_epack_c_y_x_global_desc,
+                make_tuple(PassThrough<G>{},
+                           Merge<Sequence<nonVectorizedC, Y * X>>{},
+                           PassThrough<K>{},
+                           PassThrough<GemmKPACK>{}),
+                make_tuple(Sequence<0>{}, Sequence<3, 4>{}, Sequence<1>{}, Sequence<2>{}),
+                make_tuple(Sequence<0>{}, Sequence<1>{}, Sequence<2>{}, Sequence<3>{}));
 
         constexpr auto wei_gemmg_gemmk0_gemmk1_gemmm_gemmkpack_global_desc =
             transform_tensor_descriptor(

--- a/src/kernels/composable_kernel/include/kernel_algorithm/gridwise_convolution_implicit_gemm_v4r4_gen_xdlops_fp16_bfp16_fwd_gnchw_gkcyx_gnkhw_lds_double_buffer.hpp
+++ b/src/kernels/composable_kernel/include/kernel_algorithm/gridwise_convolution_implicit_gemm_v4r4_gen_xdlops_fp16_bfp16_fwd_gnchw_gkcyx_gnkhw_lds_double_buffer.hpp
@@ -1,0 +1,266 @@
+#ifndef CK_GRIDWISE_CONVOLUTION_IMPLICIT_GEMM_V4R4_FP16_BFP16_FWD_GNCHW_GKCYX_GNKHW_LDS_DOUBLE_BUFFER_HPP
+#define CK_GRIDWISE_CONVOLUTION_IMPLICIT_GEMM_V4R4_FP16_BFP16_FWD_GNCHW_GKCYX_GNKHW_LDS_DOUBLE_BUFFER_HPP
+
+#include "common_header.hpp"
+#include "tensor_descriptor.hpp"
+#include "tensor_descriptor_helper.hpp"
+#include "ConstantMatrixDescriptor.hpp"
+#include "gridwise_gemm_xdlops_fp16_bfp16.hpp"
+#include "convolution_common.hpp"
+#include "implicitgemm_params.hpp"
+
+namespace ck {
+
+// B = merge(N, Ho, Wo)
+template <index_t GridSize,
+          index_t BlockSize,
+          class ABFloat,
+          class AccFloat,
+          class CFloat,
+          class InGlobalDesc,
+          class WeiGlobalDesc,
+          class OutGlobalDesc,
+          class ConvStrides,
+          class ConvDilations,
+          class LeftPads,
+          class RightPads,
+          index_t GemmMPerBlock,
+          index_t GemmNPerBlock,
+          index_t GemmKPerBlock,
+          index_t GemmKBlocks,
+          index_t GemmKPACK,
+          index_t GemmMPerWave,
+          index_t GemmNPerWave,
+          index_t GemmDataPerReadM,
+          index_t GemmDataPerReadN,
+          class GemmABlockCopyThreadSliceLengths_GemmG_GemmK_GemmM_GemmKPACK,
+          class GemmABlockCopyThreadClusterLengths_GemmG_GemmK_GemmM_GemmKPACK,
+          class GemmABlockCopyThreadClusterArrangeOrder,
+          class GemmABlockCopySrcAccessOrder,
+          class GemmABlockCopyDstAccessOrder,
+          index_t GemmABlockCopySrcDataPerRead_GemmK,
+          index_t GemmABlockCopyDstDataPerWrite_GemmKPACK,
+          class GemmBBlockCopyThreadSliceLengths_GemmG_GemmK_GemmN_GemmKPACK,
+          class GemmBBlockCopyThreadClusterLengths_GemmG_GemmK_GemmN_GemmKPACK,
+          class GemmBBlockCopyThreadClusterArrangeOrder,
+          class GemmBBlockCopySrcAccessOrder,
+          class GemmBBlockCopyDstAccessOrder,
+          index_t GemmBBlockCopySrcDataPerRead_GemmN,
+          index_t GemmBBlockCopyDstDataPerWrite_GemmKPACK,
+          ImplicitGemmDirection conv_dir>
+struct
+    GridwiseConvolutionImplicitGemm_v4r4_gen_xdlops_fp16_bfp16_fwd_gnchw_gkcyx_gnkhw_lds_double_buffer
+{
+    __device__ void Run(const ABFloat* const __restrict__ p_in_global,
+                        const ABFloat* const __restrict__ p_wei_global,
+                        CFloat* const __restrict__ p_out_global) const
+    {
+        constexpr auto I0 = Number<0>{};
+        constexpr auto I1 = Number<1>{};
+        constexpr auto I2 = Number<2>{};
+        constexpr auto I3 = Number<3>{};
+        constexpr auto I4 = Number<4>{};
+
+        constexpr auto in_g_n_c_hi_wi_global_desc  = InGlobalDesc{};
+        constexpr auto wei_g_k_c_y_x_global_desc   = WeiGlobalDesc{};
+        constexpr auto out_g_n_k_ho_wo_global_desc = OutGlobalDesc{};
+
+        constexpr index_t G  = in_g_n_c_hi_wi_global_desc.GetLength(I0);
+        constexpr index_t N  = in_g_n_c_hi_wi_global_desc.GetLength(I1);
+        constexpr index_t C  = in_g_n_c_hi_wi_global_desc.GetLength(I2);
+        constexpr index_t Hi = in_g_n_c_hi_wi_global_desc.GetLength(I3);
+        constexpr index_t Wi = in_g_n_c_hi_wi_global_desc.GetLength(I4);
+
+        constexpr index_t K  = out_g_n_k_ho_wo_global_desc.GetLength(I2);
+        constexpr index_t Ho = out_g_n_k_ho_wo_global_desc.GetLength(I3);
+        constexpr index_t Wo = out_g_n_k_ho_wo_global_desc.GetLength(I4);
+
+        constexpr index_t Y = wei_g_k_c_y_x_global_desc.GetLength(I3);
+        constexpr index_t X = wei_g_k_c_y_x_global_desc.GetLength(I4);
+
+        constexpr index_t ConvStrideH = ConvStrides{}[0];
+        constexpr index_t ConvStrideW = ConvStrides{}[1];
+
+        constexpr index_t ConvDilationH = ConvDilations{}[0];
+        constexpr index_t ConvDilationW = ConvDilations{}[1];
+
+        // GemmKPACK=1 for float32, =2 for bfloat16, =4 for float16
+        constexpr index_t GemmM = K;
+        constexpr index_t GemmN = N * Ho * Wo;
+
+        static_assert(C % GemmKPACK == 0, "C needs to be multiple of GemmKPACK");
+        constexpr index_t nonVectorizedC = C / GemmKPACK;
+        constexpr index_t GemmK          = nonVectorizedC * Y * X;
+
+        static_assert(GemmM % GemmMPerBlock == 0 && GemmN % GemmNPerBlock == 0 &&
+                          GemmK % (GemmKBlocks * GemmKPerBlock) == 0,
+                      "wrong! cannot divide work evenly among block");
+
+        constexpr index_t GemmKSub = GemmK / GemmKBlocks;
+
+        // sanity-check for vectorized memory load
+        static_assert((Wo == 1 || (ConvStrideW == 1 || GemmBBlockCopySrcDataPerRead_GemmN == 1)) &&
+                          (X == 1 || ConvDilationW % GemmBBlockCopySrcDataPerRead_GemmN == 0),
+                      "wrong! aligment requirement for vectorized global load of input tensor will "
+                      "be violated");
+
+        constexpr auto in_g_n_c_hip_wip_global_desc = transform_tensor_descriptor(
+            in_g_n_c_hi_wi_global_desc,
+            make_tuple(PassThrough<G>{},
+                       PassThrough<N>{},
+                       PassThrough<C>{},
+                       Pad<Sequence<Hi, Wi>, LeftPads, RightPads>{}),
+            make_tuple(Sequence<0>{}, Sequence<1>{}, Sequence<2>{}, Sequence<3, 4>{}),
+            make_tuple(Sequence<0>{}, Sequence<1>{}, Sequence<2>{}, Sequence<3, 4>{}));
+
+        constexpr index_t Hip = in_g_n_c_hip_wip_global_desc.GetLengths()[3];
+        constexpr index_t Wip = in_g_n_c_hip_wip_global_desc.GetLengths()[4];
+
+        constexpr auto in_g_n_epack_c_y_ho_x_wo_global_desc = transform_tensor_descriptor(
+            in_g_n_c_hip_wip_global_desc,
+            make_tuple(PassThrough<G>{},
+                       PassThrough<N>{},
+                       UnMerge<Sequence<GemmKPACK, nonVectorizedC>>{},
+                       Embed<Hip, Sequence<Y, Ho>, Sequence<ConvDilationH, ConvStrideH, 0>>{},
+                       Embed<Wip, Sequence<X, Wo>, Sequence<ConvDilationW, ConvStrideW, 0>>{}),
+            make_tuple(Sequence<0>{}, Sequence<1>{}, Sequence<2>{}, Sequence<3>{}, Sequence<4>{}),
+            make_tuple(Sequence<0>{},
+                       Sequence<1>{},
+                       Sequence<2, 3>{},
+                       Sequence<4, 5>{},
+                       Sequence<6, 7>{}));
+
+        constexpr auto in_gemmg_gemmk_gemmn_gemmkpack_global_desc_tmp = transform_tensor_descriptor(
+            in_g_n_epack_c_y_ho_x_wo_global_desc,
+            make_tuple(PassThrough<G>{},
+                       Merge<Sequence<nonVectorizedC, Y, X>>{},
+                       Merge<Sequence<N, Ho, Wo>>{},
+                       PassThrough<GemmKPACK>{}),
+            make_tuple(Sequence<0>{}, Sequence<3, 4, 6>{}, Sequence<1, 5, 7>{}, Sequence<2>{}),
+            make_tuple(Sequence<0>{}, Sequence<1>{}, Sequence<2>{}, Sequence<3>{}));
+
+        constexpr auto in_gemmg_gemmk0_gemmk1_gemmn_gemmkpack_global_desc =
+            transform_tensor_descriptor(
+                in_gemmg_gemmk_gemmn_gemmkpack_global_desc_tmp,
+                make_tuple(PassThrough<G>{},
+                           UnMerge<Sequence<GemmKBlocks, GemmKSub>>{},
+                           PassThrough<GemmN>{},
+                           PassThrough<GemmKPACK>{}),
+                make_tuple(Sequence<0>{}, Sequence<1>{}, Sequence<2>{}, Sequence<3>{}),
+                make_tuple(Sequence<0>{}, Sequence<1, 2>{}, Sequence<3>{}, Sequence<4>{}));
+
+        constexpr auto in_gemmg_gemmk_gemmn_gemmkpack_global_desc = transform_tensor_descriptor(
+            in_gemmg_gemmk0_gemmk1_gemmn_gemmkpack_global_desc,
+            make_tuple(Merge<Sequence<G, GemmKBlocks>>{},
+                       PassThrough<GemmKSub>{},
+                       PassThrough<GemmN>{},
+                       PassThrough<GemmKPACK>{}),
+            make_tuple(Sequence<0, 1>{}, Sequence<2>{}, Sequence<3>{}, Sequence<4>{}),
+            make_tuple(Sequence<0>{}, Sequence<1>{}, Sequence<2>{}, Sequence<3>{}));
+
+        // weight tensor
+        //   global mem
+	//
+        constexpr auto wei_g_k_epack_c_y_x_global_desc = transform_tensor_descriptor(
+            unfold_tensor_descriptor(wei_g_k_c_y_x_global_desc, I3, I4),
+            make_tuple(PassThrough<G>{},
+                       PassThrough<K>{},
+                       UnMerge<Sequence<GemmKPACK, nonVectorizedC>>{},
+                       PassThrough<Y * X>{}),
+            make_tuple(Sequence<0>{}, Sequence<1>{}, Sequence<2>{}, Sequence<3>{}),
+            make_tuple(Sequence<0>{}, Sequence<1>{}, Sequence<2, 3>{}, Sequence<4>{}));
+
+        constexpr auto wei_gemmg_gemmk_gemmm_gemmkpack_global_desc_tmp = transform_tensor_descriptor(
+            wei_g_k_epack_c_y_x_global_desc,
+            make_tuple(PassThrough<G>{},
+                       Merge<Sequence<nonVectorizedC, Y * X>>{},
+                       PassThrough<K>{},
+                       PassThrough<GemmKPACK>{}),
+            make_tuple(Sequence<0>{}, Sequence<3, 4>{}, Sequence<1>{}, Sequence<2>{}),
+            make_tuple(Sequence<0>{}, Sequence<1>{}, Sequence<2>{}, Sequence<3>{}));
+
+        constexpr auto wei_gemmg_gemmk0_gemmk1_gemmm_gemmkpack_global_desc =
+            transform_tensor_descriptor(
+                wei_gemmg_gemmk_gemmm_gemmkpack_global_desc_tmp,
+                make_tuple(PassThrough<G>{},
+                           UnMerge<Sequence<GemmKBlocks, GemmKSub>>{},
+                           PassThrough<GemmM>{},
+                           PassThrough<GemmKPACK>{}),
+                make_tuple(Sequence<0>{}, Sequence<1>{}, Sequence<2>{}, Sequence<3>{}),
+                make_tuple(Sequence<0>{}, Sequence<1, 2>{}, Sequence<3>{}, Sequence<4>{}));
+
+        constexpr auto wei_gemmg_gemmk_gemmm_gemmkpack_global_desc = transform_tensor_descriptor(
+            wei_gemmg_gemmk0_gemmk1_gemmm_gemmkpack_global_desc,
+            make_tuple(Merge<Sequence<G, GemmKBlocks>>{},
+                       PassThrough<GemmKSub>{},
+                       PassThrough<GemmM>{},
+                       PassThrough<GemmKPACK>{}),
+            make_tuple(Sequence<0, 1>{}, Sequence<2>{}, Sequence<3>{}, Sequence<4>{}),
+            make_tuple(Sequence<0>{}, Sequence<1>{}, Sequence<2>{}, Sequence<3>{}));
+
+        constexpr auto out_g_e0_n_k_ho_wo_global_desc =
+            make_native_tensor_descriptor(Sequence<out_g_n_k_ho_wo_global_desc.GetLengths()[0],
+                                                   GemmKBlocks,
+                                                   out_g_n_k_ho_wo_global_desc.GetLengths()[1],
+                                                   out_g_n_k_ho_wo_global_desc.GetLengths()[2],
+                                                   out_g_n_k_ho_wo_global_desc.GetLengths()[3],
+                                                   out_g_n_k_ho_wo_global_desc.GetLengths()[4]>{},
+                                          Sequence<out_g_n_k_ho_wo_global_desc.GetStrides()[0],
+                                                   0,
+                                                   out_g_n_k_ho_wo_global_desc.GetStrides()[1],
+                                                   out_g_n_k_ho_wo_global_desc.GetStrides()[2],
+                                                   out_g_n_k_ho_wo_global_desc.GetStrides()[3],
+                                                   out_g_n_k_ho_wo_global_desc.GetStrides()[4]>{});
+
+        constexpr auto out_gemmg_gemmm_gemmn_global_desc = transform_tensor_descriptor(
+            out_g_e0_n_k_ho_wo_global_desc,
+            make_tuple(
+                Merge<Sequence<G, GemmKBlocks>>{}, PassThrough<K>{}, Merge<Sequence<N, Ho, Wo>>{}),
+            make_tuple(Sequence<0, 1>{}, Sequence<3>{}, Sequence<2, 4, 5>{}),
+            make_tuple(Sequence<0>{}, Sequence<1>{}, Sequence<2>{}));
+
+        constexpr InMemoryDataOperation CGlobalMemoryDataOperation =
+            GemmKBlocks > 1 ? InMemoryDataOperation::AtomicAdd : InMemoryDataOperation::Set;
+
+        constexpr auto gridwise_batched_gemm =
+            GridwiseBatchedGemmTransposedANormalBNormalCXdlopsFp16Bfp16_v1<
+                GridSize,
+                BlockSize,
+                ABFloat,
+                AccFloat,
+                CFloat,
+                decltype(wei_gemmg_gemmk_gemmm_gemmkpack_global_desc),
+                decltype(in_gemmg_gemmk_gemmn_gemmkpack_global_desc),
+                decltype(out_gemmg_gemmm_gemmn_global_desc),
+                GemmMPerBlock,
+                GemmNPerBlock,
+                GemmKPerBlock,
+                GemmMPerWave,
+                GemmNPerWave,
+                GemmDataPerReadM,
+                GemmDataPerReadN,
+                GemmABlockCopyThreadSliceLengths_GemmG_GemmK_GemmM_GemmKPACK,
+                GemmABlockCopyThreadClusterLengths_GemmG_GemmK_GemmM_GemmKPACK,
+                GemmABlockCopyThreadClusterArrangeOrder,
+                GemmABlockCopySrcAccessOrder,
+                GemmABlockCopyDstAccessOrder,
+                1,
+                GemmABlockCopySrcDataPerRead_GemmK,
+                GemmABlockCopyDstDataPerWrite_GemmKPACK,
+                GemmBBlockCopyThreadSliceLengths_GemmG_GemmK_GemmN_GemmKPACK,
+                GemmBBlockCopyThreadClusterLengths_GemmG_GemmK_GemmN_GemmKPACK,
+                GemmBBlockCopyThreadClusterArrangeOrder,
+                GemmBBlockCopySrcAccessOrder,
+                GemmBBlockCopyDstAccessOrder,
+                2,
+                GemmBBlockCopySrcDataPerRead_GemmN,
+                GemmBBlockCopyDstDataPerWrite_GemmKPACK,
+                CGlobalMemoryDataOperation,
+                MBlock1NBlock0>{};
+
+        gridwise_batched_gemm.Run(p_wei_global, p_in_global, p_out_global);
+    }
+};
+
+} // namespace ck
+#endif

--- a/src/kernels/composable_kernel/include/kernel_algorithm/gridwise_convolution_implicit_gemm_v4r4_gen_xdlops_fp16_bfp16_gnchw_gkcyx_gnkhw_lds_double_buffer.hpp
+++ b/src/kernels/composable_kernel/include/kernel_algorithm/gridwise_convolution_implicit_gemm_v4r4_gen_xdlops_fp16_bfp16_gnchw_gkcyx_gnkhw_lds_double_buffer.hpp
@@ -38,23 +38,21 @@ struct make_vectorized_WeiDesc_Xdlops<ImplicitGemmDirection::ForwardData, GemmKP
         constexpr index_t nonVectorizedC = C / GemmKPACK;
 
         constexpr auto wei_g_k_epack_c_y_x_global_desc = transform_tensor_descriptor(
-            wei_g_k_c_y_x_global_desc,
+            unfold_tensor_descriptor(wei_g_k_c_y_x_global_desc, I3, I4),
             make_tuple(PassThrough<G>{},
                        PassThrough<K>{},
-                       UnMerge<Sequence<nonVectorizedC, GemmKPACK>>{},
-                       PassThrough<Y>{},
-                       PassThrough<X>{}),
-            make_tuple(Sequence<0>{}, Sequence<1>{}, Sequence<2>{}, Sequence<3>{}, Sequence<4>{}),
-            make_tuple(
-                Sequence<0>{}, Sequence<1>{}, Sequence<2, 3>{}, Sequence<4>{}, Sequence<5>{}));
+                       UnMerge<Sequence<GemmKPACK, nonVectorizedC>>{},
+                       PassThrough<Y * X>{}),
+            make_tuple(Sequence<0>{}, Sequence<1>{}, Sequence<2>{}, Sequence<3>{}),
+            make_tuple(Sequence<0>{}, Sequence<1>{}, Sequence<2, 3>{}, Sequence<4>{}));
 
         constexpr auto wei_g_e_k_epack_global_desc = transform_tensor_descriptor(
             wei_g_k_epack_c_y_x_global_desc,
             make_tuple(PassThrough<G>{},
-                       Merge<Sequence<nonVectorizedC, Y, X>>{},
+                       Merge<Sequence<nonVectorizedC, Y * X>>{},
                        PassThrough<K>{},
                        PassThrough<GemmKPACK>{}),
-            make_tuple(Sequence<0>{}, Sequence<2, 4, 5>{}, Sequence<1>{}, Sequence<3>{}),
+            make_tuple(Sequence<0>{}, Sequence<3, 4>{}, Sequence<1>{}, Sequence<2>{}),
             make_tuple(Sequence<0>{}, Sequence<1>{}, Sequence<2>{}, Sequence<3>{}));
 
         return wei_g_e_k_epack_global_desc;
@@ -86,23 +84,21 @@ struct make_vectorized_WeiDesc_Xdlops<ImplicitGemmDirection::BackwardWeight, Gem
         constexpr index_t nonVectorizedC = C / GemmKPACK;
 
         constexpr auto wei_g_k_epack_c_y_x_global_desc = transform_tensor_descriptor(
-            wei_g_k_c_y_x_global_desc,
+            unfold_tensor_descriptor(wei_g_k_c_y_x_global_desc, I3, I4),
             make_tuple(PassThrough<G>{},
                        PassThrough<K>{},
-                       UnMerge<Sequence<nonVectorizedC, GemmKPACK>>{},
-                       PassThrough<Y>{},
-                       PassThrough<X>{}),
-            make_tuple(Sequence<0>{}, Sequence<1>{}, Sequence<2>{}, Sequence<3>{}, Sequence<4>{}),
-            make_tuple(
-                Sequence<0>{}, Sequence<1>{}, Sequence<2, 3>{}, Sequence<4>{}, Sequence<5>{}));
+                       UnMerge<Sequence<GemmKPACK, nonVectorizedC>>{},
+                       PassThrough<X * Y>{}),
+            make_tuple(Sequence<0>{}, Sequence<1>{}, Sequence<2>{}, Sequence<3>{}),
+            make_tuple(Sequence<0>{}, Sequence<1>{}, Sequence<2, 3>{}, Sequence<4>{}));
 
         constexpr auto wei_g_e_k_epack_global_desc = transform_tensor_descriptor(
             wei_g_k_epack_c_y_x_global_desc,
             make_tuple(PassThrough<G>{},
-                       Merge<Sequence<nonVectorizedC, Y, X>>{},
+                       Merge<Sequence<nonVectorizedC, X * Y>>{},
                        PassThrough<K>{},
                        PassThrough<GemmKPACK>{}),
-            make_tuple(Sequence<0>{}, Sequence<2, 4, 5>{}, Sequence<1>{}, Sequence<3>{}),
+            make_tuple(Sequence<0>{}, Sequence<3, 4>{}, Sequence<1>{}, Sequence<2>{}),
             make_tuple(Sequence<0>{}, Sequence<1>{}, Sequence<2>{}, Sequence<3>{}));
 
         return wei_g_e_k_epack_global_desc;
@@ -218,7 +214,7 @@ struct
             in_g_n_c_hip_wip_global_desc,
             make_tuple(PassThrough<G>{},
                        PassThrough<N>{},
-                       UnMerge<Sequence<nonVectorizedC, GemmKPACK>>{},
+                       UnMerge<Sequence<GemmKPACK, nonVectorizedC>>{},
                        Embed<Hip, Sequence<Y, Ho>, Sequence<ConvDilationH, ConvStrideH, 0>>{},
                        Embed<Wip, Sequence<X, Wo>, Sequence<ConvDilationW, ConvStrideW, 0>>{}),
             make_tuple(Sequence<0>{}, Sequence<1>{}, Sequence<2>{}, Sequence<3>{}, Sequence<4>{}),
@@ -234,7 +230,7 @@ struct
                        Merge<Sequence<nonVectorizedC, Y, X>>{},
                        Merge<Sequence<N, Ho, Wo>>{},
                        PassThrough<GemmKPACK>{}),
-            make_tuple(Sequence<0>{}, Sequence<2, 4, 6>{}, Sequence<1, 5, 7>{}, Sequence<3>{}),
+            make_tuple(Sequence<0>{}, Sequence<3, 4, 6>{}, Sequence<1, 5, 7>{}, Sequence<2>{}),
             make_tuple(Sequence<0>{}, Sequence<1>{}, Sequence<2>{}, Sequence<3>{}));
 
         constexpr auto in_gemmg_gemmk0_gemmk1_gemmn_gemmkpack_global_desc =

--- a/src/kernels/composable_kernel/include/kernel_algorithm/gridwise_convolution_implicit_gemm_v4r4_gen_xdlops_fp16_bfp16_wrw_gnchw_gkcyx_gnkhw_lds_double_buffer.hpp
+++ b/src/kernels/composable_kernel/include/kernel_algorithm/gridwise_convolution_implicit_gemm_v4r4_gen_xdlops_fp16_bfp16_wrw_gnchw_gkcyx_gnkhw_lds_double_buffer.hpp
@@ -11,7 +11,6 @@
 
 namespace ck {
 
-
 // B = merge(N, Ho, Wo)
 template <index_t GridSize,
           index_t BlockSize,
@@ -172,14 +171,15 @@ struct
             make_tuple(
                 Sequence<0>{}, Sequence<1>{}, Sequence<2, 3>{}, Sequence<4>{}, Sequence<5>{}));
 
-        constexpr auto wei_gemmg_gemmk_gemmm_gemmkpack_global_desc_tmp = transform_tensor_descriptor(
-            wei_g_k_epack_c_y_x_global_desc,
-            make_tuple(PassThrough<G>{},
-                       Merge<Sequence<nonVectorizedC, Y, X>>{},
-                       PassThrough<K>{},
-                       PassThrough<GemmKPACK>{}),
-            make_tuple(Sequence<0>{}, Sequence<2, 4, 5>{}, Sequence<1>{}, Sequence<3>{}),
-            make_tuple(Sequence<0>{}, Sequence<1>{}, Sequence<2>{}, Sequence<3>{}));
+        constexpr auto wei_gemmg_gemmk_gemmm_gemmkpack_global_desc_tmp =
+            transform_tensor_descriptor(
+                wei_g_k_epack_c_y_x_global_desc,
+                make_tuple(PassThrough<G>{},
+                           Merge<Sequence<nonVectorizedC, Y, X>>{},
+                           PassThrough<K>{},
+                           PassThrough<GemmKPACK>{}),
+                make_tuple(Sequence<0>{}, Sequence<2, 4, 5>{}, Sequence<1>{}, Sequence<3>{}),
+                make_tuple(Sequence<0>{}, Sequence<1>{}, Sequence<2>{}, Sequence<3>{}));
 
         constexpr auto wei_gemmg_gemmk0_gemmk1_gemmm_gemmkpack_global_desc =
             transform_tensor_descriptor(

--- a/src/kernels/composable_kernel/include/kernel_algorithm/gridwise_convolution_implicit_gemm_v4r4_gen_xdlops_fp16_bfp16_wrw_gnchw_gkcyx_gnkhw_lds_double_buffer.hpp
+++ b/src/kernels/composable_kernel/include/kernel_algorithm/gridwise_convolution_implicit_gemm_v4r4_gen_xdlops_fp16_bfp16_wrw_gnchw_gkcyx_gnkhw_lds_double_buffer.hpp
@@ -1,5 +1,5 @@
-#ifndef CK_GRIDWISE_CONVOLUTION_IMPLICIT_GEMM_V4R4_FP16_BFP16_GNCHW_GKCYX_GNKHW_LDS_DOUBLE_BUFFER_HPP
-#define CK_GRIDWISE_CONVOLUTION_IMPLICIT_GEMM_V4R4_FP16_BFP16_GNCHW_GKCYX_GNKHW_LDS_DOUBLE_BUFFER_HPP
+#ifndef CK_GRIDWISE_CONVOLUTION_IMPLICIT_GEMM_V4R4_FP16_BFP16_WRW_GNCHW_GKCYX_GNKHW_LDS_DOUBLE_BUFFER_HPP
+#define CK_GRIDWISE_CONVOLUTION_IMPLICIT_GEMM_V4R4_FP16_BFP16_WRW_GNCHW_GKCYX_GNKHW_LDS_DOUBLE_BUFFER_HPP
 
 #include "common_header.hpp"
 #include "tensor_descriptor.hpp"
@@ -11,99 +11,6 @@
 
 namespace ck {
 
-template <ImplicitGemmDirection conv_dir, index_t GemmKPACK>
-struct make_vectorized_WeiDesc_Xdlops;
-
-template <index_t GemmKPACK>
-struct make_vectorized_WeiDesc_Xdlops<ImplicitGemmDirection::ForwardData, GemmKPACK>
-{
-    template <typename WeiDesc>
-    __device__ constexpr auto get(WeiDesc&)
-    {
-        constexpr auto I0 = Number<0>{};
-        constexpr auto I1 = Number<1>{};
-        constexpr auto I2 = Number<2>{};
-        constexpr auto I3 = Number<3>{};
-        constexpr auto I4 = Number<4>{};
-
-        constexpr auto wei_g_k_c_y_x_global_desc = WeiDesc{};
-
-        constexpr index_t G = wei_g_k_c_y_x_global_desc.GetLength(I0);
-        constexpr index_t K = wei_g_k_c_y_x_global_desc.GetLength(I1);
-        constexpr index_t C = wei_g_k_c_y_x_global_desc.GetLength(I2);
-        constexpr index_t Y = wei_g_k_c_y_x_global_desc.GetLength(I3);
-        constexpr index_t X = wei_g_k_c_y_x_global_desc.GetLength(I4);
-
-        static_assert(C % GemmKPACK == 0, "C needs to be multiple of vectorized GemmKPACK");
-        constexpr index_t nonVectorizedC = C / GemmKPACK;
-
-        constexpr auto wei_g_k_epack_c_y_x_global_desc = transform_tensor_descriptor(
-            unfold_tensor_descriptor(wei_g_k_c_y_x_global_desc, I3, I4),
-            make_tuple(PassThrough<G>{},
-                       PassThrough<K>{},
-                       UnMerge<Sequence<GemmKPACK, nonVectorizedC>>{},
-                       PassThrough<Y * X>{}),
-            make_tuple(Sequence<0>{}, Sequence<1>{}, Sequence<2>{}, Sequence<3>{}),
-            make_tuple(Sequence<0>{}, Sequence<1>{}, Sequence<2, 3>{}, Sequence<4>{}));
-
-        constexpr auto wei_g_e_k_epack_global_desc = transform_tensor_descriptor(
-            wei_g_k_epack_c_y_x_global_desc,
-            make_tuple(PassThrough<G>{},
-                       Merge<Sequence<nonVectorizedC, Y * X>>{},
-                       PassThrough<K>{},
-                       PassThrough<GemmKPACK>{}),
-            make_tuple(Sequence<0>{}, Sequence<3, 4>{}, Sequence<1>{}, Sequence<2>{}),
-            make_tuple(Sequence<0>{}, Sequence<1>{}, Sequence<2>{}, Sequence<3>{}));
-
-        return wei_g_e_k_epack_global_desc;
-    }
-};
-
-template <index_t GemmKPACK>
-struct make_vectorized_WeiDesc_Xdlops<ImplicitGemmDirection::BackwardWeight, GemmKPACK>
-{
-    template <typename WeiDesc>
-    __device__ constexpr auto get(WeiDesc&)
-    {
-
-        constexpr auto I0 = Number<0>{};
-        constexpr auto I1 = Number<1>{};
-        constexpr auto I2 = Number<2>{};
-        constexpr auto I3 = Number<3>{};
-        constexpr auto I4 = Number<4>{};
-
-        constexpr auto wei_g_k_c_y_x_global_desc = WeiDesc{};
-
-        constexpr index_t G = wei_g_k_c_y_x_global_desc.GetLength(I0);
-        constexpr index_t K = wei_g_k_c_y_x_global_desc.GetLength(I1);
-        constexpr index_t C = wei_g_k_c_y_x_global_desc.GetLength(I2);
-        constexpr index_t Y = wei_g_k_c_y_x_global_desc.GetLength(I3);
-        constexpr index_t X = wei_g_k_c_y_x_global_desc.GetLength(I4);
-
-        static_assert(C % GemmKPACK == 0, "C needs to be multiple of vectorized GemmKPACK");
-        constexpr index_t nonVectorizedC = C / GemmKPACK;
-
-        constexpr auto wei_g_k_epack_c_y_x_global_desc = transform_tensor_descriptor(
-            unfold_tensor_descriptor(wei_g_k_c_y_x_global_desc, I3, I4),
-            make_tuple(PassThrough<G>{},
-                       PassThrough<K>{},
-                       UnMerge<Sequence<GemmKPACK, nonVectorizedC>>{},
-                       PassThrough<X * Y>{}),
-            make_tuple(Sequence<0>{}, Sequence<1>{}, Sequence<2>{}, Sequence<3>{}),
-            make_tuple(Sequence<0>{}, Sequence<1>{}, Sequence<2, 3>{}, Sequence<4>{}));
-
-        constexpr auto wei_g_e_k_epack_global_desc = transform_tensor_descriptor(
-            wei_g_k_epack_c_y_x_global_desc,
-            make_tuple(PassThrough<G>{},
-                       Merge<Sequence<nonVectorizedC, X * Y>>{},
-                       PassThrough<K>{},
-                       PassThrough<GemmKPACK>{}),
-            make_tuple(Sequence<0>{}, Sequence<3, 4>{}, Sequence<1>{}, Sequence<2>{}),
-            make_tuple(Sequence<0>{}, Sequence<1>{}, Sequence<2>{}, Sequence<3>{}));
-
-        return wei_g_e_k_epack_global_desc;
-    }
-};
 
 // B = merge(N, Ho, Wo)
 template <index_t GridSize,
@@ -143,7 +50,7 @@ template <index_t GridSize,
           index_t GemmBBlockCopyDstDataPerWrite_GemmKPACK,
           ImplicitGemmDirection conv_dir>
 struct
-    GridwiseConvolutionImplicitGemm_v4r4_gen_xdlops_fp16_bfp16_gnchw_gkcyx_gnkhw_lds_double_buffer
+    GridwiseConvolutionImplicitGemm_v4r4_gen_xdlops_fp16_bfp16_wrw_gnchw_gkcyx_gnkhw_lds_double_buffer
 {
     __device__ void Run(const ABFloat* const __restrict__ p_in_global,
                         const ABFloat* const __restrict__ p_wei_global,
@@ -214,7 +121,7 @@ struct
             in_g_n_c_hip_wip_global_desc,
             make_tuple(PassThrough<G>{},
                        PassThrough<N>{},
-                       UnMerge<Sequence<GemmKPACK, nonVectorizedC>>{},
+                       UnMerge<Sequence<nonVectorizedC, GemmKPACK>>{},
                        Embed<Hip, Sequence<Y, Ho>, Sequence<ConvDilationH, ConvStrideH, 0>>{},
                        Embed<Wip, Sequence<X, Wo>, Sequence<ConvDilationW, ConvStrideW, 0>>{}),
             make_tuple(Sequence<0>{}, Sequence<1>{}, Sequence<2>{}, Sequence<3>{}, Sequence<4>{}),
@@ -230,7 +137,7 @@ struct
                        Merge<Sequence<nonVectorizedC, Y, X>>{},
                        Merge<Sequence<N, Ho, Wo>>{},
                        PassThrough<GemmKPACK>{}),
-            make_tuple(Sequence<0>{}, Sequence<3, 4, 6>{}, Sequence<1, 5, 7>{}, Sequence<2>{}),
+            make_tuple(Sequence<0>{}, Sequence<2, 4, 6>{}, Sequence<1, 5, 7>{}, Sequence<3>{}),
             make_tuple(Sequence<0>{}, Sequence<1>{}, Sequence<2>{}, Sequence<3>{}));
 
         constexpr auto in_gemmg_gemmk0_gemmk1_gemmn_gemmkpack_global_desc =
@@ -254,8 +161,25 @@ struct
 
         // weight tensor
         //   global mem
-        constexpr auto wei_gemmg_gemmk_gemmm_gemmkpack_global_desc_tmp =
-            make_vectorized_WeiDesc_Xdlops<conv_dir, GemmKPACK>{}.get(wei_g_k_c_y_x_global_desc);
+        constexpr auto wei_g_k_epack_c_y_x_global_desc = transform_tensor_descriptor(
+            wei_g_k_c_y_x_global_desc,
+            make_tuple(PassThrough<G>{},
+                       PassThrough<K>{},
+                       UnMerge<Sequence<nonVectorizedC, GemmKPACK>>{},
+                       PassThrough<Y>{},
+                       PassThrough<X>{}),
+            make_tuple(Sequence<0>{}, Sequence<1>{}, Sequence<2>{}, Sequence<3>{}, Sequence<4>{}),
+            make_tuple(
+                Sequence<0>{}, Sequence<1>{}, Sequence<2, 3>{}, Sequence<4>{}, Sequence<5>{}));
+
+        constexpr auto wei_gemmg_gemmk_gemmm_gemmkpack_global_desc_tmp = transform_tensor_descriptor(
+            wei_g_k_epack_c_y_x_global_desc,
+            make_tuple(PassThrough<G>{},
+                       Merge<Sequence<nonVectorizedC, Y, X>>{},
+                       PassThrough<K>{},
+                       PassThrough<GemmKPACK>{}),
+            make_tuple(Sequence<0>{}, Sequence<2, 4, 5>{}, Sequence<1>{}, Sequence<3>{}),
+            make_tuple(Sequence<0>{}, Sequence<1>{}, Sequence<2>{}, Sequence<3>{}));
 
         constexpr auto wei_gemmg_gemmk0_gemmk1_gemmm_gemmkpack_global_desc =
             transform_tensor_descriptor(

--- a/src/kernels/composable_kernel/src/kernel_wrapper/gridwise_convolution_implicit_gemm_v4r4_gen_xdlops_gnchw_gkcyx_gnkhw_lds_double_buffer.cpp
+++ b/src/kernels/composable_kernel/src/kernel_wrapper/gridwise_convolution_implicit_gemm_v4r4_gen_xdlops_gnchw_gkcyx_gnkhw_lds_double_buffer.cpp
@@ -1,7 +1,8 @@
 #include "common_header.hpp"
 #include "ConstantTensorDescriptor_deprecated.hpp"
 #include "gridwise_convolution_implicit_gemm_v4r4_gen_xdlops_gnchw_gkcyx_gnkhw_lds_double_buffer.hpp"
-#include "gridwise_convolution_implicit_gemm_v4r4_gen_xdlops_fp16_bfp16_gnchw_gkcyx_gnkhw_lds_double_buffer.hpp"
+#include "gridwise_convolution_implicit_gemm_v4r4_gen_xdlops_fp16_bfp16_fwd_gnchw_gkcyx_gnkhw_lds_double_buffer.hpp"
+#include "gridwise_convolution_implicit_gemm_v4r4_gen_xdlops_fp16_bfp16_wrw_gnchw_gkcyx_gnkhw_lds_double_buffer.hpp"
 #include "float_types.h"
 
 extern "C" __global__
@@ -231,7 +232,7 @@ extern "C" __global__
     // Backward weight in fp16/bfp16 uses atomic add to do reduction along K dimension
     // It requires output blob to be of float as no atomic add exists for half/ushort
     constexpr auto gridwise_conv =
-        GridwiseConvolutionImplicitGemm_v4r4_gen_xdlops_fp16_bfp16_gnchw_gkcyx_gnkhw_lds_double_buffer<
+        GridwiseConvolutionImplicitGemm_v4r4_gen_xdlops_fp16_bfp16_wrw_gnchw_gkcyx_gnkhw_lds_double_buffer<
             GridSize,
             BlockSize,
             FLOAT,       // Input data type = half (fp16) or ushort (bfp16)
@@ -275,7 +276,7 @@ extern "C" __global__
     // Forward data doesn't use any atomic add so output blob remains of the same type
     // as input blob
     constexpr auto gridwise_conv =
-        GridwiseConvolutionImplicitGemm_v4r4_gen_xdlops_fp16_bfp16_gnchw_gkcyx_gnkhw_lds_double_buffer<
+        GridwiseConvolutionImplicitGemm_v4r4_gen_xdlops_fp16_bfp16_fwd_gnchw_gkcyx_gnkhw_lds_double_buffer<
             GridSize,
             BlockSize,
             FLOAT,       // Input data type = half (fp16) or ushort (bfp16)

--- a/src/solver/conv_hip_implicit_gemm_v4r4_gen_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_v4r4_gen_xdlops.cpp
@@ -156,10 +156,13 @@ static inline ConvSolution GetSolutionBase(const ConvolutionContext& ctx,
             // For fp16 group cases, E = C/EPack * Y * X
             // Since C/EPack are not in contiguous memory along with Y*X, vector length
             // needs to be in multiple of Y*X
+            MIOPEN_LOG_I("mul " << (C / config.EPACKSize) * Y * X << " ABlockCopySubLengths_GemmK "
+                                << ABlockCopySubLengths_GemmK);
             ABlockCopySrcDataPerRead_GemmK =
-                ((Y * X) % ABlockCopySubLengths_GemmK) != 0
+                (((C / config.EPACKSize) * Y * X) % ABlockCopySubLengths_GemmK) != 0
                     ? 1
                     : GetReadWriteVectorSize(ABlockCopySubLengths_GemmK);
+            MIOPEN_LOG_I("gemmk " << ABlockCopySrcDataPerRead_GemmK);
         }
         else
         {

--- a/src/solver/conv_hip_implicit_gemm_v4r4_gen_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_v4r4_gen_xdlops.cpp
@@ -153,16 +153,10 @@ static inline ConvSolution GetSolutionBase(const ConvolutionContext& ctx,
     {
         if(ctx.group_counts > 1)
         {
-            // For fp16 group cases, E = C/EPack * Y * X
-            // Since C/EPack are not in contiguous memory along with Y*X, vector length
-            // needs to be in multiple of Y*X
-            MIOPEN_LOG_I("mul " << (C / config.EPACKSize) * Y * X << " ABlockCopySubLengths_GemmK "
-                                << ABlockCopySubLengths_GemmK);
+            // For bfp16/fp16 group fwd cases, E = C/EPack * Y * X, where C/EPack are in 
+	    // continuous memory with Y*X because EPack is extracted from 
             ABlockCopySrcDataPerRead_GemmK =
-                (((C / config.EPACKSize) * Y * X) % ABlockCopySubLengths_GemmK) != 0
-                    ? 1
-                    : GetReadWriteVectorSize(ABlockCopySubLengths_GemmK);
-            MIOPEN_LOG_I("gemmk " << ABlockCopySrcDataPerRead_GemmK);
+                (((C / config.EPACKSize) * Y * X) % ABlockCopySubLengths_GemmK) != 0 ? 1 : GetReadWriteVectorSize(ABlockCopySubLengths_GemmK);
         }
         else
         {

--- a/src/solver/conv_hip_implicit_gemm_v4r4_gen_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_v4r4_gen_xdlops.cpp
@@ -153,10 +153,12 @@ static inline ConvSolution GetSolutionBase(const ConvolutionContext& ctx,
     {
         if(ctx.group_counts > 1)
         {
-            // For bfp16/fp16 group fwd cases, E = C/EPack * Y * X, where C/EPack are in 
-	    // continuous memory with Y*X because EPack is extracted from 
+            // For bfp16/fp16 group fwd cases, E = C/EPack * Y * X, where C/EPack are in
+            // continuous memory with Y*X because EPack is extracted from
             ABlockCopySrcDataPerRead_GemmK =
-                (((C / config.EPACKSize) * Y * X) % ABlockCopySubLengths_GemmK) != 0 ? 1 : GetReadWriteVectorSize(ABlockCopySubLengths_GemmK);
+                (((C / config.EPACKSize) * Y * X) % ABlockCopySubLengths_GemmK) != 0
+                    ? 1
+                    : GetReadWriteVectorSize(ABlockCopySubLengths_GemmK);
         }
         else
         {


### PR DESCRIPTION
Change gemmkpack extraction logic for fp16/bfp16 group convolution to achieve vectorized reads in Matrix A along gemmK dimension in 3x3 resnext101 filter cases.  Upto 40% gains in resnext101 group configs.
 