### PR TITLE
Change half to _Float16 type in composable kernel

### DIFF
--- a/src/kernels/composable_kernel/include/kernel_algorithm/gridwise_convolution_backward_data_implicit_gemm_v1r1_xdlops_fp16_bfp16_gnchw_gkcyx_gnkhw.hpp
+++ b/src/kernels/composable_kernel/include/kernel_algorithm/gridwise_convolution_backward_data_implicit_gemm_v1r1_xdlops_fp16_bfp16_gnchw_gkcyx_gnkhw.hpp
@@ -155,11 +155,11 @@ struct GridwiseConvolutionBackwardDataImplicitGemm_v1r1_xdlops_fp16_bfp16_gnchw_
             GridwiseBatchedGemmTransposedANormalBNormalCXdlopsFp16Bfp16_v1<
                 GridSize,
                 BlockSize,
-                Float,    // Input data type = half (fp16) or ushort (bfp16)
+                Float,    // Input data type = fp16 (fp16) or ushort (bfp16)
                 AccFloat, // Acc data type = float
-                AccFloat, // Output data type = float  (not half/ushort as this kernel uses atomic
+                AccFloat, // Output data type = float  (not fp16/ushort as this kernel uses atomic
                           // add.
-                          // No ISA for half/ushort atomic add)
+                          // No ISA for fp16/ushort atomic add)
                 decltype(wei_gemmg_gemmk_gemmm_gemmkpack_global_desc),
                 decltype(out_gemmg_gemmk_gemmn_gemmkpack_global_desc),
                 decltype(in_gemmg_gemmm_gemmn_global_desc),

--- a/src/kernels/composable_kernel/include/kernel_algorithm/gridwise_convolution_backward_data_implicit_gemm_v1r1_xdlops_fp16_bfp16_nchw_kcyx_nkhw.hpp
+++ b/src/kernels/composable_kernel/include/kernel_algorithm/gridwise_convolution_backward_data_implicit_gemm_v1r1_xdlops_fp16_bfp16_nchw_kcyx_nkhw.hpp
@@ -142,10 +142,10 @@ struct GridwiseConvolutionBackwardDataImplicitGemm_v1r1_xdlops_f16_bfp16_nchw_kc
         constexpr auto gridwise_gemm = GridwiseGemmTransposedANormalBNormalCXdlopsFp16Bfp16_v1<
             GridSize,
             BlockSize,
-            Float,    // Input data type = half (fp16) or ushort (bfp16)
+            Float,    // Input data type = fp16 (fp16) or ushort (bfp16)
             AccFloat, // Acc data type = float
-            AccFloat, // Output data type = float  (not half/ushort as this kernel uses atomic add.
-                      // No ISA for half/ushort atomic add)
+            AccFloat, // Output data type = float  (not fp16/ushort as this kernel uses atomic add.
+                      // No ISA for fp16/ushort atomic add)
             decltype(wei_gemmk_gemmm_gemmkpack_global_desc),
             decltype(out_gemmk_gemmn_gemmkpack_global_desc),
             decltype(in_gemmm_gemmn_global_desc),

--- a/src/kernels/composable_kernel/include/kernel_algorithm/gridwise_convolution_implicit_gemm_v4_fp16_bfp16_nchw_kcyx_nkhw_lds_double_buffer.hpp
+++ b/src/kernels/composable_kernel/include/kernel_algorithm/gridwise_convolution_implicit_gemm_v4_fp16_bfp16_nchw_kcyx_nkhw_lds_double_buffer.hpp
@@ -405,12 +405,12 @@ struct GridwiseConvolutionImplicitGemm_v4_fp16_bfp16_nchw_kcyx_nkhw_lds_double_b
                 blockwise_wei_copy.RunLoadThreadBuffer(p_wei_block_on_global, p_wei_thread_buffer);
 
                 // LDS double buffer: GEMM on current data
-                // Vectorize the pointer to match with how half/bfloat16 datatypes are
-                // processed in gemm operation. Half type packs 4 half values while
+                // Vectorize the pointer to match with how fp16/bfloat16 datatypes are
+                // processed in gemm operation. fp16 type packs 4 fp16 values while
                 // bfloat16 packs 2 bfloat16 values. Since gemm's matrix A and B
                 // 2D indexes are computed with a single value in mind (e.g. float),
-                // to retain the same 2D indexes for half/bfloat16, we recast datatype
-                // from a single half to 4 packed half/2 packed bfloat16 respectively.
+                // to retain the same 2D indexes for fp16/bfloat16, we recast datatype
+                // from a single fp16 to 4 packed fp16/2 packed bfloat16 respectively.
                 const typename vector_type<Float, EPACK>::MemoryType* p_a_block_vec =
                     reinterpret_cast<const typename vector_type<Float, EPACK>::MemoryType*>(
                         p_wei_block_double);

--- a/src/kernels/composable_kernel/include/kernel_algorithm/gridwise_convolution_implicit_gemm_v4r1_fp16_bfp16_nchw_kcyx_nkhw_lds_double_buffer.hpp
+++ b/src/kernels/composable_kernel/include/kernel_algorithm/gridwise_convolution_implicit_gemm_v4r1_fp16_bfp16_nchw_kcyx_nkhw_lds_double_buffer.hpp
@@ -425,11 +425,11 @@ struct GridwiseConvolutionImplicitGemm_v4r1_fp16_bfp16_nchw_kcyx_nkhw_lds_double
                 blockwise_wei_copy.RunLoadThreadBuffer(p_wei_global, p_wei_thread_buffer);
 
                 // LDS double buffer: GEMM on current data
-                // Vectorize the pointer to match with how half/bfloat16 datatypes are
-                // processed in gemm operation. Half type packs 4 half values while
+                // Vectorize the pointer to match with how fp16/bfloat16 datatypes are
+                // processed in gemm operation. fp16 type packs 4 fp16 values while
                 // bfloat16 packs 2 bfloat16 values. Since gemm's matrix A and B
                 // 2D indexes are computed with vectorized data in mind (e.g. float,half4, short2),
-                // we recast datatype from a single half/bfloat16 to 4 packed half/2 packed bfloat16
+                // we recast datatype from a single fp16/bfloat16 to 4 packed fp16/2 packed bfloat16
                 // respectively.
                 const typename vector_type<Float, EPack>::MemoryType* p_a_block_vec =
                     reinterpret_cast<const typename vector_type<Float, EPack>::MemoryType*>(
@@ -465,11 +465,11 @@ struct GridwiseConvolutionImplicitGemm_v4r1_fp16_bfp16_nchw_kcyx_nkhw_lds_double
                 blockwise_wei_copy.RunLoadThreadBuffer(p_wei_global, p_wei_thread_buffer);
 
                 // LDS double buffer: GEMM on 2nd-last data
-                // Vectorize the pointer to match with how half/bfloat16 datatypes are
-                // processed in gemm operation. Half type packs 4 half values while
+                // Vectorize the pointer to match with how fp16/bfloat16 datatypes are
+                // processed in gemm operation. fp16 type packs 4 fp16 values while
                 // bfloat16 packs 2 bfloat16 values. Since gemm's matrix A and B
                 // 2D indexes are computed with vectorized data in mind (e.g. float,half4, short2),
-                // we recast datatype from a single half/bfloat16 to 4 packed half/2 packed bfloat16
+                // we recast datatype from a single fp16/bfloat16 to 4 packed fp16/2 packed bfloat16
                 // respectively.
                 const typename vector_type<Float, EPack>::MemoryType* p_a_block_vec =
                     reinterpret_cast<const typename vector_type<Float, EPack>::MemoryType*>(

--- a/src/kernels/composable_kernel/include/kernel_algorithm/gridwise_convolution_implicit_gemm_v4r4_xdlops_fp16_bfp16_nchw_kcyx_nkhw_lds_double_buffer.hpp
+++ b/src/kernels/composable_kernel/include/kernel_algorithm/gridwise_convolution_implicit_gemm_v4r4_xdlops_fp16_bfp16_nchw_kcyx_nkhw_lds_double_buffer.hpp
@@ -340,12 +340,12 @@ struct GridwiseConvolutionImplicitGemm_v4r4_xdlops_fp16_bfp16_nchw_kcyx_nkhw_lds
                 blockwise_wei_copy.RunLoadThreadBuffer(p_wei_block_on_global, p_wei_thread_buffer);
 
                 // LDS double buffer: GEMM on current data
-                // Vectorize the pointer to match with how half/bfloat16 datatypes are
-                // processed in gemm operation. Half type packs 4 half values while
+                // Vectorize the pointer to match with how fp16/bfloat16 datatypes are
+                // processed in gemm operation. fp16 type packs 4 fp16 values while
                 // bfloat16 packs 2 bfloat16 values. Since gemm's matrix A and B
                 // 2D indexes are computed with a single value in mind (e.g. float),
-                // to retain the same 2D indexes for half/bfloat16, we recast datatype
-                // from a single half to 4 packed half/2 packed bfloat16 respectively.
+                // to retain the same 2D indexes for fp16/bfloat16, we recast datatype
+                // from a single fp16 to 4 packed fp16/2 packed bfloat16 respectively.
                 const typename vector_type<Float, EPack>::MemoryType* p_a_block_vec =
                     reinterpret_cast<const typename vector_type<Float, EPack>::MemoryType*>(
                         p_wei_block_double);

--- a/src/kernels/composable_kernel/include/tensor_operation/gridwise_gemm_fp16_bfp16.hpp
+++ b/src/kernels/composable_kernel/include/tensor_operation/gridwise_gemm_fp16_bfp16.hpp
@@ -269,11 +269,11 @@ struct GridwiseGemmTransposedANormalBNormalCFp16Bfp16_v1
                 b_blockwise_copy.RunLoadThreadBuffer(p_b_global, p_b_thread_buffer);
 
                 // LDS double buffer: GEMM on current data
-                // Vectorize the pointer to match with how half/bfloat16 datatypes are
-                // processed in gemm operation. Half type packs 4 half values while
+                // Vectorize the pointer to match with how fp16/bfloat16 datatypes are
+                // processed in gemm operation. fp16 type packs 4 fp16 values while
                 // bfloat16 packs 2 bfloat16 values. Since gemm's matrix A and B
                 // 2D indexes are computed with vectorized value in mind (e.g. float, half2, half4),
-                // we recast datatype from a single half to 4 packed half/2 packed bfloat16
+                // we recast datatype from a single fp16 to 4 packed fp16/2 packed bfloat16
                 // respectively.
                 const typename vector_type<ABFloat, KPACK>::MemoryType* p_a_block_vec =
                     reinterpret_cast<const typename vector_type<ABFloat, KPACK>::MemoryType*>(

--- a/src/kernels/composable_kernel/include/tensor_operation/gridwise_gemm_xdlops_fp16_bfp16.hpp
+++ b/src/kernels/composable_kernel/include/tensor_operation/gridwise_gemm_xdlops_fp16_bfp16.hpp
@@ -252,11 +252,11 @@ struct GridwiseGemmTransposedANormalBNormalCXdlopsFp16Bfp16_v1
                 b_blockwise_copy.RunLoadThreadBuffer(p_b_global, p_b_thread_buffer);
 
                 // LDS double buffer: GEMM on current data
-                // Vectorize the pointer to match with how half/bfloat16 datatypes are
-                // processed in gemm operation. Half type packs 4 half values while
+                // Vectorize the pointer to match with how fp16/bfloat16 datatypes are
+                // processed in gemm operation. fp16 type packs 4 fp16 values while
                 // bfloat16 packs 2 bfloat16 values. Since gemm's matrix A and B
                 // 2D indexes are computed with vectorized value in mind (e.g. float, half2, half4),
-                // we recast datatype from a single half to 4 packed half/2 packed bfloat16
+                // we recast datatype from a single fp16 to 4 packed fp16/2 packed bfloat16
                 // respectively.
                 const typename vector_type<ABFloat, KPACK>::MemoryType* p_a_block_vec =
                     reinterpret_cast<const typename vector_type<ABFloat, KPACK>::MemoryType*>(
@@ -601,11 +601,11 @@ struct GridwiseBatchedGemmTransposedANormalBNormalCXdlopsFp16Bfp16_v1
                 b_blockwise_copy.RunLoadThreadBuffer(p_b_global, p_b_thread_buffer);
 
                 // LDS double buffer: GEMM on current data
-                // Vectorize the pointer to match with how half/bfloat16 datatypes are
-                // processed in gemm operation. Half type packs 4 half values while
+                // Vectorize the pointer to match with how fp16/bfloat16 datatypes are
+                // processed in gemm operation. fp16 type packs 4 fp16 values while
                 // bfloat16 packs 2 bfloat16 values. Since gemm's matrix A and B
                 // 2D indexes are computed with vectorized value in mind (e.g. float, half2, half4),
-                // we recast datatype from a single half to 4 packed half/2 packed bfloat16
+                // we recast datatype from a single fp16 to 4 packed fp16/2 packed bfloat16
                 // respectively.
                 const typename vector_type<ABFloat, KPACK>::MemoryType* p_a_block_vec =
                     reinterpret_cast<const typename vector_type<ABFloat, KPACK>::MemoryType*>(

--- a/src/kernels/composable_kernel/include/tensor_operation/xdlops_gemm.hpp
+++ b/src/kernels/composable_kernel/include/tensor_operation/xdlops_gemm.hpp
@@ -205,7 +205,7 @@ struct mfma_info<mfma_instr::mfma_f32_32x32x4f16>
 
     template <index_t MPerWave, index_t NPerWave>
     __device__ void
-    run(Number<MPerWave>, Number<NPerWave>, const half* a, const half* b, float* reg_c) const
+    run(Number<MPerWave>, Number<NPerWave>, const half_t* a, const half_t* b, float* reg_c) const
     {
         static_assert((MPerWave == 64 && NPerWave == 64) || (MPerWave == 32 && NPerWave == 64) ||
                           (MPerWave == 64 && NPerWave == 32),
@@ -237,7 +237,7 @@ struct mfma_info<mfma_instr::mfma_f32_32x32x8f16>
 
     template <index_t MPerWave, index_t NPerWave>
     __device__ void
-    run(Number<MPerWave>, Number<NPerWave>, const half* a, const half* b, float* reg_c) const
+    run(Number<MPerWave>, Number<NPerWave>, const half_t* a, const half_t* b, float* reg_c) const
     {
         static_assert((MPerWave == 32 && NPerWave == 32), "unsupported xdlops gemm");
 
@@ -267,7 +267,7 @@ struct mfma_info<mfma_instr::mfma_f32_16x16x16f16>
 
     template <index_t MPerWave, index_t NPerWave>
     __device__ void
-    run(Number<MPerWave>, Number<NPerWave>, const half* a, const half* b, float* reg_c) const
+    run(Number<MPerWave>, Number<NPerWave>, const half_t* a, const half_t* b, float* reg_c) const
     {
         static_assert((MPerWave == 16 && NPerWave == 16), "unsupported xdlops gemm");
 
@@ -297,7 +297,7 @@ struct mfma_info<mfma_instr::mfma_f32_16x16x4f16>
 
     template <index_t MPerWave, index_t NPerWave>
     __device__ void
-    run(Number<MPerWave>, Number<NPerWave>, const half* a, const half* b, float* reg_c) const
+    run(Number<MPerWave>, Number<NPerWave>, const half_t* a, const half_t* b, float* reg_c) const
     {
         static_assert((MPerWave == 16 && NPerWave == 64) || (MPerWave == 64 && NPerWave == 16),
                       "unsupported xdlops gemm");
@@ -328,7 +328,7 @@ struct mfma_info<mfma_instr::mfma_f32_4x4x4f16>
 
     template <index_t MPerWave, index_t NPerWave>
     __device__ void
-    run(Number<MPerWave>, Number<NPerWave>, const half* a, const half* b, float* reg_c) const
+    run(Number<MPerWave>, Number<NPerWave>, const half_t* a, const half_t* b, float* reg_c) const
     {
         static_assert((MPerWave == 4 || MPerWave == 8) && NPerWave == 64,
                       "unsupported xdlops gemm");
@@ -616,55 +616,55 @@ struct XdlopsGemm_t
     }
 
     template <>
-    __device__ static constexpr auto GetMFMAInfo<half, 64, 64>()
+    __device__ static constexpr auto GetMFMAInfo<half_t, 64, 64>()
     {
         return mfma_info<mfma_instr::mfma_f32_32x32x4f16>{};
     }
 
     template <>
-    __device__ static constexpr auto GetMFMAInfo<half, 64, 32>()
+    __device__ static constexpr auto GetMFMAInfo<half_t, 64, 32>()
     {
         return mfma_info<mfma_instr::mfma_f32_32x32x4f16>{};
     }
 
     template <>
-    __device__ static constexpr auto GetMFMAInfo<half, 32, 64>()
+    __device__ static constexpr auto GetMFMAInfo<half_t, 32, 64>()
     {
         return mfma_info<mfma_instr::mfma_f32_32x32x4f16>{};
     }
 
     template <>
-    __device__ static constexpr auto GetMFMAInfo<half, 32, 32>()
+    __device__ static constexpr auto GetMFMAInfo<half_t, 32, 32>()
     {
         return mfma_info<mfma_instr::mfma_f32_32x32x8f16>{};
     }
 
     template <>
-    __device__ static constexpr auto GetMFMAInfo<half, 16, 16>()
+    __device__ static constexpr auto GetMFMAInfo<half_t, 16, 16>()
     {
         return mfma_info<mfma_instr::mfma_f32_16x16x16f16>{};
     }
 
     template <>
-    __device__ static constexpr auto GetMFMAInfo<half, 16, 64>()
+    __device__ static constexpr auto GetMFMAInfo<half_t, 16, 64>()
     {
         return mfma_info<mfma_instr::mfma_f32_16x16x4f16>{};
     }
 
     template <>
-    __device__ static constexpr auto GetMFMAInfo<half, 64, 16>()
+    __device__ static constexpr auto GetMFMAInfo<half_t, 64, 16>()
     {
         return mfma_info<mfma_instr::mfma_f32_16x16x4f16>{};
     }
 
     template <>
-    __device__ static constexpr auto GetMFMAInfo<half, 4, 64>()
+    __device__ static constexpr auto GetMFMAInfo<half_t, 4, 64>()
     {
         return mfma_info<mfma_instr::mfma_f32_4x4x4f16>{};
     }
 
     template <>
-    __device__ static constexpr auto GetMFMAInfo<half, 8, 64>()
+    __device__ static constexpr auto GetMFMAInfo<half_t, 8, 64>()
     {
         return mfma_info<mfma_instr::mfma_f32_4x4x4f16>{};
     }

--- a/src/kernels/composable_kernel/include/utility/float_type.hpp
+++ b/src/kernels/composable_kernel/include/utility/float_type.hpp
@@ -11,6 +11,7 @@ typedef float float16_t __attribute__((ext_vector_type(16)));
 typedef float float32_t __attribute__((ext_vector_type(32)));
 
 // float16
+typedef _Float16 half_t;
 typedef _Float16 half2_t __attribute__((ext_vector_type(2)));
 typedef _Float16 half4_t __attribute__((ext_vector_type(4)));
 typedef _Float16 half8_t __attribute__((ext_vector_type(8)));
@@ -85,37 +86,37 @@ struct vector_type<float, 4>
 };
 
 template <>
-struct vector_type<half, 1>
+struct vector_type<half_t, 1>
 {
-    using MemoryType = half;
+    using MemoryType = half_t;
 
     template <index_t I>
-    __host__ __device__ static void SetScalar(MemoryType& v, half s, Number<I>)
+    __host__ __device__ static void SetScalar(MemoryType& v, half_t s, Number<I>)
     {
         static_assert(I < 1, "wrong");
-        *(reinterpret_cast<half*>(&v) + I) = s;
+        *(reinterpret_cast<half_t*>(&v) + I) = s;
     }
 };
 
 template <>
-struct vector_type<half, 2>
+struct vector_type<half_t, 2>
 {
     using MemoryType = half2_t;
 
     union DataType
     {
         MemoryType vector;
-        half scalar[2];
+        half_t scalar[2];
     };
 
     template <index_t I>
-    __host__ __device__ static void SetScalar(MemoryType& v, half s, Number<I>)
+    __host__ __device__ static void SetScalar(MemoryType& v, half_t s, Number<I>)
     {
         static_assert(I < 2, "wrong");
-        *(reinterpret_cast<half*>(&v) + I) = s;
+        *(reinterpret_cast<half_t*>(&v) + I) = s;
     }
 
-    __host__ __device__ static MemoryType Pack(half s0, half s1)
+    __host__ __device__ static MemoryType Pack(half_t s0, half_t s1)
     {
         DataType data;
         data.scalar[0] = s0;
@@ -125,24 +126,24 @@ struct vector_type<half, 2>
 };
 
 template <>
-struct vector_type<half, 4>
+struct vector_type<half_t, 4>
 {
     using MemoryType = half4_t;
 
     union DataType
     {
         MemoryType vector;
-        half scalar[4];
+        half_t scalar[4];
     };
 
     template <index_t I>
-    __host__ __device__ static void SetScalar(MemoryType& v, half s, Number<I>)
+    __host__ __device__ static void SetScalar(MemoryType& v, half_t s, Number<I>)
     {
         static_assert(I < 4, "wrong");
-        *(reinterpret_cast<half*>(&v) + I) = s;
+        *(reinterpret_cast<half_t*>(&v) + I) = s;
     }
 
-    __host__ __device__ static MemoryType Pack(half s0, half s1, half s2, half s3)
+    __host__ __device__ static MemoryType Pack(half_t s0, half_t s1, half_t s2, half_t s3)
     {
         DataType data;
         data.scalar[0] = s0;
@@ -154,21 +155,21 @@ struct vector_type<half, 4>
 };
 
 template <>
-struct vector_type<half, 8>
+struct vector_type<half_t, 8>
 {
     using MemoryType = half8_t;
 
     union DataType
     {
         MemoryType vector;
-        half scalar[8];
+        half_t scalar[8];
     };
 
     template <index_t I>
-    __host__ __device__ static void SetScalar(MemoryType& v, half s, Number<I>)
+    __host__ __device__ static void SetScalar(MemoryType& v, half_t s, Number<I>)
     {
         static_assert(I < 8, "wrong");
-        *(reinterpret_cast<half*>(&v) + I) = s;
+        *(reinterpret_cast<half_t*>(&v) + I) = s;
     }
 };
 
@@ -294,8 +295,8 @@ struct inner_product_with_conversion
 
     __device__ T operator()(half2_t a, half2_t b) const
     {
-        const half* p_a_half = reinterpret_cast<const half*>(&a);
-        const half* p_b_half = reinterpret_cast<const half*>(&b);
+        const half_t* p_a_half = reinterpret_cast<const half_t*>(&a);
+        const half_t* p_b_half = reinterpret_cast<const half_t*>(&b);
 
         T acc = 0;
         for(index_t v = 0; v < 2; ++v)
@@ -308,8 +309,8 @@ struct inner_product_with_conversion
 
     __device__ T operator()(half4_t a, half4_t b) const
     {
-        const half* p_a_half = reinterpret_cast<const half*>(&a);
-        const half* p_b_half = reinterpret_cast<const half*>(&b);
+        const half_t* p_a_half = reinterpret_cast<const half_t*>(&a);
+        const half_t* p_b_half = reinterpret_cast<const half_t*>(&b);
 
         T acc = 0;
         for(index_t v = 0; v < 4; ++v)

--- a/src/kernels/composable_kernel/src/kernel_wrapper/gridwise_convolution_implicit_gemm_v4r4_gen_xdlops_gnchw_gkcyx_gnkhw_lds_double_buffer.cpp
+++ b/src/kernels/composable_kernel/src/kernel_wrapper/gridwise_convolution_implicit_gemm_v4r4_gen_xdlops_gnchw_gkcyx_gnkhw_lds_double_buffer.cpp
@@ -229,15 +229,15 @@ extern "C" __global__
     gridwise_conv.Run(p_in_global, p_wei_global, p_out_global);
 #elif(MIOPEN_USE_FP16 || MIOPEN_USE_BFP16) && CK_PARAM_PROBLEM_DIRECTION == 2
     // Backward weight in fp16/bfp16 uses atomic add to do reduction along K dimension
-    // It requires output blob to be of float as no atomic add exists for half/ushort
+    // It requires output blob to be of float as no atomic add exists for fp16/ushort
     constexpr auto gridwise_conv =
         GridwiseConvolutionImplicitGemm_v4r4_gen_xdlops_fp16_bfp16_gnchw_gkcyx_gnkhw_lds_double_buffer<
             GridSize,
             BlockSize,
-            FLOAT,       // Input data type = half (fp16) or ushort (bfp16)
+            FLOAT,       // Input data type = fp16 (fp16) or ushort (bfp16)
             FLOAT_ACCUM, // Acc data type = float (see float_types.h)
-            float, // Output data type = float  (not half/ushort) as no atomic add ISA exists for
-                   // half/ushort.
+            float, // Output data type = float  (not fp16/ushort) as no atomic add ISA exists for
+                   // fp16/ushort.
             decltype(in_gnchw_desc),
             decltype(wei_gkcyx_desc),
             decltype(out_gnkhw_desc),
@@ -269,7 +269,7 @@ extern "C" __global__
             GemmBBlockCopySrcDataPerRead_GemmN,
             GemmBBlockCopyDstDataPerWrite_GemmKPACK,
             dir>{};
-    // Output blob is cast to float as no atomic add exists for half/ushort
+    // Output blob is cast to float as no atomic add exists for fp16/ushort
     gridwise_conv.Run(p_in_global, p_wei_global, reinterpret_cast<FLOAT_ACCUM*>(p_out_global));
 #elif(MIOPEN_USE_FP16 || MIOPEN_USE_BFP16) && CK_PARAM_PROBLEM_DIRECTION != 2
     // Forward data doesn't use any atomic add so output blob remains of the same type
@@ -278,9 +278,9 @@ extern "C" __global__
         GridwiseConvolutionImplicitGemm_v4r4_gen_xdlops_fp16_bfp16_gnchw_gkcyx_gnkhw_lds_double_buffer<
             GridSize,
             BlockSize,
-            FLOAT,       // Input data type = half (fp16) or ushort (bfp16)
+            FLOAT,       // Input data type = fp16 (fp16) or ushort (bfp16)
             FLOAT_ACCUM, // Acc data type = float (see float_types.h)
-            FLOAT,       // Output data type = half (fp16) or ushort (bfp16)
+            FLOAT,       // Output data type = fp16 (fp16) or ushort (bfp16)
             decltype(in_gnchw_desc),
             decltype(wei_gkcyx_desc),
             decltype(out_gnkhw_desc),

--- a/src/kernels/composable_kernel/src/kernel_wrapper/gridwise_convolution_implicit_gemm_v4r4_gen_xdlops_nchw_kcyx_nkhw_lds_double_buffer.cpp
+++ b/src/kernels/composable_kernel/src/kernel_wrapper/gridwise_convolution_implicit_gemm_v4r4_gen_xdlops_nchw_kcyx_nkhw_lds_double_buffer.cpp
@@ -229,15 +229,15 @@ extern "C" __global__
 #elif(MIOPEN_USE_FP16 || MIOPEN_USE_BFP16) && CK_PARAM_PROBLEM_DIRECTION == 2
 
     // Backward weight in fp16/bfp16 uses atomic add to do reduction along K dimension
-    // It requires output blob to be of float as no atomic add exists for half/ushort
+    // It requires output blob to be of float as no atomic add exists for fp16/ushort
     constexpr auto gridwise_conv =
         GridwiseConvolutionImplicitGemm_v4r4_gen_xdlops_fp16_bfp16_wrw_nchw_kcyx_nkhw_lds_double_buffer<
             GridSize,
             BlockSize,
-            FLOAT,       // Input data type = half (fp16) or ushort (bfp16)
+            FLOAT,       // Input data type = fp16 (fp16) or ushort (bfp16)
             FLOAT_ACCUM, // Acc data type = float (see float_types.h)
-            float, // Output data type = float  (not half/ushort) as no atomic add ISA exists for
-                   // half/ushort.
+            float, // Output data type = float  (not fp16/ushort) as no atomic add ISA exists for
+                   // fp16/ushort.
             decltype(in_nchw_desc),
             decltype(wei_kcyx_desc),
             decltype(out_nkhw_desc),
@@ -270,7 +270,7 @@ extern "C" __global__
             GemmBBlockCopyDstDataPerWrite_GemmKPACK,
             dir>{};
 
-    // Output blob is cast to float as no atomic add exists for half/ushort
+    // Output blob is cast to float as no atomic add exists for fp16/ushort
     gridwise_conv.Run(p_in_global, p_wei_global, reinterpret_cast<FLOAT_ACCUM*>(p_out_global));
 #elif(MIOPEN_USE_FP16 || MIOPEN_USE_BFP16) && CK_PARAM_PROBLEM_DIRECTION != 2
     // Forward data doesn't use any atomic add so output blob remains of the same type
@@ -287,9 +287,9 @@ extern "C" __global__
         GridwiseConvolutionImplicitGemm_v4r4_gen_xdlops_fp16_bfp16_fwd_nchw_kcyx_nkhw_lds_double_buffer<
             GridSize,
             BlockSize,
-            FLOAT,       // Input data type = half (fp16) or ushort (bfp16)
+            FLOAT,       // Input data type = fp16 (fp16) or ushort (bfp16)
             FLOAT_ACCUM, // Acc data type = float (see float_types.h)
-            FLOAT,       // Input data type = half (fp16) or ushort (bfp16)
+            FLOAT,       // Input data type = fp16 (fp16) or ushort (bfp16)
             decltype(in_nchw_desc),
             decltype(wei_kcyx_desc),
             decltype(out_nkhw_desc),

--- a/src/kernels/float_types.h
+++ b/src/kernels/float_types.h
@@ -36,7 +36,7 @@
 
 #if MIOPEN_USE_FP16 == 1
 #ifdef __HIP_PLATFORM_HCC__
-#define FLOAT half
+#define FLOAT _Float16
 #define FLOAT_ACCUM float
 #else
 #pragma OPENCL EXTENSION cl_khr_fp16 : enable


### PR DESCRIPTION
There is a mixed use of "half" and "_Float16" in HIP kernel, but they are different type. Compiler team suggested using "_Float16" everywhere.