### PR TITLE
Core implementation and auto-test of generic-reduction

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -304,6 +304,42 @@ pipeline {
                     }
                 }
 
+                stage('Hip Normal Find Mode Release') {
+                    agent{ label rocmnode("vega") }
+                    environment{
+                        cmd = """
+                            ulimit -c unlimited
+                            rm -rf build
+                            mkdir build
+                            cd build
+                            CXX=/opt/rocm/llvm/bin/clang++ cmake -DBUILD_DEV=On -DCMAKE_BUILD_TYPE=release -DMIOPEN_GPU_SYNC=On .. 
+                            make -j test_conv2d
+                            MIOPEN_FIND_MODE=1 CTEST_PARALLEL_LEVEL=4 MIOPEN_DEBUG_IMPLICIT_GEMM_NON_XDLOPS_INLINE_ASM=0 MIOPEN_CONV_PRECISE_ROCBLAS_TIMING=0 bin/test_conv2d --disable-verification-cache
+                        """
+                    }
+                    steps{
+                        buildHipClangJob('/opt/rocm/llvm/bin/clang++', '', "",  image+'-hip-clang', "/usr/local", cmd)
+                    }
+                }
+
+                stage('Hip Fast Find Mode Release') {
+                    agent{ label rocmnode("vega") }
+                    environment{
+                        cmd = """
+                            ulimit -c unlimited
+                            rm -rf build
+                            mkdir build
+                            cd build
+                            CXX=/opt/rocm/llvm/bin/clang++ cmake -DBUILD_DEV=On -DCMAKE_BUILD_TYPE=release -DMIOPEN_GPU_SYNC=On .. 
+                            make -j test_conv2d
+                            MIOPEN_FIND_MODE=2 CTEST_PARALLEL_LEVEL=4 MIOPEN_DEBUG_IMPLICIT_GEMM_NON_XDLOPS_INLINE_ASM=0 MIOPEN_CONV_PRECISE_ROCBLAS_TIMING=0 bin/test_conv2d --disable-verification-cache
+                        """
+                    }
+                    steps{
+                        buildHipClangJob('/opt/rocm/llvm/bin/clang++', '', "",  image+'-hip-clang', "/usr/local", cmd)
+                    }
+                }
+
                 stage('Hip Release on /usr/local') {
                     agent{ label rocmnode("vega") }
                     steps{
@@ -434,17 +470,21 @@ pipeline {
 
         stage("Full tests III"){
             parallel{
-                stage('Hip Release All') {
-                    agent{ label rocmnode("vega") }
-                    steps{
-                        buildJob('hcc', '-DBUILD_DEV=On -DMIOPEN_TEST_ALL=On -DCMAKE_BUILD_TYPE=release', "", image + "rocm")
-                    }
-                }
-
-                stage('Half Hip Release All') {
+                stage('Half Hip Clang Release All') {
                     agent{ label rocmnode("vega20") }
+                    environment{
+                        cmd = """
+                            ulimit -c unlimited
+                            rm -rf build
+                            mkdir build
+                            cd build
+                            CXX=/opt/rocm/llvm/bin/clang++ cmake -DBUILD_DEV=On -DCMAKE_BUILD_TYPE=release -DMIOPEN_TEST_HALF=On -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_ALL=On -DMIOPEN_TEST_FLAGS=--disable-verification-cache .. 
+                            CTEST_PARALLEL_LEVEL=4 MIOPEN_DEBUG_IMPLICIT_GEMM_NON_XDLOPS_INLINE_ASM=0 MIOPEN_CONV_PRECISE_ROCBLAS_TIMING=0 make -j\$(nproc) check
+                        """
+
+                    }
                     steps{
-                        buildJob('hcc', '-DMIOPEN_TEST_HALF=On -DBUILD_DEV=On -DMIOPEN_TEST_ALL=On -DCMAKE_BUILD_TYPE=release', "", image + "rocm")
+                        buildHipClangJob('/opt/rocm/llvm/bin/clang++', '', "", image+'-hip-clang', "/usr/local", cmd)
                     }
                 }
 
@@ -469,7 +509,7 @@ pipeline {
         }
 
 
-        // Run package building
+       // Run package building
         stage("Packages"){
             parallel {
                 stage('GCC OpenCL Release package') {

--- a/doc/src/find_and_immediate.md
+++ b/doc/src/find_and_immediate.md
@@ -158,3 +158,18 @@ If the user's architecture is not listed above they will need to run the Find AP
 ### Backend Limitations
 
 OpenCL support for immediate mode via the fallback is limited to fp32 datatypes. This is because this current release's fallback path goes through GEMM which on the OpenCL is serviced through MIOpenGEMM -- which itself only contains support for fp32. The HIP backend uses rocBLAS as its fallback path which contains a richer set of datatypes.
+
+
+### Find Modes
+
+MIOpen provides a set of Find modes which are used to accelerate the Find calls. The different modes are set by using the environment variable `MIOPEN_FIND_MODE`, and setting it to one of the values:
+
+- `NORMAL`, or `1`: Normal Find: This is the full Find mode call, which will benchmark all the solvers and return a list.
+- `FAST`, or `2`: Fast Find: Checks the [Find-Db](https://rocmsoftwareplatform.github.io/MIOpen/doc/html/finddb.html) for an entry. If there is a Find-Db hit, use that entry. If there is a miss, utilize the Immediate mode fallback. If Start-up times are expected to be faster, but worse GPU performance.
+- `HYBRID`, or `3`, or unset `MIOPEN_FIND_MODE`: Hybrid Find: Checks the [Find-Db](https://rocmsoftwareplatform.github.io/MIOpen/doc/html/finddb.html) for an entry. If there is a Find-Db hit, use that entry. If there is a miss, use the existing Find machinery. Slower start-up times than Fast Find, but no GPU performance drop.
+
+ As of MIOpen 2.4, the default mode is set to `HYBRID` mode as default. To run the full `NORMAL` Find mode, set the environment as:
+ ```
+ export MIOPEN_FIND_MODE=NORMAL
+ ```
+ 

--- a/driver/conv_driver.hpp
+++ b/driver/conv_driver.hpp
@@ -70,6 +70,8 @@
 
 #include <boost/optional.hpp>
 
+#define WORKAROUND_ISSUE_2176 1 // https://github.com/AMDComputeLibraries/MLOpen/issues/2176
+
 MIOPEN_DECLARE_ENV_VAR(MIOPEN_DRIVER_PAD_BUFFERS_2M)
 
 #if MIOPEN_BACKEND_OPENCL
@@ -158,6 +160,11 @@ bool readBufferFromFile(T* data, size_t dataNumItems, const char* fileName)
 template <typename Tgpu, typename Tref>
 class ConvDriver : public Driver
 {
+#if MIOPEN_BACKEND_OPENCL
+    typedef cl_context context_t;
+#elif MIOPEN_BACKEND_HIP
+    typedef uint32_t context_t;
+#endif
     public:
     ConvDriver() : Driver()
     {
@@ -199,17 +206,20 @@ class ConvDriver : public Driver
 
     int FindForward(int& ret_algo_count,
                     int request_algo_count,
-                    std::vector<miopenConvAlgoPerf_t>& perf_results);
+                    std::vector<miopenConvAlgoPerf_t>& perf_results,
+                    context_t ctx);
     int RunForwardGPU();
     int RunForwardCPU();
     int RunWarmupFindForwardGPU();
 
     int FindBackwardData(int& ret_algo_count,
                          int request_algo_count,
-                         std::vector<miopenConvAlgoPerf_t>& perf_results);
+                         std::vector<miopenConvAlgoPerf_t>& perf_results,
+                         context_t ctx);
     int FindBackwardWeights(int& ret_algo_count,
                             int request_algo_count,
-                            std::vector<miopenConvAlgoPerf_t>& perf_results);
+                            std::vector<miopenConvAlgoPerf_t>& perf_results,
+                            context_t ctx);
     int RunBackwardGPU();
     int RunBackwardDataCPU();
     int RunBackwardWeightsCPU();
@@ -295,6 +305,9 @@ class ConvDriver : public Driver
 
     bool is_wrw = true, is_bwd = true, is_fwd = true;
     bool is_wrw_winograd = false;
+    bool is_wrw_igemm    = false;
+    bool is_fwd_igemm    = false;
+    bool is_bwd_igemm    = false;
     bool time_enabled    = false;
     bool wall_enabled    = false;
     bool warmup_enabled  = false;
@@ -326,17 +339,39 @@ class ConvDriver : public Driver
     int RunBackwardWrwGpuImmed();
     int RunBackwardWrwGpuFind();
 
-    std::string GetVerificationCacheFileName() const;
-    std::string GetVCacheFwdOutBasename() const;
-    std::string GetVCacheBwdDataBasename() const;
-    std::string GetVCacheBwdWeightBasename() const;
-    std::string GetVCacheBiasBwdDataBasename() const;
+    double GetDefaultTolerance() const
+    {
+        // Computation error of fp16 is ~2^13 (=8192) bigger than
+        // the one of fp32 because mantissa is shorter by 13 bits.
+        auto tolerance = (sizeof(Tgpu) == 4 || sizeof(Tgpu) == 1) ? 1e-6 : 8.2e-3;
+        // bf16 mantissa has 7 bits, by 3 bits shorter than fp16.
+        if(std::is_same<Tgpu, bfloat16>::value)
+            tolerance *= 8.0;
+        return tolerance;
+    }
+
+    enum class Direction
+    {
+        Fwd,
+        Bwd,
+        WrW,
+        BwdBias
+    };
+
+    std::string GetVerificationCacheFileName(const Direction& direction) const;
     bool IsInputTensorTransform() const;
 
-    bool TryReadVerificationCache(const std::string& file_name,
+    bool TryReadVerificationCache(const Direction& direction,
                                   miopenTensorDescriptor_t& tensorDesc,
                                   Tref* data) const;
-    void TrySaveVerificationCache(const std::string& file_name, std::vector<Tref>& data) const;
+    void TrySaveVerificationCache(const Direction& direction, std::vector<Tref>& data) const;
+
+    void ResizeWorkspaceDev(context_t ctx, std::size_t size)
+    {
+        workspace_dev.reset();
+        if(size > 0)
+            workspace_dev = std::unique_ptr<GPUMem>(new GPUMem(ctx, size, 1));
+    }
 
     // Helper functions, can be moved out of class.
     void PrintImmedSolutionInfo(const miopenConvSolution_t& s) const
@@ -355,12 +390,6 @@ class ConvDriver : public Driver
         return oss.str();
     }
 
-    enum class Direction
-    {
-        Fwd,
-        Bwd,
-        WrW
-    };
     /// Find() updates find-db with the most recent information (unless find-db is disabled).
     /// Therefore, after Find(), Immediate mode returns the "best" found solution
     /// as the 1st solution in the list, and we can use Immediate mode to find out
@@ -1031,13 +1060,6 @@ int ConvDriver<Tgpu, Tref>::AllocateBuffersAndCopy()
             std::cout << "Error getting workspace size, status = " << rc << std::endl;
             return rc;
         }
-
-        const auto wsSizeof =
-            std::max(std::max(ws_sizeof_find_bwd, ws_sizeof_find_wrw), ws_sizeof_find_fwd);
-        if(wsSizeof != 0)
-        {
-            workspace_dev = std::unique_ptr<GPUMem>(new GPUMem(ctx, wsSizeof, 1));
-        }
     }
 
     if(is_fwd || is_wrw)
@@ -1261,10 +1283,12 @@ int ConvDriver<Tgpu, Tref>::AllocateBuffersAndCopy()
 template <typename Tgpu, typename Tref>
 int ConvDriver<Tgpu, Tref>::FindForward(int& ret_algo_count,
                                         int request_algo_count,
-                                        std::vector<miopenConvAlgoPerf_t>& perf_results)
+                                        std::vector<miopenConvAlgoPerf_t>& perf_results,
+                                        context_t ctx)
 {
     bool is_transform = IsInputTensorTransform();
     fwd_auxiliary.resume(wall_enabled);
+    ResizeWorkspaceDev(ctx, ws_sizeof_find_fwd);
     const auto rc = miopenFindConvolutionForwardAlgorithm(
         GetHandle(),
         (is_transform ? inputTensor_vect4 : inputTensor),
@@ -1592,9 +1616,11 @@ void ConvDriver<Tgpu, Tref>::GetSolutionAfterFind(
     case Direction::WrW:
         found_algo = static_cast<miopenConvAlgorithm_t>(found.bwd_weights_algo);
         break;
+    case Direction::BwdBias: // nop
+        MIOPEN_THROW("BwdBias is not supported");
     }
-    std::size_t immed_count;
-    miopenStatus_t rc = miopenStatusUnknownError;
+    std::size_t immed_count = 0;
+    miopenStatus_t rc       = miopenStatusUnknownError;
     switch(direction)
     {
     case Direction::Fwd:
@@ -1608,6 +1634,8 @@ void ConvDriver<Tgpu, Tref>::GetSolutionAfterFind(
     case Direction::WrW:
         rc = miopenConvolutionBackwardWeightsGetSolution(
             handle, out_tensor, in_tensor, convDesc, wei_tensor, 1, &immed_count, &solution);
+        break;
+    case Direction::BwdBias: // nop
         break;
     }
     if(rc != miopenStatusSuccess // (formatting)
@@ -1634,7 +1662,15 @@ int ConvDriver<Tgpu, Tref>::RunForwardGpuFind(const bool is_transform)
     // requested, -- so perf-db and find-db are fully updated.
     std::vector<miopenConvAlgoPerf_t> perf_results(request_algo_count);
 
-    auto rc = FindForward(ret_algo_count, request_algo_count, perf_results);
+#if MIOPEN_BACKEND_OPENCL
+    cl_context ctx;
+
+    clGetCommandQueueInfo(q, CL_QUEUE_CONTEXT, sizeof(cl_context), &ctx, nullptr);
+#elif MIOPEN_BACKEND_HIP
+    uint32_t ctx = 0;
+#endif
+
+    auto rc = FindForward(ret_algo_count, request_algo_count, perf_results, ctx);
     if(rc != miopenStatusSuccess)
         return rc;
 
@@ -1646,18 +1682,11 @@ int ConvDriver<Tgpu, Tref>::RunForwardGpuFind(const bool is_transform)
     float kernel_total_time = 0.0;
     float kernel_first_time = 0.0;
 
-#if MIOPEN_BACKEND_OPENCL
-    cl_context ctx;
+    const auto algo    = perf_results[0].fwd_algo; // use the fastest algo
+    const auto ws_size = perf_results[0].memory;
+    is_fwd_igemm       = (algo == miopenConvolutionFwdAlgoImplicitGEMM);
 
-    clGetCommandQueueInfo(q, CL_QUEUE_CONTEXT, sizeof(cl_context), &ctx, nullptr);
-#elif MIOPEN_BACKEND_HIP
-    uint32_t ctx = 0;
-#endif
-
-    workspace_dev.reset();
-    if(perf_results[0].memory > 0)
-        workspace_dev = std::unique_ptr<GPUMem>(new GPUMem(ctx, perf_results[0].memory, 1));
-
+    ResizeWorkspaceDev(ctx, ws_size);
     wall.start(wall_enabled);
 
     auto in_tens  = (is_transform ? inputTensor_vect4 : inputTensor);
@@ -1674,12 +1703,12 @@ int ConvDriver<Tgpu, Tref>::RunForwardGpuFind(const bool is_transform)
                                       wei_tens,
                                       wei_buff,
                                       convDesc,
-                                      perf_results[0].fwd_algo, // use the fastest algo
+                                      algo,
                                       &beta,
                                       outputTensor,
                                       out_dev->GetMem(),
                                       workspace_dev != nullptr ? workspace_dev->GetMem() : nullptr,
-                                      perf_results[0].memory);
+                                      ws_size);
         if(rc != miopenStatusSuccess)
             return rc;
 
@@ -1864,6 +1893,7 @@ int ConvDriver<Tgpu, Tref>::RunForwardGpuImmed(const bool is_transform)
         PrintForwardTime(kernel_total_time, kernel_first_time);
     }
 
+    is_fwd_igemm = (selected->algorithm == miopenConvolutionAlgoImplicitGEMM);
     return miopenStatusSuccess;
 }
 
@@ -1912,16 +1942,18 @@ int ConvDriver<Tgpu, Tref>::RunForwardCPU()
         dumpBufferToFile<Tref>("dump_fwd_out_cpu.bin", outhost.data.data(), outhost.data.size());
     }
 
-    TrySaveVerificationCache(GetVCacheFwdOutBasename(), outhost.data);
+    TrySaveVerificationCache(Direction::Fwd, outhost.data);
     return 0;
 }
 
 template <typename Tgpu, typename Tref>
 int ConvDriver<Tgpu, Tref>::FindBackwardData(int& ret_algo_count,
                                              int request_algo_count,
-                                             std::vector<miopenConvAlgoPerf_t>& perf_results)
+                                             std::vector<miopenConvAlgoPerf_t>& perf_results,
+                                             context_t ctx)
 {
     bwd_auxiliary.resume(wall_enabled);
+    ResizeWorkspaceDev(ctx, ws_sizeof_find_bwd);
     const auto rc = miopenFindConvolutionBackwardDataAlgorithm(
         GetHandle(),
         outputTensor,
@@ -1944,9 +1976,11 @@ int ConvDriver<Tgpu, Tref>::FindBackwardData(int& ret_algo_count,
 template <typename Tgpu, typename Tref>
 int ConvDriver<Tgpu, Tref>::FindBackwardWeights(int& ret_algo_count,
                                                 int request_algo_count,
-                                                std::vector<miopenConvAlgoPerf_t>& perf_results)
+                                                std::vector<miopenConvAlgoPerf_t>& perf_results,
+                                                context_t ctx)
 {
     wrw_auxiliary.resume(wall_enabled);
+    ResizeWorkspaceDev(ctx, ws_sizeof_find_wrw);
     const auto rc = miopenFindConvolutionBackwardWeightsAlgorithm(
         GetHandle(),
         outputTensor,
@@ -2037,7 +2071,15 @@ int ConvDriver<Tgpu, Tref>::RunBackwardDataGpuFind()
     int request_algo_count = 2;
     std::vector<miopenConvAlgoPerf_t> perf_results_data(request_algo_count);
 
-    auto rc = FindBackwardData(ret_algo_count, request_algo_count, perf_results_data);
+#if MIOPEN_BACKEND_OPENCL
+    cl_context ctx;
+
+    clGetCommandQueueInfo(q, CL_QUEUE_CONTEXT, sizeof(cl_context), &ctx, nullptr);
+#elif MIOPEN_BACKEND_HIP
+    uint32_t ctx = 0;
+#endif
+
+    auto rc = FindBackwardData(ret_algo_count, request_algo_count, perf_results_data, ctx);
     if(rc != miopenStatusSuccess)
         return rc;
 
@@ -2048,18 +2090,11 @@ int ConvDriver<Tgpu, Tref>::RunBackwardDataGpuFind()
     float kernel_first_time = 0.0;
     float alpha = static_cast<float>(1), beta = static_cast<float>(0);
 
-#if MIOPEN_BACKEND_OPENCL
-    cl_context ctx;
+    const auto algo    = perf_results_data[0].bwd_data_algo;
+    const auto ws_size = perf_results_data[0].memory;
+    is_bwd_igemm       = (algo == miopenConvolutionBwdDataAlgoImplicitGEMM);
 
-    clGetCommandQueueInfo(q, CL_QUEUE_CONTEXT, sizeof(cl_context), &ctx, nullptr);
-#elif MIOPEN_BACKEND_HIP
-    uint32_t ctx = 0;
-#endif
-
-    workspace_dev.reset();
-    if(perf_results_data[0].memory > 0)
-        workspace_dev = std::unique_ptr<GPUMem>(new GPUMem(ctx, perf_results_data[0].memory, 1));
-
+    ResizeWorkspaceDev(ctx, ws_size);
     wall.start(wall_enabled);
 
     for(int i = 0; i < num_iterations; i++)
@@ -2071,13 +2106,13 @@ int ConvDriver<Tgpu, Tref>::RunBackwardDataGpuFind()
                                            weightTensor,
                                            wei_dev->GetMem(),
                                            convDesc,
-                                           perf_results_data[0].bwd_data_algo,
+                                           algo,
                                            &beta,
                                            inputTensor,
                                            din_dev->GetMem(),
                                            workspace_dev != nullptr ? workspace_dev->GetMem()
                                                                     : nullptr,
-                                           perf_results_data[0].memory);
+                                           ws_size);
         if(rc != miopenStatusSuccess)
             return rc;
 
@@ -2242,7 +2277,15 @@ int ConvDriver<Tgpu, Tref>::RunBackwardWrwGpuFind()
     float alpha = static_cast<float>(1), beta = static_cast<float>(0);
     std::vector<miopenConvAlgoPerf_t> perf_results_weights(request_algo_count);
 
-    auto rc = FindBackwardWeights(ret_algo_count, request_algo_count, perf_results_weights);
+#if MIOPEN_BACKEND_OPENCL
+    cl_context ctx;
+
+    clGetCommandQueueInfo(q, CL_QUEUE_CONTEXT, sizeof(cl_context), &ctx, nullptr);
+#elif MIOPEN_BACKEND_HIP
+    uint32_t ctx = 0;
+#endif
+
+    auto rc = FindBackwardWeights(ret_algo_count, request_algo_count, perf_results_weights, ctx);
     if(rc != miopenStatusSuccess)
         return rc;
 
@@ -2255,19 +2298,9 @@ int ConvDriver<Tgpu, Tref>::RunBackwardWrwGpuFind()
     const auto algo    = perf_results_weights[0].bwd_weights_algo;
     const auto ws_size = perf_results_weights[0].memory;
     is_wrw_winograd    = (algo == miopenConvolutionBwdWeightsAlgoWinograd);
+    is_wrw_igemm       = (algo == miopenConvolutionBwdWeightsAlgoImplicitGEMM);
 
-#if MIOPEN_BACKEND_OPENCL
-    cl_context ctx;
-
-    clGetCommandQueueInfo(q, CL_QUEUE_CONTEXT, sizeof(cl_context), &ctx, nullptr);
-#elif MIOPEN_BACKEND_HIP
-    uint32_t ctx = 0;
-#endif
-
-    workspace_dev.reset();
-    if(perf_results_weights[0].memory > 0)
-        workspace_dev = std::unique_ptr<GPUMem>(new GPUMem(ctx, perf_results_weights[0].memory, 1));
-
+    ResizeWorkspaceDev(ctx, ws_size);
     wall.start(wall_enabled);
 
     for(int i = 0; i < num_iterations; i++)
@@ -2554,6 +2587,7 @@ int ConvDriver<Tgpu, Tref>::RunBackwardDataGpuImmed()
         PrintBackwardDataTime(kernel_total_time, kernel_first_time);
     }
 
+    is_bwd_igemm = (selected->algorithm == miopenConvolutionAlgoImplicitGEMM);
     din_dev->FromGPU(GetStream(), din.data());
     return rc;
 }
@@ -2682,6 +2716,7 @@ int ConvDriver<Tgpu, Tref>::RunBackwardWrwGpuImmed()
     }
 
     is_wrw_winograd = (selected->algorithm == miopenConvolutionAlgoWinograd);
+    is_wrw_igemm    = (selected->algorithm == miopenConvolutionAlgoImplicitGEMM);
     dwei_dev->FromGPU(GetStream(), dwei.data());
     return rc;
 }
@@ -2718,7 +2753,7 @@ int ConvDriver<Tgpu, Tref>::RunBackwardWeightsCPU()
             "dump_bwd_dwei_cpu.bin", dwei_host.data.data(), dwei_host.data.size());
     }
 
-    TrySaveVerificationCache(GetVCacheBwdWeightBasename(), dwei_host.data);
+    TrySaveVerificationCache(Direction::WrW, dwei_host.data);
     return 0;
 }
 
@@ -2753,7 +2788,7 @@ int ConvDriver<Tgpu, Tref>::RunBackwardDataCPU()
         dumpBufferToFile<Tref>("dump_bwd_din_cpu.bin", din_host.data.data(), din_host.data.size());
     }
 
-    TrySaveVerificationCache(GetVCacheBwdDataBasename(), din_host.data);
+    TrySaveVerificationCache(Direction::Bwd, din_host.data);
     return 0;
 }
 
@@ -2767,12 +2802,13 @@ int ConvDriver<Tgpu, Tref>::RunBackwardBiasCPU()
         dumpBufferToFile<Tref>("dump_bwd_db_cpu.bin", db_host.data.data(), db_host.data.size());
     }
 
-    TrySaveVerificationCache(GetVCacheBiasBwdDataBasename(), db_host.data);
+    TrySaveVerificationCache(Direction::BwdBias, db_host.data);
     return 0;
 }
 
 template <typename Tgpu, typename Tref>
-std::string ConvDriver<Tgpu, Tref>::GetVerificationCacheFileName() const
+std::string ConvDriver<Tgpu, Tref>::GetVerificationCacheFileName(
+    const ConvDriver<Tgpu, Tref>::Direction& direction) const
 {
     std::ostringstream ss;
 
@@ -2792,6 +2828,17 @@ std::string ConvDriver<Tgpu, Tref>::GetVerificationCacheFileName() const
                                      conv_strides.data(),
                                      conv_dilations.data(),
                                      &mode);
+
+    auto get_basename_string = [&]() {
+        switch(direction)
+        {
+        case Direction::Fwd: return "conv_fwd_out";
+        case Direction::Bwd: return "conv_bwd_dat";
+        case Direction::WrW: return "conv_bwd_wei";
+        case Direction::BwdBias: return "bias_bwd_dat";
+        }
+        return "<error in get_basename_string>"; // For gcc.
+    };
 
     auto get_datatype_string = [](auto type) {
         if(std::is_same<decltype(type), int8_t>::value)
@@ -2820,7 +2867,8 @@ std::string ConvDriver<Tgpu, Tref>::GetVerificationCacheFileName() const
         }
     };
 
-    ss << mode;
+    ss << get_basename_string();
+    ss << "_" << mode;
     ss << "_" << spatial_dim;
     ss << "_" << miopen::deref(convDesc).paddingMode;
     ss << "_" << miopen::deref(convDesc).GetGroupCount();
@@ -2841,16 +2889,17 @@ std::string ConvDriver<Tgpu, Tref>::GetVerificationCacheFileName() const
 }
 
 template <typename Tgpu, typename Tref>
-bool ConvDriver<Tgpu, Tref>::TryReadVerificationCache(const std::string& file_name,
-                                                      miopenTensorDescriptor_t& tensorDesc,
-                                                      Tref* data) const
+bool ConvDriver<Tgpu, Tref>::TryReadVerificationCache(
+    const ConvDriver<Tgpu, Tref>::Direction& direction,
+    miopenTensorDescriptor_t& tensorDesc,
+    Tref* data) const
 {
     const auto verification_cache_path = inflags.GetValueStr("verification_cache");
 
     if(!verification_cache_path.empty())
     {
         const auto file_path =
-            verification_cache_path + "/" + file_name + "_" + GetVerificationCacheFileName();
+            verification_cache_path + "/" + GetVerificationCacheFileName(direction);
 
         if(std::ifstream(file_path).good())
         {
@@ -2865,40 +2914,16 @@ bool ConvDriver<Tgpu, Tref>::TryReadVerificationCache(const std::string& file_na
 }
 
 template <typename Tgpu, typename Tref>
-void ConvDriver<Tgpu, Tref>::TrySaveVerificationCache(const std::string& file_name,
-                                                      std::vector<Tref>& data) const
+void ConvDriver<Tgpu, Tref>::TrySaveVerificationCache(
+    const ConvDriver<Tgpu, Tref>::Direction& direction, std::vector<Tref>& data) const
 {
     const auto verification_cache_path = inflags.GetValueStr("verification_cache");
     if(!verification_cache_path.empty())
     {
         const auto file_path =
-            verification_cache_path + "/" + file_name + "_" + GetVerificationCacheFileName();
+            verification_cache_path + "/" + GetVerificationCacheFileName(direction);
         dumpBufferToFile<Tref>(file_path.c_str(), data.data(), data.size());
     }
-}
-
-template <typename Tgpu, typename Tref>
-std::string ConvDriver<Tgpu, Tref>::GetVCacheFwdOutBasename() const
-{
-    return "conv_fwd_out";
-}
-
-template <typename Tgpu, typename Tref>
-std::string ConvDriver<Tgpu, Tref>::GetVCacheBwdDataBasename() const
-{
-    return "conv_bwd_dat";
-}
-
-template <typename Tgpu, typename Tref>
-std::string ConvDriver<Tgpu, Tref>::GetVCacheBwdWeightBasename() const
-{
-    return "conv_bwd_wei";
-}
-
-template <typename Tgpu, typename Tref>
-std::string ConvDriver<Tgpu, Tref>::GetVCacheBiasBwdDataBasename() const
-{
-    return "bias_bwd_dat";
 }
 
 template <typename Tgpu, typename Tref>
@@ -2908,7 +2933,7 @@ int ConvDriver<Tgpu, Tref>::VerifyForward()
         return 0;
 
     if(!is_fwd_run_failed)
-        if(!TryReadVerificationCache(GetVCacheFwdOutBasename(), outputTensor, outhost.data.data()))
+        if(!TryReadVerificationCache(Direction::Fwd, outputTensor, outhost.data.data()))
             RunForwardCPU();
 
     const auto isInt8 = (data_type == miopenInt8 || data_type == miopenInt8x4);
@@ -2916,11 +2941,15 @@ int ConvDriver<Tgpu, Tref>::VerifyForward()
                                    : (isInt8 ? miopen::rms_range(outhost.data, out_int8)
                                              : miopen::rms_range(outhost.data, out.data));
 
-    const Tref tolerance = ((sizeof(Tgpu) == 4 || sizeof(Tgpu) == 1) ? static_cast<Tref>(1e-6)
-                                                                     : static_cast<Tref>(7e-2));
-    if(!(error < tolerance))
+    auto tolerance = GetDefaultTolerance();
+    // iGemm's deviation is higher than other algorithms.
+    // The reason is most likely different order of computations.
+    if(is_fwd_igemm)
+        tolerance = tolerance * 10;
+
+    if(error > tolerance)
     {
-        std::cout << "Forward Convolution Failed: " << error << std::endl;
+        std::cout << "Forward Convolution Failed: " << error << " > " << tolerance << std::endl;
         return EC_VerifyFwd;
     }
     std::cout << "Forward Convolution Verifies on CPU and GPU (" << error << ')' << std::endl;
@@ -2939,22 +2968,26 @@ int ConvDriver<Tgpu, Tref>::VerifyBackward()
     if(!(is_bwd || is_wrw))
         return 0;
 
-    const double tolerance = sizeof(Tgpu) == 4 ? 1e-6 : 7e-2;
-
     int cumulative_rc = 0;
     if(is_bwd)
     {
         if(!is_bwd_run_failed)
-            if(!TryReadVerificationCache(
-                   GetVCacheBwdDataBasename(), inputTensor, din_host.data.data()))
+            if(!TryReadVerificationCache(Direction::Bwd, inputTensor, din_host.data.data()))
                 RunBackwardDataCPU();
 
         auto error_data = is_bwd_run_failed ? std::numeric_limits<double>::max()
                                             : miopen::rms_range(din_host.data, din);
 
-        if(!(error_data < tolerance))
+        auto tolerance = GetDefaultTolerance();
+        // iGemm's deviation is higher than other algorithms.
+        // The reason is most likely different order of computations.
+        if(is_bwd_igemm)
+            tolerance = tolerance * 10;
+
+        if(error_data > tolerance)
         {
-            std::cout << "Backward Convolution Data Failed: " << error_data << std::endl;
+            std::cout << "Backward Convolution Data Failed: " << error_data << " > " << tolerance
+                      << std::endl;
             cumulative_rc |= EC_VerifyBwd;
         }
         else
@@ -2967,23 +3000,36 @@ int ConvDriver<Tgpu, Tref>::VerifyBackward()
     if(is_wrw)
     {
         if(!is_wrw_run_failed)
-            if(!TryReadVerificationCache(
-                   GetVCacheBwdWeightBasename(), weightTensor, dwei_host.data.data()))
+            if(!TryReadVerificationCache(Direction::WrW, weightTensor, dwei_host.data.data()))
                 RunBackwardWeightsCPU();
 
-        // Winograd algorithm has worse precision than Direct and Gemm.
-        // Winograd-specific precision loss is roughly 2+2 bits.
-        // Affects only WrW FP32 for now.
-        auto tolerance_wrw = tolerance;
+        // WrW deviation is ~twice worse than Bwd due to more FP computations involved,
+        // which means more roundings, so GPU amd CPU computations diverge more.
+        auto tolerance = 2 * GetDefaultTolerance();
+        // Winograd and iGemm WrW algorithms reveal bigger deviation than other algos.
         if(is_wrw_winograd && std::is_same<Tgpu, float>::value)
-            tolerance_wrw *= 16.0;
+        {
+            tolerance *= 10;
+        }
+        else if(is_wrw_igemm)
+        {
+            if(std::is_same<Tgpu, float>::value)
+#if WORKAROUND_ISSUE_2176
+                tolerance = 0.01;
+#else
+                tolerance *= 10;
+#endif
+            else if(std::is_same<Tgpu, float16>::value)
+                tolerance *= 5;
+        }
 
         auto error_weights = is_wrw_run_failed ? std::numeric_limits<double>::max()
                                                : miopen::rms_range(dwei_host.data, dwei);
 
-        if(!(error_weights < tolerance_wrw))
+        if(error_weights > tolerance)
         {
-            std::cout << "Backward Convolution Weights Failed: " << error_weights << std::endl;
+            std::cout << "Backward Convolution Weights Failed: " << error_weights << " > "
+                      << tolerance << std::endl;
             cumulative_rc |= EC_VerifyWrw;
         }
         else
@@ -2995,16 +3041,17 @@ int ConvDriver<Tgpu, Tref>::VerifyBackward()
 
     if(inflags.GetValueInt("bias") != 0)
     {
-        if(!TryReadVerificationCache(
-               GetVCacheBiasBwdDataBasename(), biasTensor, db_host.data.data()))
+        if(!TryReadVerificationCache(Direction::BwdBias, biasTensor, db_host.data.data()))
         {
             RunBackwardBiasCPU();
         }
 
-        auto error_bias = miopen::rms_range(db_host.data, db);
-        if(!(error_bias < tolerance))
+        auto error_bias      = miopen::rms_range(db_host.data, db);
+        const auto tolerance = GetDefaultTolerance();
+        if(error_bias > tolerance)
         {
-            std::cout << "Backward Convolution Bias Failed: " << error_bias << std::endl;
+            std::cout << "Backward Convolution Bias Failed: " << error_bias << " > " << tolerance
+                      << std::endl;
             cumulative_rc |= EC_VerifyBwdBias;
         }
         else

--- a/include/miopen/miopen.h
+++ b/include/miopen/miopen.h
@@ -59,8 +59,9 @@
  * @defgroup RNN
  * @defgroup fusion
  * @defgroup LossFunction
+ * @defgroup TensorReduce
  *
-*/
+ */
 
 /*! Constructs type name from a struct */
 #define MIOPEN_DECLARE_OBJECT(name) \
@@ -91,7 +92,7 @@ MIOPEN_DECLARE_OBJECT(miopenHandle);
 
 /*! @enum miopenStatus_t
  * Error codes that are returned by all MIOpen API calls.
-*/
+ */
 typedef enum {
     miopenStatusSuccess        = 0, /*!< No errors */
     miopenStatusNotInitialized = 1, /*!< Data not initialized. */
@@ -110,7 +111,7 @@ typedef enum {
  *
  * @param error  miopenStatus_t type error status (input)
  * @return       errorString
-*/
+ */
 MIOPEN_EXPORT const char* miopenGetErrorString(miopenStatus_t error);
 
 /*! @brief Custom allocator function
@@ -120,7 +121,7 @@ MIOPEN_EXPORT const char* miopenGetErrorString(miopenStatus_t error);
  * @param context     A pointer a context (input)
  * @param sizeBytes   Number of bytes to allocate (input)
  *
-*/
+ */
 typedef void* (*miopenAllocatorFunction)(void* context, size_t sizeBytes);
 
 /*! @brief Custom deallocator function
@@ -130,7 +131,7 @@ typedef void* (*miopenAllocatorFunction)(void* context, size_t sizeBytes);
  * @param context     A pointer context (input)
  * @param memory      A pointer allocated memory (input)
  *
-*/
+ */
 typedef void (*miopenDeallocatorFunction)(void* context, void* memory);
 
 /*! @brief Method to return version of MIOpen
@@ -145,7 +146,7 @@ typedef void (*miopenDeallocatorFunction)(void* context, void* memory);
  * @param patch     Patch version number (output)
  *
  * @return          miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenGetVersion(size_t* major, size_t* minor, size_t* patch);
 
 /*! @brief Method to create the MIOpen handle object.
@@ -155,7 +156,7 @@ MIOPEN_EXPORT miopenStatus_t miopenGetVersion(size_t* major, size_t* minor, size
  * @param handle     A pointer to a MIOpen handle type (output)
  *
  * @return           miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenCreate(miopenHandle_t* handle);
 
 /*! @brief Create a MIOpen handle with an accelerator stream.
@@ -168,7 +169,7 @@ MIOPEN_EXPORT miopenStatus_t miopenCreate(miopenHandle_t* handle);
  * @param stream      An accelerator queue type (input)
  *
  * @return           miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenCreateWithStream(miopenHandle_t* handle,
                                                     miopenAcceleratorQueue_t stream);
 
@@ -177,7 +178,7 @@ MIOPEN_EXPORT miopenStatus_t miopenCreateWithStream(miopenHandle_t* handle,
  * This is called when breaking down the MIOpen environment.
  * @param handle     MIOpen handle (input)
  * @return           miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenDestroy(miopenHandle_t handle);
 
 /*! @brief Set accelerator command queue previously created
@@ -186,7 +187,7 @@ MIOPEN_EXPORT miopenStatus_t miopenDestroy(miopenHandle_t handle);
  * @param handle     MIOpen handle (input)
  * @param streamID   An accelerator queue type (input)
  * @return           miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenSetStream(miopenHandle_t handle,
                                              miopenAcceleratorQueue_t streamID);
 
@@ -196,7 +197,7 @@ MIOPEN_EXPORT miopenStatus_t miopenSetStream(miopenHandle_t handle,
  * @param handle     MIOpen handle (input)
  * @param streamID   Pointer to a accelerator queue type (output)
  * @return           miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenGetStream(miopenHandle_t handle,
                                              miopenAcceleratorQueue_t* streamID);
 
@@ -215,7 +216,7 @@ MIOPEN_EXPORT miopenStatus_t miopenGetStream(miopenHandle_t handle,
  *      This allows the callback function to access state set by the caller to this function,
  *      for example a stateful heap allocator or a c++ class.
  * @return           miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenSetAllocator(miopenHandle_t handle,
                                                 miopenAllocatorFunction allocator,
                                                 miopenDeallocatorFunction deallocator,
@@ -231,7 +232,7 @@ MIOPEN_EXPORT miopenStatus_t miopenSetAllocator(miopenHandle_t handle,
  * @param handle     MIOpen handle (input)
  * @param time       Pointer to a float type to contain kernel time in milliseconds (output)
  * @return           miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenGetKernelTime(miopenHandle_t handle, float* time);
 
 /*! @brief Enable profiling to retrieve kernel time
@@ -240,7 +241,7 @@ MIOPEN_EXPORT miopenStatus_t miopenGetKernelTime(miopenHandle_t handle, float* t
  * @param handle     MIOpen handle (input)
  * @param enable     Boolean to toggle profiling (input)
  * @return           miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenEnableProfiling(miopenHandle_t handle, bool enable);
 /** @} */
 // CLOSEOUT HANDLE DOXYGEN GROUP
@@ -264,7 +265,7 @@ MIOPEN_DECLARE_OBJECT(miopenFusionOpDescriptor);
 MIOPEN_DECLARE_OBJECT(miopenTensorDescriptor);
 
 /*! @ingroup convolutions
-* @brief Creates the miopenConvolutionDescriptor_t type
+ * @brief Creates the miopenConvolutionDescriptor_t type
  *
  * Convolution descriptor is an object that allows the user to specify a layer's padding, stride,
  * and dilation of the convolutional filter. Parameters must all be non-negative.
@@ -299,24 +300,29 @@ MIOPEN_DECLARE_OBJECT(miopenLRNDescriptor);
 MIOPEN_DECLARE_OBJECT(miopenActivationDescriptor);
 
 /*! @ingroup RNN
-* @brief Creates the miopenRNNDescriptor_t type
-*/
+ * @brief Creates the miopenRNNDescriptor_t type
+ */
 MIOPEN_DECLARE_OBJECT(miopenRNNDescriptor);
 
 /*! @ingroup LossFunction
-* @brief Creates the miopenCTCLossDescriptor_t type
-*/
+ * @brief Creates the miopenCTCLossDescriptor_t type
+ */
 MIOPEN_DECLARE_OBJECT(miopenCTCLossDescriptor);
 
 /*! @ingroup Dropout
-* @brief Creates the miopenDropoutDescriptor_t type
-*/
+ * @brief Creates the miopenDropoutDescriptor_t type
+ */
 MIOPEN_DECLARE_OBJECT(miopenDropoutDescriptor);
+
+/*! @ingroup TensorReduce
+ * @brief Creates the miopenReduceTensorDescriptor_t type
+ */
+MIOPEN_DECLARE_OBJECT(miopenReduceTensorDescriptor);
 
 /*! @ingroup tensor
  * @enum miopenDataType_t
  * MIOpen floating point datatypes. Both 32-bit and 16-bit floats are supported in MIOpen.
-*/
+ */
 typedef enum {
     miopenHalf  = 0, /*!< 16-bit floating point (Fully supported) */
     miopenFloat = 1, /*!< 32-bit floating point (Fully supported) */
@@ -331,7 +337,7 @@ typedef enum {
 /*! @ingroup pooling
  * @enum miopenIndexType_t
  * MIOpen index datatypes.
-*/
+ */
 typedef enum {
     miopenIndexUint8  = 0, /*!<  8-bit unsigned */
     miopenIndexUint16 = 1, /*!< 16-bit unsigned */
@@ -342,7 +348,7 @@ typedef enum {
 /*! @ingroup tensor
  * @enum miopenTensorOp_t
  * Element-wise tensor operation modes
-*/
+ */
 typedef enum {
     miopenTensorOpAdd = 0, /*!< Add tensors element-wise */
     miopenTensorOpMul = 1, /*!< Multiply two tensors element-wise */
@@ -353,7 +359,7 @@ typedef enum {
 /*! @ingroup convolutions
  *  @enum miopenConvolutionMode_t
  * Convolution mode selection for convolution layer preference.
-*/
+ */
 typedef enum {
     miopenConvolution = 0, /*!< Cross-Correlation convolution */
     miopenTranspose   = 1, /*!< Transpose convolutions -- deconvolution */
@@ -364,7 +370,7 @@ typedef enum {
 /*! @ingroup padding
  *  @enum miopenPaddingMode_t
  * Padding mode selection for convolution/Pooling layer preference
-*/
+ */
 typedef enum {
     miopenPaddingDefault = 0, /*!< MIOPEN Default Padding */
     miopenPaddingSame    = 1, /*!< Tensorflow SAME Padding */
@@ -374,7 +380,7 @@ typedef enum {
 /*! @ingroup pooling
  * @enum miopenPoolingMode_t
  * Pooling layer mode
-*/
+ */
 typedef enum {
     miopenPoolingMax              = 0, /*!< Maximum pooling */
     miopenPoolingAverage          = 1, /*!< Average pooling */
@@ -395,7 +401,7 @@ typedef enum {
 /*! @ingroup LRN
  * @enum miopenLRNMode_t
  * Local Response Normalization layer mode
-*/
+ */
 typedef enum {
     miopenLRNWithinChannel = 0, /*!< Channel independent */
     miopenLRNCrossChannel  = 1, /*!< Cross Channel */
@@ -404,7 +410,7 @@ typedef enum {
 /*! @ingroup batchnorm
  * @enum miopenBatchNormMode_t
  * Batch Normalization layer mode
-*/
+ */
 typedef enum {
     miopenBNPerActivation = 0, /*!< Element-wise normalization for fully connected layer */
     miopenBNSpatial       = 1, /*!< Mini-batch spatial normalization for convolutional layers */
@@ -428,13 +434,13 @@ typedef enum {
         8, /*!< Leaky Rectified Linear Unit \f$ \alpha * x | x <= 0; x | x > 0 \f$ */
     miopenActivationELU =
         9, /*!< Exponential Rectified Linear Unit \f$ \alpha * (e^{x} - 1) | x <= 0; x | x > 0 \f$
-              */
+            */
 } miopenActivationMode_t;
 
 /*! @ingroup softmax
  * @enum miopenSoftmaxAlgorithm_t
  * Softmax implementation algorithms
-*/
+ */
 typedef enum {
     MIOPEN_SOFTMAX_FAST     = 0, /*!< straightforward softmax */
     MIOPEN_SOFTMAX_ACCURATE = 1, /*!< scaled softmax by maximum value in input domain */
@@ -444,12 +450,65 @@ typedef enum {
 /*! @ingroup softmax
  * @enum miopenSoftmaxMode_t
  * Softmax modes
-*/
+ */
 typedef enum {
     MIOPEN_SOFTMAX_MODE_INSTANCE = 0, /*!< compute per image (N) across C, H, W */
     MIOPEN_SOFTMAX_MODE_CHANNEL =
         1, /*!< compute per spatial location (H, W) per image (N) across C */
 } miopenSoftmaxMode_t;
+
+/*! @ingroup TensorReduce
+ * @enum miopenReduceTensorOp_t
+ * Tensor Reduction operation types
+ */
+typedef enum {
+    MIOPEN_REDUCE_TENSOR_ADD = 0, /*!< the operation is adding the values of the reduced elements */
+    MIOPEN_REDUCE_TENSOR_MUL =
+        1, /*!< the operation is multiplying the values of the reduced elements */
+    MIOPEN_REDUCE_TENSOR_MIN =
+        2, /*!< the operation is getting the minimum value of the reduced elements */
+    MIOPEN_REDUCE_TENSOR_MAX =
+        3, /*!< the operation is getting the maximum value of the reduced elements */
+    // MIOPEN_REDUCE_TENSOR_AMAX =
+    //    4, /*!< the operation is getting the maximum absolute value of the reduced elements */
+    // MIOPEN_REDUCE_TENSOR_AVG =
+    //    5, /*!< the operation is getting the averaged value of the reduced elements */
+    // MIOPEN_REDUCE_TENSOR_NORM1 =
+    //    6, /*!< the operation is adding the absolute values of the reduced elements */
+    // MIOPEN_REDUCE_TENSOR_NORM2 = 7, /*!< the operation is getting the square root of the sum of
+    //                                   squares of the reduced elements */
+    // MIOPEN_REDUCE_TENSOR_MUL_NO_ZEROS =
+    //    8, /*!< the operation is same as MUL, but does not have the zero values considered */
+} miopenReduceTensorOp_t;
+
+/*! @ingroup TensorReduce
+ * @enum miopenReduceTensorOp_t
+ * Nan numbers propagation modes
+ */
+typedef enum {
+    MIOPEN_NOT_PROPAGATE_NAN = 0, /*!< does not propagate Nan number */
+    MIOPEN_PROPAGATE_NAN     = 1, /*!< propagate the Nan number by the Reduction operation */
+} miopenNanPropagation_t;
+
+/*! @ingroup TensorReduce
+ * @enum miopenReduceTensorIndices_t
+ * Reduction Indices computation modes
+ */
+typedef enum {
+    MIOPEN_REDUCE_TENSOR_NO_INDICES        = 0, /*!< Does not compuate indices */
+    MIOPEN_REDUCE_TENSOR_FLATTENED_INDICES = 1, /*!< Compute the relative, flatted indices */
+} miopenReduceTensorIndices_t;
+
+/*! @ingroup TensorReduce
+ * @enum miopenIndicesType_t
+ * Reduction Indices types
+ */
+typedef enum {
+    MIOPEN_32BIT_INDICES = 0, /*!< unsigned integer indices */
+    MIOPEN_64BIT_INDICES = 1, /*!< unsigned long indices */
+    MIOPEN_16BIT_INDICES = 2, /*!< unsigned short indices */
+    MIOPEN_8BIT_INDICES  = 3, /*!< unsigned char indices */
+} miopenIndicesType_t;
 
 /** @addtogroup tensor
  *
@@ -461,7 +520,7 @@ typedef enum {
  * API for creating an uninitialized tensor descriptor.
  * @param tensorDesc Pointer to a tensor descriptor type (output)
  * @return           miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenCreateTensorDescriptor(miopenTensorDescriptor_t* tensorDesc);
 
 /*! @brief Set shape of 4D tensor
@@ -475,7 +534,7 @@ MIOPEN_EXPORT miopenStatus_t miopenCreateTensorDescriptor(miopenTensorDescriptor
  * @param h          Data height dimension size (input)
  * @param w          Data width dimension size (input)
  * @return           miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenSet4dTensorDescriptor(
     miopenTensorDescriptor_t tensorDesc, miopenDataType_t dataType, int n, int c, int h, int w);
 
@@ -494,7 +553,7 @@ MIOPEN_EXPORT miopenStatus_t miopenSet4dTensorDescriptor(
  * @param hStride    Height dimension stride (output)
  * @param wStride    Width dimension stride (output)
  * @return           miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenGet4dTensorDescriptor(miopenTensorDescriptor_t tensorDesc,
                                                          miopenDataType_t* dataType,
                                                          int* n,
@@ -516,7 +575,7 @@ MIOPEN_EXPORT miopenStatus_t miopenGet4dTensorDescriptor(miopenTensorDescriptor_
  * @param dimsA        Array containing the size of dimensions (input)
  * @param stridesA     Array containing the size of stride (input)
  * @return             miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenSetTensorDescriptor(miopenTensorDescriptor_t tensorDesc,
                                                        miopenDataType_t dataType,
                                                        int nbDims,
@@ -530,7 +589,7 @@ MIOPEN_EXPORT miopenStatus_t miopenSetTensorDescriptor(miopenTensorDescriptor_t 
  * @param tensorDesc   Tensor descriptor type (input)
  * @param size         number of elements in tensor described by the descriptor (output)
  * @return             miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenGetTensorDescriptorSize(miopenTensorDescriptor_t tensorDesc,
                                                            int* size);
 
@@ -551,7 +610,7 @@ MIOPEN_EXPORT miopenStatus_t miopenGetTensorDescriptor(miopenTensorDescriptor_t 
  *
  * @param tensorDesc Tensor descriptor type (input)
  * @return           miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenDestroyTensorDescriptor(miopenTensorDescriptor_t tensorDesc);
 
 /*! @brief Execute element-wise tensor operations
@@ -752,48 +811,48 @@ miopenGetConvolutionNdDescriptor(miopenConvolutionDescriptor_t convDesc,
                                  miopenConvolutionMode_t* c_mode);
 
 /*! @brief Set the number of groups to be used in Group/Depthwise convolution
-*
-* Must be called before all computational APIs of group/depthwise convolution, it is preferable to
-* call miopenInitConvolutionDescriptor() first, then miopenSetConvolutionGroupCount() to fully
-* initialize group convolutions. Both Convolution Mode and Transpose Convolution Mode support
-* group/depthwise convolution. To run depthwise convolution, set groupCount value equal to number of
-* channels.
-*
-* @param convDesc   Convolution layer descriptor (output)
-* @param groupCount      number of groups, in depthwise conv using filter_number/channel_multiplier
-* (input)
-* @return           miopenStatus_t
-*/
+ *
+ * Must be called before all computational APIs of group/depthwise convolution, it is preferable to
+ * call miopenInitConvolutionDescriptor() first, then miopenSetConvolutionGroupCount() to fully
+ * initialize group convolutions. Both Convolution Mode and Transpose Convolution Mode support
+ * group/depthwise convolution. To run depthwise convolution, set groupCount value equal to number
+ * of channels.
+ *
+ * @param convDesc   Convolution layer descriptor (output)
+ * @param groupCount      number of groups, in depthwise conv using filter_number/channel_multiplier
+ * (input)
+ * @return           miopenStatus_t
+ */
 MIOPEN_EXPORT miopenStatus_t miopenSetConvolutionGroupCount(miopenConvolutionDescriptor_t convDesc,
                                                             int groupCount);
 
 /*! @brief Set the output padding to be used in 2-D Transpose convolution
-*
-* This function is optional for initialization of Transpose convolution. If applicable, it must be
-* called before all computational APIs of Transpose convolution. It is preferable to call
-* miopenInitConvolutionDescriptor() first, then miopenSetTransposeConvOutputPadding() to fully
-* initialize transpose convolutions.
-*
-* @param convDesc   Convolution layer descriptor (output)
-* @param adj_h      output padding for the height of output data (input)
-* @param adj_w      output padding for the width of output data (input)
-* @return           miopenStatus_t
-*/
+ *
+ * This function is optional for initialization of Transpose convolution. If applicable, it must be
+ * called before all computational APIs of Transpose convolution. It is preferable to call
+ * miopenInitConvolutionDescriptor() first, then miopenSetTransposeConvOutputPadding() to fully
+ * initialize transpose convolutions.
+ *
+ * @param convDesc   Convolution layer descriptor (output)
+ * @param adj_h      output padding for the height of output data (input)
+ * @param adj_w      output padding for the width of output data (input)
+ * @return           miopenStatus_t
+ */
 MIOPEN_EXPORT miopenStatus_t
 miopenSetTransposeConvOutputPadding(miopenConvolutionDescriptor_t convDesc, int adj_h, int adj_w);
 
 /*! @brief Set the output padding to be used in N-dimensional Transpose convolution
-*
-* This function is optional for initialization of Transpose convolution. If applicable, it must be
-* called before all computational APIs of Transpose convolution. It is preferable to call
-* miopenInitConvolutionNdDescriptor() first, then miopenSetTransposeConvNdOutputPadding() to fully
-* initialize transpose convolutions. Currently, 2-D and 3-D convolutions are supported.
-*
-* @param convDesc      Convolution layer descriptor (output)
-* @param spatialDim    Convolutional spatial dimension (input)
-* @param adjA          array of output padding for output data (input)
-* @return              miopenStatus_t
-*/
+ *
+ * This function is optional for initialization of Transpose convolution. If applicable, it must be
+ * called before all computational APIs of Transpose convolution. It is preferable to call
+ * miopenInitConvolutionNdDescriptor() first, then miopenSetTransposeConvNdOutputPadding() to fully
+ * initialize transpose convolutions. Currently, 2-D and 3-D convolutions are supported.
+ *
+ * @param convDesc      Convolution layer descriptor (output)
+ * @param spatialDim    Convolutional spatial dimension (input)
+ * @param adjA          array of output padding for output data (input)
+ * @return              miopenStatus_t
+ */
 MIOPEN_EXPORT miopenStatus_t miopenSetTransposeConvNdOutputPadding(
     miopenConvolutionDescriptor_t convDesc, int spatialDim, int* adjA);
 
@@ -847,7 +906,7 @@ miopenGetConvolutionNdForwardOutputDim(miopenConvolutionDescriptor_t convDesc,
  *
  * @param convDesc Convolution tensor descriptor type (input)
  * @return           miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t
 miopenDestroyConvolutionDescriptor(miopenConvolutionDescriptor_t convDesc);
 
@@ -1518,7 +1577,7 @@ MIOPEN_EXPORT miopenStatus_t miopenConvolutionForwardBias(miopenHandle_t handle,
  * @param dxDesc         Tensor descriptor for output data tensor dx (input)
  * @param workSpaceSize  Size in bytes of the memory required (output)
  * @return               miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t
 miopenConvolutionBackwardDataGetWorkSpaceSize(miopenHandle_t handle,
                                               const miopenTensorDescriptor_t dyDesc,
@@ -1642,7 +1701,7 @@ miopenConvolutionBackwardData(miopenHandle_t handle,
  * @param dwDesc         Tensor descriptor for output weights tensor dw (input)
  * @param workSpaceSize  Size in bytes of the memory required (output)
  * @return               miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t
 miopenConvolutionBackwardWeightsGetWorkSpaceSize(miopenHandle_t handle,
                                                  const miopenTensorDescriptor_t dyDesc,
@@ -2057,7 +2116,7 @@ MIOPEN_EXPORT miopenStatus_t miopenPoolingBackward(miopenHandle_t handle,
  *
  * @param poolDesc Pooling tensor descriptor type (input)
  * @return           miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenDestroyPoolingDescriptor(miopenPoolingDescriptor_t poolDesc);
 
 /** @} */
@@ -2190,7 +2249,7 @@ MIOPEN_EXPORT miopenStatus_t miopenLRNBackward(miopenHandle_t handle,
  *
  * @param lrnDesc   LRN tensor descriptor type (input)
  * @return          miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenDestroyLRNDescriptor(miopenLRNDescriptor_t lrnDesc);
 
 /** @} */
@@ -2217,7 +2276,7 @@ MIOPEN_EXPORT miopenStatus_t miopenDestroyLRNDescriptor(miopenLRNDescriptor_t lr
  * @param xDesc           Input tensor descriptor (input)
  * @param bn_mode         Batch Normalization mode (input)
  * @return                miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenDeriveBNTensorDescriptor(miopenTensorDescriptor_t derivedBnDesc,
                                                             const miopenTensorDescriptor_t xDesc,
                                                             miopenBatchNormMode_t bn_mode);
@@ -2259,7 +2318,7 @@ MIOPEN_EXPORT miopenStatus_t miopenDeriveBNTensorDescriptor(miopenTensorDescript
  * @param resultSaveMean            Saved mini-batch mean for backwards pass (output)
  * @param resultSaveInvVariance     Saved mini-batch inverse variance for backwards pass (output)
  * @return                          miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t
 miopenBatchNormalizationForwardTraining(miopenHandle_t handle,
                                         miopenBatchNormMode_t bn_mode,
@@ -2304,7 +2363,7 @@ miopenBatchNormalizationForwardTraining(miopenHandle_t handle,
  * @param estimatedVariance         Running variance saved during forward training (input)
  * @param epsilon                   Value to stabilize inverse variance calculation (input)
  * @return                          miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t
 miopenBatchNormalizationForwardInference(miopenHandle_t handle,
                                          miopenBatchNormMode_t bn_mode,
@@ -2354,7 +2413,7 @@ miopenBatchNormalizationForwardInference(miopenHandle_t handle,
  * @param savedMean                 Saved mini-batch mean for backwards pass (input)
  * @param savedInvVariance          Saved mini-bathc inverse variance for backwards pass (input)
  * @return                          miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t
 miopenBatchNormalizationBackward(miopenHandle_t handle,
                                  miopenBatchNormMode_t bn_mode,
@@ -2388,7 +2447,7 @@ miopenBatchNormalizationBackward(miopenHandle_t handle,
  *
  * @param activDesc Pointer to an activation tensor descriptor type
  * @return          miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t
 miopenCreateActivationDescriptor(miopenActivationDescriptor_t* activDesc);
 
@@ -2482,7 +2541,7 @@ MIOPEN_EXPORT miopenStatus_t miopenActivationBackward(miopenHandle_t handle,
  *
  * @param activDesc   Activation tensor descriptor type (input)
  * @return            miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t
 miopenDestroyActivationDescriptor(miopenActivationDescriptor_t activDesc);
 
@@ -2594,49 +2653,49 @@ MIOPEN_EXPORT miopenStatus_t miopenSoftmaxBackward_V2(miopenHandle_t handle,
 // CLOSEOUT SOFTMAX DOXYGEN GROUP
 
 /*! @ingroup FUSION
-* @brief MIOpen fusion interface
-*/
+ * @brief MIOpen fusion interface
+ */
 MIOPEN_DECLARE_OBJECT(miopenFusionPlanDescriptor);
 MIOPEN_DECLARE_OBJECT(miopenOperatorDescriptor);
 MIOPEN_DECLARE_OBJECT(miopenOperatorArgs);
 
 /** @addtogroup FUSION
-*
-*  @{
-*/
+ *
+ *  @{
+ */
 
 /*! @enum miopenFusionDirection_t
-* @brief Kernel fusion direction in the network
-*/
+ * @brief Kernel fusion direction in the network
+ */
 typedef enum {
     miopenVerticalFusion   = 0, /*!< fuses layers vertically, current the only supported mode */
     miopenHorizontalFusion = 1, /*!< fuses layers horizontally, this is unimplemented */
 } miopenFusionDirection_t;
 
 /*! @brief Creates the kenrel fusion plan descriptor object
-*
-* @param fusePlanDesc  Pointer to a fusion plan (output)
-* @param fuseDirection Horizontal or Vertical fusion (input)
-* @param inputDesc     Descriptor to tensor for the input (input)
-* @return              miopenStatus_t
-*/
+ *
+ * @param fusePlanDesc  Pointer to a fusion plan (output)
+ * @param fuseDirection Horizontal or Vertical fusion (input)
+ * @param inputDesc     Descriptor to tensor for the input (input)
+ * @return              miopenStatus_t
+ */
 MIOPEN_EXPORT miopenStatus_t miopenCreateFusionPlan(miopenFusionPlanDescriptor_t* fusePlanDesc,
                                                     const miopenFusionDirection_t fuseDirection,
                                                     const miopenTensorDescriptor_t inputDesc);
 
 /*! @brief Destroy the fusion plan descriptor object
-*
-* @param fusePlanDesc  A fusion plan descriptor type
-* @return              miopenStatus_t
-*/
+ *
+ * @param fusePlanDesc  A fusion plan descriptor type
+ * @return              miopenStatus_t
+ */
 MIOPEN_EXPORT miopenStatus_t miopenDestroyFusionPlan(miopenFusionPlanDescriptor_t fusePlanDesc);
 
 /*! @brief Compiles the fusion plan
-*
-* @param handle           MIOpen handle (input)
-* @param fusePlanDesc A fusion plan descriptor (input)
-* @return             miopenStatus_t
-*/
+ *
+ * @param handle           MIOpen handle (input)
+ * @param fusePlanDesc A fusion plan descriptor (input)
+ * @return             miopenStatus_t
+ */
 MIOPEN_EXPORT miopenStatus_t miopenCompileFusionPlan(miopenHandle_t handle,
                                                      miopenFusionPlanDescriptor_t fusePlanDesc);
 
@@ -2656,10 +2715,10 @@ MIOPEN_EXPORT miopenStatus_t miopenFusionPlanGetOp(miopenFusionPlanDescriptor_t 
 
 /*! @brief Query the workspace size required for the fusion plan
  *
-* @param fusePlanDesc   A fusion plan descriptor (input)
-* @param workSpaceSize  Pointer to memory to return size in bytes (output)
-* @return               miopenStatus_t
-*/
+ * @param fusePlanDesc   A fusion plan descriptor (input)
+ * @param workSpaceSize  Pointer to memory to return size in bytes (output)
+ * @return               miopenStatus_t
+ */
 MIOPEN_EXPORT miopenStatus_t
 miopenFusionPlanGetWorkSpaceSize(miopenHandle_t handle,
                                  miopenFusionPlanDescriptor_t fusePlanDesc,
@@ -2702,13 +2761,13 @@ MIOPEN_EXPORT miopenStatus_t miopenFusionPlanConvolutionSetAlgo(
     miopenFusionPlanDescriptor_t fusePlanDesc, miopenConvFwdAlgorithm_t algo);
 
 /*! @brief Creates forward convolution operator.
-*
-* @param fusePlanDesc   A fusion plan descriptor (input)
-* @param convOp         Pointer to an operator type (output)
-* @param convDesc       Convolution layer descriptor (input)
-* @param wDesc          Descriptor for the weights tensor (input)
-* @return               miopenStatus_t
-*/
+ *
+ * @param fusePlanDesc   A fusion plan descriptor (input)
+ * @param convOp         Pointer to an operator type (output)
+ * @param convDesc       Convolution layer descriptor (input)
+ * @param wDesc          Descriptor for the weights tensor (input)
+ * @return               miopenStatus_t
+ */
 MIOPEN_EXPORT miopenStatus_t miopenCreateOpConvForward(miopenFusionPlanDescriptor_t fusePlanDesc,
                                                        miopenFusionOpDescriptor_t* convOp,
                                                        miopenConvolutionDescriptor_t convDesc,
@@ -2718,12 +2777,12 @@ MIOPEN_EXPORT miopenStatus_t miopenCreateOpConvForward(miopenFusionPlanDescripto
 
 // Activation forward create ops ---
 /*! @brief Creates a forward activation operator.
-*
-* @param fusePlanDesc    A fusion plan descriptor (input)
-* @param activFwdOp         Pointer to an operator type (output)
-* @param mode            Activation version (input)
-* @return                miopenStatus_t
-*/
+ *
+ * @param fusePlanDesc    A fusion plan descriptor (input)
+ * @param activFwdOp         Pointer to an operator type (output)
+ * @param mode            Activation version (input)
+ * @return                miopenStatus_t
+ */
 MIOPEN_EXPORT miopenStatus_t
 miopenCreateOpActivationForward(miopenFusionPlanDescriptor_t fusePlanDesc,
                                 miopenFusionOpDescriptor_t* activFwdOp,
@@ -2731,12 +2790,12 @@ miopenCreateOpActivationForward(miopenFusionPlanDescriptor_t fusePlanDesc,
 
 // Activation backward create ops ---
 /*! @brief Creates a backward activation operator.
-*
-* @param fusePlanDesc    A fusion plan descriptor (input)
-* @param activBwdOp         Pointer to an operator type (output)
-* @param mode            Activation version (input)
-* @return                miopenStatus_t
-*/
+ *
+ * @param fusePlanDesc    A fusion plan descriptor (input)
+ * @param activBwdOp         Pointer to an operator type (output)
+ * @param mode            Activation version (input)
+ * @return                miopenStatus_t
+ */
 MIOPEN_EXPORT miopenStatus_t
 miopenCreateOpActivationBackward(miopenFusionPlanDescriptor_t fusePlanDesc,
                                  miopenFusionOpDescriptor_t* activBwdOp,
@@ -2744,25 +2803,25 @@ miopenCreateOpActivationBackward(miopenFusionPlanDescriptor_t fusePlanDesc,
 
 // Bias create ops ---
 /*! @brief Creates a forward bias operator.
-*
-* @param fusePlanDesc   A fusion plan descriptor (input)
-* @param biasOp         Pointer to an operator type (output)
-* @param bDesc          bias tensor descriptor (input)
-* @return               miopenStatus_t
-*/
+ *
+ * @param fusePlanDesc   A fusion plan descriptor (input)
+ * @param biasOp         Pointer to an operator type (output)
+ * @param bDesc          bias tensor descriptor (input)
+ * @return               miopenStatus_t
+ */
 MIOPEN_EXPORT miopenStatus_t miopenCreateOpBiasForward(miopenFusionPlanDescriptor_t fusePlanDesc,
                                                        miopenFusionOpDescriptor_t* biasOp,
                                                        const miopenTensorDescriptor_t bDesc);
 
 // Batch normalization create ops ---
 /*! @brief Creates a forward inference batch normalization operator.
-*
-* @param fusePlanDesc           A fusion plan descriptor (input)
-* @param bnOp                   Pointer to an operator type (output)
-* @param bn_mode                Batch normalization layer mode (input)
-* @param bnScaleBiasMeanVarDesc Gamma, beta, mean, variance tensor descriptor (input)
-* @return                       miopenStatus_t
-*/
+ *
+ * @param fusePlanDesc           A fusion plan descriptor (input)
+ * @param bnOp                   Pointer to an operator type (output)
+ * @param bn_mode                Batch normalization layer mode (input)
+ * @param bnScaleBiasMeanVarDesc Gamma, beta, mean, variance tensor descriptor (input)
+ * @return                       miopenStatus_t
+ */
 MIOPEN_EXPORT miopenStatus_t
 miopenCreateOpBatchNormInference(miopenFusionPlanDescriptor_t fusePlanDesc,
                                  miopenFusionOpDescriptor_t* bnOp,
@@ -2770,14 +2829,14 @@ miopenCreateOpBatchNormInference(miopenFusionPlanDescriptor_t fusePlanDesc,
                                  const miopenTensorDescriptor_t bnScaleBiasMeanVarDesc);
 
 /*! @brief Creates a forward training batch normalization operator.
-*
-* @param fusePlanDesc           A fusion plan descriptor (input)
-* @param bnFwdOp                   Pointer to an operator type (output)
-* @param bn_mode                Batch normalization layer mode (input)
-* @param runningMeanVariance    Toggles whether or not to save population statistics for inference;
-* batch statistic are required (input)
-* @return                       miopenStatus_t
-*/
+ *
+ * @param fusePlanDesc           A fusion plan descriptor (input)
+ * @param bnFwdOp                   Pointer to an operator type (output)
+ * @param bn_mode                Batch normalization layer mode (input)
+ * @param runningMeanVariance    Toggles whether or not to save population statistics for inference;
+ * batch statistic are required (input)
+ * @return                       miopenStatus_t
+ */
 MIOPEN_EXPORT miopenStatus_t
 miopenCreateOpBatchNormForward(miopenFusionPlanDescriptor_t fusePlanDesc,
                                miopenFusionOpDescriptor_t* bnFwdOp,
@@ -2785,12 +2844,12 @@ miopenCreateOpBatchNormForward(miopenFusionPlanDescriptor_t fusePlanDesc,
                                bool runningMeanVariance);
 
 /*! @brief Creates a back propagation batch normalization operator.
-*
-* @param fusePlanDesc           A fusion plan descriptor (input)
-* @param bnBwdOp                   Pointer to an operator type (output)
-* @param bn_mode                Batch normalization layer mode (input)
-* @return                       miopenStatus_t
-*/
+ *
+ * @param fusePlanDesc           A fusion plan descriptor (input)
+ * @param bnBwdOp                   Pointer to an operator type (output)
+ * @param bn_mode                Batch normalization layer mode (input)
+ * @return                       miopenStatus_t
+ */
 MIOPEN_EXPORT miopenStatus_t
 miopenCreateOpBatchNormBackward(miopenFusionPlanDescriptor_t fusePlanDesc,
                                 miopenFusionOpDescriptor_t* bnBwdOp,
@@ -2798,29 +2857,29 @@ miopenCreateOpBatchNormBackward(miopenFusionPlanDescriptor_t fusePlanDesc,
 
 //---
 /*! @brief Creates an operator argument object
-*
-* @param args        Pointer to an operator argument type (output)
-* @return            miopenStatus_t
-*/
+ *
+ * @param args        Pointer to an operator argument type (output)
+ * @return            miopenStatus_t
+ */
 MIOPEN_EXPORT miopenStatus_t miopenCreateOperatorArgs(miopenOperatorArgs_t* args);
 
 /*! @brief Destroys an operator argument object
-*
-* @param args        An operator argument type (output)
-* @return            miopenStatus_t
-*/
+ *
+ * @param args        An operator argument type (output)
+ * @return            miopenStatus_t
+ */
 MIOPEN_EXPORT miopenStatus_t miopenDestroyOperatorArgs(miopenOperatorArgs_t args);
 
 // Convolution set arguments ---
 /*! @brief Sets the arguments for forward convolution op
-*
-* @param args    An arguments object type (output)
-* @param convOp  Forward convolution operator (input)
-* @param alpha   Floating point scaling factor, allocated on the host (input)
-* @param beta    Floating point shift factor, allocated on the host (input)
-* @param w       Pointer to tensor memory  (input)
-* @return        miopenStatus_t
-*/
+ *
+ * @param args    An arguments object type (output)
+ * @param convOp  Forward convolution operator (input)
+ * @param alpha   Floating point scaling factor, allocated on the host (input)
+ * @param beta    Floating point shift factor, allocated on the host (input)
+ * @param w       Pointer to tensor memory  (input)
+ * @return        miopenStatus_t
+ */
 MIOPEN_EXPORT miopenStatus_t miopenSetOpArgsConvForward(miopenOperatorArgs_t args,
                                                         const miopenFusionOpDescriptor_t convOp,
                                                         const void* alpha,
@@ -2828,16 +2887,16 @@ MIOPEN_EXPORT miopenStatus_t miopenSetOpArgsConvForward(miopenOperatorArgs_t arg
                                                         const void* w);
 // Activation set arguments ---
 /*! @brief Sets the arguments for forward activation op
-*
-* @param args    An arguments object type (output)
-* @param activFwdOp   Activation backwards operator (input)
-* @param alpha   Floating point scaling factor, allocated on the host (input)
-* @param beta    Floating point shift factor, allocated on the host (input)
-* @param activAlpha  Double precision activation parameter which depends on activation mode (input)
-* @param activBeta   Double precision activation parameter which depends on activation mode (input)
-* @param activGamma  Double precision activation parameter which depends on activation mode (input)
-* @return        miopenStatus_t
-*/
+ *
+ * @param args    An arguments object type (output)
+ * @param activFwdOp   Activation backwards operator (input)
+ * @param alpha   Floating point scaling factor, allocated on the host (input)
+ * @param beta    Floating point shift factor, allocated on the host (input)
+ * @param activAlpha  Double precision activation parameter which depends on activation mode (input)
+ * @param activBeta   Double precision activation parameter which depends on activation mode (input)
+ * @param activGamma  Double precision activation parameter which depends on activation mode (input)
+ * @return        miopenStatus_t
+ */
 MIOPEN_EXPORT miopenStatus_t
 miopenSetOpArgsActivForward(miopenOperatorArgs_t args,
                             const miopenFusionOpDescriptor_t activFwdOp,
@@ -2848,18 +2907,18 @@ miopenSetOpArgsActivForward(miopenOperatorArgs_t args,
                             double activGamma);
 
 /*! @brief Sets the arguments for backward activation op
-*
-* @param args    An arguments object type (output)
-* @param activBwdOp   Activation backwards operator (input)
-* @param alpha   Floating point scaling factor, allocated on the host (input)
-* @param beta    Floating point shift factor, allocated on the host (input)
-* @param y        Data tensor y, output of activations in the forward direction (input)
-* @param reserved    Data tensor reserved memory space; currently should be nullptr (input)
-* @param activAlpha  Double precision activation parameter which depends on activation mode (input)
-* @param activBeta   Double precision activation parameter which depends on activation mode (input)
-* @param activGamma  Double precision activation parameter which depends on activation mode (input)
-* @return        miopenStatus_t
-*/
+ *
+ * @param args    An arguments object type (output)
+ * @param activBwdOp   Activation backwards operator (input)
+ * @param alpha   Floating point scaling factor, allocated on the host (input)
+ * @param beta    Floating point shift factor, allocated on the host (input)
+ * @param y        Data tensor y, output of activations in the forward direction (input)
+ * @param reserved    Data tensor reserved memory space; currently should be nullptr (input)
+ * @param activAlpha  Double precision activation parameter which depends on activation mode (input)
+ * @param activBeta   Double precision activation parameter which depends on activation mode (input)
+ * @param activGamma  Double precision activation parameter which depends on activation mode (input)
+ * @return        miopenStatus_t
+ */
 MIOPEN_EXPORT miopenStatus_t
 miopenSetOpArgsActivBackward(miopenOperatorArgs_t args,
                              const miopenFusionOpDescriptor_t activBwdOp,
@@ -2873,18 +2932,18 @@ miopenSetOpArgsActivBackward(miopenOperatorArgs_t args,
 
 // Batch Normalization set arguments ---
 /*! @brief Sets the arguments for inference batch normalization op
-*
-* @param args               An arguments object type (output)
-* @param bnOp               Batch normalization inference operator (input)
-* @param alpha              Floating point scaling factor, allocated on the host (input)
-* @param beta               Floating point shift factor, allocated on the host (input)
-* @param bnScale            Pointer to the gamma tensor memory  (input)
-* @param bnBias             Pointer to the beta tensor memory  (input)
-* @param estimatedMean      Pointer to population mean memory  (input)
-* @param estimatedVariance  Pointer to population variance memory  (input)
-* @param epsilon            Scalar value for numerical stability (input)
-* @return                   miopenStatus_t
-*/
+ *
+ * @param args               An arguments object type (output)
+ * @param bnOp               Batch normalization inference operator (input)
+ * @param alpha              Floating point scaling factor, allocated on the host (input)
+ * @param beta               Floating point shift factor, allocated on the host (input)
+ * @param bnScale            Pointer to the gamma tensor memory  (input)
+ * @param bnBias             Pointer to the beta tensor memory  (input)
+ * @param estimatedMean      Pointer to population mean memory  (input)
+ * @param estimatedVariance  Pointer to population variance memory  (input)
+ * @param epsilon            Scalar value for numerical stability (input)
+ * @return                   miopenStatus_t
+ */
 MIOPEN_EXPORT miopenStatus_t
 miopenSetOpArgsBatchNormInference(miopenOperatorArgs_t args,
                                   const miopenFusionOpDescriptor_t bnOp,
@@ -2897,21 +2956,21 @@ miopenSetOpArgsBatchNormInference(miopenOperatorArgs_t args,
                                   double epsilon);
 
 /*! @brief Sets the arguments for forward batch normalization op
-*
-* @param args               An arguments object type (output)
-* @param bnOp               Batch normalization forward operator (input)
-* @param alpha              Floating point scaling factor, allocated on the host (input)
-* @param beta               Floating point shift factor, allocated on the host (input)
-* @param bnScale            Pointer to the gamma tensor memory  (input)
-* @param bnBias             Pointer to the beta tensor memory  (input)
-* @param savedMean          Pointer to batch mean memory  (input)
-* @param savedInvVariance   Pointer to batch inverse variance memory  (input)
-* @param runningMean        Pointer to population mean memory  (input)
-* @param runningVariance    Pointer to population variance memory  (input)
-* @param expAvgFactor       Scalar value for control of population statistics (input)
-* @param epsilon            Scalar value for numerical stability (input)
-* @return                   miopenStatus_t
-*/
+ *
+ * @param args               An arguments object type (output)
+ * @param bnOp               Batch normalization forward operator (input)
+ * @param alpha              Floating point scaling factor, allocated on the host (input)
+ * @param beta               Floating point shift factor, allocated on the host (input)
+ * @param bnScale            Pointer to the gamma tensor memory  (input)
+ * @param bnBias             Pointer to the beta tensor memory  (input)
+ * @param savedMean          Pointer to batch mean memory  (input)
+ * @param savedInvVariance   Pointer to batch inverse variance memory  (input)
+ * @param runningMean        Pointer to population mean memory  (input)
+ * @param runningVariance    Pointer to population variance memory  (input)
+ * @param expAvgFactor       Scalar value for control of population statistics (input)
+ * @param epsilon            Scalar value for numerical stability (input)
+ * @return                   miopenStatus_t
+ */
 MIOPEN_EXPORT miopenStatus_t miopenSetOpArgsBatchNormForward(miopenOperatorArgs_t args,
                                                              const miopenFusionOpDescriptor_t bnOp,
                                                              const void* alpha,
@@ -2926,20 +2985,20 @@ MIOPEN_EXPORT miopenStatus_t miopenSetOpArgsBatchNormForward(miopenOperatorArgs_
                                                              double epsilon);
 
 /*! @brief Sets the arguments for backward batch normalization op
-*
-* @param args               An arguments object type (output)
-* @param bnOp               Batch normalization forward operator (input)
-* @param alpha              Floating point scaling factor, allocated on the host (input)
-* @param beta               Floating point shift factor, allocated on the host (input)
-* @param x                  Pointer to the forward input tensor memory  (input)
-* @param bnScale            Pointer to the gamma tensor memory  (input)
-* @param bnBias             Pointer to the beta tensor memory  (input)
-* @param resultBnScaleDiff  Pointer to the gamma gradient tensor memory  (output)
-* @param resultBnBiasDiff   Pointer to the beta gradient tensor memory  (output)
-* @param savedMean          Pointer to batch mean memory  (input)
-* @param savedInvVariance   Pointer to batch inverse variance memory  (input)
-* @return                   miopenStatus_t
-*/
+ *
+ * @param args               An arguments object type (output)
+ * @param bnOp               Batch normalization forward operator (input)
+ * @param alpha              Floating point scaling factor, allocated on the host (input)
+ * @param beta               Floating point shift factor, allocated on the host (input)
+ * @param x                  Pointer to the forward input tensor memory  (input)
+ * @param bnScale            Pointer to the gamma tensor memory  (input)
+ * @param bnBias             Pointer to the beta tensor memory  (input)
+ * @param resultBnScaleDiff  Pointer to the gamma gradient tensor memory  (output)
+ * @param resultBnBiasDiff   Pointer to the beta gradient tensor memory  (output)
+ * @param savedMean          Pointer to batch mean memory  (input)
+ * @param savedInvVariance   Pointer to batch inverse variance memory  (input)
+ * @return                   miopenStatus_t
+ */
 MIOPEN_EXPORT miopenStatus_t miopenSetOpArgsBatchNormBackward(miopenOperatorArgs_t args,
                                                               const miopenFusionOpDescriptor_t bnOp,
                                                               const void* alpha,
@@ -2954,31 +3013,31 @@ MIOPEN_EXPORT miopenStatus_t miopenSetOpArgsBatchNormBackward(miopenOperatorArgs
 
 // Bias forward set arguments ---
 /*! @brief Sets the arguments for forward bias op
-*
-* @param args           An arguments object type (output)
-* @param biasOp         Forward bias operator (input)
-* @param alpha          Floating point scaling factor, allocated on the host (input)
-* @param beta           Floating point shift factor, allocated on the host (input)
-* @param bias           Pointer to the forward bias input tensor memory  (input)
-* @return               miopenStatus_t
-*/
+ *
+ * @param args           An arguments object type (output)
+ * @param biasOp         Forward bias operator (input)
+ * @param alpha          Floating point scaling factor, allocated on the host (input)
+ * @param beta           Floating point shift factor, allocated on the host (input)
+ * @param bias           Pointer to the forward bias input tensor memory  (input)
+ * @return               miopenStatus_t
+ */
 MIOPEN_EXPORT miopenStatus_t miopenSetOpArgsBiasForward(miopenOperatorArgs_t args,
                                                         const miopenFusionOpDescriptor_t biasOp,
                                                         const void* alpha,
                                                         const void* beta,
                                                         const void* bias);
 /*! @brief Executes the fusion plan
-*
-*
-* @param handle           MIOpen handle (input)
-* @param fusePlanDesc     fused plan descriptor (input)
-* @param inputDesc        Descriptor of the input tensor (input)
-* @param input            Source data tensor  (input)
-* @param outputDesc       Decriptor of the output tensor (input)
-* @param output           Destination data tensor  (output)
-* @param args             An argument object of the fused kernel (input)
-* @return           miopenStatus_t
-*/
+ *
+ *
+ * @param handle           MIOpen handle (input)
+ * @param fusePlanDesc     fused plan descriptor (input)
+ * @param inputDesc        Descriptor of the input tensor (input)
+ * @param input            Source data tensor  (input)
+ * @param outputDesc       Decriptor of the output tensor (input)
+ * @param output           Destination data tensor  (output)
+ * @param args             An argument object of the fused kernel (input)
+ * @return           miopenStatus_t
+ */
 MIOPEN_EXPORT miopenStatus_t
 miopenExecuteFusionPlan(const miopenHandle_t handle,
                         const miopenFusionPlanDescriptor_t fusePlanDesc,
@@ -2991,13 +3050,13 @@ miopenExecuteFusionPlan(const miopenHandle_t handle,
 // CLOSEOUT FUSION DOXYGEN GROUP
 
 /** @addtogroup RNN
-*
-*  @{
-*/
+ *
+ *  @{
+ */
 
 /*!  @enum miopenRNNMode_t
-* RNN mode selection for rnn layer preference
-*/
+ * RNN mode selection for rnn layer preference
+ */
 typedef enum {
     miopenRNNRELU = 0, /*!< RNN with ReLU activation */
     miopenRNNTANH = 1, /*!< RNN with tanh activation */
@@ -3007,7 +3066,7 @@ typedef enum {
 
 /*! @enum miopenRNNInputMode_t
  * Recurrent Neural Network layer initial input mode
-*/
+ */
 typedef enum {
     miopenRNNlinear = 0, /*!< Matrix multiplication at the input of the first layer */
     miopenRNNskip   = 1, /*!< No operation is performed at the input of the first layer. */
@@ -3015,7 +3074,7 @@ typedef enum {
 
 /*! @enum miopenRNNAlgo_t
  * Recurrent Neural Network algorithm mode
-*/
+ */
 typedef enum {
     miopenRNNdefault = 0, /*!< Use dedicated gate-operation kernel for LSTM and fundamental
                              algorithm for vanilla RNN & GRU */
@@ -3025,7 +3084,7 @@ typedef enum {
 
 /*! @enum miopenRNNDirectionMode_t
  * Recurrent Neural Network bi-directional behavior
-*/
+ */
 typedef enum {
     miopenRNNunidirection = 0, /*!< Forward in time only. */
     miopenRNNbidirection  = 1, /*!< Forward and backwards in time. */
@@ -3033,7 +3092,7 @@ typedef enum {
 
 /*! @enum miopenRNNBiasMode_t
  * Recurrent Neural Network add on bias
-*/
+ */
 typedef enum {
     miopenRNNNoBias   = 0, /*!< No Biases will be applied to GEMM operations */
     miopenRNNwithBias = 1, /*!< Biases will be applied to GEMM operations */
@@ -3041,7 +3100,7 @@ typedef enum {
 
 /*! @enum miopenRNNGEMMalgoMode_t
  * Recurrent Neural Network add on bias
-*/
+ */
 typedef enum {
     miopenRNNAlgoGEMM = 0,
 } miopenRNNGEMMalgoMode_t;
@@ -3051,21 +3110,21 @@ typedef enum {
  * API for creating an uninitialized RNN layer descriptor.
  * @param rnnDesc    Pointer to a tensor descriptor type
  * @return           miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenCreateRNNDescriptor(miopenRNNDescriptor_t* rnnDesc);
 
 /*! @brief Retrieves a RNN layer descriptor's details
-*
-* @param rnnDesc    RNN layer descriptor (input)
-* @param rnnMode    RNN mode (output)
-* @param algoMode   RNN algorithm mode (output)
-* @param inputMode  RNN data input mode (output)
-* @param dirMode    Uni or bi direction mode (output)
-* @param biasMode   Bias used (output)
-* @param hiddenSize Size of hidden state (output)
-* @param layer      Number of stacked layers (output)
-* @return           miopenStatus_t
-*/
+ *
+ * @param rnnDesc    RNN layer descriptor (input)
+ * @param rnnMode    RNN mode (output)
+ * @param algoMode   RNN algorithm mode (output)
+ * @param inputMode  RNN data input mode (output)
+ * @param dirMode    Uni or bi direction mode (output)
+ * @param biasMode   Bias used (output)
+ * @param hiddenSize Size of hidden state (output)
+ * @param layer      Number of stacked layers (output)
+ * @return           miopenStatus_t
+ */
 MIOPEN_EXPORT miopenStatus_t miopenGetRNNDescriptor(miopenRNNDescriptor_t rnnDesc,
                                                     miopenRNNMode_t* rnnMode,
                                                     miopenRNNAlgo_t* algoMode,
@@ -3076,21 +3135,21 @@ MIOPEN_EXPORT miopenStatus_t miopenGetRNNDescriptor(miopenRNNDescriptor_t rnnDes
                                                     int* layer);
 
 /*! @brief Retrieves a RNN layer descriptor's details version 2. This version enables retrieving
-* information of the dropout descriptor of the rnn descriptor.
-*
-* @param rnnDesc     RNN layer descriptor (input)
-* @param hiddenSize  Size of hidden state (output)
-* @param layer       Number of stacked layers (output)
-* @param dropoutDesc Pre-configured dropout descriptor for dropout layer in between RNN layers
-* (output)
-* @param inputMode   RNN data input mode (output)
-* @param dirMode     Uni or bi direction mode (output)
-* @param rnnMode     RNN mode (output)
-* @param biasMode    Bias used (output)
-* @param algoMode    RNN algorithm mode (output)
-* @param dataType    Data type of RNN (output)
-* @return            miopenStatus_t
-*/
+ * information of the dropout descriptor of the rnn descriptor.
+ *
+ * @param rnnDesc     RNN layer descriptor (input)
+ * @param hiddenSize  Size of hidden state (output)
+ * @param layer       Number of stacked layers (output)
+ * @param dropoutDesc Pre-configured dropout descriptor for dropout layer in between RNN layers
+ * (output)
+ * @param inputMode   RNN data input mode (output)
+ * @param dirMode     Uni or bi direction mode (output)
+ * @param rnnMode     RNN mode (output)
+ * @param biasMode    Bias used (output)
+ * @param algoMode    RNN algorithm mode (output)
+ * @param dataType    Data type of RNN (output)
+ * @return            miopenStatus_t
+ */
 MIOPEN_EXPORT miopenStatus_t miopenGetRNNDescriptor_V2(miopenRNNDescriptor_t rnnDesc,
                                                        int* hiddenSize,
                                                        int* layer,
@@ -3103,10 +3162,10 @@ MIOPEN_EXPORT miopenStatus_t miopenGetRNNDescriptor_V2(miopenRNNDescriptor_t rnn
                                                        miopenDataType_t* dataType);
 
 /*! @brief Destroys the tensor descriptor object
-*
-* @param rnnDesc RNN tensor descriptor type (input)
-* @return           miopenStatus_t
-*/
+ *
+ * @param rnnDesc RNN tensor descriptor type (input)
+ * @return           miopenStatus_t
+ */
 MIOPEN_EXPORT miopenStatus_t miopenDestroyRNNDescriptor(miopenRNNDescriptor_t rnnDesc);
 
 /*! @brief Set the details of the RNN descriptor
@@ -3123,7 +3182,7 @@ MIOPEN_EXPORT miopenStatus_t miopenDestroyRNNDescriptor(miopenRNNDescriptor_t rn
  * @param algo         RNN algorithm selected (input)
  * @param dataType     Only fp32 currently supported for RNNs (input)
  * @return             miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenSetRNNDescriptor(miopenRNNDescriptor_t rnnDesc,
                                                     const int hsize,
                                                     const int nlayers,
@@ -3151,7 +3210,7 @@ MIOPEN_EXPORT miopenStatus_t miopenSetRNNDescriptor(miopenRNNDescriptor_t rnnDes
  * @param algo         RNN algorithm selected (input)
  * @param dataType     Only fp32 currently supported for RNNs (input)
  * @return             miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenSetRNNDescriptor_V2(miopenRNNDescriptor_t rnnDesc,
                                                        const int hsize,
                                                        const int nlayers,
@@ -3178,7 +3237,7 @@ MIOPEN_EXPORT miopenStatus_t miopenSetRNNDescriptor_V2(miopenRNNDescriptor_t rnn
  * vector length. (input)
  * @param numBytes        Number of bytes required for RNN layer execution (output)
  * @return                miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenGetRNNWorkspaceSize(miopenHandle_t handle,
                                                        const miopenRNNDescriptor_t rnnDesc,
                                                        const int sequenceLen,
@@ -3200,7 +3259,7 @@ MIOPEN_EXPORT miopenStatus_t miopenGetRNNWorkspaceSize(miopenHandle_t handle,
  * vector length. (input)
  * @param numBytes        Number of bytes required for RNN layer execution (output)
  * @return                miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenGetRNNTrainingReserveSize(miopenHandle_t handle,
                                                              miopenRNNDescriptor_t rnnDesc,
                                                              const int sequenceLen,
@@ -3218,7 +3277,7 @@ MIOPEN_EXPORT miopenStatus_t miopenGetRNNTrainingReserveSize(miopenHandle_t hand
  * @param numBytes        Number of bytes required for RNN layer execution (output)
  * @param dtype           MIOpen data type enum (input)
  * @return                miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenGetRNNParamsSize(miopenHandle_t handle,
                                                     miopenRNNDescriptor_t rnnDesc,
                                                     miopenTensorDescriptor_t xDesc,
@@ -3236,7 +3295,7 @@ MIOPEN_EXPORT miopenStatus_t miopenGetRNNParamsSize(miopenHandle_t handle,
  * @param wDesc           A previously allocated tensor descriptor (output)
  * @param dtype           MIOpen data type enum, currently only fp32 is supported (input)
  * @return                miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenGetRNNParamsDescriptor(miopenHandle_t handle,
                                                           miopenRNNDescriptor_t rnnDesc,
                                                           miopenTensorDescriptor_t xDesc,
@@ -3259,7 +3318,7 @@ MIOPEN_EXPORT miopenStatus_t miopenGetRNNParamsDescriptor(miopenHandle_t handle,
  * vector length. (input)
  * @param numBytes        Number of bytes required for input tensor (output)
  * @return                miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenGetRNNInputTensorSize(miopenHandle_t handle,
                                                          miopenRNNDescriptor_t rnnDesc,
                                                          const int seqLen,
@@ -3277,7 +3336,7 @@ MIOPEN_EXPORT miopenStatus_t miopenGetRNNInputTensorSize(miopenHandle_t handle,
  * @param xDesc           An array of previously populated tensor descriptors (input)
  * @param numBytes        Number of bytes required for input tensor (output)
  * @return                miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenGetRNNHiddenTensorSize(miopenHandle_t handle,
                                                           miopenRNNDescriptor_t rnnDesc,
                                                           const int seqLen,
@@ -3323,7 +3382,7 @@ MIOPEN_EXPORT miopenStatus_t miopenGetRNNHiddenTensorSize(miopenHandle_t handle,
  * @param paramID         ID of the internal parameter tensor (input)
  * @param numBytes        The number of bytes of the layer's parameter matrix (output)
  * @return                miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenGetRNNLayerParamSize(miopenHandle_t handle,
                                                         miopenRNNDescriptor_t rnnDesc,
                                                         const int layer,
@@ -3367,7 +3426,7 @@ MIOPEN_EXPORT miopenStatus_t miopenGetRNNLayerParamSize(miopenHandle_t handle,
  * @param biasID          ID of the internal parameter tensor (input)
  * @param numBytes        The number of bytes of the layer's bias (output)
  * @return                miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenGetRNNLayerBiasSize(miopenHandle_t handle,
                                                        miopenRNNDescriptor_t rnnDesc,
                                                        const int layer,
@@ -3431,7 +3490,7 @@ MIOPEN_EXPORT miopenStatus_t miopenGetRNNLayerBiasSize(miopenHandle_t handle,
  * @param paramDesc       Tensor descriptor for the fully packed output parameter tensor (output)
  * @param layerParam      Pointer to the memory location of the parameter tensor (output)
  * @return                miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenGetRNNLayerParam(miopenHandle_t handle,
                                                     miopenRNNDescriptor_t rnnDesc,
                                                     const int layer,
@@ -3498,7 +3557,7 @@ MIOPEN_EXPORT miopenStatus_t miopenGetRNNLayerParam(miopenHandle_t handle,
  * @param biasDesc        Descriptor of the parameter tensor (output)
  * @param layerBias       Pointer to the memory location of the bias tensor (output)
  * @return                miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenGetRNNLayerBias(miopenHandle_t handle,
                                                    miopenRNNDescriptor_t rnnDesc,
                                                    const int layer,
@@ -3562,7 +3621,7 @@ MIOPEN_EXPORT miopenStatus_t miopenGetRNNLayerBias(miopenHandle_t handle,
  * @param paramDesc         Tensor descriptor for the fully packed output parameter tensor (output)
  * @param layerParamOffset  Location for the parameter offset (output)
  * @return                  miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenGetRNNLayerParamOffset(miopenRNNDescriptor_t rnnDesc,
                                                           const int layer,
                                                           miopenTensorDescriptor_t xDesc,
@@ -3619,7 +3678,7 @@ MIOPEN_EXPORT miopenStatus_t miopenGetRNNLayerParamOffset(miopenRNNDescriptor_t 
  * @param biasDesc        Descriptor of the parameter tensor (output)
  * @param layerBiasOffset Pointer to the memory location of the bias tensor (output)
  * @return                miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenGetRNNLayerBiasOffset(miopenRNNDescriptor_t rnnDesc,
                                                          const int layer,
                                                          miopenTensorDescriptor_t xDesc,
@@ -3678,7 +3737,7 @@ MIOPEN_EXPORT miopenStatus_t miopenGetRNNLayerBiasOffset(miopenRNNDescriptor_t r
  * @param paramDesc       Descriptor of the parameter tensor (input)
  * @param layerParam      Pointer to the memory location of the parameter tensor (input)
  * @return                miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenSetRNNLayerParam(miopenHandle_t handle,
                                                     miopenRNNDescriptor_t rnnDesc,
                                                     const int layer,
@@ -3738,7 +3797,7 @@ MIOPEN_EXPORT miopenStatus_t miopenSetRNNLayerParam(miopenHandle_t handle,
  * @param biasDesc        Descriptor of the bias tensor (output)
  * @param layerBias       Pointer to the memory location of the bias tensor (output)
  * @return                miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenSetRNNLayerBias(miopenHandle_t handle,
                                                    miopenRNNDescriptor_t rnnDesc,
                                                    const int layer,
@@ -3805,7 +3864,7 @@ MIOPEN_EXPORT miopenStatus_t miopenSetRNNLayerBias(miopenHandle_t handle,
  * @param reserveSpace          Pointer to memory allocated for random states (input / output)
  * @param reserveSpaceNumBytes  Number of allocated bytes in memory for use in the forward  (input)
  * @return                      miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenRNNForwardTraining(miopenHandle_t handle,
                                                       const miopenRNNDescriptor_t rnnDesc,
                                                       const int sequenceLen,
@@ -3899,7 +3958,7 @@ MIOPEN_EXPORT miopenStatus_t miopenRNNForwardTraining(miopenHandle_t handle,
  * @param reserveSpace          Pointer to memory allocated for random states (input / output)
  * @param reserveSpaceNumBytes  Number of allocated bytes in memory for use in the forward (input)
  * @return                      miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenRNNBackwardData(miopenHandle_t handle,
                                                    const miopenRNNDescriptor_t rnnDesc,
                                                    const int sequenceLen,
@@ -3963,7 +4022,7 @@ MIOPEN_EXPORT miopenStatus_t miopenRNNBackwardData(miopenHandle_t handle,
  * @param reserveSpace          Pointer to memory allocated for random states (input)
  * @param reserveSpaceNumBytes  Number of allocated bytes in memory for use in the forward (input)
  * @return                      miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenRNNBackwardWeights(miopenHandle_t handle,
                                                       const miopenRNNDescriptor_t rnnDesc,
                                                       const int sequenceLen,
@@ -4034,7 +4093,7 @@ MIOPEN_EXPORT miopenStatus_t miopenRNNBackwardWeights(miopenHandle_t handle,
  * @param workSpace             Pointer to memory allocated for forward training (input)
  * @param workSpaceNumBytes     Number of allocated bytes in memory for the workspace (input)
  * @return                      miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenRNNForwardInference(miopenHandle_t handle,
                                                        miopenRNNDescriptor_t rnnDesc,
                                                        const int sequenceLen,
@@ -4059,13 +4118,13 @@ MIOPEN_EXPORT miopenStatus_t miopenRNNForwardInference(miopenHandle_t handle,
 // CLOSEOUT RNN DOXYGEN GROUP
 
 /** @addtogroup LossFunction
-*
-*  @{
-*/
+ *
+ *  @{
+ */
 
 /*! @enum miopenCTCLossAlgo_t
  * Algorithms available to execute the CTC loss operation
-*/
+ */
 typedef enum {
     MIOPEN_CTC_LOSS_ALGO_DETERMINISTIC = 0, /*!< Results are guaranteed to be reproducible */
 } miopenCTCLossAlgo_t;
@@ -4075,7 +4134,7 @@ typedef enum {
  * API for creating an uninitialized CTC loss function descriptor.
  * @param ctcLossDesc  Pointer to the CTC loss function descriptor type (output)
  * @return             miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenCreateCTCLossDescriptor(miopenCTCLossDescriptor_t* ctcLossDesc);
 
 /*! @brief Retrieves a CTC loss function descriptor's details
@@ -4086,7 +4145,7 @@ MIOPEN_EXPORT miopenStatus_t miopenCreateCTCLossDescriptor(miopenCTCLossDescript
  * @param blank_label_id       User defined index for blank label (output)
  * @param apply_softmax_layer  Boolean to toggle input layer property (output)
  * @return                     miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenGetCTCLossDescriptor(miopenCTCLossDescriptor_t ctcLossDesc,
                                                         miopenDataType_t* dataType,
                                                         int* blank_label_id,
@@ -4096,7 +4155,7 @@ MIOPEN_EXPORT miopenStatus_t miopenGetCTCLossDescriptor(miopenCTCLossDescriptor_
  *
  * @param ctcLossDesc  CTC loss function descriptor type (input)
  * @return             miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenDestroyCTCLossDescriptor(miopenCTCLossDescriptor_t ctcLossDesc);
 
 /*! @brief Set the details of a CTC loss function descriptor
@@ -4107,7 +4166,7 @@ MIOPEN_EXPORT miopenStatus_t miopenDestroyCTCLossDescriptor(miopenCTCLossDescrip
  * @param blank_label_id       User defined index for blank label, default 0 (input)
  * @param apply_softmax_layer  Boolean to toggle input layer property (input)
  * @return             miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenSetCTCLossDescriptor(miopenCTCLossDescriptor_t ctcLossDesc,
                                                         miopenDataType_t dataType,
                                                         const int blank_label_id,
@@ -4128,7 +4187,7 @@ MIOPEN_EXPORT miopenStatus_t miopenSetCTCLossDescriptor(miopenCTCLossDescriptor_
  * @param workSpaceSize  Number of bytes of workspace required for CTC loss operation with selected
  * algorithm (output)
  * @return               miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t
 miopenGetCTCLossWorkspaceSize(miopenHandle_t handle,
                               const miopenTensorDescriptor_t probsDesc,
@@ -4158,7 +4217,7 @@ miopenGetCTCLossWorkspaceSize(miopenHandle_t handle,
  * @param workSpaceSize  Number of bytes of workspace required for CTC loss operation with selected
  * algorithm (input)
  * @return               miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenCTCLoss(miopenHandle_t handle,
                                            const miopenTensorDescriptor_t probsDesc,
                                            const void* probs,
@@ -4183,8 +4242,8 @@ MIOPEN_EXPORT miopenStatus_t miopenCTCLoss(miopenHandle_t handle,
  */
 
 /*!  @enum miopenRNGType_t
-* random number generator type
-*/
+ * random number generator type
+ */
 typedef enum {
     MIOPEN_RNG_PSEUDO_XORWOW = 0, /*!< XORWOW pseudorandom generator */
 } miopenRNGType_t;
@@ -4193,14 +4252,14 @@ typedef enum {
  *
  * @param dropoutDesc Pointer to a dropout descriptor type
  * @return            miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenCreateDropoutDescriptor(miopenDropoutDescriptor_t* dropoutDesc);
 
 /*! @brief Destroys the dropout descriptor object
  *
  * @param dropoutDesc Dropout descriptor type (input)
  * @return            miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenDestroyDropoutDescriptor(miopenDropoutDescriptor_t dropoutDesc);
 
 /*! @brief Query the amount of memory required to run dropout
@@ -4210,7 +4269,7 @@ MIOPEN_EXPORT miopenStatus_t miopenDestroyDropoutDescriptor(miopenDropoutDescrip
  * @param reserveSpaceSizeInBytes  Number of bytes of reservespace required for executing dropout
  * (Output)
  * @return                         miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenDropoutGetReserveSpaceSize(const miopenTensorDescriptor_t xDesc,
                                                               size_t* reserveSpaceSizeInBytes);
 
@@ -4221,7 +4280,7 @@ MIOPEN_EXPORT miopenStatus_t miopenDropoutGetReserveSpaceSize(const miopenTensor
  * @param handle            MIOpen handle (input)
  * @param stateSizeInBytes  Number of bytes required to store random generator states (Output)
  * @return                  miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenDropoutGetStatesSize(miopenHandle_t handle,
                                                         size_t* stateSizeInBytes);
 
@@ -4240,7 +4299,7 @@ MIOPEN_EXPORT miopenStatus_t miopenDropoutGetStatesSize(miopenHandle_t handle,
  * @param rng_mode     Random number generator used to generate parallel random number sequences
  * (Output)
  * @return             miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenGetDropoutDescriptor(miopenDropoutDescriptor_t dropoutDesc,
                                                         miopenHandle_t handle,
                                                         float* dropout,
@@ -4271,7 +4330,7 @@ MIOPEN_EXPORT miopenStatus_t miopenGetDropoutDescriptor(miopenDropoutDescriptor_
  * @param rng_mode          Random number generator used to generate parallel random number
  * sequences (input)
  * @return                  miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenRestoreDropoutDescriptor(miopenDropoutDescriptor_t dropoutDesc,
                                                             miopenHandle_t handle,
                                                             float dropout,
@@ -4300,7 +4359,7 @@ MIOPEN_EXPORT miopenStatus_t miopenRestoreDropoutDescriptor(miopenDropoutDescrip
  * @param rng_mode          Random number generator used to generate parallel random number
  * sequences (input)
  * @return                  miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenSetDropoutDescriptor(miopenDropoutDescriptor_t dropoutDesc,
                                                         miopenHandle_t handle,
                                                         float dropout,
@@ -4327,7 +4386,7 @@ MIOPEN_EXPORT miopenStatus_t miopenSetDropoutDescriptor(miopenDropoutDescriptor_
  * @param reserveSpaceSizeInBytes  Number of bytes of reservespace required for executing forward
  * dropout (input)
  * @return                         miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenDropoutForward(miopenHandle_t handle,
                                                   const miopenDropoutDescriptor_t dropoutDesc,
                                                   const miopenTensorDescriptor_t noise_shape,
@@ -4354,7 +4413,7 @@ MIOPEN_EXPORT miopenStatus_t miopenDropoutForward(miopenHandle_t handle,
  * @param reserveSpaceSizeInBytes  Number of bytes of reservespace required for executing backward
  * dropout (input)
  * @return                         miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenDropoutBackward(miopenHandle_t handle,
                                                    const miopenDropoutDescriptor_t dropoutDesc,
                                                    const miopenTensorDescriptor_t noise_shape,
@@ -4367,6 +4426,143 @@ MIOPEN_EXPORT miopenStatus_t miopenDropoutBackward(miopenHandle_t handle,
 
 /** @} */
 // CLOSEOUT DROPOUT DOXYGEN GROUP
+
+// TensorReduce APIs
+/** @addtogroup TensorReduce
+ *
+ *  @{
+ */
+
+/*! @brief Creates the ReduceTensor descriptor object
+ *
+ * @param reduceTensorDesc Pointer to a ReduceTensor descriptor type
+ * @return            miopenStatus_t
+ */
+MIOPEN_EXPORT miopenStatus_t
+miopenCreateReduceTensorDescriptor(miopenReduceTensorDescriptor_t* reduceTensorDesc);
+
+/*! @brief Destroy the ReduceTensor descriptor object
+ *
+ * @param reduceTensorDesc  ReduceTensor descriptor type (input)
+ * @return            miopenStatus_t
+ */
+MIOPEN_EXPORT miopenStatus_t
+miopenDestroyReduceTensorDescriptor(miopenReduceTensorDescriptor_t reduceTensorDesc);
+
+/*! @brief Initialize a ReduceTensor descriptor object
+ *
+ * @param reduceTensorDesc         Pointer to the ReduceTensor descriptor object (output)
+ * @param reduceTensorOp           Enumerant specifying the operation used by ReduceTensor (input)
+ * @param reduceTensorCompType     Enumerant specifying the data type used with ReduceTensor
+ * operation (input)
+ * @param reduceTensorNanOpt       Enumerant specifying the Nan number propagation mode (input)
+ * @param reduceTensorIndices      Enumerant specifying the indices modes used by ReduceTensor
+ * (input)
+ * @param reduceTensorIndicesType  Enumerant specifying the data type of the indices (input)
+ * @return           miopenStatus_t
+ */
+MIOPEN_EXPORT miopenStatus_t
+miopenSetReduceTensorDescriptor(miopenReduceTensorDescriptor_t reduceTensorDesc,
+                                miopenReduceTensorOp_t reduceTensorOp,
+                                miopenDataType_t reduceTensorCompType,
+                                miopenNanPropagation_t reduceTensorNanOpt,
+                                miopenReduceTensorIndices_t reduceTensorIndices,
+                                miopenIndicesType_t reduceTensorIndicesType);
+
+/*! @brief Query a ReduceTensor descriptor object
+ *
+ * @param reduceTensorDesc         Pointer to the ReduceTensor descriptor object (input)
+ * @param reduceTensorOp           Pointer to enumerant specifying the operation used by
+ * ReduceTensor (output)
+ * @param reduceTensorCompType     Pointer to enumerant specifying the data type used with
+ * ReduceTensor operation (output)
+ * @param reduceTensorNanOpt       Pointer to enumerant specifying the Nan number propagation mode
+ * (output)
+ * @param reduceTensorIndices      Pointer to enumerant specifying the indices modes used by
+ * ReduceTensor (output)
+ * @param reduceTensorIndicesType  Pointer to enumerant specifying the data type of the indices
+ * (output)
+ * @return           miopenStatus_t
+ */
+MIOPEN_EXPORT miopenStatus_t
+miopenGetReduceTensorDescriptor(const miopenReduceTensorDescriptor_t reduceTensorDesc,
+                                miopenReduceTensorOp_t* reduceTensorOp,
+                                miopenDataType_t* reduceTensorCompType,
+                                miopenNanPropagation_t* reduceTensorNanOpt,
+                                miopenReduceTensorIndices_t* reduceTensorIndices,
+                                miopenIndicesType_t* reduceTensorIndicesType);
+
+/*! @brief Helper function to query the minimum index space size required by the ReduceTensor call
+ *
+ * @param handle                   MIOpen Handle (input)
+ * @param reduceTensorDesc         Pointer to the ReduceTensor descriptor object (input)
+ * @param aDesc                    Pointer to the input tensor descriptor (input)
+ * @param cDesc                    Pointer to the output tensor descriptor (input)
+ * @param sizeInBytes              Pointer to data to return the minimum index space size
+ * @return           miopenStatus_t
+ */
+MIOPEN_EXPORT miopenStatus_t
+miopenGetReductionIndicesSize(miopenHandle_t handle,
+                              const miopenReduceTensorDescriptor_t reduceTensorDesc,
+                              const miopenTensorDescriptor_t aDesc,
+                              const miopenTensorDescriptor_t cDesc,
+                              size_t* sizeInBytes);
+
+/*! @brief Helper function to query the minimum workspace size required by the ReduceTensor call
+ *
+ * @param handle                   MIOpen Handle (input)
+ * @param reduceTensorDesc         Pointer to the ReduceTensor descriptor object (input)
+ * @param aDesc                    Pointer to the input tensor descriptor (input)
+ * @param cDesc                    Pointer to the output tensor descriptor (input)
+ * @param sizeInBytes              Pointer to data to return the minimum workspace size
+ * @return           miopenStatus_t
+ */
+MIOPEN_EXPORT miopenStatus_t
+miopenGetReductionWorkSpaceSize(miopenHandle_t handle,
+                                const miopenReduceTensorDescriptor_t reduceTensorDesc,
+                                const miopenTensorDescriptor_t aDesc,
+                                const miopenTensorDescriptor_t cDesc,
+                                size_t* sizeInBytes);
+
+/*! @brief TensorReduce function doing reduction on tensor A by implementing C = alpha * reduceOp(A)
+ * + beta * C
+ *
+ * The length of each dimension of output tensor C must match the length of the corresponding
+ * dimension of
+ * input tensor A or must be equal to 1. The dimensions with length equal to 1 indicate the
+ * dimensions
+ * of A to be reduced.
+ *
+ * @param handle                   MIOpen Handle (input)
+ * @param reduceTensorDesc         Pointer to the ReduceTensor descriptor object (input)
+ * @param indices                  Address of the allocated indices data space (output)
+ * @param indicesSizeInBytes       Size in bytes of the allocated indices data space (input)
+ * @param workspace                Address of the allocated workspace data (input)
+ * @param workspaceSizeInBytes     Size in bytes of the allocated workspace data (input)
+ * @param alpha                    Pointer to scale factor for data in input tensor A (input)
+ * @param aDesc                    Pointer to the tensor descriptor for input tensor A (input)
+ * @param A                        Pointer to the data of input tensor A (input)
+ * @param beta                     Pointer to scale factor for data in output tensor C (input)
+ * @param cDesc                    Pointer to the tensor descriptor for output tensor C (input)
+ * @param C                        Pointer to the data of output tensor C (output)
+ * @return           miopenStatus_t
+ */
+MIOPEN_EXPORT miopenStatus_t
+miopenReduceTensor(miopenHandle_t handle,
+                   const miopenReduceTensorDescriptor_t reduceTensorDesc,
+                   void* indices,
+                   size_t indicesSizeInBytes,
+                   void* workspace,
+                   size_t workspaceSizeInBytes,
+                   const void* alpha,
+                   const miopenTensorDescriptor_t aDesc,
+                   const void* A,
+                   const void* beta,
+                   const miopenTensorDescriptor_t cDesc,
+                   void* C);
+
+/** @} */
+// CLOSEOUT TensorReduce DOXYGEN GROUP
 
 #ifdef __cplusplus
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -220,6 +220,7 @@ set( MIOpen_Source
     solver/conv_hip_implicit_gemm_wrw_weights_v4r4.cpp
     solver/conv_hip_implicit_gemm_v4r4_xdlops.cpp
     solver/conv_hip_implicit_gemm_v4r4_gen_xdlops.cpp
+    solver/conv_hip_implicit_gemm_fwd_v4r4_xdlops.cpp
     solver/conv_hip_implicit_gemm_v4r4_gen_xdlops_wrw_fp32.cpp
     solver/conv_hip_implicit_gemm_xdlops_common.cpp
     solver/conv_hip_implicit_gemm_nonxdlops_common.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -126,6 +126,7 @@ set( MIOpen_Source
     execution_context.cpp
     kern_db.cpp
     bz2.cpp
+    reducetensor.cpp
     include/miopen/buffer_info.hpp
     include/miopen/temp_file.hpp
     include/miopen/bfloat16.hpp
@@ -175,6 +176,8 @@ set( MIOpen_Source
     include/miopen/rnn_util.hpp
     include/miopen/bz2.hpp
     include/miopen/comgr.hpp
+    include/miopen/reducetensor.hpp
+    include/miopen/reduce_common.hpp
     md_graph.cpp
     mdg_expr.cpp
     conv/invokers/gcn_asm_1x1u.cpp

--- a/src/hip/hip_build_utils.cpp
+++ b/src/hip/hip_build_utils.cpp
@@ -118,7 +118,6 @@ boost::filesystem::path HipBuild(boost::optional<TmpDir>& tmp_dir,
         params += " -O3 ";
     }
 
-    // params += " -Wno-unused-command-line-argument -c -fno-gpu-rdc -I. ";
     params += " -Wno-unused-command-line-argument -I. ";
     params += MIOPEN_STRINGIZE(HIP_COMPILER_FLAGS);
     if(IsHccCompiler())
@@ -144,11 +143,13 @@ boost::filesystem::path HipBuild(boost::optional<TmpDir>& tmp_dir,
     {
         if(IsHccCompiler())
         {
+            params += " -gline-tables-only";
             env += " KMDUMPISA=1";
             env += " KMDUMPLLVM=1";
         }
         else if(IsHipClangCompiler())
         {
+            params += " -gline-tables-only";
             params += " -save-temps";
         }
     }
@@ -299,6 +300,23 @@ external_tool_version_t HipCompilerVersion()
 {
     static auto once = HipCompilerVersionImpl();
     return once;
+}
+
+bool external_tool_version_t::operator>(const external_tool_version_t& rhs) const
+{
+    if(major > rhs.major)
+        return true;
+    else if(major == rhs.major)
+    {
+        if(minor > rhs.minor)
+            return true;
+        else if(minor == rhs.minor)
+            return (patch > rhs.patch);
+        else
+            return false;
+    }
+    else
+        return false;
 }
 
 bool external_tool_version_t::operator>=(const external_tool_version_t& rhs) const

--- a/src/include/miopen/comgr.hpp
+++ b/src/include/miopen/comgr.hpp
@@ -47,6 +47,12 @@ void BuildOcl(const std::string& name,
               const std::string& device,
               std::vector<char>& binary);
 
+void BuildAsm(const std::string& name,
+              const std::string& text,
+              const std::string& options,
+              const std::string& device,
+              std::vector<char>& binary);
+
 } // namespace comgr
 } // namespace miopen
 

--- a/src/include/miopen/find_controls.hpp
+++ b/src/include/miopen/find_controls.hpp
@@ -128,7 +128,7 @@ class FindMode
         Fast,
         Hybrid,
         End_,
-        Default_ = Normal,
+        Default_ = Hybrid,
     };
 
     private:

--- a/src/include/miopen/hip_build_utils.hpp
+++ b/src/include/miopen/hip_build_utils.hpp
@@ -47,6 +47,7 @@ struct external_tool_version_t
     int major = -1;
     int minor = -1;
     int patch = -1;
+    bool operator>(const external_tool_version_t& rhs) const;
     bool operator>=(const external_tool_version_t& rhs) const;
 };
 

--- a/src/include/miopen/reduce_common.hpp
+++ b/src/include/miopen/reduce_common.hpp
@@ -1,0 +1,311 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2020 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#ifndef GUARD_MIOPEN_REDUCE_COMMON_HPP
+#define GUARD_MIOPEN_REDUCE_COMMON_HPP
+
+#include <half.hpp>
+#include <limits>
+#include <cmath>
+#include <miopen/miopen.h>
+#include <miopen/float_equal.hpp>
+
+#include "bfloat16.hpp"
+
+namespace reduce {
+
+enum ReductionMethod_t
+{
+    Reduce_DirectThreadWise = 1,
+    Reduce_DirectWarpWise   = 2,
+    Reduce_BlockWise        = 3,
+    Reduce_MultiBlock       = 4
+};
+
+// data type conversion
+template <typename T>
+struct type_convert
+{
+    template <typename X>
+    T operator()(X x) const
+    {
+        return static_cast<T>(x);
+    }
+};
+
+template <>
+template <>
+inline float type_convert<float>::operator()<half_float::half>(half_float::half x) const
+{
+    return half_float::half_cast<float>(x);
+};
+
+template <>
+template <>
+inline half_float::half type_convert<half_float::half>::operator()<float>(float x) const
+{
+    return half_float::half_cast<half_float::half>(x);
+};
+
+template <>
+template <>
+inline float type_convert<float>::operator()<bfloat16>(bfloat16 x) const
+{
+    return float(x);
+};
+
+template <>
+template <>
+inline bfloat16 type_convert<bfloat16>::operator()<float>(float x) const
+{
+    return bfloat16(x);
+};
+
+template <typename compType>
+static inline std::function<void(compType&, compType)> ReduceOpFn(miopenReduceTensorOp_t op_)
+{
+    switch(op_)
+    {
+    case MIOPEN_REDUCE_TENSOR_ADD: return ([&](compType& a_, compType b_) { a_ = a_ + b_; });
+
+    case MIOPEN_REDUCE_TENSOR_MUL: return ([&](compType& a_, compType b_) { a_ = a_ * b_; });
+
+    case MIOPEN_REDUCE_TENSOR_MIN:
+        return ([&](compType& a_, compType b_) {
+            if(a_ > b_)
+                a_ = b_;
+        });
+
+    case MIOPEN_REDUCE_TENSOR_MAX:
+        return ([&](compType& a_, compType b_) {
+            if(a_ < b_)
+                a_ = b_;
+        });
+    }
+
+    return (std::function<void(compType&, compType)>{});
+};
+
+template <typename compType>
+static inline std::function<void(compType&, compType, bool& changed)>
+ReduceOpFn2(miopenReduceTensorOp_t op_)
+{
+    switch(op_)
+    {
+    case MIOPEN_REDUCE_TENSOR_MIN:
+        return ([&](compType& a_, compType b_, bool& changed) {
+            if(a_ > b_)
+            {
+                a_      = b_;
+                changed = true;
+            }
+            else
+                changed = false;
+        });
+
+    case MIOPEN_REDUCE_TENSOR_MAX:
+        return ([&](compType& a_, compType b_, bool& changed) {
+            if(a_ < b_)
+            {
+                a_      = b_;
+                changed = true;
+            }
+            else
+                changed = false;
+        });
+
+    case MIOPEN_REDUCE_TENSOR_ADD:
+    case MIOPEN_REDUCE_TENSOR_MUL: return (std::function<void(compType&, compType, bool&)>{});
+    };
+
+    return (std::function<void(compType&, compType, bool&)>{});
+};
+
+template <typename compType>
+static inline compType ReduceOpZeroVal(miopenReduceTensorOp_t op_)
+{
+    switch(op_)
+    {
+    case MIOPEN_REDUCE_TENSOR_ADD: return (type_convert<compType>{}(0.0));
+
+    case MIOPEN_REDUCE_TENSOR_MUL: return (type_convert<compType>{}(1.0));
+
+    case MIOPEN_REDUCE_TENSOR_MIN: return (std::numeric_limits<compType>::max());
+
+    case MIOPEN_REDUCE_TENSOR_MAX: return (std::numeric_limits<compType>::min());
+    }
+
+    return (type_convert<compType>{}(0.0));
+};
+
+template <>
+inline half_float::half ReduceOpZeroVal<half_float::half>(miopenReduceTensorOp_t op_)
+{
+    switch(op_)
+    {
+    case MIOPEN_REDUCE_TENSOR_ADD: return (type_convert<half_float::half>{}(0.0));
+
+    case MIOPEN_REDUCE_TENSOR_MUL: return (type_convert<half_float::half>{}(1.0));
+
+    case MIOPEN_REDUCE_TENSOR_MIN:
+        return (type_convert<half_float::half>{}(std::numeric_limits<float>::max()));
+
+    case MIOPEN_REDUCE_TENSOR_MAX:
+        return (type_convert<half_float::half>{}(std::numeric_limits<float>::min()));
+    }
+
+    return (type_convert<half_float::half>{}(0.0));
+};
+
+template <typename T>
+static inline bool IsNan(T x)
+{
+    // C++ isnan() is used for float and double
+    return (std::isnan(x));
+};
+
+template <>
+inline bool IsNan<half_float::half>(half_float::half x)
+{
+    return (half_float::isnan(x));
+};
+
+template <typename T>
+static inline bool IsFinite(T x)
+{
+    // C++ isfinite() is used for float and double
+    return (std::isfinite(x));
+};
+
+template <>
+inline bool IsFinite<half_float::half>(half_float::half x)
+{
+    return (half_float::isfinite(x));
+};
+
+struct float_equal_one
+{
+    template <class T>
+    static bool apply(T x)
+    {
+        return std::isfinite(x) and
+               std::nextafter(x, std::numeric_limits<T>::lowest()) <= static_cast<T>(1.0) and
+               std::nextafter(x, std::numeric_limits<T>::max()) >= static_cast<T>(1.0);
+    }
+
+    template <class T>
+    bool operator()(T x)
+    {
+        return (float_equal_one::apply(x));
+    };
+};
+
+struct float_equal_zero
+{
+    template <class T>
+    static bool apply(T x)
+    {
+        return std::isfinite(x) and
+               std::nextafter(x, std::numeric_limits<T>::lowest()) <= static_cast<T>(0.0) and
+               std::nextafter(x, std::numeric_limits<T>::max()) >= static_cast<T>(0.0);
+    }
+
+    template <class T>
+    bool operator()(T x)
+    {
+        return (float_equal_zero::apply(x));
+    };
+};
+
+template <>
+inline bool float_equal_one::apply<half_float::half>(half_float::half x)
+{
+    return half_float::isfinite(x) and x <= type_convert<half_float::half>{}(1.0) and
+           x >= type_convert<half_float::half>{}(1.0);
+};
+
+template <>
+inline bool float_equal_zero::apply<half_float::half>(half_float::half x)
+{
+    return half_float::isfinite(x) and x <= type_convert<half_float::half>{}(0.0) and
+           x >= type_convert<half_float::half>{}(0.0);
+};
+
+template <typename compType>
+static inline void binop_with_nan_check(miopenNanPropagation_t nanOpt,
+                                        std::function<void(compType&, compType)> opReduce,
+                                        compType& accuVal,
+                                        compType currVal)
+{
+    if(nanOpt == MIOPEN_NOT_PROPAGATE_NAN)
+        opReduce(accuVal, currVal);
+    else
+    {
+        if(reduce::IsNan(currVal))
+            accuVal = currVal;
+        else
+            opReduce(accuVal, currVal);
+    };
+};
+
+template <typename compType>
+static inline void binop_with_nan_check2(miopenNanPropagation_t nanOpt,
+                                         std::function<void(compType&, compType, bool&)> opReduce,
+                                         compType& accuVal,
+                                         compType currVal,
+                                         int& accuIndex,
+                                         int currIndex)
+{
+    if(nanOpt == MIOPEN_NOT_PROPAGATE_NAN)
+    {
+        bool changed;
+
+        opReduce(accuVal, currVal, changed);
+
+        if(changed)
+            accuIndex = currIndex;
+    }
+    else
+    {
+        if(reduce::IsNan(currVal))
+        {
+            accuVal   = currVal;
+            accuIndex = currIndex;
+        }
+        else
+        {
+            bool changed;
+
+            opReduce(accuVal, currVal, changed);
+
+            if(changed)
+                accuIndex = currIndex;
+        };
+    };
+};
+
+}; // end of namespace reduce
+
+#endif

--- a/src/include/miopen/reducetensor.hpp
+++ b/src/include/miopen/reducetensor.hpp
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2017 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#ifndef GUARD_MIOPEN_REDUCETENSOR_HPP
+#define GUARD_MIOPEN_REDUCETENSOR_HPP
+
+#include <miopen/common.hpp>
+#include <miopen/kernel.hpp>
+#include <miopen/miopen.h>
+#include <miopen/object.hpp>
+#include <miopen/solver_id.hpp>
+#include <miopen/names.hpp>
+#include <miopen/tensor.hpp>
+#include <miopen/handle.hpp>
+
+#include <string>
+#include <tuple>
+#include <vector>
+
+namespace miopen {
+
+struct ReduceTensorDescriptor : miopenReduceTensorDescriptor
+{
+    ReduceTensorDescriptor() = default;
+    ReduceTensorDescriptor(miopenReduceTensorOp_t reduceTensorOp,
+                           miopenDataType_t reduceTensorCompType,
+                           miopenNanPropagation_t reduceTensorNanOpt,
+                           miopenReduceTensorIndices_t reduceTensorIndices,
+                           miopenIndicesType_t reduceTensorIndicesType);
+
+    miopenReduceTensorOp_t reduceTensorOp_;
+    miopenDataType_t reduceTensorCompType_;
+    miopenNanPropagation_t reduceTensorNanOpt_;
+    miopenReduceTensorIndices_t reduceTensorIndices_;
+    miopenIndicesType_t reduceTensorIndicesType_;
+
+    std::size_t GetWorkSpaceSize(const Handle& handle,
+                                 const TensorDescriptor& inDesc,
+                                 const TensorDescriptor& outDesc) const;
+    std::size_t GetIndicesSize(const TensorDescriptor& inDesc,
+                               const TensorDescriptor& outDesc) const;
+    void ReduceTensor(const Handle& handle,
+                      Data_t indices,
+                      size_t indicesSizeInBytes,
+                      Data_t workspace,
+                      size_t workspaceSizeInBytes,
+                      const void* alpha,
+                      const TensorDescriptor& aDesc,
+                      ConstData_t A,
+                      const void* beta,
+                      const TensorDescriptor& cDesc,
+                      Data_t C) const;
+};
+
+std::ostream& operator<<(std::ostream& stream, const ReduceTensorDescriptor& c);
+
+} // namespace miopen
+MIOPEN_DEFINE_OBJECT(miopenReduceTensorDescriptor, miopen::ReduceTensorDescriptor);
+
+#endif // GUARD_MIOPEN_CONVOLUTION_HPP_

--- a/src/kernels/composable_kernel/include/kernel_algorithm/gridwise_convolution_forward_implicit_gemm_v4r4_xdlops_nchw_kcyx_nkhw.hpp
+++ b/src/kernels/composable_kernel/include/kernel_algorithm/gridwise_convolution_forward_implicit_gemm_v4r4_xdlops_nchw_kcyx_nkhw.hpp
@@ -1,0 +1,199 @@
+#ifndef CK_GRIDWISE_GROUP_CONVOLUTION_FORWARD_IMPLICIT_GEMM_V4R4_XDLOPS_GNCHW_GKCYX_GNKHW_HPP
+#define CK_GRIDWISE_GROUP_CONVOLUTION_FORWARD_IMPLICIT_GEMM_V4R4_XDLOPS_GNCHW_GKCYX_GNKHW_HPP
+
+#include "common_header.hpp"
+#include "tensor_descriptor.hpp"
+#include "tensor_descriptor_helper.hpp"
+#include "ConstantMatrixDescriptor.hpp"
+#include "gridwise_gemm_xdlops_fp16_bfp16.hpp"
+
+namespace ck {
+
+template <index_t GridSize,
+          index_t BlockSize,
+          class ABFloat,
+          class AccFloat,
+          class CFloat,
+          class InGlobalDesc,
+          class WeiGlobalDesc,
+          class OutGlobalDesc,
+          index_t G,
+          class ConvStrides,
+          class ConvDilations,
+          class InLeftPads,
+          class InRightPads,
+          index_t GemmMPerBlock,
+          index_t GemmNPerBlock,
+          index_t GemmKPerBlock,
+          index_t GemmMPerWave,
+          index_t GemmNPerWave,
+          index_t GemmKPack,
+          class GemmABlockCopyThreadSliceLengths_GemmG_GemmK_GemmM_GemmKPack,
+          class GemmABlockCopyThreadClusterLengths_GemmG_GemmK_GemmM_GemmKPack,
+          class GemmABlockCopyThreadClusterArrangeOrder,
+          class GemmABlockCopySrcAccessOrder,
+          class GemmABlockCopyDstAccessOrder,
+          index_t GemmABlockCopySrcDataPerRead_GemmKPack,
+          index_t GemmABlockCopyDstDataPerWrite_GemmKPack,
+          class GemmBBlockCopyThreadSliceLengths_GemmG_GemmK_GemmN_GemmKPack,
+          class GemmBBlockCopyThreadClusterLengths_GemmG_GemmK_GemmN_GemmKPack,
+          class GemmBBlockCopyThreadClusterArrangeOrder,
+          class GemmBBlockCopySrcAccessOrder,
+          class GemmBBlockCopyDstAccessOrder,
+          index_t GemmBBlockCopySrcDataPerRead_GemmN,
+          index_t GemmBBlockCopyDstDataPerWrite_GemmKPack,
+          WorkgroupScheduleOrder WorkgroupSchdOrder>
+struct GridwiseConvolutionForwardImplicitGemm_v4r4_xdlops_nchw_kcyx_nkhw
+{
+    __device__ void Run(const ABFloat* const __restrict__ p_in_global,
+                        const ABFloat* const __restrict__ p_wei_global,
+                        CFloat* const __restrict__ p_out_global) const
+    {
+        constexpr auto in_n_c_hi_wi_global_desc        = InGlobalDesc{};
+        constexpr auto wei_k_cpergroup_y_x_global_desc = WeiGlobalDesc{};
+        constexpr auto out_n_k_ho_wo_global_desc       = OutGlobalDesc{};
+
+        constexpr index_t N  = in_n_c_hi_wi_global_desc.GetLengths()[0];
+        constexpr index_t C  = in_n_c_hi_wi_global_desc.GetLengths()[1];
+        constexpr index_t Hi = in_n_c_hi_wi_global_desc.GetLengths()[2];
+        constexpr index_t Wi = in_n_c_hi_wi_global_desc.GetLengths()[3];
+
+        constexpr index_t K  = out_n_k_ho_wo_global_desc.GetLengths()[1];
+        constexpr index_t Ho = out_n_k_ho_wo_global_desc.GetLengths()[2];
+        constexpr index_t Wo = out_n_k_ho_wo_global_desc.GetLengths()[3];
+
+        constexpr index_t Y = wei_k_cpergroup_y_x_global_desc.GetLengths()[2];
+        constexpr index_t X = wei_k_cpergroup_y_x_global_desc.GetLengths()[3];
+
+        constexpr index_t CPerGroup = C / G;
+        constexpr index_t KPerGroup = K / G;
+
+        static_assert(CPerGroup == wei_k_cpergroup_y_x_global_desc.GetLengths()[1], "wrong!");
+
+        constexpr index_t ConvStrideH = ConvStrides{}[0];
+        constexpr index_t ConvStrideW = ConvStrides{}[1];
+
+        constexpr index_t ConvDilationH = ConvDilations{}[0];
+        constexpr index_t ConvDilationW = ConvDilations{}[1];
+
+        constexpr index_t GemmG      = G;
+        constexpr index_t GemmM      = KPerGroup;
+        constexpr index_t GemmN      = N * Ho * Wo;
+        constexpr index_t GemmKTotal = CPerGroup * Y * X;
+
+        static_assert(GemmKTotal % GemmKPack == 0,
+                      "wrong! GemmKTotal should be multiple of GemmKPack");
+
+        constexpr index_t GemmK = GemmKTotal / GemmKPack;
+
+        static_assert(GemmM % GemmMPerBlock == 0 && GemmN % GemmNPerBlock == 0 &&
+                          GemmK % GemmKPerBlock == 0,
+                      "wrong! cannot divide work evenly among block");
+
+        // construct tensor descriptor for group convolution
+        constexpr auto in_g_n_cpergroup_hi_wi_global_desc = make_native_tensor_descriptor(
+            Sequence<G, N, CPerGroup, Hi, Wi>{},
+            Sequence<CPerGroup * Hi * Wi, C * Hi * Wi, Hi * Wi, Wi, 1>{});
+
+        constexpr auto wei_g_kpergroup_cpergroup_y_x_global_desc =
+            make_native_tensor_descriptor_packed(Sequence<G, KPerGroup, CPerGroup, Y, X>{});
+
+        constexpr auto out_g_n_kpergroup_ho_wo_global_desc = make_native_tensor_descriptor(
+            Sequence<G, N, KPerGroup, Ho, Wo>{},
+            Sequence<KPerGroup * Ho * Wo, K * Ho * Wo, Ho * Wo, Wo, 1>{});
+
+        // input tensor
+        constexpr auto in_g_n_cpergroup_hip_wip_global_desc = transform_tensor_descriptor(
+            in_g_n_cpergroup_hi_wi_global_desc,
+            make_tuple(PassThrough<G>{},
+                       PassThrough<N>{},
+                       PassThrough<CPerGroup>{},
+                       Pad<Sequence<Hi, Wi>, InLeftPads, InRightPads>{}),
+            make_tuple(Sequence<0>{}, Sequence<1>{}, Sequence<2>{}, Sequence<3, 4>{}),
+            make_tuple(Sequence<0>{}, Sequence<1>{}, Sequence<2>{}, Sequence<3, 4>{}));
+
+        constexpr index_t Hip = in_g_n_cpergroup_hip_wip_global_desc.GetLengths()[3];
+        constexpr index_t Wip = in_g_n_cpergroup_hip_wip_global_desc.GetLengths()[4];
+
+        constexpr auto in_g_n_cpergroup_y_ho_x_wo_global_desc = transform_tensor_descriptor(
+            in_g_n_cpergroup_hip_wip_global_desc,
+            make_tuple(PassThrough<G>{},
+                       PassThrough<N>{},
+                       PassThrough<CPerGroup>{},
+                       Embed<Hip, Sequence<Y, Ho>, Sequence<ConvDilationH, ConvStrideH, 0>>{},
+                       Embed<Wip, Sequence<X, Wo>, Sequence<ConvDilationW, ConvStrideW, 0>>{}),
+            make_tuple(Sequence<0>{}, Sequence<1>{}, Sequence<2>{}, Sequence<3>{}, Sequence<4>{}),
+            make_tuple(
+                Sequence<0>{}, Sequence<1>{}, Sequence<2>{}, Sequence<3, 4>{}, Sequence<5, 6>{}));
+
+        constexpr auto in_gemmg_gemmktotal_gemmn_global_desc = transform_tensor_descriptor(
+            in_g_n_cpergroup_y_ho_x_wo_global_desc,
+            make_tuple(PassThrough<G>{}, Merge<Sequence<C, Y, X>>{}, Merge<Sequence<N, Ho, Wo>>{}),
+            make_tuple(Sequence<0>{}, Sequence<2, 3, 5>{}, Sequence<1, 4, 6>{}),
+            make_tuple(Sequence<0>{}, Sequence<1>{}, Sequence<2>{}));
+
+        constexpr auto in_gemmg_gemmk_gemmn_gemmkpack_global_desc = transform_tensor_descriptor(
+            in_gemmg_gemmktotal_gemmn_global_desc,
+            make_tuple(
+                PassThrough<GemmG>{}, UnMerge<Sequence<GemmK, GemmKPack>>{}, PassThrough<GemmN>{}),
+            make_tuple(Sequence<0>{}, Sequence<1>{}, Sequence<2>{}),
+            make_tuple(Sequence<0>{}, Sequence<1, 3>{}, Sequence<2>{}));
+
+        // weight tensor
+        constexpr auto wei_gemmg_gemmm_gemmktotal_global_desc = unfold_tensor_descriptor(
+            wei_g_kpergroup_cpergroup_y_x_global_desc, Number<2>{}, Number<4>{});
+
+        constexpr auto wei_gemmg_gemmk_gemmm_gemmkpack_global_desc = transform_tensor_descriptor(
+            wei_gemmg_gemmm_gemmktotal_global_desc,
+            make_tuple(
+                PassThrough<GemmG>{}, PassThrough<GemmM>{}, UnMerge<Sequence<GemmK, GemmKPack>>{}),
+            make_tuple(Sequence<0>{}, Sequence<1>{}, Sequence<2>{}),
+            make_tuple(Sequence<0>{}, Sequence<2>{}, Sequence<1, 3>{}));
+
+        // output tensor
+        constexpr auto out_gemmg_gemmm_gemmn_global_desc = transform_tensor_descriptor(
+            out_g_n_kpergroup_ho_wo_global_desc,
+            make_tuple(PassThrough<G>{}, PassThrough<KPerGroup>{}, Merge<Sequence<N, Ho, Wo>>{}),
+            make_tuple(Sequence<0>{}, Sequence<2>{}, Sequence<1, 3, 4>{}),
+            make_tuple(Sequence<0>{}, Sequence<1>{}, Sequence<2>{}));
+
+        // gridwise batch-GEMM
+        constexpr auto gridwise_gemm = GridwiseBatchGemmXdlops_gkmkpack_gknkpack_gmn_v2<
+            GridSize,
+            BlockSize,
+            ABFloat,
+            AccFloat,
+            CFloat,
+            decltype(wei_gemmg_gemmk_gemmm_gemmkpack_global_desc),
+            decltype(in_gemmg_gemmk_gemmn_gemmkpack_global_desc),
+            decltype(out_gemmg_gemmm_gemmn_global_desc),
+            GemmMPerBlock,
+            GemmNPerBlock,
+            GemmKPerBlock,
+            GemmMPerWave,
+            GemmNPerWave,
+            GemmABlockCopyThreadSliceLengths_GemmG_GemmK_GemmM_GemmKPack,
+            GemmABlockCopyThreadClusterLengths_GemmG_GemmK_GemmM_GemmKPack,
+            GemmABlockCopyThreadClusterArrangeOrder,
+            GemmABlockCopySrcAccessOrder,
+            GemmABlockCopyDstAccessOrder,
+            3, // src vector read dimension of A matrix is GemmKPack
+            GemmABlockCopySrcDataPerRead_GemmKPack,
+            GemmABlockCopyDstDataPerWrite_GemmKPack,
+            GemmBBlockCopyThreadSliceLengths_GemmG_GemmK_GemmN_GemmKPack,
+            GemmBBlockCopyThreadClusterLengths_GemmG_GemmK_GemmN_GemmKPack,
+            GemmBBlockCopyThreadClusterArrangeOrder,
+            GemmBBlockCopySrcAccessOrder,
+            GemmBBlockCopyDstAccessOrder,
+            2, // Src vetor read diemsnion of B matrix is GemmN
+            GemmBBlockCopySrcDataPerRead_GemmN,
+            GemmBBlockCopyDstDataPerWrite_GemmKPack,
+            InMemoryDataOperation::Set,
+            WorkgroupSchdOrder>{};
+
+        gridwise_gemm.Run(p_wei_global, p_in_global, p_out_global);
+    }
+};
+
+} // namespace ck
+#endif

--- a/src/kernels/composable_kernel/include/kernel_algorithm/gridwise_generic_2d_reduction_blockwise.hpp
+++ b/src/kernels/composable_kernel/include/kernel_algorithm/gridwise_generic_2d_reduction_blockwise.hpp
@@ -1,0 +1,462 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2020 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#ifndef CK_GRIDWISE_GENERIC_2D_REDUCTION_BLOCKWISE_HPP
+#define CK_GRIDWISE_GENERIC_2D_REDUCTION_BLOCKWISE_HPP
+
+#include "float_type.hpp"
+#include "reduction_operator.hpp"
+#include "reduction_functions.hpp"
+#include "reduction_common.hpp"
+
+#include "blockwise_generic_tensor_slice_copy.hpp"
+#include "ConstantMatrixDescriptor.hpp"
+
+namespace ck {
+
+template <int BlockSize,
+          typename srcDataType,
+          typename dstDataType,
+          typename src2dDesc,
+          typename dst1dDesc,
+          typename compType,
+          ckReduceTensorOp_t op,
+          ckNanPropagation_t nanPropaOpt,
+          ckReduceTensorIndices_t reduceIndicesOpt,
+          int callId,
+          int GredAccessesPerThreadInBlock>
+struct Gridwise_generic_reduction_xy_to_x_blockwise
+{
+    static constexpr bool indexable = reduce_binary_operator<compType, op>::indexable;
+    static constexpr bool need_indices =
+        indexable && (reduceIndicesOpt != CK_REDUCE_TENSOR_NO_INDICES);
+    static constexpr bool firstCall = (callId == 0) ? true : false;
+
+    static constexpr int BlockBufferSize = BlockSize * GredAccessesPerThreadInBlock;
+
+    using opReduce = typename reduce_binary_operator<compType, op>::opType;
+
+    __device__ void Run(srcDataType alpha,
+                        const srcDataType* const __restrict__ p_src_global,
+                        dstDataType beta,
+                        dstDataType* const __restrict__ p_dst_global,
+                        int* const __restrict__ ws_indices_global,
+                        int* const __restrict__ indices_global)
+    {
+        static_if<need_indices>{}([&](auto) {
+            static_if<firstCall>{}([&](auto) {
+                RunImpl2(alpha, p_src_global, beta, p_dst_global, indices_global);
+            }).Else([&](auto) {
+                RunImpl3(
+                    alpha, p_src_global, beta, p_dst_global, ws_indices_global, indices_global);
+            });
+        }).Else([&](auto) { RunImpl1(alpha, p_src_global, beta, p_dst_global); });
+    };
+
+    __device__ static void RunImpl1(srcDataType alpha,
+                                    const srcDataType* const __restrict__ p_src_global,
+                                    dstDataType beta,
+                                    dstDataType* const __restrict__ p_dst_global)
+    {
+        // LDS
+        __shared__ compType p_in_block_buffer[BlockBufferSize];
+
+        // VGPR, only useful for thread 0
+        auto zeroVal       = opReduce::getZeroVal();
+        compType accuValue = zeroVal;
+
+        const int thread_local_id    = get_thread_local_1d_id();
+        const int block_global_1d_id = get_block_1d_id();
+
+        constexpr auto in_block_desc =
+            make_native_tensor_descriptor_packed(Sequence<1, BlockBufferSize>{});
+
+        using ThreadSliceLengths   = Sequence<1, GredAccessesPerThreadInBlock>;
+        using ThreadClusterLengths = Sequence<1, BlockSize>;
+
+        auto blockwise_src_load =
+            BlockwiseGenericTensorSliceCopy_v4<BlockSize,
+                                               src2dDesc,
+                                               decltype(in_block_desc),
+                                               decltype(in_block_desc.GetLengths()),
+                                               ThreadSliceLengths,
+                                               ThreadClusterLengths,
+                                               Sequence<0, 1>,
+                                               Sequence<0, 1>,
+                                               Sequence<0, 1>,
+                                               1,
+                                               1,
+                                               1,
+                                               1,
+                                               AddressSpace::Global,
+                                               AddressSpace::Vgpr,
+                                               AddressSpace::Lds,
+                                               InMemoryDataOperation::Set>({block_global_1d_id, 0},
+                                                                           {0, 0});
+
+        constexpr auto block_buff_2d_desc = make_native_tensor_descriptor_packed(
+            Sequence<GredAccessesPerThreadInBlock, BlockSize>{});
+
+        using blockwise_reduce = BlockwiseReduction_2d_block_buffer<decltype(block_buff_2d_desc),
+                                                                    compType,
+                                                                    true,
+                                                                    opReduce,
+                                                                    nanPropaOpt>;
+
+        const int toReduceBlocks = (src2dDesc::GetLengths()[1] + BlockSize - 1) / BlockSize;
+
+        for(int reducedBlocks = 0; reducedBlocks < toReduceBlocks;
+            reducedBlocks += GredAccessesPerThreadInBlock)
+        {
+            blockwise_reduce::set_buffer_value(p_in_block_buffer, zeroVal);
+
+            // load block data from global to LDS, no use of double buffers (to be improved)
+            blockwise_src_load.Run(
+                p_src_global, p_in_block_buffer, type_convert<srcDataType>{}(zeroVal));
+
+            __syncthreads();
+
+            int BlocksInOneOp = (reducedBlocks < toReduceBlocks - GredAccessesPerThreadInBlock)
+                                    ? GredAccessesPerThreadInBlock
+                                    : toReduceBlocks - reducedBlocks;
+            blockwise_reduce::reduce(p_in_block_buffer, BlocksInOneOp, accuValue);
+
+            constexpr auto True = integral_constant<bool, true>{};
+            blockwise_src_load.MoveSrcSliceWindow(Sequence<0, BlockBufferSize>{}, True);
+        }
+
+        using ReducedDataLengths       = Sequence<1>;
+        constexpr auto ReducedDataDesc = make_native_tensor_descriptor_packed(ReducedDataLengths{});
+
+        // The first thread in the block stores the reduced result to the global location
+        // representing the block
+        if(thread_local_id == 0)
+        {
+            if(!float_equal_one{}(alpha))
+                accuValue *= type_convert<compType>{}(alpha);
+
+            if(!float_equal_zero{}(beta))
+            {
+                auto threadwise_dst_load =
+                    ThreadwiseGenericTensorSliceCopy_v4r2<dst1dDesc,
+                                                          decltype(ReducedDataDesc),
+                                                          ReducedDataLengths,
+                                                          Sequence<0>,
+                                                          0,
+                                                          1,
+                                                          1,
+                                                          AddressSpace::Global,
+                                                          AddressSpace::Vgpr,
+                                                          InMemoryDataOperation::Set>(
+                        {block_global_1d_id}, {0});
+                dstDataType priorDstValue;
+
+                threadwise_dst_load.Run(
+                    p_dst_global, &priorDstValue, type_convert<dstDataType>{}(zeroVal));
+
+                accuValue += type_convert<compType>{}(priorDstValue * beta);
+            }
+
+            auto threadwise_dst_store =
+                ThreadwiseGenericTensorSliceCopy_v4r2<decltype(ReducedDataDesc),
+                                                      dst1dDesc,
+                                                      ReducedDataLengths,
+                                                      Sequence<0>,
+                                                      0,
+                                                      1,
+                                                      1,
+                                                      AddressSpace::Vgpr,
+                                                      AddressSpace::Global,
+                                                      InMemoryDataOperation::Set>(
+                    {0}, {block_global_1d_id});
+            threadwise_dst_store.Run(&accuValue, p_dst_global, zeroVal);
+        }
+    };
+
+    __device__ static void RunImpl2(srcDataType alpha,
+                                    const srcDataType* const __restrict__ p_src_global,
+                                    dstDataType beta,
+                                    dstDataType* const __restrict__ p_dst_global,
+                                    int* const __restrict__ indices_global)
+    {
+        // LDS
+        __shared__ compType p_in_block_buffer[BlockBufferSize];
+        __shared__ int block_indices_buffer[BlockBufferSize];
+
+        // VGPR, only useful for thread 0
+        auto zeroVal       = opReduce::getZeroVal();
+        compType accuValue = zeroVal;
+        int accuIndex      = 0;
+
+        const int thread_local_id    = get_thread_local_1d_id();
+        const int block_global_1d_id = get_block_1d_id();
+
+        constexpr auto in_block_desc =
+            make_native_tensor_descriptor_packed(Sequence<1, BlockBufferSize>{});
+
+        using ThreadSliceLengths   = Sequence<1, GredAccessesPerThreadInBlock>;
+        using ThreadClusterLengths = Sequence<1, BlockSize>;
+
+        auto blockwise_src_load =
+            BlockwiseGenericTensorSliceCopy_v4<BlockSize,
+                                               src2dDesc,
+                                               decltype(in_block_desc),
+                                               decltype(in_block_desc.GetLengths()),
+                                               ThreadSliceLengths,
+                                               ThreadClusterLengths,
+                                               Sequence<0, 1>,
+                                               Sequence<0, 1>,
+                                               Sequence<0, 1>,
+                                               1,
+                                               1,
+                                               1,
+                                               1,
+                                               AddressSpace::Global,
+                                               AddressSpace::Vgpr,
+                                               AddressSpace::Lds,
+                                               InMemoryDataOperation::Set>({block_global_1d_id, 0},
+                                                                           {0, 0});
+
+        constexpr auto block_buff_2d_desc = make_native_tensor_descriptor_packed(
+            Sequence<GredAccessesPerThreadInBlock, BlockSize>{});
+
+        using blockwise_reduce = BlockwiseReduction_2d_block_buffer<decltype(block_buff_2d_desc),
+                                                                    compType,
+                                                                    true,
+                                                                    opReduce,
+                                                                    nanPropaOpt>;
+
+        const int toReduceBlocks = (src2dDesc::GetLengths()[1] + BlockSize - 1) / BlockSize;
+
+        int indexOffset = 0;
+
+        for(int reducedBlocks = 0; reducedBlocks < toReduceBlocks;
+            reducedBlocks += GredAccessesPerThreadInBlock)
+        {
+            blockwise_reduce::set_buffer_value(p_in_block_buffer, zeroVal);
+
+            // load block data from global to LDS, no use of double buffers (to be improved)
+            blockwise_src_load.Run(
+                p_src_global, p_in_block_buffer, type_convert<srcDataType>{}(zeroVal));
+
+            __syncthreads();
+
+            // construct the indices for the current toReduce blocks
+            blockwise_reduce::init_buffer_indices(block_indices_buffer, indexOffset);
+
+            int BlocksInOneOp = (reducedBlocks < toReduceBlocks - GredAccessesPerThreadInBlock)
+                                    ? GredAccessesPerThreadInBlock
+                                    : toReduceBlocks - reducedBlocks;
+
+            blockwise_reduce::reduce2(
+                p_in_block_buffer, block_indices_buffer, BlocksInOneOp, accuValue, accuIndex);
+
+            indexOffset += BlockBufferSize;
+
+            constexpr auto True = integral_constant<bool, true>{};
+            blockwise_src_load.MoveSrcSliceWindow(Sequence<0, BlockBufferSize>{}, True);
+        }
+
+        using ReducedDataLengths       = Sequence<1>;
+        constexpr auto ReducedDataDesc = make_native_tensor_descriptor_packed(ReducedDataLengths{});
+
+        // The first thread in the block stores the reduced result to the global location
+        // representing the block
+        if(thread_local_id == 0)
+        {
+            if(!float_equal_one{}(alpha))
+                accuValue *= type_convert<compType>{}(alpha);
+
+            if(!float_equal_zero{}(beta))
+            {
+                auto threadwise_dst_load =
+                    ThreadwiseGenericTensorSliceCopy_v4r2<dst1dDesc,
+                                                          decltype(ReducedDataDesc),
+                                                          ReducedDataLengths,
+                                                          Sequence<0>,
+                                                          0,
+                                                          1,
+                                                          1,
+                                                          AddressSpace::Global,
+                                                          AddressSpace::Vgpr,
+                                                          InMemoryDataOperation::Set>(
+                        {block_global_1d_id}, {0});
+                dstDataType priorDstValue;
+
+                threadwise_dst_load.Run(
+                    p_dst_global, &priorDstValue, type_convert<dstDataType>{}(zeroVal));
+
+                accuValue += type_convert<compType>{}(priorDstValue * beta);
+            }
+
+            auto threadwise_dst_store =
+                ThreadwiseGenericTensorSliceCopy_v4r2<decltype(ReducedDataDesc),
+                                                      dst1dDesc,
+                                                      ReducedDataLengths,
+                                                      Sequence<0>,
+                                                      0,
+                                                      1,
+                                                      1,
+                                                      AddressSpace::Vgpr,
+                                                      AddressSpace::Global,
+                                                      InMemoryDataOperation::Set>(
+                    {0}, {block_global_1d_id});
+            threadwise_dst_store.Run(&accuValue, p_dst_global, zeroVal);
+            threadwise_dst_store.Run(&accuIndex, indices_global, 0);
+        }
+    };
+
+    __device__ static void RunImpl3(srcDataType alpha,
+                                    const srcDataType* const __restrict__ p_src_global,
+                                    dstDataType beta,
+                                    dstDataType* const __restrict__ p_dst_global,
+                                    int* const __restrict__ ws_indices_global,
+                                    int* const __restrict__ indices_global)
+    {
+        // LDS
+        __shared__ compType p_in_block_buffer[BlockBufferSize];
+        __shared__ int block_indices_buffer[BlockBufferSize];
+
+        // VGPR, only useful for thread 0
+        auto zeroVal       = opReduce::getZeroVal();
+        compType accuValue = zeroVal;
+        int accuIndex      = 0;
+
+        const int thread_local_id    = get_thread_local_1d_id();
+        const int block_global_1d_id = get_block_1d_id();
+
+        constexpr auto in_block_desc =
+            make_native_tensor_descriptor_packed(Sequence<1, BlockBufferSize>{});
+
+        using ThreadSliceLengths   = Sequence<1, GredAccessesPerThreadInBlock>;
+        using ThreadClusterLengths = Sequence<1, BlockSize>;
+
+        auto blockwise_src_load =
+            BlockwiseGenericTensorSliceCopy_v4<BlockSize,
+                                               src2dDesc,
+                                               decltype(in_block_desc),
+                                               decltype(in_block_desc.GetLengths()),
+                                               ThreadSliceLengths,
+                                               ThreadClusterLengths,
+                                               Sequence<0, 1>,
+                                               Sequence<0, 1>,
+                                               Sequence<0, 1>,
+                                               1,
+                                               1,
+                                               1,
+                                               1,
+                                               AddressSpace::Global,
+                                               AddressSpace::Vgpr,
+                                               AddressSpace::Lds,
+                                               InMemoryDataOperation::Set>({block_global_1d_id, 0},
+                                                                           {0, 0});
+
+        constexpr auto block_buff_2d_desc = make_native_tensor_descriptor_packed(
+            Sequence<GredAccessesPerThreadInBlock, BlockSize>{});
+
+        using blockwise_reduce = BlockwiseReduction_2d_block_buffer<decltype(block_buff_2d_desc),
+                                                                    compType,
+                                                                    true,
+                                                                    opReduce,
+                                                                    nanPropaOpt>;
+
+        const int toReduceBlocks = (src2dDesc::GetLengths()[1] + BlockSize - 1) / BlockSize;
+
+        for(int reducedBlocks = 0; reducedBlocks < toReduceBlocks;
+            reducedBlocks += GredAccessesPerThreadInBlock)
+        {
+            blockwise_reduce::set_buffer_value(p_in_block_buffer, zeroVal);
+
+            // load block data from global to LDS, no use of double buffers (to be improved)
+            blockwise_src_load.Run(
+                p_src_global, p_in_block_buffer, type_convert<srcDataType>{}(zeroVal));
+            blockwise_src_load.Run(ws_indices_global, block_indices_buffer, static_cast<int>(0));
+
+            __syncthreads();
+
+            int BlocksInOneOp = (reducedBlocks < toReduceBlocks - GredAccessesPerThreadInBlock)
+                                    ? GredAccessesPerThreadInBlock
+                                    : toReduceBlocks - reducedBlocks;
+
+            blockwise_reduce::reduce2(
+                p_in_block_buffer, block_indices_buffer, BlocksInOneOp, accuValue, accuIndex);
+
+            constexpr auto True = integral_constant<bool, true>{};
+            blockwise_src_load.MoveSrcSliceWindow(
+                Sequence<0, BlockSize * GredAccessesPerThreadInBlock>{}, True);
+        }
+
+        using ReducedDataLengths       = Sequence<1>;
+        constexpr auto ReducedDataDesc = make_native_tensor_descriptor_packed(ReducedDataLengths{});
+
+        // The first thread in the block stores the reduced result to the global location
+        // representing the block
+        if(thread_local_id == 0)
+        {
+            if(!float_equal_one{}(alpha))
+                accuValue *= type_convert<compType>{}(alpha);
+
+            if(!float_equal_zero{}(beta))
+            {
+                auto threadwise_dst_load =
+                    ThreadwiseGenericTensorSliceCopy_v4r2<dst1dDesc,
+                                                          decltype(ReducedDataDesc),
+                                                          ReducedDataLengths,
+                                                          Sequence<0>,
+                                                          0,
+                                                          1,
+                                                          1,
+                                                          AddressSpace::Global,
+                                                          AddressSpace::Vgpr,
+                                                          InMemoryDataOperation::Set>(
+                        {block_global_1d_id}, {0});
+                dstDataType priorDstValue;
+
+                threadwise_dst_load.Run(
+                    p_dst_global, &priorDstValue, type_convert<dstDataType>{}(zeroVal));
+
+                accuValue += type_convert<compType>{}(priorDstValue * beta);
+            }
+
+            auto threadwise_dst_store =
+                ThreadwiseGenericTensorSliceCopy_v4r2<decltype(ReducedDataDesc),
+                                                      dst1dDesc,
+                                                      ReducedDataLengths,
+                                                      Sequence<0>,
+                                                      0,
+                                                      1,
+                                                      1,
+                                                      AddressSpace::Vgpr,
+                                                      AddressSpace::Global,
+                                                      InMemoryDataOperation::Set>(
+                    {0}, {block_global_1d_id});
+            threadwise_dst_store.Run(&accuValue, p_dst_global, zeroVal);
+            threadwise_dst_store.Run(&accuIndex, indices_global, 0);
+        }
+    };
+};
+
+} // namespace ck
+#endif

--- a/src/kernels/composable_kernel/include/kernel_algorithm/gridwise_generic_2d_reduction_direct_threadwise.hpp
+++ b/src/kernels/composable_kernel/include/kernel_algorithm/gridwise_generic_2d_reduction_direct_threadwise.hpp
@@ -1,0 +1,364 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2020 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#ifndef CK_GRIDWISE_GENERIC_2D_REDUCTION_DIRECT_THREADWISE_HPP
+#define CK_GRIDWISE_GENERIC_2D_REDUCTION_DIRECT_THREADWISE_HPP
+
+#include "float_type.hpp"
+#include "reduction_operator.hpp"
+#include "reduction_functions.hpp"
+#include "reduction_common.hpp"
+
+#include "threadwise_generic_tensor_slice_copy.hpp"
+
+namespace ck {
+
+template <int BlockSize,
+          typename srcDataType,
+          typename dstDataType,
+          typename src2dDesc,
+          typename dst1dDesc,
+          typename compType,
+          ckReduceTensorOp_t op,
+          ckNanPropagation_t nanPropaOpt,
+          ckReduceTensorIndices_t reduceIndicesOpt,
+          int callId,
+          int GredThreadBufferLength>
+struct Gridwise_generic_reduction_xy_to_x_direct_threadwise
+{
+    static constexpr bool indexable = reduce_binary_operator<compType, op>::indexable;
+    static constexpr bool need_indices =
+        indexable && (reduceIndicesOpt != CK_REDUCE_TENSOR_NO_INDICES);
+    static constexpr bool firstCall = (callId == 0) ? true : false;
+
+    static constexpr auto toReduceLength = src2dDesc::GetLength(Number<1>{});
+
+    using opReduce = typename reduce_binary_operator<compType, op>::opType;
+
+    __device__ void Run(srcDataType alpha,
+                        const srcDataType* const __restrict__ p_src_global,
+                        dstDataType beta,
+                        dstDataType* const __restrict__ p_dst_global,
+                        int* const __restrict__ ws_indices_global,
+                        int* const __restrict__ indices_global)
+    {
+        static_if<need_indices>{}([&](auto) {
+            static_if<firstCall>{}([&](auto) {
+                RunImpl2(alpha, p_src_global, beta, p_dst_global, indices_global);
+            }).Else([&](auto) {
+                RunImpl3(
+                    alpha, p_src_global, beta, p_dst_global, ws_indices_global, indices_global);
+            });
+        }).Else([&](auto) { RunImpl1(alpha, p_src_global, beta, p_dst_global); });
+    };
+
+    __device__ static void RunImpl1(srcDataType alpha,
+                                    const srcDataType* const __restrict__ p_src_global,
+                                    dstDataType beta,
+                                    dstDataType* const __restrict__ p_dst_global)
+    {
+        compType p_in_thread_buffer[GredThreadBufferLength];
+
+        auto zeroVal       = opReduce::getZeroVal();
+        compType accuValue = zeroVal;
+
+        using ThreadBufferLengths = Sequence<1, GredThreadBufferLength>;
+        constexpr auto ThreadBufferDesc =
+            make_native_tensor_descriptor_packed(ThreadBufferLengths{});
+
+        int thread_global_1d_id = get_block_1d_id() * BlockSize + get_thread_local_1d_id();
+
+        auto threadwise_src_load =
+            ThreadwiseGenericTensorSliceCopy_v4r2<src2dDesc,
+                                                  decltype(ThreadBufferDesc),
+                                                  ThreadBufferLengths,
+                                                  Sequence<0, 1>,
+                                                  1,
+                                                  1,
+                                                  1,
+                                                  AddressSpace::Global,
+                                                  AddressSpace::Vgpr,
+                                                  InMemoryDataOperation::Set>(
+                {thread_global_1d_id, 0}, {0, 0});
+        using threadwise_reduce =
+            thread_reduce<compType, GredThreadBufferLength, opReduce, nanPropaOpt>;
+
+        for(int reducedLength = 0; reducedLength < toReduceLength;
+            reducedLength += GredThreadBufferLength)
+        {
+            // zero the data on the Thread Buffer
+            threadwise_reduce::set_buffer_value(p_in_thread_buffer, zeroVal);
+
+            threadwise_src_load.Run(
+                p_src_global, p_in_thread_buffer, type_convert<srcDataType>{}(zeroVal));
+
+            // do the reduction on the Thread Buffer
+            threadwise_reduce::reduce(p_in_thread_buffer, accuValue);
+
+            constexpr auto True = integral_constant<bool, true>{};
+            threadwise_src_load.MoveSrcSliceWindow(Sequence<0, GredThreadBufferLength>{}, True);
+        }
+
+        using ReducedDataLengths       = Sequence<1>;
+        constexpr auto ReducedDataDesc = make_native_tensor_descriptor_packed(ReducedDataLengths{});
+
+        if(!float_equal_one{}(alpha))
+            accuValue *= type_convert<compType>{}(alpha);
+
+        if(!float_equal_zero{}(beta))
+        {
+            auto threadwise_dst_load =
+                ThreadwiseGenericTensorSliceCopy_v4r2<dst1dDesc,
+                                                      decltype(ReducedDataDesc),
+                                                      ReducedDataLengths,
+                                                      Sequence<0>,
+                                                      0,
+                                                      1,
+                                                      1,
+                                                      AddressSpace::Global,
+                                                      AddressSpace::Vgpr,
+                                                      InMemoryDataOperation::Set>(
+                    {thread_global_1d_id}, {0});
+            dstDataType priorDstValue;
+
+            threadwise_dst_load.Run(
+                p_dst_global, &priorDstValue, type_convert<dstDataType>{}(zeroVal));
+
+            accuValue += type_convert<compType>{}(priorDstValue * beta);
+        }
+
+        auto threadwise_dst_store =
+            ThreadwiseGenericTensorSliceCopy_v4r2<decltype(ReducedDataDesc),
+                                                  dst1dDesc,
+                                                  ReducedDataLengths,
+                                                  Sequence<0>,
+                                                  0,
+                                                  1,
+                                                  1,
+                                                  AddressSpace::Vgpr,
+                                                  AddressSpace::Global,
+                                                  InMemoryDataOperation::Set>(
+                {0}, {thread_global_1d_id});
+
+        threadwise_dst_store.Run(&accuValue, p_dst_global, zeroVal);
+    };
+
+    __device__ static void RunImpl2(srcDataType alpha,
+                                    const srcDataType* const __restrict__ p_src_global,
+                                    dstDataType beta,
+                                    dstDataType* const __restrict__ p_dst_global,
+                                    int* const __restrict__ indices_global)
+    {
+        compType p_in_thread_buffer[GredThreadBufferLength];
+
+        auto zeroVal       = opReduce::getZeroVal();
+        compType accuValue = zeroVal;
+        int accuIndex      = 0;
+
+        using ThreadBufferLengths = Sequence<1, GredThreadBufferLength>;
+        constexpr auto ThreadBufferDesc =
+            make_native_tensor_descriptor_packed(ThreadBufferLengths{});
+
+        int thread_global_1d_id = get_block_1d_id() * BlockSize + get_thread_local_1d_id();
+
+        auto threadwise_src_load =
+            ThreadwiseGenericTensorSliceCopy_v4r2<src2dDesc,
+                                                  decltype(ThreadBufferDesc),
+                                                  ThreadBufferLengths,
+                                                  Sequence<0, 1>,
+                                                  1,
+                                                  1,
+                                                  1,
+                                                  AddressSpace::Global,
+                                                  AddressSpace::Vgpr,
+                                                  InMemoryDataOperation::Set>(
+                {thread_global_1d_id, 0}, {0, 0});
+        using threadwise_reduce =
+            thread_reduce<compType, GredThreadBufferLength, opReduce, nanPropaOpt>;
+
+        int indexStart = 0;
+        for(int reducedLength = 0; reducedLength < toReduceLength;
+            reducedLength += GredThreadBufferLength)
+        {
+            // zero the data on the Thread Buffer
+            threadwise_reduce::set_buffer_value(p_in_thread_buffer, zeroVal);
+
+            threadwise_src_load.Run(
+                p_src_global, p_in_thread_buffer, type_convert<srcDataType>{}(zeroVal));
+
+            // do the reduction on the Thread Buffer
+            threadwise_reduce::reduce2(p_in_thread_buffer, accuValue, accuIndex, indexStart);
+
+            indexStart += GredThreadBufferLength;
+
+            constexpr auto True = integral_constant<bool, true>{};
+            threadwise_src_load.MoveSrcSliceWindow(Sequence<0, GredThreadBufferLength>{}, True);
+        }
+
+        using ReducedDataLengths       = Sequence<1>;
+        constexpr auto ReducedDataDesc = make_native_tensor_descriptor_packed(ReducedDataLengths{});
+
+        if(!float_equal_one{}(alpha))
+            accuValue *= type_convert<compType>{}(alpha);
+
+        if(!float_equal_zero{}(beta))
+        {
+            auto threadwise_dst_load =
+                ThreadwiseGenericTensorSliceCopy_v4r2<dst1dDesc,
+                                                      decltype(ReducedDataDesc),
+                                                      ReducedDataLengths,
+                                                      Sequence<0>,
+                                                      0,
+                                                      1,
+                                                      1,
+                                                      AddressSpace::Global,
+                                                      AddressSpace::Vgpr,
+                                                      InMemoryDataOperation::Set>(
+                    {thread_global_1d_id}, {0});
+            dstDataType priorDstValue;
+
+            threadwise_dst_load.Run(
+                p_dst_global, &priorDstValue, type_convert<dstDataType>{}(zeroVal));
+
+            accuValue += type_convert<compType>{}(priorDstValue * beta);
+        }
+
+        auto threadwise_dst_store =
+            ThreadwiseGenericTensorSliceCopy_v4r2<decltype(ReducedDataDesc),
+                                                  dst1dDesc,
+                                                  ReducedDataLengths,
+                                                  Sequence<0>,
+                                                  0,
+                                                  1,
+                                                  1,
+                                                  AddressSpace::Vgpr,
+                                                  AddressSpace::Global,
+                                                  InMemoryDataOperation::Set>(
+                {0}, {thread_global_1d_id});
+        threadwise_dst_store.Run(&accuValue, p_dst_global, zeroVal);
+        threadwise_dst_store.Run(&accuIndex, indices_global, 0);
+    };
+
+    __device__ static void RunImpl3(srcDataType alpha,
+                                    const srcDataType* const __restrict__ p_src_global,
+                                    dstDataType beta,
+                                    dstDataType* const __restrict__ p_dst_global,
+                                    int* const __restrict__ ws_indices_global,
+                                    int* const __restrict__ indices_global)
+    {
+        compType p_in_thread_buffer[GredThreadBufferLength];
+        int thread_indices_buffer[GredThreadBufferLength]; // for store the indices from previous
+                                                           // reduction
+
+        auto zeroVal       = opReduce::getZeroVal();
+        compType accuValue = zeroVal;
+        int accuIndex      = 0;
+
+        using ThreadBufferLengths = Sequence<1, GredThreadBufferLength>;
+        constexpr auto ThreadBufferDesc =
+            make_native_tensor_descriptor_packed(ThreadBufferLengths{});
+
+        int thread_global_1d_id = get_block_1d_id() * BlockSize + get_thread_local_1d_id();
+
+        auto threadwise_src_load =
+            ThreadwiseGenericTensorSliceCopy_v4r2<src2dDesc,
+                                                  decltype(ThreadBufferDesc),
+                                                  ThreadBufferLengths,
+                                                  Sequence<0, 1>,
+                                                  1,
+                                                  1,
+                                                  1,
+                                                  AddressSpace::Global,
+                                                  AddressSpace::Vgpr,
+                                                  InMemoryDataOperation::Set>(
+                {thread_global_1d_id, 0}, {0, 0});
+        using threadwise_reduce =
+            thread_reduce<compType, GredThreadBufferLength, opReduce, nanPropaOpt>;
+
+        for(int reducedLength = 0; reducedLength < toReduceLength;
+            reducedLength += GredThreadBufferLength)
+        {
+            // zero the data on the Thread Buffer
+            threadwise_reduce::set_buffer_value(p_in_thread_buffer, zeroVal);
+
+            threadwise_src_load.Run(
+                p_src_global, p_in_thread_buffer, type_convert<srcDataType>{}(zeroVal));
+            threadwise_src_load.Run(ws_indices_global, thread_indices_buffer, static_cast<int>(0));
+
+            // do the reduction on the Thread Buffer
+            threadwise_reduce::reduce3(
+                p_in_thread_buffer, thread_indices_buffer, accuValue, accuIndex);
+
+            constexpr auto True = integral_constant<bool, true>{};
+            threadwise_src_load.MoveSrcSliceWindow(Sequence<0, GredThreadBufferLength>{}, True);
+        }
+
+        using ReducedDataLengths       = Sequence<1>;
+        constexpr auto ReducedDataDesc = make_native_tensor_descriptor_packed(ReducedDataLengths{});
+
+        if(!float_equal_one{}(alpha))
+            accuValue *= type_convert<compType>{}(alpha);
+
+        if(!float_equal_zero{}(beta))
+        {
+            auto threadwise_dst_load =
+                ThreadwiseGenericTensorSliceCopy_v4r2<dst1dDesc,
+                                                      decltype(ReducedDataDesc),
+                                                      ReducedDataLengths,
+                                                      Sequence<0>,
+                                                      0,
+                                                      1,
+                                                      1,
+                                                      AddressSpace::Global,
+                                                      AddressSpace::Vgpr,
+                                                      InMemoryDataOperation::Set>(
+                    {thread_global_1d_id}, {0});
+            dstDataType priorDstValue;
+
+            threadwise_dst_load.Run(
+                p_dst_global, &priorDstValue, type_convert<dstDataType>{}(zeroVal));
+
+            accuValue += type_convert<compType>{}(priorDstValue * beta);
+        }
+
+        auto threadwise_dst_store =
+            ThreadwiseGenericTensorSliceCopy_v4r2<decltype(ReducedDataDesc),
+                                                  dst1dDesc,
+                                                  ReducedDataLengths,
+                                                  Sequence<0>,
+                                                  0,
+                                                  1,
+                                                  1,
+                                                  AddressSpace::Vgpr,
+                                                  AddressSpace::Global,
+                                                  InMemoryDataOperation::Set>(
+                {0}, {thread_global_1d_id});
+        threadwise_dst_store.Run(&accuValue, p_dst_global, zeroVal);
+        threadwise_dst_store.Run(&accuIndex, indices_global, 0);
+    };
+};
+
+} // namespace ck
+#endif

--- a/src/kernels/composable_kernel/include/kernel_algorithm/gridwise_generic_2d_reduction_direct_warpwise.hpp
+++ b/src/kernels/composable_kernel/include/kernel_algorithm/gridwise_generic_2d_reduction_direct_warpwise.hpp
@@ -1,0 +1,397 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2020 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#ifndef CK_GRIDWISE_GENERIC_2D_REDUCTION_DIRECT_WARPWISE_HPP
+#define CK_GRIDWISE_GENERIC_2D_REDUCTION_DIRECT_WARPWISE_HPP
+
+#include "float_type.hpp"
+#include "reduction_operator.hpp"
+#include "reduction_functions.hpp"
+#include "reduction_common.hpp"
+
+#include "threadwise_generic_tensor_slice_copy.hpp"
+
+namespace ck {
+
+template <int BlockSize,
+          typename srcDataType,
+          typename dstDataType,
+          typename src2dDesc,
+          typename dst1dDesc,
+          typename compType,
+          ckReduceTensorOp_t op,
+          ckNanPropagation_t nanPropaOpt,
+          ckReduceTensorIndices_t reduceIndicesOpt,
+          int callId,
+          int GredAccessesPerThreadInWarp>
+struct Gridwise_generic_reduction_xy_to_x_direct_warpwise
+{
+    static constexpr bool indexable = reduce_binary_operator<compType, op>::indexable;
+    static constexpr bool need_indices =
+        indexable && (reduceIndicesOpt != CK_REDUCE_TENSOR_NO_INDICES);
+    static constexpr bool firstCall = (callId == 0) ? true : false;
+
+    static constexpr auto toReduceLength = src2dDesc::GetLengths()[1];
+
+    using opReduce = typename reduce_binary_operator<compType, op>::opType;
+
+    __device__ void Run(srcDataType alpha,
+                        const srcDataType* const __restrict__ p_src_global,
+                        dstDataType beta,
+                        dstDataType* const __restrict__ p_dst_global,
+                        int* const __restrict__ ws_indices_global,
+                        int* const __restrict__ indices_global)
+    {
+        static_if<need_indices>{}([&](auto) {
+            static_if<firstCall>{}([&](auto) {
+                RunImpl2(alpha, p_src_global, beta, p_dst_global, indices_global);
+            }).Else([&](auto) {
+                RunImpl3(alpha,
+                         p_src_global,
+                         beta,
+                         p_dst_global,
+                         ws_indices_global,
+                         indices_global); // wc_indices_global is needed to read the indices
+                                          // from last reduction
+            });
+        }).Else([&](auto) { RunImpl1(alpha, p_src_global, beta, p_dst_global); });
+    };
+
+    __device__ static void RunImpl1(srcDataType alpha,
+                                    const srcDataType* const __restrict__ p_src_global,
+                                    dstDataType beta,
+                                    dstDataType* const __restrict__ p_dst_global)
+    {
+        compType p_in_thread_buffer[GredAccessesPerThreadInWarp];
+
+        auto zeroVal       = opReduce::getZeroVal();
+        compType accuValue = zeroVal;
+
+        using ThreadBufferLengths = Sequence<1, GredAccessesPerThreadInWarp>;
+        constexpr auto ThreadBufferDesc =
+            make_native_tensor_descriptor_packed(ThreadBufferLengths{});
+
+        int thread_global_1d_id = get_block_1d_id() * BlockSize + get_thread_local_1d_id();
+        int warp_global_1d_id   = thread_global_1d_id / warpSize;
+        int thread_inwarp_id    = thread_global_1d_id % warpSize;
+
+        auto threadwise_src_load =
+            ThreadwiseGenericTensorSliceCopy_v4r2<src2dDesc,
+                                                  decltype(ThreadBufferDesc),
+                                                  ThreadBufferLengths,
+                                                  Sequence<0, 1>,
+                                                  1,
+                                                  1,
+                                                  1,
+                                                  AddressSpace::Global,
+                                                  AddressSpace::Vgpr,
+                                                  InMemoryDataOperation::Set>(
+                {warp_global_1d_id, thread_inwarp_id * GredAccessesPerThreadInWarp}, {0, 0});
+        using warpwise_reduce =
+            warp_reduce<compType, BlockSize, GredAccessesPerThreadInWarp, opReduce, nanPropaOpt>;
+
+        for(int reducedLength = 0; reducedLength < toReduceLength;
+            reducedLength += warpSize * GredAccessesPerThreadInWarp)
+        {
+            // zero the data on the Thread Buffer
+            warpwise_reduce::set_buffer_value(p_in_thread_buffer, zeroVal);
+
+            threadwise_src_load.Run(
+                p_src_global, p_in_thread_buffer, type_convert<srcDataType>{}(zeroVal));
+
+            // do the warp-wise reduction on data of all thread buffers
+            warpwise_reduce::reduce(p_in_thread_buffer, accuValue);
+
+            constexpr auto True = integral_constant<bool, true>{};
+            threadwise_src_load.MoveSrcSliceWindow(
+                Sequence<0, warpSize * GredAccessesPerThreadInWarp>{}, True);
+        }
+
+        using ReducedDataLengths       = Sequence<1>;
+        constexpr auto ReducedDataDesc = make_native_tensor_descriptor_packed(ReducedDataLengths{});
+
+        // The first thread in the warp stores the reduced result to the global location
+        // representing the Warp
+        if(thread_inwarp_id == 0)
+        {
+            if(!float_equal_one{}(alpha))
+                accuValue *= type_convert<compType>{}(alpha);
+
+            if(!float_equal_zero{}(beta))
+            {
+                auto threadwise_dst_load =
+                    ThreadwiseGenericTensorSliceCopy_v4r2<dst1dDesc,
+                                                          decltype(ReducedDataDesc),
+                                                          ReducedDataLengths,
+                                                          Sequence<0>,
+                                                          0,
+                                                          1,
+                                                          1,
+                                                          AddressSpace::Global,
+                                                          AddressSpace::Vgpr,
+                                                          InMemoryDataOperation::Set>(
+                        {warp_global_1d_id}, {0});
+                dstDataType priorDstValue;
+
+                threadwise_dst_load.Run(
+                    p_dst_global, &priorDstValue, type_convert<dstDataType>{}(zeroVal));
+
+                accuValue += type_convert<compType>{}(priorDstValue * beta);
+            }
+
+            auto threadwise_dst_store =
+                ThreadwiseGenericTensorSliceCopy_v4r2<decltype(ReducedDataDesc),
+                                                      dst1dDesc,
+                                                      ReducedDataLengths,
+                                                      Sequence<0>,
+                                                      0,
+                                                      1,
+                                                      1,
+                                                      AddressSpace::Vgpr,
+                                                      AddressSpace::Global,
+                                                      InMemoryDataOperation::Set>(
+                    {0}, {warp_global_1d_id});
+
+            threadwise_dst_store.Run(&accuValue, p_dst_global, zeroVal);
+        }
+    };
+
+    __device__ static void RunImpl2(srcDataType alpha,
+                                    const srcDataType* const __restrict__ p_src_global,
+                                    dstDataType beta,
+                                    dstDataType* const __restrict__ p_dst_global,
+                                    int* const __restrict__ indices_global)
+    {
+        compType p_in_thread_buffer[GredAccessesPerThreadInWarp];
+
+        auto zeroVal       = opReduce::getZeroVal();
+        compType accuValue = zeroVal;
+        int accuIndex      = 0;
+
+        using ThreadBufferLengths = Sequence<1, GredAccessesPerThreadInWarp>;
+        constexpr auto ThreadBufferDesc =
+            make_native_tensor_descriptor_packed(ThreadBufferLengths{});
+
+        int thread_global_1d_id = get_block_1d_id() * BlockSize + get_thread_local_1d_id();
+        int warp_global_1d_id   = thread_global_1d_id / warpSize;
+        int thread_inwarp_id    = thread_global_1d_id % warpSize;
+
+        auto threadwise_src_load =
+            ThreadwiseGenericTensorSliceCopy_v4r2<src2dDesc,
+                                                  decltype(ThreadBufferDesc),
+                                                  ThreadBufferLengths,
+                                                  Sequence<0, 1>,
+                                                  1,
+                                                  1,
+                                                  1,
+                                                  AddressSpace::Global,
+                                                  AddressSpace::Vgpr,
+                                                  InMemoryDataOperation::Set>(
+                {warp_global_1d_id, thread_inwarp_id * GredAccessesPerThreadInWarp}, {0, 0});
+        using warpwise_reduce =
+            warp_reduce<compType, BlockSize, GredAccessesPerThreadInWarp, opReduce, nanPropaOpt>;
+
+        int indexOffset = 0;
+        for(int reducedLength = 0; reducedLength < toReduceLength;
+            reducedLength += warpSize * GredAccessesPerThreadInWarp)
+        {
+            // zero the data on the Thread Buffer
+            warpwise_reduce::set_buffer_value(p_in_thread_buffer, zeroVal);
+
+            threadwise_src_load.Run(
+                p_src_global, p_in_thread_buffer, type_convert<srcDataType>{}(zeroVal));
+
+            // do the warp-wise reduction on data of all thread buffers
+            warpwise_reduce::reduce2(p_in_thread_buffer, accuValue, accuIndex, indexOffset);
+
+            indexOffset += warpSize * GredAccessesPerThreadInWarp;
+
+            constexpr auto True = integral_constant<bool, true>{};
+            threadwise_src_load.MoveSrcSliceWindow(
+                Sequence<0, warpSize * GredAccessesPerThreadInWarp>{}, True);
+        }
+
+        using ReducedDataLengths       = Sequence<1>;
+        constexpr auto ReducedDataDesc = make_native_tensor_descriptor_packed(ReducedDataLengths{});
+
+        // The first thread in the warp stores the reduced result to the global location
+        // representing the Warp
+        if(thread_inwarp_id == 0)
+        {
+            if(!float_equal_one{}(alpha))
+                accuValue *= type_convert<compType>{}(alpha);
+
+            if(!float_equal_zero{}(beta))
+            {
+                auto threadwise_dst_load =
+                    ThreadwiseGenericTensorSliceCopy_v4r2<dst1dDesc,
+                                                          decltype(ReducedDataDesc),
+                                                          ReducedDataLengths,
+                                                          Sequence<0>,
+                                                          0,
+                                                          1,
+                                                          1,
+                                                          AddressSpace::Global,
+                                                          AddressSpace::Vgpr,
+                                                          InMemoryDataOperation::Set>(
+                        {warp_global_1d_id}, {0});
+                dstDataType priorDstValue;
+
+                threadwise_dst_load.Run(
+                    p_dst_global, &priorDstValue, type_convert<dstDataType>{}(zeroVal));
+
+                accuValue += type_convert<compType>{}(priorDstValue * beta);
+            }
+
+            auto threadwise_dst_store =
+                ThreadwiseGenericTensorSliceCopy_v4r2<decltype(ReducedDataDesc),
+                                                      dst1dDesc,
+                                                      ReducedDataLengths,
+                                                      Sequence<0>,
+                                                      0,
+                                                      1,
+                                                      1,
+                                                      AddressSpace::Vgpr,
+                                                      AddressSpace::Global,
+                                                      InMemoryDataOperation::Set>(
+                    {0}, {warp_global_1d_id});
+
+            threadwise_dst_store.Run(&accuValue, p_dst_global, zeroVal);
+            threadwise_dst_store.Run(&accuIndex, indices_global, 0);
+        }
+    };
+
+    __device__ static void RunImpl3(srcDataType alpha,
+                                    const srcDataType* const __restrict__ p_src_global,
+                                    dstDataType beta,
+                                    dstDataType* const __restrict__ p_dst_global,
+                                    int* const __restrict__ ws_indices_global,
+                                    int* const __restrict__ indices_global)
+    {
+        compType p_in_thread_buffer[GredAccessesPerThreadInWarp];
+        int thread_indices_buffer[GredAccessesPerThreadInWarp];
+
+        auto zeroVal       = opReduce::getZeroVal();
+        compType accuValue = zeroVal;
+        int accuIndex      = 0;
+
+        using ThreadBufferLengths = Sequence<1, GredAccessesPerThreadInWarp>;
+        constexpr auto ThreadBufferDesc =
+            make_native_tensor_descriptor_packed(ThreadBufferLengths{});
+
+        int thread_global_1d_id = get_block_1d_id() * BlockSize + get_thread_local_1d_id();
+        int warp_global_1d_id   = thread_global_1d_id / warpSize;
+        int thread_inwarp_id    = thread_global_1d_id % warpSize;
+
+        auto threadwise_src_load =
+            ThreadwiseGenericTensorSliceCopy_v4r2<src2dDesc,
+                                                  decltype(ThreadBufferDesc),
+                                                  ThreadBufferLengths,
+                                                  Sequence<0, 1>,
+                                                  1,
+                                                  1,
+                                                  1,
+                                                  AddressSpace::Global,
+                                                  AddressSpace::Vgpr,
+                                                  InMemoryDataOperation::Set>(
+                {warp_global_1d_id, thread_inwarp_id * GredAccessesPerThreadInWarp}, {0, 0});
+        using warpwise_reduce =
+            warp_reduce<compType, BlockSize, GredAccessesPerThreadInWarp, opReduce, nanPropaOpt>;
+
+        // zero the data on the Thread Buffer
+        warpwise_reduce::set_buffer_value(p_in_thread_buffer, zeroVal);
+
+        for(int reducedLength = 0; reducedLength < toReduceLength;
+            reducedLength += warpSize * GredAccessesPerThreadInWarp)
+        {
+            threadwise_src_load.Run(
+                p_src_global, p_in_thread_buffer, type_convert<srcDataType>{}(zeroVal));
+            threadwise_src_load.Run(ws_indices_global, thread_indices_buffer, static_cast<int>(0));
+
+            // do the warp-wise reduction on data of all thread buffers
+            warpwise_reduce::reduce3(
+                p_in_thread_buffer, thread_indices_buffer, accuValue, accuIndex);
+
+            // zero the data on the Thread Buffer
+            warpwise_reduce::set_buffer_value(p_in_thread_buffer, zeroVal);
+
+            constexpr auto True = integral_constant<bool, true>{};
+            threadwise_src_load.MoveSrcSliceWindow(
+                Sequence<0, warpSize * GredAccessesPerThreadInWarp>{}, True);
+        }
+
+        using ReducedDataLengths       = Sequence<1>;
+        constexpr auto ReducedDataDesc = make_native_tensor_descriptor_packed(ReducedDataLengths{});
+
+        // The first thread in the warp stores the reduced result to the global location
+        // representing the Warp
+        if(thread_inwarp_id == 0)
+        {
+            if(!float_equal_one{}(alpha))
+                accuValue *= type_convert<compType>{}(alpha);
+
+            if(!float_equal_zero{}(beta))
+            {
+                auto threadwise_dst_load =
+                    ThreadwiseGenericTensorSliceCopy_v4r2<dst1dDesc,
+                                                          decltype(ReducedDataDesc),
+                                                          ReducedDataLengths,
+                                                          Sequence<0>,
+                                                          0,
+                                                          1,
+                                                          1,
+                                                          AddressSpace::Global,
+                                                          AddressSpace::Vgpr,
+                                                          InMemoryDataOperation::Set>(
+                        {warp_global_1d_id}, {0});
+                dstDataType priorDstValue;
+
+                threadwise_dst_load.Run(
+                    p_dst_global, &priorDstValue, type_convert<dstDataType>{}(zeroVal));
+
+                accuValue += type_convert<compType>{}(priorDstValue * beta);
+            }
+
+            auto threadwise_dst_store =
+                ThreadwiseGenericTensorSliceCopy_v4r2<decltype(ReducedDataDesc),
+                                                      dst1dDesc,
+                                                      ReducedDataLengths,
+                                                      Sequence<0>,
+                                                      0,
+                                                      1,
+                                                      1,
+                                                      AddressSpace::Vgpr,
+                                                      AddressSpace::Global,
+                                                      InMemoryDataOperation::Set>(
+                    {0}, {warp_global_1d_id});
+
+            threadwise_dst_store.Run(&accuValue, p_dst_global, zeroVal);
+            threadwise_dst_store.Run(&accuIndex, indices_global, 0);
+        }
+    };
+};
+
+} // namespace ck
+#endif

--- a/src/kernels/composable_kernel/include/kernel_algorithm/gridwise_generic_2d_reduction_multiblock.hpp
+++ b/src/kernels/composable_kernel/include/kernel_algorithm/gridwise_generic_2d_reduction_multiblock.hpp
@@ -1,0 +1,305 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2020 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#ifndef CK_GRIDWISE_GENERIC_2D_REDUCTION_MULTIBLOCK_HPP
+#define CK_GRIDWISE_GENERIC_2D_REDUCTION_MULTIBLOCK_HPP
+
+#include "float_type.hpp"
+#include "reduction_operator.hpp"
+#include "reduction_functions.hpp"
+#include "reduction_common.hpp"
+
+#include "blockwise_generic_tensor_slice_copy.hpp"
+#include "ConstantMatrixDescriptor.hpp"
+
+namespace ck {
+
+template <int BlockSize,
+          typename srcDataType,
+          typename dstDataType, // not used together with the beta input
+          typename src2dDesc,
+          typename dst1dDesc,
+          typename compType,
+          ckReduceTensorOp_t op,
+          ckNanPropagation_t nanPropaOpt,
+          ckReduceTensorIndices_t reduceIndicesOpt,
+          int blkGroupSize, // The number of blocks for doing each reduction
+          int GredAccessesPerThreadInBlock>
+struct Gridwise_generic_reduction_xy_to_x_multiblock
+{
+    static constexpr bool indexable = reduce_binary_operator<compType, op>::indexable;
+    static constexpr bool need_indices =
+        indexable && (reduceIndicesOpt != CK_REDUCE_TENSOR_NO_INDICES);
+
+    using opReduce = typename reduce_binary_operator<compType, op>::opType;
+
+    __device__ void Run(srcDataType alpha,
+                        const srcDataType* const __restrict__ p_src_global,
+                        dstDataType beta,
+                        srcDataType* const __restrict__ workspace_global,
+                        int* const __restrict__ ws_indices_global)
+    {
+        static_if<need_indices>{}([&](auto) {
+            RunImpl2(alpha, p_src_global, beta, workspace_global, ws_indices_global);
+        }).Else([&](auto) { RunImpl1(alpha, p_src_global, beta, workspace_global); });
+    };
+
+    __device__ static void RunImpl1(srcDataType alpha,
+                                    const srcDataType* const __restrict__ p_src_global,
+                                    dstDataType beta,
+                                    srcDataType* const __restrict__ workspace_global)
+    {
+        (void)alpha; // unused
+        (void)beta;  // unused
+
+        constexpr int BlockBufferSize = BlockSize * GredAccessesPerThreadInBlock;
+
+        // LDS
+        __shared__ compType p_in_block_buffer[BlockBufferSize];
+
+        // VGPR, only useful for thread 0
+        auto zeroVal       = opReduce::getZeroVal();
+        compType accuValue = zeroVal;
+
+        const int thread_local_id = get_thread_local_1d_id();
+        const int block_global_id = get_block_1d_id();
+        const int blkgroup_id     = block_global_id / blkGroupSize;
+        const int block_local_id  = block_global_id % blkGroupSize;
+
+        const int reduceSizePerBlock =
+            (((src2dDesc::GetLengths()[1] + blkGroupSize - 1) / blkGroupSize + BlockBufferSize -
+              1) /
+             BlockBufferSize) *
+            BlockBufferSize;
+
+        constexpr auto in_block_desc = make_native_tensor_descriptor_packed(
+            Sequence<1, BlockSize * GredAccessesPerThreadInBlock>{});
+
+        using ThreadSliceLengths   = Sequence<1, GredAccessesPerThreadInBlock>;
+        using ThreadClusterLengths = Sequence<1, BlockSize>;
+
+        auto blockwise_src_load =
+            BlockwiseGenericTensorSliceCopy_v4<BlockSize,
+                                               src2dDesc,
+                                               decltype(in_block_desc),
+                                               decltype(in_block_desc.GetLengths()),
+                                               ThreadSliceLengths,
+                                               ThreadClusterLengths,
+                                               Sequence<0, 1>,
+                                               Sequence<0, 1>,
+                                               Sequence<0, 1>,
+                                               1,
+                                               1,
+                                               1,
+                                               1,
+                                               AddressSpace::Global,
+                                               AddressSpace::Vgpr,
+                                               AddressSpace::Lds,
+                                               InMemoryDataOperation::Set>(
+                {blkgroup_id, block_local_id * reduceSizePerBlock}, {0, 0});
+
+        constexpr auto block_buff_2d_desc = make_native_tensor_descriptor_packed(
+            Sequence<GredAccessesPerThreadInBlock, BlockSize>{});
+
+        using blockwise_reduce = BlockwiseReduction_2d_block_buffer<decltype(block_buff_2d_desc),
+                                                                    compType,
+                                                                    true,
+                                                                    opReduce,
+                                                                    nanPropaOpt>;
+
+        const int toReduceBlocks = (reduceSizePerBlock + BlockSize - 1) / BlockSize;
+
+        for(int reducedBlocks = 0; reducedBlocks < toReduceBlocks;
+            reducedBlocks += GredAccessesPerThreadInBlock)
+        {
+            blockwise_reduce::set_buffer_value(p_in_block_buffer, zeroVal);
+
+            // load block data from global to LDS, no use of double buffers (to be improved)
+            blockwise_src_load.Run(
+                p_src_global, p_in_block_buffer, type_convert<srcDataType>{}(zeroVal));
+            __syncthreads();
+
+            int BlocksInOneOp = (reducedBlocks < toReduceBlocks - GredAccessesPerThreadInBlock)
+                                    ? GredAccessesPerThreadInBlock
+                                    : toReduceBlocks - reducedBlocks;
+            blockwise_reduce::reduce(p_in_block_buffer, BlocksInOneOp, accuValue);
+
+            constexpr auto True = integral_constant<bool, true>{};
+            blockwise_src_load.MoveSrcSliceWindow(Sequence<0, BlockBufferSize>{}, True);
+        }
+
+        using ReducedDataLengths       = Sequence<1>;
+        constexpr auto ReducedDataDesc = make_native_tensor_descriptor_packed(ReducedDataLengths{});
+
+        constexpr auto workspace_desc = make_native_tensor_descriptor_packed(
+            Sequence<dst1dDesc::GetLengths()[0] * blkGroupSize>{});
+
+        // The first thread in the block stores the reduced result to the global location
+        // representing the block
+        if(thread_local_id == 0)
+        {
+            auto threadwise_workspace_store =
+                ThreadwiseGenericTensorSliceCopy_v4r2<decltype(ReducedDataDesc),
+                                                      decltype(workspace_desc),
+                                                      ReducedDataLengths,
+                                                      Sequence<0>,
+                                                      0,
+                                                      1,
+                                                      1,
+                                                      AddressSpace::Vgpr,
+                                                      AddressSpace::Global,
+                                                      InMemoryDataOperation::Set>(
+                    {0}, {block_global_id});
+            threadwise_workspace_store.Run(&accuValue, workspace_global, zeroVal);
+        }
+    };
+
+    __device__ static void RunImpl2(srcDataType alpha,
+                                    const srcDataType* const __restrict__ p_src_global,
+                                    dstDataType beta,
+                                    srcDataType* const __restrict__ workspace_global,
+                                    int* const __restrict__ ws_indices_global)
+    {
+        (void)alpha; // unused
+        (void)beta;  // unused
+
+        constexpr int BlockBufferSize = BlockSize * GredAccessesPerThreadInBlock;
+
+        // LDS
+        __shared__ compType p_in_block_buffer[BlockBufferSize];
+        __shared__ int block_indices_buffer[BlockBufferSize];
+
+        // VGPR, only useful for thread 0
+        auto zeroVal       = opReduce::getZeroVal();
+        compType accuValue = zeroVal;
+        int accuIndex      = 0;
+
+        const int thread_local_id = get_thread_local_1d_id();
+        const int block_global_id = get_block_1d_id();
+        const int blkgroup_id     = block_global_id / blkGroupSize;
+        const int block_local_id  = block_global_id % blkGroupSize;
+
+        const int reduceSizePerBlock =
+            (((src2dDesc::GetLengths()[1] + blkGroupSize - 1) / blkGroupSize + BlockBufferSize -
+              1) /
+             BlockBufferSize) *
+            BlockBufferSize;
+
+        constexpr auto in_block_desc = make_native_tensor_descriptor_packed(
+            Sequence<1, BlockSize * GredAccessesPerThreadInBlock>{});
+
+        using ThreadSliceLengths   = Sequence<1, GredAccessesPerThreadInBlock>;
+        using ThreadClusterLengths = Sequence<1, BlockSize>;
+
+        auto blockwise_src_load =
+            BlockwiseGenericTensorSliceCopy_v4<BlockSize,
+                                               src2dDesc,
+                                               decltype(in_block_desc),
+                                               decltype(in_block_desc.GetLengths()),
+                                               ThreadSliceLengths,
+                                               ThreadClusterLengths,
+                                               Sequence<0, 1>,
+                                               Sequence<0, 1>,
+                                               Sequence<0, 1>,
+                                               1,
+                                               1,
+                                               1,
+                                               1,
+                                               AddressSpace::Global,
+                                               AddressSpace::Vgpr,
+                                               AddressSpace::Lds,
+                                               InMemoryDataOperation::Set>(
+                {blkgroup_id, block_local_id * reduceSizePerBlock}, {0, 0});
+
+        constexpr auto block_buff_2d_desc = make_native_tensor_descriptor_packed(
+            Sequence<GredAccessesPerThreadInBlock, BlockSize>{});
+
+        using blockwise_reduce = BlockwiseReduction_2d_block_buffer<decltype(block_buff_2d_desc),
+                                                                    compType,
+                                                                    true,
+                                                                    opReduce,
+                                                                    nanPropaOpt>;
+
+        const int toReduceBlocks = (reduceSizePerBlock + BlockSize - 1) / BlockSize;
+
+        blockwise_reduce::set_buffer_value(p_in_block_buffer, zeroVal);
+
+        int indexOffset = block_local_id * reduceSizePerBlock;
+
+        for(int reducedBlocks = 0; reducedBlocks < toReduceBlocks;
+            reducedBlocks += GredAccessesPerThreadInBlock)
+        {
+            blockwise_reduce::init_buffer_indices(block_indices_buffer, indexOffset);
+
+            // load block data from global to LDS, no use of double buffers (to be improved)
+            blockwise_src_load.Run(
+                p_src_global, p_in_block_buffer, type_convert<srcDataType>{}(zeroVal));
+            __syncthreads();
+
+            int BlocksInOneOp = (reducedBlocks < toReduceBlocks - GredAccessesPerThreadInBlock)
+                                    ? GredAccessesPerThreadInBlock
+                                    : toReduceBlocks - reducedBlocks;
+
+            blockwise_reduce::reduce2(
+                p_in_block_buffer, block_indices_buffer, BlocksInOneOp, accuValue, accuIndex);
+
+            blockwise_reduce::set_buffer_value(p_in_block_buffer, zeroVal);
+
+            indexOffset += BlockBufferSize;
+
+            constexpr auto True = integral_constant<bool, true>{};
+            blockwise_src_load.MoveSrcSliceWindow(Sequence<0, BlockBufferSize>{}, True);
+        }
+
+        using ReducedDataLengths       = Sequence<1>;
+        constexpr auto ReducedDataDesc = make_native_tensor_descriptor_packed(ReducedDataLengths{});
+
+        constexpr auto workspace_desc = make_native_tensor_descriptor_packed(
+            Sequence<dst1dDesc::GetLengths()[0] * blkGroupSize>{});
+
+        // The first thread in the block stores the reduced result to the global location
+        // representing the block
+        if(thread_local_id == 0)
+        {
+            auto threadwise_workspace_store =
+                ThreadwiseGenericTensorSliceCopy_v4r2<decltype(ReducedDataDesc),
+                                                      decltype(workspace_desc),
+                                                      ReducedDataLengths,
+                                                      Sequence<0>,
+                                                      0,
+                                                      1,
+                                                      1,
+                                                      AddressSpace::Vgpr,
+                                                      AddressSpace::Global,
+                                                      InMemoryDataOperation::Set>(
+                    {0}, {block_global_id});
+            threadwise_workspace_store.Run(&accuValue, workspace_global, zeroVal);
+            threadwise_workspace_store.Run(&accuIndex, ws_indices_global, 0);
+        }
+    };
+};
+
+} // namespace ck
+#endif

--- a/src/kernels/composable_kernel/include/kernel_algorithm/gridwise_generic_reduction.hpp
+++ b/src/kernels/composable_kernel/include/kernel_algorithm/gridwise_generic_reduction.hpp
@@ -1,0 +1,466 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2020 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#ifndef CK_GRIDWISE_GENERIC_REDUCTION_HPP
+#define CK_GRIDWISE_GENERIC_REDUCTION_HPP
+
+#include "float_type.hpp"
+#include "reduction_common.hpp"
+#include "reduction_operator.hpp"
+#include "reduction_kernel_simple_configurator.hpp"
+
+#include "tuple_ext.hpp"
+
+#include "gridwise_generic_2d_reduction_direct_threadwise.hpp"
+#include "gridwise_generic_2d_reduction_direct_warpwise.hpp"
+#include "gridwise_generic_2d_reduction_blockwise.hpp"
+#include "gridwise_generic_2d_reduction_multiblock.hpp"
+
+namespace ck {
+
+template <int BlkGroupSize,
+          int BlockSize,
+          typename srcDataType,  // the type with which the data of the source tensor are stored
+          typename dstDataType,  // the type with which the data of the destintion tensor are stored
+          typename compType,     // the type used by the reduce binary operator
+          typename srcDesc,      // the descriptor representing the source tensor to be reduced
+          typename toReduceDims, // the Sequence<...> consists of the indexes of toReduce dimensions
+                                 // in the source tensor descriptor
+          typename invariantDims, // the Sequence<...> consists of the indexes of invariant
+                                  // dimensions in the source tensor descriptor (can be empty)
+          typename dstDesc,  // the descriptor representing the destination tensor where the reduced
+                             // tensor data are saved/added
+          int op_I,          // the enumerate value representing the operation used in Reduction
+          int reduceImpl_I,  // the enumerate value representing the ReductionMethod
+          int nanPropaOpt_I, // the enumerate value representing the NanPropagation Option
+          int reduceIndicesOpt_I, // the enumerate value representing the Reduce Indices Option
+          int GredThreadBufferLength,
+          int GredAccessesPerThreadInBlock,
+          int GredAccessesPerThreadInWarp>
+struct Gridwise_generic_reduction
+{
+    static constexpr auto reduceImpl = static_cast<ckReductionMethod_t>(reduceImpl_I);
+    static constexpr bool is_method_multiblock =
+        (reduceImpl == CK_Reduce_MultiBlock) ? true : false;
+    static constexpr auto op          = static_cast<ckReduceTensorOp_t>(op_I);
+    static constexpr auto nanPropaOpt = static_cast<ckNanPropagation_t>(nanPropaOpt_I);
+    static constexpr auto reduceIndicesOpt =
+        static_cast<ckReduceTensorIndices_t>(reduceIndicesOpt_I);
+
+    template <ckReductionMethod_t impl, int callId>
+    struct Gridwise_generic_2d_reduction_wrapper;
+
+    // wrapper for switching to the Reduce_DirectThreadWise method
+    template <int callId>
+    struct Gridwise_generic_2d_reduction_wrapper<CK_Reduce_DirectThreadWise, callId>
+    {
+        template <typename src2dDesc, typename dst1dDesc>
+        __device__ static void Run(src2dDesc,
+                                   dst1dDesc,
+                                   srcDataType alpha,
+                                   const srcDataType* const __restrict__ p_src_global,
+                                   dstDataType beta,
+                                   dstDataType* const __restrict__ p_dst_global,
+                                   srcDataType* const __restrict__ ws_buf1_global,
+                                   int* const __restrict__ ws_buf2_global,
+                                   int* const __restrict__ indices_global)
+        {
+            (void)ws_buf1_global; // unused
+
+            constexpr auto invariantLen = src2dDesc::GetLengths()[0];
+            constexpr auto toReduceLen  = src2dDesc::GetLengths()[1];
+            constexpr auto copySliceLen = GredThreadBufferLength;
+            constexpr bool need_padding = (toReduceLen % copySliceLen > 0) ? true : false;
+            constexpr auto rPad =
+                ((toReduceLen + copySliceLen - 1) / copySliceLen) * copySliceLen - toReduceLen;
+
+            constexpr auto src2dDesc_2 = transform_tensor_descriptor(
+                src2dDesc{},
+                make_tuple(PassThrough<invariantLen>{},
+                           Pad<Sequence<toReduceLen>, Sequence<0>, Sequence<rPad>>{}),
+                make_tuple(Sequence<0>{}, Sequence<1>{}),
+                make_tuple(Sequence<0>{}, Sequence<1>{}));
+
+            using src2dDesc_touse =
+                typename std::conditional<need_padding, decltype(src2dDesc_2), src2dDesc>::type;
+
+            using gridwise_reduce = Gridwise_generic_reduction_xy_to_x_direct_threadwise<
+                BlockSize,
+                srcDataType,
+                dstDataType,
+                src2dDesc_touse,
+                dst1dDesc,
+                compType,
+                op,
+                nanPropaOpt,
+                reduceIndicesOpt,
+                callId,
+                GredThreadBufferLength>; // the callId indicates the first or second-time reduction
+            gridwise_reduce{}.Run(alpha,
+                                  p_src_global,
+                                  beta,
+                                  p_dst_global,
+                                  ws_buf2_global,
+                                  indices_global); // ws_buf2_global will be read at the second-time
+        };
+    };
+
+    // wrapper for switching to the Reduce_DirectWarpdWise method
+    template <int callId>
+    struct Gridwise_generic_2d_reduction_wrapper<CK_Reduce_DirectWarpWise, callId>
+    {
+        template <typename src2dDesc, typename dst1dDesc>
+        __device__ static void Run(src2dDesc,
+                                   dst1dDesc,
+                                   srcDataType alpha,
+                                   const srcDataType* const __restrict__ p_src_global,
+                                   dstDataType beta,
+                                   dstDataType* const __restrict__ p_dst_global,
+                                   srcDataType* const __restrict__ ws_buf1_global,
+                                   int* const __restrict__ ws_buf2_global,
+                                   int* const __restrict__ indices_global)
+        {
+            (void)ws_buf1_global; // unused
+
+            constexpr auto invariantLen = src2dDesc::GetLengths()[0];
+            constexpr auto toReduceLen  = src2dDesc::GetLengths()[1];
+            constexpr auto copySliceLen = warpSize * GredAccessesPerThreadInWarp;
+            constexpr bool need_padding = (toReduceLen % copySliceLen > 0) ? true : false;
+            constexpr auto rPad =
+                ((toReduceLen + copySliceLen - 1) / copySliceLen) * copySliceLen - toReduceLen;
+
+            constexpr auto src2dDesc_2 = transform_tensor_descriptor(
+                src2dDesc{},
+                make_tuple(PassThrough<invariantLen>{},
+                           Pad<Sequence<toReduceLen>, Sequence<0>, Sequence<rPad>>{}),
+                make_tuple(Sequence<0>{}, Sequence<1>{}),
+                make_tuple(Sequence<0>{}, Sequence<1>{}));
+
+            using src2dDesc_touse =
+                typename std::conditional<need_padding, decltype(src2dDesc_2), src2dDesc>::type;
+
+            using gridwise_reduce = Gridwise_generic_reduction_xy_to_x_direct_warpwise<
+                BlockSize,
+                srcDataType,
+                dstDataType,
+                src2dDesc_touse,
+                dst1dDesc,
+                compType,
+                op,
+                nanPropaOpt,
+                reduceIndicesOpt,
+                callId,
+                GredAccessesPerThreadInWarp>; // the callId indicates the first or second-time
+                                              // reduction
+            gridwise_reduce{}.Run(alpha,
+                                  p_src_global,
+                                  beta,
+                                  p_dst_global,
+                                  ws_buf2_global,
+                                  indices_global); // ws_buf2_global will be read at the second-time
+        };
+    };
+
+    // wrapper for switching to the Reduce_BlockWise method
+    template <int callId>
+    struct Gridwise_generic_2d_reduction_wrapper<CK_Reduce_BlockWise, callId>
+    {
+        template <typename src2dDesc, typename dst1dDesc>
+        __device__ static void Run(src2dDesc,
+                                   dst1dDesc,
+                                   srcDataType alpha,
+                                   const srcDataType* const __restrict__ p_src_global,
+                                   dstDataType beta,
+                                   dstDataType* const __restrict__ p_dst_global,
+                                   srcDataType* const __restrict__ ws_buf1_global,
+                                   int* const __restrict__ ws_buf2_global,
+                                   int* const __restrict__ indices_global)
+        {
+            (void)ws_buf1_global; // unused
+
+            constexpr auto invariantLen = src2dDesc::GetLengths()[0];
+            constexpr auto toReduceLen  = src2dDesc::GetLengths()[1];
+            constexpr auto copySliceLen = BlockSize * GredAccessesPerThreadInBlock;
+            constexpr bool need_padding = (toReduceLen % copySliceLen > 0) ? true : false;
+            constexpr auto rPad =
+                ((toReduceLen + copySliceLen - 1) / copySliceLen) * copySliceLen - toReduceLen;
+
+            constexpr auto src2dDesc_2 = transform_tensor_descriptor(
+                src2dDesc{},
+                make_tuple(PassThrough<invariantLen>{},
+                           Pad<Sequence<toReduceLen>, Sequence<0>, Sequence<rPad>>{}),
+                make_tuple(Sequence<0>{}, Sequence<1>{}),
+                make_tuple(Sequence<0>{}, Sequence<1>{}));
+
+            using src2dDesc_touse =
+                typename std::conditional<need_padding, decltype(src2dDesc_2), src2dDesc>::type;
+
+            using gridwise_reduce = Gridwise_generic_reduction_xy_to_x_blockwise<
+                BlockSize,
+                srcDataType,
+                dstDataType,
+                src2dDesc_touse,
+                dst1dDesc,
+                compType,
+                op,
+                nanPropaOpt,
+                reduceIndicesOpt,
+                callId,
+                GredAccessesPerThreadInBlock>; // the callId indicates the first or second-time
+                                               // reduction
+
+            gridwise_reduce{}.Run(alpha,
+                                  p_src_global,
+                                  beta,
+                                  p_dst_global,
+                                  ws_buf2_global,
+                                  indices_global); // ws_buf2_global will be read at the second-time
+        };
+    };
+
+    // wrapper for switching to the Reduce_MultiBlock method
+    template <int callId>
+    struct Gridwise_generic_2d_reduction_wrapper<CK_Reduce_MultiBlock, callId>
+    {
+        template <typename src2dDesc, typename dst1dDesc>
+        __device__ static void Run(src2dDesc,
+                                   dst1dDesc,
+                                   srcDataType alpha,
+                                   const srcDataType* const __restrict__ p_src_global,
+                                   dstDataType beta,
+                                   dstDataType* const __restrict__ p_dst_global,
+                                   srcDataType* const __restrict__ ws_buf1_global,
+                                   int* const __restrict__ ws_buf2_global,
+                                   int* const __restrict__ indices_global)
+        {
+            (void)p_dst_global;   // unused
+            (void)indices_global; // unused
+
+            constexpr auto invariantLen = src2dDesc::GetLengths()[0];
+            constexpr auto toReduceLen  = src2dDesc::GetLengths()[1];
+            constexpr auto copySliceLen = BlockSize * GredAccessesPerThreadInBlock;
+            const int reduceSizePerBlock =
+                (((toReduceLen + BlkGroupSize - 1) / BlkGroupSize + copySliceLen - 1) /
+                 copySliceLen) *
+                copySliceLen;
+            constexpr bool need_padding =
+                (toReduceLen < reduceSizePerBlock * BlkGroupSize) ? true : false;
+            constexpr auto rPad = reduceSizePerBlock * BlkGroupSize - toReduceLen;
+
+            constexpr auto src2dDesc_2 = transform_tensor_descriptor(
+                src2dDesc{},
+                make_tuple(PassThrough<invariantLen>{},
+                           Pad<Sequence<toReduceLen>, Sequence<0>, Sequence<rPad>>{}),
+                make_tuple(Sequence<0>{}, Sequence<1>{}),
+                make_tuple(Sequence<0>{}, Sequence<1>{}));
+
+            using gridwise_reduce = Gridwise_generic_reduction_xy_to_x_multiblock<
+                BlockSize,
+                srcDataType,
+                dstDataType,
+                typename std::conditional<need_padding, decltype(src2dDesc_2), src2dDesc>::type,
+                dst1dDesc,
+                compType,
+                op,
+                nanPropaOpt,
+                reduceIndicesOpt,
+                BlkGroupSize,
+                GredAccessesPerThreadInBlock>; // MultiBlock case is not used by second-time
+                                               // reduction
+
+            gridwise_reduce{}.Run(alpha,
+                                  p_src_global,
+                                  beta,
+                                  ws_buf1_global,
+                                  ws_buf2_global); // ws_buf1_global instead of p_dst_global,
+                                                   // ws_buf2_global instead of indices_global
+        };
+    };
+
+    __device__ static void Run(float alpha,
+                               const void* const __restrict__ p_src_global,
+                               float beta,
+                               void* const __restrict__ p_dst_global,
+                               void* const __restrict__ ws_buf1_global,
+                               long ws_buf2_bytes_offset,
+                               void* const __restrict__ indices_global)
+    {
+        using srcLengths = decltype(srcDesc::GetLengths());
+        using dstLengths = decltype(dstDesc::GetLengths());
+
+        using specDims = typename sequence_merge<invariantDims, toReduceDims>::type;
+        static_assert(is_valid_sequence_map<specDims>::value &&
+                          specDims::Size() == srcLengths::Size(),
+                      "Wrong invariant and/or toReduce dimensions!");
+
+        static_assert(toReduceDims::Size() >= 1,
+                      "Wrong specification of source mode, We should at "
+                      "least to have one dimension to be reduced !!");
+
+        // The number of invariant dimensions can be zero if all dimension are to be reduced
+        static_assert(
+            invariantDims::Size() > 0 || (dstLengths::Size() == 1 && dstLengths{}[0] == 1),
+            "If all source dimensions are reduced, the dest should have only one dimension !!");
+
+        constexpr bool reduceAllDims = (invariantDims::Size() == 0) ? true : false;
+
+        void* const ws_buf2_global =
+            ws_buf2_bytes_offset > 0
+                ? static_cast<void*>(static_cast<char*>(ws_buf1_global) + ws_buf2_bytes_offset)
+                : nullptr;
+
+        static_if<!reduceAllDims>{}([&](auto) { // not all dimensions are to be reduced
+            using toReduceDimLengths  = decltype(srcLengths::Extract(toReduceDims{}));
+            using invariantDimLengths = decltype(srcLengths::Extract(invariantDims{}));
+
+            // for re-ordering the tensor dimensions
+            using lowDimSeq  = typename sequence_merge<invariantDims, toReduceDims>::type;
+            using highDimSeq = typename arithmetic_sequence_gen<0, srcLengths::Size(), 1>::type;
+
+            // construct the reordered tensor descriptor according to the srcMode and dstMode
+            // mapping
+            constexpr auto reordered_srcDesc = transform_tensor_descriptor(
+                srcDesc{},
+                make_passthrough_tuple(srcLengths::Extract(lowDimSeq{})),
+                make_dimensions_tuple(lowDimSeq{}),
+                make_dimensions_tuple(highDimSeq{}));
+            constexpr auto two_dim_srcDesc = transform_tensor_descriptor(
+                reordered_srcDesc,
+                make_2d_merge_transform_tuple(invariantDimLengths{}, toReduceDimLengths{}),
+                make_tuple(typename arithmetic_sequence_gen<0, dstLengths::Size(), 1>::type{},
+                           typename arithmetic_sequence_gen<dstLengths::Size(),
+                                                            srcLengths::Size(),
+                                                            1>::type{}),
+                make_tuple(Sequence<0>{}, Sequence<1>{}));
+
+            constexpr auto one_dim_dstDesc = transform_tensor_descriptor(
+                dstDesc{},
+                make_1d_merge_transform_tuple(dstLengths{}),
+                make_tuple(typename arithmetic_sequence_gen<0, dstLengths::Size(), 1>::type{}),
+                make_tuple(Sequence<0>{}));
+
+            using gridwise_2d_reduce = Gridwise_generic_2d_reduction_wrapper<reduceImpl, 0>;
+
+            gridwise_2d_reduce{}.Run(two_dim_srcDesc,
+                                     one_dim_dstDesc,
+                                     type_convert<srcDataType>{}(alpha),
+                                     const_cast<const srcDataType* const __restrict__>(
+                                         static_cast<const srcDataType*>(p_src_global)),
+                                     type_convert<dstDataType>{}(beta),
+                                     const_cast<dstDataType* const __restrict__>(
+                                         static_cast<dstDataType*>(p_dst_global)),
+                                     static_cast<srcDataType* const __restrict__>(ws_buf1_global),
+                                     static_cast<int* const __restrict__>(ws_buf2_global),
+                                     static_cast<int* const __restrict__>(indices_global));
+        }).Else([&](auto) { // All dimensions are to be reduced
+            constexpr auto one_dim_srcDesc = transform_tensor_descriptor(
+                srcDesc{},
+                make_1d_merge_transform_tuple(srcLengths{}),
+                make_tuple(typename arithmetic_sequence_gen<0, srcLengths::Size(), 1>::type{}),
+                make_tuple(Sequence<0>{}));
+
+            constexpr auto dim_length = one_dim_srcDesc.GetLengths()[0];
+
+            constexpr auto two_dim_srcDesc =
+                transform_tensor_descriptor(one_dim_srcDesc,
+                                            make_tuple(UnMerge<Sequence<1, dim_length>>{}),
+                                            make_tuple(Sequence<0>{}),
+                                            make_tuple(Sequence<0, 1>{}));
+
+            constexpr auto one_dim_dstDesc = transform_tensor_descriptor(
+                dstDesc{},
+                make_1d_merge_transform_tuple(dstLengths{}),
+                make_tuple(typename arithmetic_sequence_gen<0, dstLengths::Size(), 1>::type{}),
+                make_tuple(Sequence<0>{}));
+
+            using gridwise_2d_reduce = Gridwise_generic_2d_reduction_wrapper<reduceImpl, 0>;
+
+            gridwise_2d_reduce{}.Run(two_dim_srcDesc,
+                                     one_dim_dstDesc,
+                                     type_convert<srcDataType>{}(alpha),
+                                     const_cast<const srcDataType* const __restrict__>(
+                                         static_cast<const srcDataType*>(p_src_global)),
+                                     type_convert<dstDataType>{}(beta),
+                                     const_cast<dstDataType* const __restrict__>(
+                                         static_cast<dstDataType*>(p_dst_global)),
+                                     static_cast<srcDataType* const __restrict__>(ws_buf1_global),
+                                     static_cast<int* const __restrict__>(ws_buf2_global),
+                                     static_cast<int* const __restrict__>(indices_global));
+        });
+    };
+
+    __device__ static void Run_2(float alpha,
+                                 const void* const __restrict__ p_src_global,
+                                 float beta,
+                                 void* const __restrict__ p_dst_global,
+                                 void* const __restrict__ ws_buf1_global,
+                                 long ws_buf2_bytes_offset,
+                                 void* const __restrict__ indices_global)
+    {
+        (void)p_src_global; // unused
+
+        using dstLengths = decltype(dstDesc::GetLengths());
+
+        constexpr auto one_dim_dstDesc = transform_tensor_descriptor(
+            dstDesc{},
+            make_1d_merge_transform_tuple(dstLengths{}),
+            make_tuple(typename arithmetic_sequence_gen<0, dstLengths::Size(), 1>::type{}),
+            make_tuple(Sequence<0>{}));
+        constexpr index_t invariantLength = one_dim_dstDesc.GetLengths()[0];
+        constexpr index_t toReduceLength  = BlkGroupSize;
+
+        constexpr auto workspace_2d_desc =
+            make_native_tensor_descriptor_packed(Sequence<invariantLength, toReduceLength>{});
+
+        void* const ws_buf2_global =
+            ws_buf2_bytes_offset > 0
+                ? static_cast<void*>(static_cast<char*>(ws_buf1_global) + ws_buf2_bytes_offset)
+                : nullptr;
+
+        static_if<is_method_multiblock>{}([&](auto) {
+            constexpr ckReductionMethod_t reduceImpl2 =
+                reduce_kernel_simple_configurator<BlockSize, warpSize>::getReductionMethod(
+                    Number<invariantLength>{}, Number<toReduceLength>{});
+
+            using gridwise_2d_reduce = Gridwise_generic_2d_reduction_wrapper<reduceImpl2, 1>;
+
+            gridwise_2d_reduce{}.Run(
+                workspace_2d_desc,
+                one_dim_dstDesc,
+                type_convert<srcDataType>{}(alpha),
+                const_cast<const srcDataType* const __restrict__>(
+                    static_cast<srcDataType*>(ws_buf1_global)),
+                type_convert<dstDataType>{}(beta),
+                const_cast<dstDataType* const __restrict__>(
+                    static_cast<dstDataType*>(p_dst_global)),
+                const_cast<dstDataType* const __restrict__>(static_cast<dstDataType*>(nullptr)),
+                static_cast<int* const __restrict__>(ws_buf2_global),
+                static_cast<int* const __restrict__>(indices_global));
+        }).Else([&](auto) {});
+    };
+};
+
+} // namespace ck
+#endif

--- a/src/kernels/composable_kernel/include/kernel_algorithm/reduction_functions.hpp
+++ b/src/kernels/composable_kernel/include/kernel_algorithm/reduction_functions.hpp
@@ -1,0 +1,623 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2020 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#ifndef CK_REDUCTION_FUNCTIONS_HPP
+#define CK_REDUCTION_FUNCTIONS_HPP
+
+#include <config.hpp>
+
+#include "reduction_common.hpp"
+#include "reduction_operator.hpp"
+
+namespace ck {
+namespace detail {
+
+template <typename T>
+__device__ bool IsNan(T x)
+{
+    // for float and double, use the builtin hip kernel functions
+    return (isnan(x));
+};
+
+template <>
+__device__ bool IsNan<half>(half x)
+{
+    return (__hisnan(x));
+};
+
+template <ckNanPropagation_t nanPropaOpt, typename opReduce, typename compType>
+struct binop_with_nan_check;
+
+template <typename opReduce, typename compType>
+struct binop_with_nan_check<CK_NOT_PROPAGATE_NAN, opReduce, compType>
+{
+    __device__ static inline void calculate(const compType& accuVal, compType currVal)
+    {
+        opReduce{}(const_cast<compType&>(accuVal), currVal);
+    };
+
+    // this method can only be called when the opReduce is indexable
+    __device__ static inline void
+    calculate(const compType& accuVal, compType currVal, int& accuIndex, int currIndex)
+    {
+        bool changed = false;
+
+        opReduce{}(const_cast<compType&>(accuVal), currVal, changed);
+
+        if(changed)
+            accuIndex = currIndex;
+    };
+};
+
+template <typename opReduce, typename compType>
+struct binop_with_nan_check<CK_PROPAGATE_NAN, opReduce, compType>
+{
+    __device__ static inline void calculate(compType& accuVal, compType currVal)
+    {
+        if(IsNan(currVal))
+            accuVal = currVal;
+        else
+            opReduce{}(accuVal, currVal);
+    };
+
+    // this method can only be called when the opReduce is indexable
+    __device__ static inline void
+    calculate(compType& accuVal, compType currVal, int& accuIndex, int currIndex)
+    {
+        if(IsNan(currVal))
+        {
+            accuVal   = currVal;
+            accuIndex = currIndex;
+        }
+        else
+        {
+            bool changed = false;
+
+            opReduce{}(accuVal, currVal, changed);
+
+            if(changed)
+                accuIndex = currIndex;
+        }
+    };
+};
+}; // namespace detail
+
+template <typename DataType, int ThreadBufferLen, typename opReduce, ckNanPropagation_t nanPropaOpt>
+struct thread_reduce
+{
+    using compType = typename opReduce::dataType;
+    using binop    = detail::binop_with_nan_check<nanPropaOpt, opReduce, compType>;
+
+    __device__ static void reduce(const DataType* p_thread_buffer, compType& accuData)
+    {
+        for(int i = 0; i < ThreadBufferLen; i++)
+        {
+            compType currVal = type_convert<compType>{}(p_thread_buffer[i]);
+            binop::calculate(accuData, currVal);
+        }
+    };
+
+    // This operator is used by Direct_ThreadWise reduction method at first-time reduction
+    __device__ static void
+    reduce2(const DataType* p_thread_buffer, compType& accuData, int& accuIndex, int indexStart)
+    {
+        for(int i = 0; i < ThreadBufferLen; i++)
+        {
+            compType currVal = type_convert<compType>{}(p_thread_buffer[i]);
+            int currIndex    = i + indexStart;
+            binop::calculate(accuData, currVal, accuIndex, currIndex);
+        }
+    };
+
+    // This operator is used by Direct_ThreadWise reduction method at second-time reduction
+    __device__ static void reduce3(const DataType* p_thread_buffer,
+                                   const int* thread_indices_buffer,
+                                   compType& accuData,
+                                   int& accuIndex)
+    {
+        for(int i = 0; i < ThreadBufferLen; i++)
+        {
+            compType currVal = type_convert<compType>{}(p_thread_buffer[i]);
+            int currIndex    = thread_indices_buffer[i];
+            binop::calculate(accuData, currVal, accuIndex, currIndex);
+        }
+    };
+
+    __device__ static void set_buffer_value(DataType* p_thread_buffer, DataType value)
+    {
+        for(int i              = 0; i < ThreadBufferLen; i++)
+            p_thread_buffer[i] = value;
+    };
+};
+
+template <typename DataType,
+          int BlockSize,
+          int ThreadBufferLen,
+          typename opReduce,
+          ckNanPropagation_t nanPropaOpt>
+struct warp_reduce
+{
+    using compType = typename opReduce::dataType;
+    using binop    = detail::binop_with_nan_check<nanPropaOpt, opReduce, compType>;
+    constexpr static bool have_builtin_shuffle = std::is_same<compType, float>::value;
+
+    __device__ static void reduce(const DataType* p_thread_buffer, compType& accuData)
+    {
+        static_if<have_builtin_shuffle>{}([&](auto) {
+            reduceImpl1(p_thread_buffer, accuData);
+        }).Else([&](auto) { reduceImpl2(p_thread_buffer, accuData); });
+    };
+
+    __device__ static void reduceImpl1(const DataType* p_thread_buffer, compType& accuData)
+    {
+        compType lAccuData = opReduce::getZeroVal();
+
+        for(int i = 0; i < ThreadBufferLen; i++)
+        {
+            compType currVal = type_convert<compType>{}(p_thread_buffer[i]);
+            binop::calculate(lAccuData, currVal);
+        }
+
+        // synchronize among all threads in this warp
+        __all(1);
+
+        for(int stride = warpSize / 2; stride > 0; stride /= 2)
+        {
+            compType tmpVal = __shfl_down(lAccuData, stride, warpSize);
+            binop::calculate(lAccuData, tmpVal);
+            __all(1);
+        }
+
+        binop::calculate(accuData, lAccuData);
+    };
+
+    __device__ static void reduceImpl2(const DataType* p_thread_buffer, compType& accuData)
+    {
+        compType lAccuData = opReduce::getZeroVal();
+
+        for(int i = 0; i < ThreadBufferLen; i++)
+        {
+            compType currVal = type_convert<compType>{}(p_thread_buffer[i]);
+            binop::calculate(lAccuData, currVal);
+        }
+
+        __syncthreads();
+
+        int thread_id        = get_thread_local_1d_id();
+        int warpId           = thread_id / warpSize;
+        int thread_inwarp_id = thread_id % warpSize;
+
+        __shared__ compType shuffle_buffer[BlockSize];
+
+        compType* myBuffer = &shuffle_buffer[warpId * warpSize];
+
+        myBuffer[thread_inwarp_id] = lAccuData;
+
+        __syncthreads();
+
+        for(int stride = warpSize / 2; stride > 0; stride /= 2)
+        {
+            if(thread_inwarp_id < warpSize)
+            {
+                compType currVal1 = myBuffer[thread_inwarp_id];
+                compType currVal2 = myBuffer[thread_inwarp_id + stride];
+
+                binop::calculate(currVal1, currVal2);
+
+                myBuffer[thread_inwarp_id] = currVal1;
+            }
+
+            __syncthreads();
+        }
+        if(thread_inwarp_id == 0)
+            binop::calculate(accuData, myBuffer[0]);
+    };
+
+    __device__ static void
+    reduce2(const DataType* p_thread_buffer, compType& accuData, int& accuIndex, int indexStart)
+    {
+        static_if<have_builtin_shuffle>{}([&](auto) {
+            reduce2Impl1(p_thread_buffer, accuData, accuIndex, indexStart);
+        }).Else([&](auto) { reduce2Impl2(p_thread_buffer, accuData, accuIndex, indexStart); });
+    };
+
+    __device__ static void reduce2Impl1(const DataType* p_thread_buffer,
+                                        compType& accuData,
+                                        int& accuIndex,
+                                        int indexStart)
+    {
+        compType lAccuData   = opReduce::getZeroVal();
+        int lAccuIndex       = 0;
+        int thread_inwarp_id = get_thread_local_1d_id() % warpSize;
+
+        for(int i = 0; i < ThreadBufferLen; i++)
+        {
+            compType currVal = type_convert<compType>{}(p_thread_buffer[i]);
+            int currIndex    = thread_inwarp_id * ThreadBufferLen + i + indexStart;
+            binop::calculate(lAccuData, currVal, lAccuIndex, currIndex);
+        }
+
+        // synchronize among all threads in this warp
+        __all(1);
+
+        for(int stride = 1; stride < warpSize; stride *= 2)
+        {
+            compType tmpVal = __shfl_down(lAccuData, stride, warpSize);
+            int tmpIndex    = __shfl_down(lAccuIndex, stride, warpSize);
+
+            binop::calculate(lAccuData, tmpVal, lAccuIndex, tmpIndex);
+            __all(1);
+        }
+
+        if(thread_inwarp_id == 0)
+            binop::calculate(accuData, lAccuData, accuIndex, lAccuIndex);
+    };
+
+    __device__ static void reduce2Impl2(const DataType* p_thread_buffer,
+                                        compType& accuData,
+                                        int& accuIndex,
+                                        int indexStart)
+    {
+        compType lAccuData   = opReduce::getZeroVal();
+        int lAccuIndex       = 0;
+        int thread_id        = get_thread_local_1d_id();
+        int warpId           = thread_id / warpSize;
+        int thread_inwarp_id = thread_id % warpSize;
+
+        for(int i = 0; i < ThreadBufferLen; i++)
+        {
+            compType currVal = type_convert<compType>{}(p_thread_buffer[i]);
+            int currIndex    = thread_inwarp_id * ThreadBufferLen + i + indexStart;
+            binop::calculate(lAccuData, currVal, lAccuIndex, currIndex);
+        }
+
+        __shared__ compType shuffle_data_buffer[BlockSize];
+        __shared__ int shuffle_indices_buffer[BlockSize];
+
+        compType* myDataBuffer = &shuffle_data_buffer[warpId * warpSize];
+        int* myIndicesBuffer   = &shuffle_indices_buffer[warpId * warpSize];
+
+        myDataBuffer[thread_inwarp_id]    = lAccuData;
+        myIndicesBuffer[thread_inwarp_id] = lAccuIndex;
+
+        __syncthreads();
+
+        for(int stride = 1; stride < warpSize; stride *= 2)
+        {
+            if(thread_inwarp_id < warpSize)
+            {
+                compType currVal1 = myDataBuffer[thread_inwarp_id];
+                compType currVal2 = myDataBuffer[thread_inwarp_id + stride];
+                int currIndex1    = myIndicesBuffer[thread_inwarp_id];
+                int currIndex2    = myIndicesBuffer[thread_inwarp_id + stride];
+
+                binop::calculate(currVal1, currVal2, currIndex1, currIndex2);
+
+                myDataBuffer[thread_inwarp_id]    = currVal1;
+                myIndicesBuffer[thread_inwarp_id] = currIndex1;
+            }
+            __syncthreads();
+        }
+
+        if(thread_inwarp_id == 0)
+            binop::calculate(accuData, myDataBuffer[0], accuIndex, myIndicesBuffer[0]);
+    };
+
+    __device__ static void reduce3(const DataType* p_thread_buffer,
+                                   const int* thread_indices_buffer,
+                                   compType& accuData,
+                                   int& accuIndex)
+    {
+        static_if<have_builtin_shuffle>{}([&](auto) {
+            reduce3Impl1(p_thread_buffer, thread_indices_buffer, accuData, accuIndex);
+        }).Else([&](auto) {
+            reduce3Impl2(p_thread_buffer, thread_indices_buffer, accuData, accuIndex);
+        });
+    };
+
+    __device__ static void reduce3Impl1(const DataType* p_thread_buffer,
+                                        const int* thread_indices_buffer,
+                                        compType& accuData,
+                                        int& accuIndex)
+    {
+        compType lAccuData = opReduce::getZeroVal();
+        int lAccuIndex     = 0;
+
+        for(int i = 0; i < ThreadBufferLen; i++)
+        {
+            compType currVal   = type_convert<compType>{}(p_thread_buffer[i]);
+            compType currIndex = thread_indices_buffer[i];
+            binop::calculate(lAccuData, currVal, lAccuIndex, currIndex);
+        }
+
+        // synchronize among all threads in this warp
+        __all(1);
+
+        for(int stride = 1; stride < warpSize; stride *= 2)
+        {
+            compType tmpVal = __shfl_down(lAccuData, stride, warpSize);
+            int tmpIndex    = __shfl_down(lAccuIndex, stride, warpSize);
+
+            binop::calculate(lAccuData, tmpVal, lAccuIndex, tmpIndex);
+            __all(1);
+        }
+
+        binop::calculate(accuData, lAccuData, accuIndex, lAccuIndex);
+    };
+
+    __device__ static void reduce3Impl2(const DataType* p_thread_buffer,
+                                        const int* thread_indices_buffer,
+                                        compType& accuData,
+                                        int& accuIndex)
+    {
+        compType lAccuData   = opReduce::getZeroVal();
+        int lAccuIndex       = 0;
+        int thread_id        = get_thread_local_1d_id();
+        int warpId           = thread_id / warpSize;
+        int thread_inwarp_id = thread_id % warpSize;
+
+        for(int i = 0; i < ThreadBufferLen; i++)
+        {
+            compType currVal   = type_convert<compType>{}(p_thread_buffer[i]);
+            compType currIndex = thread_indices_buffer[i];
+            binop::calculate(lAccuData, currVal, lAccuIndex, currIndex);
+        }
+
+        __shared__ compType shuffle_data_buffer[BlockSize];
+        __shared__ int shuffle_indices_buffer[BlockSize];
+
+        compType* myDataBuffer = &shuffle_data_buffer[warpId * warpSize];
+        int* myIndicesBuffer   = &shuffle_indices_buffer[warpId * warpSize];
+
+        myDataBuffer[thread_inwarp_id]    = lAccuData;
+        myIndicesBuffer[thread_inwarp_id] = lAccuIndex;
+
+        __syncthreads();
+
+        for(int stride = 1; stride < warpSize; stride *= 2)
+        {
+            if(thread_inwarp_id < warpSize)
+            {
+                compType currVal1 = myDataBuffer[thread_inwarp_id];
+                compType currVal2 = myDataBuffer[thread_inwarp_id + stride];
+                int currIndex1    = myIndicesBuffer[thread_inwarp_id];
+                int currIndex2    = myIndicesBuffer[thread_inwarp_id + stride];
+
+                binop::calculate(currVal1, currVal2, currIndex1, currIndex2);
+
+                myDataBuffer[thread_inwarp_id]    = currVal1;
+                myIndicesBuffer[thread_inwarp_id] = currIndex1;
+            }
+            __syncthreads();
+        }
+
+        if(thread_inwarp_id == 0)
+            binop::calculate(accuData, myDataBuffer[0], accuIndex, myIndicesBuffer[0]);
+    };
+
+    __device__ static void set_buffer_value(DataType* p_thread_buffer, DataType value)
+    {
+        for(int i              = 0; i < ThreadBufferLen; i++)
+            p_thread_buffer[i] = value;
+
+        __all(1);
+    };
+};
+
+template <typename buffer2dDesc,
+          typename DataType,
+          bool blockIsOneRow,
+          typename opReduce,
+          ckNanPropagation_t nanPropaOpt>
+struct BlockwiseReduction_2d_block_buffer
+{
+    using compType = typename opReduce::dataType;
+    constexpr static int BlockSize =
+        blockIsOneRow ? buffer2dDesc::GetLengths()[1] : buffer2dDesc::GetLengths()[0];
+    constexpr static int NumBlocks =
+        blockIsOneRow ? buffer2dDesc::GetLengths()[0] : buffer2dDesc::GetLengths()[1];
+    using binop = detail::binop_with_nan_check<nanPropaOpt, opReduce, compType>;
+
+    __device__ static void reduce(DataType* p_block_buffer, int toReduceBlocks, compType& accuData)
+    {
+        const int thread_local_id = get_thread_local_1d_id();
+        compType lAccuData        = opReduce::getZeroVal();
+
+        int offset;
+        for(int otherDimInd = 0; otherDimInd < toReduceBlocks; otherDimInd++)
+        {
+            offset = blockIsOneRow ? buffer2dDesc::CalculateOffset({otherDimInd, thread_local_id})
+                                   : buffer2dDesc::CalculateOffset({thread_local_id, otherDimInd});
+            compType opData = type_convert<compType>{}(p_block_buffer[offset]);
+
+            binop::calculate(lAccuData, opData);
+        }
+
+        offset = blockIsOneRow ? buffer2dDesc::CalculateOffset({0, thread_local_id})
+                               : buffer2dDesc::CalculateOffset({thread_local_id, 0});
+
+        p_block_buffer[offset] = lAccuData;
+
+        __syncthreads();
+
+        for(int indOffset = BlockSize / 2; indOffset > 0; indOffset /= 2)
+        {
+            if(thread_local_id < indOffset)
+            {
+                int offset1 = blockIsOneRow ? buffer2dDesc::CalculateOffset({0, thread_local_id})
+                                            : buffer2dDesc::CalculateOffset({thread_local_id, 0});
+
+                int offset2 = blockIsOneRow
+                                  ? buffer2dDesc::CalculateOffset({0, thread_local_id + indOffset})
+                                  : buffer2dDesc::CalculateOffset({thread_local_id + indOffset, 0});
+
+                compType opData1 = type_convert<compType>{}(p_block_buffer[offset1]);
+                compType opData2 = type_convert<compType>{}(p_block_buffer[offset2]);
+                binop::calculate(opData1, opData2);
+                p_block_buffer[offset1] = type_convert<DataType>{}(opData1);
+            }
+
+            __syncthreads();
+        }
+
+        if(thread_local_id == 0)
+        {
+            compType tmpVal = type_convert<compType>{}(p_block_buffer[0]);
+
+            binop::calculate(accuData, tmpVal);
+        }
+    };
+
+    __device__ static void reduce2(DataType* p_block_buffer,
+                                   int* block_indices_buffer,
+                                   int toReduceBlocks,
+                                   compType& accuData,
+                                   int& accuIndex)
+    {
+        const int thread_local_id = get_thread_local_1d_id();
+        compType lAccuData        = opReduce::getZeroVal();
+        int lAccuIndex            = 0;
+
+        static_if<blockIsOneRow>{}([&](auto) {
+            for(int otherDimInd = 0; otherDimInd < toReduceBlocks; otherDimInd++)
+            {
+                for(int indOffset = 1; indOffset < BlockSize; indOffset *= 2)
+                {
+                    if(thread_local_id % (indOffset * 2) == 0)
+                    {
+                        int offset1 = buffer2dDesc::CalculateOffset({otherDimInd, thread_local_id});
+                        int offset2 = buffer2dDesc::CalculateOffset(
+                            {otherDimInd, thread_local_id + indOffset});
+
+                        compType currVal1 = type_convert<compType>{}(p_block_buffer[offset1]);
+                        compType currVal2 = type_convert<compType>{}(p_block_buffer[offset2]);
+                        int currIndex1    = block_indices_buffer[offset1];
+                        int currIndex2    = block_indices_buffer[offset2];
+
+                        binop::calculate(currVal1, currVal2, currIndex1, currIndex2);
+                        p_block_buffer[offset1]       = type_convert<DataType>{}(currVal1);
+                        block_indices_buffer[offset1] = currIndex1;
+                    }
+                }
+                __syncthreads();
+            }
+
+            if(thread_local_id == 0)
+            {
+                for(int otherDimInd = 0; otherDimInd < toReduceBlocks; otherDimInd++)
+                {
+                    int offset = buffer2dDesc::CalculateOffset({otherDimInd, 0});
+
+                    compType tmpVal = type_convert<compType>{}(p_block_buffer[offset]);
+                    int tmpIndex    = block_indices_buffer[offset];
+
+                    binop::calculate(lAccuData, tmpVal, lAccuIndex, tmpIndex);
+                }
+
+                binop::calculate(accuData, lAccuData, accuIndex, lAccuIndex);
+            }
+        }).Else([&](auto) {
+            int offset;
+
+            for(int otherDimInd = 0; otherDimInd < toReduceBlocks; otherDimInd++)
+            {
+                offset           = buffer2dDesc::CalculateOffset({thread_local_id, otherDimInd});
+                compType currVal = type_convert<compType>{}(p_block_buffer[offset]);
+                int currIndex    = block_indices_buffer[offset];
+
+                binop::calculate(lAccuData, currVal, lAccuIndex, currIndex);
+            }
+
+            offset = buffer2dDesc::CalculateOffset({thread_local_id, 0});
+
+            p_block_buffer[offset]       = lAccuData;
+            block_indices_buffer[offset] = lAccuIndex;
+
+            __syncthreads();
+
+            for(int indOffset = 1; indOffset < BlockSize; indOffset *= 2)
+            {
+                if(thread_local_id % (indOffset * 2) == 0)
+                {
+                    int offset1 = buffer2dDesc::CalculateOffset({thread_local_id, 0});
+                    int offset2 = buffer2dDesc::CalculateOffset({thread_local_id + indOffset, 0});
+
+                    compType currVal1 = type_convert<compType>{}(p_block_buffer[offset1]);
+                    compType currVal2 = type_convert<compType>{}(p_block_buffer[offset2]);
+                    int currIndex1    = block_indices_buffer[offset1];
+                    int currIndex2    = block_indices_buffer[offset2];
+
+                    binop::calculate(currVal1, currVal2, currIndex1, currIndex2);
+                    p_block_buffer[offset1]       = type_convert<DataType>{}(currVal1);
+                    block_indices_buffer[offset1] = currIndex1;
+                }
+
+                __syncthreads();
+            }
+
+            if(thread_local_id == 0)
+            {
+                compType tmpVal = type_convert<compType>{}(p_block_buffer[0]);
+                int tmpIndex    = block_indices_buffer[0];
+
+                binop::calculate(accuData, tmpVal, accuIndex, tmpIndex);
+            }
+        });
+    };
+
+    __device__ static void set_buffer_value(DataType* p_block_buffer, DataType value)
+    {
+        int thread_id = get_thread_local_1d_id();
+
+        for(int otherDimInd = 0; otherDimInd < NumBlocks; otherDimInd++)
+        {
+            int offset = blockIsOneRow ? buffer2dDesc::CalculateOffset({otherDimInd, thread_id})
+                                       : buffer2dDesc::CalculateOffset({thread_id, otherDimInd});
+
+            p_block_buffer[offset] = value;
+
+            __syncthreads();
+        }
+    };
+
+    __device__ static void init_buffer_indices(int* block_indices_buffer, int indexStart)
+    {
+        int thread_id = get_thread_local_1d_id();
+
+        for(int otherDimInd = 0; otherDimInd < NumBlocks; otherDimInd++)
+        {
+            int offset = blockIsOneRow ? buffer2dDesc::CalculateOffset({otherDimInd, thread_id})
+                                       : buffer2dDesc::CalculateOffset({thread_id, otherDimInd});
+
+            block_indices_buffer[offset] = offset + indexStart;
+
+            __syncthreads();
+        }
+    };
+};
+
+}; // end of namespace ck
+
+#endif

--- a/src/kernels/composable_kernel/include/kernel_algorithm/reduction_kernel_simple_configurator.hpp
+++ b/src/kernels/composable_kernel/include/kernel_algorithm/reduction_kernel_simple_configurator.hpp
@@ -1,0 +1,42 @@
+#ifndef REDUCTION_KERNEL_SIMPLE_CONFIGURATOR_HPP_
+#define REDUCTION_KERNEL_SIMPLE_CONFIGURATOR_HPP_ 1
+
+#include "number.hpp"
+#include "reduction_common.hpp"
+
+namespace ck {
+
+// The simple configurator does not consider the "Reduce_MultiBlock" method, since it is usually
+// called to do the second reduction after the first calling of a "Reduce_MultiBlock" reduction.
+template <int BlockSize, int warpSize>
+struct reduce_kernel_simple_configurator
+{
+    static constexpr int numWarpsPerBlock = BlockSize / warpSize;
+
+    template <index_t invariantLength, index_t toReduceLength>
+    __device__ static constexpr int getGridSize(Number<invariantLength>, Number<toReduceLength>)
+    {
+        if(toReduceLength < warpSize / 4) // let one thread to do each reduction
+            return ((invariantLength + BlockSize - 1) / BlockSize);
+        else if(toReduceLength < BlockSize) // let one warp to do each reduction
+            return ((invariantLength + numWarpsPerBlock - 1) / numWarpsPerBlock);
+        else
+            return (invariantLength); // let one block to do each reduction
+    };
+
+    template <index_t invariantLength, index_t toReduceLength>
+    __device__ static constexpr ckReductionMethod_t getReductionMethod(Number<invariantLength>,
+                                                                       Number<toReduceLength>)
+    {
+        if(toReduceLength < warpSize / 4) // let one thread to do each reduction
+            return (CK_Reduce_DirectThreadWise);
+        else if(toReduceLength < BlockSize) // let one warp to do each reduction
+            return (CK_Reduce_DirectWarpWise);
+        else
+            return (CK_Reduce_BlockWise);
+    };
+};
+
+}; // namespace ck
+
+#endif

--- a/src/kernels/composable_kernel/include/tensor_description/tensor_descriptor.hpp
+++ b/src/kernels/composable_kernel/include/tensor_description/tensor_descriptor.hpp
@@ -475,7 +475,7 @@ struct TransformedTensorDescriptor
 #endif
 
     // a multi-index is valid if there is a corresponding point for it in the tensor
-    __host__ __device__ constexpr bool IsUpperIndexValid(const UpperIndex& idx_up) const
+    __host__ __device__ static constexpr bool IsUpperIndexValid(const UpperIndex& idx_up)
     {
         bool flag = true;
 

--- a/src/kernels/composable_kernel/include/tensor_operation/blockwise_gemm_xdlops.hpp
+++ b/src/kernels/composable_kernel/include/tensor_operation/blockwise_gemm_xdlops.hpp
@@ -16,8 +16,9 @@ template <index_t BlockSize,
           index_t GemmNPerWave,
           index_t GemmMWaves,
           index_t GemmNWaves,
-          index_t GemmDataPerReadA,
-          index_t GemmDataPerReadB>
+          index_t GemmDataPerReadA, // \todo unused parameter, remove
+          index_t GemmDataPerReadB  // \todo unused parameter, remove
+          >
 struct BlockwiseGemmBlockABlockBThreadCTransANormalBNormalC_xdlops
 {
     struct MatrixIndex
@@ -26,8 +27,14 @@ struct BlockwiseGemmBlockABlockBThreadCTransANormalBNormalC_xdlops
         index_t col;
     };
 
+    static constexpr index_t MRepeats = (GemmMPerWave > 64) ? (GemmMPerWave / 64) : 1;
+    static constexpr index_t NRepeats = (GemmNPerWave > 64) ? (GemmNPerWave / 64) : 1;
+
+    static constexpr index_t MPerXdlops = (GemmMPerWave > 64) ? 64 : GemmMPerWave;
+    static constexpr index_t NPerXdlops = (GemmNPerWave > 64) ? 64 : GemmNPerWave;
+
     static constexpr auto XdlopsGemm =
-        XdlopsGemm_t<Float, GemmMPerWave, GemmNPerWave, GemmDataPerReadA, GemmDataPerReadB>{};
+        XdlopsGemm_t<Float, MPerXdlops, NPerXdlops, GemmDataPerReadA, GemmDataPerReadB>{};
 
     index_t mMyWaveOffsetA;
     index_t mMyWaveOffsetB;
@@ -35,6 +42,20 @@ struct BlockwiseGemmBlockABlockBThreadCTransANormalBNormalC_xdlops
     static constexpr index_t WaveSize = 64;
 
     __device__ constexpr auto GetOutputLayout() const { return XdlopsGemm.GetOutputLayout(); }
+
+    __device__ constexpr auto GetMRepeats() const { return MRepeats; }
+
+    __device__ constexpr auto GetNRepeats() const { return NRepeats; }
+
+    __device__ constexpr auto GetNumBlks() const
+    {
+        return XdlopsGemm.GetOutputLayout().GetNumBlks() * MRepeats * NRepeats;
+    }
+
+    __device__ constexpr auto GetBlkSize() const
+    {
+        return XdlopsGemm.GetOutputLayout().GetBlkSize();
+    }
 
     __device__ BlockwiseGemmBlockABlockBThreadCTransANormalBNormalC_xdlops()
     {
@@ -68,8 +89,17 @@ struct BlockwiseGemmBlockABlockBThreadCTransANormalBNormalC_xdlops
         constexpr index_t N = BlockMatrixB::NCol();
         constexpr index_t K = BlockMatrixA::NRow();
 
-        XdlopsGemm.template Run<M, N, K>(
-            &p_a_block[mMyWaveOffsetA], &p_b_block[mMyWaveOffsetB], p_c_thread);
+        constexpr auto reg_size_xdlops = MPerXdlops * NPerXdlops / WaveSize;
+
+        for(index_t m = 0; m < MRepeats; m++)
+        {
+            for(index_t n = 0; n < NRepeats; n++)
+            {
+                XdlopsGemm.template Run<M, N, K>(&p_a_block[mMyWaveOffsetA + MPerXdlops * m],
+                                                 &p_b_block[mMyWaveOffsetB + NPerXdlops * n],
+                                                 p_c_thread + (NRepeats * m + n) * reg_size_xdlops);
+            }
+        }
     }
 
     __device__ static MatrixIndex GetBeginOfThreadMatrixC(index_t i)
@@ -77,32 +107,40 @@ struct BlockwiseGemmBlockABlockBThreadCTransANormalBNormalC_xdlops
 
         const index_t waveId = get_thread_local_1d_id() / WaveSize;
 
-        const auto thread_mtx_on_blk = XdlopsGemm.GetBeginOfThreadBlk(i);
+        const index_t xdlops_i = i / XdlopsGemm.GetOutputLayout().GetNumBlks();
+        const index_t j        = i % XdlopsGemm.GetOutputLayout().GetNumBlks();
 
-        const index_t col = waveId % GemmNWaves * GemmNPerWave + thread_mtx_on_blk.col;
+        const index_t m = xdlops_i / NRepeats;
+        const index_t n = xdlops_i % NRepeats;
 
-        const index_t row = waveId / GemmNWaves * GemmMPerWave + thread_mtx_on_blk.row;
+        const auto thread_mtx_on_blk = XdlopsGemm.GetBeginOfThreadBlk(j);
+
+        const index_t col =
+            (waveId % GemmNWaves) * GemmNPerWave + n * NPerXdlops + thread_mtx_on_blk.col;
+
+        const index_t row =
+            (waveId / GemmNWaves) * GemmMPerWave + m * MPerXdlops + thread_mtx_on_blk.row;
 
         return MatrixIndex{row, col};
     }
 
     __device__ constexpr auto GetThreadMatrixCDescriptor() const
     {
-        const index_t reg_size = GemmMPerWave * GemmNPerWave / WaveSize;
-        return make_ConstantMatrixDescriptor_packed(Number<reg_size>{}, Number<1>{});
+        const index_t total_reg_size = GemmMPerWave * GemmNPerWave / WaveSize;
+        return make_ConstantMatrixDescriptor_packed(Number<total_reg_size>{}, Number<1>{});
     }
 
     __device__ void XdlopsMatrixCSetZero() const
     {
-        constexpr auto thread_mtx_size = GemmMPerWave * GemmNPerWave / WaveSize;
-        XdlopsGemm.SetZeroXdlopsRegs(Number<thread_mtx_size>{});
+        constexpr auto reg_size_xdlops = MPerXdlops * NPerXdlops / WaveSize;
+        XdlopsGemm.SetZeroXdlopsRegs(Number<reg_size_xdlops>{});
     }
 
     template <class FloatC>
     __device__ void XdlopsMatrixCRead(FloatC* __restrict__ p_c_thread) const
     {
-        constexpr auto thread_mtx_size = GemmMPerWave * GemmNPerWave / WaveSize;
-        XdlopsGemm.ReadXdlopsRegs(Number<thread_mtx_size>{}, p_c_thread);
+        constexpr auto reg_size_xdlops = MPerXdlops * NPerXdlops / WaveSize;
+        XdlopsGemm.ReadXdlopsRegs(Number<reg_size_xdlops>{}, p_c_thread);
     }
 };
 

--- a/src/kernels/composable_kernel/include/tensor_operation/blockwise_generic_tensor_slice_copy.hpp
+++ b/src/kernels/composable_kernel/include/tensor_operation/blockwise_generic_tensor_slice_copy.hpp
@@ -15,6 +15,8 @@ namespace ck {
 // The dimension access order can be different for src and dst.
 // Will do valid mapping check on src data: Read 0 if src data has a invalid mapping
 // Will do valid mapping check on dst data: No write if dst data has a invalid mapping
+// BlockSize can be equal or larger than ThreadCluster size, which means some threads may not do
+// threadwise copy
 template <index_t BlockSize,
           typename BlockSrcDesc,
           typename BlockDstDesc,
@@ -54,23 +56,23 @@ struct BlockwiseGenericTensorSliceCopy_v4
             is_same<BlockSliceLengths, decltype(ThreadSliceLengths{} * ThreadClusterLengths{})>{},
             "wrong! threads should be mapped to cover entire slicing window");
 
-        // map threads to cluster
-        constexpr auto thread_cluster_desc =
-            make_cluster_descriptor(ThreadClusterLengths{}, ThreadClusterArrangeOrder{});
+        static_assert(BlockSize >= mThreadClusterDesc.GetElementSize(),
+                      "wrong! BlockSize too small");
 
-        static_assert(BlockSize == thread_cluster_desc.GetElementSize(),
-                      "wrong! BlockSize not consistent with ThreadClusterLengths");
+        if(BlockSize == mThreadClusterDesc.GetElementSize() or
+           get_thread_local_1d_id() < mThreadClusterDesc.GetElementSize())
+        {
+            const auto thread_cluster_id =
+                mThreadClusterDesc.CalculateClusterIndex(get_thread_local_1d_id());
 
-        const auto thread_cluster_id =
-            thread_cluster_desc.CalculateClusterIndex(get_thread_local_1d_id());
+            const auto thread_data_id_begin = thread_cluster_id * ThreadSliceLengths{};
 
-        const auto thread_data_id_begin = thread_cluster_id * ThreadSliceLengths{};
+            mThreadwiseLoad.SetSrcSliceOrigin(src_block_slice_origin + thread_data_id_begin);
+            mThreadwiseLoad.SetDstSliceOrigin(make_zero_array<index_t, nDim>());
 
-        mThreadwiseLoad.SetSrcSliceOrigin(src_block_slice_origin + thread_data_id_begin);
-        mThreadwiseLoad.SetDstSliceOrigin(make_zero_array<index_t, nDim>());
-
-        mThreadwiseStore.SetSrcSliceOrigin(make_zero_array<index_t, nDim>());
-        mThreadwiseStore.SetDstSliceOrigin(dst_block_slice_origin + thread_data_id_begin);
+            mThreadwiseStore.SetSrcSliceOrigin(make_zero_array<index_t, nDim>());
+            mThreadwiseStore.SetDstSliceOrigin(dst_block_slice_origin + thread_data_id_begin);
+        }
     }
 
     __device__ static constexpr index_t GetThreadBufferSize()
@@ -86,15 +88,19 @@ struct BlockwiseGenericTensorSliceCopy_v4
         constexpr bool has_optimized_address_calculation =
             decltype(mThreadwiseStore)::HasWorkingOptimizedAddressCalculation();
 
-        // TODO: threadwise copy is still being tweaked
-        if(has_optimized_address_calculation)
+        if(BlockSize == mThreadClusterDesc.GetElementSize() or
+           get_thread_local_1d_id() < mThreadClusterDesc.GetElementSize())
         {
-            mThreadwiseLoad.Run_optimized_src_address_calculation(
-                p_block_src, p_thread_buffer, zeroVal);
-        }
-        else
-        {
-            mThreadwiseLoad.Run(p_block_src, p_thread_buffer, zeroVal);
+            // TODO: threadwise copy is still being tweaked
+            if(has_optimized_address_calculation)
+            {
+                mThreadwiseLoad.Run_optimized_src_address_calculation(
+                    p_block_src, p_thread_buffer, zeroVal);
+            }
+            else
+            {
+                mThreadwiseLoad.Run(p_block_src, p_thread_buffer, zeroVal);
+            }
         }
     }
 
@@ -107,15 +113,19 @@ struct BlockwiseGenericTensorSliceCopy_v4
         constexpr bool has_optimized_address_calculation =
             decltype(mThreadwiseStore)::HasWorkingOptimizedAddressCalculation();
 
-        // TODO: threadwise copy is still being tweaked
-        if(has_optimized_address_calculation)
+        if(BlockSize == mThreadClusterDesc.GetElementSize() or
+           get_thread_local_1d_id() < mThreadClusterDesc.GetElementSize())
         {
-            mThreadwiseStore.Run_optimized_dst_address_calculation(
-                p_thread_buffer, p_block_dst, zeroVal);
-        }
-        else
-        {
-            mThreadwiseStore.Run(p_thread_buffer, p_block_dst, zeroVal);
+            // TODO: threadwise copy is still being tweaked
+            if(has_optimized_address_calculation)
+            {
+                mThreadwiseStore.Run_optimized_dst_address_calculation(
+                    p_thread_buffer, p_block_dst, zeroVal);
+            }
+            else
+            {
+                mThreadwiseStore.Run(p_thread_buffer, p_block_dst, zeroVal);
+            }
         }
     }
 
@@ -132,10 +142,14 @@ struct BlockwiseGenericTensorSliceCopy_v4
 
         BlockSrcData p_thread_buffer[GetThreadBufferSize()];
 
-        RunLoadThreadBuffer(p_block_src, p_thread_buffer, zeroVal);
+        if(BlockSize == mThreadClusterDesc.GetElementSize() or
+           get_thread_local_1d_id() < mThreadClusterDesc.GetElementSize())
+        {
+            RunLoadThreadBuffer(p_block_src, p_thread_buffer, zeroVal);
 
-        // if there is type conversion, it's done during store
-        RunStoreThreadBuffer(p_thread_buffer, p_block_dst, zeroVal);
+            // if there is type conversion, it's done during store
+            RunStoreThreadBuffer(p_thread_buffer, p_block_dst, zeroVal);
+        }
     }
 
     template <typename T, bool PositiveDirection>
@@ -143,7 +157,11 @@ struct BlockwiseGenericTensorSliceCopy_v4
     MoveSrcSliceWindow(const T& step_sizes,
                        integral_constant<bool, PositiveDirection> positive_direction)
     {
-        mThreadwiseLoad.MoveSrcSliceWindow(step_sizes, positive_direction);
+        if(BlockSize == mThreadClusterDesc.GetElementSize() or
+           get_thread_local_1d_id() < mThreadClusterDesc.GetElementSize())
+        {
+            mThreadwiseLoad.MoveSrcSliceWindow(step_sizes, positive_direction);
+        }
     }
 
     template <typename T, bool PositiveDirection>
@@ -151,7 +169,11 @@ struct BlockwiseGenericTensorSliceCopy_v4
     MoveDstSliceWindow(const T& step_sizes,
                        integral_constant<bool, PositiveDirection> positive_direction)
     {
-        mThreadwiseStore.MoveDstSliceWindow(step_sizes, positive_direction);
+        if(BlockSize == mThreadClusterDesc.GetElementSize() or
+           get_thread_local_1d_id() < mThreadClusterDesc.GetElementSize())
+        {
+            mThreadwiseStore.MoveDstSliceWindow(step_sizes, positive_direction);
+        }
     }
 
     private:
@@ -182,6 +204,9 @@ struct BlockwiseGenericTensorSliceCopy_v4
                                                                   DstInMemOp,
                                                                   1,
                                                                   DstDataStride>;
+
+    static constexpr auto mThreadClusterDesc =
+        make_cluster_descriptor(ThreadClusterLengths{}, ThreadClusterArrangeOrder{});
 
     ThreadwiseLoad mThreadwiseLoad;
     ThreadwiseStore mThreadwiseStore;

--- a/src/kernels/composable_kernel/include/tensor_operation/gridwise_gemm_xdlops.hpp
+++ b/src/kernels/composable_kernel/include/tensor_operation/gridwise_gemm_xdlops.hpp
@@ -295,8 +295,8 @@ struct GridwiseGemmTransposedANormalBNormalCXdlops_v1
 
             using CThreadCopySliceLengths = Sequence<M0, 1, M2, 1>;
 
-            constexpr index_t BlkSize = CLayout.GetBlkSize();
-            constexpr index_t NumBlks = CLayout.GetNumBlks();
+            constexpr index_t BlkSize = blockwise_gemm.GetBlkSize();
+            constexpr index_t NumBlks = blockwise_gemm.GetNumBlks();
 
             for(index_t i = 0; i < NumBlks; ++i)
             {

--- a/src/kernels/composable_kernel/include/tensor_operation/gridwise_gemm_xdlops_fp16_bfp16.hpp
+++ b/src/kernels/composable_kernel/include/tensor_operation/gridwise_gemm_xdlops_fp16_bfp16.hpp
@@ -11,6 +11,12 @@
 
 namespace ck {
 
+enum WorkgroupScheduleOrder
+{
+    MBlock1NBlock0,
+    NBlock1MBlock0
+};
+
 template <index_t Gi,
           index_t MBlockWork,
           index_t NBlockWork,
@@ -144,7 +150,7 @@ struct GridwiseGemmTransposedANormalBNormalCXdlopsFp16Bfp16_v1
             2,                          // Dst dim to be written in vector form (KPACK dimension)
             ABlockCopySrcDataPerRead,
             ABlockCopyDstDataPerWrite_KPACK,
-            AddressSpace::Generic,
+            AddressSpace::Global,
             AddressSpace::Vgpr,
             AddressSpace::Lds,
             InMemoryDataOperation::Set,
@@ -168,7 +174,7 @@ struct GridwiseGemmTransposedANormalBNormalCXdlopsFp16Bfp16_v1
             2,                          // Dst dim to be written in vector form (KPACK dimension)
             BBlockCopySrcDataPerRead,
             BBlockCopyDstDataPerWrite_KPACK,
-            AddressSpace::Generic,
+            AddressSpace::Global,
             AddressSpace::Vgpr,
             AddressSpace::Lds,
             InMemoryDataOperation::Set,
@@ -497,7 +503,7 @@ struct GridwiseBatchedGemmTransposedANormalBNormalCXdlopsFp16Bfp16_v1
             3,                          // Dst dim to be written in vector form (KPACK dimension)
             ABlockCopySrcDataPerRead,
             ABlockCopyDstDataPerWrite_KPACK,
-            AddressSpace::Generic,
+            AddressSpace::Global,
             AddressSpace::Vgpr,
             AddressSpace::Lds,
             InMemoryDataOperation::Set,
@@ -521,7 +527,7 @@ struct GridwiseBatchedGemmTransposedANormalBNormalCXdlopsFp16Bfp16_v1
             3,                          // Dst dim to be written in vector form (KPACK dimension)
             BBlockCopySrcDataPerRead,   // N dimension
             BBlockCopyDstDataPerWrite_KPACK,
-            AddressSpace::Generic,
+            AddressSpace::Global,
             AddressSpace::Vgpr,
             AddressSpace::Lds,
             InMemoryDataOperation::Set,
@@ -730,22 +736,308 @@ struct GridwiseBatchedGemmTransposedANormalBNormalCXdlopsFp16Bfp16_v1
                 const index_t n_thread_data_on_global =
                     n_block_data_on_global + c_thread_mtx_on_block.col;
 
-                ThreadwiseGenericTensorSliceCopy_v4r2<
-                    decltype(c_g_m0_m1_m2_n_thread_desc),
-                    decltype(c_g_m0_m1_m2_n_global_desc),
-                    CThreadCopySliceLengths,
-                    arithmetic_sequence_gen<0, 5, 1>::type,
-                    4,
-                    1,
-                    1,
-                    AddressSpace::Vgpr,
-                    is_same<AccFloat, CFloat>::value ? AddressSpace::Global : AddressSpace::Generic,
-                    OutputMemOp>({0, 0, 0, 0, 0},
-                                 {group_id,
-                                  m_thread_data_on_global / (M2 * M1),
-                                  m_thread_data_on_global % (M2 * M1) / M2,
-                                  m_thread_data_on_global % M2,
-                                  n_thread_data_on_global})
+                ThreadwiseGenericTensorSliceCopy_v4r2<decltype(c_g_m0_m1_m2_n_thread_desc),
+                                                      decltype(c_g_m0_m1_m2_n_global_desc),
+                                                      CThreadCopySliceLengths,
+                                                      arithmetic_sequence_gen<0, 5, 1>::type,
+                                                      4,
+                                                      1,
+                                                      1,
+                                                      AddressSpace::Vgpr,
+                                                      AddressSpace::Global,
+                                                      OutputMemOp>(
+                    {0, 0, 0, 0, 0},
+                    {group_id,
+                     m_thread_data_on_global / (M2 * M1),
+                     m_thread_data_on_global % (M2 * M1) / M2,
+                     m_thread_data_on_global % M2,
+                     n_thread_data_on_global})
+                    .Run(p_c_thread + i * BlkSize, p_c_global);
+            }
+        }
+    }
+};
+
+template <index_t GridSize,
+          index_t BlockSize,
+          class ABFloat,
+          class AccFloat,
+          class CFloat,
+          class AGlobalDesc,
+          class BGlobalDesc,
+          class CGlobalDesc,
+          index_t MPerBlock,
+          index_t NPerBlock,
+          index_t KPerBlock,
+          index_t MPerWave,
+          index_t NPerWave,
+          class ABlockCopyThreadSliceLengths_G_K_M_KPACK,
+          class ABlockCopyThreadClusterLengths_G_K_M_KPACK,
+          class ABlockCopyThreadClusterArrangeOrder,
+          class ABlockCopySrcAccessOrder,
+          class ABlockCopyDstAccessOrder,
+          index_t ABlockCopySrcVectorReadDim,
+          index_t ABlockCopySrcDataPerRead,
+          index_t ABlockCopyDstDataPerWrite_KPACK,
+          class BBlockCopyThreadSliceLengths_G_K_N_KPACK,
+          class BBlockCopyThreadClusterLengths_G_K_N_KPACK,
+          class BBlockCopyThreadClusterArrangeOrder,
+          class BBlockCopySrcAccessOrder,
+          class BBlockCopyDstAccessOrder,
+          index_t BBlockCopySrcVectorReadDim,
+          index_t BBlockCopySrcDataPerRead,
+          index_t BBlockCopyDstDataPerWrite_KPACK,
+          InMemoryDataOperation CGlobalMemoryOp,
+          WorkgroupScheduleOrder WorkgroupSchdOrder>
+struct GridwiseBatchGemmXdlops_gkmkpack_gknkpack_gmn_v2
+{
+    __device__ void Run(const ABFloat* const __restrict__ p_a_global,
+                        const ABFloat* const __restrict__ p_b_global,
+                        CFloat* const __restrict__ p_c_global) const
+    {
+        constexpr auto True = integral_constant<bool, true>{};
+
+        constexpr auto a_g_k_m_kpack_global_desc = AGlobalDesc{};
+        constexpr auto b_g_k_n_kpack_global_desc = BGlobalDesc{};
+        constexpr auto c_g_m_n_global_desc       = CGlobalDesc{};
+
+        constexpr auto G     = c_g_m_n_global_desc.GetLengths()[0];
+        constexpr auto M     = c_g_m_n_global_desc.GetLengths()[1];
+        constexpr auto N     = c_g_m_n_global_desc.GetLengths()[2];
+        constexpr auto K     = b_g_k_n_kpack_global_desc.GetLengths()[1];
+        constexpr auto KPack = b_g_k_n_kpack_global_desc.GetLengths()[3];
+
+        // divide block work by [M, N]
+        static_assert(M % MPerBlock == 0 && N % NPerBlock == 0 && K % KPerBlock == 0,
+                      "wrong! cannot divide work evenly among block");
+
+        constexpr index_t MBlockWork = M / MPerBlock;
+        constexpr index_t NBlockWork = N / NPerBlock;
+
+        constexpr index_t MWavePerBlock = MPerBlock / MPerWave;
+        constexpr index_t NWavePerBlock = NPerBlock / NPerWave;
+
+        constexpr auto block_work_sequence =
+            make_batch_block_work_sequence<G, MBlockWork, NBlockWork, WorkgroupSchdOrder>{}.get();
+        constexpr auto block_work_desc = make_cluster_descriptor(block_work_sequence);
+
+        const auto block_work_id = block_work_desc.CalculateClusterIndex(get_block_1d_id());
+
+        const index_t g_block_data_on_global = block_work_id[0];
+        const index_t m_block_data_on_global = (WorkgroupSchdOrder == MBlock1NBlock0)
+                                                   ? (block_work_id[1] * MPerBlock)
+                                                   : (block_work_id[2] * MPerBlock);
+        const index_t n_block_data_on_global = (WorkgroupSchdOrder == MBlock1NBlock0)
+                                                   ? (block_work_id[2] * NPerBlock)
+                                                   : (block_work_id[1] * NPerBlock);
+
+        //   LDS mem
+        constexpr index_t max_align = KPack;
+
+        //   LDS
+        //     be careful of LDS alignment
+        constexpr auto a_g_k_m_kpack_block_desc = make_native_tensor_descriptor_aligned(
+            Sequence<1, KPerBlock, MPerBlock, KPack>{}, Number<max_align>{});
+
+        auto a_blockwise_copy = BlockwiseGenericTensorSliceCopy_v4<
+            BlockSize,
+            decltype(a_g_k_m_kpack_global_desc),
+            decltype(a_g_k_m_kpack_block_desc),
+            decltype(a_g_k_m_kpack_block_desc.GetLengths()),
+            ABlockCopyThreadSliceLengths_G_K_M_KPACK,
+            ABlockCopyThreadClusterLengths_G_K_M_KPACK,
+            ABlockCopyThreadClusterArrangeOrder,
+            ABlockCopySrcAccessOrder,
+            ABlockCopyDstAccessOrder,
+            ABlockCopySrcVectorReadDim, // Src dim to be read in vector form
+            3,                          // Dst dim to be written in vector form (KPack dimension)
+            ABlockCopySrcDataPerRead,
+            ABlockCopyDstDataPerWrite_KPACK,
+            AddressSpace::Global,
+            AddressSpace::Vgpr,
+            AddressSpace::Lds,
+            InMemoryDataOperation::Set>({g_block_data_on_global, 0, m_block_data_on_global, 0},
+                                        {0, 0, 0, 0});
+
+        constexpr auto b_g_k_n_kpack_block_desc = make_native_tensor_descriptor_aligned(
+            Sequence<1, KPerBlock, NPerBlock, KPack>{}, Number<max_align>{});
+
+        // input blockwise copy
+        auto b_blockwise_copy = BlockwiseGenericTensorSliceCopy_v4<
+            BlockSize,
+            decltype(b_g_k_n_kpack_global_desc),
+            decltype(b_g_k_n_kpack_block_desc),
+            decltype(b_g_k_n_kpack_block_desc.GetLengths()),
+            BBlockCopyThreadSliceLengths_G_K_N_KPACK,
+            BBlockCopyThreadClusterLengths_G_K_N_KPACK,
+            BBlockCopyThreadClusterArrangeOrder,
+            BBlockCopySrcAccessOrder,
+            BBlockCopyDstAccessOrder,
+            BBlockCopySrcVectorReadDim, // Src dim to be read in vector form
+            3,                          // Dst dim to be written in vector form (KPack dimension)
+            BBlockCopySrcDataPerRead,
+            BBlockCopyDstDataPerWrite_KPACK,
+            AddressSpace::Global,
+            AddressSpace::Vgpr,
+            AddressSpace::Lds,
+            InMemoryDataOperation::Set>({g_block_data_on_global, 0, n_block_data_on_global, 0},
+                                        {0, 0, 0, 0});
+
+        // GEMM definition
+        // c_mtx += transpose(a_mtx) * b_mtx
+        //     a_mtx[KPerBlock, MPerBlock] is in LDS
+        //     b_mtx[KPerBlocl, NPerBlock] is in LDS
+        //     c_mtx[MPerBlock, NPerBlock] is distributed among threads, and saved in
+        //     register
+        constexpr auto a_k_m_block_mtx_desc =
+            make_ConstantMatrixDescriptor_packed(Number<KPerBlock>{}, Number<MPerBlock>{});
+        constexpr auto b_k_n_block_mtx_desc =
+            make_ConstantMatrixDescriptor_packed(Number<KPerBlock>{}, Number<NPerBlock>{});
+
+        const auto blockwise_gemm = BlockwiseGemmBlockABlockBThreadCTransANormalBNormalC_xdlops<
+            BlockSize,
+            decltype(a_k_m_block_mtx_desc),
+            decltype(b_k_n_block_mtx_desc),
+            ABFloat,
+            MPerWave,
+            NPerWave,
+            MWavePerBlock,
+            NWavePerBlock,
+            1,
+            1>{};
+
+        constexpr auto c_k_thread_mtx_desc = blockwise_gemm.GetThreadMatrixCDescriptor();
+
+        constexpr index_t a_block_space =
+            math::integer_least_multiple(a_g_k_m_kpack_block_desc.GetElementSpace(), max_align);
+
+        constexpr index_t b_block_space =
+            math::integer_least_multiple(b_g_k_n_kpack_block_desc.GetElementSpace(), max_align);
+
+        __shared__ ABFloat p_a_block[a_block_space];
+        __shared__ ABFloat p_b_block[b_block_space];
+
+        // register allocation for output
+        AccFloat p_c_thread[c_k_thread_mtx_desc.GetElementSpace()];
+
+        // zero out threadwise output
+        threadwise_matrix_set_zero(c_k_thread_mtx_desc, p_c_thread);
+        blockwise_gemm.XdlopsMatrixCSetZero();
+
+        // preload data into LDS
+        {
+            a_blockwise_copy.Run(p_a_global, p_a_block);
+            b_blockwise_copy.Run(p_b_global, p_b_block);
+        }
+
+        constexpr auto blockwise_a_copy_src_step = Sequence<0, KPerBlock, 0, 0>{};
+        constexpr auto blockwise_b_copy_src_step = Sequence<0, KPerBlock, 0, 0>{};
+
+        // main body
+        for(index_t k_block_data_begin = 0; k_block_data_begin < K - KPerBlock;
+            k_block_data_begin += KPerBlock)
+        {
+            ABFloat p_a_thread_buffer[a_blockwise_copy.GetThreadBufferSize()];
+            ABFloat p_b_thread_buffer[b_blockwise_copy.GetThreadBufferSize()];
+
+            // load next data from device mem
+            a_blockwise_copy.MoveSrcSliceWindow(blockwise_a_copy_src_step, True);
+            b_blockwise_copy.MoveSrcSliceWindow(blockwise_b_copy_src_step, True);
+
+            a_blockwise_copy.RunLoadThreadBuffer(p_a_global, p_a_thread_buffer);
+            b_blockwise_copy.RunLoadThreadBuffer(p_b_global, p_b_thread_buffer);
+
+            block_sync_lds();
+
+            // GEMM on current data
+            const typename vector_type<ABFloat, KPack>::MemoryType* p_a_block_vec =
+                reinterpret_cast<const typename vector_type<ABFloat, KPack>::MemoryType*>(
+                    p_a_block);
+            const typename vector_type<ABFloat, KPack>::MemoryType* p_b_block_vec =
+                reinterpret_cast<const typename vector_type<ABFloat, KPack>::MemoryType*>(
+                    p_b_block);
+            blockwise_gemm.Run(p_a_block_vec, p_b_block_vec, p_c_thread);
+
+            block_sync_lds();
+
+            // store next data to LDS
+            a_blockwise_copy.RunStoreThreadBuffer(p_a_thread_buffer, p_a_block);
+            b_blockwise_copy.RunStoreThreadBuffer(p_b_thread_buffer, p_b_block);
+        }
+
+        // tail
+        {
+            block_sync_lds();
+
+            // GEMM on last data
+            const typename vector_type<ABFloat, KPack>::MemoryType* p_a_block_vec =
+                reinterpret_cast<const typename vector_type<ABFloat, KPack>::MemoryType*>(
+                    p_a_block);
+            const typename vector_type<ABFloat, KPack>::MemoryType* p_b_block_vec =
+                reinterpret_cast<const typename vector_type<ABFloat, KPack>::MemoryType*>(
+                    p_b_block);
+            blockwise_gemm.Run(p_a_block_vec, p_b_block_vec, p_c_thread);
+        }
+
+        // load data from xldop_acc_regs
+        blockwise_gemm.XdlopsMatrixCRead(p_c_thread);
+
+        // copy output: register to global memory
+        {
+            ///\todo inconsistent layout of xdlops and tensor
+            // xdlops layout
+            // M1 = num_groups;
+            // M0 = group_size;
+            // N1 = num_blks_per_wave;
+            // N0 = num_threads_per_blks;
+            constexpr auto CLayout = blockwise_gemm.GetOutputLayout();
+            constexpr index_t M0   = CLayout.M1();
+            constexpr index_t M1   = CLayout.N1();
+            constexpr index_t M2   = CLayout.M0();
+
+            constexpr auto c_g_m0_m1_m2_n_global_desc = transform_tensor_descriptor(
+                c_g_m_n_global_desc,
+                make_tuple(PassThrough<G>{}, UnMerge<Sequence<M0, M1, M2>>{}, PassThrough<N>{}),
+                make_tuple(Sequence<0>{}, Sequence<1>{}, Sequence<2>{}),
+                make_tuple(Sequence<0>{}, Sequence<1, 2, 3>{}, Sequence<4>{}));
+
+            //     src descriptor
+            constexpr auto c_g_m0_m1_m2_n_thread_desc =
+                make_native_tensor_descriptor_packed(Sequence<1, M0, 1, M2, 1>{});
+
+            using CThreadCopySliceLengths = Sequence<1, M0, 1, M2, 1>;
+
+            constexpr index_t BlkSize = blockwise_gemm.GetBlkSize();
+            constexpr index_t NumBlks = blockwise_gemm.GetNumBlks();
+
+            for(index_t i = 0; i < NumBlks; ++i)
+            {
+                // calculate origin of thread output tensor on global memory
+                //     blockwise GEMM c matrix starting index
+                const auto c_thread_mtx_on_block = blockwise_gemm.GetBeginOfThreadMatrixC(i);
+
+                const index_t m_thread_data_on_global =
+                    m_block_data_on_global + c_thread_mtx_on_block.row;
+
+                const index_t n_thread_data_on_global =
+                    n_block_data_on_global + c_thread_mtx_on_block.col;
+
+                ThreadwiseGenericTensorSliceCopy_v4r2<decltype(c_g_m0_m1_m2_n_thread_desc),
+                                                      decltype(c_g_m0_m1_m2_n_global_desc),
+                                                      CThreadCopySliceLengths,
+                                                      arithmetic_sequence_gen<0, 5, 1>::type,
+                                                      4,
+                                                      1,
+                                                      1,
+                                                      AddressSpace::Vgpr,
+                                                      AddressSpace::Global,
+                                                      CGlobalMemoryOp>(
+                    {0, 0, 0, 0, 0},
+                    {g_block_data_on_global,
+                     m_thread_data_on_global / (M2 * M1),
+                     m_thread_data_on_global % (M2 * M1) / M2,
+                     m_thread_data_on_global % M2,
+                     n_thread_data_on_global})
                     .Run(p_c_thread + i * BlkSize, p_c_global);
             }
         }

--- a/src/kernels/composable_kernel/include/tensor_operation/threadwise_generic_tensor_slice_copy.hpp
+++ b/src/kernels/composable_kernel/include/tensor_operation/threadwise_generic_tensor_slice_copy.hpp
@@ -70,7 +70,8 @@ struct ThreadwiseGenericTensorSliceCopy_v4r2
     }
 
     template <typename SrcData, typename DstData>
-    __device__ void Run(const SrcData* p_src, DstData* p_dst) const
+    __device__ void
+    Run(const SrcData* p_src, DstData* p_dst, SrcData zeroVal = static_cast<SrcData>(0.0)) const
     {
         constexpr auto vector_access_dim = Number<SrcDstVectorReadWriteDim>{};
 
@@ -96,7 +97,7 @@ struct ThreadwiseGenericTensorSliceCopy_v4r2
             // zero out buffer
             for(index_t i = 0; i < long_vector_size; ++i)
             {
-                p_src_long_vector[i] = 0;
+                p_src_long_vector[i] = zeroVal;
             }
 
             // load data from src to the long-vector buffer
@@ -174,8 +175,8 @@ struct ThreadwiseGenericTensorSliceCopy_v4r2
     // This version is optimized for address calculation of src tensor
     // TODO: this function is not compiled to expected ISA
     template <typename SrcData, typename DstData>
-    __device__ void Run_optimized_src_address_calculation(const SrcData* p_src,
-                                                          DstData* p_dst) const
+    __device__ void Run_optimized_src_address_calculation(
+        const SrcData* p_src, DstData* p_dst, SrcData zeroVal = static_cast<SrcData>(0.0)) const
     {
         constexpr auto vector_access_dim = Number<SrcDstVectorReadWriteDim>{};
 
@@ -231,7 +232,7 @@ struct ThreadwiseGenericTensorSliceCopy_v4r2
                 // zero out buffer
                 for(index_t i = 0; i < long_vector_size; ++i)
                 {
-                    p_src_long_vector[i] = 0;
+                    p_src_long_vector[i] = zeroVal;
                 }
 
                 // Loop over SrcDstVectorReadWriteDim, and load data from src to the
@@ -322,8 +323,8 @@ struct ThreadwiseGenericTensorSliceCopy_v4r2
     // This version is optimized for address calculation of dst tensor
     // TODO: this function is not compiled to expected ISA
     template <typename SrcData, typename DstData>
-    __device__ void Run_optimized_dst_address_calculation(const SrcData* p_src,
-                                                          DstData* p_dst) const
+    __device__ void Run_optimized_dst_address_calculation(
+        const SrcData* p_src, DstData* p_dst, SrcData zeroVal = static_cast<SrcData>(0.0)) const
     {
         constexpr auto vector_access_dim = Number<SrcDstVectorReadWriteDim>{};
 
@@ -379,7 +380,7 @@ struct ThreadwiseGenericTensorSliceCopy_v4r2
                 // zero out buffer
                 for(index_t i = 0; i < long_vector_size; ++i)
                 {
-                    p_src_long_vector[i] = 0;
+                    p_src_long_vector[i] = zeroVal;
                 }
 
                 // Loop over SrcDstVectorReadWriteDim, and load data from src to the

--- a/src/kernels/composable_kernel/include/tensor_operation/xdlops_gemm.hpp
+++ b/src/kernels/composable_kernel/include/tensor_operation/xdlops_gemm.hpp
@@ -5,8 +5,6 @@
 #include "ConstantMatrixDescriptor.hpp"
 #include "math.hpp"
 
-#define WORKAROUND_SWDEV_229564 1
-
 namespace ck {
 
 enum struct mfma_instr
@@ -49,20 +47,22 @@ struct mfma_info<mfma_instr::mfma_f32_32x32x1xf32>
     static constexpr index_t n               = 32;
     static constexpr index_t k               = 1;
     static constexpr index_t cycles          = 64;
+    static constexpr index_t k_base          = 1;
 
-    template <index_t MPerWave, index_t NPerWave>
+    template <index_t MPerXdlops, index_t NPerXdlops>
     __device__ void
-    run(Number<MPerWave>, Number<NPerWave>, const float* a, const float* b, float* reg_c) const
+    run(Number<MPerXdlops>, Number<NPerXdlops>, const float* a, const float* b, float* reg_c) const
     {
-        static_assert((MPerWave == 64 && NPerWave == 64) || (MPerWave == 32 && NPerWave == 64) ||
-                          (MPerWave == 64 && NPerWave == 32),
+        static_assert((MPerXdlops == 64 && NPerXdlops == 64) ||
+                          (MPerXdlops == 32 && NPerXdlops == 64) ||
+                          (MPerXdlops == 64 && NPerXdlops == 32),
                       "unsupported xdlops gemm");
 
         const auto reg_a = *a;
         const auto reg_b = *b;
 
         auto reg_c_ = reinterpret_cast<float32_t*>(reg_c);
-        gcnasm_mfma_f32_32x32x1f32<MPerWave, NPerWave>(reg_a, reg_b, reg_c_);
+        gcnasm_mfma_f32_32x32x1f32<MPerXdlops, NPerXdlops>(reg_a, reg_b, reg_c_);
     }
 };
 
@@ -81,12 +81,13 @@ struct mfma_info<mfma_instr::mfma_f32_32x32x2xf32>
     static constexpr index_t n               = 32;
     static constexpr index_t k               = 2;
     static constexpr index_t cycles          = 64;
+    static constexpr index_t k_base          = 1;
 
-    template <index_t MPerWave, index_t NPerWave>
+    template <index_t MPerXdlops, index_t NPerXdlops>
     __device__ void
-    run(Number<MPerWave>, Number<NPerWave>, const float* a, const float* b, float* reg_c) const
+    run(Number<MPerXdlops>, Number<NPerXdlops>, const float* a, const float* b, float* reg_c) const
     {
-        static_assert((MPerWave == 32 && NPerWave == 32), "unsupported xdlops gemm");
+        static_assert((MPerXdlops == 32 && NPerXdlops == 32), "unsupported xdlops gemm");
 
         const auto reg_a = *a;
         const auto reg_b = *b;
@@ -111,12 +112,13 @@ struct mfma_info<mfma_instr::mfma_f32_16x16x4xf32>
     static constexpr index_t n               = 16;
     static constexpr index_t k               = 4;
     static constexpr index_t cycles          = 32;
+    static constexpr index_t k_base          = 1;
 
-    template <index_t MPerWave, index_t NPerWave>
+    template <index_t MPerXdlops, index_t NPerXdlops>
     __device__ void
-    run(Number<MPerWave>, Number<NPerWave>, const float* a, const float* b, float* reg_c) const
+    run(Number<MPerXdlops>, Number<NPerXdlops>, const float* a, const float* b, float* reg_c) const
     {
-        static_assert((MPerWave == 16 && NPerWave == 16), "unsupported xdlops gemm");
+        static_assert((MPerXdlops == 16 && NPerXdlops == 16), "unsupported xdlops gemm");
 
         const auto reg_a = *a;
         const auto reg_b = *b;
@@ -141,19 +143,21 @@ struct mfma_info<mfma_instr::mfma_f32_16x16x1xf32>
     static constexpr index_t n               = 16;
     static constexpr index_t k               = 1;
     static constexpr index_t cycles          = 32;
+    static constexpr index_t k_base          = 1;
 
-    template <index_t MPerWave, index_t NPerWave>
+    template <index_t MPerXdlops, index_t NPerXdlops>
     __device__ void
-    run(Number<MPerWave>, Number<NPerWave>, const float* a, const float* b, float* reg_c) const
+    run(Number<MPerXdlops>, Number<NPerXdlops>, const float* a, const float* b, float* reg_c) const
     {
-        static_assert((MPerWave == 16 && NPerWave == 64) || (MPerWave == 64 && NPerWave == 16),
+        static_assert((MPerXdlops == 16 && NPerXdlops == 64) ||
+                          (MPerXdlops == 64 && NPerXdlops == 16),
                       "unsupported xdlops gemm");
 
         const auto reg_a = *a;
         const auto reg_b = *b;
         auto reg_c_      = reinterpret_cast<float16_t*>(reg_c);
 
-        gcnasm_mfma_f32_16x16x1f32<MPerWave, NPerWave>(reg_a, reg_b, reg_c_);
+        gcnasm_mfma_f32_16x16x1f32<MPerXdlops, NPerXdlops>(reg_a, reg_b, reg_c_);
     }
 };
 
@@ -173,19 +177,20 @@ struct mfma_info<mfma_instr::mfma_f32_4x4x1xf32>
     static constexpr index_t n               = 64;
     static constexpr index_t k               = 1;
     static constexpr index_t cycles          = 8;
+    static constexpr index_t k_base          = 1;
 
-    template <index_t MPerWave, index_t NPerWave>
+    template <index_t MPerXdlops, index_t NPerXdlops>
     __device__ void
-    run(Number<MPerWave>, Number<NPerWave>, const float* a, const float* b, float* reg_c) const
+    run(Number<MPerXdlops>, Number<NPerXdlops>, const float* a, const float* b, float* reg_c) const
     {
-        static_assert((MPerWave == 4 || MPerWave == 8) && NPerWave == 64,
+        static_assert((MPerXdlops == 4 || MPerXdlops == 8) && NPerXdlops == 64,
                       "unsupported xdlops gemm");
 
         const auto reg_a = *a;
         const auto reg_b = *b;
         auto reg_c_      = reinterpret_cast<float4_t*>(reg_c);
 
-        gcnasm_mfma_f32_4x4x1f32<MPerWave, NPerWave>(reg_a, reg_b, reg_c_);
+        gcnasm_mfma_f32_4x4x1f32<MPerXdlops, NPerXdlops>(reg_a, reg_b, reg_c_);
     }
 };
 
@@ -204,20 +209,25 @@ struct mfma_info<mfma_instr::mfma_f32_32x32x4f16>
     static constexpr index_t n               = 32;
     static constexpr index_t k               = 4;
     static constexpr index_t cycles          = 64;
+    static constexpr index_t k_base          = 4;
 
-    template <index_t MPerWave, index_t NPerWave>
-    __device__ void
-    run(Number<MPerWave>, Number<NPerWave>, const half_t* a, const half_t* b, float* reg_c) const
+    template <index_t MPerXdlops, index_t NPerXdlops>
+    __device__ void run(Number<MPerXdlops>,
+                        Number<NPerXdlops>,
+                        const half_t* a,
+                        const half_t* b,
+                        float* reg_c) const
     {
-        static_assert((MPerWave == 64 && NPerWave == 64) || (MPerWave == 32 && NPerWave == 64) ||
-                          (MPerWave == 64 && NPerWave == 32),
+        static_assert((MPerXdlops == 64 && NPerXdlops == 64) ||
+                          (MPerXdlops == 32 && NPerXdlops == 64) ||
+                          (MPerXdlops == 64 && NPerXdlops == 32),
                       "unsupported xdlops gemm");
 
         const auto reg_a = *(reinterpret_cast<const half4_t*>(a));
         const auto reg_b = *(reinterpret_cast<const half4_t*>(b));
         auto reg_c_      = reinterpret_cast<float32_t*>(reg_c);
 
-        gcnasm_mfma_f32_32x32x4f16<MPerWave, NPerWave>(reg_a, reg_b, reg_c_);
+        gcnasm_mfma_f32_32x32x4f16<MPerXdlops, NPerXdlops>(reg_a, reg_b, reg_c_);
     }
 };
 
@@ -236,12 +246,16 @@ struct mfma_info<mfma_instr::mfma_f32_32x32x8f16>
     static constexpr index_t n               = 32;
     static constexpr index_t k               = 8;
     static constexpr index_t cycles          = 64;
+    static constexpr index_t k_base          = 4;
 
-    template <index_t MPerWave, index_t NPerWave>
-    __device__ void
-    run(Number<MPerWave>, Number<NPerWave>, const half_t* a, const half_t* b, float* reg_c) const
+    template <index_t MPerXdlops, index_t NPerXdlops>
+    __device__ void run(Number<MPerXdlops>,
+                        Number<NPerXdlops>,
+                        const half_t* a,
+                        const half_t* b,
+                        float* reg_c) const
     {
-        static_assert((MPerWave == 32 && NPerWave == 32), "unsupported xdlops gemm");
+        static_assert((MPerXdlops == 32 && NPerXdlops == 32), "unsupported xdlops gemm");
 
         const auto reg_a = *(reinterpret_cast<const half4_t*>(a));
         const auto reg_b = *(reinterpret_cast<const half4_t*>(b));
@@ -266,12 +280,16 @@ struct mfma_info<mfma_instr::mfma_f32_16x16x16f16>
     static constexpr index_t n               = 16;
     static constexpr index_t k               = 16;
     static constexpr index_t cycles          = 32;
+    static constexpr index_t k_base          = 4;
 
-    template <index_t MPerWave, index_t NPerWave>
-    __device__ void
-    run(Number<MPerWave>, Number<NPerWave>, const half_t* a, const half_t* b, float* reg_c) const
+    template <index_t MPerXdlops, index_t NPerXdlops>
+    __device__ void run(Number<MPerXdlops>,
+                        Number<NPerXdlops>,
+                        const half_t* a,
+                        const half_t* b,
+                        float* reg_c) const
     {
-        static_assert((MPerWave == 16 && NPerWave == 16), "unsupported xdlops gemm");
+        static_assert((MPerXdlops == 16 && NPerXdlops == 16), "unsupported xdlops gemm");
 
         const auto reg_a = *(reinterpret_cast<const half4_t*>(a));
         const auto reg_b = *(reinterpret_cast<const half4_t*>(b));
@@ -296,19 +314,24 @@ struct mfma_info<mfma_instr::mfma_f32_16x16x4f16>
     static constexpr index_t n               = 16;
     static constexpr index_t k               = 4;
     static constexpr index_t cycles          = 32;
+    static constexpr index_t k_base          = 4;
 
-    template <index_t MPerWave, index_t NPerWave>
-    __device__ void
-    run(Number<MPerWave>, Number<NPerWave>, const half_t* a, const half_t* b, float* reg_c) const
+    template <index_t MPerXdlops, index_t NPerXdlops>
+    __device__ void run(Number<MPerXdlops>,
+                        Number<NPerXdlops>,
+                        const half_t* a,
+                        const half_t* b,
+                        float* reg_c) const
     {
-        static_assert((MPerWave == 16 && NPerWave == 64) || (MPerWave == 64 && NPerWave == 16),
+        static_assert((MPerXdlops == 16 && NPerXdlops == 64) ||
+                          (MPerXdlops == 64 && NPerXdlops == 16),
                       "unsupported xdlops gemm");
 
         const auto reg_a = *(reinterpret_cast<const half4_t*>(a));
         const auto reg_b = *(reinterpret_cast<const half4_t*>(b));
         auto reg_c_      = reinterpret_cast<float16_t*>(reg_c);
 
-        gcnasm_mfma_f32_16x16x4f16<MPerWave, NPerWave>(reg_a, reg_b, reg_c_);
+        gcnasm_mfma_f32_16x16x4f16<MPerXdlops, NPerXdlops>(reg_a, reg_b, reg_c_);
     }
 };
 
@@ -327,19 +350,23 @@ struct mfma_info<mfma_instr::mfma_f32_4x4x4f16>
     static constexpr index_t n               = 64;
     static constexpr index_t k               = 4;
     static constexpr index_t cycles          = 8;
+    static constexpr index_t k_base          = 4;
 
-    template <index_t MPerWave, index_t NPerWave>
-    __device__ void
-    run(Number<MPerWave>, Number<NPerWave>, const half_t* a, const half_t* b, float* reg_c) const
+    template <index_t MPerXdlops, index_t NPerXdlops>
+    __device__ void run(Number<MPerXdlops>,
+                        Number<NPerXdlops>,
+                        const half_t* a,
+                        const half_t* b,
+                        float* reg_c) const
     {
-        static_assert((MPerWave == 4 || MPerWave == 8) && NPerWave == 64,
+        static_assert((MPerXdlops == 4 || MPerXdlops == 8) && NPerXdlops == 64,
                       "unsupported xdlops gemm");
 
         const auto reg_a = *(reinterpret_cast<const half4_t*>(a));
         const auto reg_b = *(reinterpret_cast<const half4_t*>(b));
         auto reg_c_      = reinterpret_cast<float4_t*>(reg_c);
 
-        gcnasm_mfma_f32_4x4x4f16<MPerWave, NPerWave>(reg_a, reg_b, reg_c_);
+        gcnasm_mfma_f32_4x4x4f16<MPerXdlops, NPerXdlops>(reg_a, reg_b, reg_c_);
     }
 };
 
@@ -358,20 +385,25 @@ struct mfma_info<mfma_instr::mfma_f32_32x32x2bf16>
     static constexpr index_t n               = 32;
     static constexpr index_t k               = 2;
     static constexpr index_t cycles          = 64;
+    static constexpr index_t k_base          = 2;
 
-    template <index_t MPerWave, index_t NPerWave>
-    __device__ void
-    run(Number<MPerWave>, Number<NPerWave>, const ushort* a, const ushort* b, float* reg_c) const
+    template <index_t MPerXdlops, index_t NPerXdlops>
+    __device__ void run(Number<MPerXdlops>,
+                        Number<NPerXdlops>,
+                        const ushort* a,
+                        const ushort* b,
+                        float* reg_c) const
     {
-        static_assert((MPerWave == 64 && NPerWave == 64) || (MPerWave == 32 && NPerWave == 64) ||
-                          (MPerWave == 64 && NPerWave == 32),
+        static_assert((MPerXdlops == 64 && NPerXdlops == 64) ||
+                          (MPerXdlops == 32 && NPerXdlops == 64) ||
+                          (MPerXdlops == 64 && NPerXdlops == 32),
                       "unsupported xdlops gemm");
 
         const auto reg_a = *(reinterpret_cast<const ushort2_t*>(a));
         const auto reg_b = *(reinterpret_cast<const ushort2_t*>(b));
         auto reg_c_      = reinterpret_cast<float32_t*>(reg_c);
 
-        gcnasm_mfma_f32_32x32x2bf16<MPerWave, NPerWave>(reg_a, reg_b, reg_c_);
+        gcnasm_mfma_f32_32x32x2bf16<MPerXdlops, NPerXdlops>(reg_a, reg_b, reg_c_);
     }
 };
 
@@ -390,12 +422,16 @@ struct mfma_info<mfma_instr::mfma_f32_32x32x4bf16>
     static constexpr index_t n               = 32;
     static constexpr index_t k               = 4;
     static constexpr index_t cycles          = 64;
+    static constexpr index_t k_base          = 2;
 
-    template <index_t MPerWave, index_t NPerWave>
-    __device__ void
-    run(Number<MPerWave>, Number<NPerWave>, const ushort* a, const ushort* b, float* reg_c) const
+    template <index_t MPerXdlops, index_t NPerXdlops>
+    __device__ void run(Number<MPerXdlops>,
+                        Number<NPerXdlops>,
+                        const ushort* a,
+                        const ushort* b,
+                        float* reg_c) const
     {
-        static_assert((MPerWave == 32 && NPerWave == 32), "unsupported xdlops gemm");
+        static_assert((MPerXdlops == 32 && NPerXdlops == 32), "unsupported xdlops gemm");
 
         const auto reg_a = *(reinterpret_cast<const ushort2_t*>(a));
         const auto reg_b = *(reinterpret_cast<const ushort2_t*>(b));
@@ -420,12 +456,16 @@ struct mfma_info<mfma_instr::mfma_f32_16x16x8bf16>
     static constexpr index_t n               = 16;
     static constexpr index_t k               = 8;
     static constexpr index_t cycles          = 32;
+    static constexpr index_t k_base          = 2;
 
-    template <index_t MPerWave, index_t NPerWave>
-    __device__ void
-    run(Number<MPerWave>, Number<NPerWave>, const ushort* a, const ushort* b, float* reg_c) const
+    template <index_t MPerXdlops, index_t NPerXdlops>
+    __device__ void run(Number<MPerXdlops>,
+                        Number<NPerXdlops>,
+                        const ushort* a,
+                        const ushort* b,
+                        float* reg_c) const
     {
-        static_assert((MPerWave == 16 && NPerWave == 16), "unsupported xdlops gemm");
+        static_assert((MPerXdlops == 16 && NPerXdlops == 16), "unsupported xdlops gemm");
 
         const auto reg_a = *(reinterpret_cast<const ushort2_t*>(a));
         const auto reg_b = *(reinterpret_cast<const ushort2_t*>(b));
@@ -450,19 +490,24 @@ struct mfma_info<mfma_instr::mfma_f32_16x16x2bf16>
     static constexpr index_t n               = 16;
     static constexpr index_t k               = 2;
     static constexpr index_t cycles          = 32;
+    static constexpr index_t k_base          = 2;
 
-    template <index_t MPerWave, index_t NPerWave>
-    __device__ void
-    run(Number<MPerWave>, Number<NPerWave>, const ushort* a, const ushort* b, float* reg_c) const
+    template <index_t MPerXdlops, index_t NPerXdlops>
+    __device__ void run(Number<MPerXdlops>,
+                        Number<NPerXdlops>,
+                        const ushort* a,
+                        const ushort* b,
+                        float* reg_c) const
     {
-        static_assert((MPerWave == 16 && NPerWave == 64) || (MPerWave == 64 && NPerWave == 16),
+        static_assert((MPerXdlops == 16 && NPerXdlops == 64) ||
+                          (MPerXdlops == 64 && NPerXdlops == 16),
                       "unsupported xdlops gemm");
 
         const auto reg_a = *(reinterpret_cast<const ushort2_t*>(a));
         const auto reg_b = *(reinterpret_cast<const ushort2_t*>(b));
         auto reg_c_      = reinterpret_cast<float16_t*>(reg_c);
 
-        gcnasm_mfma_f32_16x16x2bf16<MPerWave, NPerWave>(reg_a, reg_b, reg_c_);
+        gcnasm_mfma_f32_16x16x2bf16<MPerXdlops, NPerXdlops>(reg_a, reg_b, reg_c_);
     }
 };
 
@@ -481,25 +526,29 @@ struct mfma_info<mfma_instr::mfma_f32_4x4x2bf16>
     static constexpr index_t n               = 64;
     static constexpr index_t k               = 2;
     static constexpr index_t cycles          = 8;
+    static constexpr index_t k_base          = 2;
 
-    template <index_t MPerWave, index_t NPerWave>
-    __device__ void
-    run(Number<MPerWave>, Number<NPerWave>, const ushort* a, const ushort* b, float* reg_c) const
+    template <index_t MPerXdlops, index_t NPerXdlops>
+    __device__ void run(Number<MPerXdlops>,
+                        Number<NPerXdlops>,
+                        const ushort* a,
+                        const ushort* b,
+                        float* reg_c) const
     {
-        static_assert((MPerWave == 4 || MPerWave == 8) && NPerWave == 64,
+        static_assert((MPerXdlops == 4 || MPerXdlops == 8) && NPerXdlops == 64,
                       "unsupported xdlops gemm");
 
         const auto reg_a = *(reinterpret_cast<const ushort2_t*>(a));
         const auto reg_b = *(reinterpret_cast<const ushort2_t*>(b));
         auto reg_c_      = reinterpret_cast<float4_t*>(reg_c);
 
-        gcnasm_mfma_f32_4x4x2bf16<MPerWave, NPerWave>(reg_a, reg_b, reg_c_);
+        gcnasm_mfma_f32_4x4x2bf16<MPerXdlops, NPerXdlops>(reg_a, reg_b, reg_c_);
     }
 };
 
 template <class data_type,
-          index_t MPerWave,
-          index_t NPerWave,
+          index_t MPerXdlops,
+          index_t NPerXdlops,
           index_t GemmDataPerReadA,
           index_t GemmDataPerReadB>
 struct XdlopsGemm_t
@@ -522,19 +571,19 @@ struct XdlopsGemm_t
         __device__ static constexpr index_t GetNumBlks()
         {
             constexpr auto mfma_type = GetMFMAInfo();
-            return MPerWave * NPerWave / (mfma_type.m * mfma_type.n);
+            return MPerXdlops * NPerXdlops / (mfma_type.m * mfma_type.n);
         }
     };
 
     __device__ constexpr XdlopsGemm_t()
     {
-        static_assert(NPerWave == 4 || NPerWave == 8 || NPerWave == 16 || NPerWave == 32 ||
-                          NPerWave == 64,
-                      "Only support GemmNPerWave == 4, 8, 16, 32 or 64 for xdlops");
+        static_assert(NPerXdlops == 4 || NPerXdlops == 8 || NPerXdlops == 16 || NPerXdlops == 32 ||
+                          NPerXdlops == 64,
+                      "Only support GemmNPerXdlops == 4, 8, 16, 32 or 64 for xdlops");
 
-        static_assert(MPerWave == 4 || MPerWave == 8 || MPerWave == 16 || MPerWave == 32 ||
-                          MPerWave == 64,
-                      "Only support GemmMPerWave == 4, 8, 16, 32 or 64 for xdlops");
+        static_assert(MPerXdlops == 4 || MPerXdlops == 8 || MPerXdlops == 16 || MPerXdlops == 32 ||
+                          MPerXdlops == 64,
+                      "Only support GemmMPerXdlops == 4, 8, 16, 32 or 64 for xdlops");
 
         static_assert(GemmDataPerReadA == 1 && GemmDataPerReadB == 1, "GemmDataPerReadA/B != 1");
 
@@ -548,19 +597,21 @@ struct XdlopsGemm_t
                       "incorrect num_output_blks");
         static_assert(mfma_type.num_regs_blk * mfma_type.wave_size == mfma_type.m * mfma_type.n,
                       "num_regs_blk incorrect");
+
+        static_assert(mfma_type.k % mfma_type.k_base == 0, "k and k_base is inconsistent!");
     }
 
-    __device__ static constexpr bool IsABroadcast() { return NPerWave >= MPerWave; }
+    __device__ static constexpr bool IsABroadcast() { return NPerXdlops >= MPerXdlops; }
 
     __device__ static constexpr bool IsKReduction()
     {
         constexpr auto mfma_type = GetMFMAInfo();
-        return mfma_type.num_output_blks == 1 && mfma_type.num_input_blks != 1;
+        return (mfma_type.num_output_blks == 1) && (mfma_type.num_input_blks > 1);
     }
 
-    template <class data_type_  = data_type,
-              index_t MPerWave_ = MPerWave,
-              index_t NPerWave_ = NPerWave>
+    template <class data_type_    = data_type,
+              index_t MPerXdlops_ = MPerXdlops,
+              index_t NPerXdlops_ = NPerXdlops>
     __device__ static constexpr auto GetMFMAInfo();
 
     template <>
@@ -765,7 +816,7 @@ struct XdlopsGemm_t
                 // ABroadcast
                 for(index_t k = 0; k < K; ++k)
                 {
-                    for(index_t b = 0; b < MPerWave / mfma_type.m; ++b)
+                    for(index_t b = 0; b < MPerXdlops / mfma_type.m; ++b)
                     {
                         for(index_t n = 0; n < mfma_type.num_input_blks; ++n)
                         {
@@ -792,7 +843,7 @@ struct XdlopsGemm_t
                 // BBroadcast
                 for(index_t k = 0; k < K; ++k)
                 {
-                    for(index_t b = 0; b < NPerWave / mfma_type.n; ++b)
+                    for(index_t b = 0; b < NPerXdlops / mfma_type.n; ++b)
                     {
                         for(index_t n = 0; n < mfma_type.num_input_blks; ++n)
                         {
@@ -830,17 +881,29 @@ struct XdlopsGemm_t
         static_assert(is_same<FloatA, FloatB>::value, "FloatA != FloatB");
         static_assert(is_same<FloatC, float>::value, "FloatC != float");
 
+        static_assert(is_same<data_type, float>::value || is_same<data_type, half_t>::value ||
+                          is_same<data_type, ushort>::value,
+                      "base data_type must be float, half, ushort!");
+
 #if CK_USE_AMD_XDLOPS_EMULATE
         XdlopsEmulate<M, N, K>(p_a_wave, p_b_wave, p_c_thread);
 #else
         constexpr auto mfma_type = GetMFMAInfo();
 
+        const index_t laneId = get_thread_local_1d_id() % mfma_type.wave_size;
+
+        FloatA a[K];
+        FloatB b[K];
+
+        static_assert(sizeof(FloatA) % (sizeof(data_type) * mfma_type.k_base) == 0,
+                      "wrong! FloatA is consistent with mfma");
+
+        constexpr index_t nxdlops = sizeof(FloatA) / (sizeof(data_type) * mfma_type.k_base);
+
+        static_assert(!IsKReduction() || K % mfma_type.num_input_blks == 0,
+                      "K cannot divided by mfma_type.num_input_blks!");
+
         static_if<!IsKReduction()>{}([&](auto) {
-
-            const index_t laneId = get_thread_local_1d_id() % mfma_type.wave_size;
-
-            FloatA a[K];
-            FloatB b[K];
 
             // load into registers
             for(index_t k = 0; k < K; ++k)
@@ -853,23 +916,20 @@ struct XdlopsGemm_t
             auto pa = reinterpret_cast<const data_type*>(&a);
             auto pb = reinterpret_cast<const data_type*>(&b);
 
-#if WORKAROUND_SWDEV_229564
+#if CK_WORKAROUND_SWDEV_229564
 #pragma unroll
 #endif
             for(index_t k = 0; k < K; ++k)
             {
-                constexpr index_t nxdlops = sizeof(FloatA) / (mfma_type.k * sizeof(data_type));
-
-                for(index_t i = 0; i < nxdlops; ++i, pa += mfma_type.k, pb += mfma_type.k)
-                    mfma_type.run(Number<MPerWave>{}, Number<NPerWave>{}, pa, pb, p_c_thread);
+                for(index_t i = 0; i < nxdlops; ++i)
+                    mfma_type.run(Number<MPerXdlops>{},
+                                  Number<NPerXdlops>{},
+                                  &pa[(k * nxdlops + i) * mfma_type.k_base],
+                                  &pb[(k * nxdlops + i) * mfma_type.k_base],
+                                  p_c_thread);
             }
 
         }).Else([&](auto) {
-
-            const index_t laneId = get_thread_local_1d_id() % mfma_type.wave_size;
-
-            FloatA a[K];
-            FloatB b[K];
 
             const index_t blk_id = laneId / mfma_type.num_threads_blk;
             const index_t blk_td = laneId % mfma_type.num_threads_blk;
@@ -885,16 +945,17 @@ struct XdlopsGemm_t
             auto pa = reinterpret_cast<const data_type*>(&a);
             auto pb = reinterpret_cast<const data_type*>(&b);
 
-            constexpr index_t nxdlops =
-                (sizeof(FloatA) * mfma_type.num_input_blks) / (mfma_type.k * sizeof(data_type));
-
-#if WORKAROUND_SWDEV_229564
+#if CK_WORKAROUND_SWDEV_229564
 #pragma unroll
 #endif
             for(index_t k = 0; k < K; k += mfma_type.num_input_blks)
             {
-                for(index_t i = 0; i < nxdlops; ++i, pa += mfma_type.k, pb += mfma_type.k)
-                    mfma_type.run(Number<MPerWave>{}, Number<NPerWave>{}, pa, pb, p_c_thread);
+                for(index_t i = 0; i < nxdlops; ++i)
+                    mfma_type.run(Number<MPerXdlops>{},
+                                  Number<NPerXdlops>{},
+                                  &pa[(k * nxdlops + i) * mfma_type.k_base],
+                                  &pb[(k * nxdlops + i) * mfma_type.k_base],
+                                  p_c_thread);
             }
 
         });

--- a/src/kernels/composable_kernel/include/utility/amd_buffer_addressing.hpp
+++ b/src/kernels/composable_kernel/include/utility/amd_buffer_addressing.hpp
@@ -8,65 +8,149 @@ namespace ck {
 // For 128bit SGPRs in buffer_load and buffer_store instructions
 // https://rocm-documentation.readthedocs.io/en/latest/GCN_ISA_Manuals/testdocbook.html#vector-memory-buffer-instructions
 template <typename T>
-union BufferLoadStoreDwordConfig
+union BufferAddressConfig
 {
     int32x4_t data;
     T* address[2];
     int32_t range[4];
 };
 
-__device__ float __llvm_amdgcn_buffer_load(int32x4_t rsrc,
-                                           index_t vindex,
-                                           index_t offset,
-                                           bool glc,
-                                           bool slc) __asm("llvm.amdgcn.buffer.load.f32");
+__device__ float __llvm_amdgcn_buffer_load_f32(int32x4_t rsrc,
+                                               index_t vindex,
+                                               index_t offset,
+                                               bool glc,
+                                               bool slc) __asm("llvm.amdgcn.buffer.load.f32");
 
-__device__ float2_t __llvm_amdgcn_buffer_loadx2(int32x4_t rsrc,
-                                                index_t vindex,
-                                                index_t offset,
-                                                bool glc,
-                                                bool slc) __asm("llvm.amdgcn.buffer.load.v2f32");
-
-__device__ float4_t __llvm_amdgcn_buffer_loadx4(int32x4_t rsrc,
-                                                index_t vindex,
-                                                index_t offset,
-                                                bool glc,
-                                                bool slc) __asm("llvm.amdgcn.buffer.load.v4f32");
-
-__device__ void __llvm_amdgcn_buffer_store(float vdata,
-                                           int32x4_t rsrc,
-                                           index_t vindex,
-                                           index_t offset,
-                                           bool glc,
-                                           bool slc) __asm("llvm.amdgcn.buffer.store.f32");
-
-__device__ void __llvm_amdgcn_buffer_storex2(float2_t vdata,
-                                             int32x4_t rsrc,
-                                             index_t vindex,
-                                             index_t offset,
-                                             bool glc,
-                                             bool slc) __asm("llvm.amdgcn.buffer.store.v2f32");
-
-__device__ void __llvm_amdgcn_buffer_storex4(float4_t vdata,
-                                             int32x4_t rsrc,
-                                             index_t vindex,
-                                             index_t offset,
-                                             bool glc,
-                                             bool slc) __asm("llvm.amdgcn.buffer.store.v4f32");
-
-__device__ void
-__llvm_amdgcn_buffer_atomic_add(float vdata,
-                                int32x4_t rsrc,
+__device__ float2_t
+__llvm_amdgcn_buffer_load_f32x2(int32x4_t rsrc,
                                 index_t vindex,
                                 index_t offset,
-                                bool slc) __asm("llvm.amdgcn.buffer.atomic.fadd.f32");
+                                bool glc,
+                                bool slc) __asm("llvm.amdgcn.buffer.load.v2f32");
+
+__device__ float4_t
+__llvm_amdgcn_buffer_load_f32x4(int32x4_t rsrc,
+                                index_t vindex,
+                                index_t offset,
+                                bool glc,
+                                bool slc) __asm("llvm.amdgcn.buffer.load.v4f32");
+
+__device__ half_t __llvm_amdgcn_buffer_load_f16(int32x4_t rsrc,
+                                                index_t vindex,
+                                                index_t offset,
+                                                bool glc,
+                                                bool slc) __asm("llvm.amdgcn.buffer.load.f16");
+
+__device__ half2_t __llvm_amdgcn_buffer_load_f16x2(int32x4_t rsrc,
+                                                   index_t vindex,
+                                                   index_t offset,
+                                                   bool glc,
+                                                   bool slc) __asm("llvm.amdgcn.buffer.load.v2f16");
+
+__device__ half4_t __llvm_amdgcn_buffer_load_f16x4(int32x4_t rsrc,
+                                                   index_t vindex,
+                                                   index_t offset,
+                                                   bool glc,
+                                                   bool slc) __asm("llvm.amdgcn.buffer.load.v4f16");
+
+__device__ ushort __llvm_amdgcn_buffer_load_bf16(int32x4_t rsrc,
+                                                 index_t vindex,
+                                                 index_t offset,
+                                                 bool glc,
+                                                 bool slc) __asm("llvm.amdgcn.buffer.load.bf16");
+
+__device__ ushort2_t
+__llvm_amdgcn_buffer_load_bf16x2(int32x4_t rsrc,
+                                 index_t vindex,
+                                 index_t offset,
+                                 bool glc,
+                                 bool slc) __asm("llvm.amdgcn.buffer.load.v2bf16");
+
+__device__ ushort4_t
+__llvm_amdgcn_buffer_load_bf16x4(int32x4_t rsrc,
+                                 index_t vindex,
+                                 index_t offset,
+                                 bool glc,
+                                 bool slc) __asm("llvm.amdgcn.buffer.load.v4bf16");
+
+__device__ void __llvm_amdgcn_buffer_store_f32(float vdata,
+                                               int32x4_t rsrc,
+                                               index_t vindex,
+                                               index_t offset,
+                                               bool glc,
+                                               bool slc) __asm("llvm.amdgcn.buffer.store.f32");
+
+__device__ void __llvm_amdgcn_buffer_store_f32x2(float2_t vdata,
+                                                 int32x4_t rsrc,
+                                                 index_t vindex,
+                                                 index_t offset,
+                                                 bool glc,
+                                                 bool slc) __asm("llvm.amdgcn.buffer.store.v2f32");
+
+__device__ void __llvm_amdgcn_buffer_store_f32x4(float4_t vdata,
+                                                 int32x4_t rsrc,
+                                                 index_t vindex,
+                                                 index_t offset,
+                                                 bool glc,
+                                                 bool slc) __asm("llvm.amdgcn.buffer.store.v4f32");
+
+__device__ void __llvm_amdgcn_buffer_store_f16(half_t vdata,
+                                               int32x4_t rsrc,
+                                               index_t vindex,
+                                               index_t offset,
+                                               bool glc,
+                                               bool slc) __asm("llvm.amdgcn.buffer.store.f16");
+
+__device__ void __llvm_amdgcn_buffer_store_f16x2(half2_t vdata,
+                                                 int32x4_t rsrc,
+                                                 index_t vindex,
+                                                 index_t offset,
+                                                 bool glc,
+                                                 bool slc) __asm("llvm.amdgcn.buffer.store.v2f16");
+
+__device__ void __llvm_amdgcn_buffer_store_f16x4(half4_t vdata,
+                                                 int32x4_t rsrc,
+                                                 index_t vindex,
+                                                 index_t offset,
+                                                 bool glc,
+                                                 bool slc) __asm("llvm.amdgcn.buffer.store.v4f16");
+
+__device__ void __llvm_amdgcn_buffer_store_bf16(ushort vdata,
+                                                int32x4_t rsrc,
+                                                index_t vindex,
+                                                index_t offset,
+                                                bool glc,
+                                                bool slc) __asm("llvm.amdgcn.buffer.store.bf16");
+
+__device__ void
+__llvm_amdgcn_buffer_store_bf16x2(ushort2_t vdata,
+                                  int32x4_t rsrc,
+                                  index_t vindex,
+                                  index_t offset,
+                                  bool glc,
+                                  bool slc) __asm("llvm.amdgcn.buffer.store.v2bf16");
+
+__device__ void
+__llvm_amdgcn_buffer_store_bf16x4(ushort4_t vdata,
+                                  int32x4_t rsrc,
+                                  index_t vindex,
+                                  index_t offset,
+                                  bool glc,
+                                  bool slc) __asm("llvm.amdgcn.buffer.store.v4bf16");
+
+__device__ void
+__llvm_amdgcn_buffer_atomic_add_f32(float vdata,
+                                    int32x4_t rsrc,
+                                    index_t vindex,
+                                    index_t offset,
+                                    bool slc) __asm("llvm.amdgcn.buffer.atomic.fadd.f32");
 
 // buffer_load requires:
 //   1) p_src must be in global memory space, d_dst must be vgpr
 //   2) p_src to be a block-invariant pointer.
 // It is user's responsibility to make sure that is true.
 template <typename T, index_t VectorSize>
-__device__ typename vector_type<T, VectorSize>::MemoryType amd_intrinsic_buffer_load(
+__device__ typename vector_type<T, VectorSize>::MemoryType amd_buffer_load(
     const T* p_src_block, index_t src_thread_data_offset, index_t src_const_data_offset);
 
 // buffer_store requires:
@@ -74,132 +158,589 @@ __device__ typename vector_type<T, VectorSize>::MemoryType amd_intrinsic_buffer_
 //   2) p_dst to be a block-invariant pointer.
 // It is user's responsibility to make sure that is true.
 template <typename T, index_t VectorSize>
-__device__ void amd_intrinsic_buffer_store(const T* p_src,
-                                           T* p_dst_block,
-                                           index_t dst_thread_data_offset,
-                                           index_t dst_const_data_offset);
+__device__ void amd_buffer_store(const T* p_src,
+                                 T* p_dst_block,
+                                 index_t dst_thread_data_offset,
+                                 index_t dst_const_data_offset);
 
 template <typename T, index_t VectorSize>
-__device__ void amd_intrinsic_buffer_atomic_add(const T* p_src,
-                                                T* p_dst_block,
+__device__ void amd_buffer_atomic_add(const T* p_src,
+                                      T* p_dst_block,
+                                      index_t dst_thread_data_offset,
+                                      index_t dst_const_data_offset);
+
+template <>
+__device__ float amd_buffer_load<float, 1>(const float* p_src_block,
+                                           index_t src_thread_data_offset,
+                                           index_t src_const_data_offset)
+{
+    BufferAddressConfig<float> src_block_config;
+
+    // fill in byte 0 - 1
+    src_block_config.address[0] = const_cast<float*>(p_src_block);
+    // fill in byte 2
+    src_block_config.range[2] = -1;
+    // fill in byte 3
+    src_block_config.range[3] = 0x00027000;
+
+    index_t src_thread_addr_offset = src_thread_data_offset * sizeof(float);
+    index_t src_const_addr_offset  = src_const_data_offset * sizeof(float);
+
+    return __llvm_amdgcn_buffer_load_f32(
+        src_block_config.data, 0, src_thread_addr_offset + src_const_addr_offset, false, false);
+}
+
+template <>
+__device__ float2_t amd_buffer_load<float, 2>(const float* p_src_block,
+                                              index_t src_thread_data_offset,
+                                              index_t src_const_data_offset)
+{
+    BufferAddressConfig<float> src_block_config;
+
+    // fill in byte 0 - 1
+    src_block_config.address[0] = const_cast<float*>(p_src_block);
+    // fill in byte 2
+    src_block_config.range[2] = -1;
+    // fill in byte 3
+    src_block_config.range[3] = 0x00027000;
+
+    index_t src_thread_addr_offset = src_thread_data_offset * sizeof(float);
+    index_t src_const_addr_offset  = src_const_data_offset * sizeof(float);
+
+    return __llvm_amdgcn_buffer_load_f32x2(
+        src_block_config.data, 0, src_thread_addr_offset + src_const_addr_offset, false, false);
+}
+
+template <>
+__device__ float4_t amd_buffer_load<float, 4>(const float* p_src_block,
+                                              index_t src_thread_data_offset,
+                                              index_t src_const_data_offset)
+{
+    BufferAddressConfig<float> src_block_config;
+
+    // fill in byte 0 - 1
+    src_block_config.address[0] = const_cast<float*>(p_src_block);
+    // fill in byte 2
+    src_block_config.range[2] = -1;
+    // fill in byte 3
+    src_block_config.range[3] = 0x00027000;
+
+    index_t src_thread_addr_offset = src_thread_data_offset * sizeof(float);
+    index_t src_const_addr_offset  = src_const_data_offset * sizeof(float);
+
+    return __llvm_amdgcn_buffer_load_f32x4(
+        src_block_config.data, 0, src_thread_addr_offset + src_const_addr_offset, false, false);
+}
+
+template <>
+__device__ half_t amd_buffer_load<half_t, 1>(const half_t* p_src_block,
+                                             index_t src_thread_data_offset,
+                                             index_t src_const_data_offset)
+{
+    BufferAddressConfig<half_t> src_block_config;
+
+    // fill in byte 0 - 1
+    src_block_config.address[0] = const_cast<half_t*>(p_src_block);
+    // fill in byte 2
+    src_block_config.range[2] = -1;
+    // fill in byte 3
+    src_block_config.range[3] = 0x00027000;
+
+#if !CK_WORKAROUND_SWDEV_231101
+    index_t src_thread_addr_offset = src_thread_data_offset * sizeof(half_t);
+    index_t src_const_addr_offset  = src_const_data_offset * sizeof(half_t);
+
+    return __llvm_amdgcn_buffer_load_f16(
+        src_block_config.data, 0, src_thread_addr_offset + src_const_addr_offset, false, false);
+#else
+    return p_src_block[src_thread_data_offset + src_const_data_offset];
+#endif
+}
+
+template <>
+__device__ half2_t amd_buffer_load<half_t, 2>(const half_t* p_src_block,
+                                              index_t src_thread_data_offset,
+                                              index_t src_const_data_offset)
+{
+    BufferAddressConfig<half_t> src_block_config;
+
+    // fill in byte 0 - 1
+    src_block_config.address[0] = const_cast<half_t*>(p_src_block);
+    // fill in byte 2
+    src_block_config.range[2] = -1;
+    // fill in byte 3
+    src_block_config.range[3] = 0x00027000;
+
+    index_t src_thread_addr_offset = src_thread_data_offset * sizeof(half_t);
+    index_t src_const_addr_offset  = src_const_data_offset * sizeof(half_t);
+
+#if !CK_WORKAROUND_SWDEV_231101
+    return __llvm_amdgcn_buffer_load_f16x2(
+        src_block_config.data, 0, src_thread_addr_offset + src_const_addr_offset, false, false);
+#else
+    float dst_out_tmp = __llvm_amdgcn_buffer_load_f32(
+        src_block_config.data, 0, src_thread_addr_offset + src_const_addr_offset, false, false);
+
+    return *reinterpret_cast<half2_t*>(&dst_out_tmp);
+#endif
+}
+
+template <>
+__device__ half4_t amd_buffer_load<half_t, 4>(const half_t* p_src_block,
+                                              index_t src_thread_data_offset,
+                                              index_t src_const_data_offset)
+{
+    BufferAddressConfig<half_t> src_block_config;
+
+    // fill in byte 0 - 1
+    src_block_config.address[0] = const_cast<half_t*>(p_src_block);
+    // fill in byte 2
+    src_block_config.range[2] = -1;
+    // fill in byte 3
+    src_block_config.range[3] = 0x00027000;
+
+    index_t src_thread_addr_offset = src_thread_data_offset * sizeof(half_t);
+    index_t src_const_addr_offset  = src_const_data_offset * sizeof(half_t);
+
+#if !CK_WORKAROUND_SWDEV_231101
+    return __llvm_amdgcn_buffer_load_f16x4(
+        src_block_config.data, 0, src_thread_addr_offset + src_const_addr_offset, false, false);
+#else
+    float2_t dst_out_tmp = __llvm_amdgcn_buffer_load_f32x2(
+        src_block_config.data, 0, src_thread_addr_offset + src_const_addr_offset, false, false);
+
+    return *reinterpret_cast<half4_t*>(&dst_out_tmp);
+#endif
+}
+
+template <>
+__device__ half8_t amd_buffer_load<half_t, 8>(const half_t* p_src_block,
+                                              index_t src_thread_data_offset,
+                                              index_t src_const_data_offset)
+{
+    BufferAddressConfig<half_t> src_block_config;
+
+    // fill in byte 0 - 1
+    src_block_config.address[0] = const_cast<half_t*>(p_src_block);
+    // fill in byte 2
+    src_block_config.range[2] = -1;
+    // fill in byte 3
+    src_block_config.range[3] = 0x00027000;
+
+    index_t src_thread_addr_offset = src_thread_data_offset * sizeof(half_t);
+    index_t src_const_addr_offset  = src_const_data_offset * sizeof(half_t);
+
+#if !CK_WORKAROUND_SWDEV_231101
+    static_assert(false, "wrong! not supported");
+#else
+    float4_t dst_out_tmp = __llvm_amdgcn_buffer_load_f32x4(
+        src_block_config.data, 0, src_thread_addr_offset + src_const_addr_offset, false, false);
+
+    return *reinterpret_cast<half8_t*>(&dst_out_tmp);
+#endif
+}
+
+template <>
+__device__ ushort amd_buffer_load<ushort, 1>(const ushort* p_src_block,
+                                             index_t src_thread_data_offset,
+                                             index_t src_const_data_offset)
+{
+    BufferAddressConfig<ushort> src_block_config;
+
+    // fill in byte 0 - 1
+    src_block_config.address[0] = const_cast<ushort*>(p_src_block);
+    // fill in byte 2
+    src_block_config.range[2] = -1;
+    // fill in byte 3
+    src_block_config.range[3] = 0x00027000;
+
+#if !CK_WORKAROUND_SWDEV_231101
+    index_t src_thread_addr_offset = src_thread_data_offset * sizeof(ushort);
+    index_t src_const_addr_offset  = src_const_data_offset * sizeof(ushort);
+
+    return __llvm_amdgcn_buffer_load_bf16(
+        src_block_config.data, 0, src_thread_addr_offset + src_const_addr_offset, false, false);
+#else
+    return p_src_block[src_thread_data_offset + src_const_data_offset];
+#endif
+}
+
+template <>
+__device__ ushort2_t amd_buffer_load<ushort, 2>(const ushort* p_src_block,
+                                                index_t src_thread_data_offset,
+                                                index_t src_const_data_offset)
+{
+    BufferAddressConfig<ushort> src_block_config;
+
+    // fill in byte 0 - 1
+    src_block_config.address[0] = const_cast<ushort*>(p_src_block);
+    // fill in byte 2
+    src_block_config.range[2] = -1;
+    // fill in byte 3
+    src_block_config.range[3] = 0x00027000;
+
+    index_t src_thread_addr_offset = src_thread_data_offset * sizeof(ushort);
+    index_t src_const_addr_offset  = src_const_data_offset * sizeof(ushort);
+
+#if !CK_WORKAROUND_SWDEV_231101
+    return __llvm_amdgcn_buffer_load_bf16x2(
+        src_block_config.data, 0, src_thread_addr_offset + src_const_addr_offset, false, false);
+#else
+    float dst_out_tmp = __llvm_amdgcn_buffer_load_f32(
+        src_block_config.data, 0, src_thread_addr_offset + src_const_addr_offset, false, false);
+
+    return *reinterpret_cast<ushort2_t*>(&dst_out_tmp);
+#endif
+}
+
+template <>
+__device__ ushort4_t amd_buffer_load<ushort, 4>(const ushort* p_src_block,
+                                                index_t src_thread_data_offset,
+                                                index_t src_const_data_offset)
+{
+    BufferAddressConfig<ushort> src_block_config;
+
+    // fill in byte 0 - 1
+    src_block_config.address[0] = const_cast<ushort*>(p_src_block);
+    // fill in byte 2
+    src_block_config.range[2] = -1;
+    // fill in byte 3
+    src_block_config.range[3] = 0x00027000;
+
+    index_t src_thread_addr_offset = src_thread_data_offset * sizeof(ushort);
+    index_t src_const_addr_offset  = src_const_data_offset * sizeof(ushort);
+
+#if !CK_WORKAROUND_SWDEV_231101
+    return __llvm_amdgcn_buffer_load_bf16x4(
+        src_block_config.data, 0, src_thread_addr_offset + src_const_addr_offset, false, false);
+#else
+    float2_t dst_out_tmp = __llvm_amdgcn_buffer_load_f32x2(
+        src_block_config.data, 0, src_thread_addr_offset + src_const_addr_offset, false, false);
+
+    return *reinterpret_cast<ushort4_t*>(&dst_out_tmp);
+#endif
+}
+
+template <>
+__device__ ushort8_t amd_buffer_load<ushort, 8>(const ushort* p_src_block,
+                                                index_t src_thread_data_offset,
+                                                index_t src_const_data_offset)
+{
+    BufferAddressConfig<ushort> src_block_config;
+
+    // fill in byte 0 - 1
+    src_block_config.address[0] = const_cast<ushort*>(p_src_block);
+    // fill in byte 2
+    src_block_config.range[2] = -1;
+    // fill in byte 3
+    src_block_config.range[3] = 0x00027000;
+
+    index_t src_thread_addr_offset = src_thread_data_offset * sizeof(ushort);
+    index_t src_const_addr_offset  = src_const_data_offset * sizeof(ushort);
+
+#if !CK_WORKAROUND_SWDEV_231101
+    static_assert(false, "wrong! not implemented");
+#else
+    float4_t dst_out_tmp = __llvm_amdgcn_buffer_load_f32x4(
+        src_block_config.data, 0, src_thread_addr_offset + src_const_addr_offset, false, false);
+
+    return *reinterpret_cast<ushort8_t*>(&dst_out_tmp);
+#endif
+}
+
+template <>
+__device__ void amd_buffer_store<float, 1>(const float* p_src,
+                                           float* p_dst_block,
+                                           index_t dst_thread_data_offset,
+                                           index_t dst_const_data_offset)
+{
+    BufferAddressConfig<float> dst_block_config;
+
+    // fill in byte 0 - 1
+    dst_block_config.address[0] = p_dst_block;
+    // fill in byte 2
+    dst_block_config.range[2] = -1;
+    // fill in byte 3
+    dst_block_config.range[3] = 0x00027000;
+
+    index_t dst_thread_addr_offset = dst_thread_data_offset * sizeof(float);
+    index_t dst_const_addr_offset  = dst_const_data_offset * sizeof(float);
+
+    __llvm_amdgcn_buffer_store_f32(*p_src,
+                                   dst_block_config.data,
+                                   0,
+                                   dst_thread_addr_offset + dst_const_addr_offset,
+                                   false,
+                                   false);
+}
+
+template <>
+__device__ void amd_buffer_store<float, 2>(const float* p_src,
+                                           float* p_dst_block,
+                                           index_t dst_thread_data_offset,
+                                           index_t dst_const_data_offset)
+{
+    BufferAddressConfig<float> dst_block_config;
+
+    // fill in byte 0 - 1
+    dst_block_config.address[0] = p_dst_block;
+    // fill in byte 2
+    dst_block_config.range[2] = -1;
+    // fill in byte 3
+    dst_block_config.range[3] = 0x00027000;
+
+    index_t dst_thread_addr_offset = dst_thread_data_offset * sizeof(float);
+    index_t dst_const_addr_offset  = dst_const_data_offset * sizeof(float);
+
+    __llvm_amdgcn_buffer_store_f32x2(*reinterpret_cast<const float2_t*>(p_src),
+                                     dst_block_config.data,
+                                     0,
+                                     dst_thread_addr_offset + dst_const_addr_offset,
+                                     false,
+                                     false);
+}
+
+template <>
+__device__ void amd_buffer_store<float, 4>(const float* p_src,
+                                           float* p_dst_block,
+                                           index_t dst_thread_data_offset,
+                                           index_t dst_const_data_offset)
+{
+    BufferAddressConfig<float> dst_block_config;
+
+    // fill in byte 0 - 1
+    dst_block_config.address[0] = p_dst_block;
+    // fill in byte 2
+    dst_block_config.range[2] = -1;
+    // fill in byte 3
+    dst_block_config.range[3] = 0x00027000;
+
+    index_t dst_thread_addr_offset = dst_thread_data_offset * sizeof(float);
+    index_t dst_const_addr_offset  = dst_const_data_offset * sizeof(float);
+
+    __llvm_amdgcn_buffer_store_f32x4(*reinterpret_cast<const float4_t*>(p_src),
+                                     dst_block_config.data,
+                                     0,
+                                     dst_thread_addr_offset + dst_const_addr_offset,
+                                     false,
+                                     false);
+}
+
+template <>
+__device__ void amd_buffer_store<half_t, 1>(const half_t* p_src,
+                                            half_t* p_dst_block,
+                                            index_t dst_thread_data_offset,
+                                            index_t dst_const_data_offset)
+{
+    BufferAddressConfig<half_t> dst_block_config;
+
+    // fill in byte 0 - 1
+    dst_block_config.address[0] = p_dst_block;
+    // fill in byte 2
+    dst_block_config.range[2] = -1;
+    // fill in byte 3
+    dst_block_config.range[3] = 0x00027000;
+
+#if !CK_WORKAROUND_SWDEV_231101
+    index_t dst_thread_addr_offset = dst_thread_data_offset * sizeof(half_t);
+    index_t dst_const_addr_offset  = dst_const_data_offset * sizeof(half_t);
+
+    __llvm_amdgcn_buffer_store_f16(*p_src,
+                                   dst_block_config.data,
+                                   0,
+                                   dst_thread_addr_offset + dst_const_addr_offset,
+                                   false,
+                                   false);
+#else
+    p_dst_block[dst_thread_data_offset + dst_const_data_offset] = *p_src;
+#endif
+}
+
+template <>
+__device__ void amd_buffer_store<half_t, 2>(const half_t* p_src,
+                                            half_t* p_dst_block,
+                                            index_t dst_thread_data_offset,
+                                            index_t dst_const_data_offset)
+{
+    BufferAddressConfig<half_t> dst_block_config;
+
+    // fill in byte 0 - 1
+    dst_block_config.address[0] = p_dst_block;
+    // fill in byte 2
+    dst_block_config.range[2] = -1;
+    // fill in byte 3
+    dst_block_config.range[3] = 0x00027000;
+
+    index_t dst_thread_addr_offset = dst_thread_data_offset * sizeof(half_t);
+    index_t dst_const_addr_offset  = dst_const_data_offset * sizeof(half_t);
+
+#if !CK_WORKAROUND_SWDEV_231101
+    __llvm_amdgcn_buffer_store_f16x2(*reinterpret_cast<const half2_t*>(p_src),
+                                     dst_block_config.data,
+                                     0,
+                                     dst_thread_addr_offset + dst_const_addr_offset,
+                                     false,
+                                     false);
+#else
+    const float* p_src_tmp = reinterpret_cast<const float*>(p_src);
+
+    __llvm_amdgcn_buffer_store_f32(*p_src_tmp,
+                                   dst_block_config.data,
+                                   0,
+                                   dst_thread_addr_offset + dst_const_addr_offset,
+                                   false,
+                                   false);
+#endif
+}
+
+template <>
+__device__ void amd_buffer_store<half_t, 4>(const half_t* p_src,
+                                            half_t* p_dst_block,
+                                            index_t dst_thread_data_offset,
+                                            index_t dst_const_data_offset)
+{
+    index_t dst_thread_addr_offset = dst_thread_data_offset * sizeof(half_t);
+    index_t dst_const_addr_offset  = dst_const_data_offset * sizeof(half_t);
+
+    BufferAddressConfig<half_t> dst_block_config;
+
+    // fill in byte 0 - 1
+    dst_block_config.address[0] = p_dst_block;
+    // fill in byte 2
+    dst_block_config.range[2] = -1;
+    // fill in byte 3
+    dst_block_config.range[3] = 0x00027000;
+
+#if !CK_WORKAROUND_SWDEV_231101
+    __llvm_amdgcn_buffer_store_f16x4(*reinterpret_cast<const half4_t*>(p_src),
+                                     dst_block_config.data,
+                                     0,
+                                     dst_thread_addr_offset + dst_const_addr_offset,
+                                     false,
+                                     false);
+#else
+    const float2_t* p_src_tmp = reinterpret_cast<const float2_t*>(p_src);
+
+    __llvm_amdgcn_buffer_store_f32x2(*p_src_tmp,
+                                     dst_block_config.data,
+                                     0,
+                                     dst_thread_addr_offset + dst_const_addr_offset,
+                                     false,
+                                     false);
+#endif
+}
+
+template <>
+__device__ void amd_buffer_store<ushort, 1>(const ushort* p_src,
+                                            ushort* p_dst_block,
+                                            index_t dst_thread_data_offset,
+                                            index_t dst_const_data_offset)
+{
+    BufferAddressConfig<ushort> dst_block_config;
+
+    // fill in byte 0 - 1
+    dst_block_config.address[0] = p_dst_block;
+    // fill in byte 2
+    dst_block_config.range[2] = -1;
+    // fill in byte 3
+    dst_block_config.range[3] = 0x00027000;
+
+#if !CK_WORKAROUND_SWDEV_231101
+    index_t dst_thread_addr_offset = dst_thread_data_offset * sizeof(ushort);
+    index_t dst_const_addr_offset  = dst_const_data_offset * sizeof(ushort);
+
+    __llvm_amdgcn_buffer_store_bf16(*p_src,
+                                    dst_block_config.data,
+                                    0,
+                                    dst_thread_addr_offset + dst_const_addr_offset,
+                                    false,
+                                    false);
+#else
+    p_dst_block[dst_thread_data_offset + dst_const_data_offset] = *p_src;
+#endif
+}
+
+template <>
+__device__ void amd_buffer_store<ushort, 2>(const ushort* p_src,
+                                            ushort* p_dst_block,
+                                            index_t dst_thread_data_offset,
+                                            index_t dst_const_data_offset)
+{
+    BufferAddressConfig<ushort> dst_block_config;
+
+    // fill in byte 0 - 1
+    dst_block_config.address[0] = p_dst_block;
+    // fill in byte 2
+    dst_block_config.range[2] = -1;
+    // fill in byte 3
+    dst_block_config.range[3] = 0x00027000;
+
+    index_t dst_thread_addr_offset = dst_thread_data_offset * sizeof(ushort);
+    index_t dst_const_addr_offset  = dst_const_data_offset * sizeof(ushort);
+
+#if !CK_WORKAROUND_SWDEV_231101
+    __llvm_amdgcn_buffer_store_bf16x2(*p_src,
+                                      dst_block_config.data,
+                                      0,
+                                      dst_thread_addr_offset + dst_const_addr_offset,
+                                      false,
+                                      false);
+#else
+    const float* p_src_tmp = reinterpret_cast<const float*>(p_src);
+
+    __llvm_amdgcn_buffer_store_f32(*p_src_tmp,
+                                   dst_block_config.data,
+                                   0,
+                                   dst_thread_addr_offset + dst_const_addr_offset,
+                                   false,
+                                   false);
+#endif
+}
+
+template <>
+__device__ void amd_buffer_store<ushort, 4>(const ushort* p_src,
+                                            ushort* p_dst_block,
+                                            index_t dst_thread_data_offset,
+                                            index_t dst_const_data_offset)
+{
+    BufferAddressConfig<ushort> dst_block_config;
+
+    // fill in byte 0 - 1
+    dst_block_config.address[0] = p_dst_block;
+    // fill in byte 2
+    dst_block_config.range[2] = -1;
+    // fill in byte 3
+    dst_block_config.range[3] = 0x00027000;
+
+    index_t dst_thread_addr_offset = dst_thread_data_offset * sizeof(ushort);
+    index_t dst_const_addr_offset  = dst_const_data_offset * sizeof(ushort);
+
+#if !CK_WORKAROUND_SWDEV_231101
+    __llvm_amdgcn_buffer_store_bf16x4(*p_src,
+                                      dst_block_config.data,
+                                      0,
+                                      dst_thread_addr_offset + dst_const_addr_offset,
+                                      false,
+                                      false);
+#else
+    const float2_t* p_src_tmp = reinterpret_cast<const float2_t*>(p_src);
+
+    __llvm_amdgcn_buffer_store_f32x2(*p_src_tmp,
+                                     dst_block_config.data,
+                                     0,
+                                     dst_thread_addr_offset + dst_const_addr_offset,
+                                     false,
+                                     false);
+#endif
+}
+
+template <>
+__device__ void amd_buffer_atomic_add<float, 1>(const float* p_src,
+                                                float* p_dst_block,
                                                 index_t dst_thread_data_offset,
-                                                index_t dst_const_data_offset);
-
-template <>
-__device__ float amd_intrinsic_buffer_load<float, 1>(const float* p_src_block,
-                                                     index_t src_thread_data_offset,
-                                                     index_t src_const_data_offset)
+                                                index_t dst_const_data_offset)
 {
-    float dst;
-
-    index_t src_thread_addr_offset = src_thread_data_offset * sizeof(float);
-    index_t src_const_addr_offset  = src_const_data_offset * sizeof(float);
-
-    BufferLoadStoreDwordConfig<float> src_block_config;
-
-    // fill in byte 0 - 1
-    src_block_config.address[0] = const_cast<float*>(p_src_block);
-    // fill in byte 2
-    src_block_config.range[2] = -1;
-    // fill in byte 3
-    src_block_config.range[3] = 0x00027000;
-
-#if CK_USE_AMD_BUFFER_ADDRESSING_INTRINSIC
-    dst = __llvm_amdgcn_buffer_load(
-        src_block_config.data, 0, src_thread_addr_offset + src_const_addr_offset, false, false);
-#else
-    asm volatile(
-        "\n \
-    buffer_load_dword %0, %1, %2, %3 offen offset:0 \n \
-    s_waitcnt 0 \n \
-    "
-        : "=v"(dst)
-        : "v"(src_thread_addr_offset), "s"(src_block_config.data), "s"(src_const_addr_offset));
-#endif
-
-    return dst;
-}
-
-template <>
-__device__ float2_t amd_intrinsic_buffer_load<float, 2>(const float* p_src_block,
-                                                        index_t src_thread_data_offset,
-                                                        index_t src_const_data_offset)
-{
-    float2_t dst;
-
-    index_t src_thread_addr_offset = src_thread_data_offset * sizeof(float);
-    index_t src_const_addr_offset  = src_const_data_offset * sizeof(float);
-
-    BufferLoadStoreDwordConfig<float> src_block_config;
-
-    // fill in byte 0 - 1
-    src_block_config.address[0] = const_cast<float*>(p_src_block);
-    // fill in byte 2
-    src_block_config.range[2] = -1;
-    // fill in byte 3
-    src_block_config.range[3] = 0x00027000;
-
-#if CK_USE_AMD_BUFFER_ADDRESSING_INTRINSIC
-    dst = __llvm_amdgcn_buffer_loadx2(
-        src_block_config.data, 0, src_thread_addr_offset + src_const_addr_offset, false, false);
-#else
-    asm volatile(
-        "\n \
-    buffer_load_dwordx2 %0, %1, %2, %3 offen offset:0 \n \
-    s_waitcnt 0 \n \
-    "
-        : "=v"(dst)
-        : "v"(src_thread_addr_offset), "s"(src_block_config.data), "s"(src_const_addr_offset));
-#endif
-
-    return dst;
-}
-
-template <>
-__device__ float4_t amd_intrinsic_buffer_load<float, 4>(const float* p_src_block,
-                                                        index_t src_thread_data_offset,
-                                                        index_t src_const_data_offset)
-{
-    float4_t dst;
-
-    index_t src_thread_addr_offset = src_thread_data_offset * sizeof(float);
-    index_t src_const_addr_offset  = src_const_data_offset * sizeof(float);
-
-    BufferLoadStoreDwordConfig<float> src_block_config;
-
-    // fill in byte 0 - 1
-    src_block_config.address[0] = const_cast<float*>(p_src_block);
-    // fill in byte 2
-    src_block_config.range[2] = -1;
-    // fill in byte 3
-    src_block_config.range[3] = 0x00027000;
-
-#if CK_USE_AMD_BUFFER_ADDRESSING_INTRINSIC
-    dst = __llvm_amdgcn_buffer_loadx4(
-        src_block_config.data, 0, src_thread_addr_offset + src_const_addr_offset, false, false);
-#else
-    asm volatile(
-        "\n \
-    buffer_load_dwordx4 %0, %1, %2, %3 offen offset:0 \n \
-    s_waitcnt 0 \n \
-    "
-        : "=v"(dst)
-        : "v"(src_thread_addr_offset), "s"(src_block_config.data), "s"(src_const_addr_offset));
-#endif
-
-    return dst;
-}
-
-template <>
-__device__ void amd_intrinsic_buffer_store<float, 1>(const float* p_src,
-                                                     float* p_dst_block,
-                                                     index_t dst_thread_data_offset,
-                                                     index_t dst_const_data_offset)
-{
-    index_t dst_thread_addr_offset = dst_thread_data_offset * sizeof(float);
-    index_t dst_const_addr_offset  = dst_const_data_offset * sizeof(float);
-
-    BufferLoadStoreDwordConfig<float> dst_block_config;
+    BufferAddressConfig<float> dst_block_config;
 
     // fill in byte 0 - 1
     dst_block_config.address[0] = p_dst_block;
@@ -208,147 +749,35 @@ __device__ void amd_intrinsic_buffer_store<float, 1>(const float* p_src,
     // fill in byte 3
     dst_block_config.range[3] = 0x00027000;
 
-#if CK_USE_AMD_BUFFER_ADDRESSING_INTRINSIC
-    __llvm_amdgcn_buffer_store(*p_src,
-                               dst_block_config.data,
-                               0,
-                               dst_thread_addr_offset + dst_const_addr_offset,
-                               false,
-                               false);
-#else
-    asm volatile("\n \
-    buffer_store_dword %1, %2, %0, %3 offen offset:0 \n \
-    "
-                 :
-                 : "s"(dst_block_config.data),
-                   "v"(*p_src),
-                   "v"(dst_thread_addr_offset),
-                   "s"(dst_const_addr_offset));
-#endif
-}
-
-template <>
-__device__ void amd_intrinsic_buffer_store<float, 2>(const float* p_src,
-                                                     float* p_dst_block,
-                                                     index_t dst_thread_data_offset,
-                                                     index_t dst_const_data_offset)
-{
     index_t dst_thread_addr_offset = dst_thread_data_offset * sizeof(float);
     index_t dst_const_addr_offset  = dst_const_data_offset * sizeof(float);
 
-    BufferLoadStoreDwordConfig<float> dst_block_config;
-
-    // fill in byte 0 - 1
-    dst_block_config.address[0] = p_dst_block;
-    // fill in byte 2
-    dst_block_config.range[2] = -1;
-    // fill in byte 3
-    dst_block_config.range[3] = 0x00027000;
-
-#if CK_USE_AMD_BUFFER_ADDRESSING_INTRINSIC
-    __llvm_amdgcn_buffer_storex2(*reinterpret_cast<const float2_t*>(p_src),
-                                 dst_block_config.data,
-                                 0,
-                                 dst_thread_addr_offset + dst_const_addr_offset,
-                                 false,
-                                 false);
-#else
-    asm volatile("\n \
-    buffer_store_dwordx2 %1, %2, %0, %3 offen offset:0 \n \
-    "
-                 :
-                 : "s"(dst_block_config.data),
-                   "v"(*reinterpret_cast<const float2_t*>(p_src)),
-                   "v"(dst_thread_addr_offset),
-                   "s"(dst_const_addr_offset));
-#endif
-}
-
-template <>
-__device__ void amd_intrinsic_buffer_store<float, 4>(const float* p_src,
-                                                     float* p_dst_block,
-                                                     index_t dst_thread_data_offset,
-                                                     index_t dst_const_data_offset)
-{
-    index_t dst_thread_addr_offset = dst_thread_data_offset * sizeof(float);
-    index_t dst_const_addr_offset  = dst_const_data_offset * sizeof(float);
-
-    BufferLoadStoreDwordConfig<float> dst_block_config;
-
-    // fill in byte 0 - 1
-    dst_block_config.address[0] = p_dst_block;
-    // fill in byte 2
-    dst_block_config.range[2] = -1;
-    // fill in byte 3
-    dst_block_config.range[3] = 0x00027000;
-
-#if CK_USE_AMD_BUFFER_ADDRESSING_INTRINSIC
-    __llvm_amdgcn_buffer_storex4(*reinterpret_cast<const float4_t*>(p_src),
-                                 dst_block_config.data,
-                                 0,
-                                 dst_thread_addr_offset + dst_const_addr_offset,
-                                 false,
-                                 false);
-#else
-    asm volatile("\n \
-    buffer_store_dwordx4 %1, %2, %0, %3 offen offset:0 \n \
-    "
-                 :
-                 : "s"(dst_block_config.data),
-                   "v"(*reinterpret_cast<const float4_t*>(p_src)),
-                   "v"(dst_thread_addr_offset),
-                   "s"(dst_const_addr_offset));
-#endif
-}
-
-template <>
-__device__ void amd_intrinsic_buffer_atomic_add<float, 1>(const float* p_src,
-                                                          float* p_dst_block,
-                                                          index_t dst_thread_data_offset,
-                                                          index_t dst_const_data_offset)
-{
-    index_t dst_thread_addr_offset = dst_thread_data_offset * sizeof(float);
-    index_t dst_const_addr_offset  = dst_const_data_offset * sizeof(float);
-
-    BufferLoadStoreDwordConfig<float> dst_block_config;
-
-    // fill in byte 0 - 1
-    dst_block_config.address[0] = p_dst_block;
-    // fill in byte 2
-    dst_block_config.range[2] = -1;
-    // fill in byte 3
-    dst_block_config.range[3] = 0x00027000;
-
-#if CK_USE_AMD_BUFFER_ADDRESSING_INTRINSIC
-    __llvm_amdgcn_buffer_atomic_add(
+    __llvm_amdgcn_buffer_atomic_add_f32(
         *p_src, dst_block_config.data, 0, dst_thread_addr_offset + dst_const_addr_offset, false);
-#else
-    static_assert(false, " wrong! not implemented");
-#endif
 }
 
 template <>
-__device__ void amd_intrinsic_buffer_atomic_add<float, 2>(const float* p_src,
-                                                          float* p_dst_block,
-                                                          index_t dst_thread_data_offset,
-                                                          index_t dst_const_data_offset)
+__device__ void amd_buffer_atomic_add<float, 2>(const float* p_src,
+                                                float* p_dst_block,
+                                                index_t dst_thread_data_offset,
+                                                index_t dst_const_data_offset)
 {
     for(index_t i = 0; i < 2; ++i)
     {
-        amd_intrinsic_buffer_atomic_add<float, 1>(
+        amd_buffer_atomic_add<float, 1>(
             &p_src[i], p_dst_block, dst_thread_data_offset, dst_const_data_offset + i);
     }
 }
 
 template <>
-__device__ void amd_intrinsic_buffer_atomic_add<float, 4>(const float* p_src,
-                                                          float* p_dst_block,
-                                                          index_t dst_thread_data_offset,
-                                                          index_t dst_const_data_offset)
+__device__ void amd_buffer_atomic_add<float, 4>(const float* p_src,
+                                                float* p_dst_block,
+                                                index_t dst_thread_data_offset,
+                                                index_t dst_const_data_offset)
 {
     for(index_t i = 0; i < 4; ++i)
     {
-        amd_intrinsic_buffer_atomic_add<float, 1>(
+        amd_buffer_atomic_add<float, 1>(
             &p_src[i], p_dst_block, dst_thread_data_offset, dst_const_data_offset + i);
     }
 }

--- a/src/kernels/composable_kernel/include/utility/common_header.hpp
+++ b/src/kernels/composable_kernel/include/utility/common_header.hpp
@@ -16,13 +16,10 @@
 #include "functional3.hpp"
 #include "functional4.hpp"
 #include "in_memory_operation.hpp"
+#include "synchronization.hpp"
 
 #if CK_USE_AMD_INLINE_ASM
 #include "amd_inline_asm.hpp"
-#endif
-
-#if CK_USE_AMD_BUFFER_ADDRESSING
-#include "amd_buffer_addressing.hpp"
 #endif
 
 #if CK_USE_AMD_XDLOPS

--- a/src/kernels/composable_kernel/include/utility/config.hpp
+++ b/src/kernels/composable_kernel/include/utility/config.hpp
@@ -25,11 +25,7 @@
 #define CK_USE_AMD_BUFFER_ADDRESSING 1
 #endif
 
-#ifndef CK_USE_AMD_BUFFER_ADDRESSING_INTRINSIC
-#define CK_USE_AMD_BUFFER_ADDRESSING_INTRINSIC 1
-#endif
-
-// only support gfx908
+// only gfx908 support native floating point atomic add
 #ifndef CK_USE_AMD_BUFFER_ATOMIC_ADD
 #define CK_USE_AMD_BUFFER_ATOMIC_ADD 0
 #endif
@@ -47,6 +43,11 @@
 #define CK_USE_AMD_XDLOPS_EMULATE 0 // For internal debug purposes
 #endif
 
+// block synchronization only s_wait lgkmcnt(0), not vmcnt(0)
+#ifndef CK_BLOCK_SYNC_LDS_WITHOUT_SYNC_VMEM
+#define CK_BLOCK_SYNC_LDS_WITHOUT_SYNC_VMEM 1
+#endif
+
 // experimental implementation
 #define CK_EXPERIMENTAL_BLOCKWISE_GEMM_USE_PIPELINE 1
 #define CK_EXPERIMENTAL_TENSOR_COORDINATE_USE_CALCULATE_OFFSET_DIFF 0
@@ -54,8 +55,24 @@
 #define CK_EXPERIMENTAL_USE_MORE_COMPILE_STATIC_BLOCKWISE_GENERIC_SLICE_COPY_V1 0
 #define CK_EXPERIMENTAL_USE_MORE_COMPILE_STATIC_THREADWISE_GENERIC_TENSOR_SLICE_COPY_V1R2 0
 #define CK_EXPERIMENTAL_USE_MORE_COMPILE_STATIC_THREADWISE_GENERIC_TENSOR_SLICE_COPY_V2R1 0
+
+#ifndef CK_EXPERIMENTAL_IMPLICIT_GEMM_BACKWARD_DATA_V4R1_OUTPUT_SKIP_OUT_OF_BOUND_CHECK
 #define CK_EXPERIMENTAL_IMPLICIT_GEMM_BACKWARD_DATA_V4R1_OUTPUT_SKIP_OUT_OF_BOUND_CHECK 0
+#endif
+
+#ifndef CK_EXPERIMENTAL_IMPLICIT_GEMM_BACKWARD_DATA_V4R1_INPUT_SKIP_OUT_OF_BOUND_CHECK
 #define CK_EXPERIMENTAL_IMPLICIT_GEMM_BACKWARD_DATA_V4R1_INPUT_SKIP_OUT_OF_BOUND_CHECK 0
+#endif
+
+// workaround: put all workaround here
+// workaround for unnecessary VGPA <--> AGRP data movement when using mfma LLVM intrinsic
+#ifndef CK_WORKAROUND_SWDEV_229564
+#define CK_WORKAROUND_SWDEV_229564 1
+#endif
+// workaround for buffer load/store fp16/bfp16 intrinsic bug
+#ifndef CK_WORKAROUND_SWDEV_231101
+#define CK_WORKAROUND_SWDEV_231101 1
+#endif
 
 namespace ck {
 
@@ -71,12 +88,6 @@ enum InMemoryDataOperation
 {
     Set,
     AtomicAdd
-};
-
-enum WorkgroupScheduleOrder
-{
-    MBlock1NBlock0,
-    NBlock1MBlock0
 };
 
 #if CK_UNSIGNED_INDEX_TYPE

--- a/src/kernels/composable_kernel/include/utility/float_type.hpp
+++ b/src/kernels/composable_kernel/include/utility/float_type.hpp
@@ -274,6 +274,20 @@ struct type_convert
 
 template <>
 template <>
+__device__ float type_convert<float>::operator()<half>(half x) const
+{
+    return __half2float(x);
+};
+
+template <>
+template <>
+__device__ half type_convert<half>::operator()<float>(float x) const
+{
+    return __float2half(x);
+};
+
+template <>
+template <>
 __device__ float type_convert<float>::operator()<ushort>(ushort x) const
 {
     return bfloat16_to_float(x);

--- a/src/kernels/composable_kernel/include/utility/float_type.hpp
+++ b/src/kernels/composable_kernel/include/utility/float_type.hpp
@@ -305,6 +305,34 @@ struct inner_product_with_conversion
 {
     static constexpr auto convert = type_convert<T>();
 
+    __device__ T operator()(float4_t a, float4_t b) const
+    {
+        const float* p_a_float = reinterpret_cast<const float*>(&a);
+        const float* p_b_float = reinterpret_cast<const float*>(&b);
+
+        T acc = 0;
+        for(index_t v = 0; v < 4; ++v)
+        {
+            acc += convert(p_a_float[v]) * convert(p_b_float[v]);
+        }
+
+        return acc;
+    }
+
+    __device__ T operator()(float2_t a, float2_t b) const
+    {
+        const float* p_a_float = reinterpret_cast<const float*>(&a);
+        const float* p_b_float = reinterpret_cast<const float*>(&b);
+
+        T acc = 0;
+        for(index_t v = 0; v < 2; ++v)
+        {
+            acc += convert(p_a_float[v]) * convert(p_b_float[v]);
+        }
+
+        return acc;
+    }
+
     __device__ T operator()(float a, float b) const { return convert(a) * convert(b); }
 
     __device__ T operator()(half2_t a, half2_t b) const
@@ -334,6 +362,19 @@ struct inner_product_with_conversion
         return acc;
     }
 
+    __device__ T operator()(half8_t a, half8_t b) const
+    {
+        const half_t* p_a_half = reinterpret_cast<const half_t*>(&a);
+        const half_t* p_b_half = reinterpret_cast<const half_t*>(&b);
+
+        T acc = 0;
+        for(index_t v = 0; v < 8; ++v)
+        {
+            acc += convert(p_a_half[v]) * convert(p_b_half[v]);
+        }
+        return acc;
+    }
+
     __device__ T operator()(ushort2_t a, ushort2_t b) const
     {
         const ushort* p_a_bfloat16 = reinterpret_cast<const ushort*>(&a);
@@ -355,6 +396,19 @@ struct inner_product_with_conversion
 
         T acc = 0;
         for(index_t v = 0; v < 4; ++v)
+        {
+            acc += convert(p_a_bfloat16[v]) * convert(p_b_bfloat16[v]);
+        }
+        return acc;
+    }
+
+    __device__ T operator()(ushort8_t a, ushort8_t b) const
+    {
+        const ushort* p_a_bfloat16 = reinterpret_cast<const ushort*>(&a);
+        const ushort* p_b_bfloat16 = reinterpret_cast<const ushort*>(&b);
+
+        T acc = 0;
+        for(index_t v = 0; v < 8; ++v)
         {
             acc += convert(p_a_bfloat16[v]) * convert(p_b_bfloat16[v]);
         }

--- a/src/kernels/composable_kernel/include/utility/in_memory_operation.hpp
+++ b/src/kernels/composable_kernel/include/utility/in_memory_operation.hpp
@@ -2,7 +2,10 @@
 #define CK_IN_MEMORY_OPERATION_AMD_HPP
 
 #include "float_type.hpp"
+
+#if CK_USE_AMD_BUFFER_ADDRESSING
 #include "amd_buffer_addressing.hpp"
+#endif
 
 namespace ck {
 
@@ -37,73 +40,91 @@ __device__ void atomic_add_impl<float4_t>(float4_t* p_dst, float4_t src)
     }
 }
 
-template <typename T,
-          index_t DataPerAccess,
-          AddressSpace SrcAddressSpace,
-          AddressSpace DstAddressSpace>
-__device__ void set_data(const T* p_src, index_t src_offset, T* p_dst, index_t dst_offset)
+template <typename T, index_t DataPerAccess>
+struct SetData
 {
     using vector_t = typename vector_type<T, DataPerAccess>::MemoryType;
 
-#if CK_USE_AMD_BUFFER_ADDRESSING
-    static_if<!std::is_same<T, float>::value>{}([&](auto) {
-        // TODO: use vector_type or AMD intrinsic copying for integer type
-        // for (index_t i=0; i < DataPerAccess; i++)
-        //     p_dst[dst_offset+i] = p_src[src_offset+i];
+    // This version is only for compatibility, don't use this version if possible
+    template <AddressSpace SrcAddressSpace, AddressSpace DstAddressSpace>
+    __device__ void Run(const T* p_src, index_t src_offset, T* p_dst, index_t dst_offset) const
+    {
         *reinterpret_cast<vector_t*>(&p_dst[dst_offset]) =
             *reinterpret_cast<const vector_t*>(&p_src[src_offset]);
-    }).Else([&](auto) {
-        // TODO: use static_if::ElseIf, instead of nested static_if
-        static_if<SrcAddressSpace == AddressSpace::Global &&
-                  DstAddressSpace == AddressSpace::Vgpr>{}([&](auto) {
-            // buffer_load requires:
-            //   1) p_src must be in global memory space, d_dst must be vgpr
-            //   2) p_src to be a block-invariant pointer.
-            // It is user's responsibility to make sure that is true.
-            *reinterpret_cast<vector_t*>(&p_dst[dst_offset]) =
-                amd_intrinsic_buffer_load<T, DataPerAccess>(p_src, src_offset, 0);
-        }).Else([&](auto) {
-            static_if<SrcAddressSpace == AddressSpace::Vgpr &&
-                      DstAddressSpace == AddressSpace::Global>{}([&](auto) {
-                // buffer_store requires:
-                //   1) p_src must be in vgpr space, d_dst must be global memory
-                //   2) p_dst to be a block-invariant pointer.
-                // It is user's responsibility to make sure that is true.
-                amd_intrinsic_buffer_store<T, DataPerAccess>(
-                    &(p_src[src_offset]), p_dst, dst_offset, 0);
-            }).Else([&](auto) {
-                *reinterpret_cast<vector_t*>(&p_dst[dst_offset]) =
-                    *reinterpret_cast<const vector_t*>(&p_src[src_offset]);
-            });
-        });
-    });
-#else
-    *reinterpret_cast<vector_t*>(&p_dst[dst_offset]) =
-        *reinterpret_cast<const vector_t*>(&p_src[src_offset]);
+    }
+
+#if CK_USE_AMD_BUFFER_ADDRESSING
+    // buffer_load requires:
+    //   1) p_src must be in global memory space, d_dst must be vgpr
+    //   2) p_src to be a block-invariant pointer.
+    // It is user's responsibility to make sure that is true.
+    template <>
+    __device__ void Run<AddressSpace::Global, AddressSpace::Vgpr>(const T* p_src,
+                                                                  index_t src_offset,
+                                                                  T* p_dst,
+                                                                  index_t dst_offset) const
+    {
+        *reinterpret_cast<vector_t*>(&p_dst[dst_offset]) =
+            amd_buffer_load<T, DataPerAccess>(p_src, src_offset, 0);
+    }
+
+    // buffer_store requires:
+    //   1) p_src must be in vgpr space, d_dst must be global memory
+    //   2) p_dst to be a block-invariant pointer.
+    // It is user's responsibility to make sure that is true.
+    template <>
+    __device__ void Run<AddressSpace::Vgpr, AddressSpace::Global>(const T* p_src,
+                                                                  index_t src_offset,
+                                                                  T* p_dst,
+                                                                  index_t dst_offset) const
+    {
+        amd_buffer_store<T, DataPerAccess>(&(p_src[src_offset]), p_dst, dst_offset, 0);
+    }
 #endif
-}
+};
 
-template <typename T,
-          index_t DataPerAccess,
-          AddressSpace SrcAddressSpace,
-          AddressSpace DstAddressSpace>
-__device__ void atomic_add_data(const T* p_src, index_t src_offset, T* p_dst, index_t dst_offset)
+template <index_t DataPerAccess>
+struct SetData<int, DataPerAccess>
 {
-    static_if<SrcAddressSpace == AddressSpace::Vgpr &&
-              DstAddressSpace == AddressSpace::Global>{}([&](auto) {
-#if CK_USE_AMD_BUFFER_ATOMIC_ADD
-        amd_intrinsic_buffer_atomic_add<T, DataPerAccess>(
-            &(p_src[src_offset]), p_dst, dst_offset, 0);
-#else
-        using vector_t = typename vector_type<T, DataPerAccess>::MemoryType;
+    using vector_t = typename vector_type<int, DataPerAccess>::MemoryType;
 
+    // This version is only for compatibility, don't use this version if possible
+    template <AddressSpace SrcAddressSpace, AddressSpace DstAddressSpace>
+    __device__ void Run(const int* p_src, index_t src_offset, int* p_dst, index_t dst_offset) const
+    {
+        *reinterpret_cast<vector_t*>(&p_dst[dst_offset]) =
+            *reinterpret_cast<const vector_t*>(&p_src[src_offset]);
+    }
+};
+
+template <typename T, index_t DataPerAccess>
+struct AtomicAddData
+{
+    using vector_t = typename vector_type<T, DataPerAccess>::MemoryType;
+
+    // This version is only for compatibility, don't use this version if possible
+    template <AddressSpace SrcAddressSpace, AddressSpace DstAddressSpace>
+    __device__ void Run(const T* p_src, index_t src_offset, T* p_dst, index_t dst_offset) const
+    {
         atomic_add_impl(reinterpret_cast<vector_t*>(&p_dst[dst_offset]),
                         *reinterpret_cast<const vector_t*>(&p_src[src_offset]));
+    }
+
+#if CK_USE_AMD_BUFFER_ADDRESSING && CK_USE_AMD_BUFFER_ATOMIC_ADD
+    // buffer_atomic_add requires:
+    //   1) p_src must be in vgpr space, d_dst must be global memory
+    //   2) p_dst to be a block-invariant pointer.
+    // It is user's responsibility to make sure that is true.
+    template <>
+    __device__ void Run<AddressSpace::Vgpr, AddressSpace::Global>(const T* p_src,
+                                                                  index_t src_offset,
+                                                                  T* p_dst,
+                                                                  index_t dst_offset) const
+    {
+        amd_buffer_atomic_add<T, DataPerAccess>(&(p_src[src_offset]), p_dst, dst_offset, 0);
+    }
 #endif
-    }).Else([&](auto fwd) {
-        static_assert(fwd(false), "atomic_add doesn't support this memory space");
-    });
-}
+};
 
 template <typename T,
           index_t DataPerAccess,
@@ -118,36 +139,36 @@ __device__ void transfer_data(const T* p_src, index_t src_offset, T* p_dst, inde
                       DstInMemOp == InMemoryDataOperation::AtomicAdd,
                   "wrong! InMemoryDataOperation not supported!");
 
-    static_if<(SrcDataStride > 1 || DstDataStride > 1)>{}([&](auto) {
-
-        for(index_t j = 0; j < DataPerAccess; j++)
-        {
-            // TODO: use static_if::ElseIf
-            static_if<DstInMemOp == InMemoryDataOperation::Set>{}([&](auto) {
-                set_data<T, 1, SrcAddressSpace, DstAddressSpace>(
-                    p_src, src_offset + j * SrcDataStride, p_dst, dst_offset + j * DstDataStride);
-            });
-
-            static_if<DstInMemOp == InMemoryDataOperation::AtomicAdd>{}([&](auto) {
-                atomic_add_data<T, 1, SrcAddressSpace, DstAddressSpace>(
-                    p_src, src_offset + j * SrcDataStride, p_dst, dst_offset + j * DstDataStride);
-            });
-        }
-
-    }).Else([&](auto) {
-
+    // keep it simple, don't use static_if here, otherwise compiler will do weird things
+    if(SrcDataStride == 1 && DstDataStride == 1)
+    {
         // TODO: use static_if::ElseIf
         static_if<DstInMemOp == InMemoryDataOperation::Set>{}([&](auto) {
-            set_data<T, DataPerAccess, SrcAddressSpace, DstAddressSpace>(
+            SetData<T, DataPerAccess>{}.template Run<SrcAddressSpace, DstAddressSpace>(
                 p_src, src_offset, p_dst, dst_offset);
         });
 
         static_if<DstInMemOp == InMemoryDataOperation::AtomicAdd>{}([&](auto) {
-            atomic_add_data<T, DataPerAccess, SrcAddressSpace, DstAddressSpace>(
+            AtomicAddData<T, DataPerAccess>{}.template Run<SrcAddressSpace, DstAddressSpace>(
                 p_src, src_offset, p_dst, dst_offset);
         });
+    }
+    else
+    {
+        for(index_t i = 0; i < DataPerAccess; i++)
+        {
+            // TODO: use static_if::ElseIf
+            static_if<DstInMemOp == InMemoryDataOperation::Set>{}([&](auto) {
+                SetData<T, 1>{}.template Run<SrcAddressSpace, DstAddressSpace>(
+                    p_src, src_offset + i * SrcDataStride, p_dst, dst_offset + i * DstDataStride);
+            });
 
-    });
+            static_if<DstInMemOp == InMemoryDataOperation::AtomicAdd>{}([&](auto) {
+                AtomicAddData<T, 1>{}.template Run<SrcAddressSpace, DstAddressSpace>(
+                    p_src, src_offset + i * SrcDataStride, p_dst, dst_offset + i * DstDataStride);
+            });
+        }
+    }
 }
 
 } // namespace ck

--- a/src/kernels/composable_kernel/include/utility/in_memory_operation.hpp
+++ b/src/kernels/composable_kernel/include/utility/in_memory_operation.hpp
@@ -46,27 +46,35 @@ __device__ void set_data(const T* p_src, index_t src_offset, T* p_dst, index_t d
     using vector_t = typename vector_type<T, DataPerAccess>::MemoryType;
 
 #if CK_USE_AMD_BUFFER_ADDRESSING
-    // TODO: use static_if::ElseIf, instead of nested static_if
-    static_if<SrcAddressSpace == AddressSpace::Global &&
-              DstAddressSpace == AddressSpace::Vgpr>{}([&](auto) {
-        // buffer_load requires:
-        //   1) p_src must be in global memory space, d_dst must be vgpr
-        //   2) p_src to be a block-invariant pointer.
-        // It is user's responsibility to make sure that is true.
+    static_if<!std::is_same<T, float>::value>{}([&](auto) {
+        // TODO: use vector_type or AMD intrinsic copying for integer type
+        // for (index_t i=0; i < DataPerAccess; i++)
+        //     p_dst[dst_offset+i] = p_src[src_offset+i];
         *reinterpret_cast<vector_t*>(&p_dst[dst_offset]) =
-            amd_intrinsic_buffer_load<T, DataPerAccess>(p_src, src_offset, 0);
+            *reinterpret_cast<const vector_t*>(&p_src[src_offset]);
     }).Else([&](auto) {
-        static_if<SrcAddressSpace == AddressSpace::Vgpr &&
-                  DstAddressSpace == AddressSpace::Global>{}([&](auto) {
-            // buffer_store requires:
-            //   1) p_src must be in vgpr space, d_dst must be global memory
-            //   2) p_dst to be a block-invariant pointer.
+        // TODO: use static_if::ElseIf, instead of nested static_if
+        static_if<SrcAddressSpace == AddressSpace::Global &&
+                  DstAddressSpace == AddressSpace::Vgpr>{}([&](auto) {
+            // buffer_load requires:
+            //   1) p_src must be in global memory space, d_dst must be vgpr
+            //   2) p_src to be a block-invariant pointer.
             // It is user's responsibility to make sure that is true.
-            amd_intrinsic_buffer_store<T, DataPerAccess>(
-                &(p_src[src_offset]), p_dst, dst_offset, 0);
-        }).Else([&](auto) {
             *reinterpret_cast<vector_t*>(&p_dst[dst_offset]) =
-                *reinterpret_cast<const vector_t*>(&p_src[src_offset]);
+                amd_intrinsic_buffer_load<T, DataPerAccess>(p_src, src_offset, 0);
+        }).Else([&](auto) {
+            static_if<SrcAddressSpace == AddressSpace::Vgpr &&
+                      DstAddressSpace == AddressSpace::Global>{}([&](auto) {
+                // buffer_store requires:
+                //   1) p_src must be in vgpr space, d_dst must be global memory
+                //   2) p_dst to be a block-invariant pointer.
+                // It is user's responsibility to make sure that is true.
+                amd_intrinsic_buffer_store<T, DataPerAccess>(
+                    &(p_src[src_offset]), p_dst, dst_offset, 0);
+            }).Else([&](auto) {
+                *reinterpret_cast<vector_t*>(&p_dst[dst_offset]) =
+                    *reinterpret_cast<const vector_t*>(&p_src[src_offset]);
+            });
         });
     });
 #else

--- a/src/kernels/composable_kernel/include/utility/reduction_common.hpp
+++ b/src/kernels/composable_kernel/include/utility/reduction_common.hpp
@@ -114,13 +114,13 @@ struct get_type_from_type_enum<ckInt32>
 struct float_equal
 {
     template <class T>
-    static bool apply(T x, T y)
+    __device__ static inline bool apply(T x, T y)
     {
         return x <= y and x >= y;
     }
 
     template <class T>
-    bool operator()(T x, T y)
+    __device__ inline bool operator()(T x, T y)
     {
         return (float_equal::apply(x, y));
     };
@@ -129,13 +129,13 @@ struct float_equal
 struct float_equal_one
 {
     template <class T>
-    static bool apply(T x)
+    __device__ static inline bool apply(T x)
     {
         return x <= type_convert<T>{}(1.0f) and x >= type_convert<T>{}(1.0f);
     }
 
     template <class T>
-    bool operator()(T x)
+    __device__ inline bool operator()(T x)
     {
         return (float_equal_one::apply(x));
     };
@@ -144,13 +144,13 @@ struct float_equal_one
 struct float_equal_zero
 {
     template <class T>
-    static bool apply(T x)
+    __device__ static inline bool apply(T x)
     {
         return x <= type_convert<T>{}(0.0f) and x >= type_convert<T>{}(0.0f);
     }
 
     template <class T>
-    bool operator()(T x)
+    __device__ inline bool operator()(T x)
     {
         return (float_equal_zero::apply(x));
     };

--- a/src/kernels/composable_kernel/include/utility/reduction_common.hpp
+++ b/src/kernels/composable_kernel/include/utility/reduction_common.hpp
@@ -1,0 +1,161 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2020 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#ifndef CK_REDUCTION_COMMON_HPP
+#define CK_REDUCTION_COMMON_HPP
+
+#include "config.hpp"
+
+// this enumerate should be synchronized with include/miopen/reduce_common.hpp
+namespace ck {
+typedef enum {
+    CK_Reduce_DirectThreadWise = 1,
+    CK_Reduce_DirectWarpWise   = 2,
+    CK_Reduce_BlockWise        = 3,
+    CK_Reduce_MultiBlock       = 4
+} ckReductionMethod_t; // end of namespace ck
+
+// this enumerate should be synchronized with include/miopen.h
+typedef enum {
+    CK_REDUCE_TENSOR_ADD = 0,
+    CK_REDUCE_TENSOR_MUL = 1,
+    CK_REDUCE_TENSOR_MIN = 2,
+    CK_REDUCE_TENSOR_MAX = 3,
+    // CK_REDUCE_TENSOR_AMAX = 4,
+    // CK_REDUCE_TENSOR_AVG =  5,
+    // CK_REDUCE_TENSOR_NORM1 = 6,
+    // CK_REDUCE_TENSOR_NORM2 = 7,
+    // CK_REDUCE_TENSOR_MUL_NO_ZEROS = 8,
+} ckReduceTensorOp_t;
+
+typedef enum {
+    CK_NOT_PROPAGATE_NAN = 0,
+    CK_PROPAGATE_NAN     = 1,
+} ckNanPropagation_t;
+
+typedef enum {
+    CK_REDUCE_TENSOR_NO_INDICES        = 0,
+    CK_REDUCE_TENSOR_FLATTENED_INDICES = 1,
+} ckReduceTensorIndices_t;
+
+typedef enum {
+    CK_32BIT_INDICES = 0,
+    CK_64BIT_INDICES = 1,
+    CK_16BIT_INDICES = 2,
+    CK_8BIT_INDICES  = 3,
+} ckIndicesType_t;
+
+// this enumerate should be synchronized with include/miopen.h
+typedef enum {
+    ckHalf     = 0,
+    ckFloat    = 1,
+    ckInt32    = 2,
+    ckInt8     = 3,
+    ckInt8x4   = 4,
+    ckBFloat16 = 5,
+    ckDouble   = 6,
+} ckDataType_t;
+
+template <ckDataType_t typeNum>
+struct get_type_from_type_enum;
+
+template <>
+struct get_type_from_type_enum<ckHalf>
+{
+    using type = half;
+};
+
+template <>
+struct get_type_from_type_enum<ckBFloat16>
+{
+    using type = ushort;
+};
+
+template <>
+struct get_type_from_type_enum<ckFloat>
+{
+    using type = float;
+};
+
+template <>
+struct get_type_from_type_enum<ckDouble>
+{
+    using type = double;
+};
+
+template <>
+struct get_type_from_type_enum<ckInt32>
+{
+    using type = int;
+};
+
+struct float_equal
+{
+    template <class T>
+    static bool apply(T x, T y)
+    {
+        return x <= y and x >= y;
+    }
+
+    template <class T>
+    bool operator()(T x, T y)
+    {
+        return (float_equal::apply(x, y));
+    };
+};
+
+struct float_equal_one
+{
+    template <class T>
+    static bool apply(T x)
+    {
+        return x <= type_convert<T>{}(1.0f) and x >= type_convert<T>{}(1.0f);
+    }
+
+    template <class T>
+    bool operator()(T x)
+    {
+        return (float_equal_one::apply(x));
+    };
+};
+
+struct float_equal_zero
+{
+    template <class T>
+    static bool apply(T x)
+    {
+        return x <= type_convert<T>{}(0.0f) and x >= type_convert<T>{}(0.0f);
+    }
+
+    template <class T>
+    bool operator()(T x)
+    {
+        return (float_equal_zero::apply(x));
+    };
+};
+
+}; // end of namespace ck
+
+#endif

--- a/src/kernels/composable_kernel/include/utility/reduction_operator.hpp
+++ b/src/kernels/composable_kernel/include/utility/reduction_operator.hpp
@@ -1,0 +1,177 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2020 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#ifndef CK_REDUCTION_OPERATOR_HPP
+#define CK_REDUCTION_OPERATOR_HPP
+
+#include <limits>
+#include "reduction_common.hpp"
+
+namespace ck {
+
+namespace reduce {
+
+template <class T>
+struct Add
+{
+    using dataType = T;
+
+    __device__ static T getZeroVal() { return type_convert<T>{}(0.0f); };
+
+    __device__ inline constexpr void operator()(T& a, T b) const { a = a + b; }
+
+    static constexpr bool indexable = false;
+};
+
+template <class T>
+struct Mul
+{
+    using dataType = T;
+
+    __device__ static T getZeroVal() { return type_convert<T>{}(1.0f); };
+
+    __device__ inline constexpr void operator()(T& a, T b) const { a = a * b; }
+
+    static constexpr bool indexable = false;
+};
+
+template <class T>
+struct Max
+{
+    using dataType = T;
+
+    __device__ static T getZeroVal() { return std::numeric_limits<T>::min(); };
+
+    __device__ inline constexpr void operator()(T& a, T b) const
+    {
+        if(a < b)
+            a = b;
+    }
+
+    __device__ inline constexpr void operator()(T& a, T b, bool& changed) const
+    {
+        if(a < b)
+        {
+            a       = b;
+            changed = true;
+        }
+        else
+            changed = false;
+    }
+
+    static constexpr bool indexable = true;
+};
+
+template <class T>
+struct Min
+{
+    using dataType = T;
+
+    __device__ static T getZeroVal() { return std::numeric_limits<T>::max(); };
+
+    __device__ inline constexpr void operator()(T& a, T b) const
+    {
+        if(a > b)
+            a = b;
+    }
+
+    __device__ inline constexpr void operator()(T& a, T b, bool& changed) const
+    {
+        if(a > b)
+        {
+            a       = b;
+            changed = true;
+        }
+        else
+            changed = false;
+    }
+
+    static constexpr bool indexable = true;
+};
+
+template <>
+__device__ half Max<half>::getZeroVal()
+{
+    return type_convert<half>{}(std::numeric_limits<float>::min());
+};
+
+template <>
+__device__ half Min<half>::getZeroVal()
+{
+    return type_convert<half>{}(std::numeric_limits<float>::max());
+};
+
+}; // end of namespace reduce
+
+template <typename T, ckReduceTensorOp_t op>
+struct reduce_binary_operator;
+
+template <typename T>
+struct reduce_binary_operator<T, CK_REDUCE_TENSOR_ADD>
+{
+    using opType   = reduce::Add<T>;
+    using dataType = T;
+
+    __device__ static T getZeroVal() { return reduce::Add<T>::getZeroVal(); };
+
+    static constexpr bool indexable = reduce::Add<T>::indexable;
+};
+
+template <typename T>
+struct reduce_binary_operator<T, CK_REDUCE_TENSOR_MUL>
+{
+    using opType   = reduce::Mul<T>;
+    using dataType = T;
+
+    __device__ static T getZeroVal() { return reduce::Mul<T>::getZeroVal(); };
+
+    static constexpr bool indexable = reduce::Mul<T>::indexable;
+};
+
+template <typename T>
+struct reduce_binary_operator<T, CK_REDUCE_TENSOR_MIN>
+{
+    using opType   = reduce::Min<T>;
+    using dataType = T;
+
+    __device__ static T getZeroVal() { return reduce::Min<T>::getZeroVal(); };
+
+    static constexpr bool indexable = reduce::Min<T>::indexable;
+};
+
+template <typename T>
+struct reduce_binary_operator<T, CK_REDUCE_TENSOR_MAX>
+{
+    using opType   = reduce::Max<T>;
+    using dataType = T;
+
+    __device__ static T getZeroVal() { return reduce::Max<T>::getZeroVal(); };
+
+    static constexpr bool indexable = reduce::Max<T>::indexable;
+};
+
+} // end of namespace ck
+
+#endif

--- a/src/kernels/composable_kernel/include/utility/synchronization.hpp
+++ b/src/kernels/composable_kernel/include/utility/synchronization.hpp
@@ -1,0 +1,25 @@
+#ifndef CK_SYNCHRONIZATION_AMD_HPP
+#define CK_SYNCHRONIZATION_AMD_HPP
+
+#include "config.hpp"
+
+namespace ck {
+
+__device__ void __llvm_amdgcn_s_barrier() __asm("llvm.amdgcn.s.barrier");
+
+__device__ void block_sync_lds()
+{
+#if CK_BLOCK_SYNC_LDS_WITHOUT_SYNC_VMEM
+    asm volatile("\
+    s_waitcnt lgkmcnt(0) \n \
+    s_barrier \
+    " ::);
+#else
+    __llvm_amdgcn_s_barrier();
+#endif
+}
+
+__device__ void block_sync_lds_vmem() { __llvm_amdgcn_s_barrier(); }
+
+} // namespace ck
+#endif

--- a/src/kernels/composable_kernel/include/utility/tuple_ext.hpp
+++ b/src/kernels/composable_kernel/include/utility/tuple_ext.hpp
@@ -1,0 +1,36 @@
+#ifndef CK_TUPLE_EXT_HPP_
+#define CK_TUPLE_EXT_HPP_
+
+#include "sequence.hpp"
+#include "tuple.hpp"
+#include "multi_index_transform.hpp"
+
+namespace ck {
+
+template <index_t... Ns>
+__host__ __device__ constexpr auto make_passthrough_tuple(Sequence<Ns...>)
+{
+    return make_tuple(PassThrough<Ns>{}...);
+};
+
+template <index_t... Ids>
+__host__ __device__ constexpr auto make_dimensions_tuple(Sequence<Ids...>)
+{
+    return make_tuple(Sequence<Ids>{}...);
+};
+
+template <typename Seq1, typename Seq2>
+__host__ __device__ constexpr auto make_2d_merge_transform_tuple(Seq1, Seq2)
+{
+    return make_tuple(Merge<Seq1>{}, Merge<Seq2>{});
+};
+
+template <typename Seq>
+__host__ __device__ constexpr auto make_1d_merge_transform_tuple(Seq)
+{
+    return make_tuple(Merge<Seq>{});
+};
+
+}; // end of namespace ck
+
+#endif

--- a/src/kernels/composable_kernel/src/kernel_wrapper/gridwise_convolution_forward_implicit_gemm_v4r4_xdlops_nchw_kcyx_nkhw.cpp
+++ b/src/kernels/composable_kernel/src/kernel_wrapper/gridwise_convolution_forward_implicit_gemm_v4r4_xdlops_nchw_kcyx_nkhw.cpp
@@ -1,0 +1,178 @@
+#include "common_header.hpp"
+#include "gridwise_convolution_forward_implicit_gemm_v4r4_xdlops_nchw_kcyx_nkhw.hpp"
+#include "float_types.h"
+
+extern "C" __global__
+    __launch_bounds__(CK_PARAM_DEPENDENT_BLOCK_SIZE) void gridwise_convolution_forward_implicit_gemm_v4r4_xdlops_nchw_kcyx_nkhw(
+        const FLOAT* const __restrict__ p_in_global,
+        const FLOAT* const __restrict__ p_wei_global,
+        FLOAT* const __restrict__ p_out_global)
+{
+    using namespace ck;
+
+    // read params: problem description
+    constexpr index_t G  = CK_PARAM_PROBLEM_G;
+    constexpr index_t N  = CK_PARAM_PROBLEM_N;
+    constexpr index_t K  = CK_PARAM_PROBLEM_K;
+    constexpr index_t C  = CK_PARAM_PROBLEM_C;
+    constexpr index_t Hi = CK_PARAM_PROBLEM_HI;
+    constexpr index_t Wi = CK_PARAM_PROBLEM_WI;
+    constexpr index_t Ho = CK_PARAM_PROBLEM_HO;
+    constexpr index_t Wo = CK_PARAM_PROBLEM_WO;
+    constexpr index_t Y  = CK_PARAM_PROBLEM_Y;
+    constexpr index_t X  = CK_PARAM_PROBLEM_X;
+
+    constexpr index_t ConvStrideH = CK_PARAM_PROBLEM_CONV_STRIDE_H;
+    constexpr index_t ConvStrideW = CK_PARAM_PROBLEM_CONV_STRIDE_W;
+
+    constexpr index_t ConvDilationH = CK_PARAM_PROBLEM_CONV_DILATION_H;
+    constexpr index_t ConvDilationW = CK_PARAM_PROBLEM_CONV_DILATION_W;
+
+    constexpr index_t InLeftPadH = CK_PARAM_PROBLEM_IN_LEFT_PAD_H;
+    constexpr index_t InLeftPadW = CK_PARAM_PROBLEM_IN_LEFT_PAD_W;
+
+    constexpr index_t InRightPadH = CK_PARAM_PROBLEM_IN_RIGHT_PAD_H;
+    constexpr index_t InRightPadW = CK_PARAM_PROBLEM_IN_RIGHT_PAD_W;
+
+    constexpr auto CPerGroup = C / G;
+
+    constexpr auto in_n_c_hi_wi_desc =
+        make_native_tensor_descriptor_packed(Sequence<N, C, Hi, Wi>{});
+    constexpr auto wei_k_cpergroup_y_x_desc =
+        make_native_tensor_descriptor_packed(Sequence<K, CPerGroup, Y, X>{});
+    constexpr auto out_n_k_ho_wo_desc =
+        make_native_tensor_descriptor_packed(Sequence<N, K, Ho, Wo>{});
+
+    using ConvStrides   = Sequence<ConvStrideH, ConvStrideW>;
+    using ConvDilations = Sequence<ConvDilationH, ConvDilationW>;
+
+    using InLeftPads  = Sequence<InLeftPadH, InLeftPadW>;
+    using InRightPads = Sequence<InRightPadH, InRightPadW>;
+
+    // read params: tunning parameters
+    constexpr index_t GemmMPerBlock = CK_PARAM_TUNABLE_GEMM_M_PER_BLOCK;
+    constexpr index_t GemmNPerBlock = CK_PARAM_TUNABLE_GEMM_N_PER_BLOCK;
+    constexpr index_t GemmKPerBlock = CK_PARAM_TUNABLE_GEMM_K_PER_BLOCK;
+    constexpr index_t GemmMPerWave  = CK_PARAM_TUNABLE_GEMM_M_PER_WAVE;
+    constexpr index_t GemmNPerWave  = CK_PARAM_TUNABLE_GEMM_N_PER_WAVE;
+    constexpr index_t GemmKPack     = CK_PARAM_TUNABLE_GEMM_KPACK;
+
+    // read params: dependent parameters
+    constexpr index_t BlockSize = CK_PARAM_DEPENDENT_BLOCK_SIZE;
+    constexpr index_t GridSize  = CK_PARAM_DEPENDENT_GRID_SIZE;
+
+    // A matrix copy
+    constexpr index_t GemmABlockCopyClusterLengths_GemmK =
+        CK_PARAM_DEPENDENT_GEMM_A_BLOCK_COPY_CLUSTER_LENGTHS_GEMM_K;
+    constexpr index_t GemmABlockCopyClusterLengths_GemmM =
+        CK_PARAM_DEPENDENT_GEMM_A_BLOCK_COPY_CLUSTER_LENGTHS_GEMM_M;
+    constexpr index_t GemmABlockCopyClusterLengths_GemmKPack =
+        CK_PARAM_DEPENDENT_GEMM_A_BLOCK_COPY_CLUSTER_LENGTHS_GEMM_KPACK;
+
+    constexpr index_t GemmABlockCopyThreadSliceLengths_GemmK =
+        GemmKPerBlock / GemmABlockCopyClusterLengths_GemmK;
+    constexpr index_t GemmABlockCopyThreadSliceLengths_GemmM =
+        GemmMPerBlock / GemmABlockCopyClusterLengths_GemmM;
+    constexpr index_t GemmABlockCopyThreadSliceLengths_GemmKPack =
+        GemmKPack / GemmABlockCopyClusterLengths_GemmKPack;
+
+    using GemmABlockCopyClusterLengths_GemmG_GemmK_GemmM_GemmKPack =
+        Sequence<1,
+                 GemmABlockCopyClusterLengths_GemmK,
+                 GemmABlockCopyClusterLengths_GemmM,
+                 GemmABlockCopyClusterLengths_GemmKPack>;
+    using GemmABlockCopySubLengths_GemmG_GemmK_GemmM_GemmKPack =
+        Sequence<1,
+                 GemmABlockCopyThreadSliceLengths_GemmK,
+                 GemmABlockCopyThreadSliceLengths_GemmM,
+                 GemmABlockCopyThreadSliceLengths_GemmKPack>;
+
+    using GemmABlockCopyThreadClusterArrangeOrder =
+        Sequence<0, 2, 1, 3>;                                  // [GemmG, GemmM, GemmK, GemmKPack]
+    using GemmABlockCopySrcAccessOrder = Sequence<0, 2, 1, 3>; // [GemmG, GemmM, GemmK, GemmKPack]
+    using GemmABlockCopyDstAccessOrder = Sequence<0, 1, 2, 3>; // [GemmG, GemmK, GemmM, GemmKPack]
+
+    constexpr index_t GemmABlockCopySrcDataPerRead_GemmKPack =
+        CK_PARAM_DEPENDENT_GEMM_A_BLOCK_COPY_SRC_DATA_PER_READ_GEMM_KPACK;
+
+    constexpr index_t GemmABlockCopyDstDataPerWrite_GemmKPack =
+        CK_PARAM_DEPENDENT_GEMM_A_BLOCK_COPY_DST_DATA_PER_WRITE_GEMM_KPACK;
+
+    // B matrix Copy
+    constexpr index_t GemmBBlockCopyClusterLengths_GemmK =
+        CK_PARAM_DEPENDENT_GEMM_B_BLOCK_COPY_CLUSTER_LENGTHS_GEMM_K;
+    constexpr index_t GemmBBlockCopyClusterLengths_GemmN =
+        CK_PARAM_DEPENDENT_GEMM_B_BLOCK_COPY_CLUSTER_LENGTHS_GEMM_N;
+    constexpr index_t GemmBBlockCopyClusterLengths_GemmKPack =
+        CK_PARAM_DEPENDENT_GEMM_B_BLOCK_COPY_CLUSTER_LENGTHS_GEMM_KPACK;
+
+    constexpr index_t GemmBBlockCopyThreadSliceLengths_GemmK =
+        GemmKPerBlock / GemmBBlockCopyClusterLengths_GemmK;
+    constexpr index_t GemmBBlockCopyThreadSliceLengths_GemmN =
+        GemmNPerBlock / GemmBBlockCopyClusterLengths_GemmN;
+    constexpr index_t GemmBBlockCopyThreadSliceLengths_GemmKPack =
+        GemmKPack / GemmBBlockCopyClusterLengths_GemmKPack;
+
+    using GemmBBlockCopyClusterLengths_GemmG_GemmK_GemmN_GemmKPack =
+        Sequence<1,
+                 GemmBBlockCopyClusterLengths_GemmK,
+                 GemmBBlockCopyClusterLengths_GemmN,
+                 GemmBBlockCopyClusterLengths_GemmKPack>;
+    using GemmBBlockCopySubLengths_GemmG_GemmK_GemmN_GemmKPack =
+        Sequence<1,
+                 GemmBBlockCopyThreadSliceLengths_GemmK,
+                 GemmBBlockCopyThreadSliceLengths_GemmN,
+                 GemmBBlockCopyThreadSliceLengths_GemmKPack>;
+
+    using GemmBBlockCopyThreadClusterArrangeOrder =
+        Sequence<0, 1, 3, 2>;                                  // [GemmG, GemmK, GemmKPack, GemmN]
+    using GemmBBlockCopySrcAccessOrder = Sequence<0, 1, 3, 2>; // [GemmG, GemmK, GemmKPack, GemmN]
+    using GemmBBlockCopyDstAccessOrder = Sequence<0, 1, 2, 3>; // [GemmG, GemmK, GemmN, GemmKPack]
+
+    constexpr index_t GemmBBlockCopySrcDataPerRead_GemmN =
+        CK_PARAM_DEPENDENT_GEMM_B_BLOCK_COPY_SRC_DATA_PER_READ_GEMM_N;
+
+    constexpr index_t GemmBBlockCopyDstDataPerWrite_GemmKPack =
+        CK_PARAM_DEPENDENT_GEMM_B_BLOCK_COPY_DST_DATA_PER_WRITE_GEMM_KPACK;
+
+    // gridwise GEMM
+    constexpr auto wkgrp_schd_order = NBlock1MBlock0;
+
+    constexpr auto gridwise_conv =
+        GridwiseConvolutionForwardImplicitGemm_v4r4_xdlops_nchw_kcyx_nkhw<
+            GridSize,
+            BlockSize,
+            FLOAT,       // Input data type
+            FLOAT_ACCUM, // Acc data type
+            FLOAT,       // Ouput data type
+            decltype(in_n_c_hi_wi_desc),
+            decltype(wei_k_cpergroup_y_x_desc),
+            decltype(out_n_k_ho_wo_desc),
+            G,
+            ConvStrides,
+            ConvDilations,
+            InLeftPads,
+            InRightPads,
+            GemmMPerBlock,
+            GemmNPerBlock,
+            GemmKPerBlock,
+            GemmMPerWave,
+            GemmNPerWave,
+            GemmKPack,
+            GemmABlockCopySubLengths_GemmG_GemmK_GemmM_GemmKPack,
+            GemmABlockCopyClusterLengths_GemmG_GemmK_GemmM_GemmKPack,
+            GemmABlockCopyThreadClusterArrangeOrder,
+            GemmABlockCopySrcAccessOrder,
+            GemmABlockCopyDstAccessOrder,
+            GemmABlockCopySrcDataPerRead_GemmKPack,
+            GemmABlockCopyDstDataPerWrite_GemmKPack,
+            GemmBBlockCopySubLengths_GemmG_GemmK_GemmN_GemmKPack,
+            GemmBBlockCopyClusterLengths_GemmG_GemmK_GemmN_GemmKPack,
+            GemmBBlockCopyThreadClusterArrangeOrder,
+            GemmBBlockCopySrcAccessOrder,
+            GemmBBlockCopyDstAccessOrder,
+            GemmBBlockCopySrcDataPerRead_GemmN,
+            GemmBBlockCopyDstDataPerWrite_GemmKPack,
+            wkgrp_schd_order>{};
+    gridwise_conv.Run(p_in_global, p_wei_global, p_out_global);
+}

--- a/src/kernels/composable_kernel/src/kernel_wrapper/gridwise_generic_reduction.cpp
+++ b/src/kernels/composable_kernel/src/kernel_wrapper/gridwise_generic_reduction.cpp
@@ -1,0 +1,125 @@
+#include "config.hpp"
+#include "number.hpp"
+#include "sequence.hpp"
+#include "tensor_descriptor_helper.hpp"
+#include "reduction_common.hpp"
+#include "gridwise_generic_reduction.hpp"
+
+using namespace ck;
+
+using srcDataType =
+    typename get_type_from_type_enum<static_cast<ckDataType_t>(CK_PARAM_SRC_DATATYPE)>::type;
+using dstDataType =
+    typename get_type_from_type_enum<static_cast<ckDataType_t>(CK_PARAM_DST_DATATYPE)>::type;
+using compType =
+    typename get_type_from_type_enum<static_cast<ckDataType_t>(CK_PARAM_REDUCE_COMPTYPE)>::type;
+
+constexpr int blockSize = CK_PARAM_BLOCKSIZE; // tunable
+constexpr int blkGroupSize =
+    CK_PARAM_BLKGROUPSIZE; // determined by the problem and the selected BlockSize
+
+using srcLengths = Sequence<CK_PARAM_SRC_DESC_LENGTHS>;
+using srcStrides = Sequence<CK_PARAM_SRC_DESC_STRIDES>;
+using dstLengths = Sequence<CK_PARAM_DST_DESC_LENGTHS>;
+using dstStrides = Sequence<CK_PARAM_DST_DESC_STRIDES>;
+
+using toReduceDims  = Sequence<CK_PARAM_TOREDUCE_DIMS>;
+using invariantDims = Sequence<CK_PARAM_INVARIANT_DIMS>;
+
+constexpr ckReduceTensorOp_t op          = static_cast<ckReduceTensorOp_t>(CK_PARAM_REDUCE_OP);
+constexpr ckReductionMethod_t reduceImpl = static_cast<ckReductionMethod_t>(CK_PARAM_REDUCE_IMPL);
+constexpr ckNanPropagation_t nanPropaOpt = static_cast<ckNanPropagation_t>(CK_PARAM_NAN_PROPAGATE);
+constexpr ckReduceTensorIndices_t reduceIndicesOpt =
+    static_cast<ckReduceTensorIndices_t>(CK_PARAM_REDUCE_INDICES);
+
+constexpr int GredThreadBufferLength       = CK_PARAM_THREAD_BUFFER_LENGTH;        // tunable
+constexpr int GredAccessesPerThreadInBlock = CK_PARAM_ACCESSES_PER_THREAD_INBLOCK; // tunable
+constexpr int GredAccessesPerThreadInWarp  = CK_PARAM_ACCESSES_PER_THREAD_INWARP;  // tunable
+
+extern "C" __global__ void gridwise_generic_reduce_1(float alpha,
+                                                     const void* p_src_global,
+                                                     float beta,
+                                                     void* p_dst_global,
+                                                     void* ws_buf1_global,
+                                                     long ws_buf2_bytes_offset,
+                                                     void* indices_global)
+{
+    static_assert(srcLengths::Size() > 0 && srcLengths::Size() == srcStrides::Size(),
+                  "The source desc specification is invalid!");
+    static_assert(dstLengths::Size() > 0 && dstLengths::Size() == dstStrides::Size(),
+                  "The destination desc specification is invalid!");
+    static_assert(dstLengths::Size() <= srcLengths::Size(),
+                  "The destination lengths should be less than source lengths!");
+
+    constexpr auto srcDesc = make_native_tensor_descriptor(srcLengths{}, srcStrides{});
+    constexpr auto dstDesc = make_native_tensor_descriptor(dstLengths{}, dstStrides{});
+
+    constexpr auto gridwise_reduce = Gridwise_generic_reduction<blkGroupSize,
+                                                                blockSize,
+                                                                srcDataType,
+                                                                dstDataType,
+                                                                compType,
+                                                                decltype(srcDesc),
+                                                                toReduceDims,
+                                                                invariantDims,
+                                                                decltype(dstDesc),
+                                                                static_cast<int>(op),
+                                                                static_cast<int>(reduceImpl),
+                                                                static_cast<int>(nanPropaOpt),
+                                                                static_cast<int>(reduceIndicesOpt),
+                                                                GredThreadBufferLength,
+                                                                GredAccessesPerThreadInBlock,
+                                                                GredAccessesPerThreadInWarp>{};
+
+    gridwise_reduce.Run(alpha,
+                        const_cast<const void* const __restrict__>(p_src_global),
+                        beta,
+                        const_cast<void* const __restrict__>(p_dst_global),
+                        const_cast<void* const __restrict__>(ws_buf1_global),
+                        ws_buf2_bytes_offset,
+                        const_cast<void* const __restrict__>(indices_global));
+};
+
+extern "C" __global__ void gridwise_generic_reduce_2(float alpha,
+                                                     const void* p_src_global,
+                                                     float beta,
+                                                     void* p_dst_global,
+                                                     void* ws_buf1_global,
+                                                     long ws_buf2_bytes_offset,
+                                                     void* indices_global)
+{
+    static_assert(srcLengths::Size() > 0 && srcLengths::Size() == srcStrides::Size(),
+                  "The source desc specification is invalid!");
+    static_assert(dstLengths::Size() > 0 && dstLengths::Size() == dstStrides::Size(),
+                  "The destination desc specification is invalid!");
+    static_assert(dstLengths::Size() <= srcLengths::Size(),
+                  "The destination lengths should be less than source lengths!");
+
+    constexpr auto srcDesc = make_native_tensor_descriptor(srcLengths{}, srcStrides{});
+    constexpr auto dstDesc = make_native_tensor_descriptor(dstLengths{}, dstStrides{});
+
+    constexpr auto gridwise_reduce = Gridwise_generic_reduction<blkGroupSize,
+                                                                blockSize,
+                                                                srcDataType,
+                                                                dstDataType,
+                                                                compType,
+                                                                decltype(srcDesc),
+                                                                toReduceDims,
+                                                                invariantDims,
+                                                                decltype(dstDesc),
+                                                                static_cast<int>(op),
+                                                                static_cast<int>(reduceImpl),
+                                                                static_cast<int>(nanPropaOpt),
+                                                                static_cast<int>(reduceIndicesOpt),
+                                                                GredThreadBufferLength,
+                                                                GredAccessesPerThreadInBlock,
+                                                                GredAccessesPerThreadInWarp>{};
+
+    gridwise_reduce.Run_2(alpha,
+                          const_cast<const void* const __restrict__>(p_src_global),
+                          beta,
+                          const_cast<void* const __restrict__>(p_dst_global),
+                          const_cast<void* const __restrict__>(ws_buf1_global),
+                          ws_buf2_bytes_offset,
+                          const_cast<void* const __restrict__>(indices_global));
+};

--- a/src/mlo_dir_conv.cpp
+++ b/src/mlo_dir_conv.cpp
@@ -130,11 +130,13 @@ static auto GetDirectSolvers()
 
 static auto GetImplicitGemmSolvers()
 {
-    return miopen::solver::SolverContainer<miopen::solver::ConvHipImplicitGemmV4R4GenXdlopsFwdFp32,
+    return miopen::solver::SolverContainer<miopen::solver::ConvHipImplicitGemmForwardV4R4Xdlops,
+                                           miopen::solver::ConvHipImplicitGemmV4R4GenXdlopsFwdFp32,
                                            miopen::solver::ConvHipImplicitGemmV4R4Xdlops_1x1,
                                            miopen::solver::ConvHipImplicitGemmV4R4GenFwdXdlops,
                                            miopen::solver::ConvHipImplicitGemmV4R4FwdXdlops,
                                            miopen::solver::ConvHipImplicitGemmBwdDataV1R1Xdlops,
+                                           miopen::solver::ConvHipImplicitGemmBwdDataV4R1Xdlops,
                                            miopen::solver::ConvHipImplicitGemmV4_1x1,
                                            miopen::solver::ConvHipImplicitGemmV4Fwd,
                                            miopen::solver::ConvHipImplicitGemmV4R1Fwd,

--- a/src/ocl/batchnormocl.cpp
+++ b/src/ocl/batchnormocl.cpp
@@ -891,7 +891,7 @@ void BatchNormBackward(Handle& handle,
         // N*H*W < 32M and H*W > 1024, use batchnorm variant#1 implementation which parallelize
         // work groups over channels and loop through NHW.
         //*************************************************************************************************
-        if((in_nhw < (32 * 1024 * 1024) && in_cstride > 1024) || (n > 768))
+        if((in_nhw < (32 * 1024 * 1024) && in_cstride > 1024) || ((n > 768) && (in_cstride > 63)))
         {
             variant    = 1;
             xlocalsize = 1024;

--- a/src/readonlyramdb.cpp
+++ b/src/readonlyramdb.cpp
@@ -39,7 +39,7 @@ ReadonlyRamDb& ReadonlyRamDb::GetCached(const std::string& path,
                                         const std::size_t /*num_cu*/)
 {
     static std::mutex mutex;
-    static const std::lock_guard<std::mutex> lock{mutex};
+    const std::lock_guard<std::mutex> lock{mutex};
 
     static auto instances = std::map<std::string, ReadonlyRamDb*>{};
     const auto it         = instances.find(path);

--- a/src/reducetensor.cpp
+++ b/src/reducetensor.cpp
@@ -1,0 +1,585 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2020 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#include <miopen/config.h>
+#include <miopen/errors.hpp>
+#include <miopen/miopen.h>
+#include <miopen/visit_float.hpp>
+#include <miopen/reduce_common.hpp>
+#include <miopen/handle.hpp>
+#include <miopen/reducetensor.hpp>
+
+#include <cassert>
+#include <cstddef>
+#include <algorithm>
+#include <cmath>
+#include <ostream>
+#include <iostream>
+
+namespace miopen {
+
+using reduce::ReductionMethod_t;
+using reduce::Reduce_DirectThreadWise;
+using reduce::Reduce_DirectWarpWise;
+using reduce::Reduce_BlockWise;
+using reduce::Reduce_MultiBlock;
+
+using reduce::type_convert;
+
+namespace detail {
+
+struct get_tunable_reduction_kernel_constants
+{
+    int GredThreadBufferLength;
+    int GredAccessesPerThreadInBlock;
+    int GredAccessesPerThreadInWarp;
+
+    get_tunable_reduction_kernel_constants(ReductionMethod_t reduceImpl)
+    {
+        switch(reduceImpl)
+        {
+        case Reduce_DirectThreadWise:
+            GredThreadBufferLength       = 8;
+            GredAccessesPerThreadInBlock = 0;
+            GredAccessesPerThreadInWarp  = 0;
+            break;
+        case Reduce_BlockWise:
+            GredThreadBufferLength       = 0;
+            GredAccessesPerThreadInBlock = 2;
+            GredAccessesPerThreadInWarp  = 0;
+            break;
+        case Reduce_DirectWarpWise:
+            GredThreadBufferLength       = 0;
+            GredAccessesPerThreadInBlock = 0;
+            GredAccessesPerThreadInWarp  = 2;
+            break;
+        case Reduce_MultiBlock:
+            GredThreadBufferLength =
+                8; // needed since the second-time reduction could be DirectThreadWise
+            GredAccessesPerThreadInBlock =
+                2; // needed since the second-time reduction could be BlockWise
+            GredAccessesPerThreadInWarp =
+                2; // needed since the second-time reduction could be DirectWarpWise
+            break;
+        };
+    };
+};
+
+struct ReductionKernelConfigurator
+{
+    ReductionKernelConfigurator() = default;
+
+    ReductionKernelConfigurator(int blockSize, int warpSize)
+        : blockSize_(blockSize), warpSize_(warpSize)
+    {
+        GredDirectThreadWiseUpperReductionLen = warpSize;
+        GredDirectWarpWiseUpperReductionLen   = blockSize;
+        GredBlockWiseUpperReductionLen        = blockSize * 4;
+        GredUpperNumBlocksPerReduction        = 32;
+
+        numWarpsPerBlock = blockSize / warpSize;
+    };
+
+    int blockSize_;
+    int warpSize_;
+    int numWarpsPerBlock;
+
+    std::size_t GredDirectThreadWiseUpperReductionLen;
+    std::size_t GredDirectWarpWiseUpperReductionLen;
+    std::size_t GredBlockWiseUpperReductionLen;
+    std::size_t GredUpperNumBlocksPerReduction;
+
+    std::size_t getGridSize(std::size_t invariantLength, std::size_t toReduceLength) const
+    {
+        assert(invariantLength > 0 && toReduceLength > 1);
+
+        if(invariantLength == 1)
+        {
+            if(toReduceLength <
+               GredBlockWiseUpperReductionLen) // let one block to do this only reduction
+                return (1);
+            else
+                return ((toReduceLength + blockSize_ - 1) /
+                        blockSize_); // let multiple blocks to do this only reduction
+        }
+        else
+        {
+            if(toReduceLength <
+               GredDirectThreadWiseUpperReductionLen) // let one thread to do each reduction
+                return ((invariantLength + blockSize_ - 1) / blockSize_);
+            else if(toReduceLength <
+                    GredDirectWarpWiseUpperReductionLen) // let one warp to do each reduction
+                return ((invariantLength + numWarpsPerBlock - 1) / numWarpsPerBlock);
+            else if(toReduceLength <
+                    GredBlockWiseUpperReductionLen) // let one block to do each reduction
+                return (invariantLength);
+            else
+            { // let multiple blocks to do each reduction
+                std::size_t expBlocksPerReduction =
+                    (toReduceLength + GredBlockWiseUpperReductionLen - 1) /
+                    GredBlockWiseUpperReductionLen;
+
+                if(expBlocksPerReduction > GredUpperNumBlocksPerReduction)
+                    return (invariantLength * GredUpperNumBlocksPerReduction);
+                else
+                    return (invariantLength * expBlocksPerReduction);
+            };
+        };
+    };
+
+    ReductionMethod_t getReductionMethod(std::size_t invariantLength,
+                                         std::size_t toReduceLength) const
+    {
+        assert(invariantLength > 0 && toReduceLength > 1);
+
+        if(invariantLength == 1)
+        {
+            if(toReduceLength <
+               GredBlockWiseUpperReductionLen) // let one block to do this only reduction
+                return (Reduce_BlockWise);
+            else // let multiple blocks to do this only reduction
+                return (Reduce_MultiBlock);
+        }
+        else
+        {
+            if(toReduceLength <
+               GredDirectThreadWiseUpperReductionLen) // let one thread to do each reduction
+                return (Reduce_DirectThreadWise);
+            else if(toReduceLength <
+                    GredDirectWarpWiseUpperReductionLen) // let one warp to do each reduction
+                return (Reduce_DirectWarpWise);
+            else if(toReduceLength <
+                    GredBlockWiseUpperReductionLen) // let one block to do each reduction
+                return (Reduce_BlockWise);
+            else
+                return (Reduce_MultiBlock); // let multiple blocks to do each reduction
+        };
+    };
+
+    std::size_t getWorkSpaceSize(std::size_t invariantLength, std::size_t toReduceLength) const
+    {
+        assert(invariantLength > 0 && toReduceLength > 1);
+
+        if(getReductionMethod(invariantLength, toReduceLength) == Reduce_MultiBlock)
+        {
+            auto gridSize = getGridSize(invariantLength, toReduceLength);
+
+            return (gridSize);
+        };
+
+        return (0);
+    };
+
+    std::size_t getGridSize_2(std::size_t invariantLength, std::size_t toReduceLength) const
+    {
+        if(toReduceLength < warpSize_ / 4) // let one thread to do each reduction
+            return ((invariantLength + blockSize_ - 1) / blockSize_);
+        else if(toReduceLength < blockSize_) // let one warp to do each reduction
+            return ((invariantLength + numWarpsPerBlock - 1) / numWarpsPerBlock);
+        else
+            return (invariantLength); // let one block to do each reduction
+    };
+};
+
+inline int GetIndicesTypeSize(miopenIndicesType_t t)
+{
+    switch(t)
+    {
+    case MIOPEN_32BIT_INDICES: return (4);
+    case MIOPEN_64BIT_INDICES: return (8);
+    case MIOPEN_16BIT_INDICES: return (2);
+    case MIOPEN_8BIT_INDICES: return (1);
+    }
+    MIOPEN_THROW("Unknown data type");
+}
+
+inline int GetDataTypeSize(miopenDataType_t t)
+{
+    switch(t)
+    {
+    case miopenHalf: return (2);
+    case miopenFloat: return (4);
+    case miopenInt8: return (1);
+    case miopenInt8x4: return (4);
+    case miopenBFloat16: return (2);
+    case miopenInt32: return (4);
+    default:
+        MIOPEN_THROW("Only float, half, bfloat16, int8, int8x4 data type is supported.");
+        break;
+    };
+};
+
+}; // end of namespace detail
+
+ReduceTensorDescriptor::ReduceTensorDescriptor(miopenReduceTensorOp_t reduceTensorOp,
+                                               miopenDataType_t reduceTensorCompType,
+                                               miopenNanPropagation_t reduceTensorNanOpt,
+                                               miopenReduceTensorIndices_t reduceTensorIndices,
+                                               miopenIndicesType_t reduceTensorIndicesType)
+    : reduceTensorOp_(reduceTensorOp),
+      reduceTensorCompType_(reduceTensorCompType),
+      reduceTensorNanOpt_(reduceTensorNanOpt),
+      reduceTensorIndices_(reduceTensorIndices),
+      reduceTensorIndicesType_(reduceTensorIndicesType)
+{
+    if(reduceTensorIndices == MIOPEN_REDUCE_TENSOR_FLATTENED_INDICES &&
+       reduceTensorIndicesType != MIOPEN_32BIT_INDICES)
+        MIOPEN_THROW("Only int32 type is supported for ReduceTensor indices.");
+};
+
+// return the size of the workspace in bytes, so that the workspace buffer can be prepared by the
+// user
+std::size_t ReduceTensorDescriptor::GetWorkSpaceSize(const Handle& handle,
+                                                     const TensorDescriptor& inDesc,
+                                                     const TensorDescriptor& outDesc) const
+{
+    const auto& inDescLengths  = inDesc.GetLengths();
+    const auto& outDescLengths = outDesc.GetLengths();
+
+    if(inDescLengths.size() != outDescLengths.size())
+        MIOPEN_THROW("The number of dimensions of the input and output tensor should match.");
+
+    for(int i = 0; i < inDescLengths.size(); i++)
+    {
+        if(outDescLengths[i] != 1 && outDescLengths[i] != inDescLengths[i])
+            MIOPEN_THROW("The length of the output tensor dimension should either be 1 or be equal "
+                         "to the length of the corresponding dimension of the input tensor.");
+    };
+
+    auto invariantLength = outDesc.GetElementSize();
+    auto toReduceLength  = inDesc.GetElementSize() / invariantLength;
+
+    detail::ReductionKernelConfigurator configurator(256, handle.GetWavefrontWidth());
+
+    auto workspace_size = configurator.getWorkSpaceSize(invariantLength, toReduceLength);
+
+    auto reduceIndicesOpt = this->reduceTensorIndices_;
+    auto reduceOp         = this->reduceTensorOp_;
+    bool need_indices =
+        (reduceIndicesOpt == MIOPEN_REDUCE_TENSOR_FLATTENED_INDICES) &&
+        (reduceOp == MIOPEN_REDUCE_TENSOR_MIN || reduceOp == MIOPEN_REDUCE_TENSOR_MAX);
+
+    std::size_t wsSizeInBytes =
+        !need_indices ? workspace_size * detail::GetDataTypeSize(inDesc.GetType())
+                      : workspace_size * (detail::GetDataTypeSize(inDesc.GetType()) + sizeof(int)) +
+                            64 + sizeof(int);
+
+    return (wsSizeInBytes);
+};
+
+// return the size of the reduction indices in bytes, so that the indices buffer can be prepared by
+// the user
+std::size_t ReduceTensorDescriptor::GetIndicesSize(const TensorDescriptor& inDesc,
+                                                   const TensorDescriptor& outDesc) const
+{
+    const auto& inDescLengths  = inDesc.GetLengths();
+    const auto& outDescLengths = outDesc.GetLengths();
+
+    if(inDescLengths.size() != outDescLengths.size())
+        MIOPEN_THROW("The number of dimensions of the input and output tensor should match.");
+
+    for(int i = 0; i < inDescLengths.size(); i++)
+    {
+        if(outDescLengths[i] != 1 && outDescLengths[i] != inDescLengths[i])
+            MIOPEN_THROW("The length of the output tensor dimension should either be 1 or be equal "
+                         "to the length of the corresponding dimension of the input tensor.");
+    };
+
+    auto reduceIndicesOpt = this->reduceTensorIndices_;
+    auto reduceOp         = this->reduceTensorOp_;
+    bool need_indices =
+        (reduceIndicesOpt == MIOPEN_REDUCE_TENSOR_FLATTENED_INDICES) &&
+        (reduceOp == MIOPEN_REDUCE_TENSOR_MIN || reduceOp == MIOPEN_REDUCE_TENSOR_MAX);
+
+    if(!need_indices)
+        return (0);
+
+    return (outDesc.GetElementSize() * sizeof(int));
+};
+
+void ReduceTensorDescriptor::ReduceTensor(const Handle& handle,
+                                          Data_t indices,
+                                          size_t indicesSizeInBytes,
+                                          Data_t workspace,
+                                          size_t workspaceSizeInBytes,
+                                          const void* alpha,
+                                          const TensorDescriptor& aDesc,
+                                          ConstData_t A,
+                                          const void* beta,
+                                          const TensorDescriptor& cDesc,
+                                          Data_t C) const
+{
+    const auto srcDataType       = aDesc.GetType();
+    const auto dstDataType       = cDesc.GetType();
+    const auto compType          = this->reduceTensorCompType_;
+    const auto reduceOp          = this->reduceTensorOp_;
+    const auto nanPropaOpt       = this->reduceTensorNanOpt_;
+    const auto reduceIndicesOpt  = this->reduceTensorIndices_;
+    const auto reduceIndicesType = this->reduceTensorIndicesType_;
+
+    const auto& inDescLengths  = aDesc.GetLengths();
+    const auto& inDescStrides  = aDesc.GetStrides();
+    const auto& outDescLengths = cDesc.GetLengths();
+    const auto& outDescStrides = cDesc.GetStrides();
+
+    bool need_indices =
+        (reduceIndicesOpt == MIOPEN_REDUCE_TENSOR_FLATTENED_INDICES) &&
+        (reduceOp == MIOPEN_REDUCE_TENSOR_MIN || reduceOp == MIOPEN_REDUCE_TENSOR_MAX);
+
+    if(inDescLengths.size() > 6)
+        MIOPEN_THROW("Invalid TensorDescriptor, at most number of dimensions of 6 is supported.");
+
+    if(need_indices && (reduceIndicesType != MIOPEN_32BIT_INDICES))
+        MIOPEN_THROW("Only int32 type can be used for ReduceTensor indices.");
+
+    if(inDescLengths.size() != outDescLengths.size())
+        MIOPEN_THROW("The number of dimensions of the input and output tensor should match.");
+
+    for(int i = 0; i < inDescLengths.size(); i++)
+    {
+        if(outDescLengths[i] != 1 && outDescLengths[i] != inDescLengths[i])
+            MIOPEN_THROW("The length of the output tensor dimension should either be 1 or be equal "
+                         "to the length of the corresponding dimension of the input tensor.");
+    };
+
+    std::size_t ws_sizeInBytes      = this->GetWorkSpaceSize(handle, aDesc, cDesc);
+    std::size_t indices_sizeInBytes = this->GetIndicesSize(aDesc, cDesc);
+
+    if(ws_sizeInBytes > workspaceSizeInBytes)
+        MIOPEN_THROW("The workspace size allocated is not enough!");
+
+    if(indices_sizeInBytes > indicesSizeInBytes)
+        MIOPEN_THROW("The indices size allocated is not enough!");
+
+    // void* ws_buf1_global = static_cast<void*>(workspace);
+    Data_t ws_buf1_global     = workspace;
+    long ws_buf2_bytes_offset = 0;
+
+    if(need_indices && workspace != nullptr)
+    {
+        std::size_t aTypeSize = detail::GetDataTypeSize(aDesc.GetType());
+
+        long byteOffset =
+            static_cast<long>((workspaceSizeInBytes / (aTypeSize + sizeof(int))) * aTypeSize);
+
+        ws_buf2_bytes_offset = ((byteOffset + 63) / 64) * 64;
+    };
+
+    // invariantLength and toReduceLength are used to determine the kernel configuration
+    auto invariantLength = cDesc.GetElementSize();
+    auto toReduceLength  = aDesc.GetElementSize() / invariantLength;
+
+    std::vector<std::size_t> invariantLengths;
+    std::vector<std::size_t>
+        invariantStrides; // for construct the compressed destinaton descriptor used for Reduction
+    std::vector<int> toReduceDims;
+    std::vector<int> invariantDims;
+
+    for(int i = 0; i < inDescLengths.size(); i++)
+    {
+        if(outDescLengths[i] == inDescLengths[i])
+        { //  this dimension is invariant
+            invariantDims.push_back(i);
+            invariantLengths.push_back(inDescLengths[i]);
+            invariantStrides.push_back(outDescStrides[i]);
+        }
+        else
+        { // this dimension is toReduce
+            toReduceDims.push_back(i);
+        }
+    };
+
+    if(toReduceDims.empty())
+        MIOPEN_THROW("Invalid TensorDescriptor, at least one dimension of the input tensor should "
+                     "be reduced.");
+
+    const int blockSize = 256; // tunable
+    detail::ReductionKernelConfigurator configurator(blockSize, handle.GetWavefrontWidth());
+
+    ReductionMethod_t reduceImpl = configurator.getReductionMethod(invariantLength, toReduceLength);
+    auto gridSize                = configurator.getGridSize(invariantLength, toReduceLength);
+    int blkGroupSize =
+        (reduceImpl == Reduce_MultiBlock) ? static_cast<int>(gridSize / invariantLength) : 0;
+
+    bool useTwoCalls = (reduceImpl == Reduce_MultiBlock);
+
+    bool reduceAllDims = invariantDims.empty();
+
+    detail::get_tunable_reduction_kernel_constants get_constants(reduceImpl);
+
+    int GredThreadBufferLength       = get_constants.GredThreadBufferLength;
+    int GredAccessesPerThreadInBlock = get_constants.GredAccessesPerThreadInBlock;
+    int GredAccessesPerThreadInWarp  = get_constants.GredAccessesPerThreadInWarp;
+
+    std::string param;
+
+    param = std::string(" -std=c++14 ");
+    param += " -DCK_PARAM_BLOCKSIZE=" + std::to_string(blockSize);
+    param += " -DCK_PARAM_BLKGROUPSIZE=" + std::to_string(blkGroupSize);
+    param += " -DCK_PARAM_SRC_DATATYPE=" + std::to_string(static_cast<int>(srcDataType));
+    param += " -DCK_PARAM_DST_DATATYPE=" + std::to_string(static_cast<int>(dstDataType));
+    param += " -DCK_PARAM_REDUCE_COMPTYPE=" + std::to_string(static_cast<int>(compType));
+
+    param += " -DCK_PARAM_SRC_DESC_LENGTHS=";
+    for(int i = 0; i < inDescLengths.size(); i++)
+    {
+        param += std::to_string(inDescLengths[i]);
+        if(i < inDescLengths.size() - 1)
+            param += ",";
+    };
+
+    param += " -DCK_PARAM_SRC_DESC_STRIDES=";
+    for(int i = 0; i < inDescStrides.size(); i++)
+    {
+        param += std::to_string(inDescStrides[i]);
+        if(i < inDescStrides.size() - 1)
+            param += ",";
+    };
+
+    if(!reduceAllDims)
+    {
+        param += " -DCK_PARAM_DST_DESC_LENGTHS=";
+        for(int i = 0; i < invariantLengths.size(); i++)
+        {
+            param += std::to_string(invariantLengths[i]);
+            if(i < invariantLengths.size() - 1)
+                param += ",";
+        };
+
+        param += " -DCK_PARAM_DST_DESC_STRIDES=";
+        for(int i = 0; i < invariantStrides.size(); i++)
+        {
+            param += std::to_string(invariantStrides[i]);
+            if(i < invariantLengths.size() - 1)
+                param += ",";
+        };
+    }
+    else
+    {
+        param += " -DCK_PARAM_DST_DESC_LENGTHS=1";
+        param += " -DCK_PARAM_DST_DESC_STRIDES=1";
+    };
+
+    param += " -DCK_PARAM_TOREDUCE_DIMS=";
+    for(int i = 0; i < toReduceDims.size(); i++)
+    {
+        param += std::to_string(toReduceDims[i]);
+        if(i < toReduceDims.size() - 1)
+            param += ",";
+    };
+
+    if(!reduceAllDims)
+    {
+        param += " -DCK_PARAM_INVARIANT_DIMS=";
+        for(int i = 0; i < invariantDims.size(); i++)
+        {
+            param += std::to_string(invariantDims[i]);
+            if(i < invariantDims.size() - 1)
+                param += ",";
+        };
+    }
+    else
+        param += " -DCK_PARAM_INVARIANT_DIMS= ";
+
+    param += " -DCK_PARAM_REDUCE_OP=" + std::to_string(static_cast<int>(reduceOp));
+    param += " -DCK_PARAM_NAN_PROPAGATE=" + std::to_string(static_cast<int>(nanPropaOpt));
+    param += " -DCK_PARAM_REDUCE_INDICES=" + std::to_string(static_cast<int>(reduceIndicesOpt));
+
+    param += " -DCK_PARAM_THREAD_BUFFER_LENGTH=" + std::to_string(GredThreadBufferLength);
+    param +=
+        " -DCK_PARAM_ACCESSES_PER_THREAD_INBLOCK=" + std::to_string(GredAccessesPerThreadInBlock);
+    param +=
+        " -DCK_PARAM_ACCESSES_PER_THREAD_INWARP=" + std::to_string(GredAccessesPerThreadInWarp);
+
+    param += " -DCK_PARAM_REDUCE_IMPL=" + std::to_string(static_cast<int>(reduceImpl));
+
+    // to remove the warning from clang-tidy checking
+    param += " -DMIOPEN_USE_FP32=0 -DMIOPEN_USE_FP16=0 ";
+
+    std::string program_name = "gridwise_generic_reduction.cpp";
+    std::string algo_name    = "generic_reduce_tensor";
+    std::string network_config;
+
+    network_config = "reduce_T" + std::to_string(srcDataType) + std::to_string(dstDataType) +
+                     std::to_string(compType) + "IN";
+    for(auto dimLen : inDescLengths)
+        network_config += std::to_string(dimLen) + "_";
+    network_config += "OUT";
+    for(auto dimLen : outDescLengths)
+        network_config += std::to_string(dimLen) + "_";
+    network_config += "BSIZE_" + std::to_string(blockSize);
+
+    // kernel for the first call
+    std::string kernel_name1 = "gridwise_generic_reduce_1";
+
+    const std::vector<size_t> vld_1 = {static_cast<size_t>(blockSize), size_t{1}, size_t{1}};
+    const std::vector<size_t> vgd_1 = {
+        static_cast<size_t>(gridSize * blockSize), size_t{1}, size_t{1}};
+
+    visit_float(srcDataType, [&](auto as_float) {
+        float alphaVal = type_convert<float>{}(*as_float(alpha));
+        float betaVal  = type_convert<float>{}(*as_float(beta));
+
+        handle.AddKernel(
+            algo_name, network_config, program_name, kernel_name1, vld_1, vgd_1, param)(
+            alphaVal, A, betaVal, C, ws_buf1_global, ws_buf2_bytes_offset, indices);
+    });
+
+    if(useTwoCalls)
+    {
+        int toReduceLength_2 = blkGroupSize;
+        int gridSize_2       = configurator.getGridSize_2(invariantLength, toReduceLength_2);
+
+        // compile option and network config for the second-time call
+        const std::vector<size_t> vld_2 = {static_cast<size_t>(blockSize), size_t{1}, size_t{1}};
+        const std::vector<size_t> vgd_2 = {
+            static_cast<size_t>(gridSize_2 * blockSize), size_t{1}, size_t{1}};
+
+        // kernel for the second call
+        std::string kernel_name2 = "gridwise_generic_reduce_2";
+
+        visit_float(srcDataType, [&](auto as_float) {
+            float alphaVal = type_convert<float>{}(*as_float(alpha));
+            float betaVal  = type_convert<float>{}(*as_float(beta));
+
+            handle.AddKernel(
+                algo_name, network_config, program_name, kernel_name2, vld_2, vgd_2, param)(
+                alphaVal, A, betaVal, C, ws_buf1_global, ws_buf2_bytes_offset, indices);
+        });
+    };
+};
+
+std::ostream& operator<<(std::ostream& stream, const ReduceTensorDescriptor& desc)
+{
+    stream << "ReduceTensor Descriptor : " << std::endl;
+    stream << "Reduction Operation Type : " << desc.reduceTensorOp_ << std::endl;
+    stream << "Reduction CompType : " << desc.reduceTensorCompType_ << std::endl;
+    stream << "NanPropagation Option : " << desc.reduceTensorNanOpt_ << std::endl;
+    stream << "Indices Option : " << desc.reduceTensorIndices_ << std::endl;
+
+    return (stream);
+};
+
+} // end of namespace miopen

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -324,6 +324,9 @@ inline SolverRegistrar::SolverRegistrar(IdRegistryData& registry)
 
     RegisterWithSolver(
         registry, ++id, ConvAsmImplicitGemmV4R1DynamicFwd_1x1{}, miopenConvolutionAlgoImplicitGEMM);
+
+    RegisterWithSolver(
+        registry, ++id, ConvHipImplicitGemmForwardV4R4Xdlops{}, miopenConvolutionAlgoImplicitGEMM);
 }
 
 } // namespace solver

--- a/src/solver/conv_hip_implicit_gemm_fwd_v4r4_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_fwd_v4r4_xdlops.cpp
@@ -1,0 +1,967 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2020 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <miopen/conv/invokers/impl_gemm.hpp>
+#include <miopen/solver.hpp>
+#include <miopen/handle.hpp>
+#include <miopen/generic_search.hpp>
+#include <miopen/hip_build_utils.hpp>
+#include "implicitgemm_util.hpp"
+
+namespace miopen {
+namespace solver {
+
+PerformanceImplicitGemmForwardV4R4Xdlops::PerformanceImplicitGemmForwardV4R4Xdlops()
+    : PerformanceImplicitGemmForwardV4R4Xdlops::PerformanceImplicitGemmForwardV4R4Xdlops(
+          4, 4, 1, 4, 4, 1, false, false)
+{
+}
+
+PerformanceImplicitGemmForwardV4R4Xdlops::PerformanceImplicitGemmForwardV4R4Xdlops(
+    int GemmMPerBlock_,
+    int GemmNPerBlock_,
+    int GemmKPerBlock_,
+    int GemmMPerWave_,
+    int GemmNPerWave_,
+    int GemmKPack_,
+    bool GemmAThreadCopyMoreGemmK_,
+    bool GemmBThreadCopyMoreGemmKPack_)
+    : GemmMPerBlock(GemmMPerBlock_),
+      GemmNPerBlock(GemmNPerBlock_),
+      GemmKPerBlock(GemmKPerBlock_),
+      GemmMPerWave(GemmMPerWave_),
+      GemmNPerWave(GemmNPerWave_),
+      GemmKPack(GemmKPack_),
+      GemmAThreadCopyMoreGemmK(GemmAThreadCopyMoreGemmK_),
+      GemmBThreadCopyMoreGemmKPack(GemmBThreadCopyMoreGemmKPack_)
+{
+}
+
+bool PerformanceImplicitGemmForwardV4R4Xdlops::
+operator==(const PerformanceImplicitGemmForwardV4R4Xdlops& other) const
+{
+    // clang-format off
+    return GemmMPerBlock == other.GemmMPerBlock
+        && GemmNPerBlock == other.GemmNPerBlock
+        && GemmKPerBlock == other.GemmKPerBlock
+        && GemmMPerWave == other.GemmMPerWave
+        && GemmNPerWave == other.GemmNPerWave
+        && GemmKPack == other.GemmKPack 
+        && GemmAThreadCopyMoreGemmK  == other.GemmAThreadCopyMoreGemmK
+        && GemmBThreadCopyMoreGemmKPack  == other.GemmBThreadCopyMoreGemmKPack;
+    // clang-format on
+}
+
+bool PerformanceImplicitGemmForwardV4R4Xdlops::SetNextValue()
+{
+    do
+    {
+        // list performance parameters in reverse order, in order for tuning to iterate over the
+        // range in normal order
+        if(!NextFlag<false, true>(GemmBThreadCopyMoreGemmKPack))
+            break;
+        if(!NextFlag<false, false>(GemmAThreadCopyMoreGemmK))
+            break;
+        if(!NextTwoPower<1, 8>(GemmKPack))
+            break;
+        if(!NextTwoPower<4, 128>(GemmNPerWave))
+            break;
+        if(!NextTwoPower<4, 128>(GemmMPerWave))
+            break;
+        if(!NextTwoPower<1, 8>(GemmKPerBlock))
+            break;
+        if(!NextTwoPower<4, 256>(GemmNPerBlock))
+            break;
+        if(!NextTwoPower<4, 256>(GemmMPerBlock))
+            break;
+        return false;
+    } while(false);
+
+    return true;
+}
+
+void PerformanceImplicitGemmForwardV4R4Xdlops::EuristicInit(const ConvolutionContext& ctx)
+{
+    PerformanceImplicitGemmForwardV4R4Xdlops tmp;
+
+    // loop over certain ranges of tuning parameter
+    auto get_euristic_config = [&](auto is_valid_func) {
+        if(ctx.IsFp32())
+        {
+            tmp = {256, 256, 8, 128, 128, 4, false, true};
+
+            bool all_visited = false;
+            do
+            {
+                do
+                {
+                    // list in reverse order of importance,
+                    // and favor large GEMM
+                    if(!PreviousTwoPower<1, 8>(tmp.GemmKPerBlock))
+                        break;
+                    if(!PreviousTwoPower<1, 4>(tmp.GemmKPack))
+                        break;
+                    if(!PreviousTwoPower<4, 128>(tmp.GemmNPerWave))
+                        break;
+                    if(!PreviousTwoPower<4, 128>(tmp.GemmMPerWave))
+                        break;
+                    if(!PreviousTwoPower<4, 256>(tmp.GemmNPerBlock))
+                        break;
+                    if(!PreviousTwoPower<4, 256>(tmp.GemmMPerBlock))
+                        break;
+
+                    all_visited = true;
+                } while(false);
+
+                if(is_valid_func(tmp, ctx))
+                    break;
+            } while(!all_visited);
+        }
+        else if(ctx.IsFp16())
+        {
+            tmp = {256, 256, 8, 128, 128, 8, false, true};
+
+            bool all_visited = false;
+            do
+            {
+                do
+                {
+                    // list in reverse order of importance,
+                    // and favor large GEMM
+                    if(!PreviousTwoPower<1, 8>(tmp.GemmKPerBlock))
+                        break;
+                    if(!PreviousTwoPower<4, 8>(tmp.GemmKPack))
+                        break;
+                    if(!PreviousTwoPower<4, 128>(tmp.GemmNPerWave))
+                        break;
+                    if(!PreviousTwoPower<4, 128>(tmp.GemmMPerWave))
+                        break;
+                    if(!PreviousTwoPower<4, 256>(tmp.GemmNPerBlock))
+                        break;
+                    if(!PreviousTwoPower<4, 256>(tmp.GemmMPerBlock))
+                        break;
+
+                    all_visited = true;
+                } while(false);
+
+                if(is_valid_func(tmp, ctx))
+                    break;
+            } while(!all_visited);
+        }
+        else if(ctx.IsBfp16())
+        {
+            tmp = {256, 256, 8, 128, 128, 8, false, true};
+
+            bool all_visited = false;
+            do
+            {
+                do
+                {
+                    // list in reverse order of importance,
+                    // and favor large GEMM
+                    if(!PreviousTwoPower<1, 8>(tmp.GemmKPerBlock))
+                        break;
+                    if(!PreviousTwoPower<2, 8>(tmp.GemmKPack))
+                        break;
+                    if(!PreviousTwoPower<4, 128>(tmp.GemmNPerWave))
+                        break;
+                    if(!PreviousTwoPower<4, 128>(tmp.GemmMPerWave))
+                        break;
+                    if(!PreviousTwoPower<4, 256>(tmp.GemmNPerBlock))
+                        break;
+                    if(!PreviousTwoPower<4, 256>(tmp.GemmMPerBlock))
+                        break;
+
+                    all_visited = true;
+                } while(false);
+
+                if(is_valid_func(tmp, ctx))
+                    break;
+            } while(!all_visited);
+        }
+        else
+        {
+            MIOPEN_LOG_E("Only fp32, fp16, and bfp16 are supported");
+            assert(false);
+        }
+    };
+
+    // first round: really valid and fast
+    get_euristic_config([](auto config, auto conv_context) {
+        return config.IsReallyValid(conv_context) && config.IsFastToBeUsedForTuning(conv_context);
+    });
+
+    // second round: really valid
+    if(!tmp.IsReallyValid(ctx))
+    {
+        get_euristic_config(
+            [](auto config, auto conv_context) { return config.IsReallyValid(conv_context); });
+    }
+
+    // final check
+    if(!tmp.IsReallyValid(ctx))
+    {
+        MIOPEN_LOG_E("All attempts failed");
+        assert(false);
+    }
+    *this = tmp;
+    MIOPEN_LOG_I(ToString());
+}
+
+std::string PerformanceImplicitGemmForwardV4R4Xdlops::ToString() const
+{
+    std::ostringstream ss;
+    Serialize(ss);
+    return ss.str();
+}
+
+std::tuple<int, bool> PerformanceImplicitGemmForwardV4R4Xdlops::CalculateBlockSize() const
+{
+    int block_size = 0;
+
+    try
+    {
+        if(!(GemmMPerBlock % GemmMPerWave == 0 && GemmNPerBlock % GemmNPerWave == 0))
+            MIOPEN_THROW("invalid performance parameter");
+
+        const auto WaveSize = 64;
+        block_size = (GemmNPerBlock * GemmMPerBlock) / (GemmMPerWave * GemmNPerWave) * WaveSize;
+    }
+    catch(...)
+    {
+        return std::make_tuple(-1, false);
+    }
+
+    return std::make_tuple(block_size, true);
+}
+
+std::tuple<int, bool>
+PerformanceImplicitGemmForwardV4R4Xdlops::CalculateGridSize(const ConvolutionContext& ctx) const
+{
+    int GridSize = 0;
+
+    try
+    {
+        int gemm_g = -1;
+        int gemm_m = -1;
+        int gemm_n = -1;
+
+        std::tie(gemm_g, gemm_m, gemm_n, std::ignore) =
+            ConvHipImplicitGemmForwardV4R4Xdlops::CalculateGemmSize(ctx);
+
+        if(!(gemm_m % GemmMPerBlock == 0 && gemm_n % GemmNPerBlock == 0))
+            MIOPEN_THROW("invalid performance parameter");
+
+        GridSize = gemm_g * (gemm_m / GemmMPerBlock) * (gemm_n / GemmNPerBlock);
+    }
+    catch(...)
+    {
+        return std::make_tuple(-1, false);
+    }
+
+    return std::make_tuple(GridSize, true);
+}
+
+std::tuple<int, int, int, int, int, bool>
+PerformanceImplicitGemmForwardV4R4Xdlops::CalculateGemmABlockCopyPerformanceParameters(
+    const ConvolutionContext& ctx) const
+{
+    // A tensor shape [GemmG, GemmK, GemmM, GemmKPack]
+
+    int ClusterLengths_GemmK     = -1;
+    int ClusterLengths_GemmM     = -1;
+    int ClusterLengths_GemmKPack = -1;
+    int SrcDataPerRead_GemmKPack = ctx.IsFp32() ? amd_buffer_load_max_length<float>()
+                                                : amd_buffer_load_max_length<half_float::half>();
+    int DstDataPerWrite_GemmKPack = ctx.IsFp32() ? amd_lds_write_max_length<float>()
+                                                 : amd_lds_write_max_length<half_float::half>();
+
+    try
+    {
+        bool valid = false;
+
+        int block_size = -1;
+
+        std::tie(block_size, valid) = CalculateBlockSize();
+
+        if(!valid)
+            MIOPEN_THROW("invalid performance parameter");
+
+        // GemmKPack is src vector read dimension, bounded by GemmKPack
+        SrcDataPerRead_GemmKPack = gcd(SrcDataPerRead_GemmKPack, GemmKPack);
+
+        // calculate threadwise copy size
+        auto data_per_thread_copy =
+            std::max(1, (GemmKPerBlock * GemmMPerBlock * GemmKPack) / block_size);
+
+        // make sure a thread can do a full vector load, at the cost that some threads
+        // may not do threadwise copy at all
+        data_per_thread_copy = lcm(data_per_thread_copy, SrcDataPerRead_GemmKPack);
+
+        const auto data_per_thread_copy_gemmkpack = SrcDataPerRead_GemmKPack;
+        const auto tmp = data_per_thread_copy / data_per_thread_copy_gemmkpack;
+
+        int data_per_thread_copy_gemmk = -1;
+        int data_per_thread_copy_gemmm = -1;
+
+        if(GemmAThreadCopyMoreGemmK)
+        {
+            data_per_thread_copy_gemmk = gcd(GemmKPerBlock, tmp);
+            data_per_thread_copy_gemmm = tmp / data_per_thread_copy_gemmk;
+        }
+        else
+        {
+            data_per_thread_copy_gemmm = gcd(GemmMPerBlock, tmp);
+            data_per_thread_copy_gemmk = tmp / data_per_thread_copy_gemmm;
+        }
+
+        // vector write into LDS
+        DstDataPerWrite_GemmKPack = gcd(DstDataPerWrite_GemmKPack, data_per_thread_copy_gemmkpack);
+
+        if(!(GemmKPerBlock % data_per_thread_copy_gemmk == 0 &&
+             GemmMPerBlock % data_per_thread_copy_gemmm == 0 &&
+             GemmKPack % data_per_thread_copy_gemmkpack == 0))
+            MIOPEN_THROW("invalid performance parameter");
+
+        ClusterLengths_GemmK     = GemmKPerBlock / data_per_thread_copy_gemmk;
+        ClusterLengths_GemmM     = GemmMPerBlock / data_per_thread_copy_gemmm;
+        ClusterLengths_GemmKPack = GemmKPack / data_per_thread_copy_gemmkpack;
+
+        // blockwise-copy support that block_size is larger than thread cluster size, which means
+        // some threads may not do threadwise copy
+        if(block_size < ClusterLengths_GemmK * ClusterLengths_GemmM * ClusterLengths_GemmKPack)
+            MIOPEN_THROW("invalid performance parameter");
+    }
+    catch(...)
+    {
+        return std::make_tuple(-1, -1, -1, -1, -1, false);
+    }
+
+    return std::make_tuple(ClusterLengths_GemmK,
+                           ClusterLengths_GemmM,
+                           ClusterLengths_GemmKPack,
+                           SrcDataPerRead_GemmKPack,
+                           DstDataPerWrite_GemmKPack,
+                           true);
+}
+
+std::tuple<int, int, int, int, int, bool>
+PerformanceImplicitGemmForwardV4R4Xdlops::CalculateGemmBBlockCopyPerformanceParameters(
+    const ConvolutionContext& ctx) const
+{
+    // B tensor shape [GemmG, GemmK, GemmN, GemmKPack]
+
+    int ClusterLengths_GemmK     = -1;
+    int ClusterLengths_GemmN     = -1;
+    int ClusterLengths_GemmKPack = -1;
+    int SrcDataPerRead_GemmN     = ctx.IsFp32() ? amd_buffer_load_max_length<float>()
+                                            : amd_buffer_load_max_length<half_float::half>();
+    int DstDataPerWrite_GemmKPack = ctx.IsFp32() ? amd_lds_write_max_length<float>()
+                                                 : amd_lds_write_max_length<half_float::half>();
+
+    try
+    {
+        bool valid = false;
+
+        int block_size = -1;
+
+        std::tie(block_size, valid) = CalculateBlockSize();
+
+        if(!valid)
+            MIOPEN_THROW("invalid performance parameter");
+
+        // GemmN is src vector read dimension
+        // calculate vector length on gemmn dimension based on global tensor layout
+        const auto y  = ConvolutionContextInterpreter::GetFilterHeightY(ctx);
+        const auto x  = ConvolutionContextInterpreter::GetFilterWidthX(ctx);
+        const auto ho = ConvolutionContextInterpreter::GetOutputHeightHo(ctx);
+        const auto wo = ConvolutionContextInterpreter::GetOutputWidthWo(ctx);
+        const auto conv_stride_h =
+            ConvolutionContextInterpreter::GetAdjustedConvolutionStrideH(ctx);
+        const auto conv_stride_w =
+            ConvolutionContextInterpreter::GetAdjustedConvolutionStrideW(ctx);
+        const auto conv_dilation_w =
+            ConvolutionContextInterpreter::GetAdjustedConvolutionDilationW(ctx);
+        const auto in_left_pad_h  = ConvolutionContextInterpreter::GetInputLeftPadH(ctx);
+        const auto in_left_pad_w  = ConvolutionContextInterpreter::GetInputLeftPadW(ctx);
+        const auto in_right_pad_h = ConvolutionContextInterpreter::GetAdjustedInputRightPadH(ctx);
+        const auto in_right_pad_w = ConvolutionContextInterpreter::GetAdjustedInputRightPadW(ctx);
+
+        // GemmN is src vector read dimension, bounded by input tensor global memory layout
+        // TODO this logic need to be more aggresive
+        if(y == 1 && x == 1 && conv_stride_h == 1 && conv_stride_w == 1 && in_left_pad_h == 0 &&
+           in_left_pad_w == 0 && in_right_pad_h == 0 && in_right_pad_w == 0)
+        {
+            SrcDataPerRead_GemmN = gcd(SrcDataPerRead_GemmN, ho * wo);
+        }
+        else if(conv_stride_w == 1 && in_left_pad_w == 0 && in_right_pad_w == 0)
+        {
+            SrcDataPerRead_GemmN = gcd(SrcDataPerRead_GemmN, wo);
+        }
+        else if(conv_stride_w == 1)
+        {
+            SrcDataPerRead_GemmN =
+                gcd(SrcDataPerRead_GemmN, wo, in_left_pad_w, in_right_pad_w, conv_dilation_w);
+        }
+        else
+        {
+            SrcDataPerRead_GemmN = 1;
+        }
+
+        // SrcDataPerRead_GemmN also bounded by GemmNPerBlock
+        SrcDataPerRead_GemmN = gcd(SrcDataPerRead_GemmN, GemmNPerBlock);
+
+        // calculate threadwise copy size
+        auto data_per_thread_copy =
+            std::max(1, (GemmKPerBlock * GemmNPerBlock * GemmKPack) / block_size);
+
+        // make sure a thread can do a full vector load, at the cost that some threads
+        // may not do threadwise copy at all
+        data_per_thread_copy = lcm(data_per_thread_copy, SrcDataPerRead_GemmN);
+
+        const auto data_per_thread_copy_gemmn = SrcDataPerRead_GemmN;
+        const auto tmp                        = data_per_thread_copy / data_per_thread_copy_gemmn;
+
+        int data_per_thread_copy_gemmkpack = -1;
+        int data_per_thread_copy_gemmk     = -1;
+
+        if(GemmBThreadCopyMoreGemmKPack)
+        {
+            data_per_thread_copy_gemmkpack = gcd(GemmKPack, tmp);
+            data_per_thread_copy_gemmk     = tmp / data_per_thread_copy_gemmkpack;
+        }
+        else
+        {
+            data_per_thread_copy_gemmk     = gcd(GemmKPerBlock, tmp);
+            data_per_thread_copy_gemmkpack = tmp / data_per_thread_copy_gemmk;
+        }
+
+        // vector write into LDS
+        DstDataPerWrite_GemmKPack = gcd(DstDataPerWrite_GemmKPack, data_per_thread_copy_gemmkpack);
+
+        if(!(GemmKPerBlock % data_per_thread_copy_gemmk == 0 &&
+             GemmNPerBlock % data_per_thread_copy_gemmn == 0 &&
+             GemmKPack % data_per_thread_copy_gemmkpack == 0))
+            MIOPEN_THROW("invalid performance parameter");
+
+        ClusterLengths_GemmK     = GemmKPerBlock / data_per_thread_copy_gemmk;
+        ClusterLengths_GemmN     = GemmNPerBlock / data_per_thread_copy_gemmn;
+        ClusterLengths_GemmKPack = GemmKPack / data_per_thread_copy_gemmkpack;
+
+        // blockwise-copy support that block_size is larger than thread cluster size, which means
+        // some threads may not do threadwise copy
+        if(block_size < ClusterLengths_GemmK * ClusterLengths_GemmN * ClusterLengths_GemmKPack)
+            MIOPEN_THROW("invalid performance parameter");
+    }
+    catch(...)
+    {
+        return std::make_tuple(-1, -1, -1, -1, -1, false);
+    }
+
+    return std::make_tuple(ClusterLengths_GemmK,
+                           ClusterLengths_GemmN,
+                           ClusterLengths_GemmKPack,
+                           SrcDataPerRead_GemmN,
+                           DstDataPerWrite_GemmKPack,
+                           true);
+}
+
+std::tuple<std::size_t, bool> PerformanceImplicitGemmForwardV4R4Xdlops::CalculateLdsNumberOfByte(
+    const ConvolutionContext& ctx) const
+{
+    const auto a_block_space = GemmKPerBlock * GemmMPerBlock * GemmKPack;
+    const auto b_block_space = GemmKPerBlock * GemmNPerBlock * GemmKPack;
+
+    std::size_t lds_size =
+        (a_block_space + b_block_space) * (ctx.IsFp32() ? sizeof(float) : sizeof(half_float::half));
+
+    return std::make_tuple(lds_size, true);
+}
+
+// Used by IsReallyValid()
+bool PerformanceImplicitGemmForwardV4R4Xdlops::IsValidValue() const
+{
+    // clang-format off
+    return IsTwoPower<4, 256>(GemmMPerBlock)
+        && IsTwoPower<4, 256>(GemmNPerBlock)
+        && IsTwoPower<1, 8>(GemmKPerBlock)
+        && IsTwoPower<4, 128>(GemmMPerWave)
+        && IsTwoPower<4, 128>(GemmNPerWave)
+        && IsTwoPower<1, 8>(GemmKPack);
+    // clang-format on
+}
+
+// Used by EuristicInit() and GenericSearch
+// Only return false if a performance config will violate requirements given by kernel algorithm
+bool PerformanceImplicitGemmForwardV4R4Xdlops::IsReallyValid(const ConvolutionContext& ctx) const
+{
+    if(!IsValidValue())
+        return false;
+
+    if(!IsValidBlockwiseGemmXdlops(
+           ctx, GemmMPerBlock, GemmNPerBlock, GemmKPerBlock, GemmMPerWave, GemmNPerWave, GemmKPack))
+        return false;
+
+    bool valid = false;
+
+    // check blockwise GEMM size
+    {
+        int gemm_m       = -1;
+        int gemm_n       = -1;
+        int gemm_k_total = -1;
+
+        std::tie(std::ignore, gemm_m, gemm_n, gemm_k_total) =
+            ConvHipImplicitGemmForwardV4R4Xdlops::CalculateGemmSize(ctx);
+
+        if(gemm_k_total % GemmKPack != 0)
+            return false;
+
+        const auto gemm_k = gemm_k_total / GemmKPack;
+
+        if(!(gemm_m % GemmMPerBlock == 0 && gemm_n % GemmNPerBlock == 0 &&
+             gemm_k % GemmKPerBlock == 0))
+            return false;
+    }
+
+    // check blockwise copy of A matrix
+    {
+        std::tie(std::ignore, std::ignore, std::ignore, std::ignore, std::ignore, valid) =
+            CalculateGemmABlockCopyPerformanceParameters(ctx);
+
+        if(!valid)
+            return false;
+    }
+
+    // check blockwise copy of B matrix
+    {
+        std::tie(std::ignore, std::ignore, std::ignore, std::ignore, std::ignore, valid) =
+            CalculateGemmBBlockCopyPerformanceParameters(ctx);
+
+        if(!valid)
+            return false;
+    }
+
+    // check LDS allocation
+    std::size_t lds_size = 0;
+    std::tie(lds_size, valid) = CalculateLdsNumberOfByte(ctx);
+
+    return (valid and lds_size <= get_lds_max_number_of_byte());
+}
+
+// Used by GenericSearch, not used by EuristicInit
+// Return false if a performance config is known to be sub-optimal, comparing to other performance
+// config inside tuning range
+bool PerformanceImplicitGemmForwardV4R4Xdlops::IsFastToBeUsedForTuning(
+    const ConvolutionContext& ctx) const
+{
+    // somehow, 128x128 wave-wise GEMM tend to spill register
+    // TODO revisit this when 128x128 wave-wise GEMM become efficient
+    {
+        if(GemmMPerWave * GemmNPerWave > 64 * 128)
+            return false;
+    }
+
+#if WORKAROUND_SWDEV_240356
+    {
+        if(ctx.IsBfp16() && GemmMPerWave * GemmNPerWave > 64 * 64)
+            return false;
+    }
+#endif
+
+    // don't need too many blocks
+    {
+        int gemm_m = 0;
+        int gemm_n = 0;
+
+        std::tie(std::ignore, gemm_m, gemm_n, std::ignore) =
+            ConvHipImplicitGemmForwardV4R4Xdlops::CalculateGemmSize(ctx);
+
+        // this is grid size using current blockwise-GEMM
+        const int grid_size = (gemm_m * gemm_n) / (GemmMPerBlock * GemmNPerBlock);
+
+        // this the the biggest blockwise-GEMM you can do
+        int max_blockwise_gemm_size =
+#if WORKAROUND_SWDEV_240356
+            gcd(128, gemm_m) * gcd(128, gemm_n);
+#else
+            std::max(gcd(256, gemm_m) * gcd(128, gemm_n), gcd(128, gemm_m) * gcd(256, gemm_n));
+#endif
+
+        // this is the grid size using the biggest blockwise-GEMM
+        auto grid_size_max_blockwise_gemm =
+            (std::size_t(gemm_m) * gemm_n) / max_blockwise_gemm_size;
+
+        const float ratio = float(grid_size) / grid_size_max_blockwise_gemm;
+
+        if(grid_size_max_blockwise_gemm > 600)
+        {
+            if(ratio > 1.41)
+                return false;
+        }
+        if(grid_size_max_blockwise_gemm > 480)
+        {
+            if(ratio > 1.81)
+                return false;
+        }
+        if(grid_size_max_blockwise_gemm > 360)
+        {
+            if(ratio > 2.21)
+                return false;
+        }
+        if(grid_size_max_blockwise_gemm > 240)
+        {
+            if(ratio > 3.21)
+                return false;
+        }
+        else if(grid_size_max_blockwise_gemm > 120)
+        {
+            if(ratio > 6.21)
+                return false;
+        }
+    }
+
+    // don't need too many waves per block
+    {
+        const int wave_per_block = (GemmMPerBlock / GemmMPerWave) * (GemmNPerBlock / GemmNPerWave);
+
+        if(!(wave_per_block > 1 && wave_per_block <= 4))
+        {
+            return false;
+        }
+    }
+
+    // avoid skinny blockwise GEMM whenever possible
+    {
+        int gemm_m = 0;
+        int gemm_n = 0;
+
+        std::tie(std::ignore, gemm_m, gemm_n, std::ignore) =
+            ConvHipImplicitGemmForwardV4R4Xdlops::CalculateGemmSize(ctx);
+
+        if(GemmMPerBlock > 2 * GemmNPerBlock)
+        {
+            if(gemm_n % (2 * GemmNPerBlock) == 0)
+                return false;
+        }
+
+        if(GemmNPerBlock > 2 * GemmMPerBlock)
+        {
+            if(gemm_m % (2 * GemmMPerBlock) == 0)
+                return false;
+        }
+    }
+
+    // avoid skinny wavewise GEMM whenever possible
+    {
+        if(GemmMPerWave > 2 * GemmNPerWave)
+        {
+            if(GemmNPerBlock % (2 * GemmNPerWave) == 0)
+                return false;
+        }
+
+        if(GemmNPerWave > 2 * GemmMPerWave)
+        {
+            if(GemmMPerBlock % (2 * GemmMPerWave) == 0)
+                return false;
+        }
+    }
+
+    // each thread should not too much data
+    {
+        const int block_size = (GemmMPerBlock / GemmMPerWave) * (GemmNPerBlock / GemmNPerWave) * 64;
+
+        const int a_data_per_thread_copy = (GemmKPerBlock * GemmMPerBlock * GemmKPack) / block_size;
+        const int b_data_per_thread_copy = (GemmKPerBlock * GemmNPerBlock * GemmKPack) / block_size;
+
+        if(ctx.IsFp32())
+        {
+            if(a_data_per_thread_copy > 16 || b_data_per_thread_copy > 16)
+                return false;
+        }
+        else if(ctx.IsFp16() || ctx.IsBfp16())
+        {
+            if(a_data_per_thread_copy > 32 || b_data_per_thread_copy > 32)
+                return false;
+        }
+    }
+
+    // GemmKPerBlock*GemmKPack should not be too small, otherwise read performance of A matrix would
+    // be bad
+    {
+        if(ctx.IsFp32())
+        {
+            if(GemmKPack > 4)
+                return false;
+
+            if(GemmKPerBlock * GemmKPack < 8)
+                return false;
+        }
+        else if(ctx.IsFp16() || ctx.IsBfp16())
+        {
+            if(GemmKPerBlock * GemmKPack < 16)
+                return false;
+        }
+    }
+
+    return true;
+}
+
+// Used by GenericSearch, not used by EuristicInit
+// Return false, if you don't want to this to be included in tuning range used by generic search
+// A performance config may still be valid w.r.t algorithm correctness, even when IsValid() return
+// false
+bool PerformanceImplicitGemmForwardV4R4Xdlops::IsValid(const ConvolutionContext& ctx) const
+{
+    return IsReallyValid(ctx) && IsFastToBeUsedForTuning(ctx);
+}
+
+// Used by GenericSearch, not used by EuristicInit
+bool ConvHipImplicitGemmForwardV4R4Xdlops::IsValidPerformanceConfig(
+    const ConvolutionContext& ctx, const PerformanceImplicitGemmForwardV4R4Xdlops& c) const
+{
+    return c.IsReallyValid(ctx);
+}
+
+std::tuple<int, int, int, int>
+ConvHipImplicitGemmForwardV4R4Xdlops::CalculateGemmSize(const ConvolutionContext& ctx)
+{
+    const auto g  = ConvolutionContextInterpreter::GetGroupCountG(ctx);
+    const auto n  = ConvolutionContextInterpreter::GetBatchN(ctx);
+    const auto k  = ConvolutionContextInterpreter::GetOutputChannelK(ctx);
+    const auto c  = ConvolutionContextInterpreter::GetInputChannelC(ctx);
+    const auto ho = ConvolutionContextInterpreter::GetOutputHeightHo(ctx);
+    const auto wo = ConvolutionContextInterpreter::GetOutputWidthWo(ctx);
+    const auto y  = ConvolutionContextInterpreter::GetFilterHeightY(ctx);
+    const auto x  = ConvolutionContextInterpreter::GetFilterWidthX(ctx);
+
+    const auto k_per_group = k / g;
+    const auto c_per_group = c / g;
+
+    const auto gemm_g       = g;
+    const auto gemm_m       = k_per_group;
+    const auto gemm_n       = n * ho * wo;
+    const auto gemm_k_total = c_per_group * y * x;
+
+    return std::make_tuple(gemm_g, gemm_m, gemm_n, gemm_k_total);
+}
+
+PerformanceImplicitGemmForwardV4R4Xdlops
+ConvHipImplicitGemmForwardV4R4Xdlops::GetPerformanceConfig(const ConvolutionContext& ctx) const
+{
+    PerformanceImplicitGemmForwardV4R4Xdlops config;
+    config.EuristicInit(ctx);
+    MIOPEN_LOG_I(config.ToString());
+    return config;
+}
+
+ConvSolution ConvHipImplicitGemmForwardV4R4Xdlops::GetSolution(
+    const ConvolutionContext& ctx,
+    const PerformanceImplicitGemmForwardV4R4Xdlops& config,
+    bool) const
+{
+    ConvSolution result;
+    KernelInfo construction_parameters;
+
+    assert(config.IsReallyValid(ctx));
+
+    construction_parameters.kernel_file =
+        "gridwise_convolution_forward_implicit_gemm_v4r4_xdlops_nchw_kcyx_nkhw.cpp";
+
+    construction_parameters.kernel_name =
+        "gridwise_convolution_forward_implicit_gemm_v4r4_xdlops_nchw_kcyx_nkhw";
+
+    int grid_size  = 0;
+    int block_size = 0;
+
+    std::tie(grid_size, std::ignore)  = config.CalculateGridSize(ctx);
+    std::tie(block_size, std::ignore) = config.CalculateBlockSize();
+
+    construction_parameters.l_wk.push_back(block_size);
+    construction_parameters.l_wk.push_back(1);
+    construction_parameters.l_wk.push_back(1);
+
+    construction_parameters.g_wk.push_back(block_size * grid_size);
+    construction_parameters.g_wk.push_back(1);
+    construction_parameters.g_wk.push_back(1);
+
+    int GemmABlockCopyClusterLengths_GemmK      = -1;
+    int GemmABlockCopyClusterLengths_GemmM      = -1;
+    int GemmABlockCopyClusterLengths_GemmKPack  = -1;
+    int GemmABlockCopySrcDataPerRead_GemmKPack  = -1;
+    int GemmABlockCopyDstDataPerWrite_GemmKPack = -1;
+
+    int GemmBBlockCopyClusterLengths_GemmK      = -1;
+    int GemmBBlockCopyClusterLengths_GemmN      = -1;
+    int GemmBBlockCopyClusterLengths_GemmKPack  = -1;
+    int GemmBBlockCopySrcDataPerRead_GemmN      = -1;
+    int GemmBBlockCopyDstDataPerWrite_GemmKPack = -1;
+
+    std::tie(GemmABlockCopyClusterLengths_GemmK,
+             GemmABlockCopyClusterLengths_GemmM,
+             GemmABlockCopyClusterLengths_GemmKPack,
+             GemmABlockCopySrcDataPerRead_GemmKPack,
+             GemmABlockCopyDstDataPerWrite_GemmKPack,
+             std::ignore) = config.CalculateGemmABlockCopyPerformanceParameters(ctx);
+
+    std::tie(GemmBBlockCopyClusterLengths_GemmK,
+             GemmBBlockCopyClusterLengths_GemmN,
+             GemmBBlockCopyClusterLengths_GemmKPack,
+             GemmBBlockCopySrcDataPerRead_GemmN,
+             GemmBBlockCopyDstDataPerWrite_GemmKPack,
+             std::ignore) = config.CalculateGemmBBlockCopyPerformanceParameters(ctx);
+
+    // clang-format off
+    construction_parameters.comp_options =
+        std::string(" -std=c++14 ") +
+        std::string(" -DCK_PARAM_PROBLEM_G=") + std::to_string(ConvolutionContextInterpreter::GetGroupCountG(ctx)) +
+        std::string(" -DCK_PARAM_PROBLEM_N=") + std::to_string(ConvolutionContextInterpreter::GetBatchN(ctx)) +
+        std::string(" -DCK_PARAM_PROBLEM_K=") + std::to_string(ConvolutionContextInterpreter::GetOutputChannelK(ctx)) +
+        std::string(" -DCK_PARAM_PROBLEM_C=") + std::to_string(ConvolutionContextInterpreter::GetInputChannelC(ctx)) +
+        std::string(" -DCK_PARAM_PROBLEM_HI=") + std::to_string(ConvolutionContextInterpreter::GetInputHeightHi(ctx)) +
+        std::string(" -DCK_PARAM_PROBLEM_WI=") + std::to_string(ConvolutionContextInterpreter::GetInputWidthWi(ctx)) +
+        std::string(" -DCK_PARAM_PROBLEM_HO=") + std::to_string(ConvolutionContextInterpreter::GetOutputHeightHo(ctx)) +
+        std::string(" -DCK_PARAM_PROBLEM_WO=") + std::to_string(ConvolutionContextInterpreter::GetOutputWidthWo(ctx)) +
+        std::string(" -DCK_PARAM_PROBLEM_Y=") + std::to_string(ConvolutionContextInterpreter::GetFilterHeightY(ctx)) +
+        std::string(" -DCK_PARAM_PROBLEM_X=") + std::to_string(ConvolutionContextInterpreter::GetFilterWidthX(ctx)) +
+        std::string(" -DCK_PARAM_PROBLEM_CONV_STRIDE_H=") + std::to_string(ConvolutionContextInterpreter::GetAdjustedConvolutionStrideH(ctx)) +
+        std::string(" -DCK_PARAM_PROBLEM_CONV_STRIDE_W=") + std::to_string(ConvolutionContextInterpreter::GetAdjustedConvolutionStrideW(ctx)) +
+        std::string(" -DCK_PARAM_PROBLEM_CONV_DILATION_H=") + std::to_string(ConvolutionContextInterpreter::GetAdjustedConvolutionDilationH(ctx)) +
+        std::string(" -DCK_PARAM_PROBLEM_CONV_DILATION_W=") + std::to_string(ConvolutionContextInterpreter::GetAdjustedConvolutionDilationW(ctx)) +
+        std::string(" -DCK_PARAM_PROBLEM_IN_LEFT_PAD_H=") + std::to_string(ConvolutionContextInterpreter::GetInputLeftPadH(ctx)) +
+        std::string(" -DCK_PARAM_PROBLEM_IN_LEFT_PAD_W=") + std::to_string(ConvolutionContextInterpreter::GetInputLeftPadW(ctx)) +
+        std::string(" -DCK_PARAM_PROBLEM_IN_RIGHT_PAD_H=") + std::to_string(ConvolutionContextInterpreter::GetAdjustedInputRightPadH(ctx)) +
+        std::string(" -DCK_PARAM_PROBLEM_IN_RIGHT_PAD_W=") + std::to_string(ConvolutionContextInterpreter::GetAdjustedInputRightPadW(ctx)) +
+        std::string(" -DCK_PARAM_TUNABLE_GEMM_M_PER_BLOCK=") + std::to_string(config.GemmMPerBlock) +
+        std::string(" -DCK_PARAM_TUNABLE_GEMM_N_PER_BLOCK=") + std::to_string(config.GemmNPerBlock) +
+        std::string(" -DCK_PARAM_TUNABLE_GEMM_K_PER_BLOCK=") + std::to_string(config.GemmKPerBlock) +
+        std::string(" -DCK_PARAM_TUNABLE_GEMM_M_PER_WAVE=") + std::to_string(config.GemmMPerWave) +
+        std::string(" -DCK_PARAM_TUNABLE_GEMM_N_PER_WAVE=") + std::to_string(config.GemmNPerWave) +
+        std::string(" -DCK_PARAM_TUNABLE_GEMM_KPACK=") + std::to_string(config.GemmKPack) +
+        std::string(" -DCK_PARAM_DEPENDENT_BLOCK_SIZE=") + std::to_string(block_size) +
+        std::string(" -DCK_PARAM_DEPENDENT_GRID_SIZE=") + std::to_string(grid_size) +
+        std::string(" -DCK_PARAM_DEPENDENT_GEMM_A_BLOCK_COPY_CLUSTER_LENGTHS_GEMM_K=") + std::to_string(GemmABlockCopyClusterLengths_GemmK) +
+        std::string(" -DCK_PARAM_DEPENDENT_GEMM_A_BLOCK_COPY_CLUSTER_LENGTHS_GEMM_M=") + std::to_string(GemmABlockCopyClusterLengths_GemmM) +
+        std::string(" -DCK_PARAM_DEPENDENT_GEMM_A_BLOCK_COPY_CLUSTER_LENGTHS_GEMM_KPACK=") + std::to_string(GemmABlockCopyClusterLengths_GemmKPack) +
+        std::string(" -DCK_PARAM_DEPENDENT_GEMM_A_BLOCK_COPY_SRC_DATA_PER_READ_GEMM_KPACK=") + std::to_string(GemmABlockCopySrcDataPerRead_GemmKPack) +
+        std::string(" -DCK_PARAM_DEPENDENT_GEMM_A_BLOCK_COPY_DST_DATA_PER_WRITE_GEMM_KPACK=") + std::to_string(GemmABlockCopyDstDataPerWrite_GemmKPack) +
+        std::string(" -DCK_PARAM_DEPENDENT_GEMM_B_BLOCK_COPY_CLUSTER_LENGTHS_GEMM_K=") + std::to_string(GemmBBlockCopyClusterLengths_GemmK) +
+        std::string(" -DCK_PARAM_DEPENDENT_GEMM_B_BLOCK_COPY_CLUSTER_LENGTHS_GEMM_N=") + std::to_string(GemmBBlockCopyClusterLengths_GemmN) +
+        std::string(" -DCK_PARAM_DEPENDENT_GEMM_B_BLOCK_COPY_CLUSTER_LENGTHS_GEMM_KPACK=") + std::to_string(GemmBBlockCopyClusterLengths_GemmKPack) +
+        std::string(" -DCK_PARAM_DEPENDENT_GEMM_B_BLOCK_COPY_SRC_DATA_PER_READ_GEMM_N=") + std::to_string(GemmBBlockCopySrcDataPerRead_GemmN) +
+        std::string(" -DCK_PARAM_DEPENDENT_GEMM_B_BLOCK_COPY_DST_DATA_PER_WRITE_GEMM_KPACK=") + std::to_string(GemmBBlockCopyDstDataPerWrite_GemmKPack) +
+        std::string(" -DCK_USE_AMD_XDLOPS=") + std::to_string(IsXdlopsSupport(ctx) ? 1 : 0) +
+        std::string(" -DCK_USE_AMD_XDLOPS_INLINE_ASM=") + std::to_string(miopen::IsEnabled(MIOPEN_DEBUG_IMPLICIT_GEMM_XDLOPS_INLINE_ASM{}) ? 1 : 0) +
+        std::string(" -DCK_USE_AMD_XDLOPS_EMULATE=") + (miopen::IsEnabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_XDLOPS_EMULATE{}) ? '1' : '0') +
+        std::string(" -DCK_BLOCK_SYNC_LDS_WITHOUT_SYNC_VMEM=") + (miopen::IsDisabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_BLOCK_SYNC_LDS_WITHOUT_SYNC_VMEM{}) ? '0' : '1') +
+        std::string(" -DCK_WORKAROUND_SWDEV_229564=") + std::to_string(WORKAROUND_SWDEV_229564) +
+        std::string(" -DCK_WORKAROUND_SWDEV_231101=") + std::to_string(WORKAROUND_SWDEV_231101) +
+        ctx.general_compile_options;
+    // clang-format on
+
+    result.invoker_factory = conv::MakeImplGemmDataInvokerFactory(ctx);
+    result.construction_params.push_back(construction_parameters);
+    return result;
+}
+
+int ConvHipImplicitGemmForwardV4R4Xdlops::RunAndMeasureSolution(const miopen::Handle& profile_h,
+                                                                ConstData_t bot_buf,
+                                                                Data_t top_buf,
+                                                                ConstData_t wei_buf,
+                                                                ConstData_t bias_buf,
+                                                                const ConvolutionContext& ctx,
+                                                                const ConvSolution& solution,
+                                                                float& elapsed_time) const
+{
+    assert(bias_buf == nullptr);
+    (void)bias_buf;
+
+    return RunAndMeasureSolutionBase(
+        profile_h, bot_buf, top_buf, wei_buf, ctx, solution, elapsed_time);
+}
+
+bool ConvHipImplicitGemmForwardV4R4Xdlops::IsApplicable(const ConvolutionContext& ctx) const
+{
+    if(!IsXdlopsSupport(ctx))
+        return false;
+
+    if(!(ctx.IsFp32() || ctx.IsFp16() || ctx.IsBfp16()))
+        return false;
+
+    if(!ctx.direction.IsForward())
+        return false;
+
+    if(!ctx.Is2d())
+        return false;
+
+    if(!IsIndexRangeLargeEnough(ctx))
+        return false;
+
+#if WORKAROUND_SWDEV_239555
+    if(ctx.IsFp16() || ctx.IsBfp16())
+    {
+        const auto y              = ConvolutionContextInterpreter::GetFilterHeightY(ctx);
+        const auto x              = ConvolutionContextInterpreter::GetFilterWidthX(ctx);
+        const auto in_left_pad_h  = ConvolutionContextInterpreter::GetInputLeftPadH(ctx);
+        const auto in_left_pad_w  = ConvolutionContextInterpreter::GetInputLeftPadW(ctx);
+        const auto in_right_pad_h = ConvolutionContextInterpreter::GetAdjustedInputRightPadH(ctx);
+        const auto in_right_pad_w = ConvolutionContextInterpreter::GetAdjustedInputRightPadW(ctx);
+
+        if((y > 1 || x > 1) &&
+           (in_left_pad_h > 0 || in_left_pad_w > 0 || in_right_pad_h > 0 || in_right_pad_w > 0))
+            return false;
+    }
+#endif
+
+    // gemm size
+    {
+        int gemm_g       = -1;
+        int gemm_m       = -1;
+        int gemm_n       = -1;
+        int gemm_k_total = -1;
+
+        std::tie(gemm_g, gemm_m, gemm_n, gemm_k_total) = CalculateGemmSize(ctx);
+
+        if(!IsValidGridGemmXdlops(gemm_m, gemm_n, gemm_k_total))
+            return false;
+    }
+
+    // this particular EuristicInit is so comprehensive, that if it cannot predict a valid
+    // performance config, the problem is probably not applicable
+    PerformanceImplicitGemmForwardV4R4Xdlops config;
+    config.EuristicInit(ctx);
+
+    return config.IsReallyValid(ctx);
+}
+
+PerformanceImplicitGemmForwardV4R4Xdlops
+ConvHipImplicitGemmForwardV4R4Xdlops::Search(const ConvolutionContext& ctx) const
+
+{
+    return GenericSearchFwd(*this, ctx);
+}
+
+} // namespace solver
+} // namespace miopen

--- a/src/solver/conv_hip_implicit_gemm_v4r4_gen_xdlops_fwd_fp32.cpp
+++ b/src/solver/conv_hip_implicit_gemm_v4r4_gen_xdlops_fwd_fp32.cpp
@@ -249,9 +249,9 @@ bool PerformanceImplicitGemmV4R4GenXdlopsFwdFp32::IsValid(const ConvolutionConte
     // heuristic to reduce search space
     {
         // use largest XdlopsGemm
-        if(GemmMPerBlock >= 64 && GemmMPerWave != 64)
+        if(GemmMPerBlock >= 64 && GemmMPerWave < 64)
             return false;
-        if(GemmNPerBlock >= 64 && GemmNPerWave != 64)
+        if(GemmNPerBlock >= 64 && GemmNPerWave < 64)
             return false;
         if((GemmMPerBlock == 32 || GemmMPerBlock == 16) && GemmMPerWave != GemmMPerBlock)
             return false;
@@ -335,8 +335,8 @@ bool PerformanceImplicitGemmV4R4GenXdlopsFwdFp32::IsValidValue() const
         IsTwoPower<4,128>(GemmMPerBlock)
         && IsTwoPower<16,128>(GemmNPerBlock)
         && IsTwoPower<4,16>(GemmKPerBlock)
-        && IsTwoPower<4,64>(GemmMPerWave)
-        && IsTwoPower<16,64>(GemmNPerWave);
+        && IsTwoPower<4,128>(GemmMPerWave)
+        && IsTwoPower<16,128>(GemmNPerWave);
     // clang-format on
 }
 
@@ -350,9 +350,9 @@ bool PerformanceImplicitGemmV4R4GenXdlopsFwdFp32::SetNextValue()
             break;
         if(!NextTwoPower<4, 16>(GemmKPerBlock))
             break;
-        if(!NextTwoPower<4, 64>(GemmMPerWave))
+        if(!NextTwoPower<4, 128>(GemmMPerWave))
             break;
-        if(!NextTwoPower<16, 64>(GemmNPerWave))
+        if(!NextTwoPower<16, 128>(GemmNPerWave))
             break;
         return false;
     } while(false);

--- a/src/solver/implicitgemm_util.hpp
+++ b/src/solver/implicitgemm_util.hpp
@@ -6,24 +6,34 @@
 #include <miopen/hip_build_utils.hpp>
 #include <miopen/mlo_internal.hpp>
 
-MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_XDLOPS)
-MIOPEN_DECLARE_ENV_VAR(
-    MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_XDLOPS_EMULATE) // For internal debug purposes
-
 MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEBUG_IMPLICIT_GEMM_NON_XDLOPS_INLINE_ASM)
+MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_XDLOPS)
+MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_XDLOPS_EMULATE)
 MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEBUG_IMPLICIT_GEMM_XDLOPS_INLINE_ASM)
+MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_BLOCK_SYNC_LDS_WITHOUT_SYNC_VMEM)
 
 #define WORKAROUND_SWDEV_200782 1
-
 #define WORKAROUND_SWDEV_229277_227616_229195 1
+// workaround for unnecessary VGPA <--> AGRP data movement when using mfma LLVM intrinsic
+#define WORKAROUND_SWDEV_229564 1
+// workaround for buffer load/store fp16/bfp16 intrinsic bug
+#define WORKAROUND_SWDEV_231101 1
+// workaround compiler bug: GPU memory access fault when there is padding in fp16/bfp16 case
+#define WORKAROUND_SWDEV_239555 1
+// LLVM xdlops instrinsic will do unnecessey VGRP <--> AGPR movement, and result in
+// register spill, for bfloat16 datatype, when doing wave-wise GEMM larger than 64x64
+#define WORKAROUND_SWDEV_240356 1
 
 namespace miopen {
+
 namespace solver {
 
 // greatest common divisor, aka highest common factor
 template <typename T>
 T gcd(T x, T y)
 {
+    assert(!(x == 0 && y == 0));
+
     if(x == y || x == 0)
     {
         return y;
@@ -380,6 +390,33 @@ inline static bool NextTwoPower(int& v)
     return false;
 }
 
+template <int L, int H>
+inline static bool PreviousTwoPower(int& v)
+{
+    static_assert((((L - 1) & L) == 0), "L is not power of 2");
+    static_assert((((H - 1) & H) == 0), "H is not power of 2");
+    assert((IsTwoPower<L, H>(v)));
+    if(v == L)
+    {
+        v = H;
+        return true;
+    }
+    v /= 2;
+    return false;
+}
+
+template <bool L, bool H>
+inline static bool NextFlag(bool& v)
+{
+    if(v == H)
+    {
+        v = L;
+        return true;
+    }
+    v = H;
+    return false;
+}
+
 static inline bool IsXdlopsSupport(const ConvolutionContext& c)
 {
     if(miopen::IsEnabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_XDLOPS_EMULATE{}))
@@ -399,11 +436,13 @@ static inline bool IsXdlopsSupport(const ConvolutionContext& c)
 #endif
 }
 
+///\todo remove
 inline static uint32_t GetReadWriteVectorSize(const int v)
 {
     return v % 4 == 0 ? 4 : (v % 2 == 0 ? 2 : 1);
 }
 
+///\todo remove
 inline static uint32_t GetEPackLength(const ConvolutionContext& ctx, bool isXdlopsInvoked)
 {
     // Based on data type, Es are packed
@@ -423,6 +462,7 @@ inline static uint32_t GetEPackLength(const ConvolutionContext& ctx, bool isXdlo
     return EPACK;
 }
 
+///\todo remove
 static inline bool IsValidXdlopsGemm(const int GemmMPerBlock,
                                      const int GemmNPerBlock,
                                      const int GemmKPackedPerBlock, // packed
@@ -442,9 +482,60 @@ static inline bool IsValidXdlopsGemm(const int GemmMPerBlock,
         return false;
     if(GemmMPerWave == 16 && GemmNPerWave == 16 && GemmKPackedPerBlock % 4 != 0)
         return false;
+    if(GemmMPerWave > 64 && GemmNPerWave < 64)
+        return false;
+    if(GemmNPerWave > 64 && GemmMPerWave < 64)
+        return false;
 
-    const auto WaveSize  = 64;
-    const auto BlockSize = GemmNPerBlock * GemmMPerBlock / (GemmMPerWave * GemmNPerWave) * WaveSize;
+    const auto WaveSize = 64;
+    const auto BlockSize =
+        (GemmNPerBlock * GemmMPerBlock) / (GemmMPerWave * GemmNPerWave) * WaveSize;
+
+    if(BlockSize < 64 || BlockSize > 256)
+        return false;
+
+    return (GemmMPerBlock % GemmMPerWave) == 0 && (GemmNPerBlock % GemmNPerWave) == 0;
+}
+
+static inline bool IsIndexRangeLargeEnough(const ConvolutionContext& ctx)
+{
+    // composable kernel use int32_t for memory offset, which covers 2GB of memory maximum
+    const std::size_t max_index_range = std::size_t(2) * 1024 * 1024 * 1024;
+
+    return ctx.bot_sz < max_index_range && ctx.weights_sz < max_index_range &&
+           ctx.top_sz < max_index_range;
+}
+
+static inline bool IsValidBlockwiseGemmXdlops(const ConvolutionContext& ctx,
+                                              const int GemmMPerBlock,
+                                              const int GemmNPerBlock,
+                                              const int GemmKPerBlock,
+                                              const int GemmMPerWave,
+                                              const int GemmNPerWave,
+                                              const int GemmKPack)
+{
+    // unsupported xdlops-gemm
+    if(ctx.IsFp16() && GemmKPack % 4 != 0)
+        return false;
+    if(ctx.IsBfp16() && GemmKPack % 2 != 0)
+        return false;
+
+    if(GemmMPerWave == 16 && GemmNPerWave == 32)
+        return false;
+    if(GemmMPerWave == 32 && GemmNPerWave == 16)
+        return false;
+    if(GemmMPerWave == 8 && GemmNPerWave != 64)
+        return false;
+    if(GemmMPerWave == 4 && GemmNPerWave != 64)
+        return false;
+    if(GemmMPerWave == 32 && GemmNPerWave == 32 && GemmKPerBlock % 2 != 0)
+        return false;
+    if(GemmMPerWave == 16 && GemmNPerWave == 16 && GemmKPerBlock % 4 != 0)
+        return false;
+
+    const auto WaveSize = 64;
+    const auto BlockSize =
+        (GemmNPerBlock * GemmMPerBlock) / (GemmMPerWave * GemmNPerWave) * WaveSize;
 
     if(BlockSize < 64 || BlockSize > 256)
         return false;
@@ -465,6 +556,7 @@ IsValidGridGemmXdlops(const std::size_t GemmM, const std::size_t GemmN, const st
            (GemmK * GemmN) % WaveSize == 0 && GemmN % 16 == 0 && GemmM % 4 == 0 && GemmK % 4 == 0;
 }
 
+///\todo remove
 static inline bool IsApplicableXdlops(const ConvolutionContext& ctx)
 {
     if(!IsXdlopsSupport(ctx))
@@ -516,6 +608,7 @@ static inline bool IsApplicableXdlops(const ConvolutionContext& ctx)
     return IsValidGridGemmXdlops(GemmM, GemmN, GemmK);
 }
 
+///\todo remove
 template <class PerformanceImplicitGemm_t>
 inline static auto GetPerformanceConfigBase(const ConvolutionContext& ctx)
 {
@@ -525,6 +618,7 @@ inline static auto GetPerformanceConfigBase(const ConvolutionContext& ctx)
     return pp;
 }
 
+///\todo remove
 static inline size_t ComputeLDSRequiredSize(const ConvolutionContext& ctx,
                                             const int BPerBlock,
                                             const int KPerBlock,
@@ -633,6 +727,10 @@ int amd_buffer_load_max_length()
     {
         return 4;
     }
+    else if(std::is_same<half_float::half, T>())
+    {
+        return 8;
+    }
     else
     {
         MIOPEN_LOG_I("not implemented");
@@ -646,6 +744,10 @@ int amd_buffer_store_max_length()
     if(std::is_same<float, T>())
     {
         return 4;
+    }
+    else if(std::is_same<half_float::half, T>())
+    {
+        return 8;
     }
     else
     {
@@ -661,6 +763,10 @@ int amd_lds_read_max_length()
     {
         return 4;
     }
+    else if(std::is_same<half_float::half, T>())
+    {
+        return 8;
+    }
     else
     {
         MIOPEN_LOG_I("not implemented");
@@ -675,6 +781,10 @@ int amd_lds_write_max_length()
     {
         return 4;
     }
+    else if(std::is_same<half_float::half, T>())
+    {
+        return 8;
+    }
     else
     {
         MIOPEN_LOG_I("not implemented");
@@ -686,4 +796,5 @@ constexpr std::size_t get_lds_max_number_of_byte() { return 65536; }
 
 } // namespace solver
 } // namespace miopen
+
 #endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -169,6 +169,7 @@ set( LONG_TESTS
     pooling3d.cpp
     soft_max.cpp
     lrn_test.cpp
+    reduce_test.cpp
     )
 
 set( SHORT_TESTS

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -186,6 +186,10 @@ struct conv_forward : output_tensor_fixture
         size_t sz_fwd_workspace;
         STATUS(miopenConvolutionForwardGetWorkSpaceSize(
             handle, convFilter, inputTensor, convDesc, outputTensor, &sz_fwd_workspace));
+        // OCL fails to allocate zero workspace. Let's allocate small workspace instead to simplify
+        // subsequent code.
+        if(sz_fwd_workspace == 0)
+            sz_fwd_workspace = 256;
 
         std::vector<float> in(sz_in);
         std::vector<float> wei(sz_wei);
@@ -284,7 +288,7 @@ struct conv_forward : output_tensor_fixture
                                             convFilter,
                                             wei_dev,
                                             convDesc,
-                                            miopenConvolutionFwdAlgoDirect,
+                                            perf.fwd_algo,
                                             &beta,
                                             outputTensor,
                                             out_dev,

--- a/test/network_data.hpp
+++ b/test/network_data.hpp
@@ -436,7 +436,9 @@ get_bn_spatial_inputs(int n = MIOPEN_TEST_DEFAULT_BATCH_SIZE_FACTOR)
         { pick_batch_size(32, n),  256,  28,  28  },
         { pick_batch_size(32, n),  3,    224, 224 },
         { pick_batch_size(32, n),  480,  128, 256 },
-        { pick_batch_size(32, n),  528,  64,  128 }
+        { pick_batch_size(32, n),  528,  64,  128 },
+        { pick_batch_size(770, n),  1,  8,  8 },
+        { pick_batch_size(770, n),  1024,  1,  1 }
     };
     // clang-format on
 }

--- a/test/reduce_test.cpp
+++ b/test/reduce_test.cpp
@@ -1,0 +1,826 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2020 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#include "driver.hpp"
+#include "test.hpp"
+#include "verify.hpp"
+#include "get_handle.hpp"
+#include "tensor_holder.hpp"
+#include <miopen/miopen.h>
+#include <miopen/tensor.hpp>
+#include <miopen/stringutils.hpp>
+#include <miopen/reducetensor.hpp>
+#include <random>
+#include <algorithm>
+#include <iterator>
+#include <limits>
+#include <iostream>
+
+#include <miopen/reduce_common.hpp>
+
+static void get_all_indexes(const std::vector<std::size_t>& dimLengths,
+                            int dim,
+                            std::vector<std::vector<std::size_t>>& indexes)
+{
+    if(dim < dimLengths.size())
+    {
+        std::vector<std::vector<std::size_t>> updated_indexes;
+
+        if(dim == 0)
+        {
+            assert(indexes.size() == 0);
+            assert(dimLengths[dim] > 0);
+            for(std::size_t i = 0; i < dimLengths[dim]; i++)
+            {
+                std::vector<std::size_t> index = {i};
+
+                updated_indexes.push_back(index);
+            };
+        }
+        else
+        {
+            // go through all the current indexes
+            for(const auto& index : indexes)
+                for(std::size_t i = 0; i < dimLengths[dim]; i++)
+                {
+                    auto index_new = index;
+                    index_new.push_back(i);
+
+                    updated_indexes.push_back(index_new);
+                };
+        };
+
+        // update to the indexes (output)
+        indexes = updated_indexes;
+
+        // further to construct the indexes from the updated status
+        get_all_indexes(dimLengths, dim + 1, indexes);
+    };
+};
+
+static std::size_t get_offset_from_index(const std::vector<std::size_t>& strides,
+                                         const std::vector<std::size_t>& index)
+{
+    std::size_t offset = 0;
+
+    assert(strides.size() == index.size());
+
+    for(int i = 0; i < index.size(); i++)
+        offset += strides[i] * index[i];
+
+    return (offset);
+};
+
+static std::size_t get_flatten_offset(const std::vector<std::size_t>& lengths,
+                                      const std::vector<std::size_t>& index)
+{
+    std::size_t offset = 0;
+
+    assert(lengths.size() == index.size() && lengths.size() > 0);
+
+    int len            = lengths.size();
+    std::size_t stride = 1;
+
+    // for len==1, the loop is not executed
+    for(int i = len - 1; i > 0; i--)
+    {
+        offset += stride * index[i];
+
+        stride *= lengths[i];
+    };
+
+    offset += stride * index[0];
+
+    return (offset);
+};
+
+template <class T, bool toVerifyData>
+struct verify_reduce_with_indices
+{
+    miopen::ReduceTensorDescriptor reduce;
+    tensor<T> input;
+    tensor<T> output;
+    tensor<T> workspace;
+    tensor<int> indices;
+    T alpha;
+    T beta;
+
+    miopenReduceTensorOp_t reduceOp;
+    miopenDataType_t compTypeVal;
+    miopenNanPropagation_t nanOpt;
+    miopenReduceTensorIndices_t indicesOpt;
+    miopenIndicesType_t indicesType;
+
+    verify_reduce_with_indices(const miopen::ReduceTensorDescriptor& reduce_,
+                               const tensor<T>& input_,
+                               const tensor<T>& output_,
+                               const tensor<T>& workspace_,
+                               const tensor<int>& indices_,
+                               T alpha_,
+                               T beta_)
+    {
+        reduce    = reduce_;
+        input     = input_;
+        output    = output_;
+        workspace = workspace_;
+        indices   = indices_;
+        alpha     = alpha_;
+        beta      = beta_;
+
+        reduceOp    = reduce.reduceTensorOp_;
+        compTypeVal = reduce.reduceTensorCompType_;
+        nanOpt      = reduce.reduceTensorNanOpt_;
+        indicesOpt  = reduce.reduceTensorIndices_;
+        indicesType = reduce.reduceTensorIndicesType_;
+    }
+
+    tensor<float> cpu() const
+    {
+        using reduce::type_convert;
+
+        std::tuple<tensor<T>, tensor<int>> results;
+
+        if(compTypeVal == miopenFloat)
+        {
+            if(std::is_same<T, double>::value)
+                results = cpuImpl<double>();
+            else
+                results = cpuImpl<float>();
+        }
+        else if(compTypeVal == miopenHalf)
+        {
+            if(std::is_same<T, double>::value)
+                results = cpuImpl<double>();
+            else
+                results = cpuImpl<float>();
+        };
+
+        if(toVerifyData)
+        {
+            const auto dimLengths = output.desc.GetLengths();
+
+            auto result_dataFloat = make_tensor<float>(dimLengths);
+
+            auto& result_dataT = std::get<0>(results);
+
+            for(size_t i                 = 0; i < result_dataT.data.size(); i++)
+                result_dataFloat.data[i] = type_convert<float>{}(result_dataT.data[i]);
+
+            return (result_dataFloat);
+        }
+        else
+        {
+            const auto dimLengths = indices.desc.GetLengths();
+
+            auto result_indicesFloat = make_tensor<float>(dimLengths);
+
+            auto& result_indices = std::get<1>(results);
+
+            for(size_t i                    = 0; i < result_indices.data.size(); i++)
+                result_indicesFloat.data[i] = static_cast<float>(result_indices.data[i]);
+
+            return (result_indicesFloat);
+        };
+    };
+
+    tensor<float> gpu() const
+    {
+        using reduce::type_convert;
+
+        std::tuple<tensor<T>, tensor<int>> results;
+
+        results = gpuImpl();
+
+        if(toVerifyData)
+        {
+            const auto dimLengths = output.desc.GetLengths();
+
+            auto result_dataFloat = make_tensor<float>(dimLengths);
+
+            tensor<T>& result_dataT = std::get<0>(results);
+
+            for(size_t i                 = 0; i < result_dataT.data.size(); i++)
+                result_dataFloat.data[i] = type_convert<float>{}(result_dataT.data[i]);
+
+            return (result_dataFloat);
+        }
+        else
+        {
+            const auto dimLengths = indices.desc.GetLengths();
+
+            auto result_indicesFloat = make_tensor<float>(dimLengths);
+
+            tensor<int>& result_indices = std::get<1>(results);
+
+            for(size_t i                    = 0; i < result_indices.data.size(); i++)
+                result_indicesFloat.data[i] = static_cast<float>(result_indices.data[i]);
+
+            return (result_indicesFloat);
+        };
+    };
+
+    template <typename compType>
+    std::tuple<tensor<T>, tensor<int>> cpuImpl() const
+    {
+        using reduce::ReduceOpFn2;
+        using reduce::ReduceOpZeroVal;
+        using reduce::float_equal_one;
+        using reduce::float_equal_zero;
+        using reduce::type_convert;
+        using reduce::binop_with_nan_check;
+        using reduce::binop_with_nan_check2;
+
+        auto inLengths  = input.desc.GetLengths();
+        auto outLengths = output.desc.GetLengths();
+        auto inStrides  = input.desc.GetStrides();
+        auto outStrides = output.desc.GetStrides();
+
+        // replicate
+        auto res         = output;
+        auto res_indices = indices;
+
+        std::vector<std::size_t> invariantLengths;
+        std::vector<std::size_t> toReduceLengths;
+
+        std::vector<int> invariantDims;
+        std::vector<int> toReduceDims;
+
+        for(int i = 0; i < inLengths.size(); i++)
+            if(inLengths[i] == outLengths[i])
+                invariantDims.push_back(i);
+            else
+                toReduceDims.push_back(i);
+
+        invariantLengths.resize(invariantDims.size());
+        for(int i               = 0; i < invariantDims.size(); i++)
+            invariantLengths[i] = inLengths[invariantDims[i]];
+
+        toReduceLengths.resize(toReduceDims.size());
+        for(int i              = 0; i < toReduceDims.size(); i++)
+            toReduceLengths[i] = inLengths[toReduceDims[i]];
+
+        bool reduceAllDims = invariantDims.empty();
+
+        auto opReduce = ReduceOpFn2<compType>(reduceOp);
+
+        if(reduceAllDims)
+        {
+            std::vector<std::vector<std::size_t>> indexes_1;
+
+            get_all_indexes(inLengths, 0, indexes_1);
+
+            compType accuVal = ReduceOpZeroVal<compType>(reduceOp);
+            int accuIndex    = 0;
+
+            // go through indexes of the invariant dimensions
+            for(const auto& src_index : indexes_1)
+            {
+                auto src_offset = get_offset_from_index(inStrides, src_index);
+
+                auto currVal = type_convert<compType>{}(input.data[src_offset]);
+
+                int currIndex = get_flatten_offset(inLengths, src_index);
+                binop_with_nan_check2(nanOpt, opReduce, accuVal, currVal, accuIndex, currIndex);
+            };
+
+            // scale the accumulated value
+            if(!float_equal_one{}(alpha))
+                accuVal *= type_convert<compType>{}(alpha);
+
+            // scale the prior dst value and add it to the accumulated value
+            if(!float_equal_zero{}(beta))
+            {
+                accuVal += type_convert<compType>{}(output.data[0] * beta);
+            };
+
+            // store the reduced value to dst location
+            res.data[0]         = type_convert<T>{}(accuVal);
+            res_indices.data[0] = accuIndex;
+        }
+        else
+        {
+            std::vector<std::vector<std::size_t>> indexes_1, indexes_2;
+
+            get_all_indexes(invariantLengths, 0, indexes_1);
+            get_all_indexes(toReduceLengths, 0, indexes_2);
+
+            // go through indexes of the invariant dimensions
+            for(const auto& index_1 : indexes_1)
+            {
+                std::vector<std::size_t> src_index;
+                std::vector<std::size_t> dst_index;
+
+                src_index.resize(inLengths.size());
+                dst_index.resize(inLengths.size());
+
+                std::fill(dst_index.begin(), dst_index.end(), 0);
+
+                for(int k                       = 0; k < invariantDims.size(); k++)
+                    dst_index[invariantDims[k]] = index_1[k];
+
+                int dst_offset = get_offset_from_index(outStrides, dst_index);
+
+                // generate the part of the index belonging to the invariant dims
+                for(int k                       = 0; k < invariantDims.size(); k++)
+                    src_index[invariantDims[k]] = index_1[k];
+
+                compType accuVal = ReduceOpZeroVal<compType>(reduceOp);
+                int accuIndex    = 0;
+
+                // go through indexes of the toReduce dimensions
+                for(const auto& index_2 : indexes_2)
+                {
+                    // generate the part of the index belonging to the toReduce dims
+                    for(int k                      = 0; k < toReduceDims.size(); k++)
+                        src_index[toReduceDims[k]] = index_2[k];
+
+                    auto src_offset = get_offset_from_index(inStrides, src_index);
+
+                    auto currVal = type_convert<compType>{}(input.data[src_offset]);
+
+                    auto currIndex = get_flatten_offset(toReduceLengths, index_2);
+                    binop_with_nan_check2(nanOpt, opReduce, accuVal, currVal, accuIndex, currIndex);
+                };
+
+                // scale the accumulated value
+                if(!float_equal_one{}(alpha))
+                    accuVal *= type_convert<compType>{}(alpha);
+
+                // scale the prior dst value and add it to the accumulated value
+                if(!float_equal_zero{}(beta))
+                    accuVal += type_convert<compType>{}(output.data[dst_offset] * beta);
+
+                // store the reduced value to dst location
+                res.data[dst_offset]         = type_convert<T>{}(accuVal);
+                res_indices.data[dst_offset] = accuIndex; // store the index
+            };
+        };
+
+        return (std::make_tuple(res, res_indices));
+    }
+
+    std::tuple<tensor<T>, tensor<int>> gpuImpl() const
+    {
+        auto&& handle   = get_handle();
+        auto input_dev  = handle.Write(input.data);
+        auto output_dev = handle.Write(output.data);
+
+        // replicate
+        auto res         = output;
+        auto res_indices = indices;
+
+        auto indices_dev = handle.Write(indices.data);
+
+        std::size_t ws_sizeInBytes      = workspace.desc.GetElementSize() * sizeof(T);
+        std::size_t indices_sizeInBytes = indices.desc.GetElementSize() * sizeof(int);
+
+        if(ws_sizeInBytes > 0)
+        {
+            auto workspace_dev = handle.Write(workspace.data);
+
+            reduce.ReduceTensor(get_handle(),
+                                indices_dev.get(),
+                                indices_sizeInBytes,
+                                workspace_dev.get(),
+                                ws_sizeInBytes,
+                                static_cast<const void*>(&alpha),
+                                input.desc,
+                                input_dev.get(),
+                                static_cast<const void*>(&beta),
+                                output.desc,
+                                output_dev.get());
+        }
+        else
+        {
+            reduce.ReduceTensor(get_handle(),
+                                indices_dev.get(),
+                                indices_sizeInBytes,
+                                nullptr,
+                                0,
+                                static_cast<const void*>(&alpha),
+                                input.desc,
+                                input_dev.get(),
+                                static_cast<const void*>(&beta),
+                                output.desc,
+                                output_dev.get());
+        };
+
+        res.data         = handle.Read<T>(output_dev, res.data.size());
+        res_indices.data = handle.Read<int>(indices_dev, res_indices.data.size());
+
+        return (std::make_tuple(res, res_indices));
+    }
+
+    void fail(int) const
+    {
+        std::cout << "verify_reduce_with_indices failed" << std::endl;
+        std::cout << "Input Tensor"
+                  << " " << input.desc.ToString() << std::endl;
+    }
+};
+
+template <class T>
+struct verify_reduce_no_indices
+{
+    miopen::ReduceTensorDescriptor reduce;
+    tensor<T> input;
+    tensor<T> output;
+    tensor<T> workspace;
+    T alpha;
+    T beta;
+
+    miopenReduceTensorOp_t reduceOp;
+    miopenDataType_t compTypeVal;
+    miopenNanPropagation_t nanOpt;
+
+    verify_reduce_no_indices(const miopen::ReduceTensorDescriptor& reduce_,
+                             const tensor<T>& input_,
+                             const tensor<T>& output_,
+                             const tensor<T>& workspace_,
+                             T alpha_,
+                             T beta_)
+    {
+        reduce    = reduce_;
+        input     = input_;
+        output    = output_;
+        workspace = workspace_;
+        alpha     = alpha_;
+        beta      = beta_;
+
+        reduceOp    = reduce.reduceTensorOp_;
+        compTypeVal = reduce.reduceTensorCompType_;
+        nanOpt      = reduce.reduceTensorNanOpt_;
+    }
+
+    tensor<T> cpu()
+    {
+        if(compTypeVal == miopenFloat)
+        {
+            if(std::is_same<T, double>::value)
+                return (cpuImpl<double>());
+            else
+                return (cpuImpl<float>());
+        }
+        else if(compTypeVal == miopenHalf || compTypeVal == miopenBFloat16)
+        {
+            if(std::is_same<T, double>::value)
+                return (cpuImpl<double>());
+            else
+                return (cpuImpl<float>());
+        };
+
+        return (tensor<T>{});
+    };
+
+    template <typename compType>
+    tensor<T> cpuImpl() const
+    {
+        using reduce::ReduceOpFn;
+        using reduce::ReduceOpZeroVal;
+        using reduce::float_equal_one;
+        using reduce::float_equal_zero;
+        using reduce::type_convert;
+        using reduce::binop_with_nan_check;
+        using reduce::binop_with_nan_check2;
+
+        auto inLengths  = input.desc.GetLengths();
+        auto outLengths = output.desc.GetLengths();
+        auto inStrides  = input.desc.GetStrides();
+        auto outStrides = output.desc.GetStrides();
+
+        // replicate
+        auto res = output;
+
+        std::vector<std::size_t> invariantLengths;
+        std::vector<std::size_t> toReduceLengths;
+
+        std::vector<int> invariantDims;
+        std::vector<int> toReduceDims;
+
+        for(int i = 0; i < inLengths.size(); i++)
+            if(inLengths[i] == outLengths[i])
+                invariantDims.push_back(i);
+            else
+                toReduceDims.push_back(i);
+
+        invariantLengths.resize(invariantDims.size());
+        for(int i               = 0; i < invariantDims.size(); i++)
+            invariantLengths[i] = inLengths[invariantDims[i]];
+
+        toReduceLengths.resize(toReduceDims.size());
+        for(int i              = 0; i < toReduceDims.size(); i++)
+            toReduceLengths[i] = inLengths[toReduceDims[i]];
+
+        bool reduceAllDims = invariantDims.empty();
+
+        auto opReduce = ReduceOpFn<compType>(reduceOp);
+
+        if(reduceAllDims)
+        {
+            std::vector<std::vector<std::size_t>> indexes_1;
+
+            get_all_indexes(inLengths, 0, indexes_1);
+
+            compType accuVal = ReduceOpZeroVal<compType>(reduceOp);
+
+            // go through indexes of the invariant dimensions
+            for(const auto& src_index : indexes_1)
+            {
+                auto src_offset = get_offset_from_index(inStrides, src_index);
+
+                auto currVal = type_convert<compType>{}(input.data[src_offset]);
+
+                binop_with_nan_check(nanOpt, opReduce, accuVal, currVal);
+            };
+
+            // scale the accumulated value
+            if(!float_equal_one{}(alpha))
+                accuVal *= type_convert<compType>{}(alpha);
+
+            // scale the prior dst value and add it to the accumulated value
+            if(!float_equal_one{}(beta))
+                accuVal += type_convert<compType>{}(output.data[0] * beta);
+
+            // store the reduced value to dst location
+            res.data[0] = type_convert<T>{}(accuVal);
+        }
+        else
+        {
+            std::vector<std::vector<std::size_t>> indexes_1, indexes_2;
+
+            get_all_indexes(invariantLengths, 0, indexes_1);
+            get_all_indexes(toReduceLengths, 0, indexes_2);
+
+            // go through indexes of the invariant dimensions
+            for(const auto& index_1 : indexes_1)
+            {
+                std::vector<std::size_t> src_index;
+                std::vector<std::size_t> dst_index;
+
+                src_index.resize(inLengths.size());
+                dst_index.resize(inLengths.size());
+
+                std::fill(dst_index.begin(), dst_index.end(), 0);
+
+                for(int k                       = 0; k < invariantDims.size(); k++)
+                    dst_index[invariantDims[k]] = index_1[k];
+
+                int dst_offset = get_offset_from_index(outStrides, dst_index);
+
+                // generate the part of the index belonging to the invariant dims
+                for(int k                       = 0; k < invariantDims.size(); k++)
+                    src_index[invariantDims[k]] = index_1[k];
+
+                compType accuVal = ReduceOpZeroVal<compType>(reduceOp);
+
+                // go through indexes of the toReduce dimensions
+                for(const auto& index_2 : indexes_2)
+                {
+                    // generate the part of the index belonging to the toReduce dims
+                    for(int k                      = 0; k < toReduceDims.size(); k++)
+                        src_index[toReduceDims[k]] = index_2[k];
+
+                    auto src_offset = get_offset_from_index(inStrides, src_index);
+
+                    auto currVal = type_convert<compType>{}(input.data[src_offset]);
+
+                    binop_with_nan_check(nanOpt, opReduce, accuVal, currVal);
+                };
+
+                // scale the accumulated value
+                if(!float_equal_one{}(alpha))
+                    accuVal *= type_convert<compType>{}(alpha);
+
+                // scale the prior dst value and add it to the accumulated value
+                if(!float_equal_zero{}(beta))
+                    accuVal += type_convert<compType>{}(output.data[dst_offset] * beta);
+
+                // store the reduced value to dst location
+                res.data[dst_offset] = type_convert<T>{}(accuVal);
+            };
+        };
+
+        return (res);
+    }
+
+    tensor<T> gpu() const
+    {
+        auto&& handle   = get_handle();
+        auto input_dev  = handle.Write(input.data);
+        auto output_dev = handle.Write(output.data);
+
+        // replicate
+        auto res = output;
+
+        std::size_t ws_sizeInBytes = workspace.desc.GetElementSize() * sizeof(T);
+
+        if(ws_sizeInBytes > 0)
+        {
+            auto workspace_dev = handle.Write(workspace.data);
+
+            reduce.ReduceTensor(get_handle(),
+                                nullptr,
+                                0,
+                                workspace_dev.get(),
+                                ws_sizeInBytes,
+                                static_cast<const void*>(&alpha),
+                                input.desc,
+                                input_dev.get(),
+                                static_cast<const void*>(&beta),
+                                output.desc,
+                                output_dev.get());
+        }
+        else
+        {
+            reduce.ReduceTensor(get_handle(),
+                                nullptr,
+                                0,
+                                nullptr,
+                                0,
+                                static_cast<const void*>(&alpha),
+                                input.desc,
+                                input_dev.get(),
+                                static_cast<const void*>(&beta),
+                                output.desc,
+                                output_dev.get());
+        };
+
+        res.data = handle.Read<T>(output_dev, res.data.size());
+
+        return (res);
+    }
+
+    void fail(int) const
+    {
+        std::cout << "verify_reduce_no_indices failed" << std::endl;
+        std::cout << "Input Tensor"
+                  << " " << input.desc.ToString() << std::endl;
+    }
+};
+
+template <class T>
+struct reduce_driver : test_driver
+{
+    int reduceOp                    = 0; //  miopenReduceTensorOp_t reduceOp;
+    int compTypeVal                 = 1; //  miopenDataType_t compTypeVal;
+    int nanOpt                      = 0; //  miopenNanPropagation_t nanOpt;
+    int indicesOpt                  = 0; //  miopenReduceTensorIndices_t indicesOpt;
+    miopenIndicesType_t indicesType = MIOPEN_32BIT_INDICES;
+
+    std::vector<std::size_t> inLengths; // the lengths of the input tensor's dimensions
+    std::vector<int>
+        toReduceDims; // the indexes of the dimensions to be reduced in the input tensor
+
+    std::vector<float> scales;
+    float alpha = 1.0f;
+    float beta  = 0.0f;
+
+    std::vector<std::vector<std::size_t>> get_tensor_lengths()
+    {
+        return {
+            {64, 3, 280, 81},
+        };
+    }
+
+    std::vector<std::vector<int>> get_toreduce_dims()
+    {
+        return {
+            {0},
+            {1},
+            {2},
+            {3},
+            {0, 1},
+            {1, 2},
+            {0, 3},
+            {1, 3},
+            {0, 2},
+            {2, 3},
+            {0, 1, 3},
+            {1, 2, 3},
+            {0, 1, 2, 3},
+        };
+    }
+
+    reduce_driver()
+    {
+        add(inLengths, "D", generate_data(get_tensor_lengths()));
+        add(toReduceDims, "R", generate_data(get_toreduce_dims()));
+        add(reduceOp, "ReduceOp", generate_data({0, 2}));
+        add(compTypeVal, "CompType", generate_data({1}));
+        add(nanOpt, "N", generate_data({0}));
+        add(indicesOpt, "I", generate_data({0, 1}));
+
+        add(scales, "scales", generate_data({{1.0f, 0.0f}, {0.5f, 0.5f}}));
+
+        auto&& handle = get_handle();
+        handle.EnableProfiling();
+    }
+
+    void run()
+    {
+        using reduce::type_convert;
+
+        miopen::ReduceTensorDescriptor reduceDesc(
+            static_cast<miopenReduceTensorOp_t>(reduceOp),
+            static_cast<miopenDataType_t>(compTypeVal),
+            static_cast<miopenNanPropagation_t>(nanOpt),
+            static_cast<miopenReduceTensorIndices_t>(indicesOpt),
+            indicesType);
+
+        alpha = scales[0];
+        beta  = scales[1];
+
+        auto outLengths = this->inLengths;
+
+        assert(toReduceDims.size() <= outLengths.size());
+        for(int i = 0; i < toReduceDims.size(); i++)
+            assert(toReduceDims[i] < inLengths.size());
+
+        // set the lengths of the dimensions to be reduced to 1 to represent the output Tensor
+        for(int i                       = 0; i < toReduceDims.size(); i++)
+            outLengths[toReduceDims[i]] = static_cast<std::size_t>(1);
+
+        unsigned long max_value =
+            miopen_type<T>{} == miopenHalf ? 5 : miopen_type<T>{} == miopenInt8 ? 127 : 17;
+
+        auto gen_value = [&](auto... is) {
+            return (tensor_elem_gen_integer{max_value}(is...) *
+                    tensor_elem_gen_checkboard_sign{}(is...));
+        };
+
+        auto inputTensor  = tensor<T>{this->inLengths}.generate(gen_value);
+        auto outputTensor = tensor<T>{outLengths};
+
+        std::fill(outputTensor.begin(), outputTensor.end(), type_convert<T>{}(0.0f));
+
+        auto indices_nelem =
+            reduceDesc.GetIndicesSize(inputTensor.desc, outputTensor.desc) / sizeof(int);
+
+        auto ws_sizeInBytes =
+            reduceDesc.GetWorkSpaceSize(get_handle(), inputTensor.desc, outputTensor.desc);
+        auto workspace_nelem = (indices_nelem == 0) ? ws_sizeInBytes / sizeof(T)
+                                                    : (ws_sizeInBytes + sizeof(T) - 1) / sizeof(T);
+
+        std::vector<std::size_t> wsLengths = {static_cast<std::size_t>(workspace_nelem), 1};
+        auto workspaceTensor               = tensor<T>{wsLengths};
+
+        std::fill(workspaceTensor.begin(), workspaceTensor.end(), type_convert<T>{}(0.0f));
+
+        if(indices_nelem > 0)
+        {
+            std::vector<std::size_t> indicesLengths = {static_cast<std::size_t>(indices_nelem), 1};
+            auto indicesTensor                      = tensor<int>{indicesLengths};
+
+            std::fill(indicesTensor.begin(), indicesTensor.end(), 1);
+
+            verify(verify_reduce_with_indices<T, true>(reduceDesc,
+                                                       inputTensor,
+                                                       outputTensor,
+                                                       workspaceTensor,
+                                                       indicesTensor,
+                                                       type_convert<T>{}(1.0),
+                                                       type_convert<T>{}(0.0)));
+
+            verify_equals(verify_reduce_with_indices<T, false>(reduceDesc,
+                                                               inputTensor,
+                                                               outputTensor,
+                                                               workspaceTensor,
+                                                               indicesTensor,
+                                                               type_convert<T>{}(1.0),
+                                                               type_convert<T>{}(0.0)));
+        }
+        else
+        {
+            verify(verify_reduce_no_indices<T>(reduceDesc,
+                                               inputTensor,
+                                               outputTensor,
+                                               workspaceTensor,
+                                               type_convert<T>{}(alpha),
+                                               type_convert<T>{}(beta)));
+        };
+    };
+};
+
+int main(int argc, const char* argv[]) { test_drive<reduce_driver<float>>(argc, argv); };

--- a/test/tensor_holder.hpp
+++ b/test/tensor_holder.hpp
@@ -329,6 +329,22 @@ tensor<T> make_tensor(std::initializer_list<std::size_t> dims, G g)
     return tensor<T>{miopen::TensorDescriptor{miopen_type<T>{}, dims}}.generate(g);
 }
 
+// This is needed since there is no TensorDescriptor(miopenDataType_t t, const size_t* plens, int
+// size) constructor
+template <class T>
+tensor<T> make_tensor(const std::vector<std::size_t>& dims)
+{
+    std::vector<int> tmpDims;
+
+    tmpDims.resize(dims.size());
+
+    for(int i      = 0; i < tmpDims.size(); i++)
+        tmpDims[i] = static_cast<int>(dims[i]);
+
+    return tensor<T>{miopen::TensorDescriptor{
+        miopen_type<T>{}, tmpDims.data(), static_cast<int>(tmpDims.size())}};
+};
+
 template <class T, class X>
 tensor<T> make_tensor(const std::vector<X>& dims)
 {


### PR DESCRIPTION
This is core the implementation of the generic_reduction. The generic_reduction provides the functionality of generic tensor reduction similar to what provided by cudnnReduceTensor(), and it is based on the composable-kernel facility available with MIOpen. The core implementation include
four commits: 
1. Tiny adding/changes to composable_kernel to support generic-reduction.
2. Kernel-layer implementation of generic-reduction, which includes the source of four kernels. kernel wrapper and some common helper functions. 
3. Implementation of host-layer c++ interface (miopenReduceTensorDescriptor class) for generic-reduction. 
4. Auto-test support (#>make check) for generic-reduction, which include an c++ file providing verifying testing of the generic-function function and also some host-layer helper functions. 

Four reduction methods are implemented by the kernels which are called DirectThreadwise, DirectWarpwise, Blockwise, MultBlockwise. The selection of which reduction method is based on the specification of the reduction problem(the input tensor description and the dimensions to reduce). And the reduction process is hierarchical (at most two layers), where the first-call of MultiBlockwise reduction will be followed by one of the three other reduction methods as second-call.

The following are some important source files explained: 
1. src/reducetensor.cpp -- the host c++ interfaces for generic_reduction, in which the host-side codes compile, cache, find and launch the kernels
2. src/kernels/composable_kernel/include/kernel_algorithms/gridwise_generic_reduction.hpp -- the top layer kernel, which does tensor transformation and call one of the four xy_to_x kernels to do 2d to 1d tensor reduction
3. src/kernels/composable_kernel/include/kernel_algorithms gridwise_generic_2d_reduction_<xxx>.hpp -- the four xy_to_x kernels representing four different reduction methods respectively
4. src/kernels/composable_kernel/src/kernel_wrapper/gridwise_generic_reduction.cpp -- the "global" entry of the all kernels, in which the compiler definitions are received and tensor descriptors are created to represent the reduction task.
5. test/reduce_test.cpp -- the auto-tester called by "#make check". The verification is done by comparing the device-based reduction result with that of host-based one. Various reduction cases are covered.
