### PR TITLE
Fix readonlyramdb MT issue

### DIFF
--- a/src/readonlyramdb.cpp
+++ b/src/readonlyramdb.cpp
@@ -39,7 +39,7 @@ ReadonlyRamDb& ReadonlyRamDb::GetCached(const std::string& path,
                                         const std::size_t /*num_cu*/)
 {
     static std::mutex mutex;
-    std::lock_guard<std::mutex> lock{mutex};
+    const std::lock_guard<std::mutex> lock{mutex};
 
     static auto instances = std::map<std::string, ReadonlyRamDb*>{};
     const auto it         = instances.find(path);

--- a/src/readonlyramdb.cpp
+++ b/src/readonlyramdb.cpp
@@ -39,7 +39,7 @@ ReadonlyRamDb& ReadonlyRamDb::GetCached(const std::string& path,
                                         const std::size_t /*num_cu*/)
 {
     static std::mutex mutex;
-    static const std::lock_guard<std::mutex> lock{mutex};
+    std::lock_guard<std::mutex> lock{mutex};
 
     static auto instances = std::map<std::string, ReadonlyRamDb*>{};
     const auto it         = instances.find(path);


### PR DESCRIPTION
The issue may lead to UB when loading the read-only cache of the system-find-db in the multi-threaded apps. MP (multi-process) applications are not affected. 