### PR TITLE
Improve hip-clang version detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,6 +152,7 @@ endif()
 
 # HIP is always required
 find_package(hip REQUIRED PATHS /opt/rocm)
+message(STATUS "Build with HIP ${hip_VERSION}")
 target_flags(HIP_COMPILER_FLAGS hip::device)
 # Remove cuda arch flags
 string(REGEX REPLACE --cuda-gpu-arch=[a-z0-9]+ "" HIP_COMPILER_FLAGS "${HIP_COMPILER_FLAGS}")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -289,7 +289,7 @@ pipeline {
 
                     }
                     steps{
-                        buildHipClangJob('/opt/rocm/llvm/bin/clang++', '', "",  image+'-hip-clang', "/usr/local", cmd)
+                        buildHipClangJob('/opt/rocm/llvm/bin/clang++', '', "MIOPEN_LOG_LEVEL=5",  image+'-hip-clang', "/usr/local", cmd)
                     }
                 }
 

--- a/include/miopen/config.h.in
+++ b/include/miopen/config.h.in
@@ -42,6 +42,14 @@
 #cmakedefine01 MIOPEN_HCC_ENABLE_COV3
 #cmakedefine01 MIOPEN_DISABLE_USERDB
 
+// "_PACKAGE_" to avoid name contentions: the macros like
+// HIP_VERSION_MAJOR are defined in hip_version.h.
+// clang-format off
+#define HIP_PACKAGE_VERSION_MAJOR @hip_VERSION_MAJOR@
+#define HIP_PACKAGE_VERSION_MINOR @hip_VERSION_MINOR@
+#define HIP_PACKAGE_VERSION_PATCH @hip_VERSION_PATCH@
+// clang-format on
+
 // Truncation rounding or (default) rounding to nearest even (RNE) is enabled.
 // This switch controls two related but different aspects of MIOpen behavior:
 // 1.  How host code performs conversions of float to bfloat16, important only

--- a/src/execution_context.cpp
+++ b/src/execution_context.cpp
@@ -164,7 +164,7 @@ static rocm_meta_version AmdRocmMetadataVersionDetect(const miopen::ExecutionCon
         }
 #else
         (void)context;
-        if(miopen::HipGetHccVersion() >=
+        if(miopen::HipCompilerVersion() >=
            miopen::external_tool_version_t{2, 10, 19392}) // ROCm 2.10 RC 1341
             rmv = rocm_meta_version::AMDHSA_COv2_COv3;
         else

--- a/src/execution_context.cpp
+++ b/src/execution_context.cpp
@@ -155,7 +155,7 @@ static rocm_meta_version AmdRocmMetadataVersionDetect(const miopen::ExecutionCon
             const int num = std::stoi(platform_version.substr(num_begin + 1));
             if(num >= 3137) // ROCm 3.5 RC
                 rmv = rocm_meta_version::AMDHSA_COv3;
-            if(num >= 3029) // ROCm 2.10 RC 1341
+            else if(num >= 3029) // ROCm 2.10 RC 1341
                 rmv = rocm_meta_version::AMDHSA_COv2_COv3;
             else
                 rmv = rocm_meta_version::AMDHSA_COv2;

--- a/src/execution_context.cpp
+++ b/src/execution_context.cpp
@@ -153,6 +153,8 @@ static rocm_meta_version AmdRocmMetadataVersionDetect(const miopen::ExecutionCon
         if(num_begin != std::string::npos)
         {
             const int num = std::stoi(platform_version.substr(num_begin + 1));
+            if(num >= 3137) // ROCm 3.5 RC
+                rmv = rocm_meta_version::AMDHSA_COv3;
             if(num >= 3029) // ROCm 2.10 RC 1341
                 rmv = rocm_meta_version::AMDHSA_COv2_COv3;
             else
@@ -165,7 +167,10 @@ static rocm_meta_version AmdRocmMetadataVersionDetect(const miopen::ExecutionCon
 #else
         (void)context;
         if(miopen::HipCompilerVersion() >=
-           miopen::external_tool_version_t{2, 10, 19392}) // ROCm 2.10 RC 1341
+           miopen::external_tool_version_t{3, 5, 0}) // ROCm 3.5 RC and up
+            rmv = rocm_meta_version::AMDHSA_COv3;
+        else if(miopen::HipCompilerVersion() >=
+                miopen::external_tool_version_t{2, 10, 19392}) // ROCm 2.10 RC 1341
             rmv = rocm_meta_version::AMDHSA_COv2_COv3;
         else
             rmv = rocm_meta_version::Default;

--- a/src/hip/hip_build_utils.cpp
+++ b/src/hip/hip_build_utils.cpp
@@ -24,13 +24,13 @@
 *
 *******************************************************************************/
 
+#include <miopen/config.h>
 #include <miopen/hip_build_utils.hpp>
 #include <miopen/stringutils.hpp>
 #include <miopen/exec_utils.hpp>
 #include <miopen/logger.hpp>
 #include <miopen/env.hpp>
 #include <boost/optional.hpp>
-#include <hip/hip_version.h>
 #include <sstream>
 #include <string>
 
@@ -271,10 +271,25 @@ static external_tool_version_t HipCompilerVersionImpl()
     }
     else
     {
-        MIOPEN_LOG_NQI2("Read version information from hip_version.h");
-        version.major = HIP_VERSION_MAJOR;
-        version.minor = HIP_VERSION_MINOR;
-        version.patch = HIP_VERSION_PATCH;
+#ifdef HIP_PACKAGE_VERSION_MAJOR
+        MIOPEN_LOG_NQI2("Read version information from HIP package...");
+        version.major = HIP_PACKAGE_VERSION_MAJOR;
+#ifdef HIP_PACKAGE_VERSION_MINOR
+        version.minor = HIP_PACKAGE_VERSION_MINOR;
+#else
+        version.minor = 0;
+#endif
+#ifdef HIP_PACKAGE_VERSION_PATCH
+        version.patch = HIP_PACKAGE_VERSION_PATCH;
+#else
+        version.patch = 0;
+#endif
+#else // HIP_PACKAGE_VERSION_MAJOR is not defined. CMake failed to find HIP package.
+        MIOPEN_LOG_NQI2("...assuming 3.2.0 (hip-clang RC)");
+        version.major = 3;
+        version.minor = 2;
+        version.patch = 0;
+#endif
     }
     MIOPEN_LOG_NQI(version.major << '.' << version.minor << '.' << version.patch);
     return version;

--- a/src/hipoc/hipoc_program.cpp
+++ b/src/hipoc/hipoc_program.cpp
@@ -65,7 +65,7 @@ inline bool ProduceCoV3()
     // Otherwise, let's assume that OpenCL kernels shall be compiled to
     // CO v3 format by default since ROCm 3.0. The simplest way to find out
     // this right now is checking the HIP compiler version string.
-    return (HipGetHccVersion() >= external_tool_version_t{3, 0, -1});
+    return (HipCompilerVersion() >= external_tool_version_t{3, 0, -1});
 }
 
 /// Returns option for enabling/disabling CO v3 generation for the compiler

--- a/src/include/miopen/hip_build_utils.hpp
+++ b/src/include/miopen/hip_build_utils.hpp
@@ -50,10 +50,10 @@ struct external_tool_version_t
     bool operator>=(const external_tool_version_t& rhs) const;
 };
 
-external_tool_version_t HipGetHccVersion();
+external_tool_version_t HipCompilerVersion();
 
 bool IsHccCompiler();
-bool IsClangXXCompiler();
+bool IsHipClangCompiler();
 
 } // namespace miopen
 

--- a/src/solver/conv_hip_implicit_gemm_v4.cpp
+++ b/src/solver/conv_hip_implicit_gemm_v4.cpp
@@ -77,7 +77,7 @@ bool ConvHipImplicitGemmV4Fwd::IsApplicable(const ConvolutionContext& ctx) const
         return false;
 
 #if WORKAROUND_ISSUE_2174_2222_2224_2243
-    if(miopen::HipGetHccVersion() >= external_tool_version_t{2, 6, 0})
+    if(miopen::HipCompilerVersion() >= external_tool_version_t{2, 6, 0})
     {
         if(!(ctx.kernel_dilation_h == 1 && ctx.kernel_dilation_w == 1))
             return false;
@@ -122,7 +122,7 @@ bool ConvHipImplicitGemmV4WrW::IsApplicable(const ConvolutionContext& ctx) const
         return false;
 
 #if WORKAROUND_ISSUE_2174_2222_2224_2243
-    if(miopen::HipGetHccVersion() >= external_tool_version_t{2, 6, 0})
+    if(miopen::HipCompilerVersion() >= external_tool_version_t{2, 6, 0})
     {
         if(!(ctx.kernel_stride_w == 1 && ctx.kernel_stride_h == 1))
             return false;

--- a/src/solver/implicitgemm_util.hpp
+++ b/src/solver/implicitgemm_util.hpp
@@ -391,7 +391,7 @@ static inline bool IsXdlopsSupport(const ConvolutionContext& c)
     return StartsWith(c.GetStream().GetDeviceName(), "gfx908") &&
 #if WORKAROUND_SWDEV_200782
            /// \todo Remove workaround when we drop suport of HCC older than 2.10.19392.
-           ((miopen::HipGetHccVersion() >= external_tool_version_t{2, 10, 19392})
+           ((miopen::HipCompilerVersion() >= external_tool_version_t{2, 10, 19392})
                 ? !miopen::IsDisabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_XDLOPS{})
                 : miopen::IsEnabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_XDLOPS{}));
 #else


### PR DESCRIPTION
- hip-clang compiler version borrowed from HIP package.
  - Resolves a bullet from issue 2514 https://github.com/AMDComputeLibraries/MLOpen/issues/2514
- Detected that CO v2 is not supported since ROCm3.5 RC.
  - This finally closes work related to https://github.com/AMDComputeLibraries/MLOpen/issues/2514
- [CI testing] Raise log level to 5 for the "Hip clang debug COMGR" stage
