### PR TITLE
[Hotfix] Disable stride > 1 optimization for v4r4_gen solver

### DIFF
--- a/src/solver/conv_hip_implicit_gemm_v4r4_gen_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_v4r4_gen_xdlops.cpp
@@ -121,7 +121,6 @@ static inline ConvSolution GetSolutionBase(const ConvolutionContext& ctx,
     const int C              = KernelInputChannelC(ctx);
     const auto hi            = ConvolutionContextInterpreter::GetInputHeightHi(ctx);
     const auto wi            = ConvolutionContextInterpreter::GetInputWidthWi(ctx);
-    const auto wo_           = ConvolutionContextInterpreter::GetOutputWidthWo(ctx);
     const auto conv_stride_h = ConvolutionContextInterpreter::GetAdjustedConvolutionStrideH(ctx);
     const auto conv_stride_w = ConvolutionContextInterpreter::GetAdjustedConvolutionStrideW(ctx);
     const auto conv_dilation_w =
@@ -136,10 +135,6 @@ static inline ConvSolution GetSolutionBase(const ConvolutionContext& ctx,
     {
         // \todo there are more configs that can go through this if branch
         BBlockCopySrcDataPerRead_GemmN = gcd(BBlockCopySrcDataPerRead_GemmN, hi * wi);
-    }
-    else if(in_left_pad_w == 0 && in_right_pad_w == 0)
-    {
-        BBlockCopySrcDataPerRead_GemmN = gcd(BBlockCopySrcDataPerRead_GemmN, wo_);
     }
     else if(conv_stride_w == 1)
     {


### PR DESCRIPTION
- Fixed the failure (static_assert) that original v4r4_gen kernels are incompatible with the stride > 1 optimization  (PR #192)
- Disabled the optimization in original v4r4_gen kernels/solvers
- Will add the optimization back in refactored solver/kernel PRs