### PR TITLE
Tidy fix in ConvHipImplicitGemmV4R4WrW

### DIFF
--- a/src/include/miopen/solver.hpp
+++ b/src/include/miopen/solver.hpp
@@ -914,7 +914,7 @@ struct ConvHipImplicitGemmV4R4WrW : SolverBase<ConvolutionContext>
     bool IsValidPerformanceConfig(const ConvolutionContext& ctx,
                                   const PerformanceImplicitGemmV4R4WrW& config) const;
     PerformanceImplicitGemmV4R4WrW Search(const ConvolutionContext&) const;
-    int RunAndMeasureSolution(miopen::Handle& profile_h,
+    int RunAndMeasureSolution(const miopen::Handle& profile_h,
                               ConstData_t bot_buf,
                               ConstData_t top_buf,
                               Data_t wei_buf,

--- a/src/solver/conv_hip_implicit_gemm_wrw_weights_v4r4.cpp
+++ b/src/solver/conv_hip_implicit_gemm_wrw_weights_v4r4.cpp
@@ -624,7 +624,7 @@ ConvHipImplicitGemmV4R4WrW::Search(const ConvolutionContext& context) const
     return GenericSearchWrW(*this, context);
 }
 
-int ConvHipImplicitGemmV4R4WrW::RunAndMeasureSolution(miopen::Handle& profile_h,
+int ConvHipImplicitGemmV4R4WrW::RunAndMeasureSolution(const miopen::Handle& profile_h,
                                                       ConstData_t bot_buf,
                                                       ConstData_t top_buf,
                                                       Data_t wei_buf,


### PR DESCRIPTION
Missing `const` in a new solver originated from #205 