### PR TITLE
Dont install sys db files if UserDB access is disabled

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -642,6 +642,7 @@ rocm_export_targets(
 
 
 # Install db files
+if(NOT MIOPEN_DISABLE_USERDB)
 install(FILES
     kernels/miopen.db
     kernels/gfx803_36.HIP.fdb.txt
@@ -657,5 +658,5 @@ install(FILES
     kernels/gfx906_64.OpenCL.fdb.txt
     kernels/gfx906_60.OpenCL.fdb.txt
  DESTINATION ${DATA_INSTALL_DIR}/db)
-
+endif()
 rocm_install_symlink_subdir(${MIOPEN_INSTALL_DIR})

--- a/src/find_db.cpp
+++ b/src/find_db.cpp
@@ -47,8 +47,13 @@ boost::optional<std::string>& testing_find_db_path_override()
 template <class TDb>
 std::string FindDbRecord_t<TDb>::GetInstalledPath(Handle& handle)
 {
+#if !MIOPEN_DISABLE_USERDB
     return GetSystemDbPath() + "/" + handle.GetDbBasename() + "." + GetSystemFindDbSuffix() +
            ".fdb.txt";
+#else
+    (void)(handle);
+    return "";
+#endif
 }
 
 template <class TDb>

--- a/src/include/miopen/find_db.hpp
+++ b/src/include/miopen/find_db.hpp
@@ -87,9 +87,13 @@ class FindDbRecord_t
                                                : GetUserPath(handle)),
           installed_path(testing_find_db_path_override() ? *testing_find_db_path_override()
                                                          : GetInstalledPath(handle)),
+#if MIOPEN_DISABLE_USERDB
+          db(boost::optional<DbTimer<TDb>>{})
+#else
           db(boost::make_optional<DbTimer<TDb>>(testing_find_db_enabled &&
                                                     !IsEnabled(MIOPEN_DEBUG_DISABLE_FIND_DB{}),
                                                 DbTimer<TDb>{installed_path, path, "", 0}))
+#endif
     {
         if(!db.is_initialized())
             return;


### PR DESCRIPTION
This would still log a warning, complaining we can't access the sys db 