### PR TITLE
Workaround for SWDEV-233338

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -250,7 +250,7 @@ pipeline {
                     }
                 }
 
-                stage('hip-clang DEBUG PARALLEL=1 CXX=hcc') {
+                stage('Hip clang release') {
                     agent{ label rocmnode("vega") }
                     environment{
                         cmd = """
@@ -258,8 +258,8 @@ pipeline {
                             rm -rf build
                             mkdir build
                             cd build
-                            CXX=${compilerpath} cmake -DBUILD_DEV=On -DCMAKE_BUILD_TYPE=debug -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS=--disable-verification-cache .. 
-                            CTEST_PARALLEL_LEVEL=1 MIOPEN_DEBUG_IMPLICIT_GEMM_NON_XDLOPS_INLINE_ASM=0 MIOPEN_CONV_PRECISE_ROCBLAS_TIMING=0 make -j\$(nproc) check
+                            CXX=/opt/rocm/llvm/bin/clang++ cmake -DBUILD_DEV=On -DCMAKE_BUILD_TYPE=release -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS=--disable-verification-cache .. 
+                            CTEST_PARALLEL_LEVEL=4 MIOPEN_DEBUG_IMPLICIT_GEMM_NON_XDLOPS_INLINE_ASM=0 MIOPEN_CONV_PRECISE_ROCBLAS_TIMING=0 make -j\$(nproc) check
                         """
 
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -250,7 +250,7 @@ pipeline {
                     }
                 }
 
-                stage('Hip clang release') {
+                stage('Hip clang debug') {
                     agent{ label rocmnode("vega") }
                     environment{
                         cmd = """
@@ -258,7 +258,7 @@ pipeline {
                             rm -rf build
                             mkdir build
                             cd build
-                            CXX=/opt/rocm/llvm/bin/clang++ cmake -DBUILD_DEV=On -DCMAKE_BUILD_TYPE=release -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS=--disable-verification-cache .. 
+                            CXX=/opt/rocm/llvm/bin/clang++ cmake -DBUILD_DEV=On -DCMAKE_BUILD_TYPE=debug -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS=--disable-verification-cache .. 
                             CTEST_PARALLEL_LEVEL=4 MIOPEN_DEBUG_IMPLICIT_GEMM_NON_XDLOPS_INLINE_ASM=0 MIOPEN_CONV_PRECISE_ROCBLAS_TIMING=0 make -j\$(nproc) check
                         """
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -250,7 +250,7 @@ pipeline {
                     }
                 }
 
-                stage('hip-clang DEBUG PARALLEL 1') {
+                stage('hip-clang DEBUG PARALLEL=1 CXX=hcc') {
                     agent{ label rocmnode("vega") }
                     environment{
                         cmd = """
@@ -258,7 +258,7 @@ pipeline {
                             rm -rf build
                             mkdir build
                             cd build
-                            CXX=/opt/rocm/llvm/bin/clang++ cmake -DBUILD_DEV=On -DCMAKE_BUILD_TYPE=debug -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS=--disable-verification-cache .. 
+                            CXX=${compilerpath} cmake -DBUILD_DEV=On -DCMAKE_BUILD_TYPE=debug -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS=--disable-verification-cache .. 
                             CTEST_PARALLEL_LEVEL=1 MIOPEN_DEBUG_IMPLICIT_GEMM_NON_XDLOPS_INLINE_ASM=0 MIOPEN_CONV_PRECISE_ROCBLAS_TIMING=0 make -j\$(nproc) check
                         """
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -250,7 +250,7 @@ pipeline {
                     }
                 }
 
-                stage('Hip clang release') {
+                stage('hip-clang DEBUG PARALLEL 1') {
                     agent{ label rocmnode("vega") }
                     environment{
                         cmd = """
@@ -258,8 +258,8 @@ pipeline {
                             rm -rf build
                             mkdir build
                             cd build
-                            CXX=/opt/rocm/llvm/bin/clang++ cmake -DBUILD_DEV=On -DCMAKE_BUILD_TYPE=release -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS=--disable-verification-cache .. 
-                            CTEST_PARALLEL_LEVEL=4 MIOPEN_DEBUG_IMPLICIT_GEMM_NON_XDLOPS_INLINE_ASM=0 MIOPEN_CONV_PRECISE_ROCBLAS_TIMING=0 make -j\$(nproc) check
+                            CXX=/opt/rocm/llvm/bin/clang++ cmake -DBUILD_DEV=On -DCMAKE_BUILD_TYPE=debug -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS=--disable-verification-cache .. 
+                            CTEST_PARALLEL_LEVEL=1 MIOPEN_DEBUG_IMPLICIT_GEMM_NON_XDLOPS_INLINE_ASM=0 MIOPEN_CONV_PRECISE_ROCBLAS_TIMING=0 make -j\$(nproc) check
                         """
 
                     }

--- a/src/ocl/convolutionocl.cpp
+++ b/src/ocl/convolutionocl.cpp
@@ -731,7 +731,6 @@ static void DirConvFindCore(Handle& handle,
         const auto all = conv.FindWinogradSolutions(ctx);
         PrecompileSolutions(handle, all);
         const auto algorithm_name = AlgorithmName{"miopenConvolutionFwdAlgoWinograd"};
-        PrecompileSolutions(handle, all);
         EvaluateInvokers(handle, all, algorithm_name, network_config, invoke_ctx, record);
     }
 

--- a/test/find_db.cpp
+++ b/test/find_db.cpp
@@ -203,5 +203,6 @@ struct FindDbTest : test_driver
 int main(int argc, const char* argv[])
 {
     setenv("MIOPEN_LOG_LEVEL", "6", 1);
+    setenv("MIOPEN_COMPILE_PARALLEL_LEVEL", "1", 1);
     test_drive<miopen::FindDbTest>(argc, argv);
 }


### PR DESCRIPTION
- Workaround for SWDEV-233338
- Formalized workaround for SWDEV-220166
- Better logging
  - Issue `Error` message if assembler is not available. Substantial performance regression is highly likely, and we consider that as serious defect.

Manually tested.