### PR TITLE
prevent v4r4 wrw use for backward data

### DIFF
--- a/src/solver/conv_hip_implicit_gemm_wrw_weights_v4r4.cpp
+++ b/src/solver/conv_hip_implicit_gemm_wrw_weights_v4r4.cpp
@@ -585,7 +585,7 @@ ConvHipImplicitGemmV4R4WrW::CalculateGemmSize(const ConvolutionContext& ctx)
 
 bool ConvHipImplicitGemmV4R4WrW::IsApplicable(const ConvolutionContext& ctx) const
 {
-    if(ctx.direction.IsForward())
+    if(ctx.direction.IsForward() || ctx.direction.IsBackwardData())
         return false;
 
     if(!ctx.Is2d() && !ctx.Is3d())


### PR DESCRIPTION
v4r4 wrw use for backward weights, not for backward data