### PR TITLE
Install CXX headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,7 @@ endif()
 list(APPEND CMAKE_PREFIX_PATH /opt/rocm /opt/rocm/llvm /opt/rocm/hip /opt/rocm/hcc)
 
 option(ENABLE_HIP_WORKAROUNDS Off)
+set(MIOPEN_INSTALL_CXX_HEADERS Off CACHE BOOL "Install MIOpen's C++ header interface")
 
 set( MIOPEN_BACKEND ${MIOPEN_DEFAULT_BACKEND} CACHE STRING
     "Which of MIOpens's backends to use?" )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -603,25 +603,19 @@ endif()
 
 ############################################################
 # Installation
+set(MIOPEN_CXX_HEADER_PATH)
 if(MIOPEN_INSTALL_CXX_HEADERS)
-rocm_install_targets(
-  TARGETS MIOpen
-  INCLUDE
-    ${PROJECT_SOURCE_DIR}/include
-    ${PROJECT_BINARY_DIR}/include
-    ${PROJECT_SOURCE_DIR}/src/include
-  PREFIX ${MIOPEN_INSTALL_DIR}
- )
-else()
-rocm_install_targets(
-  TARGETS MIOpen
-  INCLUDE
-    ${PROJECT_SOURCE_DIR}/include
-    ${PROJECT_BINARY_DIR}/include
-    ${PROJECT_SOURCE_DIR}/src/include
-  PREFIX ${MIOPEN_INSTALL_DIR}
- )
+set(MIOPEN_CXX_HEADER_PATH ${PROJECT_SOURCE_DIR}/src/include)
 endif()
+
+rocm_install_targets(
+  TARGETS MIOpen
+  INCLUDE
+    ${PROJECT_SOURCE_DIR}/include
+    ${PROJECT_BINARY_DIR}/include
+    ${MIOPEN_CXX_HEADER_PATH}
+  PREFIX ${MIOPEN_INSTALL_DIR}
+)
 
 rocm_export_targets(
   TARGETS MIOpen

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -603,13 +603,25 @@ endif()
 
 ############################################################
 # Installation
+if(MIOPEN_INSTALL_CXX_HEADERS)
 rocm_install_targets(
   TARGETS MIOpen
   INCLUDE
     ${PROJECT_SOURCE_DIR}/include
     ${PROJECT_BINARY_DIR}/include
+    ${PROJECT_SOURCE_DIR}/src/include
   PREFIX ${MIOPEN_INSTALL_DIR}
  )
+else()
+rocm_install_targets(
+  TARGETS MIOpen
+  INCLUDE
+    ${PROJECT_SOURCE_DIR}/include
+    ${PROJECT_BINARY_DIR}/include
+    ${PROJECT_SOURCE_DIR}/src/include
+  PREFIX ${MIOPEN_INSTALL_DIR}
+ )
+endif()
 
 rocm_export_targets(
   TARGETS MIOpen


### PR DESCRIPTION
Add a CMake variable to control this behavior ( default off)
Installs all CXX headers so that a client can bypass C-API limitations