### PR TITLE
Moving SQLite calls to cpp files

### DIFF
--- a/src/include/miopen/kern_db.hpp
+++ b/src/include/miopen/kern_db.hpp
@@ -105,13 +105,13 @@ class KernDb : public SQLiteBase<KernDb>
             return true;
         auto del_query =
             "DELETE FROM " + T::table_name() + " WHERE " + problem_config.Where() + ";";
-        sqlite3_stmt_ptr pStmt = Prepare(del_query);
-        auto rc                = SQLRety([&]() { return sqlite3_step(pStmt.get()); });
+        auto stmt = SQL::Statement{sql, del_query};
+        auto rc   = stmt.Step();
         if(rc == SQLITE_DONE)
             return true;
         else
         {
-            MIOPEN_THROW(miopenStatusInternalError, SQLErrorMessage());
+            MIOPEN_THROW(miopenStatusInternalError, sql.ErrorMessage());
             return false;
         }
     }
@@ -124,18 +124,15 @@ class KernDb : public SQLiteBase<KernDb>
         // Where clause with inserted values defeats the purpose of a prepraed statement
         auto select_query = "SELECT kernel_blob, kernel_hash, uncompressed_size FROM " +
                             T::table_name() + " WHERE " + problem_config.Where() + ";";
-        sqlite3_stmt_ptr pStmt = Prepare(select_query);
+        auto stmt = SQL::Statement{sql, select_query};
         // only one result field
         // assert one row
-        auto rc = SQLRety([&]() { return sqlite3_step(pStmt.get()); });
+        auto rc = stmt.Step();
         if(rc == SQLITE_ROW)
         {
-            auto ptr = sqlite3_column_blob(pStmt.get(), 0);
-            auto sz  = sqlite3_column_bytes(pStmt.get(), 0);
-            std::string compressed_blob(reinterpret_cast<const char*>(ptr), sz);
-            std::string md5_hash(reinterpret_cast<const char*>(sqlite3_column_text(pStmt.get(), 1)),
-                                 sqlite3_column_bytes(pStmt.get(), 1));
-            auto uncompressed_size         = sqlite3_column_int64(pStmt.get(), 2);
+            auto compressed_blob           = stmt.ColumnBlob(0);
+            auto md5_hash                  = stmt.ColumnText(1);
+            auto uncompressed_size         = stmt.ColumnInt64(2);
             std::string& decompressed_blob = compressed_blob;
             if(uncompressed_size != 0)
             {
@@ -165,44 +162,24 @@ class KernDb : public SQLiteBase<KernDb>
         auto uncompressed_size = problem_config.kernel_blob.size();
         bool success           = false;
         auto compressed_blob   = compress_fn(problem_config.kernel_blob, &success);
-        sqlite3_stmt_ptr pStmt = Prepare(insert_query);
-        sqlite3_bind_text(pStmt.get(),
-                          1,
-                          problem_config.kernel_name.data(),
-                          problem_config.kernel_name.size(),
-                          SQLITE_TRANSIENT); // NOLINT
-        sqlite3_bind_text(pStmt.get(),
-                          2,
-                          problem_config.kernel_args.data(),
-                          problem_config.kernel_args.size(),
-                          SQLITE_TRANSIENT); // NOLINT
+        auto stmt              = SQL::Statement{sql, insert_query};
+        stmt.BindText(1, problem_config.kernel_name);
+        stmt.BindText(2, problem_config.kernel_args);
         if(!success)
         {
-            sqlite3_bind_blob(pStmt.get(),
-                              3,
-                              problem_config.kernel_blob.data(),
-                              problem_config.kernel_blob.size(),
-                              SQLITE_TRANSIENT); // NOLINT
-            sqlite3_bind_int64(pStmt.get(), 5, 0);
+            stmt.BindBlob(3, problem_config.kernel_blob);
+            stmt.BindInt64(5, 0);
         }
         else
         {
-            sqlite3_bind_blob(pStmt.get(),
-                              3,
-                              compressed_blob.data(),
-                              compressed_blob.size(),
-                              SQLITE_TRANSIENT); // NOLINT
-            sqlite3_bind_int64(pStmt.get(), 5, uncompressed_size);
+            stmt.BindBlob(3, compressed_blob);
+            stmt.BindInt64(5, uncompressed_size);
         }
-        sqlite3_bind_text(pStmt.get(),
-                          4,
-                          md5_sum.data(),
-                          md5_sum.size(),
-                          SQLITE_TRANSIENT); // NOLINT
+        stmt.BindText(4, md5_sum);
 
-        auto rc = SQLRety([&]() { return sqlite3_step(pStmt.get()); });
+        auto rc = stmt.Step();
         if(rc != SQLITE_DONE)
-            MIOPEN_THROW(miopenStatusInternalError, SQLErrorMessage());
+            MIOPEN_THROW(miopenStatusInternalError, sql.ErrorMessage());
         return problem_config.kernel_blob;
     }
 };

--- a/src/include/miopen/kern_db.hpp
+++ b/src/include/miopen/kern_db.hpp
@@ -105,8 +105,8 @@ class KernDb : public SQLiteBase<KernDb>
             return true;
         auto del_query =
             "DELETE FROM " + T::table_name() + " WHERE " + problem_config.Where() + ";";
-        auto stmt = SQL::Statement{sql, del_query};
-        auto rc   = stmt.Step();
+        auto stmt = SQLite::Statement{sql, del_query};
+        auto rc   = stmt.Step(sql);
         if(rc == SQLITE_DONE)
             return true;
         else
@@ -124,10 +124,10 @@ class KernDb : public SQLiteBase<KernDb>
         // Where clause with inserted values defeats the purpose of a prepraed statement
         auto select_query = "SELECT kernel_blob, kernel_hash, uncompressed_size FROM " +
                             T::table_name() + " WHERE " + problem_config.Where() + ";";
-        auto stmt = SQL::Statement{sql, select_query};
+        auto stmt = SQLite::Statement{sql, select_query};
         // only one result field
         // assert one row
-        auto rc = stmt.Step();
+        auto rc = stmt.Step(sql);
         if(rc == SQLITE_ROW)
         {
             auto compressed_blob           = stmt.ColumnBlob(0);
@@ -146,7 +146,7 @@ class KernDb : public SQLiteBase<KernDb>
         else if(rc == SQLITE_DONE)
             return boost::none;
         else
-            MIOPEN_THROW(miopenStatusInternalError, SQLErrorMessage());
+            MIOPEN_THROW(miopenStatusInternalError, sql.ErrorMessage());
         return boost::none;
     }
 
@@ -162,7 +162,7 @@ class KernDb : public SQLiteBase<KernDb>
         auto uncompressed_size = problem_config.kernel_blob.size();
         bool success           = false;
         auto compressed_blob   = compress_fn(problem_config.kernel_blob, &success);
-        auto stmt              = SQL::Statement{sql, insert_query};
+        auto stmt              = SQLite::Statement{sql, insert_query};
         stmt.BindText(1, problem_config.kernel_name);
         stmt.BindText(2, problem_config.kernel_args);
         if(!success)
@@ -177,7 +177,7 @@ class KernDb : public SQLiteBase<KernDb>
         }
         stmt.BindText(4, md5_sum);
 
-        auto rc = stmt.Step();
+        auto rc = stmt.Step(sql);
         if(rc != SQLITE_DONE)
             MIOPEN_THROW(miopenStatusInternalError, sql.ErrorMessage());
         return problem_config.kernel_blob;

--- a/src/include/miopen/sqlite_db.hpp
+++ b/src/include/miopen/sqlite_db.hpp
@@ -172,7 +172,12 @@ class SQLite
         Statement(const SQLite& sql,
                   const std::string& query,
                   const std::vector<std::string>& vals);
+        Statement();
         ~Statement();
+        Statement(Statement&&);
+        Statement(const Statement&) = delete;
+        Statement& operator         =(Statement&&);
+        Statement& operator=(const Statement&) = delete;
         int Step(const SQLite& sql);
         std::string ColumnText(int idx);
         std::string ColumnBlob(int idx);
@@ -183,13 +188,18 @@ class SQLite
     };
 
     using SQLRes_t = std::vector<std::unordered_map<std::string, std::string>>;
-    SQLite() : pImpl(nullptr) {}
+    SQLite();
     SQLite(const std::string& filename_, bool is_system);
     ~SQLite();
+    SQLite(SQLite&&);
+    SQLite(const SQLite&) = delete;
+    SQLite& operator      =(SQLite&&);
+    SQLite& operator=(const SQLite&) = delete;
     bool Valid();
     bool Exec(const std::string& query, SQLRes_t& res) const;
     bool Exec(const std::string& query) const;
     int Changes() const;
+    int Retry(std::function<int()>) const;
     std::string ErrorMessage() const;
 };
 

--- a/src/include/miopen/sqlite_db.hpp
+++ b/src/include/miopen/sqlite_db.hpp
@@ -155,22 +155,45 @@ struct SQLiteSerializable
     }
 };
 
+class SQLite
+{
+    class impl;
+    // do we need propagate const
+    std::unique<impl> pImpl;
+    using SQLRes_t = std::vector<std::unordered_map<std::string, std::string>>;
+
+    public:
+    SQLite();
+    bool Valid();
+    bool Exec(const std::string& query, SQLRes_t& res);
+    bool Exec(const std::string& query);
+    int Changes();
+    std::string ErrorMessage();
+};
+
+class SQLiteStmt
+{
+    class impl;
+    std::unique_ptr<impl> pImpl;
+
+    public:
+    SQLiteStmt(const std::string& query);
+    SQLiteStmt(const std::string& query, const std::vector<std::string>& vals);
+    int Step();
+    std::string ColumnText(int idx);
+    std::string ColumnBlob(int idx);
+    int64_t ColumnInt64(int idx);
+    int BindText(int idx, const std::string& txt);
+    int BindBlob(int idx, const std::string& blob);
+    int BindInt64(int idx, int64_t);
+};
+
 template <typename Derived>
 class SQLiteBase
 {
     protected:
-    struct SQLiteCloser
-    {
-        void operator()(sqlite3* ptr)
-        {
-            std::string filename_(sqlite3_db_filename(ptr, "main"));
-            SQLiteBase::SQLRety([&]() { return sqlite3_close(ptr); }, filename_);
-        }
-    };
-    using sqlite3_ptr      = std::unique_ptr<sqlite3, SQLiteCloser>;
-    using exclusive_lock   = boost::unique_lock<LockFile>;
-    using shared_lock      = boost::shared_lock<LockFile>;
-    using sqlite3_stmt_ptr = MIOPEN_MANAGE_PTR(sqlite3_stmt*, sqlite3_finalize);
+    using exclusive_lock = boost::unique_lock<LockFile>;
+    using shared_lock    = boost::shared_lock<LockFile>;
     static boost::system_time GetLockTimeout()
     {
         return boost::get_system_time() + boost::posix_time::milliseconds(60000);
@@ -184,7 +207,7 @@ class SQLiteBase
         : filename(filename_),
           arch(arch_),
           num_cu(num_cu_),
-          lock_file(LockFile::Get(LockFilePath(filename_).c_str()))
+          lock_file(LockFile::Get(LockFilePath(filename_).c_str())),
     {
         MIOPEN_LOG_I2("Initializing " << (is_system ? "system" : "user") << " database file "
                                       << filename);
@@ -201,26 +224,15 @@ class SQLiteBase
                     boost::filesystem::permissions(directory, boost::filesystem::all_all);
             }
         }
-        sqlite3* ptr_tmp;
-        int rc = 0;
-        if(is_system)
-            rc = sqlite3_open_v2(filename_.c_str(), &ptr_tmp, SQLITE_OPEN_READONLY, nullptr);
-        else
-            rc = sqlite3_open_v2(
-                filename_.c_str(), &ptr_tmp, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE, nullptr);
-        ptrDb = sqlite3_ptr{ptr_tmp};
-        if(rc != 0)
+        sql = SQL{filename_};
+        if(!sql.Valid())
         {
             dbInvalid = true;
             if(!is_system)
-            {
                 MIOPEN_THROW(miopenStatusInternalError, "Cannot open database file:" + filename_);
-            }
             else
-            {
                 MIOPEN_LOG_W("Unable to read system database file:" + filename_ +
                              " Performance may degrade");
-            }
         }
         else
             dbInvalid = false;
@@ -229,17 +241,6 @@ class SQLiteBase
     static Derived&
     GetCached(const std::string& path, bool is_system, const std::string& arch, std::size_t num_cu);
     // TODO: Fix this for the overhead of having fields per record
-    using SQLRes_t = std::vector<std::unordered_map<std::string, std::string>>;
-
-    static int find_callback(void* _res, int argc, char** argv, char** azColName)
-    {
-        SQLRes_t* res = static_cast<SQLRes_t*>(_res);
-        std::unordered_map<std::string, std::string> record;
-        for(auto i               = 0; i < argc; i++)
-            record[azColName[i]] = (argv[i] != nullptr) ? argv[i] : "NULL";
-        res->push_back(record);
-        return 0;
-    }
 
     inline auto CheckTableColumns(const std::string& tableName,
                                   const std::vector<std::string>& goldenList) const
@@ -249,7 +250,7 @@ class SQLiteBase
         {
             const auto lock = shared_lock(lock_file, GetLockTimeout());
             MIOPEN_VALIDATE_LOCK(lock);
-            SQLExec(sql_cfg_fds, cfg_res);
+            sql.Exec(sql_cfg_fds, cfg_res);
         }
         std::vector<std::string> cfg_fds(cfg_res.size());
         std::transform(
@@ -268,107 +269,6 @@ class SQLiteBase
             }
         }
         return AllFound;
-    }
-
-    inline auto SQLExec(const std::string& query)
-    {
-        MIOPEN_LOG_T(std::this_thread::get_id() << ":" << query);
-        {
-            auto rc = SQLRety([&]() {
-                return sqlite3_exec(ptrDb.get(), query.c_str(), find_callback, nullptr, nullptr);
-            });
-            if(rc != SQLITE_OK)
-            {
-                MIOPEN_LOG_I2(query);
-                MIOPEN_THROW(miopenStatusInternalError, SQLErrorMessage());
-                sqlite3_close(ptrDb.get());
-                return false;
-            }
-        }
-        return true;
-    }
-    inline auto SQLExec(const std::string& query, SQLRes_t& res) const
-    {
-        res.clear();
-        MIOPEN_LOG_T(std::this_thread::get_id() << ":" << query);
-        {
-            auto rc = SQLRety([&]() {
-                return sqlite3_exec(
-                    ptrDb.get(), query.c_str(), find_callback, static_cast<void*>(&res), nullptr);
-            });
-            if(rc != SQLITE_OK)
-            {
-                MIOPEN_LOG_I2(query);
-                MIOPEN_THROW(miopenStatusInternalError, SQLErrorMessage());
-                sqlite3_close(ptrDb.get());
-                return false;
-            }
-        }
-        return true;
-    }
-
-    template <class F>
-    inline int SQLRety(F f) const
-    {
-        return SQLiteBase::SQLRety(f, filename);
-    }
-
-    template <class F>
-    static inline int SQLRety(F f, std::string filename)
-    {
-        auto timeout_end = std::chrono::high_resolution_clock::now() +
-                           std::chrono::seconds(30); // TODO: make configurable
-        auto tries = 0;
-        while(true)
-        {
-            int rc = f();
-            if(rc == SQLITE_BUSY)
-            {
-                MIOPEN_LOG_I2("Database" + filename + "  busy, retrying ...");
-                ++tries;
-                if(tries > 50)
-                    std::this_thread::sleep_for(std::chrono::microseconds(100));
-                else
-                    std::this_thread::yield();
-            }
-            else
-                return rc;
-            if(std::chrono::high_resolution_clock::now() > timeout_end)
-                MIOPEN_THROW("Timeout while waiting for Database: " + filename);
-        }
-    }
-
-    inline std::string SQLErrorMessage() const
-    {
-        std::string errMsg = "Internal error while accessing SQLite database: ";
-        return errMsg + sqlite3_errmsg(ptrDb.get());
-    }
-
-    auto Prepare(const std::string& query) const
-    {
-        sqlite3_stmt* ptr = nullptr;
-        MIOPEN_LOG_I2(query);
-        auto rc = sqlite3_prepare_v2(ptrDb.get(), query.c_str(), query.size(), &ptr, nullptr);
-        if(rc != SQLITE_OK)
-        {
-            std::string err_msg = "SQLite prepare error: ";
-            MIOPEN_THROW(miopenStatusInternalError, err_msg + sqlite3_errmsg(ptrDb.get()));
-        }
-        return sqlite3_stmt_ptr{ptr};
-    }
-    auto PrepareAndBind(const std::string& query, std::vector<std::string>& values) const
-    {
-        auto stmt = Prepare(query);
-        int cnt   = 1;
-        for(auto& kinder : values)
-        {
-            auto rc = sqlite3_bind_text(
-                stmt.get(), cnt++, kinder.data(), kinder.size(), SQLITE_TRANSIENT); // NOLINT
-            if(rc != SQLITE_OK)
-                MIOPEN_THROW(miopenStatusInternalError, SQLErrorMessage());
-        }
-        MIOPEN_LOG_I2("[" << JoinStrings(values, ",") << "]");
-        return stmt;
     }
 
     template <typename... U>
@@ -424,8 +324,8 @@ class SQLiteBase
     std::string arch;
     size_t num_cu;
     LockFile& lock_file;
-    sqlite3_ptr ptrDb = nullptr;
     bool dbInvalid;
+    SQLite sql;
 };
 
 template <typename Derived>
@@ -461,12 +361,12 @@ class SQLitePerfDb : public SQLiteBase<SQLitePerfDb>
         std::string clause;
         std::vector<std::string> vals;
         std::tie(clause, vals) = prob_desc.InsertQuery();
-        auto stmt = PrepareAndBind(clause, vals);
-        auto rc   = SQLRety([&]() { return sqlite3_step(stmt.get()); });
+        auto stmt = SQL : Statement{sql, clause, vals};
+        auto rc   = stmt.Step();
         if(rc != SQLITE_DONE)
             MIOPEN_THROW(miopenStatusInternalError,
                          "Failed to insert config: " + SQLErrorMessage());
-        auto cnt = sqlite3_changes(ptrDb.get());
+        auto cnt = sql.Changes();
         MIOPEN_LOG_I2(cnt << " rows updated");
     }
     template <class T>
@@ -476,20 +376,16 @@ class SQLitePerfDb : public SQLiteBase<SQLitePerfDb>
         std::vector<std::string> vals;
         std::tie(clause, vals) = prob_desc.WhereClause();
         auto query = "SELECT id FROM " + prob_desc.table_name() + " WHERE ( " + clause + " );";
-        auto stmt  = PrepareAndBind(query, vals);
+        auto stmt  = SQL::Statement{sql, query, vals};
         while(true)
         {
-            auto rc = SQLRety([&]() { return sqlite3_step(stmt.get()); });
+            auto rc = stmt.Step();
             if(rc == SQLITE_ROW)
-            {
-                auto id =
-                    std::string(reinterpret_cast<const char*>(sqlite3_column_text(stmt.get(), 0)));
-                return id;
-            }
+                return stmt.ColumnText(0);
             else if(rc == SQLITE_DONE)
                 return "";
             else if(rc == SQLITE_ERROR || rc == SQLITE_MISUSE)
-                MIOPEN_THROW(miopenStatusInternalError, SQLErrorMessage());
+                MIOPEN_THROW(miopenStatusInternalError, sql.ErrorMessage());
         }
     }
     template <typename T>
@@ -511,18 +407,13 @@ class SQLitePerfDb : public SQLiteBase<SQLitePerfDb>
             "AND (arch = '" + arch + "' ) "
             "AND (num_cu = '" + std::to_string(num_cu) + "');";
         // clang-format on
-        auto stmt = PrepareAndBind(select_query, values);
+        auto stmt = SQL::Statement{sql, select_query, values};
         DbRecord rec;
         while(true)
         {
-            auto rc = SQLRety([&]() { return sqlite3_step(stmt.get()); });
+            auto rc = stmt.Step();
             if(rc == SQLITE_ROW)
-            {
-                auto c_slvr   = sqlite3_column_text(stmt.get(), 0);
-                auto c_params = sqlite3_column_text(stmt.get(), 1);
-                rec.SetValues(std::string(reinterpret_cast<const char*>(c_slvr)),
-                              std::string(reinterpret_cast<const char*>(c_params)));
-            }
+                rec.SetValues(stmt.ColumnText(0), stmt.ColumnText(1));
             else if(rc == SQLITE_DONE)
                 break;
             else if(rc == SQLITE_ERROR || rc == SQLITE_MISUSE)
@@ -554,14 +445,14 @@ class SQLitePerfDb : public SQLiteBase<SQLitePerfDb>
             + clause + " ) )"
             "AND solver == '" +  id + "' ;";
         // clang-format on
-        auto stmt = PrepareAndBind(query, values);
-        auto rc   = SQLRety([&]() { return sqlite3_step(stmt.get()); });
+        auto stmt = SQL::Statement{sql, query, values};
+        auto rc   = stmt.Step();
         if(rc == SQLITE_DONE)
             return true;
         else
         {
             std::string msg = "Unable to remove database entry: ";
-            MIOPEN_LOG_E(msg + SQLErrorMessage());
+            MIOPEN_LOG_E(msg + sql.ErrorMessage());
             return false;
         }
     }
@@ -579,12 +470,12 @@ class SQLitePerfDb : public SQLiteBase<SQLitePerfDb>
             std::string clause;
             std::vector<std::string> vals;
             std::tie(clause, vals) = problem_config.InsertQuery();
-            auto stmt = PrepareAndBind(clause, vals);
-            auto rc   = SQLRety([&]() { return sqlite3_step(stmt.get()); });
+            auto stmt = SQL::Statement{sql, clause, vals};
+            auto rc   = stmt.Step();
             if(rc != SQLITE_DONE)
                 MIOPEN_THROW(miopenStatusInternalError,
-                             "Failed to insert config: " + SQLErrorMessage());
-            auto cnt = sqlite3_changes(ptrDb.get());
+                             "Failed to insert config: " + sql.ErrorMessage());
+            auto cnt = sql.Changes();
             MIOPEN_LOG_I2(cnt << " rows updated");
         }
 
@@ -608,12 +499,12 @@ class SQLitePerfDb : public SQLiteBase<SQLitePerfDb>
             vals.push_back(params.str());
             vals.push_back(arch);
             vals.push_back(std::to_string(num_cu));
-            auto stmt = PrepareAndBind(query, vals);
-            auto rc   = SQLRety([&]() { return sqlite3_step(stmt.get()); });
+            auto stmt = SQL::Statement{sql, query, vals};
+            auto rc   = stmt.Step();
             if(rc != SQLITE_DONE)
             {
                 MIOPEN_LOG_E("Failed to insert performance record in the database: " +
-                             SQLErrorMessage());
+                             sql.ErrorMessage());
                 return boost::none;
             }
         }
@@ -648,8 +539,8 @@ class SQLitePerfDb : public SQLiteBase<SQLitePerfDb>
             "SELECT id FROM config WHERE ( "
             + clause + " ))";
         // clang-format on
-        auto stmt = PrepareAndBind(query, values);
-        auto rc   = SQLRety([&]() { return sqlite3_step(stmt.get()); });
+        auto stmt = SQL::Statement{sql, query, values};
+        auto rc   = stmt.Step();
         if(rc != SQLITE_DONE)
         {
             MIOPEN_LOG_E("Unable to Clear databaes entry: " + SQLErrorMessage());

--- a/src/include/miopen/sqlite_db.hpp
+++ b/src/include/miopen/sqlite_db.hpp
@@ -195,7 +195,7 @@ class SQLite
     SQLite(const SQLite&) = delete;
     SQLite& operator      =(SQLite&&);
     SQLite& operator=(const SQLite&) = delete;
-    bool Valid();
+    bool Valid() const;
     bool Exec(const std::string& query, SQLRes_t& res) const;
     bool Exec(const std::string& query) const;
     int Changes() const;

--- a/src/kern_db.cpp
+++ b/src/kern_db.cpp
@@ -49,7 +49,7 @@ KernDb::KernDb(const std::string& filename_,
         const auto lock = exclusive_lock(lock_file, GetLockTimeout());
         MIOPEN_VALIDATE_LOCK(lock);
         const std::string create_table = KernelConfig::CreateQuery();
-        if(!SQLExec(create_table))
+        if(!sql.Exec(create_table))
             MIOPEN_THROW(miopenStatusInternalError);
         MIOPEN_LOG_I2("Database created successfully");
     }

--- a/src/kern_db.cpp
+++ b/src/kern_db.cpp
@@ -57,8 +57,7 @@ KernDb::KernDb(const std::string& filename_,
         const auto lock = exclusive_lock(lock_file, GetLockTimeout());
         MIOPEN_VALIDATE_LOCK(lock);
         const std::string create_table = KernelConfig::CreateQuery();
-        if(!sql.Exec(create_table))
-            MIOPEN_THROW(miopenStatusInternalError);
+        sql.Exec(create_table);
         MIOPEN_LOG_I2("Database created successfully");
     }
     if(!CheckTableColumns(KernelConfig::table_name(), KernelConfig::FieldNames()))

--- a/src/sqlite_db.cpp
+++ b/src/sqlite_db.cpp
@@ -202,7 +202,7 @@ class SQLite::Statement::impl
     }
     std::string ColumnText(int idx)
     {
-        auto bytes = sqlite3_column_bytes(ptrStmt.get(), idx);
+        size_t bytes = sqlite3_column_bytes(ptrStmt.get(), idx);
         return std::string{reinterpret_cast<const char*>(sqlite3_column_text(ptrStmt.get(), idx)),
                            bytes};
     }
@@ -252,7 +252,7 @@ bool SQLite::Exec(const std::string& query, SQLRes_t& res) const { return pImpl-
 int SQLite::Changes() const { return pImpl->Changes(); }
 int SQLite::Retry(std::function<int()> f) const { return pImpl->Retry(f); }
 std::string SQLite::ErrorMessage() const { return pImpl->ErrorMessage(); }
-
+bool SQLite::Valid() const { return pImpl->isValid; }
 SQLite::Statement::Statement(const SQLite& sql, const std::string& query)
     : pImpl{std::make_unique<impl>(sql, query)}
 {
@@ -264,6 +264,9 @@ SQLite::Statement::Statement(const SQLite& sql,
 {
 }
 SQLite::Statement::~Statement() = default;
+SQLite::Statement::Statement() : pImpl{nullptr} {}
+SQLite::Statement::Statement(Statement&&)     = default;
+SQLite::Statement& SQLite::Statement::operator=(Statement&&) = default;
 int SQLite::Statement::Step(const SQLite& sql) { return pImpl->Step(sql); }
 
 std::string SQLite::Statement::ColumnText(int idx) { return pImpl->ColumnText(idx); }
@@ -276,11 +279,6 @@ int SQLite::Statement::BindText(int idx, const std::string& txt)
 {
     return pImpl->BindText(idx, txt);
 }
-
-SQLite::Statement::Statement() : pImpl{nullptr} {}
-SQLite::Statement::~Statement()               = default;
-SQLite::Statement::Statement(Statement&&)     = default;
-SQLite::Statement& SQLite::Statement::operator=(Statement&&) = default;
 
 int SQLite::Statement::BindBlob(int idx, const std::string& blob)
 {

--- a/src/sqlite_db.cpp
+++ b/src/sqlite_db.cpp
@@ -57,7 +57,7 @@ class SQLite::impl
         void operator()(sqlite3* ptr)
         {
             std::string filename_(sqlite3_db_filename(ptr, "main"));
-            SQLiteBase::SQLRety([&]() { return sqlite3_close(ptr); }, filename_);
+            SQLite::Retry([&]() { return sqlite3_close(ptr); }, filename_);
         }
     };
 
@@ -118,9 +118,9 @@ class SQLite::impl
         res->push_back(record);
         return 0;
     }
-    inline int Retry(std::function<int()> f) const { return SQLiteBase::SQLRety(f, filename); }
+    int Retry(std::function<int()> f) const { return SQLiteBase::SQLRety(f, filename); }
 
-    static inline int Retry(std::function<int()> f, std::string filename)
+    static int Retry(std::function<int()> f, std::string filename) const
     {
         auto timeout_end = std::chrono::high_resolution_clock::now() +
                            std::chrono::seconds(30); // TODO: make configurable
@@ -144,9 +144,9 @@ class SQLite::impl
         }
     }
 
-    int Changes() { return sqlite3_changes(ptrDb.get()); }
+    int Changes() const { return sqlite3_changes(ptrDb.get()); }
 
-    inline std::string ErrorMessage() const
+    std::string ErrorMessage() const
     {
         std::string errMsg = "Internal error while accessing SQLite database: ";
         return errMsg + sqlite3_errmsg(ptrDb.get());

--- a/test/sqlite_perfdb.cpp
+++ b/test/sqlite_perfdb.cpp
@@ -327,7 +327,8 @@ class SchemaTest : public DbTest
     public:
     void Run() const
     {
-        SQLitePerfDb db_inst(std::string(temp_file), false, "gfx906", 64);
+        SQLitePerfDb db_inst(
+            std::string(temp_file), false, "gfx906", 64); // cppcheck-suppress unreadVariable
 
         // check if the config and perf_db tables exist
         SQLite::result_type res = db_inst.sql.Exec(

--- a/test/sqlite_perfdb.cpp
+++ b/test/sqlite_perfdb.cpp
@@ -243,8 +243,7 @@ class DbTest
 
     void ClearDb(SQLitePerfDb& db) const
     {
-        auto res = db.SQLExec("delete from config; delete from perf_db;");
-        EXPECT(res);
+        db.sql.Exec("delete from config; delete from perf_db;");
     }
 
     void ResetDb() const {}
@@ -331,32 +330,24 @@ class SchemaTest : public DbTest
         SQLitePerfDb db_inst(std::string(temp_file), false, "gfx906", 64);
 
         // check if the config and perf_db tables exist
-        SQLitePerfDb::SQLRes_t res;
-        if(db_inst.SQLExec(
-               // clang-format off
-               "SELECT name, sql "
-               "FROM sqlite_master "
-               "WHERE type='table' "
-                 "AND name = 'config';"
-               // clang-format on
-               ,
-               res))
-            EXPECT(res.size() == 1);
-        else
-            EXPECT(false);
-        if(db_inst.SQLExec(
-               // clang-format off
-               "SELECT name, sql "
-               "FROM sqlite_master "
-               "WHERE type='table' "
-                 "AND name = 'perf_db';"
-               // clang-format on
-               ,
-               res))
-
-            EXPECT(res.size() == 1);
-        else
-            EXPECT(false);
+        SQLite::result_type res = db_inst.sql.Exec(
+            // clang-format off
+                "SELECT name, sql "
+                "FROM sqlite_master "
+                "WHERE type='table' "
+                "AND name = 'config';"
+            // clang-format on
+            );
+        EXPECT(res.size() == 1);
+        res = db_inst.sql.Exec(
+            // clang-format off
+                "SELECT name, sql "
+                "FROM sqlite_master "
+                "WHERE type='table' "
+                "AND name = 'perf_db';"
+            // clang-format on
+            );
+        EXPECT(res.size() == 1);
         // TODO: check for indices
     }
 };
@@ -379,11 +370,11 @@ class DbFindTest : public DbTest
         const SolverData sol;
         std::ostringstream ss;
         sol.Serialize(ss);
-        EXPECT(db_inst.SQLExec(
+        db_inst.sql.Exec(
             // clang-formagt off
             "INSERT INTO perf_db(config, solver, params, arch, num_cu) "
             "VALUES( " +
-            id + ", '" + id0() + "', '" + ss.str() + "', 'gfx906', 64);"));
+            id + ", '" + id0() + "', '" + ss.str() + "', 'gfx906', 64);");
         // clang-fromat on
 
         auto sol_res = db_inst.FindRecord(p);


### PR DESCRIPTION
Currently we are not linking in the static version of sqlite, however, when we link in the static version the test breaks when the symbols are hidden. This is because part of the sqlite code is in the header and some other code is in the cpp file which cause two different instances of sqlite to be used in the test which is a problem because of the global variables used in sqlite

We need to put all the code that calls the sqlite api in cpp files, this should also improve compile time

Resolves #184 