### PR TITLE
Copy elision warning in ROCm 3.3 (HIP)

### DIFF
--- a/src/include/miopen/sqlite_db.hpp
+++ b/src/include/miopen/sqlite_db.hpp
@@ -249,7 +249,7 @@ class SQLiteBase
                     boost::filesystem::permissions(directory, boost::filesystem::all_all);
             }
         }
-        sql = std::move(SQLite{filename_, is_system});
+        sql = SQLite{filename_, is_system};
         if(!sql.Valid())
         {
             dbInvalid = true;


### PR DESCRIPTION
When compiling MIOpen on ROCm 3.3(HIP backend) the following warning appears:

```c++
/home/rocm-user/MIOpen/src/include/miopen/sqlite_db.hpp:252:15: warning: moving a temporary object prevents copy elision [-Wpessimizing-move]
        sql = std::move(SQLite{filename_, is_system});
              ^
/home/rocm-user/MIOpen/src/include/miopen/sqlite_db.hpp:252:15: note: remove std::move call here
        sql = std::move(SQLite{filename_, is_system});
```

This PR addresses that by removing the `std::move` as suggested by the compiler. 

Resolves #213 