### PR TITLE
MPWinogradWRW solver update  gfx906

### DIFF
--- a/src/solver/conv_multipass_wino3x3WrW.cpp
+++ b/src/solver/conv_multipass_wino3x3WrW.cpp
@@ -384,7 +384,7 @@ bool ConvWinograd3x3MultipassWrW<WinoDataH, WinoFilterH, WinoDataW, WinoFilterW>
 
     const std::string name = params.GetStream().GetDeviceName();
 #if WORKAROUND_SWDEV_234193
-    if(params.IsFp16() && StartsWith(name, "gfx908"))
+    if(params.IsFp16() && (StartsWith(name, "gfx908") || StartsWith(name, "gfx906")))
     {
         if(wino_data_tile == 3 && wino_filter_tile == 4)
             if(!miopen::IsEnabled(MIOPEN_DEBUG_AMD_WINOGRAD_MPASS_F3X4{}))


### PR DESCRIPTION
MultipassWinogradWrW3x{4,5,6} disabled by default for fp16 n gfx906
