### PR TITLE
Add env var to disable immed mode fallback

### DIFF
--- a/src/ocl/convolutionocl.cpp
+++ b/src/ocl/convolutionocl.cpp
@@ -72,7 +72,7 @@ MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM)
 MIOPEN_DECLARE_ENV_VAR(MIOPEN_CONV_PRECISE_ROCBLAS_TIMING)
 MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEBUG_CONV_FFT)
 MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEBUG_CONV_SCGEMM)
-MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEBUG_CONV_DISABLE_FALLBACK)
+MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEBUG_CONV_IMMED_FALLBACK)
 
 #if MIOPEN_USE_GEMM
 #ifdef CPPCHECK
@@ -1614,7 +1614,7 @@ std::size_t ConvolutionDescriptor::GetFwdSolutionCountFallback(const TensorDescr
     ValidateGroupCount(xDesc, wDesc, *this);
 
     if(IsGemmApplicableFwd(wDesc, xDesc, yDesc) &&
-       !miopen::IsDisabled(MIOPEN_DEBUG_CONV_DISABLE_FALLBACK{}))
+       !miopen::IsDisabled(MIOPEN_DEBUG_CONV_IMMED_FALLBACK{}))
     {
         MIOPEN_LOG_I("Fallback path, GEMM");
         return 1;
@@ -1642,7 +1642,7 @@ std::size_t ConvolutionDescriptor::GetBwdSolutionCountFallback(const TensorDescr
     ValidateGroupCount(dxDesc, wDesc, *this); // See comment in Forward method.
 
     if(IsGemmApplicableBwd(dyDesc, wDesc, dxDesc) &&
-       !miopen::IsDisabled(MIOPEN_DEBUG_CONV_DISABLE_FALLBACK{}))
+       !miopen::IsDisabled(MIOPEN_DEBUG_CONV_IMMED_FALLBACK{}))
     {
         MIOPEN_LOG_I("Fallback path, GEMM");
         return 1;
@@ -1722,7 +1722,7 @@ std::size_t ConvolutionDescriptor::GetWrwSolutionCountFallback(const TensorDescr
     ValidateGroupCount(xDesc, dwDesc, *this); // See comment in Forward method.
 
     if(IsGemmApplicableWrw(xDesc, dyDesc, dwDesc) &&
-       !miopen::IsDisabled(MIOPEN_DEBUG_CONV_DISABLE_FALLBACK{}))
+       !miopen::IsDisabled(MIOPEN_DEBUG_CONV_IMMED_FALLBACK{}))
     {
         MIOPEN_LOG_I("Fallback path, GEMM");
         return 1;
@@ -1865,7 +1865,7 @@ void ConvolutionDescriptor::GetForwardSolutionsFallback(Handle& handle,
     auto i = std::size_t{0};
 
     if(IsGemmApplicableFwd(wDesc, xDesc, yDesc) &&
-       !miopen::IsDisabled(MIOPEN_DEBUG_CONV_DISABLE_FALLBACK{}))
+       !miopen::IsDisabled(MIOPEN_DEBUG_CONV_IMMED_FALLBACK{}))
     {
         MIOPEN_LOG_I("Fallback path, GEMM");
         if(i < maxSolutionCount)
@@ -1896,7 +1896,7 @@ void ConvolutionDescriptor::GetBwdSolutionsFallback(Handle& /*handle*/,
     auto i = std::size_t{0};
 
     if(IsGemmApplicableBwd(dyDesc, wDesc, dxDesc) &&
-       !miopen::IsDisabled(MIOPEN_DEBUG_CONV_DISABLE_FALLBACK{}))
+       !miopen::IsDisabled(MIOPEN_DEBUG_CONV_IMMED_FALLBACK{}))
     {
         MIOPEN_LOG_I("Fallback path, GEMM");
         if(i < maxSolutionCount)
@@ -1926,7 +1926,7 @@ void ConvolutionDescriptor::GetWrwSolutionsFallback(Handle& /*handle*/,
     auto i = std::size_t{0};
 
     if(IsGemmApplicableWrw(dyDesc, xDesc, dwDesc) &&
-       !miopen::IsDisabled(MIOPEN_DEBUG_CONV_DISABLE_FALLBACK{}))
+       !miopen::IsDisabled(MIOPEN_DEBUG_CONV_IMMED_FALLBACK{}))
     {
         MIOPEN_LOG_I("Fallback path, GEMM");
         if(i < maxSolutionCount)

--- a/src/ocl/convolutionocl.cpp
+++ b/src/ocl/convolutionocl.cpp
@@ -72,6 +72,7 @@ MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM)
 MIOPEN_DECLARE_ENV_VAR(MIOPEN_CONV_PRECISE_ROCBLAS_TIMING)
 MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEBUG_CONV_FFT)
 MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEBUG_CONV_SCGEMM)
+MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEBUG_CONV_DISABLE_FALLBACK)
 
 #if MIOPEN_USE_GEMM
 #ifdef CPPCHECK
@@ -1612,7 +1613,8 @@ std::size_t ConvolutionDescriptor::GetFwdSolutionCountFallback(const TensorDescr
     // Regular (find-db) path have been verified during Find().
     ValidateGroupCount(xDesc, wDesc, *this);
 
-    if(IsGemmApplicableFwd(wDesc, xDesc, yDesc))
+    if(IsGemmApplicableFwd(wDesc, xDesc, yDesc) &&
+       !miopen::IsDisabled(MIOPEN_DEBUG_CONV_DISABLE_FALLBACK{}))
     {
         MIOPEN_LOG_I("Fallback path, GEMM");
         return 1;
@@ -1639,7 +1641,8 @@ std::size_t ConvolutionDescriptor::GetBwdSolutionCountFallback(const TensorDescr
 {
     ValidateGroupCount(dxDesc, wDesc, *this); // See comment in Forward method.
 
-    if(IsGemmApplicableBwd(dyDesc, wDesc, dxDesc))
+    if(IsGemmApplicableBwd(dyDesc, wDesc, dxDesc) &&
+       !miopen::IsDisabled(MIOPEN_DEBUG_CONV_DISABLE_FALLBACK{}))
     {
         MIOPEN_LOG_I("Fallback path, GEMM");
         return 1;
@@ -1718,7 +1721,8 @@ std::size_t ConvolutionDescriptor::GetWrwSolutionCountFallback(const TensorDescr
 {
     ValidateGroupCount(xDesc, dwDesc, *this); // See comment in Forward method.
 
-    if(IsGemmApplicableWrw(xDesc, dyDesc, dwDesc))
+    if(IsGemmApplicableWrw(xDesc, dyDesc, dwDesc) &&
+       !miopen::IsDisabled(MIOPEN_DEBUG_CONV_DISABLE_FALLBACK{}))
     {
         MIOPEN_LOG_I("Fallback path, GEMM");
         return 1;
@@ -1860,7 +1864,8 @@ void ConvolutionDescriptor::GetForwardSolutionsFallback(Handle& handle,
     ValidateGroupCount(xDesc, wDesc, *this);
     auto i = std::size_t{0};
 
-    if(IsGemmApplicableFwd(wDesc, xDesc, yDesc))
+    if(IsGemmApplicableFwd(wDesc, xDesc, yDesc) &&
+       !miopen::IsDisabled(MIOPEN_DEBUG_CONV_DISABLE_FALLBACK{}))
     {
         MIOPEN_LOG_I("Fallback path, GEMM");
         if(i < maxSolutionCount)
@@ -1890,7 +1895,8 @@ void ConvolutionDescriptor::GetBwdSolutionsFallback(Handle& /*handle*/,
     ValidateGroupCount(dxDesc, wDesc, *this);
     auto i = std::size_t{0};
 
-    if(IsGemmApplicableBwd(dyDesc, wDesc, dxDesc))
+    if(IsGemmApplicableBwd(dyDesc, wDesc, dxDesc) &&
+       !miopen::IsDisabled(MIOPEN_DEBUG_CONV_DISABLE_FALLBACK{}))
     {
         MIOPEN_LOG_I("Fallback path, GEMM");
         if(i < maxSolutionCount)
@@ -1919,7 +1925,8 @@ void ConvolutionDescriptor::GetWrwSolutionsFallback(Handle& /*handle*/,
     ValidateGroupCount(xDesc, dwDesc, *this);
     auto i = std::size_t{0};
 
-    if(IsGemmApplicableWrw(dyDesc, xDesc, dwDesc))
+    if(IsGemmApplicableWrw(dyDesc, xDesc, dwDesc) &&
+       !miopen::IsDisabled(MIOPEN_DEBUG_CONV_DISABLE_FALLBACK{}))
     {
         MIOPEN_LOG_I("Fallback path, GEMM");
         if(i < maxSolutionCount)


### PR DESCRIPTION
By default immediate mode uses GEMM as the fallback method if no known kernel exists for a config. This env variable makes it possible to disable the fallback by exporting:

```bash
export MIOPEN_DEBUG_CONV_IMMED_FALLBACK=0
# Or "no", "false", "disable", "disabled"
```

When there is no entry in the find-db for a config and the above env variable is set the convolution will fail and GEMM will not be executed. 

This would be useful for testing #262 