### PR TITLE
Prioritize llvm-amdgpu if exists on OpenCL Backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,20 +114,20 @@ set_property( CACHE MIOPEN_BACKEND PROPERTY STRINGS
 if( MIOPEN_BACKEND STREQUAL "OpenCL")
     set(MIOPEN_BACKEND_OPENCL 1)
     find_package( OpenCL REQUIRED )
-    find_program(MIOPEN_HIP_COMPILER hcc
+    find_program(MIOPEN_HIP_COMPILER clang++
             PATH_SUFFIXES bin
-            PATHS /opt/rocm
+            PATHS /opt/rocm/llvm
     )
     set(MIOPEN_USE_MIOPENGEMM ON CACHE BOOL "")
     if(MIOPEN_HIP_COMPILER)
-        message("hip compiler: ${MIOPEN_HIP_COMPILER}")
+        message(STATUS "hip compiler: ${MIOPEN_HIP_COMPILER}")
     else()
-        find_program(MIOPEN_HIP_COMPILER clang++
+        find_program(MIOPEN_HIP_COMPILER hcc
             PATH_SUFFIXES bin
-	        PATHS /opt/rocm/llvm
+	        PATHS /opt/rocm
         )
         if(MIOPEN_HIP_COMPILER)
-            message("hip compiler: ${MIOPEN_HIP_COMPILER}")
+            message(STATUS "hip compiler: ${MIOPEN_HIP_COMPILER}")
         else()
             message(FATAL_ERROR "hip compiler not found")
         endif()


### PR DESCRIPTION
Usually llvm-amdgpu doesn't exist in HCC environment, but HCC sometimes exists in HIP-Clang environment. However, HCC compiler may have mismatches with llvm-amdgpu libraries. Let's prioritize clang++ in llvm. This doesn't affect HIP/HCC environment.