### PR TITLE
Fix empty path in perf db

### DIFF
--- a/src/include/miopen/execution_context.hpp
+++ b/src/include/miopen/execution_context.hpp
@@ -101,7 +101,7 @@ struct ExecutionContext
         // an empty user-db path indicates user intent to disable
         // the database. Default in when dev builds are on
         // clang-format off
-	auto udb = GetUserDbPath();
+	const auto& udb = GetUserDbPath();
 	if(udb.empty())
 		return "";
         return udb

--- a/src/include/miopen/execution_context.hpp
+++ b/src/include/miopen/execution_context.hpp
@@ -98,8 +98,13 @@ struct ExecutionContext
 
     std::string GetUserPerfDbPath() const
     {
+        // an empty user-db path indicates user intent to disable
+        // the database. Default in when dev builds are on
         // clang-format off
-        return GetUserDbPath()
+	auto udb = GetUserDbPath();
+	if(udb.empty())
+		return "";
+        return udb
 #if MIOPEN_ENABLE_SQLITE
              + "miopen_" + SQLitePerfDb::MIOPEN_PERFDB_SCHEMA_VER + ".udb";
 #else

--- a/src/include/miopen/execution_context.hpp
+++ b/src/include/miopen/execution_context.hpp
@@ -85,16 +85,16 @@ struct ExecutionContext
     std::string GetPerfDbPath() const
     {
         boost::filesystem::path pdb_path(GetSystemDbPath());
-        std::string filename =
+        std::ostringstream filename;
 // clang-format off
 #if MIOPEN_ENABLE_SQLITE
-            "miopen.db";
+            filename << "miopen.db";
 #else
-            GetStream().GetDbBasename()
-            + ".cd.pdb.txt";
+            filename << GetStream().GetDbBasename()
+            << ".cd.pdb.txt";
 #endif
         // clang-format on
-        return (pdb_path / filename).string();
+        return (pdb_path / filename.str()).string();
     }
 
     std::string GetUserPerfDbPath() const
@@ -106,17 +106,17 @@ struct ExecutionContext
 	if(udb.empty())
 		return "";
         boost::filesystem::path pdb_path(udb);
-        std::string filename = 
+        std::ostringstream filename;
 #if MIOPEN_ENABLE_SQLITE
-             ("miopen_" + std::string{SQLitePerfDb::MIOPEN_PERFDB_SCHEMA_VER} + ".udb");
+             filename << "miopen_" << SQLitePerfDb::MIOPEN_PERFDB_SCHEMA_VER << ".udb";
 #else
-             (GetStream().GetDbBasename()
-             + "."
-             + GetUserDbSuffix()
-             + ".cd.updb.txt");
+             filename << GetStream().GetDbBasename()
+             << "."
+             << GetUserDbSuffix()
+             << ".cd.updb.txt";
 #endif
         // clang-format on
-        return (pdb_path / filename).string();
+        return (pdb_path / filename.str()).string();
     }
 
     private:

--- a/src/include/miopen/execution_context.hpp
+++ b/src/include/miopen/execution_context.hpp
@@ -84,16 +84,17 @@ struct ExecutionContext
 
     std::string GetPerfDbPath() const
     {
-        // clang-format off
-        return GetSystemDbPath()
+        boost::filesystem::path pdb_path(GetSystemDbPath());
+        std::string filename =
+// clang-format off
 #if MIOPEN_ENABLE_SQLITE
-            + "/miopen.db";
+            "miopen.db";
 #else
-            + "/"
-            + GetStream().GetDbBasename()
+            GetStream().GetDbBasename()
             + ".cd.pdb.txt";
 #endif
         // clang-format on
+        return (pdb_path / filename).string();
     }
 
     std::string GetUserPerfDbPath() const
@@ -104,16 +105,18 @@ struct ExecutionContext
 	const auto& udb = GetUserDbPath();
 	if(udb.empty())
 		return "";
-        return udb
+        boost::filesystem::path pdb_path(udb);
+        std::string filename = 
 #if MIOPEN_ENABLE_SQLITE
-             + "miopen_" + SQLitePerfDb::MIOPEN_PERFDB_SCHEMA_VER + ".udb";
+             ("miopen_" + std::string{SQLitePerfDb::MIOPEN_PERFDB_SCHEMA_VER} + ".udb");
 #else
-             + GetStream().GetDbBasename()
+             (GetStream().GetDbBasename()
              + "."
              + GetUserDbSuffix()
-             + ".cd.updb.txt";
+             + ".cd.updb.txt");
 #endif
         // clang-format on
+        return (pdb_path / filename).string();
     }
 
     private:

--- a/src/include/miopen/sqlite_db.hpp
+++ b/src/include/miopen/sqlite_db.hpp
@@ -199,6 +199,11 @@ class SQLiteBase
         {
             auto file            = boost::filesystem::path(filename_);
             const auto directory = file.remove_filename();
+            if(directory.string().empty())
+            {
+                dbInvalid = true;
+                return;
+            }
 
             if(!(boost::filesystem::exists(directory)))
             {


### PR DESCRIPTION
If an empty path is passed as the perf-db target directory, this results in perf-db files with just the filename resulting in an empty directory path. Which causes `boost::create_directory` function to seg fault. 

This PR ensures that

* PDB path with only filename is not created
* Empty path is not passed to create directory