### PR TITLE
[comgr] HIP support

### DIFF
--- a/src/comgr.cpp
+++ b/src/comgr.cpp
@@ -24,8 +24,10 @@
  *
  *******************************************************************************/
 
+#include <miopen/algorithm.hpp>
 #include <miopen/env.hpp>
 #include <miopen/errors.hpp>
+#include <miopen/kernel.hpp>
 #include <miopen/logger.hpp>
 #include <miopen/stringutils.hpp>
 #include <amd_comgr.h>
@@ -38,9 +40,15 @@
 
 MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEBUG_COMGR_LOG_CALLS)
 MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEBUG_COMGR_LOG_OPTIONS)
+
 /// Integer, set to max number of first characters
 /// you would like to log onto console.
 MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEBUG_COMGR_LOG_SOURCE_TEXT)
+
+/// \todo Temporary for debugging:
+MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEBUG_COMGR_COMPILER_OPTIONS_INSERT)
+/// \todo Temporary for debugging:
+MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEBUG_COMGR_HIP_BUILD_FATBIN)
 
 /// \todo see issue #1222, PR #1316
 MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEBUG_SRAM_EDC_DISABLED)
@@ -115,13 +123,70 @@ static void AddOcl20CompilerOptions(OptionList& list)
 /// (or even can be harmful) for building via comgr layer.
 ///
 /// \todo Produce proper options in, er, proper places, and get rid of this.
-static void RemoveSuperfluousOptions(OptionList& list)
+static void RemoveOclOptionsUnwanted(OptionList& list)
 {
     list.erase(remove_if(list.begin(),
                          list.end(),
                          [&](const auto& option) { return StartsWith(option, "-mcpu="); }),
                list.end());
 }
+
+static auto GetOptionsNoSplit()
+{
+    static const std::vector<std::string> rv = {
+        "-isystem", "-L", "-Wl,-rpath", "-Xclang", "-hip-path", "-mllvm", "-x"};
+    return rv;
+}
+
+namespace hip {
+
+static bool IsLinkerOption(const std::string& option)
+{
+    return miopen::StartsWith(option, "-L") || miopen::StartsWith(option, "-Wl,") ||
+           option == "-ldl" || option == "-lm" || option == "--hip-link";
+}
+
+static void RemoveCommonOptionsUnwanted(OptionList& list)
+{
+    list.erase(remove_if(list.begin(),
+                         list.end(),
+                         [&](const auto& option) { // clang-format off
+                             return miopen::StartsWith(option, "-mcpu=")
+                                || (option == "-hc")
+                                || (option == "-x hip")
+                                || (option == "--hip-link")
+                                || miopen::StartsWith(option, "-mllvm -amdgpu-early-inline-all")
+                                || miopen::StartsWith(option, "-mllvm -amdgpu-function-calls")
+                                || miopen::StartsWith(option, "--hip-device-lib-path="); // clang-format on
+                         }),
+               list.end());
+}
+
+static void RemoveCompilerOptionsUnwanted(OptionList& list)
+{
+    RemoveCommonOptionsUnwanted(list);
+    list.erase(remove_if(list.begin(),
+                         list.end(),
+                         [&](const auto& option) { // clang-format off
+                             return (!miopen::IsEnabled(MIOPEN_DEBUG_COMGR_HIP_BUILD_FATBIN{})
+                                    && (IsLinkerOption(option))); // clang-format on
+                         }),
+               list.end());
+}
+
+static void RemoveLinkOptionsUnwanted(OptionList& list)
+{
+    RemoveCommonOptionsUnwanted(list);
+    list.erase(remove_if(list.begin(),
+                         list.end(),
+                         [&](const auto& option) { // clang-format off
+                             return miopen::StartsWith(option, "-D")
+                                || miopen::StartsWith(option, "-isystem"); // clang-format on
+                         }),
+               list.end());
+}
+
+} // namespace hip
 
 /// \todo Get list of supported isa names from comgr and select.
 static std::string GetIsaName(const std::string& device)
@@ -132,8 +197,6 @@ static std::string GetIsaName(const std::string& device)
                                        : "";
     return {"amdgcn-amd-amdhsa--" + device + ecc_suffix};
 }
-
-/// \todo Handle "-cl-fp32-correctly-rounded-divide-sqrt".
 
 } // namespace lc
 #undef OCL_EARLY_INLINE
@@ -206,13 +269,19 @@ static std::string to_string(const amd_comgr_action_kind_t val)
     return oss.str();
 }
 
-static bool PrintVersion()
+static bool PrintVersionImpl()
 {
     std::size_t major = 0;
     std::size_t minor = 0;
     (void)amd_comgr_get_version(&major, &minor);
     MIOPEN_LOG_NQI("comgr v." << major << '.' << minor);
     return true;
+}
+
+static void PrintVersion()
+{
+    static const auto once = PrintVersionImpl();
+    std::ignore            = once;
 }
 
 static std::string GetStatusText(const amd_comgr_status_t status)
@@ -225,12 +294,19 @@ static std::string GetStatusText(const amd_comgr_status_t status)
 
 static void LogOptions(const char* options[], size_t count)
 {
-    if(miopen::IsEnabled(MIOPEN_DEBUG_COMGR_LOG_OPTIONS{}) &&
-       miopen::IsLogging(miopen::LoggingLevel::Info))
+    static const auto control = miopen::Value(MIOPEN_DEBUG_COMGR_LOG_OPTIONS{}, 0);
+    if(!(control != 0 && miopen::IsLogging(miopen::LoggingLevel::Info)))
+        return;
+    if(control == 2)
+    {
+        for(std::size_t i = 0; i < count; ++i)
+            MIOPEN_LOG_I(options[i]);
+    }
+    else
     {
         std::ostringstream oss;
         for(std::size_t i = 0; i < count; ++i)
-            oss << options[i] << '\t';
+            oss << options[i] << ' ';
         MIOPEN_LOG_I(oss.str());
     }
 }
@@ -349,7 +425,7 @@ class Dataset : ComgrOwner
         AddData(d);
         const auto show_first = miopen::Value(MIOPEN_DEBUG_COMGR_LOG_SOURCE_TEXT{}, 0);
         if(show_first > 0 && miopen::IsLogging(miopen::LoggingLevel::Info) &&
-           type == AMD_COMGR_DATA_KIND_SOURCE)
+           (type == AMD_COMGR_DATA_KIND_SOURCE || type == AMD_COMGR_DATA_KIND_INCLUDE))
         {
             const auto text_length = (content.size() > show_first) ? show_first : content.size();
             const std::string text(content, 0, text_length);
@@ -456,28 +532,127 @@ static std::string GetLog(const Dataset& dataset, const bool comgr_error_handlin
     return text;
 }
 
+static void SetIsaName(const ActionInfo& action, const std::string& device)
+{
+    // This can't be implemented in ActionInfo because
+    // comgr wrappers should not depend on compiler implementation.
+    const auto isaName = compiler::lc::GetIsaName(device);
+    MIOPEN_LOG_I2(isaName);
+    action.SetIsaName(isaName);
+}
+
+static std::string GetDebugCompilerOptionsInsert()
+{
+    const char* p = miopen::GetStringEnv(MIOPEN_DEBUG_COMGR_COMPILER_OPTIONS_INSERT{});
+    if(p == nullptr)
+        p = "";
+    return {p};
+}
+
+void BuildHip(const std::string& name,
+              const std::string& text,
+              const std::string& options,
+              const std::string& device,
+              std::vector<char>& binary)
+{
+    PrintVersion();
+    try
+    {
+        const Dataset inputs;
+        inputs.AddData(name, text, AMD_COMGR_DATA_KIND_SOURCE);
+
+        // For OCL and ASM sources, we do insert contents of include
+        // files directly into the source text during library build phase by means
+        // of the addkernels tool. We don't do that for HIP sources, and, therefore
+        // have to export include files prior compilation.
+        // Note that we do not need any "subdirs" in the include "pathnames" so far.
+        const auto incNames = miopen::GetHipKernelIncList();
+        for(const auto& inc : incNames)
+            inputs.AddData(inc, miopen::GetKernelInc(inc), AMD_COMGR_DATA_KIND_INCLUDE);
+
+        const ActionInfo action;
+        action.SetLanguage(AMD_COMGR_LANGUAGE_HIP);
+        SetIsaName(action, device);
+        action.SetLogging(true);
+
+        const Dataset exe;
+        if(miopen::IsEnabled(MIOPEN_DEBUG_COMGR_HIP_BUILD_FATBIN{}))
+        {
+            auto raw = options                                 //
+                       + " " + GetDebugCompilerOptionsInsert() //
+                       + " " + MIOPEN_STRINGIZE(HIP_COMPILER_FLAGS);
+            auto optCompile = miopen::SplitSpaceSeparated(raw, compiler::lc::GetOptionsNoSplit());
+            compiler::lc::hip::RemoveCompilerOptionsUnwanted(optCompile);
+            action.SetOptionList(optCompile);
+            action.Do(AMD_COMGR_ACTION_COMPILE_SOURCE_TO_FATBIN, inputs, exe);
+        }
+        else
+        {
+            auto raw = std::string(" -O3 ")                    // Without this, fails in lld.
+                       + options                               //
+                       + " " + GetDebugCompilerOptionsInsert() //
+                       + " " + MIOPEN_STRINGIZE(HIP_COMPILER_FLAGS);
+            auto optCompile = miopen::SplitSpaceSeparated(raw, compiler::lc::GetOptionsNoSplit());
+            auto optLink    = optCompile;
+            compiler::lc::hip::RemoveCompilerOptionsUnwanted(optCompile);
+            compiler::lc::hip::RemoveLinkOptionsUnwanted(optLink);
+
+            action.SetOptionList(optCompile);
+            const Dataset compiledBc;
+            action.Do(AMD_COMGR_ACTION_COMPILE_SOURCE_TO_BC, inputs, compiledBc);
+
+            OptionList addDevLibs;
+            addDevLibs.push_back("wavefrontsize64");
+            addDevLibs.push_back("daz_opt");     // Assume that it's ok to flush denormals to zero.
+            addDevLibs.push_back("finite_only"); // No need to handle INF correcly.
+            addDevLibs.push_back("unsafe_math"); // Prefer speed over correctness for FP math.
+            action.SetOptionList(addDevLibs);
+            const Dataset withDevLibs;
+            action.Do(AMD_COMGR_ACTION_ADD_DEVICE_LIBRARIES, compiledBc, withDevLibs);
+
+            action.SetOptionList(optLink);
+            const Dataset linkedBc;
+            action.Do(AMD_COMGR_ACTION_LINK_BC_TO_BC, withDevLibs, linkedBc);
+            const Dataset relocatable;
+            action.Do(AMD_COMGR_ACTION_CODEGEN_BC_TO_RELOCATABLE, linkedBc, relocatable);
+
+            action.SetOptionList(OptionList());
+            action.Do(AMD_COMGR_ACTION_LINK_RELOCATABLE_TO_EXECUTABLE, relocatable, exe);
+        }
+
+        constexpr auto INTENTIONALY_UNKNOWN = static_cast<amd_comgr_status_t>(0xffff);
+        if(exe.GetDataCount(AMD_COMGR_DATA_KIND_EXECUTABLE) < 1)
+            throw ComgrError{INTENTIONALY_UNKNOWN, "Executable binary not found"};
+        // Assume that the first exec data contains the binary we need.
+        const auto data = exe.GetData(AMD_COMGR_DATA_KIND_EXECUTABLE, 0);
+        data.GetBytes(binary);
+    }
+    catch(ComgrError& ex)
+    {
+        MIOPEN_LOG_E("comgr status = " << GetStatusText(ex.status));
+        if(!ex.text.empty())
+            MIOPEN_LOG_W(ex.text);
+    }
+}
+
 void BuildOcl(const std::string& name,
               const std::string& text,
               const std::string& options,
               const std::string& device,
               std::vector<char>& binary)
 {
-    static const auto once = PrintVersion(); // Nice to see in the user's logs.
-    std::ignore            = once;
-
+    PrintVersion(); // Nice to see in the user's logs.
     try
     {
         const Dataset inputs;
         inputs.AddData(name, text, AMD_COMGR_DATA_KIND_SOURCE);
         const ActionInfo action;
         action.SetLanguage(AMD_COMGR_LANGUAGE_OPENCL_2_0);
-        const auto isaName = compiler::lc::GetIsaName(device);
-        MIOPEN_LOG_I2(isaName);
-        action.SetIsaName(isaName);
+        SetIsaName(action, device);
         action.SetLogging(true);
 
-        auto optCompile = SplitSpaceSeparated(options);
-        compiler::lc::RemoveSuperfluousOptions(optCompile);
+        auto optCompile = miopen::SplitSpaceSeparated(options);
+        compiler::lc::RemoveOclOptionsUnwanted(optCompile);
         compiler::lc::AddOcl20CompilerOptions(optCompile);
         action.SetOptionList(optCompile);
 

--- a/src/hipoc/hipoc_program.cpp
+++ b/src/hipoc/hipoc_program.cpp
@@ -189,6 +189,10 @@ struct HIPOCProgramImpl
         }
         if(miopen::EndsWith(filename, ".cpp"))
         {
+#if MIOPEN_WORKAROUND_ROCM_COMPILER_SUPPORT_ISSUE_27
+            static std::mutex mutex;
+            std::lock_guard<std::mutex> lock(mutex);
+#endif
             comgr::BuildHip(filename, src, params, device, binary);
         }
         else

--- a/src/hipoc/hipoc_program.cpp
+++ b/src/hipoc/hipoc_program.cpp
@@ -183,10 +183,13 @@ struct HIPOCProgramImpl
         (void)filename;
         return false;
 #else
-        if(miopen::EndsWith(filename, ".so") || miopen::EndsWith(filename, ".s") ||
-           miopen::EndsWith(filename, ".cpp"))
+        if(miopen::EndsWith(filename, ".so") || miopen::EndsWith(filename, ".s"))
         {
             return false;
+        }
+        if(miopen::EndsWith(filename, ".cpp"))
+        {
+            comgr::BuildHip(filename, src, params, device, binary);
         }
         else
         {

--- a/src/include/miopen/comgr.hpp
+++ b/src/include/miopen/comgr.hpp
@@ -35,6 +35,12 @@
 namespace miopen {
 namespace comgr {
 
+void BuildHip(const std::string& name,
+              const std::string& text,
+              const std::string& options,
+              const std::string& device,
+              std::vector<char>& binary);
+
 void BuildOcl(const std::string& name,
               const std::string& text,
               const std::string& options,

--- a/src/include/miopen/kernel.hpp
+++ b/src/include/miopen/kernel.hpp
@@ -35,6 +35,7 @@ namespace miopen {
 std::string GetKernelSrc(std::string name);
 std::string GetKernelInc(std::string key);
 std::vector<std::string> GetKernelIncList();
+std::vector<std::string> GetHipKernelIncList();
 } // namespace miopen
 
 #if MIOPEN_BACKEND_OPENCL

--- a/src/include/miopen/stringutils.hpp
+++ b/src/include/miopen/stringutils.hpp
@@ -26,10 +26,13 @@
 #ifndef GUARD_MIOPEN_STRINGUTILS_HPP
 #define GUARD_MIOPEN_STRINGUTILS_HPP
 
+#include <miopen/algorithm.hpp>
+#include <miopen/errors.hpp>
 #include <algorithm>
 #include <iterator>
 #include <numeric>
 #include <string>
+#include <vector>
 #include <sstream>
 
 #define MIOPEN_STRINGIZE_1(...) #__VA_ARGS__
@@ -96,9 +99,32 @@ inline std::string RemovePrefix(std::string s, std::string prefix)
 
 inline std::vector<std::string> SplitSpaceSeparated(const std::string& in)
 {
-    std::stringstream ss(in);
+    std::istringstream ss(in);
     std::istream_iterator<std::string> begin(ss), end;
     return {begin, end};
+}
+
+inline std::vector<std::string> SplitSpaceSeparated(const std::string& in,
+                                                    const std::vector<std::string>& dontSplitAfter)
+{
+    std::vector<std::string> rv;
+    std::istringstream ss(in);
+    std::string s;
+    while(ss >> s)
+    {
+        if(any_of(dontSplitAfter, [&](const auto& dont) { return dont == s; }))
+        {
+            std::string s2;
+            if(ss >> s2)
+            {
+                rv.push_back(s + ' ' + s2); // Exactly one space is important.
+                continue;
+            }
+            MIOPEN_THROW("Error parsing string: '" + in + '\'');
+        }
+        rv.push_back(s);
+    }
+    return rv;
 }
 
 } // namespace miopen

--- a/src/include/miopen/stringutils.hpp
+++ b/src/include/miopen/stringutils.hpp
@@ -117,7 +117,8 @@ inline std::vector<std::string> SplitSpaceSeparated(const std::string& in,
             std::string s2;
             if(ss >> s2)
             {
-                rv.push_back(s + ' ' + s2); // Exactly one space is important.
+                s += std::string(" ").append(s2); // Exactly one space is important.
+                rv.push_back(s);
                 continue;
             }
             MIOPEN_THROW("Error parsing string: '" + in + '\'');

--- a/src/kernels/kernel_includes.cpp.in
+++ b/src/kernels/kernel_includes.cpp.in
@@ -36,6 +36,7 @@ const std::map<std::string, std::string>& kernel_includes()
     static const std::map<std::string, std::string> data{${INIT_KERNELS}};
     return data;
 }
+
 std::string GetKernelInc(std::string key)
 {
     auto it = kernel_includes().find(key);
@@ -44,6 +45,7 @@ std::string GetKernelInc(std::string key)
 
     return it->second;
 }
+
 std::vector<std::string> GetKernelIncList()
 {
     std::vector<std::string> keys;
@@ -54,4 +56,17 @@ std::vector<std::string> GetKernelIncList()
                    [](decltype(m)::value_type const& pair) { return pair.first; });
     return keys;
 }
+
+std::vector<std::string> GetHipKernelIncList()
+{
+    auto keys = GetKernelIncList();
+    keys.erase(std::remove_if(keys.begin(),
+                              keys.end(),
+                              [&](const auto& key) {
+                                  return !(EndsWith(key, ".hpp") || EndsWith(key, ".h"));
+                              }),
+               keys.end());
+    return keys;
+}
+
 } // namespace miopen

--- a/test/handle_test.cpp
+++ b/test/handle_test.cpp
@@ -31,11 +31,11 @@
 #include <thread>
 #include "test.hpp"
 
-/// In comgr-driven OCL builds, -Werror does not working.
+/// In comgr-driven OCL and HIP builds, -Werror is not working.
 /// Also -Wunused-parameter is not enabled by default and can't be enabled.
 /// Let's skip the test for now.
-/// \todo Create ticket for compiler.
-#define WORKAROUND_COMGR_OCL_WARNING_ISSUES MIOPEN_USE_COMGR
+/// \todo Create ticket for comgr.
+#define WORKAROUND_COMGR_WARNING_ISSUES MIOPEN_USE_COMGR
 
 enum kernel_type_t
 {
@@ -165,15 +165,12 @@ std::string WriteNop(kernel_type_t kern_type)
 void test_warnings(kernel_type_t kern_type)
 {
     auto&& h = get_handle();
-#if MIOPEN_BUILD_DEV
-#if !WORKAROUND_COMGR_OCL_WARNING_ISSUES
+#if MIOPEN_BUILD_DEV && !WORKAROUND_COMGR_WARNING_ISSUES
     if(kern_type == miopenOpenCLKernelType)
         EXPECT(throws([&] {
             h.AddKernel("GEMM", "", WriteNop(kern_type), "write", {1, 1, 1}, {1, 1, 1}, "");
         }));
-    else
-#endif
-        if(kern_type == miopenHIPKernelType)
+    else if(kern_type == miopenHIPKernelType)
         EXPECT(throws([&] {
             h.AddKernel("NoAlgo",
                         "",


### PR DESCRIPTION
- Two paths: "in-process" and one-step "COMPILE_SOURCE_TO_FATBIN".
  - The latter is experimental and doesn't work for now
    - Can be enabled by `MIOPEN_DEBUG_COMGR_HIP_BUILD_FATBIN`.
- Added .hpp/.h includes to the input dataset.
- Build options: `HIP_COMPILER_FLAGS` transformed and added.
- Added env var `MIOPEN_DEBUG_COMGR_COMPILER_OPTIONS_INSERT` for debugging.
- Some refactors.

Some details about performance: https://github.com/ROCmSoftwarePlatform/MIOpen/pull/289#issuecomment-645494178