### PR TITLE
Re-enable SQLite binary cache

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,7 @@ include(CheckCXXCompilerFlag)
 
 set(MIOPEN_ENABLE_SQLITE On CACHE BOOL "")
 # Use SQLITE for compiled kernels, when turned off this will use raw files
-set(MIOPEN_ENABLE_SQLITE_KERN_CACHE Off CACHE BOOL "")
+set(MIOPEN_ENABLE_SQLITE_KERN_CACHE On CACHE BOOL "")
 if(MIOPEN_ENABLE_SQLITE)
     # MIOpen now depends on SQLite as well
     find_package(PkgConfig)

--- a/src/binary_cache.cpp
+++ b/src/binary_cache.cpp
@@ -73,7 +73,6 @@ static boost::filesystem::path ComputeUserCachePath()
 #endif
 }
 
-#if !MIOPEN_ENABLE_SQLITE_KERN_CACHE
 boost::filesystem::path GetCachePath(bool is_system)
 {
     static const boost::filesystem::path user_path = ComputeUserCachePath();
@@ -83,7 +82,6 @@ boost::filesystem::path GetCachePath(bool is_system)
     else
         return user_path;
 }
-#endif // !MIOPEN_ENABLE_SQLITE_KERN_CACHE
 
 static bool IsCacheDisabled()
 {
@@ -109,7 +107,6 @@ KDb GetDb(const std::string& device, size_t num_cu)
     return {sys_path.string(), user_path.string(), device, num_cu};
 }
 
-#if !MIOPEN_ENABLE_SQLITE_KERN_CACHE
 boost::filesystem::path GetCacheFile(const std::string& device,
                                      const std::string& name,
                                      const std::string& args,
@@ -118,7 +115,6 @@ boost::filesystem::path GetCacheFile(const std::string& device,
     std::string filename = (is_kernel_str ? miopen::md5(name) : name) + ".o";
     return GetCachePath(false) / miopen::md5(device + ":" + args) / filename;
 }
-#endif
 
 #if MIOPEN_ENABLE_SQLITE_KERN_CACHE
 std::string LoadBinary(const std::string& device,

--- a/src/binary_cache.cpp
+++ b/src/binary_cache.cpp
@@ -148,15 +148,15 @@ void SaveBinary(const std::string& hsaco,
                 const std::string& args,
                 bool is_kernel_str)
 {
+    if(miopen::IsCacheDisabled())
+        return;
+
     auto db = GetDb(device, num_cu);
 
     std::string filename = (is_kernel_str ? miopen::md5(name) : name) + ".o";
     KernelConfig cfg{filename, args, hsaco};
     MIOPEN_LOG_I2("Saving binary for: " << name << " ;args: " << args);
-    if(miopen::IsCacheDisabled())
-        db.RemoveRecord(cfg);
-    else
-        db.StoreRecord(cfg);
+    db.StoreRecord(cfg);
 }
 #else
 boost::filesystem::path LoadBinary(const std::string& device,

--- a/src/include/miopen/binary_cache.hpp
+++ b/src/include/miopen/binary_cache.hpp
@@ -28,16 +28,11 @@
 #define GUARD_MLOPEN_BINARY_CACHE_HPP
 
 #include <miopen/config.h>
-
-#if !MIOPEN_ENABLE_SQLITE_KERN_CACHE
 #include <boost/filesystem/path.hpp>
-#endif
-
 #include <string>
 
 namespace miopen {
 
-#if !MIOPEN_ENABLE_SQLITE_KERN_CACHE
 boost::filesystem::path GetCacheFile(const std::string& device,
                                      const std::string& name,
                                      const std::string& args,
@@ -45,6 +40,7 @@ boost::filesystem::path GetCacheFile(const std::string& device,
 
 boost::filesystem::path GetCachePath(bool is_system);
 
+#if !MIOPEN_ENABLE_SQLITE_KERN_CACHE
 boost::filesystem::path LoadBinary(const std::string& device,
                                    std::size_t num_cu,
                                    const std::string& name,


### PR DESCRIPTION
- Revert workaround introduced in #240,  0335a64 "Switch to using the file-based binary cache by default. "
- Fix: Do not remove kernels from cache when it is disabled.
- [tests] Fix build of `test_cache`.
