### PR TITLE
[comgr] Build ASM kernels

### DIFF
--- a/src/hipoc/hipoc_program.cpp
+++ b/src/hipoc/hipoc_program.cpp
@@ -188,31 +188,19 @@ struct HIPOCProgramImpl
             binary.resize(sz);
             std::memcpy(&binary[0], src.c_str(), sz);
         }
-        else if(miopen::EndsWith(filename, ".cpp"))
-        {
-#if MIOPEN_WORKAROUND_ROCM_COMPILER_SUPPORT_ISSUE_27
-            static std::mutex mutex;
-            std::lock_guard<std::mutex> lock(mutex);
-#endif
-            comgr::BuildHip(filename, src, params, device, binary);
-        }
-        else if(miopen::EndsWith(filename, ".s"))
-        {
-#if MIOPEN_WORKAROUND_ROCM_COMPILER_SUPPORT_ISSUE_27
-            static std::mutex mutex;
-            std::lock_guard<std::mutex> lock(mutex);
-#endif
-            comgr::BuildAsm(filename, src, params, device, binary);
-        }
         else
         {
 #if MIOPEN_WORKAROUND_ROCM_COMPILER_SUPPORT_ISSUE_27
             static std::mutex mutex;
             std::lock_guard<std::mutex> lock(mutex);
 #endif
-            comgr::BuildOcl(filename, src, params, device, binary);
+            if(miopen::EndsWith(filename, ".cpp"))
+                comgr::BuildHip(filename, src, params, device, binary);
+            else if(miopen::EndsWith(filename, ".s"))
+                comgr::BuildAsm(filename, src, params, device, binary);
+            else
+                comgr::BuildOcl(filename, src, params, device, binary);
         }
-
         if(binary.empty())
             MIOPEN_THROW("Code object build failed. Source: " + filename);
     }

--- a/src/hipoc/hipoc_program.cpp
+++ b/src/hipoc/hipoc_program.cpp
@@ -38,6 +38,7 @@
 #include <miopen/comgr.hpp>
 #include <boost/optional.hpp>
 
+#include <cstring>
 #include <mutex>
 #include <sstream>
 
@@ -184,9 +185,12 @@ struct HIPOCProgramImpl
         return false;
 #else
         if(miopen::EndsWith(filename, ".so"))
-            return false;
-
-        if(miopen::EndsWith(filename, ".cpp"))
+        {
+            std::size_t sz = src.length();
+            binary.resize(sz);
+            std::memcpy(&binary[0], src.c_str(), sz);
+        }
+        else if(miopen::EndsWith(filename, ".cpp"))
         {
 #if MIOPEN_WORKAROUND_ROCM_COMPILER_SUPPORT_ISSUE_27
             static std::mutex mutex;

--- a/src/hipoc/hipoc_program.cpp
+++ b/src/hipoc/hipoc_program.cpp
@@ -183,10 +183,9 @@ struct HIPOCProgramImpl
         (void)filename;
         return false;
 #else
-        if(miopen::EndsWith(filename, ".so") || miopen::EndsWith(filename, ".s"))
-        {
+        if(miopen::EndsWith(filename, ".so"))
             return false;
-        }
+
         if(miopen::EndsWith(filename, ".cpp"))
         {
 #if MIOPEN_WORKAROUND_ROCM_COMPILER_SUPPORT_ISSUE_27
@@ -194,6 +193,14 @@ struct HIPOCProgramImpl
             std::lock_guard<std::mutex> lock(mutex);
 #endif
             comgr::BuildHip(filename, src, params, device, binary);
+        }
+        else if(miopen::EndsWith(filename, ".s"))
+        {
+#if MIOPEN_WORKAROUND_ROCM_COMPILER_SUPPORT_ISSUE_27
+            static std::mutex mutex;
+            std::lock_guard<std::mutex> lock(mutex);
+#endif
+            comgr::BuildAsm(filename, src, params, device, binary);
         }
         else
         {

--- a/src/include/miopen/comgr.hpp
+++ b/src/include/miopen/comgr.hpp
@@ -47,6 +47,12 @@ void BuildOcl(const std::string& name,
               const std::string& device,
               std::vector<char>& binary);
 
+void BuildAsm(const std::string& name,
+              const std::string& text,
+              const std::string& options,
+              const std::string& device,
+              std::vector<char>& binary);
+
 } // namespace comgr
 } // namespace miopen
 


### PR DESCRIPTION
- Added support for assembling kernels via comgr.
- Added support for binary kernels.
- Finally disabled spare build path (via temp file) when comgr is used.
- Refactored workaround for the comgr MT issue.

## Testing

No correctness problems. No GPU time and Wall time regressions. Some (~1.8X) Aux Wall time improvements. Logs & csv files can be provided by request.