### PR TITLE
Adding of the MIOpenDriver reduce module for generic-reduction

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -304,6 +304,42 @@ pipeline {
                     }
                 }
 
+                stage('Hip Normal Find Mode Release') {
+                    agent{ label rocmnode("vega") }
+                    environment{
+                        cmd = """
+                            ulimit -c unlimited
+                            rm -rf build
+                            mkdir build
+                            cd build
+                            CXX=/opt/rocm/llvm/bin/clang++ cmake -DBUILD_DEV=On -DCMAKE_BUILD_TYPE=release -DMIOPEN_GPU_SYNC=On .. 
+                            make -j test_conv2d
+                            MIOPEN_FIND_MODE=1 CTEST_PARALLEL_LEVEL=4 MIOPEN_DEBUG_IMPLICIT_GEMM_NON_XDLOPS_INLINE_ASM=0 MIOPEN_CONV_PRECISE_ROCBLAS_TIMING=0 bin/test_conv2d --disable-verification-cache
+                        """
+                    }
+                    steps{
+                        buildHipClangJob('/opt/rocm/llvm/bin/clang++', '', "",  image+'-hip-clang', "/usr/local", cmd)
+                    }
+                }
+
+                stage('Hip Fast Find Mode Release') {
+                    agent{ label rocmnode("vega") }
+                    environment{
+                        cmd = """
+                            ulimit -c unlimited
+                            rm -rf build
+                            mkdir build
+                            cd build
+                            CXX=/opt/rocm/llvm/bin/clang++ cmake -DBUILD_DEV=On -DCMAKE_BUILD_TYPE=release -DMIOPEN_GPU_SYNC=On .. 
+                            make -j test_conv2d
+                            MIOPEN_FIND_MODE=2 CTEST_PARALLEL_LEVEL=4 MIOPEN_DEBUG_IMPLICIT_GEMM_NON_XDLOPS_INLINE_ASM=0 MIOPEN_CONV_PRECISE_ROCBLAS_TIMING=0 bin/test_conv2d --disable-verification-cache
+                        """
+                    }
+                    steps{
+                        buildHipClangJob('/opt/rocm/llvm/bin/clang++', '', "",  image+'-hip-clang', "/usr/local", cmd)
+                    }
+                }
+
                 stage('Hip Release on /usr/local') {
                     agent{ label rocmnode("vega") }
                     steps{
@@ -434,17 +470,21 @@ pipeline {
 
         stage("Full tests III"){
             parallel{
-                stage('Hip Release All') {
-                    agent{ label rocmnode("vega") }
-                    steps{
-                        buildJob('hcc', '-DBUILD_DEV=On -DMIOPEN_TEST_ALL=On -DCMAKE_BUILD_TYPE=release', "", image + "rocm")
-                    }
-                }
-
-                stage('Half Hip Release All') {
+                stage('Half Hip Clang Release All') {
                     agent{ label rocmnode("vega20") }
+                    environment{
+                        cmd = """
+                            ulimit -c unlimited
+                            rm -rf build
+                            mkdir build
+                            cd build
+                            CXX=/opt/rocm/llvm/bin/clang++ cmake -DBUILD_DEV=On -DCMAKE_BUILD_TYPE=release -DMIOPEN_TEST_HALF=On -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_ALL=On -DMIOPEN_TEST_FLAGS=--disable-verification-cache .. 
+                            CTEST_PARALLEL_LEVEL=4 MIOPEN_DEBUG_IMPLICIT_GEMM_NON_XDLOPS_INLINE_ASM=0 MIOPEN_CONV_PRECISE_ROCBLAS_TIMING=0 make -j\$(nproc) check
+                        """
+
+                    }
                     steps{
-                        buildJob('hcc', '-DMIOPEN_TEST_HALF=On -DBUILD_DEV=On -DMIOPEN_TEST_ALL=On -DCMAKE_BUILD_TYPE=release', "", image + "rocm")
+                        buildHipClangJob('/opt/rocm/llvm/bin/clang++', '', "", image+'-hip-clang', "/usr/local", cmd)
                     }
                 }
 
@@ -469,7 +509,7 @@ pipeline {
         }
 
 
-        // Run package building
+       // Run package building
         stage("Packages"){
             parallel {
                 stage('GCC OpenCL Release package') {

--- a/doc/src/find_and_immediate.md
+++ b/doc/src/find_and_immediate.md
@@ -158,3 +158,18 @@ If the user's architecture is not listed above they will need to run the Find AP
 ### Backend Limitations
 
 OpenCL support for immediate mode via the fallback is limited to fp32 datatypes. This is because this current release's fallback path goes through GEMM which on the OpenCL is serviced through MIOpenGEMM -- which itself only contains support for fp32. The HIP backend uses rocBLAS as its fallback path which contains a richer set of datatypes.
+
+
+### Find Modes
+
+MIOpen provides a set of Find modes which are used to accelerate the Find calls. The different modes are set by using the environment variable `MIOPEN_FIND_MODE`, and setting it to one of the values:
+
+- `NORMAL`, or `1`: Normal Find: This is the full Find mode call, which will benchmark all the solvers and return a list.
+- `FAST`, or `2`: Fast Find: Checks the [Find-Db](https://rocmsoftwareplatform.github.io/MIOpen/doc/html/finddb.html) for an entry. If there is a Find-Db hit, use that entry. If there is a miss, utilize the Immediate mode fallback. If Start-up times are expected to be faster, but worse GPU performance.
+- `HYBRID`, or `3`, or unset `MIOPEN_FIND_MODE`: Hybrid Find: Checks the [Find-Db](https://rocmsoftwareplatform.github.io/MIOpen/doc/html/finddb.html) for an entry. If there is a Find-Db hit, use that entry. If there is a miss, use the existing Find machinery. Slower start-up times than Fast Find, but no GPU performance drop.
+
+ As of MIOpen 2.4, the default mode is set to `HYBRID` mode as default. To run the full `NORMAL` Find mode, set the environment as:
+ ```
+ export MIOPEN_FIND_MODE=NORMAL
+ ```
+ 

--- a/driver/conv_driver.hpp
+++ b/driver/conv_driver.hpp
@@ -70,6 +70,8 @@
 
 #include <boost/optional.hpp>
 
+#define WORKAROUND_ISSUE_2176 1 // https://github.com/AMDComputeLibraries/MLOpen/issues/2176
+
 MIOPEN_DECLARE_ENV_VAR(MIOPEN_DRIVER_PAD_BUFFERS_2M)
 
 #if MIOPEN_BACKEND_OPENCL
@@ -158,6 +160,11 @@ bool readBufferFromFile(T* data, size_t dataNumItems, const char* fileName)
 template <typename Tgpu, typename Tref>
 class ConvDriver : public Driver
 {
+#if MIOPEN_BACKEND_OPENCL
+    typedef cl_context context_t;
+#elif MIOPEN_BACKEND_HIP
+    typedef uint32_t context_t;
+#endif
     public:
     ConvDriver() : Driver()
     {
@@ -199,17 +206,20 @@ class ConvDriver : public Driver
 
     int FindForward(int& ret_algo_count,
                     int request_algo_count,
-                    std::vector<miopenConvAlgoPerf_t>& perf_results);
+                    std::vector<miopenConvAlgoPerf_t>& perf_results,
+                    context_t ctx);
     int RunForwardGPU();
     int RunForwardCPU();
     int RunWarmupFindForwardGPU();
 
     int FindBackwardData(int& ret_algo_count,
                          int request_algo_count,
-                         std::vector<miopenConvAlgoPerf_t>& perf_results);
+                         std::vector<miopenConvAlgoPerf_t>& perf_results,
+                         context_t ctx);
     int FindBackwardWeights(int& ret_algo_count,
                             int request_algo_count,
-                            std::vector<miopenConvAlgoPerf_t>& perf_results);
+                            std::vector<miopenConvAlgoPerf_t>& perf_results,
+                            context_t ctx);
     int RunBackwardGPU();
     int RunBackwardDataCPU();
     int RunBackwardWeightsCPU();
@@ -295,6 +305,9 @@ class ConvDriver : public Driver
 
     bool is_wrw = true, is_bwd = true, is_fwd = true;
     bool is_wrw_winograd = false;
+    bool is_wrw_igemm    = false;
+    bool is_fwd_igemm    = false;
+    bool is_bwd_igemm    = false;
     bool time_enabled    = false;
     bool wall_enabled    = false;
     bool warmup_enabled  = false;
@@ -326,17 +339,39 @@ class ConvDriver : public Driver
     int RunBackwardWrwGpuImmed();
     int RunBackwardWrwGpuFind();
 
-    std::string GetVerificationCacheFileName() const;
-    std::string GetVCacheFwdOutBasename() const;
-    std::string GetVCacheBwdDataBasename() const;
-    std::string GetVCacheBwdWeightBasename() const;
-    std::string GetVCacheBiasBwdDataBasename() const;
+    double GetDefaultTolerance() const
+    {
+        // Computation error of fp16 is ~2^13 (=8192) bigger than
+        // the one of fp32 because mantissa is shorter by 13 bits.
+        auto tolerance = (sizeof(Tgpu) == 4 || sizeof(Tgpu) == 1) ? 1e-6 : 8.2e-3;
+        // bf16 mantissa has 7 bits, by 3 bits shorter than fp16.
+        if(std::is_same<Tgpu, bfloat16>::value)
+            tolerance *= 8.0;
+        return tolerance;
+    }
+
+    enum class Direction
+    {
+        Fwd,
+        Bwd,
+        WrW,
+        BwdBias
+    };
+
+    std::string GetVerificationCacheFileName(const Direction& direction) const;
     bool IsInputTensorTransform() const;
 
-    bool TryReadVerificationCache(const std::string& file_name,
+    bool TryReadVerificationCache(const Direction& direction,
                                   miopenTensorDescriptor_t& tensorDesc,
                                   Tref* data) const;
-    void TrySaveVerificationCache(const std::string& file_name, std::vector<Tref>& data) const;
+    void TrySaveVerificationCache(const Direction& direction, std::vector<Tref>& data) const;
+
+    void ResizeWorkspaceDev(context_t ctx, std::size_t size)
+    {
+        workspace_dev.reset();
+        if(size > 0)
+            workspace_dev = std::unique_ptr<GPUMem>(new GPUMem(ctx, size, 1));
+    }
 
     // Helper functions, can be moved out of class.
     void PrintImmedSolutionInfo(const miopenConvSolution_t& s) const
@@ -355,12 +390,6 @@ class ConvDriver : public Driver
         return oss.str();
     }
 
-    enum class Direction
-    {
-        Fwd,
-        Bwd,
-        WrW
-    };
     /// Find() updates find-db with the most recent information (unless find-db is disabled).
     /// Therefore, after Find(), Immediate mode returns the "best" found solution
     /// as the 1st solution in the list, and we can use Immediate mode to find out
@@ -1031,13 +1060,6 @@ int ConvDriver<Tgpu, Tref>::AllocateBuffersAndCopy()
             std::cout << "Error getting workspace size, status = " << rc << std::endl;
             return rc;
         }
-
-        const auto wsSizeof =
-            std::max(std::max(ws_sizeof_find_bwd, ws_sizeof_find_wrw), ws_sizeof_find_fwd);
-        if(wsSizeof != 0)
-        {
-            workspace_dev = std::unique_ptr<GPUMem>(new GPUMem(ctx, wsSizeof, 1));
-        }
     }
 
     if(is_fwd || is_wrw)
@@ -1261,10 +1283,12 @@ int ConvDriver<Tgpu, Tref>::AllocateBuffersAndCopy()
 template <typename Tgpu, typename Tref>
 int ConvDriver<Tgpu, Tref>::FindForward(int& ret_algo_count,
                                         int request_algo_count,
-                                        std::vector<miopenConvAlgoPerf_t>& perf_results)
+                                        std::vector<miopenConvAlgoPerf_t>& perf_results,
+                                        context_t ctx)
 {
     bool is_transform = IsInputTensorTransform();
     fwd_auxiliary.resume(wall_enabled);
+    ResizeWorkspaceDev(ctx, ws_sizeof_find_fwd);
     const auto rc = miopenFindConvolutionForwardAlgorithm(
         GetHandle(),
         (is_transform ? inputTensor_vect4 : inputTensor),
@@ -1592,9 +1616,11 @@ void ConvDriver<Tgpu, Tref>::GetSolutionAfterFind(
     case Direction::WrW:
         found_algo = static_cast<miopenConvAlgorithm_t>(found.bwd_weights_algo);
         break;
+    case Direction::BwdBias: // nop
+        MIOPEN_THROW("BwdBias is not supported");
     }
-    std::size_t immed_count;
-    miopenStatus_t rc = miopenStatusUnknownError;
+    std::size_t immed_count = 0;
+    miopenStatus_t rc       = miopenStatusUnknownError;
     switch(direction)
     {
     case Direction::Fwd:
@@ -1608,6 +1634,8 @@ void ConvDriver<Tgpu, Tref>::GetSolutionAfterFind(
     case Direction::WrW:
         rc = miopenConvolutionBackwardWeightsGetSolution(
             handle, out_tensor, in_tensor, convDesc, wei_tensor, 1, &immed_count, &solution);
+        break;
+    case Direction::BwdBias: // nop
         break;
     }
     if(rc != miopenStatusSuccess // (formatting)
@@ -1634,7 +1662,15 @@ int ConvDriver<Tgpu, Tref>::RunForwardGpuFind(const bool is_transform)
     // requested, -- so perf-db and find-db are fully updated.
     std::vector<miopenConvAlgoPerf_t> perf_results(request_algo_count);
 
-    auto rc = FindForward(ret_algo_count, request_algo_count, perf_results);
+#if MIOPEN_BACKEND_OPENCL
+    cl_context ctx;
+
+    clGetCommandQueueInfo(q, CL_QUEUE_CONTEXT, sizeof(cl_context), &ctx, nullptr);
+#elif MIOPEN_BACKEND_HIP
+    uint32_t ctx = 0;
+#endif
+
+    auto rc = FindForward(ret_algo_count, request_algo_count, perf_results, ctx);
     if(rc != miopenStatusSuccess)
         return rc;
 
@@ -1646,18 +1682,11 @@ int ConvDriver<Tgpu, Tref>::RunForwardGpuFind(const bool is_transform)
     float kernel_total_time = 0.0;
     float kernel_first_time = 0.0;
 
-#if MIOPEN_BACKEND_OPENCL
-    cl_context ctx;
+    const auto algo    = perf_results[0].fwd_algo; // use the fastest algo
+    const auto ws_size = perf_results[0].memory;
+    is_fwd_igemm       = (algo == miopenConvolutionFwdAlgoImplicitGEMM);
 
-    clGetCommandQueueInfo(q, CL_QUEUE_CONTEXT, sizeof(cl_context), &ctx, nullptr);
-#elif MIOPEN_BACKEND_HIP
-    uint32_t ctx = 0;
-#endif
-
-    workspace_dev.reset();
-    if(perf_results[0].memory > 0)
-        workspace_dev = std::unique_ptr<GPUMem>(new GPUMem(ctx, perf_results[0].memory, 1));
-
+    ResizeWorkspaceDev(ctx, ws_size);
     wall.start(wall_enabled);
 
     auto in_tens  = (is_transform ? inputTensor_vect4 : inputTensor);
@@ -1674,12 +1703,12 @@ int ConvDriver<Tgpu, Tref>::RunForwardGpuFind(const bool is_transform)
                                       wei_tens,
                                       wei_buff,
                                       convDesc,
-                                      perf_results[0].fwd_algo, // use the fastest algo
+                                      algo,
                                       &beta,
                                       outputTensor,
                                       out_dev->GetMem(),
                                       workspace_dev != nullptr ? workspace_dev->GetMem() : nullptr,
-                                      perf_results[0].memory);
+                                      ws_size);
         if(rc != miopenStatusSuccess)
             return rc;
 
@@ -1864,6 +1893,7 @@ int ConvDriver<Tgpu, Tref>::RunForwardGpuImmed(const bool is_transform)
         PrintForwardTime(kernel_total_time, kernel_first_time);
     }
 
+    is_fwd_igemm = (selected->algorithm == miopenConvolutionAlgoImplicitGEMM);
     return miopenStatusSuccess;
 }
 
@@ -1912,16 +1942,18 @@ int ConvDriver<Tgpu, Tref>::RunForwardCPU()
         dumpBufferToFile<Tref>("dump_fwd_out_cpu.bin", outhost.data.data(), outhost.data.size());
     }
 
-    TrySaveVerificationCache(GetVCacheFwdOutBasename(), outhost.data);
+    TrySaveVerificationCache(Direction::Fwd, outhost.data);
     return 0;
 }
 
 template <typename Tgpu, typename Tref>
 int ConvDriver<Tgpu, Tref>::FindBackwardData(int& ret_algo_count,
                                              int request_algo_count,
-                                             std::vector<miopenConvAlgoPerf_t>& perf_results)
+                                             std::vector<miopenConvAlgoPerf_t>& perf_results,
+                                             context_t ctx)
 {
     bwd_auxiliary.resume(wall_enabled);
+    ResizeWorkspaceDev(ctx, ws_sizeof_find_bwd);
     const auto rc = miopenFindConvolutionBackwardDataAlgorithm(
         GetHandle(),
         outputTensor,
@@ -1944,9 +1976,11 @@ int ConvDriver<Tgpu, Tref>::FindBackwardData(int& ret_algo_count,
 template <typename Tgpu, typename Tref>
 int ConvDriver<Tgpu, Tref>::FindBackwardWeights(int& ret_algo_count,
                                                 int request_algo_count,
-                                                std::vector<miopenConvAlgoPerf_t>& perf_results)
+                                                std::vector<miopenConvAlgoPerf_t>& perf_results,
+                                                context_t ctx)
 {
     wrw_auxiliary.resume(wall_enabled);
+    ResizeWorkspaceDev(ctx, ws_sizeof_find_wrw);
     const auto rc = miopenFindConvolutionBackwardWeightsAlgorithm(
         GetHandle(),
         outputTensor,
@@ -2037,7 +2071,15 @@ int ConvDriver<Tgpu, Tref>::RunBackwardDataGpuFind()
     int request_algo_count = 2;
     std::vector<miopenConvAlgoPerf_t> perf_results_data(request_algo_count);
 
-    auto rc = FindBackwardData(ret_algo_count, request_algo_count, perf_results_data);
+#if MIOPEN_BACKEND_OPENCL
+    cl_context ctx;
+
+    clGetCommandQueueInfo(q, CL_QUEUE_CONTEXT, sizeof(cl_context), &ctx, nullptr);
+#elif MIOPEN_BACKEND_HIP
+    uint32_t ctx = 0;
+#endif
+
+    auto rc = FindBackwardData(ret_algo_count, request_algo_count, perf_results_data, ctx);
     if(rc != miopenStatusSuccess)
         return rc;
 
@@ -2048,18 +2090,11 @@ int ConvDriver<Tgpu, Tref>::RunBackwardDataGpuFind()
     float kernel_first_time = 0.0;
     float alpha = static_cast<float>(1), beta = static_cast<float>(0);
 
-#if MIOPEN_BACKEND_OPENCL
-    cl_context ctx;
+    const auto algo    = perf_results_data[0].bwd_data_algo;
+    const auto ws_size = perf_results_data[0].memory;
+    is_bwd_igemm       = (algo == miopenConvolutionBwdDataAlgoImplicitGEMM);
 
-    clGetCommandQueueInfo(q, CL_QUEUE_CONTEXT, sizeof(cl_context), &ctx, nullptr);
-#elif MIOPEN_BACKEND_HIP
-    uint32_t ctx = 0;
-#endif
-
-    workspace_dev.reset();
-    if(perf_results_data[0].memory > 0)
-        workspace_dev = std::unique_ptr<GPUMem>(new GPUMem(ctx, perf_results_data[0].memory, 1));
-
+    ResizeWorkspaceDev(ctx, ws_size);
     wall.start(wall_enabled);
 
     for(int i = 0; i < num_iterations; i++)
@@ -2071,13 +2106,13 @@ int ConvDriver<Tgpu, Tref>::RunBackwardDataGpuFind()
                                            weightTensor,
                                            wei_dev->GetMem(),
                                            convDesc,
-                                           perf_results_data[0].bwd_data_algo,
+                                           algo,
                                            &beta,
                                            inputTensor,
                                            din_dev->GetMem(),
                                            workspace_dev != nullptr ? workspace_dev->GetMem()
                                                                     : nullptr,
-                                           perf_results_data[0].memory);
+                                           ws_size);
         if(rc != miopenStatusSuccess)
             return rc;
 
@@ -2242,7 +2277,15 @@ int ConvDriver<Tgpu, Tref>::RunBackwardWrwGpuFind()
     float alpha = static_cast<float>(1), beta = static_cast<float>(0);
     std::vector<miopenConvAlgoPerf_t> perf_results_weights(request_algo_count);
 
-    auto rc = FindBackwardWeights(ret_algo_count, request_algo_count, perf_results_weights);
+#if MIOPEN_BACKEND_OPENCL
+    cl_context ctx;
+
+    clGetCommandQueueInfo(q, CL_QUEUE_CONTEXT, sizeof(cl_context), &ctx, nullptr);
+#elif MIOPEN_BACKEND_HIP
+    uint32_t ctx = 0;
+#endif
+
+    auto rc = FindBackwardWeights(ret_algo_count, request_algo_count, perf_results_weights, ctx);
     if(rc != miopenStatusSuccess)
         return rc;
 
@@ -2255,19 +2298,9 @@ int ConvDriver<Tgpu, Tref>::RunBackwardWrwGpuFind()
     const auto algo    = perf_results_weights[0].bwd_weights_algo;
     const auto ws_size = perf_results_weights[0].memory;
     is_wrw_winograd    = (algo == miopenConvolutionBwdWeightsAlgoWinograd);
+    is_wrw_igemm       = (algo == miopenConvolutionBwdWeightsAlgoImplicitGEMM);
 
-#if MIOPEN_BACKEND_OPENCL
-    cl_context ctx;
-
-    clGetCommandQueueInfo(q, CL_QUEUE_CONTEXT, sizeof(cl_context), &ctx, nullptr);
-#elif MIOPEN_BACKEND_HIP
-    uint32_t ctx = 0;
-#endif
-
-    workspace_dev.reset();
-    if(perf_results_weights[0].memory > 0)
-        workspace_dev = std::unique_ptr<GPUMem>(new GPUMem(ctx, perf_results_weights[0].memory, 1));
-
+    ResizeWorkspaceDev(ctx, ws_size);
     wall.start(wall_enabled);
 
     for(int i = 0; i < num_iterations; i++)
@@ -2554,6 +2587,7 @@ int ConvDriver<Tgpu, Tref>::RunBackwardDataGpuImmed()
         PrintBackwardDataTime(kernel_total_time, kernel_first_time);
     }
 
+    is_bwd_igemm = (selected->algorithm == miopenConvolutionAlgoImplicitGEMM);
     din_dev->FromGPU(GetStream(), din.data());
     return rc;
 }
@@ -2682,6 +2716,7 @@ int ConvDriver<Tgpu, Tref>::RunBackwardWrwGpuImmed()
     }
 
     is_wrw_winograd = (selected->algorithm == miopenConvolutionAlgoWinograd);
+    is_wrw_igemm    = (selected->algorithm == miopenConvolutionAlgoImplicitGEMM);
     dwei_dev->FromGPU(GetStream(), dwei.data());
     return rc;
 }
@@ -2718,7 +2753,7 @@ int ConvDriver<Tgpu, Tref>::RunBackwardWeightsCPU()
             "dump_bwd_dwei_cpu.bin", dwei_host.data.data(), dwei_host.data.size());
     }
 
-    TrySaveVerificationCache(GetVCacheBwdWeightBasename(), dwei_host.data);
+    TrySaveVerificationCache(Direction::WrW, dwei_host.data);
     return 0;
 }
 
@@ -2753,7 +2788,7 @@ int ConvDriver<Tgpu, Tref>::RunBackwardDataCPU()
         dumpBufferToFile<Tref>("dump_bwd_din_cpu.bin", din_host.data.data(), din_host.data.size());
     }
 
-    TrySaveVerificationCache(GetVCacheBwdDataBasename(), din_host.data);
+    TrySaveVerificationCache(Direction::Bwd, din_host.data);
     return 0;
 }
 
@@ -2767,12 +2802,13 @@ int ConvDriver<Tgpu, Tref>::RunBackwardBiasCPU()
         dumpBufferToFile<Tref>("dump_bwd_db_cpu.bin", db_host.data.data(), db_host.data.size());
     }
 
-    TrySaveVerificationCache(GetVCacheBiasBwdDataBasename(), db_host.data);
+    TrySaveVerificationCache(Direction::BwdBias, db_host.data);
     return 0;
 }
 
 template <typename Tgpu, typename Tref>
-std::string ConvDriver<Tgpu, Tref>::GetVerificationCacheFileName() const
+std::string ConvDriver<Tgpu, Tref>::GetVerificationCacheFileName(
+    const ConvDriver<Tgpu, Tref>::Direction& direction) const
 {
     std::ostringstream ss;
 
@@ -2792,6 +2828,17 @@ std::string ConvDriver<Tgpu, Tref>::GetVerificationCacheFileName() const
                                      conv_strides.data(),
                                      conv_dilations.data(),
                                      &mode);
+
+    auto get_basename_string = [&]() {
+        switch(direction)
+        {
+        case Direction::Fwd: return "conv_fwd_out";
+        case Direction::Bwd: return "conv_bwd_dat";
+        case Direction::WrW: return "conv_bwd_wei";
+        case Direction::BwdBias: return "bias_bwd_dat";
+        }
+        return "<error in get_basename_string>"; // For gcc.
+    };
 
     auto get_datatype_string = [](auto type) {
         if(std::is_same<decltype(type), int8_t>::value)
@@ -2820,7 +2867,8 @@ std::string ConvDriver<Tgpu, Tref>::GetVerificationCacheFileName() const
         }
     };
 
-    ss << mode;
+    ss << get_basename_string();
+    ss << "_" << mode;
     ss << "_" << spatial_dim;
     ss << "_" << miopen::deref(convDesc).paddingMode;
     ss << "_" << miopen::deref(convDesc).GetGroupCount();
@@ -2841,16 +2889,17 @@ std::string ConvDriver<Tgpu, Tref>::GetVerificationCacheFileName() const
 }
 
 template <typename Tgpu, typename Tref>
-bool ConvDriver<Tgpu, Tref>::TryReadVerificationCache(const std::string& file_name,
-                                                      miopenTensorDescriptor_t& tensorDesc,
-                                                      Tref* data) const
+bool ConvDriver<Tgpu, Tref>::TryReadVerificationCache(
+    const ConvDriver<Tgpu, Tref>::Direction& direction,
+    miopenTensorDescriptor_t& tensorDesc,
+    Tref* data) const
 {
     const auto verification_cache_path = inflags.GetValueStr("verification_cache");
 
     if(!verification_cache_path.empty())
     {
         const auto file_path =
-            verification_cache_path + "/" + file_name + "_" + GetVerificationCacheFileName();
+            verification_cache_path + "/" + GetVerificationCacheFileName(direction);
 
         if(std::ifstream(file_path).good())
         {
@@ -2865,40 +2914,16 @@ bool ConvDriver<Tgpu, Tref>::TryReadVerificationCache(const std::string& file_na
 }
 
 template <typename Tgpu, typename Tref>
-void ConvDriver<Tgpu, Tref>::TrySaveVerificationCache(const std::string& file_name,
-                                                      std::vector<Tref>& data) const
+void ConvDriver<Tgpu, Tref>::TrySaveVerificationCache(
+    const ConvDriver<Tgpu, Tref>::Direction& direction, std::vector<Tref>& data) const
 {
     const auto verification_cache_path = inflags.GetValueStr("verification_cache");
     if(!verification_cache_path.empty())
     {
         const auto file_path =
-            verification_cache_path + "/" + file_name + "_" + GetVerificationCacheFileName();
+            verification_cache_path + "/" + GetVerificationCacheFileName(direction);
         dumpBufferToFile<Tref>(file_path.c_str(), data.data(), data.size());
     }
-}
-
-template <typename Tgpu, typename Tref>
-std::string ConvDriver<Tgpu, Tref>::GetVCacheFwdOutBasename() const
-{
-    return "conv_fwd_out";
-}
-
-template <typename Tgpu, typename Tref>
-std::string ConvDriver<Tgpu, Tref>::GetVCacheBwdDataBasename() const
-{
-    return "conv_bwd_dat";
-}
-
-template <typename Tgpu, typename Tref>
-std::string ConvDriver<Tgpu, Tref>::GetVCacheBwdWeightBasename() const
-{
-    return "conv_bwd_wei";
-}
-
-template <typename Tgpu, typename Tref>
-std::string ConvDriver<Tgpu, Tref>::GetVCacheBiasBwdDataBasename() const
-{
-    return "bias_bwd_dat";
 }
 
 template <typename Tgpu, typename Tref>
@@ -2908,7 +2933,7 @@ int ConvDriver<Tgpu, Tref>::VerifyForward()
         return 0;
 
     if(!is_fwd_run_failed)
-        if(!TryReadVerificationCache(GetVCacheFwdOutBasename(), outputTensor, outhost.data.data()))
+        if(!TryReadVerificationCache(Direction::Fwd, outputTensor, outhost.data.data()))
             RunForwardCPU();
 
     const auto isInt8 = (data_type == miopenInt8 || data_type == miopenInt8x4);
@@ -2916,11 +2941,15 @@ int ConvDriver<Tgpu, Tref>::VerifyForward()
                                    : (isInt8 ? miopen::rms_range(outhost.data, out_int8)
                                              : miopen::rms_range(outhost.data, out.data));
 
-    const Tref tolerance = ((sizeof(Tgpu) == 4 || sizeof(Tgpu) == 1) ? static_cast<Tref>(1e-6)
-                                                                     : static_cast<Tref>(7e-2));
-    if(!(error < tolerance))
+    auto tolerance = GetDefaultTolerance();
+    // iGemm's deviation is higher than other algorithms.
+    // The reason is most likely different order of computations.
+    if(is_fwd_igemm)
+        tolerance = tolerance * 10;
+
+    if(error > tolerance)
     {
-        std::cout << "Forward Convolution Failed: " << error << std::endl;
+        std::cout << "Forward Convolution Failed: " << error << " > " << tolerance << std::endl;
         return EC_VerifyFwd;
     }
     std::cout << "Forward Convolution Verifies on CPU and GPU (" << error << ')' << std::endl;
@@ -2939,22 +2968,26 @@ int ConvDriver<Tgpu, Tref>::VerifyBackward()
     if(!(is_bwd || is_wrw))
         return 0;
 
-    const double tolerance = sizeof(Tgpu) == 4 ? 1e-6 : 7e-2;
-
     int cumulative_rc = 0;
     if(is_bwd)
     {
         if(!is_bwd_run_failed)
-            if(!TryReadVerificationCache(
-                   GetVCacheBwdDataBasename(), inputTensor, din_host.data.data()))
+            if(!TryReadVerificationCache(Direction::Bwd, inputTensor, din_host.data.data()))
                 RunBackwardDataCPU();
 
         auto error_data = is_bwd_run_failed ? std::numeric_limits<double>::max()
                                             : miopen::rms_range(din_host.data, din);
 
-        if(!(error_data < tolerance))
+        auto tolerance = GetDefaultTolerance();
+        // iGemm's deviation is higher than other algorithms.
+        // The reason is most likely different order of computations.
+        if(is_bwd_igemm)
+            tolerance = tolerance * 10;
+
+        if(error_data > tolerance)
         {
-            std::cout << "Backward Convolution Data Failed: " << error_data << std::endl;
+            std::cout << "Backward Convolution Data Failed: " << error_data << " > " << tolerance
+                      << std::endl;
             cumulative_rc |= EC_VerifyBwd;
         }
         else
@@ -2967,23 +3000,36 @@ int ConvDriver<Tgpu, Tref>::VerifyBackward()
     if(is_wrw)
     {
         if(!is_wrw_run_failed)
-            if(!TryReadVerificationCache(
-                   GetVCacheBwdWeightBasename(), weightTensor, dwei_host.data.data()))
+            if(!TryReadVerificationCache(Direction::WrW, weightTensor, dwei_host.data.data()))
                 RunBackwardWeightsCPU();
 
-        // Winograd algorithm has worse precision than Direct and Gemm.
-        // Winograd-specific precision loss is roughly 2+2 bits.
-        // Affects only WrW FP32 for now.
-        auto tolerance_wrw = tolerance;
+        // WrW deviation is ~twice worse than Bwd due to more FP computations involved,
+        // which means more roundings, so GPU amd CPU computations diverge more.
+        auto tolerance = 2 * GetDefaultTolerance();
+        // Winograd and iGemm WrW algorithms reveal bigger deviation than other algos.
         if(is_wrw_winograd && std::is_same<Tgpu, float>::value)
-            tolerance_wrw *= 16.0;
+        {
+            tolerance *= 10;
+        }
+        else if(is_wrw_igemm)
+        {
+            if(std::is_same<Tgpu, float>::value)
+#if WORKAROUND_ISSUE_2176
+                tolerance = 0.01;
+#else
+                tolerance *= 10;
+#endif
+            else if(std::is_same<Tgpu, float16>::value)
+                tolerance *= 5;
+        }
 
         auto error_weights = is_wrw_run_failed ? std::numeric_limits<double>::max()
                                                : miopen::rms_range(dwei_host.data, dwei);
 
-        if(!(error_weights < tolerance_wrw))
+        if(error_weights > tolerance)
         {
-            std::cout << "Backward Convolution Weights Failed: " << error_weights << std::endl;
+            std::cout << "Backward Convolution Weights Failed: " << error_weights << " > "
+                      << tolerance << std::endl;
             cumulative_rc |= EC_VerifyWrw;
         }
         else
@@ -2995,16 +3041,17 @@ int ConvDriver<Tgpu, Tref>::VerifyBackward()
 
     if(inflags.GetValueInt("bias") != 0)
     {
-        if(!TryReadVerificationCache(
-               GetVCacheBiasBwdDataBasename(), biasTensor, db_host.data.data()))
+        if(!TryReadVerificationCache(Direction::BwdBias, biasTensor, db_host.data.data()))
         {
             RunBackwardBiasCPU();
         }
 
-        auto error_bias = miopen::rms_range(db_host.data, db);
-        if(!(error_bias < tolerance))
+        auto error_bias      = miopen::rms_range(db_host.data, db);
+        const auto tolerance = GetDefaultTolerance();
+        if(error_bias > tolerance)
         {
-            std::cout << "Backward Convolution Bias Failed: " << error_bias << std::endl;
+            std::cout << "Backward Convolution Bias Failed: " << error_bias << " > " << tolerance
+                      << std::endl;
             cumulative_rc |= EC_VerifyBwdBias;
         }
         else

--- a/driver/driver.hpp
+++ b/driver/driver.hpp
@@ -130,7 +130,7 @@ void PadBufferSize(size_t& sz, int datatype_sz)
     printf(
         "Supported Base Arguments: conv[fp16|int8|bfp16], CBAInfer[fp16], pool[fp16], lrn[fp16], "
         "activ[fp16], softmax[fp16], bnorm[fp16], rnn[fp16], gemm, ctc, dropout[fp16], "
-        "tensorop[fp16]\n");
+        "tensorop[fp16], reduce[fp16]\n");
     exit(0);
 }
 
@@ -150,7 +150,7 @@ std::string ParseBaseArg(int argc, char* argv[])
        arg != "softmax" && arg != "softmaxfp16" && arg != "bnorm" && arg != "bnormfp16" &&
        arg != "rnn" && arg != "rnnfp16" && arg != "gemm" /*&& arg != "gemmfp16"*/ && arg != "ctc" &&
        arg != "dropout" && arg != "dropoutfp16" && arg != "tensorop" && arg != "tensoropfp16" &&
-       arg != "--version")
+       arg != "reduce" && arg != "reducefp16" && arg != "--version")
     {
         printf("Invalid Base Input Argument\n");
         Usage();

--- a/driver/miopen_ReductionHost.hpp
+++ b/driver/miopen_ReductionHost.hpp
@@ -1,0 +1,417 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2020 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#ifndef GUARD_MIOPEN_REDUCTION_HOST_HPP_
+#define GUARD_MIOPEN_REDUCTION_HOST_HPP_
+
+#include <vector>
+#include <functional>
+#include <limits>
+#include <type_traits>
+#include <cassert>
+#include <cmath>
+
+#include <miopen/reduce_common.hpp>
+
+#include "tensor_driver.hpp"
+
+using float16 = half_float::half;
+
+static inline void
+get_all_indexes(const std::vector<int>& dimLengths, int dim, std::vector<std::vector<int>>& indexes)
+{
+    if(dim < dimLengths.size())
+    {
+        std::vector<std::vector<int>> updated_indexes;
+
+        if(dim == 0)
+        {
+            for(int i = 0; i < dimLengths[dim]; i++)
+            {
+                std::vector<int> index = {i};
+
+                updated_indexes.push_back(index);
+            };
+        }
+        else
+        {
+            // go through all the current indexes
+            for(const auto& index : indexes)
+                for(int i = 0; i < dimLengths[dim]; i++)
+                {
+                    auto index_new = index; // explicit copying
+
+                    index_new.push_back(i);
+
+                    updated_indexes.push_back(index_new);
+                };
+        };
+
+        // update to the indexes (output)
+        indexes = updated_indexes;
+
+        // further to construct the indexes from the updated status
+        get_all_indexes(dimLengths, dim + 1, indexes);
+    };
+};
+
+static inline int get_offset_from_index(const std::vector<int>& strides,
+                                        const std::vector<int>& index)
+{
+    int offset = 0;
+
+    assert(index.size() == strides.size());
+    for(int i = 0; i < index.size(); i++)
+        offset += strides[i] * index[i];
+
+    return (offset);
+};
+
+static inline int get_flatten_offset(const std::vector<int>& lengths, const std::vector<int>& index)
+{
+    int offset = 0;
+
+    assert(lengths.size() == index.size() && lengths.size() > 0);
+
+    int len    = lengths.size();
+    int stride = 1;
+
+    // for len==1, the loop is not executed
+    for(int i = len - 1; i > 0; i--)
+    {
+        offset += stride * index[i];
+
+        stride *= lengths[i];
+    };
+
+    offset += stride * index[0];
+
+    return (offset);
+};
+
+template <typename Tgpu, typename Tref>
+class miopenReductionHost
+{
+    public:
+    miopenReductionHost() = default;
+    miopenReductionHost(const miopenReduceTensorDescriptor_t reduceDesc,
+                        miopenTensorDescriptor_t inDesc,
+                        miopenTensorDescriptor_t outDesc,
+                        const std::vector<int>& invariantDims_,
+                        const std::vector<int>& toReduceDims_)
+    {
+        miopenGetReduceTensorDescriptor(
+            reduceDesc, &reduceOp, &compTypeVal, &nanOpt, &indicesOpt, &indicesType);
+
+        this->inLengths  = GetTensorLengths(inDesc);
+        this->outLengths = GetTensorLengths(outDesc);
+        this->inStrides  = GetTensorStrides(inDesc);
+        this->outStrides = GetTensorStrides(outDesc);
+
+        this->invariantDims = invariantDims_;
+        this->toReduceDims  = toReduceDims_;
+
+        assert(this->inLengths.size() == this->outLengths.size());
+        assert(!this->toReduceDims.empty());
+
+        for(const auto dim : this->invariantDims)
+            this->invariantLengths.push_back(this->inLengths[dim]);
+
+        for(const auto dim : this->toReduceDims)
+            toReduceLengths.push_back(this->inLengths[dim]);
+
+        this->reduceAllDims = this->invariantDims.empty();
+    };
+
+    ~miopenReductionHost(){};
+
+    void Run(Tgpu alpha, const Tgpu* in_data, Tgpu beta, Tref* out_data, int* indices)
+    {
+        if(compTypeVal == miopenFloat)
+        {
+            if(std::is_same<Tref, double>::value)
+                RunImpl<double>(alpha, in_data, beta, out_data, indices);
+            else
+                RunImpl<float>(alpha, in_data, beta, out_data, indices);
+        }
+        else if(compTypeVal == miopenHalf)
+        {
+            if(std::is_same<Tref, double>::value || std::is_same<Tref, float>::value)
+                RunImpl<Tref>(alpha, in_data, beta, out_data, indices);
+            else
+                RunImpl<float16>(alpha, in_data, beta, out_data, indices);
+        };
+
+        return;
+    };
+
+    private:
+    miopenReduceTensorOp_t reduceOp;
+    miopenDataType_t compTypeVal;
+    miopenNanPropagation_t nanOpt;
+    miopenReduceTensorIndices_t indicesOpt;
+    miopenIndicesType_t indicesType;
+
+    std::vector<int> inLengths;
+    std::vector<int> outLengths;
+    std::vector<int> inStrides;
+    std::vector<int> outStrides;
+
+    std::vector<int> invariantLengths;
+    std::vector<int> toReduceLengths;
+
+    std::vector<int> invariantDims;
+    std::vector<int> toReduceDims;
+
+    bool reduceAllDims;
+
+    template <typename compType>
+    void RunImpl(Tgpu alpha, const Tgpu* in_data, Tgpu beta, Tref* out_data, int* indices)
+    {
+        bool need_indices =
+            (indicesOpt == MIOPEN_REDUCE_TENSOR_FLATTENED_INDICES) &&
+            (reduceOp == MIOPEN_REDUCE_TENSOR_MIN || reduceOp == MIOPEN_REDUCE_TENSOR_MAX);
+
+        if(need_indices)
+            RunImpl_with_indices<compType>(alpha, in_data, beta, out_data, indices);
+        else
+            RunImpl_no_indices<compType>(alpha, in_data, beta, out_data);
+    };
+
+    template <typename compType>
+    void
+    RunImpl_with_indices(Tgpu alpha, const Tgpu* in_data, Tgpu beta, Tref* out_data, int* indices)
+    {
+        using reduce::ReduceOpFn2;
+        using reduce::ReduceOpZeroVal;
+        using reduce::float_equal_one;
+        using reduce::float_equal_zero;
+        using reduce::type_convert;
+        using reduce::binop_with_nan_check;
+        using reduce::binop_with_nan_check2;
+
+        auto opReduce = ReduceOpFn2<compType>(this->reduceOp);
+
+        if(reduceAllDims)
+        {
+            std::vector<std::vector<int>> indexes_1;
+
+            get_all_indexes(inLengths, 0, indexes_1); // generate the input indexes space
+
+            auto accuVal  = ReduceOpZeroVal<compType>(this->reduceOp);
+            int accuIndex = 0;
+
+            // go through indexes of the invariant dimensions
+            for(const auto& src_index : indexes_1)
+            {
+                auto src_offset = get_offset_from_index(this->inStrides, src_index);
+
+                auto currVal = type_convert<compType>{}(in_data[src_offset]);
+
+                auto currIndex = get_flatten_offset(inLengths, src_index);
+                binop_with_nan_check2(nanOpt, opReduce, accuVal, currVal, accuIndex, currIndex);
+            };
+
+            // scale the accumulated value
+            if(!float_equal_one{}(alpha))
+                accuVal *= type_convert<compType>{}(alpha);
+
+            // scale the prior dst value and add it to the accumulated value
+            if(!float_equal_zero{}(beta))
+                accuVal += type_convert<compType>{}(out_data[0] * type_convert<Tref>{}(beta));
+
+            // store the reduced value to dst location
+            out_data[0] = type_convert<Tref>{}(accuVal);
+            indices[0]  = accuIndex;
+        }
+        else
+        {
+            std::vector<std::vector<int>> indexes_1, indexes_2;
+
+            get_all_indexes(
+                this->invariantLengths, 0, indexes_1); // generate the invariant indexes space
+            get_all_indexes(
+                this->toReduceLengths, 0, indexes_2); // generate the toReduce indexes space
+
+            // go through indexes of the invariant dimensions
+            for(const auto& index_1 : indexes_1)
+            {
+                std::vector<int> src_index;
+                std::vector<int> dst_index;
+
+                src_index.resize(this->inLengths.size());
+                dst_index.resize(this->inLengths.size());
+
+                // initialize the src index
+                std::fill(dst_index.begin(), dst_index.end(), 0);
+
+                for(int k                       = 0; k < invariantDims.size(); k++)
+                    dst_index[invariantDims[k]] = index_1[k];
+
+                int dst_offset = get_offset_from_index(this->outStrides, dst_index);
+
+                // generate the part of src index belonging to invariant dims
+                for(int k                       = 0; k < invariantDims.size(); k++)
+                    src_index[invariantDims[k]] = index_1[k];
+
+                compType accuVal = ReduceOpZeroVal<compType>(this->reduceOp);
+                int accuIndex    = 0;
+
+                // go through indexes of the toReduce dimensions
+                for(const auto& index_2 : indexes_2)
+                {
+                    // generate the part of src index belonging to toReduce dims
+                    for(int k                      = 0; k < toReduceDims.size(); k++)
+                        src_index[toReduceDims[k]] = index_2[k];
+
+                    auto src_offset = get_offset_from_index(this->inStrides, src_index);
+
+                    auto currVal = type_convert<compType>{}(in_data[src_offset]);
+
+                    auto currIndex = get_flatten_offset(toReduceLengths, index_2);
+                    binop_with_nan_check2(nanOpt, opReduce, accuVal, currVal, accuIndex, currIndex);
+                };
+
+                // scale the accumulated value
+                if(!float_equal_one{}(alpha))
+                    accuVal *= type_convert<compType>{}(alpha);
+
+                // scale the prior dst value and add it to the accumulated value
+                if(!float_equal_zero{}(beta))
+                    accuVal +=
+                        type_convert<compType>{}(out_data[dst_offset] * type_convert<Tref>{}(beta));
+
+                // store the reduced value to dst location
+                out_data[dst_offset] = type_convert<Tref>{}(accuVal);
+                indices[dst_offset]  = accuIndex;
+            };
+        };
+    }; // end of RunImpl_with_indices()
+
+    template <typename compType>
+    void RunImpl_no_indices(Tgpu alpha, const Tgpu* in_data, Tgpu beta, Tref* out_data)
+    {
+        using reduce::ReduceOpFn;
+        using reduce::ReduceOpZeroVal;
+        using reduce::float_equal_one;
+        using reduce::float_equal_zero;
+        using reduce::type_convert;
+        using reduce::binop_with_nan_check;
+        using reduce::binop_with_nan_check2;
+
+        auto opReduce = ReduceOpFn<compType>(this->reduceOp);
+
+        if(reduceAllDims)
+        {
+            std::vector<std::vector<int>> indexes_1;
+
+            get_all_indexes(inLengths, 0, indexes_1); // generate the input indexes space
+
+            auto accuVal = ReduceOpZeroVal<compType>(this->reduceOp);
+
+            // go through indexes of the invariant dimensions
+            for(const auto& src_index : indexes_1)
+            {
+                auto src_offset = get_offset_from_index(this->inStrides, src_index);
+
+                auto currVal = type_convert<compType>{}(in_data[src_offset]);
+
+                binop_with_nan_check(nanOpt, opReduce, accuVal, currVal);
+            };
+
+            // scale the accumulated value
+            if(!float_equal_one{}(alpha))
+                accuVal *= type_convert<compType>{}(alpha);
+
+            // scale the prior dst value and add it to the accumulated value
+            if(!float_equal_zero{}(beta))
+                accuVal += type_convert<compType>{}(out_data[0] * type_convert<Tref>{}(beta));
+
+            // store the reduced value to dst location
+            out_data[0] = type_convert<Tref>{}(accuVal);
+        }
+        else
+        {
+            std::vector<std::vector<int>> indexes_1, indexes_2;
+
+            get_all_indexes(
+                this->invariantLengths, 0, indexes_1); // generate the invariant indexes space
+            get_all_indexes(
+                this->toReduceLengths, 0, indexes_2); // generate the toReduce indexes space
+
+            // go through indexes of the invariant dimensions
+            for(const auto& index_1 : indexes_1)
+            {
+                std::vector<int> src_index;
+                std::vector<int> dst_index;
+
+                src_index.resize(this->inLengths.size());
+                dst_index.resize(this->inLengths.size());
+
+                // initialize the src index
+                std::fill(dst_index.begin(), dst_index.end(), 0);
+
+                for(int k                       = 0; k < invariantDims.size(); k++)
+                    dst_index[invariantDims[k]] = index_1[k];
+
+                int dst_offset = get_offset_from_index(this->outStrides, dst_index);
+
+                // generate the part of src index belonging to invariant dims
+                for(int k                       = 0; k < invariantDims.size(); k++)
+                    src_index[invariantDims[k]] = index_1[k];
+
+                compType accuVal = ReduceOpZeroVal<compType>(this->reduceOp);
+
+                // go through indexes of the toReduce dimensions
+                for(const auto& index_2 : indexes_2)
+                {
+                    // generate the part of src index belonging to toReduce dims
+                    for(int k                      = 0; k < toReduceDims.size(); k++)
+                        src_index[toReduceDims[k]] = index_2[k];
+
+                    auto src_offset = get_offset_from_index(this->inStrides, src_index);
+
+                    auto currVal = type_convert<compType>{}(in_data[src_offset]);
+
+                    binop_with_nan_check(nanOpt, opReduce, accuVal, currVal);
+                };
+
+                // scale the accumulated value
+                if(!float_equal_one{}(alpha))
+                    accuVal *= type_convert<compType>{}(alpha);
+
+                // scale the prior dst value and add it to the accumulated value
+                if(!float_equal_zero{}(beta))
+                    accuVal +=
+                        type_convert<compType>{}(out_data[dst_offset] * type_convert<Tref>{}(beta));
+
+                // store the reduced value to dst location
+                out_data[dst_offset] = type_convert<Tref>{}(accuVal);
+            };
+        };
+    }; // end of RunImpl_no_indices()
+};
+
+#endif

--- a/driver/reduce_driver.hpp
+++ b/driver/reduce_driver.hpp
@@ -1,0 +1,508 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2020 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#ifndef GUARD_MIOPEN_REDUCE_DRIVER_HPP
+#define GUARD_MIOPEN_REDUCE_DRIVER_HPP
+
+#include "../test/verify.hpp"
+#include "InputFlags.hpp"
+#include "driver.hpp"
+#include "tensor_driver.hpp"
+#include "timer.hpp"
+#include <algorithm>
+#include <cstdlib>
+#include <float.h>
+#include <memory>
+#include <miopen/miopen.h>
+#include <miopen/reduce_common.hpp>
+#include <miopen/tensor.hpp>
+#include <miopen/bfloat16.hpp>
+#include <numeric>
+#include <vector>
+#include <string>
+#include <cassert>
+#include "random.hpp"
+
+#include "miopen_ReductionHost.hpp"
+
+template <typename Tgpu, typename Tref>
+class ReduceDriver : public Driver
+{
+    public:
+    ReduceDriver() : Driver()
+    {
+        miopenCreateTensorDescriptor(&inputTensor);
+        miopenCreateTensorDescriptor(&outputTensor);
+
+        miopenCreateReduceTensorDescriptor(&reduceDesc);
+
+        data_type = (sizeof(Tgpu) == 4) ? miopenFloat : miopenHalf;
+    }
+
+    int AddCmdLineArgs();
+    int ParseCmdLineArgs(int argc, char* argv[]);
+    InputFlags& GetInputFlags() { return inflags; }
+
+    int GetandSetData();
+    std::vector<int> GetInputTensorLengthsFromCmdLine();
+    std::vector<int> GetDimsToReduceFromCmdLine();
+
+    int SetReduceTensorDescriptorFromCmdLineArgs();
+
+    int AllocateBuffersAndCopy();
+
+    int RunForwardGPU();
+    int RunForwardCPU();
+
+    int RunBackwardGPU();
+    int RunBackwardCPU();
+
+    int VerifyBackward();
+    int VerifyForward();
+
+    ~ReduceDriver()
+    {
+
+        miopenDestroyTensorDescriptor(outputTensor);
+        miopenDestroyTensorDescriptor(inputTensor);
+
+        miopenDestroyReduceTensorDescriptor(reduceDesc);
+    }
+
+    private:
+    InputFlags inflags;
+
+    miopenTensorDescriptor_t inputTensor;
+    miopenTensorDescriptor_t outputTensor;
+    std::vector<int> dimsToReduce;
+    std::vector<int> dimsInvariant;
+
+    std::unique_ptr<GPUMem> in_dev;
+    std::unique_ptr<GPUMem> out_dev;
+    std::unique_ptr<GPUMem> ws_dev;
+    std::unique_ptr<GPUMem> indices_dev;
+
+    std::vector<Tgpu> in;
+    std::vector<Tgpu> out;
+    std::vector<Tref> outhost;
+    std::vector<int> out_indices;
+    std::vector<int> outhost_indices;
+
+    bool need_indices;
+    std::size_t ws_sizeInBytes;
+    std::size_t indices_sizeInBytes;
+
+    miopenReduceTensorDescriptor_t reduceDesc;
+};
+
+template <typename Tgpu, typename Tref>
+int ReduceDriver<Tgpu, Tref>::ParseCmdLineArgs(int argc, char* argv[])
+{
+    inflags.Parse(argc, argv);
+
+    if(inflags.GetValueInt("time") == 1)
+    {
+        miopenEnableProfiling(GetHandle(), true);
+    }
+    return 0;
+}
+
+template <typename Tgpu, typename Tref>
+int ReduceDriver<Tgpu, Tref>::GetandSetData()
+{
+    std::vector<int> inLengths    = GetInputTensorLengthsFromCmdLine();
+    std::vector<int> toReduceDims = GetDimsToReduceFromCmdLine();
+    std::vector<int> outLengths   = inLengths;
+    std::vector<int> invariantDims;
+
+    assert(toReduceDims.size() <= inLengths.size());
+    for(int i = 0; i < toReduceDims.size(); i++)
+        assert(toReduceDims[i] < inLengths.size());
+
+    // set the lengths of the dimensions to be reduced to 1 to represent the output Tensor
+    for(int i                       = 0; i < toReduceDims.size(); i++)
+        outLengths[toReduceDims[i]] = 1;
+
+    SetTensorNd(inputTensor, inLengths, data_type);
+    SetTensorNd(outputTensor, outLengths, data_type);
+    SetReduceTensorDescriptorFromCmdLineArgs();
+
+    this->dimsToReduce = toReduceDims;
+
+    for(int i = 0; i < inLengths.size(); i++)
+        if(inLengths[i] == outLengths[i])
+            invariantDims.push_back(i);
+
+    this->dimsInvariant = invariantDims;
+
+    return (0);
+}
+
+template <typename Tgpu, typename Tref>
+int ReduceDriver<Tgpu, Tref>::AddCmdLineArgs()
+{
+    inflags.AddInputFlag("forw", 'F', "1", "Run only Forward (Default=1)", "int");
+    inflags.AddInputFlag("DimLengths",
+                         'D',
+                         "100,60,16,240",
+                         "The dimensional lengths of the input tensor",
+                         "string");
+    inflags.AddInputFlag(
+        "DimsToReduce", 'R', "0,2", "The indices of the dimensions to be reduced", "string");
+    inflags.AddInputFlag("ReduceOp",
+                         'O',
+                         "0,2",
+                         "Reduction Operation Type (check the enum miopenReduceTensorOp_t in "
+                         "miopen.h) (Default=0 to represent Add of two values)",
+                         "int");
+    inflags.AddInputFlag("CompType",
+                         'C',
+                         "1",
+                         "The computation type of the Reduce operation (check the enum "
+                         "miopenDataType_t in miopen.h) (Default=1(Float)",
+                         "int");
+    inflags.AddInputFlag("NanPropagation",
+                         'N',
+                         "0",
+                         "Nan number propagation mode (check the miopenNanPropagation_t in "
+                         "miopen.h) (Default=0 to indicate no Nan propagation)",
+                         "int");
+    inflags.AddInputFlag("IndicesUsed",
+                         'I',
+                         "0,1",
+                         "whether indices of the reduced values are outputed when Min/Max "
+                         "operation is used (Default=0 to indicate no indices outputed)",
+                         "int");
+
+    inflags.AddInputFlag("alpha", 'A', "1.0", "Scale factor for input tensor", "double");
+    inflags.AddInputFlag("beta", 'B', "0.0", "Scale factor for output tensor", "double");
+
+    inflags.AddInputFlag(
+        "wall", 'w', "0", "Wall-clock Time Each Layer, Requires time == 1 (Default=0)", "int");
+
+    inflags.AddInputFlag("iter", 'i', "1", "Number of Iterations (Default=1)", "int");
+    inflags.AddInputFlag("verify", 'V', "1", "Verify Each Layer (Default=1)", "int");
+    inflags.AddInputFlag("time", 't', "0", "Time Each Layer (Default=0)", "int");
+
+    return 0;
+}
+
+template <typename Tgpu, typename Tref>
+std::vector<int> ReduceDriver<Tgpu, Tref>::GetInputTensorLengthsFromCmdLine()
+{
+    std::string lengthsStr = inflags.GetValueStr("DimLengths");
+
+    std::vector<int> lengths;
+    std::size_t pos = 0;
+    std::size_t new_pos;
+
+    new_pos = lengthsStr.find(',', pos);
+    while(new_pos != std::string::npos)
+    {
+        std::string sliceStr = lengthsStr.substr(pos, new_pos - pos);
+
+        int len = std::stoi(sliceStr);
+
+        lengths.push_back(len);
+
+        pos     = new_pos + 1;
+        new_pos = lengthsStr.find(',', pos);
+    };
+
+    std::string sliceStr = lengthsStr.substr(pos);
+    int len              = std::stoi(sliceStr);
+
+    lengths.push_back(len);
+
+    return (lengths);
+}
+
+template <typename Tgpu, typename Tref>
+std::vector<int> ReduceDriver<Tgpu, Tref>::GetDimsToReduceFromCmdLine()
+{
+    std::string lengthsStr = inflags.GetValueStr("DimsToReduce");
+
+    std::vector<int> lengths;
+    std::size_t pos = 0;
+    std::size_t new_pos;
+
+    new_pos = lengthsStr.find(',', pos);
+    while(new_pos != std::string::npos)
+    {
+        std::string sliceStr = lengthsStr.substr(pos, new_pos - pos);
+
+        int len = std::stoi(sliceStr);
+
+        lengths.push_back(len);
+
+        pos     = new_pos + 1;
+        new_pos = lengthsStr.find(',', pos);
+    };
+
+    std::string sliceStr = lengthsStr.substr(pos);
+    int len              = std::stoi(sliceStr);
+
+    lengths.push_back(len);
+
+    return (lengths);
+}
+
+template <typename Tgpu, typename Tref>
+int ReduceDriver<Tgpu, Tref>::SetReduceTensorDescriptorFromCmdLineArgs()
+{
+    miopenReduceTensorOp_t reduceOp =
+        static_cast<miopenReduceTensorOp_t>(inflags.GetValueInt("ReduceOp"));
+    miopenDataType_t compType = static_cast<miopenDataType_t>(inflags.GetValueInt("CompType"));
+    miopenNanPropagation_t nanOpt =
+        static_cast<miopenNanPropagation_t>(inflags.GetValueInt("NanPropagation"));
+    miopenReduceTensorIndices_t indicesOpt =
+        static_cast<miopenReduceTensorIndices_t>(inflags.GetValueInt("IndicesUsed"));
+    miopenIndicesType_t indicesType = MIOPEN_32BIT_INDICES;
+
+    // no other place is better to place this line of codes
+    this->need_indices =
+        (indicesOpt == MIOPEN_REDUCE_TENSOR_FLATTENED_INDICES) &&
+        (reduceOp == MIOPEN_REDUCE_TENSOR_MIN || reduceOp == MIOPEN_REDUCE_TENSOR_MAX);
+
+    return (miopenSetReduceTensorDescriptor(
+        reduceDesc, reduceOp, compType, nanOpt, indicesOpt, indicesType));
+}
+
+template <typename Tgpu, typename Tref>
+int ReduceDriver<Tgpu, Tref>::AllocateBuffersAndCopy()
+{
+    using reduce::type_convert;
+
+    size_t in_nelem  = GetTensorSize(inputTensor);
+    size_t out_nelem = GetTensorSize(outputTensor);
+
+    miopenGetReductionWorkSpaceSize(
+        GetHandle(), reduceDesc, inputTensor, outputTensor, &this->ws_sizeInBytes);
+    miopenGetReductionIndicesSize(
+        GetHandle(), reduceDesc, inputTensor, outputTensor, &this->indices_sizeInBytes);
+
+    size_t ws_nelem = (!this->need_indices) ? this->ws_sizeInBytes / sizeof(Tgpu)
+                                            : this->ws_sizeInBytes / (sizeof(Tgpu) + sizeof(int));
+    size_t indices_nelem = this->indices_sizeInBytes / sizeof(int);
+
+#if MIOPEN_BACKEND_OPENCL
+    cl_context ctx;
+
+    clGetCommandQueueInfo(q, CL_QUEUE_CONTEXT, sizeof(cl_context), &ctx, nullptr);
+#elif MIOPEN_BACKEND_HIP
+    uint32_t ctx = 0;
+#endif
+    in_dev  = std::unique_ptr<GPUMem>(new GPUMem(ctx, in_nelem, sizeof(Tgpu)));
+    out_dev = std::unique_ptr<GPUMem>(new GPUMem(ctx, out_nelem, sizeof(Tgpu)));
+    ws_dev  = this->need_indices ? std::unique_ptr<GPUMem>(new GPUMem(
+                                      ctx, ws_nelem * 2, std::max<int>(sizeof(Tgpu), sizeof(int))))
+                                : std::unique_ptr<GPUMem>(new GPUMem(ctx, ws_nelem, sizeof(int)));
+
+    indices_dev = std::unique_ptr<GPUMem>(new GPUMem(ctx, indices_nelem, sizeof(int)));
+
+    in              = std::vector<Tgpu>(in_nelem, type_convert<Tgpu>{}(0.3f));
+    out             = std::vector<Tgpu>(out_nelem, type_convert<Tgpu>{}(0.2f));
+    outhost         = std::vector<Tref>(out_nelem, type_convert<Tref>{}(0.2f));
+    out_indices     = std::vector<int>(indices_nelem, static_cast<int>(0));
+    outhost_indices = std::vector<int>(indices_nelem, static_cast<int>(0));
+
+    for(int i = 0; i < in_nelem; i++)
+    {
+        in[i] = RAN_GEN<Tgpu>(type_convert<Tgpu>{}(0.0f), type_convert<Tgpu>{}(1.0f));
+    }
+
+#if MIOPEN_BACKEND_OPENCL
+    cl_int status;
+#elif MIOPEN_BACKEND_HIP
+    int status;
+#endif
+    status = in_dev->ToGPU(q, in.data());
+    status |= out_dev->ToGPU(q, out.data());
+
+    if(status != CL_SUCCESS)
+        printf("Error copying data to GPU\n");
+
+    return miopenStatusSuccess;
+}
+
+template <typename Tgpu, typename Tref>
+int ReduceDriver<Tgpu, Tref>::RunForwardGPU()
+{
+    auto alpha =
+        reduce::type_convert<Tgpu>{}(static_cast<float>(this->inflags.GetValueDouble("alpha")));
+    auto beta =
+        reduce::type_convert<Tgpu>{}(static_cast<float>(this->inflags.GetValueDouble("beta")));
+
+    if(this->need_indices)
+    {
+        alpha = reduce::type_convert<Tgpu>{}(1.0f);
+        beta  = reduce::type_convert<Tgpu>{}(0.0f);
+    };
+
+    bool output_accumulate =
+        !(reduce::float_equal_one{}(alpha) && reduce::float_equal_zero{}(beta));
+
+    miopenReduceTensor(GetHandle(),
+                       reduceDesc,
+                       this->need_indices ? indices_dev->GetMem() : nullptr, // indices
+                       this->need_indices ? indices_sizeInBytes : 0,    // indices size in bytes
+                       ws_sizeInBytes > 0 ? ws_dev->GetMem() : nullptr, // workspace
+                       ws_sizeInBytes,                                  // workspace size in bytes
+                       &alpha,
+                       inputTensor,
+                       in_dev->GetMem(),
+                       &beta,
+                       outputTensor,
+                       out_dev->GetMem());
+
+    // must get the output here, since the host-based method only run once
+    if(output_accumulate)
+    {
+        out_dev->FromGPU(GetStream(), out.data());
+        indices_dev->FromGPU(GetStream(), out_indices.data());
+    };
+
+    Timer t;
+    START_TIME
+
+    for(int i = 0; i < inflags.GetValueInt("iter"); i++)
+    {
+        miopenReduceTensor(GetHandle(),
+                           reduceDesc,
+                           this->need_indices ? indices_dev->GetMem() : nullptr, // indices
+                           this->need_indices ? indices_sizeInBytes : 0,    // indices size in bytes
+                           ws_sizeInBytes > 0 ? ws_dev->GetMem() : nullptr, // workspace
+                           ws_sizeInBytes, // workspace size in bytes
+                           &alpha,
+                           inputTensor,
+                           in_dev->GetMem(),
+                           &beta,
+                           outputTensor,
+                           out_dev->GetMem());
+    }
+
+    // for verifying correctness
+    if(!output_accumulate)
+    {
+        out_dev->FromGPU(GetStream(), out.data());
+        indices_dev->FromGPU(GetStream(), out_indices.data());
+    };
+
+    if(inflags.GetValueInt("time") == 1)
+    {
+        float time = 0.0;
+        miopenGetKernelTime(GetHandle(), &time);
+
+        STOP_TIME
+        if(WALL_CLOCK)
+            printf("Wall-clock Time Forward LRN Elapsed: %f ms\n",
+                   t.gettime_ms() / inflags.GetValueInt("iter"));
+        printf("GPU Kernel Time Forward LRN Elapsed: %f ms\n", time);
+    }
+
+    return miopenStatusSuccess;
+}
+
+template <typename Tgpu, typename Tref>
+int ReduceDriver<Tgpu, Tref>::RunForwardCPU()
+{
+    return (0);
+}
+
+template <typename Tgpu, typename Tref>
+int ReduceDriver<Tgpu, Tref>::RunBackwardGPU()
+{
+    return miopenStatusSuccess;
+}
+
+template <typename Tgpu, typename Tref>
+int ReduceDriver<Tgpu, Tref>::VerifyForward()
+{
+    miopenReductionHost<Tgpu, Tref> hostReduction(this->reduceDesc,
+                                                  this->inputTensor,
+                                                  this->outputTensor,
+                                                  this->dimsInvariant,
+                                                  this->dimsToReduce);
+
+    auto alpha =
+        reduce::type_convert<Tgpu>{}(static_cast<float>(this->inflags.GetValueDouble("alpha")));
+    auto beta =
+        reduce::type_convert<Tgpu>{}(static_cast<float>(this->inflags.GetValueDouble("beta")));
+
+    if(indices_sizeInBytes > 0)
+    {
+        alpha = reduce::type_convert<Tgpu>{}(1.0f);
+        beta  = reduce::type_convert<Tgpu>{}(0.0f);
+    };
+
+    hostReduction.Run(alpha, in.data(), beta, outhost.data(), outhost_indices.data());
+
+    auto error = miopen::rms_range(outhost, out);
+    const Tref tolerance =
+        std::is_same<Tgpu, float16>::value ? static_cast<Tref>(2e-3) : static_cast<Tref>(1.5e-4);
+    if(error > tolerance)
+    {
+        std::cout << "ReduceTensor() Failed: " << error << "\n";
+    }
+    else
+    {
+        if(out_indices.size() > 0)
+        {
+            auto error2 = miopen::rms_range(outhost_indices, out_indices);
+
+            if(static_cast<float>(error2) != 0.0f)
+            {
+                std::cout << "ReduceTensor() with indices output Failed: " << error2 << "\n";
+            }
+            else
+            {
+                printf("ReduceTensor() with indices output Verifies on CPU and GPU (err=%f, "
+                       "err2=%f)\n",
+                       error,
+                       error2);
+            };
+        }
+        else
+        {
+            printf("ReduceTensor() Verifies on CPU and GPU (err=%f)\n", error);
+        };
+    };
+
+    return 0;
+}
+
+template <typename Tgpu, typename Tref>
+int ReduceDriver<Tgpu, Tref>::RunBackwardCPU()
+{
+    return 0;
+}
+
+template <typename Tgpu, typename Tref>
+int ReduceDriver<Tgpu, Tref>::VerifyBackward()
+{
+    return 0;
+}
+
+#endif // GUARD_MIOPEN_CONV_DRIVER_HPP

--- a/driver/tensor_driver.hpp
+++ b/driver/tensor_driver.hpp
@@ -79,11 +79,18 @@ std::vector<int> GetTensorStrides(miopenTensorDescriptor_t& tensor)
             tensor, &nstride, &cstride, &dstride, &hstride, &wstride);
         return std::vector<int>({nstride, cstride, dstride, hstride, wstride});
     }
-    else
+    else if(size == 4)
     {
         miopenGet4dTensorDescriptorStrides(tensor, &nstride, &cstride, &hstride, &wstride);
         return std::vector<int>({nstride, cstride, hstride, wstride});
     }
+
+    std::vector<int> tensor_strides;
+    tensor_strides.resize(miopen::deref(tensor).GetSize());
+
+    miopenGetTensorDescriptor(tensor, nullptr, nullptr, tensor_strides.data());
+
+    return tensor_strides;
 }
 
 int SetTensor4d(miopenTensorDescriptor_t t,

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -217,6 +217,7 @@ set( MIOpen_Source
     solver/conv_hip_implicit_gemm_wrw_weights_v4r4.cpp
     solver/conv_hip_implicit_gemm_v4r4_xdlops.cpp
     solver/conv_hip_implicit_gemm_v4r4_gen_xdlops.cpp
+    solver/conv_hip_implicit_gemm_fwd_v4r4_xdlops.cpp
     solver/conv_hip_implicit_gemm_v4r4_gen_xdlops_wrw_fp32.cpp
     solver/conv_hip_implicit_gemm_xdlops_common.cpp
     solver/conv_hip_implicit_gemm_nonxdlops_common.cpp

--- a/src/hip/hip_build_utils.cpp
+++ b/src/hip/hip_build_utils.cpp
@@ -118,7 +118,6 @@ boost::filesystem::path HipBuild(boost::optional<TmpDir>& tmp_dir,
         params += " -O3 ";
     }
 
-    // params += " -Wno-unused-command-line-argument -c -fno-gpu-rdc -I. ";
     params += " -Wno-unused-command-line-argument -I. ";
     params += MIOPEN_STRINGIZE(HIP_COMPILER_FLAGS);
     if(IsHccCompiler())
@@ -144,11 +143,13 @@ boost::filesystem::path HipBuild(boost::optional<TmpDir>& tmp_dir,
     {
         if(IsHccCompiler())
         {
+            params += " -gline-tables-only";
             env += " KMDUMPISA=1";
             env += " KMDUMPLLVM=1";
         }
         else if(IsHipClangCompiler())
         {
+            params += " -gline-tables-only";
             params += " -save-temps";
         }
     }
@@ -299,6 +300,23 @@ external_tool_version_t HipCompilerVersion()
 {
     static auto once = HipCompilerVersionImpl();
     return once;
+}
+
+bool external_tool_version_t::operator>(const external_tool_version_t& rhs) const
+{
+    if(major > rhs.major)
+        return true;
+    else if(major == rhs.major)
+    {
+        if(minor > rhs.minor)
+            return true;
+        else if(minor == rhs.minor)
+            return (patch > rhs.patch);
+        else
+            return false;
+    }
+    else
+        return false;
 }
 
 bool external_tool_version_t::operator>=(const external_tool_version_t& rhs) const

--- a/src/include/miopen/comgr.hpp
+++ b/src/include/miopen/comgr.hpp
@@ -47,6 +47,12 @@ void BuildOcl(const std::string& name,
               const std::string& device,
               std::vector<char>& binary);
 
+void BuildAsm(const std::string& name,
+              const std::string& text,
+              const std::string& options,
+              const std::string& device,
+              std::vector<char>& binary);
+
 } // namespace comgr
 } // namespace miopen
 

--- a/src/include/miopen/find_controls.hpp
+++ b/src/include/miopen/find_controls.hpp
@@ -128,7 +128,7 @@ class FindMode
         Fast,
         Hybrid,
         End_,
-        Default_ = Normal,
+        Default_ = Hybrid,
     };
 
     private:

--- a/src/include/miopen/hip_build_utils.hpp
+++ b/src/include/miopen/hip_build_utils.hpp
@@ -47,6 +47,7 @@ struct external_tool_version_t
     int major = -1;
     int minor = -1;
     int patch = -1;
+    bool operator>(const external_tool_version_t& rhs) const;
     bool operator>=(const external_tool_version_t& rhs) const;
 };
 

--- a/src/kernels/composable_kernel/include/kernel_algorithm/gridwise_convolution_forward_implicit_gemm_v4r4_xdlops_nchw_kcyx_nkhw.hpp
+++ b/src/kernels/composable_kernel/include/kernel_algorithm/gridwise_convolution_forward_implicit_gemm_v4r4_xdlops_nchw_kcyx_nkhw.hpp
@@ -1,0 +1,199 @@
+#ifndef CK_GRIDWISE_GROUP_CONVOLUTION_FORWARD_IMPLICIT_GEMM_V4R4_XDLOPS_GNCHW_GKCYX_GNKHW_HPP
+#define CK_GRIDWISE_GROUP_CONVOLUTION_FORWARD_IMPLICIT_GEMM_V4R4_XDLOPS_GNCHW_GKCYX_GNKHW_HPP
+
+#include "common_header.hpp"
+#include "tensor_descriptor.hpp"
+#include "tensor_descriptor_helper.hpp"
+#include "ConstantMatrixDescriptor.hpp"
+#include "gridwise_gemm_xdlops_fp16_bfp16.hpp"
+
+namespace ck {
+
+template <index_t GridSize,
+          index_t BlockSize,
+          class ABFloat,
+          class AccFloat,
+          class CFloat,
+          class InGlobalDesc,
+          class WeiGlobalDesc,
+          class OutGlobalDesc,
+          index_t G,
+          class ConvStrides,
+          class ConvDilations,
+          class InLeftPads,
+          class InRightPads,
+          index_t GemmMPerBlock,
+          index_t GemmNPerBlock,
+          index_t GemmKPerBlock,
+          index_t GemmMPerWave,
+          index_t GemmNPerWave,
+          index_t GemmKPack,
+          class GemmABlockCopyThreadSliceLengths_GemmG_GemmK_GemmM_GemmKPack,
+          class GemmABlockCopyThreadClusterLengths_GemmG_GemmK_GemmM_GemmKPack,
+          class GemmABlockCopyThreadClusterArrangeOrder,
+          class GemmABlockCopySrcAccessOrder,
+          class GemmABlockCopyDstAccessOrder,
+          index_t GemmABlockCopySrcDataPerRead_GemmKPack,
+          index_t GemmABlockCopyDstDataPerWrite_GemmKPack,
+          class GemmBBlockCopyThreadSliceLengths_GemmG_GemmK_GemmN_GemmKPack,
+          class GemmBBlockCopyThreadClusterLengths_GemmG_GemmK_GemmN_GemmKPack,
+          class GemmBBlockCopyThreadClusterArrangeOrder,
+          class GemmBBlockCopySrcAccessOrder,
+          class GemmBBlockCopyDstAccessOrder,
+          index_t GemmBBlockCopySrcDataPerRead_GemmN,
+          index_t GemmBBlockCopyDstDataPerWrite_GemmKPack,
+          WorkgroupScheduleOrder WorkgroupSchdOrder>
+struct GridwiseConvolutionForwardImplicitGemm_v4r4_xdlops_nchw_kcyx_nkhw
+{
+    __device__ void Run(const ABFloat* const __restrict__ p_in_global,
+                        const ABFloat* const __restrict__ p_wei_global,
+                        CFloat* const __restrict__ p_out_global) const
+    {
+        constexpr auto in_n_c_hi_wi_global_desc        = InGlobalDesc{};
+        constexpr auto wei_k_cpergroup_y_x_global_desc = WeiGlobalDesc{};
+        constexpr auto out_n_k_ho_wo_global_desc       = OutGlobalDesc{};
+
+        constexpr index_t N  = in_n_c_hi_wi_global_desc.GetLengths()[0];
+        constexpr index_t C  = in_n_c_hi_wi_global_desc.GetLengths()[1];
+        constexpr index_t Hi = in_n_c_hi_wi_global_desc.GetLengths()[2];
+        constexpr index_t Wi = in_n_c_hi_wi_global_desc.GetLengths()[3];
+
+        constexpr index_t K  = out_n_k_ho_wo_global_desc.GetLengths()[1];
+        constexpr index_t Ho = out_n_k_ho_wo_global_desc.GetLengths()[2];
+        constexpr index_t Wo = out_n_k_ho_wo_global_desc.GetLengths()[3];
+
+        constexpr index_t Y = wei_k_cpergroup_y_x_global_desc.GetLengths()[2];
+        constexpr index_t X = wei_k_cpergroup_y_x_global_desc.GetLengths()[3];
+
+        constexpr index_t CPerGroup = C / G;
+        constexpr index_t KPerGroup = K / G;
+
+        static_assert(CPerGroup == wei_k_cpergroup_y_x_global_desc.GetLengths()[1], "wrong!");
+
+        constexpr index_t ConvStrideH = ConvStrides{}[0];
+        constexpr index_t ConvStrideW = ConvStrides{}[1];
+
+        constexpr index_t ConvDilationH = ConvDilations{}[0];
+        constexpr index_t ConvDilationW = ConvDilations{}[1];
+
+        constexpr index_t GemmG      = G;
+        constexpr index_t GemmM      = KPerGroup;
+        constexpr index_t GemmN      = N * Ho * Wo;
+        constexpr index_t GemmKTotal = CPerGroup * Y * X;
+
+        static_assert(GemmKTotal % GemmKPack == 0,
+                      "wrong! GemmKTotal should be multiple of GemmKPack");
+
+        constexpr index_t GemmK = GemmKTotal / GemmKPack;
+
+        static_assert(GemmM % GemmMPerBlock == 0 && GemmN % GemmNPerBlock == 0 &&
+                          GemmK % GemmKPerBlock == 0,
+                      "wrong! cannot divide work evenly among block");
+
+        // construct tensor descriptor for group convolution
+        constexpr auto in_g_n_cpergroup_hi_wi_global_desc = make_native_tensor_descriptor(
+            Sequence<G, N, CPerGroup, Hi, Wi>{},
+            Sequence<CPerGroup * Hi * Wi, C * Hi * Wi, Hi * Wi, Wi, 1>{});
+
+        constexpr auto wei_g_kpergroup_cpergroup_y_x_global_desc =
+            make_native_tensor_descriptor_packed(Sequence<G, KPerGroup, CPerGroup, Y, X>{});
+
+        constexpr auto out_g_n_kpergroup_ho_wo_global_desc = make_native_tensor_descriptor(
+            Sequence<G, N, KPerGroup, Ho, Wo>{},
+            Sequence<KPerGroup * Ho * Wo, K * Ho * Wo, Ho * Wo, Wo, 1>{});
+
+        // input tensor
+        constexpr auto in_g_n_cpergroup_hip_wip_global_desc = transform_tensor_descriptor(
+            in_g_n_cpergroup_hi_wi_global_desc,
+            make_tuple(PassThrough<G>{},
+                       PassThrough<N>{},
+                       PassThrough<CPerGroup>{},
+                       Pad<Sequence<Hi, Wi>, InLeftPads, InRightPads>{}),
+            make_tuple(Sequence<0>{}, Sequence<1>{}, Sequence<2>{}, Sequence<3, 4>{}),
+            make_tuple(Sequence<0>{}, Sequence<1>{}, Sequence<2>{}, Sequence<3, 4>{}));
+
+        constexpr index_t Hip = in_g_n_cpergroup_hip_wip_global_desc.GetLengths()[3];
+        constexpr index_t Wip = in_g_n_cpergroup_hip_wip_global_desc.GetLengths()[4];
+
+        constexpr auto in_g_n_cpergroup_y_ho_x_wo_global_desc = transform_tensor_descriptor(
+            in_g_n_cpergroup_hip_wip_global_desc,
+            make_tuple(PassThrough<G>{},
+                       PassThrough<N>{},
+                       PassThrough<CPerGroup>{},
+                       Embed<Hip, Sequence<Y, Ho>, Sequence<ConvDilationH, ConvStrideH, 0>>{},
+                       Embed<Wip, Sequence<X, Wo>, Sequence<ConvDilationW, ConvStrideW, 0>>{}),
+            make_tuple(Sequence<0>{}, Sequence<1>{}, Sequence<2>{}, Sequence<3>{}, Sequence<4>{}),
+            make_tuple(
+                Sequence<0>{}, Sequence<1>{}, Sequence<2>{}, Sequence<3, 4>{}, Sequence<5, 6>{}));
+
+        constexpr auto in_gemmg_gemmktotal_gemmn_global_desc = transform_tensor_descriptor(
+            in_g_n_cpergroup_y_ho_x_wo_global_desc,
+            make_tuple(PassThrough<G>{}, Merge<Sequence<C, Y, X>>{}, Merge<Sequence<N, Ho, Wo>>{}),
+            make_tuple(Sequence<0>{}, Sequence<2, 3, 5>{}, Sequence<1, 4, 6>{}),
+            make_tuple(Sequence<0>{}, Sequence<1>{}, Sequence<2>{}));
+
+        constexpr auto in_gemmg_gemmk_gemmn_gemmkpack_global_desc = transform_tensor_descriptor(
+            in_gemmg_gemmktotal_gemmn_global_desc,
+            make_tuple(
+                PassThrough<GemmG>{}, UnMerge<Sequence<GemmK, GemmKPack>>{}, PassThrough<GemmN>{}),
+            make_tuple(Sequence<0>{}, Sequence<1>{}, Sequence<2>{}),
+            make_tuple(Sequence<0>{}, Sequence<1, 3>{}, Sequence<2>{}));
+
+        // weight tensor
+        constexpr auto wei_gemmg_gemmm_gemmktotal_global_desc = unfold_tensor_descriptor(
+            wei_g_kpergroup_cpergroup_y_x_global_desc, Number<2>{}, Number<4>{});
+
+        constexpr auto wei_gemmg_gemmk_gemmm_gemmkpack_global_desc = transform_tensor_descriptor(
+            wei_gemmg_gemmm_gemmktotal_global_desc,
+            make_tuple(
+                PassThrough<GemmG>{}, PassThrough<GemmM>{}, UnMerge<Sequence<GemmK, GemmKPack>>{}),
+            make_tuple(Sequence<0>{}, Sequence<1>{}, Sequence<2>{}),
+            make_tuple(Sequence<0>{}, Sequence<2>{}, Sequence<1, 3>{}));
+
+        // output tensor
+        constexpr auto out_gemmg_gemmm_gemmn_global_desc = transform_tensor_descriptor(
+            out_g_n_kpergroup_ho_wo_global_desc,
+            make_tuple(PassThrough<G>{}, PassThrough<KPerGroup>{}, Merge<Sequence<N, Ho, Wo>>{}),
+            make_tuple(Sequence<0>{}, Sequence<2>{}, Sequence<1, 3, 4>{}),
+            make_tuple(Sequence<0>{}, Sequence<1>{}, Sequence<2>{}));
+
+        // gridwise batch-GEMM
+        constexpr auto gridwise_gemm = GridwiseBatchGemmXdlops_gkmkpack_gknkpack_gmn_v2<
+            GridSize,
+            BlockSize,
+            ABFloat,
+            AccFloat,
+            CFloat,
+            decltype(wei_gemmg_gemmk_gemmm_gemmkpack_global_desc),
+            decltype(in_gemmg_gemmk_gemmn_gemmkpack_global_desc),
+            decltype(out_gemmg_gemmm_gemmn_global_desc),
+            GemmMPerBlock,
+            GemmNPerBlock,
+            GemmKPerBlock,
+            GemmMPerWave,
+            GemmNPerWave,
+            GemmABlockCopyThreadSliceLengths_GemmG_GemmK_GemmM_GemmKPack,
+            GemmABlockCopyThreadClusterLengths_GemmG_GemmK_GemmM_GemmKPack,
+            GemmABlockCopyThreadClusterArrangeOrder,
+            GemmABlockCopySrcAccessOrder,
+            GemmABlockCopyDstAccessOrder,
+            3, // src vector read dimension of A matrix is GemmKPack
+            GemmABlockCopySrcDataPerRead_GemmKPack,
+            GemmABlockCopyDstDataPerWrite_GemmKPack,
+            GemmBBlockCopyThreadSliceLengths_GemmG_GemmK_GemmN_GemmKPack,
+            GemmBBlockCopyThreadClusterLengths_GemmG_GemmK_GemmN_GemmKPack,
+            GemmBBlockCopyThreadClusterArrangeOrder,
+            GemmBBlockCopySrcAccessOrder,
+            GemmBBlockCopyDstAccessOrder,
+            2, // Src vetor read diemsnion of B matrix is GemmN
+            GemmBBlockCopySrcDataPerRead_GemmN,
+            GemmBBlockCopyDstDataPerWrite_GemmKPack,
+            InMemoryDataOperation::Set,
+            WorkgroupSchdOrder>{};
+
+        gridwise_gemm.Run(p_wei_global, p_in_global, p_out_global);
+    }
+};
+
+} // namespace ck
+#endif

--- a/src/kernels/composable_kernel/include/tensor_operation/blockwise_gemm_xdlops.hpp
+++ b/src/kernels/composable_kernel/include/tensor_operation/blockwise_gemm_xdlops.hpp
@@ -16,8 +16,9 @@ template <index_t BlockSize,
           index_t GemmNPerWave,
           index_t GemmMWaves,
           index_t GemmNWaves,
-          index_t GemmDataPerReadA,
-          index_t GemmDataPerReadB>
+          index_t GemmDataPerReadA, // \todo unused parameter, remove
+          index_t GemmDataPerReadB  // \todo unused parameter, remove
+          >
 struct BlockwiseGemmBlockABlockBThreadCTransANormalBNormalC_xdlops
 {
     struct MatrixIndex
@@ -26,8 +27,14 @@ struct BlockwiseGemmBlockABlockBThreadCTransANormalBNormalC_xdlops
         index_t col;
     };
 
+    static constexpr index_t MRepeats = (GemmMPerWave > 64) ? (GemmMPerWave / 64) : 1;
+    static constexpr index_t NRepeats = (GemmNPerWave > 64) ? (GemmNPerWave / 64) : 1;
+
+    static constexpr index_t MPerXdlops = (GemmMPerWave > 64) ? 64 : GemmMPerWave;
+    static constexpr index_t NPerXdlops = (GemmNPerWave > 64) ? 64 : GemmNPerWave;
+
     static constexpr auto XdlopsGemm =
-        XdlopsGemm_t<Float, GemmMPerWave, GemmNPerWave, GemmDataPerReadA, GemmDataPerReadB>{};
+        XdlopsGemm_t<Float, MPerXdlops, NPerXdlops, GemmDataPerReadA, GemmDataPerReadB>{};
 
     index_t mMyWaveOffsetA;
     index_t mMyWaveOffsetB;
@@ -35,6 +42,20 @@ struct BlockwiseGemmBlockABlockBThreadCTransANormalBNormalC_xdlops
     static constexpr index_t WaveSize = 64;
 
     __device__ constexpr auto GetOutputLayout() const { return XdlopsGemm.GetOutputLayout(); }
+
+    __device__ constexpr auto GetMRepeats() const { return MRepeats; }
+
+    __device__ constexpr auto GetNRepeats() const { return NRepeats; }
+
+    __device__ constexpr auto GetNumBlks() const
+    {
+        return XdlopsGemm.GetOutputLayout().GetNumBlks() * MRepeats * NRepeats;
+    }
+
+    __device__ constexpr auto GetBlkSize() const
+    {
+        return XdlopsGemm.GetOutputLayout().GetBlkSize();
+    }
 
     __device__ BlockwiseGemmBlockABlockBThreadCTransANormalBNormalC_xdlops()
     {
@@ -68,8 +89,17 @@ struct BlockwiseGemmBlockABlockBThreadCTransANormalBNormalC_xdlops
         constexpr index_t N = BlockMatrixB::NCol();
         constexpr index_t K = BlockMatrixA::NRow();
 
-        XdlopsGemm.template Run<M, N, K>(
-            &p_a_block[mMyWaveOffsetA], &p_b_block[mMyWaveOffsetB], p_c_thread);
+        constexpr auto reg_size_xdlops = MPerXdlops * NPerXdlops / WaveSize;
+
+        for(index_t m = 0; m < MRepeats; m++)
+        {
+            for(index_t n = 0; n < NRepeats; n++)
+            {
+                XdlopsGemm.template Run<M, N, K>(&p_a_block[mMyWaveOffsetA + MPerXdlops * m],
+                                                 &p_b_block[mMyWaveOffsetB + NPerXdlops * n],
+                                                 p_c_thread + (NRepeats * m + n) * reg_size_xdlops);
+            }
+        }
     }
 
     __device__ static MatrixIndex GetBeginOfThreadMatrixC(index_t i)
@@ -77,32 +107,40 @@ struct BlockwiseGemmBlockABlockBThreadCTransANormalBNormalC_xdlops
 
         const index_t waveId = get_thread_local_1d_id() / WaveSize;
 
-        const auto thread_mtx_on_blk = XdlopsGemm.GetBeginOfThreadBlk(i);
+        const index_t xdlops_i = i / XdlopsGemm.GetOutputLayout().GetNumBlks();
+        const index_t j        = i % XdlopsGemm.GetOutputLayout().GetNumBlks();
 
-        const index_t col = waveId % GemmNWaves * GemmNPerWave + thread_mtx_on_blk.col;
+        const index_t m = xdlops_i / NRepeats;
+        const index_t n = xdlops_i % NRepeats;
 
-        const index_t row = waveId / GemmNWaves * GemmMPerWave + thread_mtx_on_blk.row;
+        const auto thread_mtx_on_blk = XdlopsGemm.GetBeginOfThreadBlk(j);
+
+        const index_t col =
+            (waveId % GemmNWaves) * GemmNPerWave + n * NPerXdlops + thread_mtx_on_blk.col;
+
+        const index_t row =
+            (waveId / GemmNWaves) * GemmMPerWave + m * MPerXdlops + thread_mtx_on_blk.row;
 
         return MatrixIndex{row, col};
     }
 
     __device__ constexpr auto GetThreadMatrixCDescriptor() const
     {
-        const index_t reg_size = GemmMPerWave * GemmNPerWave / WaveSize;
-        return make_ConstantMatrixDescriptor_packed(Number<reg_size>{}, Number<1>{});
+        const index_t total_reg_size = GemmMPerWave * GemmNPerWave / WaveSize;
+        return make_ConstantMatrixDescriptor_packed(Number<total_reg_size>{}, Number<1>{});
     }
 
     __device__ void XdlopsMatrixCSetZero() const
     {
-        constexpr auto thread_mtx_size = GemmMPerWave * GemmNPerWave / WaveSize;
-        XdlopsGemm.SetZeroXdlopsRegs(Number<thread_mtx_size>{});
+        constexpr auto reg_size_xdlops = MPerXdlops * NPerXdlops / WaveSize;
+        XdlopsGemm.SetZeroXdlopsRegs(Number<reg_size_xdlops>{});
     }
 
     template <class FloatC>
     __device__ void XdlopsMatrixCRead(FloatC* __restrict__ p_c_thread) const
     {
-        constexpr auto thread_mtx_size = GemmMPerWave * GemmNPerWave / WaveSize;
-        XdlopsGemm.ReadXdlopsRegs(Number<thread_mtx_size>{}, p_c_thread);
+        constexpr auto reg_size_xdlops = MPerXdlops * NPerXdlops / WaveSize;
+        XdlopsGemm.ReadXdlopsRegs(Number<reg_size_xdlops>{}, p_c_thread);
     }
 };
 

--- a/src/kernels/composable_kernel/include/tensor_operation/gridwise_gemm_xdlops.hpp
+++ b/src/kernels/composable_kernel/include/tensor_operation/gridwise_gemm_xdlops.hpp
@@ -295,8 +295,8 @@ struct GridwiseGemmTransposedANormalBNormalCXdlops_v1
 
             using CThreadCopySliceLengths = Sequence<M0, 1, M2, 1>;
 
-            constexpr index_t BlkSize = CLayout.GetBlkSize();
-            constexpr index_t NumBlks = CLayout.GetNumBlks();
+            constexpr index_t BlkSize = blockwise_gemm.GetBlkSize();
+            constexpr index_t NumBlks = blockwise_gemm.GetNumBlks();
 
             for(index_t i = 0; i < NumBlks; ++i)
             {

--- a/src/kernels/composable_kernel/include/tensor_operation/gridwise_gemm_xdlops_fp16_bfp16.hpp
+++ b/src/kernels/composable_kernel/include/tensor_operation/gridwise_gemm_xdlops_fp16_bfp16.hpp
@@ -11,6 +11,12 @@
 
 namespace ck {
 
+enum WorkgroupScheduleOrder
+{
+    MBlock1NBlock0,
+    NBlock1MBlock0
+};
+
 template <index_t Gi,
           index_t MBlockWork,
           index_t NBlockWork,
@@ -144,7 +150,7 @@ struct GridwiseGemmTransposedANormalBNormalCXdlopsFp16Bfp16_v1
             2,                          // Dst dim to be written in vector form (KPACK dimension)
             ABlockCopySrcDataPerRead,
             ABlockCopyDstDataPerWrite_KPACK,
-            AddressSpace::Generic,
+            AddressSpace::Global,
             AddressSpace::Vgpr,
             AddressSpace::Lds,
             InMemoryDataOperation::Set,
@@ -168,7 +174,7 @@ struct GridwiseGemmTransposedANormalBNormalCXdlopsFp16Bfp16_v1
             2,                          // Dst dim to be written in vector form (KPACK dimension)
             BBlockCopySrcDataPerRead,
             BBlockCopyDstDataPerWrite_KPACK,
-            AddressSpace::Generic,
+            AddressSpace::Global,
             AddressSpace::Vgpr,
             AddressSpace::Lds,
             InMemoryDataOperation::Set,
@@ -497,7 +503,7 @@ struct GridwiseBatchedGemmTransposedANormalBNormalCXdlopsFp16Bfp16_v1
             3,                          // Dst dim to be written in vector form (KPACK dimension)
             ABlockCopySrcDataPerRead,
             ABlockCopyDstDataPerWrite_KPACK,
-            AddressSpace::Generic,
+            AddressSpace::Global,
             AddressSpace::Vgpr,
             AddressSpace::Lds,
             InMemoryDataOperation::Set,
@@ -521,7 +527,7 @@ struct GridwiseBatchedGemmTransposedANormalBNormalCXdlopsFp16Bfp16_v1
             3,                          // Dst dim to be written in vector form (KPACK dimension)
             BBlockCopySrcDataPerRead,   // N dimension
             BBlockCopyDstDataPerWrite_KPACK,
-            AddressSpace::Generic,
+            AddressSpace::Global,
             AddressSpace::Vgpr,
             AddressSpace::Lds,
             InMemoryDataOperation::Set,
@@ -730,22 +736,308 @@ struct GridwiseBatchedGemmTransposedANormalBNormalCXdlopsFp16Bfp16_v1
                 const index_t n_thread_data_on_global =
                     n_block_data_on_global + c_thread_mtx_on_block.col;
 
-                ThreadwiseGenericTensorSliceCopy_v4r2<
-                    decltype(c_g_m0_m1_m2_n_thread_desc),
-                    decltype(c_g_m0_m1_m2_n_global_desc),
-                    CThreadCopySliceLengths,
-                    arithmetic_sequence_gen<0, 5, 1>::type,
-                    4,
-                    1,
-                    1,
-                    AddressSpace::Vgpr,
-                    is_same<AccFloat, CFloat>::value ? AddressSpace::Global : AddressSpace::Generic,
-                    OutputMemOp>({0, 0, 0, 0, 0},
-                                 {group_id,
-                                  m_thread_data_on_global / (M2 * M1),
-                                  m_thread_data_on_global % (M2 * M1) / M2,
-                                  m_thread_data_on_global % M2,
-                                  n_thread_data_on_global})
+                ThreadwiseGenericTensorSliceCopy_v4r2<decltype(c_g_m0_m1_m2_n_thread_desc),
+                                                      decltype(c_g_m0_m1_m2_n_global_desc),
+                                                      CThreadCopySliceLengths,
+                                                      arithmetic_sequence_gen<0, 5, 1>::type,
+                                                      4,
+                                                      1,
+                                                      1,
+                                                      AddressSpace::Vgpr,
+                                                      AddressSpace::Global,
+                                                      OutputMemOp>(
+                    {0, 0, 0, 0, 0},
+                    {group_id,
+                     m_thread_data_on_global / (M2 * M1),
+                     m_thread_data_on_global % (M2 * M1) / M2,
+                     m_thread_data_on_global % M2,
+                     n_thread_data_on_global})
+                    .Run(p_c_thread + i * BlkSize, p_c_global);
+            }
+        }
+    }
+};
+
+template <index_t GridSize,
+          index_t BlockSize,
+          class ABFloat,
+          class AccFloat,
+          class CFloat,
+          class AGlobalDesc,
+          class BGlobalDesc,
+          class CGlobalDesc,
+          index_t MPerBlock,
+          index_t NPerBlock,
+          index_t KPerBlock,
+          index_t MPerWave,
+          index_t NPerWave,
+          class ABlockCopyThreadSliceLengths_G_K_M_KPACK,
+          class ABlockCopyThreadClusterLengths_G_K_M_KPACK,
+          class ABlockCopyThreadClusterArrangeOrder,
+          class ABlockCopySrcAccessOrder,
+          class ABlockCopyDstAccessOrder,
+          index_t ABlockCopySrcVectorReadDim,
+          index_t ABlockCopySrcDataPerRead,
+          index_t ABlockCopyDstDataPerWrite_KPACK,
+          class BBlockCopyThreadSliceLengths_G_K_N_KPACK,
+          class BBlockCopyThreadClusterLengths_G_K_N_KPACK,
+          class BBlockCopyThreadClusterArrangeOrder,
+          class BBlockCopySrcAccessOrder,
+          class BBlockCopyDstAccessOrder,
+          index_t BBlockCopySrcVectorReadDim,
+          index_t BBlockCopySrcDataPerRead,
+          index_t BBlockCopyDstDataPerWrite_KPACK,
+          InMemoryDataOperation CGlobalMemoryOp,
+          WorkgroupScheduleOrder WorkgroupSchdOrder>
+struct GridwiseBatchGemmXdlops_gkmkpack_gknkpack_gmn_v2
+{
+    __device__ void Run(const ABFloat* const __restrict__ p_a_global,
+                        const ABFloat* const __restrict__ p_b_global,
+                        CFloat* const __restrict__ p_c_global) const
+    {
+        constexpr auto True = integral_constant<bool, true>{};
+
+        constexpr auto a_g_k_m_kpack_global_desc = AGlobalDesc{};
+        constexpr auto b_g_k_n_kpack_global_desc = BGlobalDesc{};
+        constexpr auto c_g_m_n_global_desc       = CGlobalDesc{};
+
+        constexpr auto G     = c_g_m_n_global_desc.GetLengths()[0];
+        constexpr auto M     = c_g_m_n_global_desc.GetLengths()[1];
+        constexpr auto N     = c_g_m_n_global_desc.GetLengths()[2];
+        constexpr auto K     = b_g_k_n_kpack_global_desc.GetLengths()[1];
+        constexpr auto KPack = b_g_k_n_kpack_global_desc.GetLengths()[3];
+
+        // divide block work by [M, N]
+        static_assert(M % MPerBlock == 0 && N % NPerBlock == 0 && K % KPerBlock == 0,
+                      "wrong! cannot divide work evenly among block");
+
+        constexpr index_t MBlockWork = M / MPerBlock;
+        constexpr index_t NBlockWork = N / NPerBlock;
+
+        constexpr index_t MWavePerBlock = MPerBlock / MPerWave;
+        constexpr index_t NWavePerBlock = NPerBlock / NPerWave;
+
+        constexpr auto block_work_sequence =
+            make_batch_block_work_sequence<G, MBlockWork, NBlockWork, WorkgroupSchdOrder>{}.get();
+        constexpr auto block_work_desc = make_cluster_descriptor(block_work_sequence);
+
+        const auto block_work_id = block_work_desc.CalculateClusterIndex(get_block_1d_id());
+
+        const index_t g_block_data_on_global = block_work_id[0];
+        const index_t m_block_data_on_global = (WorkgroupSchdOrder == MBlock1NBlock0)
+                                                   ? (block_work_id[1] * MPerBlock)
+                                                   : (block_work_id[2] * MPerBlock);
+        const index_t n_block_data_on_global = (WorkgroupSchdOrder == MBlock1NBlock0)
+                                                   ? (block_work_id[2] * NPerBlock)
+                                                   : (block_work_id[1] * NPerBlock);
+
+        //   LDS mem
+        constexpr index_t max_align = KPack;
+
+        //   LDS
+        //     be careful of LDS alignment
+        constexpr auto a_g_k_m_kpack_block_desc = make_native_tensor_descriptor_aligned(
+            Sequence<1, KPerBlock, MPerBlock, KPack>{}, Number<max_align>{});
+
+        auto a_blockwise_copy = BlockwiseGenericTensorSliceCopy_v4<
+            BlockSize,
+            decltype(a_g_k_m_kpack_global_desc),
+            decltype(a_g_k_m_kpack_block_desc),
+            decltype(a_g_k_m_kpack_block_desc.GetLengths()),
+            ABlockCopyThreadSliceLengths_G_K_M_KPACK,
+            ABlockCopyThreadClusterLengths_G_K_M_KPACK,
+            ABlockCopyThreadClusterArrangeOrder,
+            ABlockCopySrcAccessOrder,
+            ABlockCopyDstAccessOrder,
+            ABlockCopySrcVectorReadDim, // Src dim to be read in vector form
+            3,                          // Dst dim to be written in vector form (KPack dimension)
+            ABlockCopySrcDataPerRead,
+            ABlockCopyDstDataPerWrite_KPACK,
+            AddressSpace::Global,
+            AddressSpace::Vgpr,
+            AddressSpace::Lds,
+            InMemoryDataOperation::Set>({g_block_data_on_global, 0, m_block_data_on_global, 0},
+                                        {0, 0, 0, 0});
+
+        constexpr auto b_g_k_n_kpack_block_desc = make_native_tensor_descriptor_aligned(
+            Sequence<1, KPerBlock, NPerBlock, KPack>{}, Number<max_align>{});
+
+        // input blockwise copy
+        auto b_blockwise_copy = BlockwiseGenericTensorSliceCopy_v4<
+            BlockSize,
+            decltype(b_g_k_n_kpack_global_desc),
+            decltype(b_g_k_n_kpack_block_desc),
+            decltype(b_g_k_n_kpack_block_desc.GetLengths()),
+            BBlockCopyThreadSliceLengths_G_K_N_KPACK,
+            BBlockCopyThreadClusterLengths_G_K_N_KPACK,
+            BBlockCopyThreadClusterArrangeOrder,
+            BBlockCopySrcAccessOrder,
+            BBlockCopyDstAccessOrder,
+            BBlockCopySrcVectorReadDim, // Src dim to be read in vector form
+            3,                          // Dst dim to be written in vector form (KPack dimension)
+            BBlockCopySrcDataPerRead,
+            BBlockCopyDstDataPerWrite_KPACK,
+            AddressSpace::Global,
+            AddressSpace::Vgpr,
+            AddressSpace::Lds,
+            InMemoryDataOperation::Set>({g_block_data_on_global, 0, n_block_data_on_global, 0},
+                                        {0, 0, 0, 0});
+
+        // GEMM definition
+        // c_mtx += transpose(a_mtx) * b_mtx
+        //     a_mtx[KPerBlock, MPerBlock] is in LDS
+        //     b_mtx[KPerBlocl, NPerBlock] is in LDS
+        //     c_mtx[MPerBlock, NPerBlock] is distributed among threads, and saved in
+        //     register
+        constexpr auto a_k_m_block_mtx_desc =
+            make_ConstantMatrixDescriptor_packed(Number<KPerBlock>{}, Number<MPerBlock>{});
+        constexpr auto b_k_n_block_mtx_desc =
+            make_ConstantMatrixDescriptor_packed(Number<KPerBlock>{}, Number<NPerBlock>{});
+
+        const auto blockwise_gemm = BlockwiseGemmBlockABlockBThreadCTransANormalBNormalC_xdlops<
+            BlockSize,
+            decltype(a_k_m_block_mtx_desc),
+            decltype(b_k_n_block_mtx_desc),
+            ABFloat,
+            MPerWave,
+            NPerWave,
+            MWavePerBlock,
+            NWavePerBlock,
+            1,
+            1>{};
+
+        constexpr auto c_k_thread_mtx_desc = blockwise_gemm.GetThreadMatrixCDescriptor();
+
+        constexpr index_t a_block_space =
+            math::integer_least_multiple(a_g_k_m_kpack_block_desc.GetElementSpace(), max_align);
+
+        constexpr index_t b_block_space =
+            math::integer_least_multiple(b_g_k_n_kpack_block_desc.GetElementSpace(), max_align);
+
+        __shared__ ABFloat p_a_block[a_block_space];
+        __shared__ ABFloat p_b_block[b_block_space];
+
+        // register allocation for output
+        AccFloat p_c_thread[c_k_thread_mtx_desc.GetElementSpace()];
+
+        // zero out threadwise output
+        threadwise_matrix_set_zero(c_k_thread_mtx_desc, p_c_thread);
+        blockwise_gemm.XdlopsMatrixCSetZero();
+
+        // preload data into LDS
+        {
+            a_blockwise_copy.Run(p_a_global, p_a_block);
+            b_blockwise_copy.Run(p_b_global, p_b_block);
+        }
+
+        constexpr auto blockwise_a_copy_src_step = Sequence<0, KPerBlock, 0, 0>{};
+        constexpr auto blockwise_b_copy_src_step = Sequence<0, KPerBlock, 0, 0>{};
+
+        // main body
+        for(index_t k_block_data_begin = 0; k_block_data_begin < K - KPerBlock;
+            k_block_data_begin += KPerBlock)
+        {
+            ABFloat p_a_thread_buffer[a_blockwise_copy.GetThreadBufferSize()];
+            ABFloat p_b_thread_buffer[b_blockwise_copy.GetThreadBufferSize()];
+
+            // load next data from device mem
+            a_blockwise_copy.MoveSrcSliceWindow(blockwise_a_copy_src_step, True);
+            b_blockwise_copy.MoveSrcSliceWindow(blockwise_b_copy_src_step, True);
+
+            a_blockwise_copy.RunLoadThreadBuffer(p_a_global, p_a_thread_buffer);
+            b_blockwise_copy.RunLoadThreadBuffer(p_b_global, p_b_thread_buffer);
+
+            block_sync_lds();
+
+            // GEMM on current data
+            const typename vector_type<ABFloat, KPack>::MemoryType* p_a_block_vec =
+                reinterpret_cast<const typename vector_type<ABFloat, KPack>::MemoryType*>(
+                    p_a_block);
+            const typename vector_type<ABFloat, KPack>::MemoryType* p_b_block_vec =
+                reinterpret_cast<const typename vector_type<ABFloat, KPack>::MemoryType*>(
+                    p_b_block);
+            blockwise_gemm.Run(p_a_block_vec, p_b_block_vec, p_c_thread);
+
+            block_sync_lds();
+
+            // store next data to LDS
+            a_blockwise_copy.RunStoreThreadBuffer(p_a_thread_buffer, p_a_block);
+            b_blockwise_copy.RunStoreThreadBuffer(p_b_thread_buffer, p_b_block);
+        }
+
+        // tail
+        {
+            block_sync_lds();
+
+            // GEMM on last data
+            const typename vector_type<ABFloat, KPack>::MemoryType* p_a_block_vec =
+                reinterpret_cast<const typename vector_type<ABFloat, KPack>::MemoryType*>(
+                    p_a_block);
+            const typename vector_type<ABFloat, KPack>::MemoryType* p_b_block_vec =
+                reinterpret_cast<const typename vector_type<ABFloat, KPack>::MemoryType*>(
+                    p_b_block);
+            blockwise_gemm.Run(p_a_block_vec, p_b_block_vec, p_c_thread);
+        }
+
+        // load data from xldop_acc_regs
+        blockwise_gemm.XdlopsMatrixCRead(p_c_thread);
+
+        // copy output: register to global memory
+        {
+            ///\todo inconsistent layout of xdlops and tensor
+            // xdlops layout
+            // M1 = num_groups;
+            // M0 = group_size;
+            // N1 = num_blks_per_wave;
+            // N0 = num_threads_per_blks;
+            constexpr auto CLayout = blockwise_gemm.GetOutputLayout();
+            constexpr index_t M0   = CLayout.M1();
+            constexpr index_t M1   = CLayout.N1();
+            constexpr index_t M2   = CLayout.M0();
+
+            constexpr auto c_g_m0_m1_m2_n_global_desc = transform_tensor_descriptor(
+                c_g_m_n_global_desc,
+                make_tuple(PassThrough<G>{}, UnMerge<Sequence<M0, M1, M2>>{}, PassThrough<N>{}),
+                make_tuple(Sequence<0>{}, Sequence<1>{}, Sequence<2>{}),
+                make_tuple(Sequence<0>{}, Sequence<1, 2, 3>{}, Sequence<4>{}));
+
+            //     src descriptor
+            constexpr auto c_g_m0_m1_m2_n_thread_desc =
+                make_native_tensor_descriptor_packed(Sequence<1, M0, 1, M2, 1>{});
+
+            using CThreadCopySliceLengths = Sequence<1, M0, 1, M2, 1>;
+
+            constexpr index_t BlkSize = blockwise_gemm.GetBlkSize();
+            constexpr index_t NumBlks = blockwise_gemm.GetNumBlks();
+
+            for(index_t i = 0; i < NumBlks; ++i)
+            {
+                // calculate origin of thread output tensor on global memory
+                //     blockwise GEMM c matrix starting index
+                const auto c_thread_mtx_on_block = blockwise_gemm.GetBeginOfThreadMatrixC(i);
+
+                const index_t m_thread_data_on_global =
+                    m_block_data_on_global + c_thread_mtx_on_block.row;
+
+                const index_t n_thread_data_on_global =
+                    n_block_data_on_global + c_thread_mtx_on_block.col;
+
+                ThreadwiseGenericTensorSliceCopy_v4r2<decltype(c_g_m0_m1_m2_n_thread_desc),
+                                                      decltype(c_g_m0_m1_m2_n_global_desc),
+                                                      CThreadCopySliceLengths,
+                                                      arithmetic_sequence_gen<0, 5, 1>::type,
+                                                      4,
+                                                      1,
+                                                      1,
+                                                      AddressSpace::Vgpr,
+                                                      AddressSpace::Global,
+                                                      CGlobalMemoryOp>(
+                    {0, 0, 0, 0, 0},
+                    {g_block_data_on_global,
+                     m_thread_data_on_global / (M2 * M1),
+                     m_thread_data_on_global % (M2 * M1) / M2,
+                     m_thread_data_on_global % M2,
+                     n_thread_data_on_global})
                     .Run(p_c_thread + i * BlkSize, p_c_global);
             }
         }

--- a/src/kernels/composable_kernel/include/tensor_operation/xdlops_gemm.hpp
+++ b/src/kernels/composable_kernel/include/tensor_operation/xdlops_gemm.hpp
@@ -5,8 +5,6 @@
 #include "ConstantMatrixDescriptor.hpp"
 #include "math.hpp"
 
-#define WORKAROUND_SWDEV_229564 1
-
 namespace ck {
 
 enum struct mfma_instr
@@ -49,20 +47,22 @@ struct mfma_info<mfma_instr::mfma_f32_32x32x1xf32>
     static constexpr index_t n               = 32;
     static constexpr index_t k               = 1;
     static constexpr index_t cycles          = 64;
+    static constexpr index_t k_base          = 1;
 
-    template <index_t MPerWave, index_t NPerWave>
+    template <index_t MPerXdlops, index_t NPerXdlops>
     __device__ void
-    run(Number<MPerWave>, Number<NPerWave>, const float* a, const float* b, float* reg_c) const
+    run(Number<MPerXdlops>, Number<NPerXdlops>, const float* a, const float* b, float* reg_c) const
     {
-        static_assert((MPerWave == 64 && NPerWave == 64) || (MPerWave == 32 && NPerWave == 64) ||
-                          (MPerWave == 64 && NPerWave == 32),
+        static_assert((MPerXdlops == 64 && NPerXdlops == 64) ||
+                          (MPerXdlops == 32 && NPerXdlops == 64) ||
+                          (MPerXdlops == 64 && NPerXdlops == 32),
                       "unsupported xdlops gemm");
 
         const auto reg_a = *a;
         const auto reg_b = *b;
 
         auto reg_c_ = reinterpret_cast<float32_t*>(reg_c);
-        gcnasm_mfma_f32_32x32x1f32<MPerWave, NPerWave>(reg_a, reg_b, reg_c_);
+        gcnasm_mfma_f32_32x32x1f32<MPerXdlops, NPerXdlops>(reg_a, reg_b, reg_c_);
     }
 };
 
@@ -81,12 +81,13 @@ struct mfma_info<mfma_instr::mfma_f32_32x32x2xf32>
     static constexpr index_t n               = 32;
     static constexpr index_t k               = 2;
     static constexpr index_t cycles          = 64;
+    static constexpr index_t k_base          = 1;
 
-    template <index_t MPerWave, index_t NPerWave>
+    template <index_t MPerXdlops, index_t NPerXdlops>
     __device__ void
-    run(Number<MPerWave>, Number<NPerWave>, const float* a, const float* b, float* reg_c) const
+    run(Number<MPerXdlops>, Number<NPerXdlops>, const float* a, const float* b, float* reg_c) const
     {
-        static_assert((MPerWave == 32 && NPerWave == 32), "unsupported xdlops gemm");
+        static_assert((MPerXdlops == 32 && NPerXdlops == 32), "unsupported xdlops gemm");
 
         const auto reg_a = *a;
         const auto reg_b = *b;
@@ -111,12 +112,13 @@ struct mfma_info<mfma_instr::mfma_f32_16x16x4xf32>
     static constexpr index_t n               = 16;
     static constexpr index_t k               = 4;
     static constexpr index_t cycles          = 32;
+    static constexpr index_t k_base          = 1;
 
-    template <index_t MPerWave, index_t NPerWave>
+    template <index_t MPerXdlops, index_t NPerXdlops>
     __device__ void
-    run(Number<MPerWave>, Number<NPerWave>, const float* a, const float* b, float* reg_c) const
+    run(Number<MPerXdlops>, Number<NPerXdlops>, const float* a, const float* b, float* reg_c) const
     {
-        static_assert((MPerWave == 16 && NPerWave == 16), "unsupported xdlops gemm");
+        static_assert((MPerXdlops == 16 && NPerXdlops == 16), "unsupported xdlops gemm");
 
         const auto reg_a = *a;
         const auto reg_b = *b;
@@ -141,19 +143,21 @@ struct mfma_info<mfma_instr::mfma_f32_16x16x1xf32>
     static constexpr index_t n               = 16;
     static constexpr index_t k               = 1;
     static constexpr index_t cycles          = 32;
+    static constexpr index_t k_base          = 1;
 
-    template <index_t MPerWave, index_t NPerWave>
+    template <index_t MPerXdlops, index_t NPerXdlops>
     __device__ void
-    run(Number<MPerWave>, Number<NPerWave>, const float* a, const float* b, float* reg_c) const
+    run(Number<MPerXdlops>, Number<NPerXdlops>, const float* a, const float* b, float* reg_c) const
     {
-        static_assert((MPerWave == 16 && NPerWave == 64) || (MPerWave == 64 && NPerWave == 16),
+        static_assert((MPerXdlops == 16 && NPerXdlops == 64) ||
+                          (MPerXdlops == 64 && NPerXdlops == 16),
                       "unsupported xdlops gemm");
 
         const auto reg_a = *a;
         const auto reg_b = *b;
         auto reg_c_      = reinterpret_cast<float16_t*>(reg_c);
 
-        gcnasm_mfma_f32_16x16x1f32<MPerWave, NPerWave>(reg_a, reg_b, reg_c_);
+        gcnasm_mfma_f32_16x16x1f32<MPerXdlops, NPerXdlops>(reg_a, reg_b, reg_c_);
     }
 };
 
@@ -173,19 +177,20 @@ struct mfma_info<mfma_instr::mfma_f32_4x4x1xf32>
     static constexpr index_t n               = 64;
     static constexpr index_t k               = 1;
     static constexpr index_t cycles          = 8;
+    static constexpr index_t k_base          = 1;
 
-    template <index_t MPerWave, index_t NPerWave>
+    template <index_t MPerXdlops, index_t NPerXdlops>
     __device__ void
-    run(Number<MPerWave>, Number<NPerWave>, const float* a, const float* b, float* reg_c) const
+    run(Number<MPerXdlops>, Number<NPerXdlops>, const float* a, const float* b, float* reg_c) const
     {
-        static_assert((MPerWave == 4 || MPerWave == 8) && NPerWave == 64,
+        static_assert((MPerXdlops == 4 || MPerXdlops == 8) && NPerXdlops == 64,
                       "unsupported xdlops gemm");
 
         const auto reg_a = *a;
         const auto reg_b = *b;
         auto reg_c_      = reinterpret_cast<float4_t*>(reg_c);
 
-        gcnasm_mfma_f32_4x4x1f32<MPerWave, NPerWave>(reg_a, reg_b, reg_c_);
+        gcnasm_mfma_f32_4x4x1f32<MPerXdlops, NPerXdlops>(reg_a, reg_b, reg_c_);
     }
 };
 
@@ -204,20 +209,25 @@ struct mfma_info<mfma_instr::mfma_f32_32x32x4f16>
     static constexpr index_t n               = 32;
     static constexpr index_t k               = 4;
     static constexpr index_t cycles          = 64;
+    static constexpr index_t k_base          = 4;
 
-    template <index_t MPerWave, index_t NPerWave>
-    __device__ void
-    run(Number<MPerWave>, Number<NPerWave>, const half_t* a, const half_t* b, float* reg_c) const
+    template <index_t MPerXdlops, index_t NPerXdlops>
+    __device__ void run(Number<MPerXdlops>,
+                        Number<NPerXdlops>,
+                        const half_t* a,
+                        const half_t* b,
+                        float* reg_c) const
     {
-        static_assert((MPerWave == 64 && NPerWave == 64) || (MPerWave == 32 && NPerWave == 64) ||
-                          (MPerWave == 64 && NPerWave == 32),
+        static_assert((MPerXdlops == 64 && NPerXdlops == 64) ||
+                          (MPerXdlops == 32 && NPerXdlops == 64) ||
+                          (MPerXdlops == 64 && NPerXdlops == 32),
                       "unsupported xdlops gemm");
 
         const auto reg_a = *(reinterpret_cast<const half4_t*>(a));
         const auto reg_b = *(reinterpret_cast<const half4_t*>(b));
         auto reg_c_      = reinterpret_cast<float32_t*>(reg_c);
 
-        gcnasm_mfma_f32_32x32x4f16<MPerWave, NPerWave>(reg_a, reg_b, reg_c_);
+        gcnasm_mfma_f32_32x32x4f16<MPerXdlops, NPerXdlops>(reg_a, reg_b, reg_c_);
     }
 };
 
@@ -236,12 +246,16 @@ struct mfma_info<mfma_instr::mfma_f32_32x32x8f16>
     static constexpr index_t n               = 32;
     static constexpr index_t k               = 8;
     static constexpr index_t cycles          = 64;
+    static constexpr index_t k_base          = 4;
 
-    template <index_t MPerWave, index_t NPerWave>
-    __device__ void
-    run(Number<MPerWave>, Number<NPerWave>, const half_t* a, const half_t* b, float* reg_c) const
+    template <index_t MPerXdlops, index_t NPerXdlops>
+    __device__ void run(Number<MPerXdlops>,
+                        Number<NPerXdlops>,
+                        const half_t* a,
+                        const half_t* b,
+                        float* reg_c) const
     {
-        static_assert((MPerWave == 32 && NPerWave == 32), "unsupported xdlops gemm");
+        static_assert((MPerXdlops == 32 && NPerXdlops == 32), "unsupported xdlops gemm");
 
         const auto reg_a = *(reinterpret_cast<const half4_t*>(a));
         const auto reg_b = *(reinterpret_cast<const half4_t*>(b));
@@ -266,12 +280,16 @@ struct mfma_info<mfma_instr::mfma_f32_16x16x16f16>
     static constexpr index_t n               = 16;
     static constexpr index_t k               = 16;
     static constexpr index_t cycles          = 32;
+    static constexpr index_t k_base          = 4;
 
-    template <index_t MPerWave, index_t NPerWave>
-    __device__ void
-    run(Number<MPerWave>, Number<NPerWave>, const half_t* a, const half_t* b, float* reg_c) const
+    template <index_t MPerXdlops, index_t NPerXdlops>
+    __device__ void run(Number<MPerXdlops>,
+                        Number<NPerXdlops>,
+                        const half_t* a,
+                        const half_t* b,
+                        float* reg_c) const
     {
-        static_assert((MPerWave == 16 && NPerWave == 16), "unsupported xdlops gemm");
+        static_assert((MPerXdlops == 16 && NPerXdlops == 16), "unsupported xdlops gemm");
 
         const auto reg_a = *(reinterpret_cast<const half4_t*>(a));
         const auto reg_b = *(reinterpret_cast<const half4_t*>(b));
@@ -296,19 +314,24 @@ struct mfma_info<mfma_instr::mfma_f32_16x16x4f16>
     static constexpr index_t n               = 16;
     static constexpr index_t k               = 4;
     static constexpr index_t cycles          = 32;
+    static constexpr index_t k_base          = 4;
 
-    template <index_t MPerWave, index_t NPerWave>
-    __device__ void
-    run(Number<MPerWave>, Number<NPerWave>, const half_t* a, const half_t* b, float* reg_c) const
+    template <index_t MPerXdlops, index_t NPerXdlops>
+    __device__ void run(Number<MPerXdlops>,
+                        Number<NPerXdlops>,
+                        const half_t* a,
+                        const half_t* b,
+                        float* reg_c) const
     {
-        static_assert((MPerWave == 16 && NPerWave == 64) || (MPerWave == 64 && NPerWave == 16),
+        static_assert((MPerXdlops == 16 && NPerXdlops == 64) ||
+                          (MPerXdlops == 64 && NPerXdlops == 16),
                       "unsupported xdlops gemm");
 
         const auto reg_a = *(reinterpret_cast<const half4_t*>(a));
         const auto reg_b = *(reinterpret_cast<const half4_t*>(b));
         auto reg_c_      = reinterpret_cast<float16_t*>(reg_c);
 
-        gcnasm_mfma_f32_16x16x4f16<MPerWave, NPerWave>(reg_a, reg_b, reg_c_);
+        gcnasm_mfma_f32_16x16x4f16<MPerXdlops, NPerXdlops>(reg_a, reg_b, reg_c_);
     }
 };
 
@@ -327,19 +350,23 @@ struct mfma_info<mfma_instr::mfma_f32_4x4x4f16>
     static constexpr index_t n               = 64;
     static constexpr index_t k               = 4;
     static constexpr index_t cycles          = 8;
+    static constexpr index_t k_base          = 4;
 
-    template <index_t MPerWave, index_t NPerWave>
-    __device__ void
-    run(Number<MPerWave>, Number<NPerWave>, const half_t* a, const half_t* b, float* reg_c) const
+    template <index_t MPerXdlops, index_t NPerXdlops>
+    __device__ void run(Number<MPerXdlops>,
+                        Number<NPerXdlops>,
+                        const half_t* a,
+                        const half_t* b,
+                        float* reg_c) const
     {
-        static_assert((MPerWave == 4 || MPerWave == 8) && NPerWave == 64,
+        static_assert((MPerXdlops == 4 || MPerXdlops == 8) && NPerXdlops == 64,
                       "unsupported xdlops gemm");
 
         const auto reg_a = *(reinterpret_cast<const half4_t*>(a));
         const auto reg_b = *(reinterpret_cast<const half4_t*>(b));
         auto reg_c_      = reinterpret_cast<float4_t*>(reg_c);
 
-        gcnasm_mfma_f32_4x4x4f16<MPerWave, NPerWave>(reg_a, reg_b, reg_c_);
+        gcnasm_mfma_f32_4x4x4f16<MPerXdlops, NPerXdlops>(reg_a, reg_b, reg_c_);
     }
 };
 
@@ -358,20 +385,25 @@ struct mfma_info<mfma_instr::mfma_f32_32x32x2bf16>
     static constexpr index_t n               = 32;
     static constexpr index_t k               = 2;
     static constexpr index_t cycles          = 64;
+    static constexpr index_t k_base          = 2;
 
-    template <index_t MPerWave, index_t NPerWave>
-    __device__ void
-    run(Number<MPerWave>, Number<NPerWave>, const ushort* a, const ushort* b, float* reg_c) const
+    template <index_t MPerXdlops, index_t NPerXdlops>
+    __device__ void run(Number<MPerXdlops>,
+                        Number<NPerXdlops>,
+                        const ushort* a,
+                        const ushort* b,
+                        float* reg_c) const
     {
-        static_assert((MPerWave == 64 && NPerWave == 64) || (MPerWave == 32 && NPerWave == 64) ||
-                          (MPerWave == 64 && NPerWave == 32),
+        static_assert((MPerXdlops == 64 && NPerXdlops == 64) ||
+                          (MPerXdlops == 32 && NPerXdlops == 64) ||
+                          (MPerXdlops == 64 && NPerXdlops == 32),
                       "unsupported xdlops gemm");
 
         const auto reg_a = *(reinterpret_cast<const ushort2_t*>(a));
         const auto reg_b = *(reinterpret_cast<const ushort2_t*>(b));
         auto reg_c_      = reinterpret_cast<float32_t*>(reg_c);
 
-        gcnasm_mfma_f32_32x32x2bf16<MPerWave, NPerWave>(reg_a, reg_b, reg_c_);
+        gcnasm_mfma_f32_32x32x2bf16<MPerXdlops, NPerXdlops>(reg_a, reg_b, reg_c_);
     }
 };
 
@@ -390,12 +422,16 @@ struct mfma_info<mfma_instr::mfma_f32_32x32x4bf16>
     static constexpr index_t n               = 32;
     static constexpr index_t k               = 4;
     static constexpr index_t cycles          = 64;
+    static constexpr index_t k_base          = 2;
 
-    template <index_t MPerWave, index_t NPerWave>
-    __device__ void
-    run(Number<MPerWave>, Number<NPerWave>, const ushort* a, const ushort* b, float* reg_c) const
+    template <index_t MPerXdlops, index_t NPerXdlops>
+    __device__ void run(Number<MPerXdlops>,
+                        Number<NPerXdlops>,
+                        const ushort* a,
+                        const ushort* b,
+                        float* reg_c) const
     {
-        static_assert((MPerWave == 32 && NPerWave == 32), "unsupported xdlops gemm");
+        static_assert((MPerXdlops == 32 && NPerXdlops == 32), "unsupported xdlops gemm");
 
         const auto reg_a = *(reinterpret_cast<const ushort2_t*>(a));
         const auto reg_b = *(reinterpret_cast<const ushort2_t*>(b));
@@ -420,12 +456,16 @@ struct mfma_info<mfma_instr::mfma_f32_16x16x8bf16>
     static constexpr index_t n               = 16;
     static constexpr index_t k               = 8;
     static constexpr index_t cycles          = 32;
+    static constexpr index_t k_base          = 2;
 
-    template <index_t MPerWave, index_t NPerWave>
-    __device__ void
-    run(Number<MPerWave>, Number<NPerWave>, const ushort* a, const ushort* b, float* reg_c) const
+    template <index_t MPerXdlops, index_t NPerXdlops>
+    __device__ void run(Number<MPerXdlops>,
+                        Number<NPerXdlops>,
+                        const ushort* a,
+                        const ushort* b,
+                        float* reg_c) const
     {
-        static_assert((MPerWave == 16 && NPerWave == 16), "unsupported xdlops gemm");
+        static_assert((MPerXdlops == 16 && NPerXdlops == 16), "unsupported xdlops gemm");
 
         const auto reg_a = *(reinterpret_cast<const ushort2_t*>(a));
         const auto reg_b = *(reinterpret_cast<const ushort2_t*>(b));
@@ -450,19 +490,24 @@ struct mfma_info<mfma_instr::mfma_f32_16x16x2bf16>
     static constexpr index_t n               = 16;
     static constexpr index_t k               = 2;
     static constexpr index_t cycles          = 32;
+    static constexpr index_t k_base          = 2;
 
-    template <index_t MPerWave, index_t NPerWave>
-    __device__ void
-    run(Number<MPerWave>, Number<NPerWave>, const ushort* a, const ushort* b, float* reg_c) const
+    template <index_t MPerXdlops, index_t NPerXdlops>
+    __device__ void run(Number<MPerXdlops>,
+                        Number<NPerXdlops>,
+                        const ushort* a,
+                        const ushort* b,
+                        float* reg_c) const
     {
-        static_assert((MPerWave == 16 && NPerWave == 64) || (MPerWave == 64 && NPerWave == 16),
+        static_assert((MPerXdlops == 16 && NPerXdlops == 64) ||
+                          (MPerXdlops == 64 && NPerXdlops == 16),
                       "unsupported xdlops gemm");
 
         const auto reg_a = *(reinterpret_cast<const ushort2_t*>(a));
         const auto reg_b = *(reinterpret_cast<const ushort2_t*>(b));
         auto reg_c_      = reinterpret_cast<float16_t*>(reg_c);
 
-        gcnasm_mfma_f32_16x16x2bf16<MPerWave, NPerWave>(reg_a, reg_b, reg_c_);
+        gcnasm_mfma_f32_16x16x2bf16<MPerXdlops, NPerXdlops>(reg_a, reg_b, reg_c_);
     }
 };
 
@@ -481,25 +526,29 @@ struct mfma_info<mfma_instr::mfma_f32_4x4x2bf16>
     static constexpr index_t n               = 64;
     static constexpr index_t k               = 2;
     static constexpr index_t cycles          = 8;
+    static constexpr index_t k_base          = 2;
 
-    template <index_t MPerWave, index_t NPerWave>
-    __device__ void
-    run(Number<MPerWave>, Number<NPerWave>, const ushort* a, const ushort* b, float* reg_c) const
+    template <index_t MPerXdlops, index_t NPerXdlops>
+    __device__ void run(Number<MPerXdlops>,
+                        Number<NPerXdlops>,
+                        const ushort* a,
+                        const ushort* b,
+                        float* reg_c) const
     {
-        static_assert((MPerWave == 4 || MPerWave == 8) && NPerWave == 64,
+        static_assert((MPerXdlops == 4 || MPerXdlops == 8) && NPerXdlops == 64,
                       "unsupported xdlops gemm");
 
         const auto reg_a = *(reinterpret_cast<const ushort2_t*>(a));
         const auto reg_b = *(reinterpret_cast<const ushort2_t*>(b));
         auto reg_c_      = reinterpret_cast<float4_t*>(reg_c);
 
-        gcnasm_mfma_f32_4x4x2bf16<MPerWave, NPerWave>(reg_a, reg_b, reg_c_);
+        gcnasm_mfma_f32_4x4x2bf16<MPerXdlops, NPerXdlops>(reg_a, reg_b, reg_c_);
     }
 };
 
 template <class data_type,
-          index_t MPerWave,
-          index_t NPerWave,
+          index_t MPerXdlops,
+          index_t NPerXdlops,
           index_t GemmDataPerReadA,
           index_t GemmDataPerReadB>
 struct XdlopsGemm_t
@@ -522,19 +571,19 @@ struct XdlopsGemm_t
         __device__ static constexpr index_t GetNumBlks()
         {
             constexpr auto mfma_type = GetMFMAInfo();
-            return MPerWave * NPerWave / (mfma_type.m * mfma_type.n);
+            return MPerXdlops * NPerXdlops / (mfma_type.m * mfma_type.n);
         }
     };
 
     __device__ constexpr XdlopsGemm_t()
     {
-        static_assert(NPerWave == 4 || NPerWave == 8 || NPerWave == 16 || NPerWave == 32 ||
-                          NPerWave == 64,
-                      "Only support GemmNPerWave == 4, 8, 16, 32 or 64 for xdlops");
+        static_assert(NPerXdlops == 4 || NPerXdlops == 8 || NPerXdlops == 16 || NPerXdlops == 32 ||
+                          NPerXdlops == 64,
+                      "Only support GemmNPerXdlops == 4, 8, 16, 32 or 64 for xdlops");
 
-        static_assert(MPerWave == 4 || MPerWave == 8 || MPerWave == 16 || MPerWave == 32 ||
-                          MPerWave == 64,
-                      "Only support GemmMPerWave == 4, 8, 16, 32 or 64 for xdlops");
+        static_assert(MPerXdlops == 4 || MPerXdlops == 8 || MPerXdlops == 16 || MPerXdlops == 32 ||
+                          MPerXdlops == 64,
+                      "Only support GemmMPerXdlops == 4, 8, 16, 32 or 64 for xdlops");
 
         static_assert(GemmDataPerReadA == 1 && GemmDataPerReadB == 1, "GemmDataPerReadA/B != 1");
 
@@ -548,19 +597,21 @@ struct XdlopsGemm_t
                       "incorrect num_output_blks");
         static_assert(mfma_type.num_regs_blk * mfma_type.wave_size == mfma_type.m * mfma_type.n,
                       "num_regs_blk incorrect");
+
+        static_assert(mfma_type.k % mfma_type.k_base == 0, "k and k_base is inconsistent!");
     }
 
-    __device__ static constexpr bool IsABroadcast() { return NPerWave >= MPerWave; }
+    __device__ static constexpr bool IsABroadcast() { return NPerXdlops >= MPerXdlops; }
 
     __device__ static constexpr bool IsKReduction()
     {
         constexpr auto mfma_type = GetMFMAInfo();
-        return mfma_type.num_output_blks == 1 && mfma_type.num_input_blks != 1;
+        return (mfma_type.num_output_blks == 1) && (mfma_type.num_input_blks > 1);
     }
 
-    template <class data_type_  = data_type,
-              index_t MPerWave_ = MPerWave,
-              index_t NPerWave_ = NPerWave>
+    template <class data_type_    = data_type,
+              index_t MPerXdlops_ = MPerXdlops,
+              index_t NPerXdlops_ = NPerXdlops>
     __device__ static constexpr auto GetMFMAInfo();
 
     template <>
@@ -765,7 +816,7 @@ struct XdlopsGemm_t
                 // ABroadcast
                 for(index_t k = 0; k < K; ++k)
                 {
-                    for(index_t b = 0; b < MPerWave / mfma_type.m; ++b)
+                    for(index_t b = 0; b < MPerXdlops / mfma_type.m; ++b)
                     {
                         for(index_t n = 0; n < mfma_type.num_input_blks; ++n)
                         {
@@ -792,7 +843,7 @@ struct XdlopsGemm_t
                 // BBroadcast
                 for(index_t k = 0; k < K; ++k)
                 {
-                    for(index_t b = 0; b < NPerWave / mfma_type.n; ++b)
+                    for(index_t b = 0; b < NPerXdlops / mfma_type.n; ++b)
                     {
                         for(index_t n = 0; n < mfma_type.num_input_blks; ++n)
                         {
@@ -830,17 +881,29 @@ struct XdlopsGemm_t
         static_assert(is_same<FloatA, FloatB>::value, "FloatA != FloatB");
         static_assert(is_same<FloatC, float>::value, "FloatC != float");
 
+        static_assert(is_same<data_type, float>::value || is_same<data_type, half_t>::value ||
+                          is_same<data_type, ushort>::value,
+                      "base data_type must be float, half, ushort!");
+
 #if CK_USE_AMD_XDLOPS_EMULATE
         XdlopsEmulate<M, N, K>(p_a_wave, p_b_wave, p_c_thread);
 #else
         constexpr auto mfma_type = GetMFMAInfo();
 
+        const index_t laneId = get_thread_local_1d_id() % mfma_type.wave_size;
+
+        FloatA a[K];
+        FloatB b[K];
+
+        static_assert(sizeof(FloatA) % (sizeof(data_type) * mfma_type.k_base) == 0,
+                      "wrong! FloatA is consistent with mfma");
+
+        constexpr index_t nxdlops = sizeof(FloatA) / (sizeof(data_type) * mfma_type.k_base);
+
+        static_assert(!IsKReduction() || K % mfma_type.num_input_blks == 0,
+                      "K cannot divided by mfma_type.num_input_blks!");
+
         static_if<!IsKReduction()>{}([&](auto) {
-
-            const index_t laneId = get_thread_local_1d_id() % mfma_type.wave_size;
-
-            FloatA a[K];
-            FloatB b[K];
 
             // load into registers
             for(index_t k = 0; k < K; ++k)
@@ -853,23 +916,20 @@ struct XdlopsGemm_t
             auto pa = reinterpret_cast<const data_type*>(&a);
             auto pb = reinterpret_cast<const data_type*>(&b);
 
-#if WORKAROUND_SWDEV_229564
+#if CK_WORKAROUND_SWDEV_229564
 #pragma unroll
 #endif
             for(index_t k = 0; k < K; ++k)
             {
-                constexpr index_t nxdlops = sizeof(FloatA) / (mfma_type.k * sizeof(data_type));
-
-                for(index_t i = 0; i < nxdlops; ++i, pa += mfma_type.k, pb += mfma_type.k)
-                    mfma_type.run(Number<MPerWave>{}, Number<NPerWave>{}, pa, pb, p_c_thread);
+                for(index_t i = 0; i < nxdlops; ++i)
+                    mfma_type.run(Number<MPerXdlops>{},
+                                  Number<NPerXdlops>{},
+                                  &pa[(k * nxdlops + i) * mfma_type.k_base],
+                                  &pb[(k * nxdlops + i) * mfma_type.k_base],
+                                  p_c_thread);
             }
 
         }).Else([&](auto) {
-
-            const index_t laneId = get_thread_local_1d_id() % mfma_type.wave_size;
-
-            FloatA a[K];
-            FloatB b[K];
 
             const index_t blk_id = laneId / mfma_type.num_threads_blk;
             const index_t blk_td = laneId % mfma_type.num_threads_blk;
@@ -885,16 +945,17 @@ struct XdlopsGemm_t
             auto pa = reinterpret_cast<const data_type*>(&a);
             auto pb = reinterpret_cast<const data_type*>(&b);
 
-            constexpr index_t nxdlops =
-                (sizeof(FloatA) * mfma_type.num_input_blks) / (mfma_type.k * sizeof(data_type));
-
-#if WORKAROUND_SWDEV_229564
+#if CK_WORKAROUND_SWDEV_229564
 #pragma unroll
 #endif
             for(index_t k = 0; k < K; k += mfma_type.num_input_blks)
             {
-                for(index_t i = 0; i < nxdlops; ++i, pa += mfma_type.k, pb += mfma_type.k)
-                    mfma_type.run(Number<MPerWave>{}, Number<NPerWave>{}, pa, pb, p_c_thread);
+                for(index_t i = 0; i < nxdlops; ++i)
+                    mfma_type.run(Number<MPerXdlops>{},
+                                  Number<NPerXdlops>{},
+                                  &pa[(k * nxdlops + i) * mfma_type.k_base],
+                                  &pb[(k * nxdlops + i) * mfma_type.k_base],
+                                  p_c_thread);
             }
 
         });

--- a/src/kernels/composable_kernel/include/utility/amd_buffer_addressing.hpp
+++ b/src/kernels/composable_kernel/include/utility/amd_buffer_addressing.hpp
@@ -8,65 +8,149 @@ namespace ck {
 // For 128bit SGPRs in buffer_load and buffer_store instructions
 // https://rocm-documentation.readthedocs.io/en/latest/GCN_ISA_Manuals/testdocbook.html#vector-memory-buffer-instructions
 template <typename T>
-union BufferLoadStoreDwordConfig
+union BufferAddressConfig
 {
     int32x4_t data;
     T* address[2];
     int32_t range[4];
 };
 
-__device__ float __llvm_amdgcn_buffer_load(int32x4_t rsrc,
-                                           index_t vindex,
-                                           index_t offset,
-                                           bool glc,
-                                           bool slc) __asm("llvm.amdgcn.buffer.load.f32");
+__device__ float __llvm_amdgcn_buffer_load_f32(int32x4_t rsrc,
+                                               index_t vindex,
+                                               index_t offset,
+                                               bool glc,
+                                               bool slc) __asm("llvm.amdgcn.buffer.load.f32");
 
-__device__ float2_t __llvm_amdgcn_buffer_loadx2(int32x4_t rsrc,
-                                                index_t vindex,
-                                                index_t offset,
-                                                bool glc,
-                                                bool slc) __asm("llvm.amdgcn.buffer.load.v2f32");
-
-__device__ float4_t __llvm_amdgcn_buffer_loadx4(int32x4_t rsrc,
-                                                index_t vindex,
-                                                index_t offset,
-                                                bool glc,
-                                                bool slc) __asm("llvm.amdgcn.buffer.load.v4f32");
-
-__device__ void __llvm_amdgcn_buffer_store(float vdata,
-                                           int32x4_t rsrc,
-                                           index_t vindex,
-                                           index_t offset,
-                                           bool glc,
-                                           bool slc) __asm("llvm.amdgcn.buffer.store.f32");
-
-__device__ void __llvm_amdgcn_buffer_storex2(float2_t vdata,
-                                             int32x4_t rsrc,
-                                             index_t vindex,
-                                             index_t offset,
-                                             bool glc,
-                                             bool slc) __asm("llvm.amdgcn.buffer.store.v2f32");
-
-__device__ void __llvm_amdgcn_buffer_storex4(float4_t vdata,
-                                             int32x4_t rsrc,
-                                             index_t vindex,
-                                             index_t offset,
-                                             bool glc,
-                                             bool slc) __asm("llvm.amdgcn.buffer.store.v4f32");
-
-__device__ void
-__llvm_amdgcn_buffer_atomic_add(float vdata,
-                                int32x4_t rsrc,
+__device__ float2_t
+__llvm_amdgcn_buffer_load_f32x2(int32x4_t rsrc,
                                 index_t vindex,
                                 index_t offset,
-                                bool slc) __asm("llvm.amdgcn.buffer.atomic.fadd.f32");
+                                bool glc,
+                                bool slc) __asm("llvm.amdgcn.buffer.load.v2f32");
+
+__device__ float4_t
+__llvm_amdgcn_buffer_load_f32x4(int32x4_t rsrc,
+                                index_t vindex,
+                                index_t offset,
+                                bool glc,
+                                bool slc) __asm("llvm.amdgcn.buffer.load.v4f32");
+
+__device__ half_t __llvm_amdgcn_buffer_load_f16(int32x4_t rsrc,
+                                                index_t vindex,
+                                                index_t offset,
+                                                bool glc,
+                                                bool slc) __asm("llvm.amdgcn.buffer.load.f16");
+
+__device__ half2_t __llvm_amdgcn_buffer_load_f16x2(int32x4_t rsrc,
+                                                   index_t vindex,
+                                                   index_t offset,
+                                                   bool glc,
+                                                   bool slc) __asm("llvm.amdgcn.buffer.load.v2f16");
+
+__device__ half4_t __llvm_amdgcn_buffer_load_f16x4(int32x4_t rsrc,
+                                                   index_t vindex,
+                                                   index_t offset,
+                                                   bool glc,
+                                                   bool slc) __asm("llvm.amdgcn.buffer.load.v4f16");
+
+__device__ ushort __llvm_amdgcn_buffer_load_bf16(int32x4_t rsrc,
+                                                 index_t vindex,
+                                                 index_t offset,
+                                                 bool glc,
+                                                 bool slc) __asm("llvm.amdgcn.buffer.load.bf16");
+
+__device__ ushort2_t
+__llvm_amdgcn_buffer_load_bf16x2(int32x4_t rsrc,
+                                 index_t vindex,
+                                 index_t offset,
+                                 bool glc,
+                                 bool slc) __asm("llvm.amdgcn.buffer.load.v2bf16");
+
+__device__ ushort4_t
+__llvm_amdgcn_buffer_load_bf16x4(int32x4_t rsrc,
+                                 index_t vindex,
+                                 index_t offset,
+                                 bool glc,
+                                 bool slc) __asm("llvm.amdgcn.buffer.load.v4bf16");
+
+__device__ void __llvm_amdgcn_buffer_store_f32(float vdata,
+                                               int32x4_t rsrc,
+                                               index_t vindex,
+                                               index_t offset,
+                                               bool glc,
+                                               bool slc) __asm("llvm.amdgcn.buffer.store.f32");
+
+__device__ void __llvm_amdgcn_buffer_store_f32x2(float2_t vdata,
+                                                 int32x4_t rsrc,
+                                                 index_t vindex,
+                                                 index_t offset,
+                                                 bool glc,
+                                                 bool slc) __asm("llvm.amdgcn.buffer.store.v2f32");
+
+__device__ void __llvm_amdgcn_buffer_store_f32x4(float4_t vdata,
+                                                 int32x4_t rsrc,
+                                                 index_t vindex,
+                                                 index_t offset,
+                                                 bool glc,
+                                                 bool slc) __asm("llvm.amdgcn.buffer.store.v4f32");
+
+__device__ void __llvm_amdgcn_buffer_store_f16(half_t vdata,
+                                               int32x4_t rsrc,
+                                               index_t vindex,
+                                               index_t offset,
+                                               bool glc,
+                                               bool slc) __asm("llvm.amdgcn.buffer.store.f16");
+
+__device__ void __llvm_amdgcn_buffer_store_f16x2(half2_t vdata,
+                                                 int32x4_t rsrc,
+                                                 index_t vindex,
+                                                 index_t offset,
+                                                 bool glc,
+                                                 bool slc) __asm("llvm.amdgcn.buffer.store.v2f16");
+
+__device__ void __llvm_amdgcn_buffer_store_f16x4(half4_t vdata,
+                                                 int32x4_t rsrc,
+                                                 index_t vindex,
+                                                 index_t offset,
+                                                 bool glc,
+                                                 bool slc) __asm("llvm.amdgcn.buffer.store.v4f16");
+
+__device__ void __llvm_amdgcn_buffer_store_bf16(ushort vdata,
+                                                int32x4_t rsrc,
+                                                index_t vindex,
+                                                index_t offset,
+                                                bool glc,
+                                                bool slc) __asm("llvm.amdgcn.buffer.store.bf16");
+
+__device__ void
+__llvm_amdgcn_buffer_store_bf16x2(ushort2_t vdata,
+                                  int32x4_t rsrc,
+                                  index_t vindex,
+                                  index_t offset,
+                                  bool glc,
+                                  bool slc) __asm("llvm.amdgcn.buffer.store.v2bf16");
+
+__device__ void
+__llvm_amdgcn_buffer_store_bf16x4(ushort4_t vdata,
+                                  int32x4_t rsrc,
+                                  index_t vindex,
+                                  index_t offset,
+                                  bool glc,
+                                  bool slc) __asm("llvm.amdgcn.buffer.store.v4bf16");
+
+__device__ void
+__llvm_amdgcn_buffer_atomic_add_f32(float vdata,
+                                    int32x4_t rsrc,
+                                    index_t vindex,
+                                    index_t offset,
+                                    bool slc) __asm("llvm.amdgcn.buffer.atomic.fadd.f32");
 
 // buffer_load requires:
 //   1) p_src must be in global memory space, d_dst must be vgpr
 //   2) p_src to be a block-invariant pointer.
 // It is user's responsibility to make sure that is true.
 template <typename T, index_t VectorSize>
-__device__ typename vector_type<T, VectorSize>::MemoryType amd_intrinsic_buffer_load(
+__device__ typename vector_type<T, VectorSize>::MemoryType amd_buffer_load(
     const T* p_src_block, index_t src_thread_data_offset, index_t src_const_data_offset);
 
 // buffer_store requires:
@@ -74,132 +158,589 @@ __device__ typename vector_type<T, VectorSize>::MemoryType amd_intrinsic_buffer_
 //   2) p_dst to be a block-invariant pointer.
 // It is user's responsibility to make sure that is true.
 template <typename T, index_t VectorSize>
-__device__ void amd_intrinsic_buffer_store(const T* p_src,
-                                           T* p_dst_block,
-                                           index_t dst_thread_data_offset,
-                                           index_t dst_const_data_offset);
+__device__ void amd_buffer_store(const T* p_src,
+                                 T* p_dst_block,
+                                 index_t dst_thread_data_offset,
+                                 index_t dst_const_data_offset);
 
 template <typename T, index_t VectorSize>
-__device__ void amd_intrinsic_buffer_atomic_add(const T* p_src,
-                                                T* p_dst_block,
+__device__ void amd_buffer_atomic_add(const T* p_src,
+                                      T* p_dst_block,
+                                      index_t dst_thread_data_offset,
+                                      index_t dst_const_data_offset);
+
+template <>
+__device__ float amd_buffer_load<float, 1>(const float* p_src_block,
+                                           index_t src_thread_data_offset,
+                                           index_t src_const_data_offset)
+{
+    BufferAddressConfig<float> src_block_config;
+
+    // fill in byte 0 - 1
+    src_block_config.address[0] = const_cast<float*>(p_src_block);
+    // fill in byte 2
+    src_block_config.range[2] = -1;
+    // fill in byte 3
+    src_block_config.range[3] = 0x00027000;
+
+    index_t src_thread_addr_offset = src_thread_data_offset * sizeof(float);
+    index_t src_const_addr_offset  = src_const_data_offset * sizeof(float);
+
+    return __llvm_amdgcn_buffer_load_f32(
+        src_block_config.data, 0, src_thread_addr_offset + src_const_addr_offset, false, false);
+}
+
+template <>
+__device__ float2_t amd_buffer_load<float, 2>(const float* p_src_block,
+                                              index_t src_thread_data_offset,
+                                              index_t src_const_data_offset)
+{
+    BufferAddressConfig<float> src_block_config;
+
+    // fill in byte 0 - 1
+    src_block_config.address[0] = const_cast<float*>(p_src_block);
+    // fill in byte 2
+    src_block_config.range[2] = -1;
+    // fill in byte 3
+    src_block_config.range[3] = 0x00027000;
+
+    index_t src_thread_addr_offset = src_thread_data_offset * sizeof(float);
+    index_t src_const_addr_offset  = src_const_data_offset * sizeof(float);
+
+    return __llvm_amdgcn_buffer_load_f32x2(
+        src_block_config.data, 0, src_thread_addr_offset + src_const_addr_offset, false, false);
+}
+
+template <>
+__device__ float4_t amd_buffer_load<float, 4>(const float* p_src_block,
+                                              index_t src_thread_data_offset,
+                                              index_t src_const_data_offset)
+{
+    BufferAddressConfig<float> src_block_config;
+
+    // fill in byte 0 - 1
+    src_block_config.address[0] = const_cast<float*>(p_src_block);
+    // fill in byte 2
+    src_block_config.range[2] = -1;
+    // fill in byte 3
+    src_block_config.range[3] = 0x00027000;
+
+    index_t src_thread_addr_offset = src_thread_data_offset * sizeof(float);
+    index_t src_const_addr_offset  = src_const_data_offset * sizeof(float);
+
+    return __llvm_amdgcn_buffer_load_f32x4(
+        src_block_config.data, 0, src_thread_addr_offset + src_const_addr_offset, false, false);
+}
+
+template <>
+__device__ half_t amd_buffer_load<half_t, 1>(const half_t* p_src_block,
+                                             index_t src_thread_data_offset,
+                                             index_t src_const_data_offset)
+{
+    BufferAddressConfig<half_t> src_block_config;
+
+    // fill in byte 0 - 1
+    src_block_config.address[0] = const_cast<half_t*>(p_src_block);
+    // fill in byte 2
+    src_block_config.range[2] = -1;
+    // fill in byte 3
+    src_block_config.range[3] = 0x00027000;
+
+#if !CK_WORKAROUND_SWDEV_231101
+    index_t src_thread_addr_offset = src_thread_data_offset * sizeof(half_t);
+    index_t src_const_addr_offset  = src_const_data_offset * sizeof(half_t);
+
+    return __llvm_amdgcn_buffer_load_f16(
+        src_block_config.data, 0, src_thread_addr_offset + src_const_addr_offset, false, false);
+#else
+    return p_src_block[src_thread_data_offset + src_const_data_offset];
+#endif
+}
+
+template <>
+__device__ half2_t amd_buffer_load<half_t, 2>(const half_t* p_src_block,
+                                              index_t src_thread_data_offset,
+                                              index_t src_const_data_offset)
+{
+    BufferAddressConfig<half_t> src_block_config;
+
+    // fill in byte 0 - 1
+    src_block_config.address[0] = const_cast<half_t*>(p_src_block);
+    // fill in byte 2
+    src_block_config.range[2] = -1;
+    // fill in byte 3
+    src_block_config.range[3] = 0x00027000;
+
+    index_t src_thread_addr_offset = src_thread_data_offset * sizeof(half_t);
+    index_t src_const_addr_offset  = src_const_data_offset * sizeof(half_t);
+
+#if !CK_WORKAROUND_SWDEV_231101
+    return __llvm_amdgcn_buffer_load_f16x2(
+        src_block_config.data, 0, src_thread_addr_offset + src_const_addr_offset, false, false);
+#else
+    float dst_out_tmp = __llvm_amdgcn_buffer_load_f32(
+        src_block_config.data, 0, src_thread_addr_offset + src_const_addr_offset, false, false);
+
+    return *reinterpret_cast<half2_t*>(&dst_out_tmp);
+#endif
+}
+
+template <>
+__device__ half4_t amd_buffer_load<half_t, 4>(const half_t* p_src_block,
+                                              index_t src_thread_data_offset,
+                                              index_t src_const_data_offset)
+{
+    BufferAddressConfig<half_t> src_block_config;
+
+    // fill in byte 0 - 1
+    src_block_config.address[0] = const_cast<half_t*>(p_src_block);
+    // fill in byte 2
+    src_block_config.range[2] = -1;
+    // fill in byte 3
+    src_block_config.range[3] = 0x00027000;
+
+    index_t src_thread_addr_offset = src_thread_data_offset * sizeof(half_t);
+    index_t src_const_addr_offset  = src_const_data_offset * sizeof(half_t);
+
+#if !CK_WORKAROUND_SWDEV_231101
+    return __llvm_amdgcn_buffer_load_f16x4(
+        src_block_config.data, 0, src_thread_addr_offset + src_const_addr_offset, false, false);
+#else
+    float2_t dst_out_tmp = __llvm_amdgcn_buffer_load_f32x2(
+        src_block_config.data, 0, src_thread_addr_offset + src_const_addr_offset, false, false);
+
+    return *reinterpret_cast<half4_t*>(&dst_out_tmp);
+#endif
+}
+
+template <>
+__device__ half8_t amd_buffer_load<half_t, 8>(const half_t* p_src_block,
+                                              index_t src_thread_data_offset,
+                                              index_t src_const_data_offset)
+{
+    BufferAddressConfig<half_t> src_block_config;
+
+    // fill in byte 0 - 1
+    src_block_config.address[0] = const_cast<half_t*>(p_src_block);
+    // fill in byte 2
+    src_block_config.range[2] = -1;
+    // fill in byte 3
+    src_block_config.range[3] = 0x00027000;
+
+    index_t src_thread_addr_offset = src_thread_data_offset * sizeof(half_t);
+    index_t src_const_addr_offset  = src_const_data_offset * sizeof(half_t);
+
+#if !CK_WORKAROUND_SWDEV_231101
+    static_assert(false, "wrong! not supported");
+#else
+    float4_t dst_out_tmp = __llvm_amdgcn_buffer_load_f32x4(
+        src_block_config.data, 0, src_thread_addr_offset + src_const_addr_offset, false, false);
+
+    return *reinterpret_cast<half8_t*>(&dst_out_tmp);
+#endif
+}
+
+template <>
+__device__ ushort amd_buffer_load<ushort, 1>(const ushort* p_src_block,
+                                             index_t src_thread_data_offset,
+                                             index_t src_const_data_offset)
+{
+    BufferAddressConfig<ushort> src_block_config;
+
+    // fill in byte 0 - 1
+    src_block_config.address[0] = const_cast<ushort*>(p_src_block);
+    // fill in byte 2
+    src_block_config.range[2] = -1;
+    // fill in byte 3
+    src_block_config.range[3] = 0x00027000;
+
+#if !CK_WORKAROUND_SWDEV_231101
+    index_t src_thread_addr_offset = src_thread_data_offset * sizeof(ushort);
+    index_t src_const_addr_offset  = src_const_data_offset * sizeof(ushort);
+
+    return __llvm_amdgcn_buffer_load_bf16(
+        src_block_config.data, 0, src_thread_addr_offset + src_const_addr_offset, false, false);
+#else
+    return p_src_block[src_thread_data_offset + src_const_data_offset];
+#endif
+}
+
+template <>
+__device__ ushort2_t amd_buffer_load<ushort, 2>(const ushort* p_src_block,
+                                                index_t src_thread_data_offset,
+                                                index_t src_const_data_offset)
+{
+    BufferAddressConfig<ushort> src_block_config;
+
+    // fill in byte 0 - 1
+    src_block_config.address[0] = const_cast<ushort*>(p_src_block);
+    // fill in byte 2
+    src_block_config.range[2] = -1;
+    // fill in byte 3
+    src_block_config.range[3] = 0x00027000;
+
+    index_t src_thread_addr_offset = src_thread_data_offset * sizeof(ushort);
+    index_t src_const_addr_offset  = src_const_data_offset * sizeof(ushort);
+
+#if !CK_WORKAROUND_SWDEV_231101
+    return __llvm_amdgcn_buffer_load_bf16x2(
+        src_block_config.data, 0, src_thread_addr_offset + src_const_addr_offset, false, false);
+#else
+    float dst_out_tmp = __llvm_amdgcn_buffer_load_f32(
+        src_block_config.data, 0, src_thread_addr_offset + src_const_addr_offset, false, false);
+
+    return *reinterpret_cast<ushort2_t*>(&dst_out_tmp);
+#endif
+}
+
+template <>
+__device__ ushort4_t amd_buffer_load<ushort, 4>(const ushort* p_src_block,
+                                                index_t src_thread_data_offset,
+                                                index_t src_const_data_offset)
+{
+    BufferAddressConfig<ushort> src_block_config;
+
+    // fill in byte 0 - 1
+    src_block_config.address[0] = const_cast<ushort*>(p_src_block);
+    // fill in byte 2
+    src_block_config.range[2] = -1;
+    // fill in byte 3
+    src_block_config.range[3] = 0x00027000;
+
+    index_t src_thread_addr_offset = src_thread_data_offset * sizeof(ushort);
+    index_t src_const_addr_offset  = src_const_data_offset * sizeof(ushort);
+
+#if !CK_WORKAROUND_SWDEV_231101
+    return __llvm_amdgcn_buffer_load_bf16x4(
+        src_block_config.data, 0, src_thread_addr_offset + src_const_addr_offset, false, false);
+#else
+    float2_t dst_out_tmp = __llvm_amdgcn_buffer_load_f32x2(
+        src_block_config.data, 0, src_thread_addr_offset + src_const_addr_offset, false, false);
+
+    return *reinterpret_cast<ushort4_t*>(&dst_out_tmp);
+#endif
+}
+
+template <>
+__device__ ushort8_t amd_buffer_load<ushort, 8>(const ushort* p_src_block,
+                                                index_t src_thread_data_offset,
+                                                index_t src_const_data_offset)
+{
+    BufferAddressConfig<ushort> src_block_config;
+
+    // fill in byte 0 - 1
+    src_block_config.address[0] = const_cast<ushort*>(p_src_block);
+    // fill in byte 2
+    src_block_config.range[2] = -1;
+    // fill in byte 3
+    src_block_config.range[3] = 0x00027000;
+
+    index_t src_thread_addr_offset = src_thread_data_offset * sizeof(ushort);
+    index_t src_const_addr_offset  = src_const_data_offset * sizeof(ushort);
+
+#if !CK_WORKAROUND_SWDEV_231101
+    static_assert(false, "wrong! not implemented");
+#else
+    float4_t dst_out_tmp = __llvm_amdgcn_buffer_load_f32x4(
+        src_block_config.data, 0, src_thread_addr_offset + src_const_addr_offset, false, false);
+
+    return *reinterpret_cast<ushort8_t*>(&dst_out_tmp);
+#endif
+}
+
+template <>
+__device__ void amd_buffer_store<float, 1>(const float* p_src,
+                                           float* p_dst_block,
+                                           index_t dst_thread_data_offset,
+                                           index_t dst_const_data_offset)
+{
+    BufferAddressConfig<float> dst_block_config;
+
+    // fill in byte 0 - 1
+    dst_block_config.address[0] = p_dst_block;
+    // fill in byte 2
+    dst_block_config.range[2] = -1;
+    // fill in byte 3
+    dst_block_config.range[3] = 0x00027000;
+
+    index_t dst_thread_addr_offset = dst_thread_data_offset * sizeof(float);
+    index_t dst_const_addr_offset  = dst_const_data_offset * sizeof(float);
+
+    __llvm_amdgcn_buffer_store_f32(*p_src,
+                                   dst_block_config.data,
+                                   0,
+                                   dst_thread_addr_offset + dst_const_addr_offset,
+                                   false,
+                                   false);
+}
+
+template <>
+__device__ void amd_buffer_store<float, 2>(const float* p_src,
+                                           float* p_dst_block,
+                                           index_t dst_thread_data_offset,
+                                           index_t dst_const_data_offset)
+{
+    BufferAddressConfig<float> dst_block_config;
+
+    // fill in byte 0 - 1
+    dst_block_config.address[0] = p_dst_block;
+    // fill in byte 2
+    dst_block_config.range[2] = -1;
+    // fill in byte 3
+    dst_block_config.range[3] = 0x00027000;
+
+    index_t dst_thread_addr_offset = dst_thread_data_offset * sizeof(float);
+    index_t dst_const_addr_offset  = dst_const_data_offset * sizeof(float);
+
+    __llvm_amdgcn_buffer_store_f32x2(*reinterpret_cast<const float2_t*>(p_src),
+                                     dst_block_config.data,
+                                     0,
+                                     dst_thread_addr_offset + dst_const_addr_offset,
+                                     false,
+                                     false);
+}
+
+template <>
+__device__ void amd_buffer_store<float, 4>(const float* p_src,
+                                           float* p_dst_block,
+                                           index_t dst_thread_data_offset,
+                                           index_t dst_const_data_offset)
+{
+    BufferAddressConfig<float> dst_block_config;
+
+    // fill in byte 0 - 1
+    dst_block_config.address[0] = p_dst_block;
+    // fill in byte 2
+    dst_block_config.range[2] = -1;
+    // fill in byte 3
+    dst_block_config.range[3] = 0x00027000;
+
+    index_t dst_thread_addr_offset = dst_thread_data_offset * sizeof(float);
+    index_t dst_const_addr_offset  = dst_const_data_offset * sizeof(float);
+
+    __llvm_amdgcn_buffer_store_f32x4(*reinterpret_cast<const float4_t*>(p_src),
+                                     dst_block_config.data,
+                                     0,
+                                     dst_thread_addr_offset + dst_const_addr_offset,
+                                     false,
+                                     false);
+}
+
+template <>
+__device__ void amd_buffer_store<half_t, 1>(const half_t* p_src,
+                                            half_t* p_dst_block,
+                                            index_t dst_thread_data_offset,
+                                            index_t dst_const_data_offset)
+{
+    BufferAddressConfig<half_t> dst_block_config;
+
+    // fill in byte 0 - 1
+    dst_block_config.address[0] = p_dst_block;
+    // fill in byte 2
+    dst_block_config.range[2] = -1;
+    // fill in byte 3
+    dst_block_config.range[3] = 0x00027000;
+
+#if !CK_WORKAROUND_SWDEV_231101
+    index_t dst_thread_addr_offset = dst_thread_data_offset * sizeof(half_t);
+    index_t dst_const_addr_offset  = dst_const_data_offset * sizeof(half_t);
+
+    __llvm_amdgcn_buffer_store_f16(*p_src,
+                                   dst_block_config.data,
+                                   0,
+                                   dst_thread_addr_offset + dst_const_addr_offset,
+                                   false,
+                                   false);
+#else
+    p_dst_block[dst_thread_data_offset + dst_const_data_offset] = *p_src;
+#endif
+}
+
+template <>
+__device__ void amd_buffer_store<half_t, 2>(const half_t* p_src,
+                                            half_t* p_dst_block,
+                                            index_t dst_thread_data_offset,
+                                            index_t dst_const_data_offset)
+{
+    BufferAddressConfig<half_t> dst_block_config;
+
+    // fill in byte 0 - 1
+    dst_block_config.address[0] = p_dst_block;
+    // fill in byte 2
+    dst_block_config.range[2] = -1;
+    // fill in byte 3
+    dst_block_config.range[3] = 0x00027000;
+
+    index_t dst_thread_addr_offset = dst_thread_data_offset * sizeof(half_t);
+    index_t dst_const_addr_offset  = dst_const_data_offset * sizeof(half_t);
+
+#if !CK_WORKAROUND_SWDEV_231101
+    __llvm_amdgcn_buffer_store_f16x2(*reinterpret_cast<const half2_t*>(p_src),
+                                     dst_block_config.data,
+                                     0,
+                                     dst_thread_addr_offset + dst_const_addr_offset,
+                                     false,
+                                     false);
+#else
+    const float* p_src_tmp = reinterpret_cast<const float*>(p_src);
+
+    __llvm_amdgcn_buffer_store_f32(*p_src_tmp,
+                                   dst_block_config.data,
+                                   0,
+                                   dst_thread_addr_offset + dst_const_addr_offset,
+                                   false,
+                                   false);
+#endif
+}
+
+template <>
+__device__ void amd_buffer_store<half_t, 4>(const half_t* p_src,
+                                            half_t* p_dst_block,
+                                            index_t dst_thread_data_offset,
+                                            index_t dst_const_data_offset)
+{
+    index_t dst_thread_addr_offset = dst_thread_data_offset * sizeof(half_t);
+    index_t dst_const_addr_offset  = dst_const_data_offset * sizeof(half_t);
+
+    BufferAddressConfig<half_t> dst_block_config;
+
+    // fill in byte 0 - 1
+    dst_block_config.address[0] = p_dst_block;
+    // fill in byte 2
+    dst_block_config.range[2] = -1;
+    // fill in byte 3
+    dst_block_config.range[3] = 0x00027000;
+
+#if !CK_WORKAROUND_SWDEV_231101
+    __llvm_amdgcn_buffer_store_f16x4(*reinterpret_cast<const half4_t*>(p_src),
+                                     dst_block_config.data,
+                                     0,
+                                     dst_thread_addr_offset + dst_const_addr_offset,
+                                     false,
+                                     false);
+#else
+    const float2_t* p_src_tmp = reinterpret_cast<const float2_t*>(p_src);
+
+    __llvm_amdgcn_buffer_store_f32x2(*p_src_tmp,
+                                     dst_block_config.data,
+                                     0,
+                                     dst_thread_addr_offset + dst_const_addr_offset,
+                                     false,
+                                     false);
+#endif
+}
+
+template <>
+__device__ void amd_buffer_store<ushort, 1>(const ushort* p_src,
+                                            ushort* p_dst_block,
+                                            index_t dst_thread_data_offset,
+                                            index_t dst_const_data_offset)
+{
+    BufferAddressConfig<ushort> dst_block_config;
+
+    // fill in byte 0 - 1
+    dst_block_config.address[0] = p_dst_block;
+    // fill in byte 2
+    dst_block_config.range[2] = -1;
+    // fill in byte 3
+    dst_block_config.range[3] = 0x00027000;
+
+#if !CK_WORKAROUND_SWDEV_231101
+    index_t dst_thread_addr_offset = dst_thread_data_offset * sizeof(ushort);
+    index_t dst_const_addr_offset  = dst_const_data_offset * sizeof(ushort);
+
+    __llvm_amdgcn_buffer_store_bf16(*p_src,
+                                    dst_block_config.data,
+                                    0,
+                                    dst_thread_addr_offset + dst_const_addr_offset,
+                                    false,
+                                    false);
+#else
+    p_dst_block[dst_thread_data_offset + dst_const_data_offset] = *p_src;
+#endif
+}
+
+template <>
+__device__ void amd_buffer_store<ushort, 2>(const ushort* p_src,
+                                            ushort* p_dst_block,
+                                            index_t dst_thread_data_offset,
+                                            index_t dst_const_data_offset)
+{
+    BufferAddressConfig<ushort> dst_block_config;
+
+    // fill in byte 0 - 1
+    dst_block_config.address[0] = p_dst_block;
+    // fill in byte 2
+    dst_block_config.range[2] = -1;
+    // fill in byte 3
+    dst_block_config.range[3] = 0x00027000;
+
+    index_t dst_thread_addr_offset = dst_thread_data_offset * sizeof(ushort);
+    index_t dst_const_addr_offset  = dst_const_data_offset * sizeof(ushort);
+
+#if !CK_WORKAROUND_SWDEV_231101
+    __llvm_amdgcn_buffer_store_bf16x2(*p_src,
+                                      dst_block_config.data,
+                                      0,
+                                      dst_thread_addr_offset + dst_const_addr_offset,
+                                      false,
+                                      false);
+#else
+    const float* p_src_tmp = reinterpret_cast<const float*>(p_src);
+
+    __llvm_amdgcn_buffer_store_f32(*p_src_tmp,
+                                   dst_block_config.data,
+                                   0,
+                                   dst_thread_addr_offset + dst_const_addr_offset,
+                                   false,
+                                   false);
+#endif
+}
+
+template <>
+__device__ void amd_buffer_store<ushort, 4>(const ushort* p_src,
+                                            ushort* p_dst_block,
+                                            index_t dst_thread_data_offset,
+                                            index_t dst_const_data_offset)
+{
+    BufferAddressConfig<ushort> dst_block_config;
+
+    // fill in byte 0 - 1
+    dst_block_config.address[0] = p_dst_block;
+    // fill in byte 2
+    dst_block_config.range[2] = -1;
+    // fill in byte 3
+    dst_block_config.range[3] = 0x00027000;
+
+    index_t dst_thread_addr_offset = dst_thread_data_offset * sizeof(ushort);
+    index_t dst_const_addr_offset  = dst_const_data_offset * sizeof(ushort);
+
+#if !CK_WORKAROUND_SWDEV_231101
+    __llvm_amdgcn_buffer_store_bf16x4(*p_src,
+                                      dst_block_config.data,
+                                      0,
+                                      dst_thread_addr_offset + dst_const_addr_offset,
+                                      false,
+                                      false);
+#else
+    const float2_t* p_src_tmp = reinterpret_cast<const float2_t*>(p_src);
+
+    __llvm_amdgcn_buffer_store_f32x2(*p_src_tmp,
+                                     dst_block_config.data,
+                                     0,
+                                     dst_thread_addr_offset + dst_const_addr_offset,
+                                     false,
+                                     false);
+#endif
+}
+
+template <>
+__device__ void amd_buffer_atomic_add<float, 1>(const float* p_src,
+                                                float* p_dst_block,
                                                 index_t dst_thread_data_offset,
-                                                index_t dst_const_data_offset);
-
-template <>
-__device__ float amd_intrinsic_buffer_load<float, 1>(const float* p_src_block,
-                                                     index_t src_thread_data_offset,
-                                                     index_t src_const_data_offset)
+                                                index_t dst_const_data_offset)
 {
-    float dst;
-
-    index_t src_thread_addr_offset = src_thread_data_offset * sizeof(float);
-    index_t src_const_addr_offset  = src_const_data_offset * sizeof(float);
-
-    BufferLoadStoreDwordConfig<float> src_block_config;
-
-    // fill in byte 0 - 1
-    src_block_config.address[0] = const_cast<float*>(p_src_block);
-    // fill in byte 2
-    src_block_config.range[2] = -1;
-    // fill in byte 3
-    src_block_config.range[3] = 0x00027000;
-
-#if CK_USE_AMD_BUFFER_ADDRESSING_INTRINSIC
-    dst = __llvm_amdgcn_buffer_load(
-        src_block_config.data, 0, src_thread_addr_offset + src_const_addr_offset, false, false);
-#else
-    asm volatile(
-        "\n \
-    buffer_load_dword %0, %1, %2, %3 offen offset:0 \n \
-    s_waitcnt 0 \n \
-    "
-        : "=v"(dst)
-        : "v"(src_thread_addr_offset), "s"(src_block_config.data), "s"(src_const_addr_offset));
-#endif
-
-    return dst;
-}
-
-template <>
-__device__ float2_t amd_intrinsic_buffer_load<float, 2>(const float* p_src_block,
-                                                        index_t src_thread_data_offset,
-                                                        index_t src_const_data_offset)
-{
-    float2_t dst;
-
-    index_t src_thread_addr_offset = src_thread_data_offset * sizeof(float);
-    index_t src_const_addr_offset  = src_const_data_offset * sizeof(float);
-
-    BufferLoadStoreDwordConfig<float> src_block_config;
-
-    // fill in byte 0 - 1
-    src_block_config.address[0] = const_cast<float*>(p_src_block);
-    // fill in byte 2
-    src_block_config.range[2] = -1;
-    // fill in byte 3
-    src_block_config.range[3] = 0x00027000;
-
-#if CK_USE_AMD_BUFFER_ADDRESSING_INTRINSIC
-    dst = __llvm_amdgcn_buffer_loadx2(
-        src_block_config.data, 0, src_thread_addr_offset + src_const_addr_offset, false, false);
-#else
-    asm volatile(
-        "\n \
-    buffer_load_dwordx2 %0, %1, %2, %3 offen offset:0 \n \
-    s_waitcnt 0 \n \
-    "
-        : "=v"(dst)
-        : "v"(src_thread_addr_offset), "s"(src_block_config.data), "s"(src_const_addr_offset));
-#endif
-
-    return dst;
-}
-
-template <>
-__device__ float4_t amd_intrinsic_buffer_load<float, 4>(const float* p_src_block,
-                                                        index_t src_thread_data_offset,
-                                                        index_t src_const_data_offset)
-{
-    float4_t dst;
-
-    index_t src_thread_addr_offset = src_thread_data_offset * sizeof(float);
-    index_t src_const_addr_offset  = src_const_data_offset * sizeof(float);
-
-    BufferLoadStoreDwordConfig<float> src_block_config;
-
-    // fill in byte 0 - 1
-    src_block_config.address[0] = const_cast<float*>(p_src_block);
-    // fill in byte 2
-    src_block_config.range[2] = -1;
-    // fill in byte 3
-    src_block_config.range[3] = 0x00027000;
-
-#if CK_USE_AMD_BUFFER_ADDRESSING_INTRINSIC
-    dst = __llvm_amdgcn_buffer_loadx4(
-        src_block_config.data, 0, src_thread_addr_offset + src_const_addr_offset, false, false);
-#else
-    asm volatile(
-        "\n \
-    buffer_load_dwordx4 %0, %1, %2, %3 offen offset:0 \n \
-    s_waitcnt 0 \n \
-    "
-        : "=v"(dst)
-        : "v"(src_thread_addr_offset), "s"(src_block_config.data), "s"(src_const_addr_offset));
-#endif
-
-    return dst;
-}
-
-template <>
-__device__ void amd_intrinsic_buffer_store<float, 1>(const float* p_src,
-                                                     float* p_dst_block,
-                                                     index_t dst_thread_data_offset,
-                                                     index_t dst_const_data_offset)
-{
-    index_t dst_thread_addr_offset = dst_thread_data_offset * sizeof(float);
-    index_t dst_const_addr_offset  = dst_const_data_offset * sizeof(float);
-
-    BufferLoadStoreDwordConfig<float> dst_block_config;
+    BufferAddressConfig<float> dst_block_config;
 
     // fill in byte 0 - 1
     dst_block_config.address[0] = p_dst_block;
@@ -208,147 +749,35 @@ __device__ void amd_intrinsic_buffer_store<float, 1>(const float* p_src,
     // fill in byte 3
     dst_block_config.range[3] = 0x00027000;
 
-#if CK_USE_AMD_BUFFER_ADDRESSING_INTRINSIC
-    __llvm_amdgcn_buffer_store(*p_src,
-                               dst_block_config.data,
-                               0,
-                               dst_thread_addr_offset + dst_const_addr_offset,
-                               false,
-                               false);
-#else
-    asm volatile("\n \
-    buffer_store_dword %1, %2, %0, %3 offen offset:0 \n \
-    "
-                 :
-                 : "s"(dst_block_config.data),
-                   "v"(*p_src),
-                   "v"(dst_thread_addr_offset),
-                   "s"(dst_const_addr_offset));
-#endif
-}
-
-template <>
-__device__ void amd_intrinsic_buffer_store<float, 2>(const float* p_src,
-                                                     float* p_dst_block,
-                                                     index_t dst_thread_data_offset,
-                                                     index_t dst_const_data_offset)
-{
     index_t dst_thread_addr_offset = dst_thread_data_offset * sizeof(float);
     index_t dst_const_addr_offset  = dst_const_data_offset * sizeof(float);
 
-    BufferLoadStoreDwordConfig<float> dst_block_config;
-
-    // fill in byte 0 - 1
-    dst_block_config.address[0] = p_dst_block;
-    // fill in byte 2
-    dst_block_config.range[2] = -1;
-    // fill in byte 3
-    dst_block_config.range[3] = 0x00027000;
-
-#if CK_USE_AMD_BUFFER_ADDRESSING_INTRINSIC
-    __llvm_amdgcn_buffer_storex2(*reinterpret_cast<const float2_t*>(p_src),
-                                 dst_block_config.data,
-                                 0,
-                                 dst_thread_addr_offset + dst_const_addr_offset,
-                                 false,
-                                 false);
-#else
-    asm volatile("\n \
-    buffer_store_dwordx2 %1, %2, %0, %3 offen offset:0 \n \
-    "
-                 :
-                 : "s"(dst_block_config.data),
-                   "v"(*reinterpret_cast<const float2_t*>(p_src)),
-                   "v"(dst_thread_addr_offset),
-                   "s"(dst_const_addr_offset));
-#endif
-}
-
-template <>
-__device__ void amd_intrinsic_buffer_store<float, 4>(const float* p_src,
-                                                     float* p_dst_block,
-                                                     index_t dst_thread_data_offset,
-                                                     index_t dst_const_data_offset)
-{
-    index_t dst_thread_addr_offset = dst_thread_data_offset * sizeof(float);
-    index_t dst_const_addr_offset  = dst_const_data_offset * sizeof(float);
-
-    BufferLoadStoreDwordConfig<float> dst_block_config;
-
-    // fill in byte 0 - 1
-    dst_block_config.address[0] = p_dst_block;
-    // fill in byte 2
-    dst_block_config.range[2] = -1;
-    // fill in byte 3
-    dst_block_config.range[3] = 0x00027000;
-
-#if CK_USE_AMD_BUFFER_ADDRESSING_INTRINSIC
-    __llvm_amdgcn_buffer_storex4(*reinterpret_cast<const float4_t*>(p_src),
-                                 dst_block_config.data,
-                                 0,
-                                 dst_thread_addr_offset + dst_const_addr_offset,
-                                 false,
-                                 false);
-#else
-    asm volatile("\n \
-    buffer_store_dwordx4 %1, %2, %0, %3 offen offset:0 \n \
-    "
-                 :
-                 : "s"(dst_block_config.data),
-                   "v"(*reinterpret_cast<const float4_t*>(p_src)),
-                   "v"(dst_thread_addr_offset),
-                   "s"(dst_const_addr_offset));
-#endif
-}
-
-template <>
-__device__ void amd_intrinsic_buffer_atomic_add<float, 1>(const float* p_src,
-                                                          float* p_dst_block,
-                                                          index_t dst_thread_data_offset,
-                                                          index_t dst_const_data_offset)
-{
-    index_t dst_thread_addr_offset = dst_thread_data_offset * sizeof(float);
-    index_t dst_const_addr_offset  = dst_const_data_offset * sizeof(float);
-
-    BufferLoadStoreDwordConfig<float> dst_block_config;
-
-    // fill in byte 0 - 1
-    dst_block_config.address[0] = p_dst_block;
-    // fill in byte 2
-    dst_block_config.range[2] = -1;
-    // fill in byte 3
-    dst_block_config.range[3] = 0x00027000;
-
-#if CK_USE_AMD_BUFFER_ADDRESSING_INTRINSIC
-    __llvm_amdgcn_buffer_atomic_add(
+    __llvm_amdgcn_buffer_atomic_add_f32(
         *p_src, dst_block_config.data, 0, dst_thread_addr_offset + dst_const_addr_offset, false);
-#else
-    static_assert(false, " wrong! not implemented");
-#endif
 }
 
 template <>
-__device__ void amd_intrinsic_buffer_atomic_add<float, 2>(const float* p_src,
-                                                          float* p_dst_block,
-                                                          index_t dst_thread_data_offset,
-                                                          index_t dst_const_data_offset)
+__device__ void amd_buffer_atomic_add<float, 2>(const float* p_src,
+                                                float* p_dst_block,
+                                                index_t dst_thread_data_offset,
+                                                index_t dst_const_data_offset)
 {
     for(index_t i = 0; i < 2; ++i)
     {
-        amd_intrinsic_buffer_atomic_add<float, 1>(
+        amd_buffer_atomic_add<float, 1>(
             &p_src[i], p_dst_block, dst_thread_data_offset, dst_const_data_offset + i);
     }
 }
 
 template <>
-__device__ void amd_intrinsic_buffer_atomic_add<float, 4>(const float* p_src,
-                                                          float* p_dst_block,
-                                                          index_t dst_thread_data_offset,
-                                                          index_t dst_const_data_offset)
+__device__ void amd_buffer_atomic_add<float, 4>(const float* p_src,
+                                                float* p_dst_block,
+                                                index_t dst_thread_data_offset,
+                                                index_t dst_const_data_offset)
 {
     for(index_t i = 0; i < 4; ++i)
     {
-        amd_intrinsic_buffer_atomic_add<float, 1>(
+        amd_buffer_atomic_add<float, 1>(
             &p_src[i], p_dst_block, dst_thread_data_offset, dst_const_data_offset + i);
     }
 }

--- a/src/kernels/composable_kernel/include/utility/common_header.hpp
+++ b/src/kernels/composable_kernel/include/utility/common_header.hpp
@@ -16,13 +16,10 @@
 #include "functional3.hpp"
 #include "functional4.hpp"
 #include "in_memory_operation.hpp"
+#include "synchronization.hpp"
 
 #if CK_USE_AMD_INLINE_ASM
 #include "amd_inline_asm.hpp"
-#endif
-
-#if CK_USE_AMD_BUFFER_ADDRESSING
-#include "amd_buffer_addressing.hpp"
 #endif
 
 #if CK_USE_AMD_XDLOPS

--- a/src/kernels/composable_kernel/include/utility/config.hpp
+++ b/src/kernels/composable_kernel/include/utility/config.hpp
@@ -25,11 +25,7 @@
 #define CK_USE_AMD_BUFFER_ADDRESSING 1
 #endif
 
-#ifndef CK_USE_AMD_BUFFER_ADDRESSING_INTRINSIC
-#define CK_USE_AMD_BUFFER_ADDRESSING_INTRINSIC 1
-#endif
-
-// only support gfx908
+// only gfx908 support native floating point atomic add
 #ifndef CK_USE_AMD_BUFFER_ATOMIC_ADD
 #define CK_USE_AMD_BUFFER_ATOMIC_ADD 0
 #endif
@@ -47,6 +43,11 @@
 #define CK_USE_AMD_XDLOPS_EMULATE 0 // For internal debug purposes
 #endif
 
+// block synchronization only s_wait lgkmcnt(0), not vmcnt(0)
+#ifndef CK_BLOCK_SYNC_LDS_WITHOUT_SYNC_VMEM
+#define CK_BLOCK_SYNC_LDS_WITHOUT_SYNC_VMEM 1
+#endif
+
 // experimental implementation
 #define CK_EXPERIMENTAL_BLOCKWISE_GEMM_USE_PIPELINE 1
 #define CK_EXPERIMENTAL_TENSOR_COORDINATE_USE_CALCULATE_OFFSET_DIFF 0
@@ -54,8 +55,24 @@
 #define CK_EXPERIMENTAL_USE_MORE_COMPILE_STATIC_BLOCKWISE_GENERIC_SLICE_COPY_V1 0
 #define CK_EXPERIMENTAL_USE_MORE_COMPILE_STATIC_THREADWISE_GENERIC_TENSOR_SLICE_COPY_V1R2 0
 #define CK_EXPERIMENTAL_USE_MORE_COMPILE_STATIC_THREADWISE_GENERIC_TENSOR_SLICE_COPY_V2R1 0
+
+#ifndef CK_EXPERIMENTAL_IMPLICIT_GEMM_BACKWARD_DATA_V4R1_OUTPUT_SKIP_OUT_OF_BOUND_CHECK
 #define CK_EXPERIMENTAL_IMPLICIT_GEMM_BACKWARD_DATA_V4R1_OUTPUT_SKIP_OUT_OF_BOUND_CHECK 0
+#endif
+
+#ifndef CK_EXPERIMENTAL_IMPLICIT_GEMM_BACKWARD_DATA_V4R1_INPUT_SKIP_OUT_OF_BOUND_CHECK
 #define CK_EXPERIMENTAL_IMPLICIT_GEMM_BACKWARD_DATA_V4R1_INPUT_SKIP_OUT_OF_BOUND_CHECK 0
+#endif
+
+// workaround: put all workaround here
+// workaround for unnecessary VGPA <--> AGRP data movement when using mfma LLVM intrinsic
+#ifndef CK_WORKAROUND_SWDEV_229564
+#define CK_WORKAROUND_SWDEV_229564 1
+#endif
+// workaround for buffer load/store fp16/bfp16 intrinsic bug
+#ifndef CK_WORKAROUND_SWDEV_231101
+#define CK_WORKAROUND_SWDEV_231101 1
+#endif
 
 namespace ck {
 
@@ -71,12 +88,6 @@ enum InMemoryDataOperation
 {
     Set,
     AtomicAdd
-};
-
-enum WorkgroupScheduleOrder
-{
-    MBlock1NBlock0,
-    NBlock1MBlock0
 };
 
 #if CK_UNSIGNED_INDEX_TYPE

--- a/src/kernels/composable_kernel/include/utility/float_type.hpp
+++ b/src/kernels/composable_kernel/include/utility/float_type.hpp
@@ -291,6 +291,34 @@ struct inner_product_with_conversion
 {
     static constexpr auto convert = type_convert<T>();
 
+    __device__ T operator()(float4_t a, float4_t b) const
+    {
+        const float* p_a_float = reinterpret_cast<const float*>(&a);
+        const float* p_b_float = reinterpret_cast<const float*>(&b);
+
+        T acc = 0;
+        for(index_t v = 0; v < 4; ++v)
+        {
+            acc += convert(p_a_float[v]) * convert(p_b_float[v]);
+        }
+
+        return acc;
+    }
+
+    __device__ T operator()(float2_t a, float2_t b) const
+    {
+        const float* p_a_float = reinterpret_cast<const float*>(&a);
+        const float* p_b_float = reinterpret_cast<const float*>(&b);
+
+        T acc = 0;
+        for(index_t v = 0; v < 2; ++v)
+        {
+            acc += convert(p_a_float[v]) * convert(p_b_float[v]);
+        }
+
+        return acc;
+    }
+
     __device__ T operator()(float a, float b) const { return convert(a) * convert(b); }
 
     __device__ T operator()(half2_t a, half2_t b) const
@@ -320,6 +348,19 @@ struct inner_product_with_conversion
         return acc;
     }
 
+    __device__ T operator()(half8_t a, half8_t b) const
+    {
+        const half_t* p_a_half = reinterpret_cast<const half_t*>(&a);
+        const half_t* p_b_half = reinterpret_cast<const half_t*>(&b);
+
+        T acc = 0;
+        for(index_t v = 0; v < 8; ++v)
+        {
+            acc += convert(p_a_half[v]) * convert(p_b_half[v]);
+        }
+        return acc;
+    }
+
     __device__ T operator()(ushort2_t a, ushort2_t b) const
     {
         const ushort* p_a_bfloat16 = reinterpret_cast<const ushort*>(&a);
@@ -341,6 +382,19 @@ struct inner_product_with_conversion
 
         T acc = 0;
         for(index_t v = 0; v < 4; ++v)
+        {
+            acc += convert(p_a_bfloat16[v]) * convert(p_b_bfloat16[v]);
+        }
+        return acc;
+    }
+
+    __device__ T operator()(ushort8_t a, ushort8_t b) const
+    {
+        const ushort* p_a_bfloat16 = reinterpret_cast<const ushort*>(&a);
+        const ushort* p_b_bfloat16 = reinterpret_cast<const ushort*>(&b);
+
+        T acc = 0;
+        for(index_t v = 0; v < 8; ++v)
         {
             acc += convert(p_a_bfloat16[v]) * convert(p_b_bfloat16[v]);
         }

--- a/src/kernels/composable_kernel/include/utility/in_memory_operation.hpp
+++ b/src/kernels/composable_kernel/include/utility/in_memory_operation.hpp
@@ -2,7 +2,10 @@
 #define CK_IN_MEMORY_OPERATION_AMD_HPP
 
 #include "float_type.hpp"
+
+#if CK_USE_AMD_BUFFER_ADDRESSING
 #include "amd_buffer_addressing.hpp"
+#endif
 
 namespace ck {
 
@@ -37,65 +40,77 @@ __device__ void atomic_add_impl<float4_t>(float4_t* p_dst, float4_t src)
     }
 }
 
-template <typename T,
-          index_t DataPerAccess,
-          AddressSpace SrcAddressSpace,
-          AddressSpace DstAddressSpace>
-__device__ void set_data(const T* p_src, index_t src_offset, T* p_dst, index_t dst_offset)
+template <typename T, index_t DataPerAccess>
+struct SetData
 {
     using vector_t = typename vector_type<T, DataPerAccess>::MemoryType;
 
-#if CK_USE_AMD_BUFFER_ADDRESSING
-    // TODO: use static_if::ElseIf, instead of nested static_if
-    static_if<SrcAddressSpace == AddressSpace::Global &&
-              DstAddressSpace == AddressSpace::Vgpr>{}([&](auto) {
-        // buffer_load requires:
-        //   1) p_src must be in global memory space, d_dst must be vgpr
-        //   2) p_src to be a block-invariant pointer.
-        // It is user's responsibility to make sure that is true.
+    // This version is only for compatibility, don't use this version if possible
+    template <AddressSpace SrcAddressSpace, AddressSpace DstAddressSpace>
+    __device__ void Run(const T* p_src, index_t src_offset, T* p_dst, index_t dst_offset) const
+    {
         *reinterpret_cast<vector_t*>(&p_dst[dst_offset]) =
-            amd_intrinsic_buffer_load<T, DataPerAccess>(p_src, src_offset, 0);
-    }).Else([&](auto) {
-        static_if<SrcAddressSpace == AddressSpace::Vgpr &&
-                  DstAddressSpace == AddressSpace::Global>{}([&](auto) {
-            // buffer_store requires:
-            //   1) p_src must be in vgpr space, d_dst must be global memory
-            //   2) p_dst to be a block-invariant pointer.
-            // It is user's responsibility to make sure that is true.
-            amd_intrinsic_buffer_store<T, DataPerAccess>(
-                &(p_src[src_offset]), p_dst, dst_offset, 0);
-        }).Else([&](auto) {
-            *reinterpret_cast<vector_t*>(&p_dst[dst_offset]) =
-                *reinterpret_cast<const vector_t*>(&p_src[src_offset]);
-        });
-    });
-#else
-    *reinterpret_cast<vector_t*>(&p_dst[dst_offset]) =
-        *reinterpret_cast<const vector_t*>(&p_src[src_offset]);
+            *reinterpret_cast<const vector_t*>(&p_src[src_offset]);
+    }
+
+#if CK_USE_AMD_BUFFER_ADDRESSING
+    // buffer_load requires:
+    //   1) p_src must be in global memory space, d_dst must be vgpr
+    //   2) p_src to be a block-invariant pointer.
+    // It is user's responsibility to make sure that is true.
+    template <>
+    __device__ void Run<AddressSpace::Global, AddressSpace::Vgpr>(const T* p_src,
+                                                                  index_t src_offset,
+                                                                  T* p_dst,
+                                                                  index_t dst_offset) const
+    {
+        *reinterpret_cast<vector_t*>(&p_dst[dst_offset]) =
+            amd_buffer_load<T, DataPerAccess>(p_src, src_offset, 0);
+    }
+
+    // buffer_store requires:
+    //   1) p_src must be in vgpr space, d_dst must be global memory
+    //   2) p_dst to be a block-invariant pointer.
+    // It is user's responsibility to make sure that is true.
+    template <>
+    __device__ void Run<AddressSpace::Vgpr, AddressSpace::Global>(const T* p_src,
+                                                                  index_t src_offset,
+                                                                  T* p_dst,
+                                                                  index_t dst_offset) const
+    {
+        amd_buffer_store<T, DataPerAccess>(&(p_src[src_offset]), p_dst, dst_offset, 0);
+    }
 #endif
-}
+};
 
-template <typename T,
-          index_t DataPerAccess,
-          AddressSpace SrcAddressSpace,
-          AddressSpace DstAddressSpace>
-__device__ void atomic_add_data(const T* p_src, index_t src_offset, T* p_dst, index_t dst_offset)
+template <typename T, index_t DataPerAccess>
+struct AtomicAddData
 {
-    static_if<SrcAddressSpace == AddressSpace::Vgpr &&
-              DstAddressSpace == AddressSpace::Global>{}([&](auto) {
-#if CK_USE_AMD_BUFFER_ATOMIC_ADD
-        amd_intrinsic_buffer_atomic_add<T, DataPerAccess>(
-            &(p_src[src_offset]), p_dst, dst_offset, 0);
-#else
-        using vector_t = typename vector_type<T, DataPerAccess>::MemoryType;
+    using vector_t = typename vector_type<T, DataPerAccess>::MemoryType;
 
+    // This version is only for compatibility, don't use this version if possible
+    template <AddressSpace SrcAddressSpace, AddressSpace DstAddressSpace>
+    __device__ void Run(const T* p_src, index_t src_offset, T* p_dst, index_t dst_offset) const
+    {
         atomic_add_impl(reinterpret_cast<vector_t*>(&p_dst[dst_offset]),
                         *reinterpret_cast<const vector_t*>(&p_src[src_offset]));
+    }
+
+#if CK_USE_AMD_BUFFER_ADDRESSING && CK_USE_AMD_BUFFER_ATOMIC_ADD
+    // buffer_atomic_add requires:
+    //   1) p_src must be in vgpr space, d_dst must be global memory
+    //   2) p_dst to be a block-invariant pointer.
+    // It is user's responsibility to make sure that is true.
+    template <>
+    __device__ void Run<AddressSpace::Vgpr, AddressSpace::Global>(const T* p_src,
+                                                                  index_t src_offset,
+                                                                  T* p_dst,
+                                                                  index_t dst_offset) const
+    {
+        amd_buffer_atomic_add<T, DataPerAccess>(&(p_src[src_offset]), p_dst, dst_offset, 0);
+    }
 #endif
-    }).Else([&](auto fwd) {
-        static_assert(fwd(false), "atomic_add doesn't support this memory space");
-    });
-}
+};
 
 template <typename T,
           index_t DataPerAccess,
@@ -110,36 +125,36 @@ __device__ void transfer_data(const T* p_src, index_t src_offset, T* p_dst, inde
                       DstInMemOp == InMemoryDataOperation::AtomicAdd,
                   "wrong! InMemoryDataOperation not supported!");
 
-    static_if<(SrcDataStride > 1 || DstDataStride > 1)>{}([&](auto) {
-
-        for(index_t j = 0; j < DataPerAccess; j++)
-        {
-            // TODO: use static_if::ElseIf
-            static_if<DstInMemOp == InMemoryDataOperation::Set>{}([&](auto) {
-                set_data<T, 1, SrcAddressSpace, DstAddressSpace>(
-                    p_src, src_offset + j * SrcDataStride, p_dst, dst_offset + j * DstDataStride);
-            });
-
-            static_if<DstInMemOp == InMemoryDataOperation::AtomicAdd>{}([&](auto) {
-                atomic_add_data<T, 1, SrcAddressSpace, DstAddressSpace>(
-                    p_src, src_offset + j * SrcDataStride, p_dst, dst_offset + j * DstDataStride);
-            });
-        }
-
-    }).Else([&](auto) {
-
+    // keep it simple, don't use static_if here, otherwise compiler will do weird things
+    if(SrcDataStride == 1 && DstDataStride == 1)
+    {
         // TODO: use static_if::ElseIf
         static_if<DstInMemOp == InMemoryDataOperation::Set>{}([&](auto) {
-            set_data<T, DataPerAccess, SrcAddressSpace, DstAddressSpace>(
+            SetData<T, DataPerAccess>{}.template Run<SrcAddressSpace, DstAddressSpace>(
                 p_src, src_offset, p_dst, dst_offset);
         });
 
         static_if<DstInMemOp == InMemoryDataOperation::AtomicAdd>{}([&](auto) {
-            atomic_add_data<T, DataPerAccess, SrcAddressSpace, DstAddressSpace>(
+            AtomicAddData<T, DataPerAccess>{}.template Run<SrcAddressSpace, DstAddressSpace>(
                 p_src, src_offset, p_dst, dst_offset);
         });
+    }
+    else
+    {
+        for(index_t i = 0; i < DataPerAccess; i++)
+        {
+            // TODO: use static_if::ElseIf
+            static_if<DstInMemOp == InMemoryDataOperation::Set>{}([&](auto) {
+                SetData<T, 1>{}.template Run<SrcAddressSpace, DstAddressSpace>(
+                    p_src, src_offset + i * SrcDataStride, p_dst, dst_offset + i * DstDataStride);
+            });
 
-    });
+            static_if<DstInMemOp == InMemoryDataOperation::AtomicAdd>{}([&](auto) {
+                AtomicAddData<T, 1>{}.template Run<SrcAddressSpace, DstAddressSpace>(
+                    p_src, src_offset + i * SrcDataStride, p_dst, dst_offset + i * DstDataStride);
+            });
+        }
+    }
 }
 
 } // namespace ck

--- a/src/kernels/composable_kernel/include/utility/synchronization.hpp
+++ b/src/kernels/composable_kernel/include/utility/synchronization.hpp
@@ -1,0 +1,25 @@
+#ifndef CK_SYNCHRONIZATION_AMD_HPP
+#define CK_SYNCHRONIZATION_AMD_HPP
+
+#include "config.hpp"
+
+namespace ck {
+
+__device__ void __llvm_amdgcn_s_barrier() __asm("llvm.amdgcn.s.barrier");
+
+__device__ void block_sync_lds()
+{
+#if CK_BLOCK_SYNC_LDS_WITHOUT_SYNC_VMEM
+    asm volatile("\
+    s_waitcnt lgkmcnt(0) \n \
+    s_barrier \
+    " ::);
+#else
+    __llvm_amdgcn_s_barrier();
+#endif
+}
+
+__device__ void block_sync_lds_vmem() { __llvm_amdgcn_s_barrier(); }
+
+} // namespace ck
+#endif

--- a/src/kernels/composable_kernel/src/kernel_wrapper/gridwise_convolution_forward_implicit_gemm_v4r4_xdlops_nchw_kcyx_nkhw.cpp
+++ b/src/kernels/composable_kernel/src/kernel_wrapper/gridwise_convolution_forward_implicit_gemm_v4r4_xdlops_nchw_kcyx_nkhw.cpp
@@ -1,0 +1,178 @@
+#include "common_header.hpp"
+#include "gridwise_convolution_forward_implicit_gemm_v4r4_xdlops_nchw_kcyx_nkhw.hpp"
+#include "float_types.h"
+
+extern "C" __global__
+    __launch_bounds__(CK_PARAM_DEPENDENT_BLOCK_SIZE) void gridwise_convolution_forward_implicit_gemm_v4r4_xdlops_nchw_kcyx_nkhw(
+        const FLOAT* const __restrict__ p_in_global,
+        const FLOAT* const __restrict__ p_wei_global,
+        FLOAT* const __restrict__ p_out_global)
+{
+    using namespace ck;
+
+    // read params: problem description
+    constexpr index_t G  = CK_PARAM_PROBLEM_G;
+    constexpr index_t N  = CK_PARAM_PROBLEM_N;
+    constexpr index_t K  = CK_PARAM_PROBLEM_K;
+    constexpr index_t C  = CK_PARAM_PROBLEM_C;
+    constexpr index_t Hi = CK_PARAM_PROBLEM_HI;
+    constexpr index_t Wi = CK_PARAM_PROBLEM_WI;
+    constexpr index_t Ho = CK_PARAM_PROBLEM_HO;
+    constexpr index_t Wo = CK_PARAM_PROBLEM_WO;
+    constexpr index_t Y  = CK_PARAM_PROBLEM_Y;
+    constexpr index_t X  = CK_PARAM_PROBLEM_X;
+
+    constexpr index_t ConvStrideH = CK_PARAM_PROBLEM_CONV_STRIDE_H;
+    constexpr index_t ConvStrideW = CK_PARAM_PROBLEM_CONV_STRIDE_W;
+
+    constexpr index_t ConvDilationH = CK_PARAM_PROBLEM_CONV_DILATION_H;
+    constexpr index_t ConvDilationW = CK_PARAM_PROBLEM_CONV_DILATION_W;
+
+    constexpr index_t InLeftPadH = CK_PARAM_PROBLEM_IN_LEFT_PAD_H;
+    constexpr index_t InLeftPadW = CK_PARAM_PROBLEM_IN_LEFT_PAD_W;
+
+    constexpr index_t InRightPadH = CK_PARAM_PROBLEM_IN_RIGHT_PAD_H;
+    constexpr index_t InRightPadW = CK_PARAM_PROBLEM_IN_RIGHT_PAD_W;
+
+    constexpr auto CPerGroup = C / G;
+
+    constexpr auto in_n_c_hi_wi_desc =
+        make_native_tensor_descriptor_packed(Sequence<N, C, Hi, Wi>{});
+    constexpr auto wei_k_cpergroup_y_x_desc =
+        make_native_tensor_descriptor_packed(Sequence<K, CPerGroup, Y, X>{});
+    constexpr auto out_n_k_ho_wo_desc =
+        make_native_tensor_descriptor_packed(Sequence<N, K, Ho, Wo>{});
+
+    using ConvStrides   = Sequence<ConvStrideH, ConvStrideW>;
+    using ConvDilations = Sequence<ConvDilationH, ConvDilationW>;
+
+    using InLeftPads  = Sequence<InLeftPadH, InLeftPadW>;
+    using InRightPads = Sequence<InRightPadH, InRightPadW>;
+
+    // read params: tunning parameters
+    constexpr index_t GemmMPerBlock = CK_PARAM_TUNABLE_GEMM_M_PER_BLOCK;
+    constexpr index_t GemmNPerBlock = CK_PARAM_TUNABLE_GEMM_N_PER_BLOCK;
+    constexpr index_t GemmKPerBlock = CK_PARAM_TUNABLE_GEMM_K_PER_BLOCK;
+    constexpr index_t GemmMPerWave  = CK_PARAM_TUNABLE_GEMM_M_PER_WAVE;
+    constexpr index_t GemmNPerWave  = CK_PARAM_TUNABLE_GEMM_N_PER_WAVE;
+    constexpr index_t GemmKPack     = CK_PARAM_TUNABLE_GEMM_KPACK;
+
+    // read params: dependent parameters
+    constexpr index_t BlockSize = CK_PARAM_DEPENDENT_BLOCK_SIZE;
+    constexpr index_t GridSize  = CK_PARAM_DEPENDENT_GRID_SIZE;
+
+    // A matrix copy
+    constexpr index_t GemmABlockCopyClusterLengths_GemmK =
+        CK_PARAM_DEPENDENT_GEMM_A_BLOCK_COPY_CLUSTER_LENGTHS_GEMM_K;
+    constexpr index_t GemmABlockCopyClusterLengths_GemmM =
+        CK_PARAM_DEPENDENT_GEMM_A_BLOCK_COPY_CLUSTER_LENGTHS_GEMM_M;
+    constexpr index_t GemmABlockCopyClusterLengths_GemmKPack =
+        CK_PARAM_DEPENDENT_GEMM_A_BLOCK_COPY_CLUSTER_LENGTHS_GEMM_KPACK;
+
+    constexpr index_t GemmABlockCopyThreadSliceLengths_GemmK =
+        GemmKPerBlock / GemmABlockCopyClusterLengths_GemmK;
+    constexpr index_t GemmABlockCopyThreadSliceLengths_GemmM =
+        GemmMPerBlock / GemmABlockCopyClusterLengths_GemmM;
+    constexpr index_t GemmABlockCopyThreadSliceLengths_GemmKPack =
+        GemmKPack / GemmABlockCopyClusterLengths_GemmKPack;
+
+    using GemmABlockCopyClusterLengths_GemmG_GemmK_GemmM_GemmKPack =
+        Sequence<1,
+                 GemmABlockCopyClusterLengths_GemmK,
+                 GemmABlockCopyClusterLengths_GemmM,
+                 GemmABlockCopyClusterLengths_GemmKPack>;
+    using GemmABlockCopySubLengths_GemmG_GemmK_GemmM_GemmKPack =
+        Sequence<1,
+                 GemmABlockCopyThreadSliceLengths_GemmK,
+                 GemmABlockCopyThreadSliceLengths_GemmM,
+                 GemmABlockCopyThreadSliceLengths_GemmKPack>;
+
+    using GemmABlockCopyThreadClusterArrangeOrder =
+        Sequence<0, 2, 1, 3>;                                  // [GemmG, GemmM, GemmK, GemmKPack]
+    using GemmABlockCopySrcAccessOrder = Sequence<0, 2, 1, 3>; // [GemmG, GemmM, GemmK, GemmKPack]
+    using GemmABlockCopyDstAccessOrder = Sequence<0, 1, 2, 3>; // [GemmG, GemmK, GemmM, GemmKPack]
+
+    constexpr index_t GemmABlockCopySrcDataPerRead_GemmKPack =
+        CK_PARAM_DEPENDENT_GEMM_A_BLOCK_COPY_SRC_DATA_PER_READ_GEMM_KPACK;
+
+    constexpr index_t GemmABlockCopyDstDataPerWrite_GemmKPack =
+        CK_PARAM_DEPENDENT_GEMM_A_BLOCK_COPY_DST_DATA_PER_WRITE_GEMM_KPACK;
+
+    // B matrix Copy
+    constexpr index_t GemmBBlockCopyClusterLengths_GemmK =
+        CK_PARAM_DEPENDENT_GEMM_B_BLOCK_COPY_CLUSTER_LENGTHS_GEMM_K;
+    constexpr index_t GemmBBlockCopyClusterLengths_GemmN =
+        CK_PARAM_DEPENDENT_GEMM_B_BLOCK_COPY_CLUSTER_LENGTHS_GEMM_N;
+    constexpr index_t GemmBBlockCopyClusterLengths_GemmKPack =
+        CK_PARAM_DEPENDENT_GEMM_B_BLOCK_COPY_CLUSTER_LENGTHS_GEMM_KPACK;
+
+    constexpr index_t GemmBBlockCopyThreadSliceLengths_GemmK =
+        GemmKPerBlock / GemmBBlockCopyClusterLengths_GemmK;
+    constexpr index_t GemmBBlockCopyThreadSliceLengths_GemmN =
+        GemmNPerBlock / GemmBBlockCopyClusterLengths_GemmN;
+    constexpr index_t GemmBBlockCopyThreadSliceLengths_GemmKPack =
+        GemmKPack / GemmBBlockCopyClusterLengths_GemmKPack;
+
+    using GemmBBlockCopyClusterLengths_GemmG_GemmK_GemmN_GemmKPack =
+        Sequence<1,
+                 GemmBBlockCopyClusterLengths_GemmK,
+                 GemmBBlockCopyClusterLengths_GemmN,
+                 GemmBBlockCopyClusterLengths_GemmKPack>;
+    using GemmBBlockCopySubLengths_GemmG_GemmK_GemmN_GemmKPack =
+        Sequence<1,
+                 GemmBBlockCopyThreadSliceLengths_GemmK,
+                 GemmBBlockCopyThreadSliceLengths_GemmN,
+                 GemmBBlockCopyThreadSliceLengths_GemmKPack>;
+
+    using GemmBBlockCopyThreadClusterArrangeOrder =
+        Sequence<0, 1, 3, 2>;                                  // [GemmG, GemmK, GemmKPack, GemmN]
+    using GemmBBlockCopySrcAccessOrder = Sequence<0, 1, 3, 2>; // [GemmG, GemmK, GemmKPack, GemmN]
+    using GemmBBlockCopyDstAccessOrder = Sequence<0, 1, 2, 3>; // [GemmG, GemmK, GemmN, GemmKPack]
+
+    constexpr index_t GemmBBlockCopySrcDataPerRead_GemmN =
+        CK_PARAM_DEPENDENT_GEMM_B_BLOCK_COPY_SRC_DATA_PER_READ_GEMM_N;
+
+    constexpr index_t GemmBBlockCopyDstDataPerWrite_GemmKPack =
+        CK_PARAM_DEPENDENT_GEMM_B_BLOCK_COPY_DST_DATA_PER_WRITE_GEMM_KPACK;
+
+    // gridwise GEMM
+    constexpr auto wkgrp_schd_order = NBlock1MBlock0;
+
+    constexpr auto gridwise_conv =
+        GridwiseConvolutionForwardImplicitGemm_v4r4_xdlops_nchw_kcyx_nkhw<
+            GridSize,
+            BlockSize,
+            FLOAT,       // Input data type
+            FLOAT_ACCUM, // Acc data type
+            FLOAT,       // Ouput data type
+            decltype(in_n_c_hi_wi_desc),
+            decltype(wei_k_cpergroup_y_x_desc),
+            decltype(out_n_k_ho_wo_desc),
+            G,
+            ConvStrides,
+            ConvDilations,
+            InLeftPads,
+            InRightPads,
+            GemmMPerBlock,
+            GemmNPerBlock,
+            GemmKPerBlock,
+            GemmMPerWave,
+            GemmNPerWave,
+            GemmKPack,
+            GemmABlockCopySubLengths_GemmG_GemmK_GemmM_GemmKPack,
+            GemmABlockCopyClusterLengths_GemmG_GemmK_GemmM_GemmKPack,
+            GemmABlockCopyThreadClusterArrangeOrder,
+            GemmABlockCopySrcAccessOrder,
+            GemmABlockCopyDstAccessOrder,
+            GemmABlockCopySrcDataPerRead_GemmKPack,
+            GemmABlockCopyDstDataPerWrite_GemmKPack,
+            GemmBBlockCopySubLengths_GemmG_GemmK_GemmN_GemmKPack,
+            GemmBBlockCopyClusterLengths_GemmG_GemmK_GemmN_GemmKPack,
+            GemmBBlockCopyThreadClusterArrangeOrder,
+            GemmBBlockCopySrcAccessOrder,
+            GemmBBlockCopyDstAccessOrder,
+            GemmBBlockCopySrcDataPerRead_GemmN,
+            GemmBBlockCopyDstDataPerWrite_GemmKPack,
+            wkgrp_schd_order>{};
+    gridwise_conv.Run(p_in_global, p_wei_global, p_out_global);
+}

--- a/src/mlo_dir_conv.cpp
+++ b/src/mlo_dir_conv.cpp
@@ -130,11 +130,13 @@ static auto GetDirectSolvers()
 
 static auto GetImplicitGemmSolvers()
 {
-    return miopen::solver::SolverContainer<miopen::solver::ConvHipImplicitGemmV4R4GenXdlopsFwdFp32,
+    return miopen::solver::SolverContainer<miopen::solver::ConvHipImplicitGemmForwardV4R4Xdlops,
+                                           miopen::solver::ConvHipImplicitGemmV4R4GenXdlopsFwdFp32,
                                            miopen::solver::ConvHipImplicitGemmV4R4Xdlops_1x1,
                                            miopen::solver::ConvHipImplicitGemmV4R4GenFwdXdlops,
                                            miopen::solver::ConvHipImplicitGemmV4R4FwdXdlops,
                                            miopen::solver::ConvHipImplicitGemmBwdDataV1R1Xdlops,
+                                           miopen::solver::ConvHipImplicitGemmBwdDataV4R1Xdlops,
                                            miopen::solver::ConvHipImplicitGemmV4_1x1,
                                            miopen::solver::ConvHipImplicitGemmV4Fwd,
                                            miopen::solver::ConvHipImplicitGemmV4R1Fwd,

--- a/src/ocl/batchnormocl.cpp
+++ b/src/ocl/batchnormocl.cpp
@@ -891,7 +891,7 @@ void BatchNormBackward(Handle& handle,
         // N*H*W < 32M and H*W > 1024, use batchnorm variant#1 implementation which parallelize
         // work groups over channels and loop through NHW.
         //*************************************************************************************************
-        if((in_nhw < (32 * 1024 * 1024) && in_cstride > 1024) || (n > 768))
+        if((in_nhw < (32 * 1024 * 1024) && in_cstride > 1024) || ((n > 768) && (in_cstride > 63)))
         {
             variant    = 1;
             xlocalsize = 1024;

--- a/src/readonlyramdb.cpp
+++ b/src/readonlyramdb.cpp
@@ -39,7 +39,7 @@ ReadonlyRamDb& ReadonlyRamDb::GetCached(const std::string& path,
                                         const std::size_t /*num_cu*/)
 {
     static std::mutex mutex;
-    static const std::lock_guard<std::mutex> lock{mutex};
+    const std::lock_guard<std::mutex> lock{mutex};
 
     static auto instances = std::map<std::string, ReadonlyRamDb*>{};
     const auto it         = instances.find(path);

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -324,6 +324,9 @@ inline SolverRegistrar::SolverRegistrar(IdRegistryData& registry)
 
     RegisterWithSolver(
         registry, ++id, ConvAsmImplicitGemmV4R1DynamicFwd_1x1{}, miopenConvolutionAlgoImplicitGEMM);
+
+    RegisterWithSolver(
+        registry, ++id, ConvHipImplicitGemmForwardV4R4Xdlops{}, miopenConvolutionAlgoImplicitGEMM);
 }
 
 } // namespace solver

--- a/src/solver/conv_hip_implicit_gemm_fwd_v4r4_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_fwd_v4r4_xdlops.cpp
@@ -1,0 +1,967 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2020 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <miopen/conv/invokers/impl_gemm.hpp>
+#include <miopen/solver.hpp>
+#include <miopen/handle.hpp>
+#include <miopen/generic_search.hpp>
+#include <miopen/hip_build_utils.hpp>
+#include "implicitgemm_util.hpp"
+
+namespace miopen {
+namespace solver {
+
+PerformanceImplicitGemmForwardV4R4Xdlops::PerformanceImplicitGemmForwardV4R4Xdlops()
+    : PerformanceImplicitGemmForwardV4R4Xdlops::PerformanceImplicitGemmForwardV4R4Xdlops(
+          4, 4, 1, 4, 4, 1, false, false)
+{
+}
+
+PerformanceImplicitGemmForwardV4R4Xdlops::PerformanceImplicitGemmForwardV4R4Xdlops(
+    int GemmMPerBlock_,
+    int GemmNPerBlock_,
+    int GemmKPerBlock_,
+    int GemmMPerWave_,
+    int GemmNPerWave_,
+    int GemmKPack_,
+    bool GemmAThreadCopyMoreGemmK_,
+    bool GemmBThreadCopyMoreGemmKPack_)
+    : GemmMPerBlock(GemmMPerBlock_),
+      GemmNPerBlock(GemmNPerBlock_),
+      GemmKPerBlock(GemmKPerBlock_),
+      GemmMPerWave(GemmMPerWave_),
+      GemmNPerWave(GemmNPerWave_),
+      GemmKPack(GemmKPack_),
+      GemmAThreadCopyMoreGemmK(GemmAThreadCopyMoreGemmK_),
+      GemmBThreadCopyMoreGemmKPack(GemmBThreadCopyMoreGemmKPack_)
+{
+}
+
+bool PerformanceImplicitGemmForwardV4R4Xdlops::
+operator==(const PerformanceImplicitGemmForwardV4R4Xdlops& other) const
+{
+    // clang-format off
+    return GemmMPerBlock == other.GemmMPerBlock
+        && GemmNPerBlock == other.GemmNPerBlock
+        && GemmKPerBlock == other.GemmKPerBlock
+        && GemmMPerWave == other.GemmMPerWave
+        && GemmNPerWave == other.GemmNPerWave
+        && GemmKPack == other.GemmKPack 
+        && GemmAThreadCopyMoreGemmK  == other.GemmAThreadCopyMoreGemmK
+        && GemmBThreadCopyMoreGemmKPack  == other.GemmBThreadCopyMoreGemmKPack;
+    // clang-format on
+}
+
+bool PerformanceImplicitGemmForwardV4R4Xdlops::SetNextValue()
+{
+    do
+    {
+        // list performance parameters in reverse order, in order for tuning to iterate over the
+        // range in normal order
+        if(!NextFlag<false, true>(GemmBThreadCopyMoreGemmKPack))
+            break;
+        if(!NextFlag<false, false>(GemmAThreadCopyMoreGemmK))
+            break;
+        if(!NextTwoPower<1, 8>(GemmKPack))
+            break;
+        if(!NextTwoPower<4, 128>(GemmNPerWave))
+            break;
+        if(!NextTwoPower<4, 128>(GemmMPerWave))
+            break;
+        if(!NextTwoPower<1, 8>(GemmKPerBlock))
+            break;
+        if(!NextTwoPower<4, 256>(GemmNPerBlock))
+            break;
+        if(!NextTwoPower<4, 256>(GemmMPerBlock))
+            break;
+        return false;
+    } while(false);
+
+    return true;
+}
+
+void PerformanceImplicitGemmForwardV4R4Xdlops::EuristicInit(const ConvolutionContext& ctx)
+{
+    PerformanceImplicitGemmForwardV4R4Xdlops tmp;
+
+    // loop over certain ranges of tuning parameter
+    auto get_euristic_config = [&](auto is_valid_func) {
+        if(ctx.IsFp32())
+        {
+            tmp = {256, 256, 8, 128, 128, 4, false, true};
+
+            bool all_visited = false;
+            do
+            {
+                do
+                {
+                    // list in reverse order of importance,
+                    // and favor large GEMM
+                    if(!PreviousTwoPower<1, 8>(tmp.GemmKPerBlock))
+                        break;
+                    if(!PreviousTwoPower<1, 4>(tmp.GemmKPack))
+                        break;
+                    if(!PreviousTwoPower<4, 128>(tmp.GemmNPerWave))
+                        break;
+                    if(!PreviousTwoPower<4, 128>(tmp.GemmMPerWave))
+                        break;
+                    if(!PreviousTwoPower<4, 256>(tmp.GemmNPerBlock))
+                        break;
+                    if(!PreviousTwoPower<4, 256>(tmp.GemmMPerBlock))
+                        break;
+
+                    all_visited = true;
+                } while(false);
+
+                if(is_valid_func(tmp, ctx))
+                    break;
+            } while(!all_visited);
+        }
+        else if(ctx.IsFp16())
+        {
+            tmp = {256, 256, 8, 128, 128, 8, false, true};
+
+            bool all_visited = false;
+            do
+            {
+                do
+                {
+                    // list in reverse order of importance,
+                    // and favor large GEMM
+                    if(!PreviousTwoPower<1, 8>(tmp.GemmKPerBlock))
+                        break;
+                    if(!PreviousTwoPower<4, 8>(tmp.GemmKPack))
+                        break;
+                    if(!PreviousTwoPower<4, 128>(tmp.GemmNPerWave))
+                        break;
+                    if(!PreviousTwoPower<4, 128>(tmp.GemmMPerWave))
+                        break;
+                    if(!PreviousTwoPower<4, 256>(tmp.GemmNPerBlock))
+                        break;
+                    if(!PreviousTwoPower<4, 256>(tmp.GemmMPerBlock))
+                        break;
+
+                    all_visited = true;
+                } while(false);
+
+                if(is_valid_func(tmp, ctx))
+                    break;
+            } while(!all_visited);
+        }
+        else if(ctx.IsBfp16())
+        {
+            tmp = {256, 256, 8, 128, 128, 8, false, true};
+
+            bool all_visited = false;
+            do
+            {
+                do
+                {
+                    // list in reverse order of importance,
+                    // and favor large GEMM
+                    if(!PreviousTwoPower<1, 8>(tmp.GemmKPerBlock))
+                        break;
+                    if(!PreviousTwoPower<2, 8>(tmp.GemmKPack))
+                        break;
+                    if(!PreviousTwoPower<4, 128>(tmp.GemmNPerWave))
+                        break;
+                    if(!PreviousTwoPower<4, 128>(tmp.GemmMPerWave))
+                        break;
+                    if(!PreviousTwoPower<4, 256>(tmp.GemmNPerBlock))
+                        break;
+                    if(!PreviousTwoPower<4, 256>(tmp.GemmMPerBlock))
+                        break;
+
+                    all_visited = true;
+                } while(false);
+
+                if(is_valid_func(tmp, ctx))
+                    break;
+            } while(!all_visited);
+        }
+        else
+        {
+            MIOPEN_LOG_E("Only fp32, fp16, and bfp16 are supported");
+            assert(false);
+        }
+    };
+
+    // first round: really valid and fast
+    get_euristic_config([](auto config, auto conv_context) {
+        return config.IsReallyValid(conv_context) && config.IsFastToBeUsedForTuning(conv_context);
+    });
+
+    // second round: really valid
+    if(!tmp.IsReallyValid(ctx))
+    {
+        get_euristic_config(
+            [](auto config, auto conv_context) { return config.IsReallyValid(conv_context); });
+    }
+
+    // final check
+    if(!tmp.IsReallyValid(ctx))
+    {
+        MIOPEN_LOG_E("All attempts failed");
+        assert(false);
+    }
+    *this = tmp;
+    MIOPEN_LOG_I(ToString());
+}
+
+std::string PerformanceImplicitGemmForwardV4R4Xdlops::ToString() const
+{
+    std::ostringstream ss;
+    Serialize(ss);
+    return ss.str();
+}
+
+std::tuple<int, bool> PerformanceImplicitGemmForwardV4R4Xdlops::CalculateBlockSize() const
+{
+    int block_size = 0;
+
+    try
+    {
+        if(!(GemmMPerBlock % GemmMPerWave == 0 && GemmNPerBlock % GemmNPerWave == 0))
+            MIOPEN_THROW("invalid performance parameter");
+
+        const auto WaveSize = 64;
+        block_size = (GemmNPerBlock * GemmMPerBlock) / (GemmMPerWave * GemmNPerWave) * WaveSize;
+    }
+    catch(...)
+    {
+        return std::make_tuple(-1, false);
+    }
+
+    return std::make_tuple(block_size, true);
+}
+
+std::tuple<int, bool>
+PerformanceImplicitGemmForwardV4R4Xdlops::CalculateGridSize(const ConvolutionContext& ctx) const
+{
+    int GridSize = 0;
+
+    try
+    {
+        int gemm_g = -1;
+        int gemm_m = -1;
+        int gemm_n = -1;
+
+        std::tie(gemm_g, gemm_m, gemm_n, std::ignore) =
+            ConvHipImplicitGemmForwardV4R4Xdlops::CalculateGemmSize(ctx);
+
+        if(!(gemm_m % GemmMPerBlock == 0 && gemm_n % GemmNPerBlock == 0))
+            MIOPEN_THROW("invalid performance parameter");
+
+        GridSize = gemm_g * (gemm_m / GemmMPerBlock) * (gemm_n / GemmNPerBlock);
+    }
+    catch(...)
+    {
+        return std::make_tuple(-1, false);
+    }
+
+    return std::make_tuple(GridSize, true);
+}
+
+std::tuple<int, int, int, int, int, bool>
+PerformanceImplicitGemmForwardV4R4Xdlops::CalculateGemmABlockCopyPerformanceParameters(
+    const ConvolutionContext& ctx) const
+{
+    // A tensor shape [GemmG, GemmK, GemmM, GemmKPack]
+
+    int ClusterLengths_GemmK     = -1;
+    int ClusterLengths_GemmM     = -1;
+    int ClusterLengths_GemmKPack = -1;
+    int SrcDataPerRead_GemmKPack = ctx.IsFp32() ? amd_buffer_load_max_length<float>()
+                                                : amd_buffer_load_max_length<half_float::half>();
+    int DstDataPerWrite_GemmKPack = ctx.IsFp32() ? amd_lds_write_max_length<float>()
+                                                 : amd_lds_write_max_length<half_float::half>();
+
+    try
+    {
+        bool valid = false;
+
+        int block_size = -1;
+
+        std::tie(block_size, valid) = CalculateBlockSize();
+
+        if(!valid)
+            MIOPEN_THROW("invalid performance parameter");
+
+        // GemmKPack is src vector read dimension, bounded by GemmKPack
+        SrcDataPerRead_GemmKPack = gcd(SrcDataPerRead_GemmKPack, GemmKPack);
+
+        // calculate threadwise copy size
+        auto data_per_thread_copy =
+            std::max(1, (GemmKPerBlock * GemmMPerBlock * GemmKPack) / block_size);
+
+        // make sure a thread can do a full vector load, at the cost that some threads
+        // may not do threadwise copy at all
+        data_per_thread_copy = lcm(data_per_thread_copy, SrcDataPerRead_GemmKPack);
+
+        const auto data_per_thread_copy_gemmkpack = SrcDataPerRead_GemmKPack;
+        const auto tmp = data_per_thread_copy / data_per_thread_copy_gemmkpack;
+
+        int data_per_thread_copy_gemmk = -1;
+        int data_per_thread_copy_gemmm = -1;
+
+        if(GemmAThreadCopyMoreGemmK)
+        {
+            data_per_thread_copy_gemmk = gcd(GemmKPerBlock, tmp);
+            data_per_thread_copy_gemmm = tmp / data_per_thread_copy_gemmk;
+        }
+        else
+        {
+            data_per_thread_copy_gemmm = gcd(GemmMPerBlock, tmp);
+            data_per_thread_copy_gemmk = tmp / data_per_thread_copy_gemmm;
+        }
+
+        // vector write into LDS
+        DstDataPerWrite_GemmKPack = gcd(DstDataPerWrite_GemmKPack, data_per_thread_copy_gemmkpack);
+
+        if(!(GemmKPerBlock % data_per_thread_copy_gemmk == 0 &&
+             GemmMPerBlock % data_per_thread_copy_gemmm == 0 &&
+             GemmKPack % data_per_thread_copy_gemmkpack == 0))
+            MIOPEN_THROW("invalid performance parameter");
+
+        ClusterLengths_GemmK     = GemmKPerBlock / data_per_thread_copy_gemmk;
+        ClusterLengths_GemmM     = GemmMPerBlock / data_per_thread_copy_gemmm;
+        ClusterLengths_GemmKPack = GemmKPack / data_per_thread_copy_gemmkpack;
+
+        // blockwise-copy support that block_size is larger than thread cluster size, which means
+        // some threads may not do threadwise copy
+        if(block_size < ClusterLengths_GemmK * ClusterLengths_GemmM * ClusterLengths_GemmKPack)
+            MIOPEN_THROW("invalid performance parameter");
+    }
+    catch(...)
+    {
+        return std::make_tuple(-1, -1, -1, -1, -1, false);
+    }
+
+    return std::make_tuple(ClusterLengths_GemmK,
+                           ClusterLengths_GemmM,
+                           ClusterLengths_GemmKPack,
+                           SrcDataPerRead_GemmKPack,
+                           DstDataPerWrite_GemmKPack,
+                           true);
+}
+
+std::tuple<int, int, int, int, int, bool>
+PerformanceImplicitGemmForwardV4R4Xdlops::CalculateGemmBBlockCopyPerformanceParameters(
+    const ConvolutionContext& ctx) const
+{
+    // B tensor shape [GemmG, GemmK, GemmN, GemmKPack]
+
+    int ClusterLengths_GemmK     = -1;
+    int ClusterLengths_GemmN     = -1;
+    int ClusterLengths_GemmKPack = -1;
+    int SrcDataPerRead_GemmN     = ctx.IsFp32() ? amd_buffer_load_max_length<float>()
+                                            : amd_buffer_load_max_length<half_float::half>();
+    int DstDataPerWrite_GemmKPack = ctx.IsFp32() ? amd_lds_write_max_length<float>()
+                                                 : amd_lds_write_max_length<half_float::half>();
+
+    try
+    {
+        bool valid = false;
+
+        int block_size = -1;
+
+        std::tie(block_size, valid) = CalculateBlockSize();
+
+        if(!valid)
+            MIOPEN_THROW("invalid performance parameter");
+
+        // GemmN is src vector read dimension
+        // calculate vector length on gemmn dimension based on global tensor layout
+        const auto y  = ConvolutionContextInterpreter::GetFilterHeightY(ctx);
+        const auto x  = ConvolutionContextInterpreter::GetFilterWidthX(ctx);
+        const auto ho = ConvolutionContextInterpreter::GetOutputHeightHo(ctx);
+        const auto wo = ConvolutionContextInterpreter::GetOutputWidthWo(ctx);
+        const auto conv_stride_h =
+            ConvolutionContextInterpreter::GetAdjustedConvolutionStrideH(ctx);
+        const auto conv_stride_w =
+            ConvolutionContextInterpreter::GetAdjustedConvolutionStrideW(ctx);
+        const auto conv_dilation_w =
+            ConvolutionContextInterpreter::GetAdjustedConvolutionDilationW(ctx);
+        const auto in_left_pad_h  = ConvolutionContextInterpreter::GetInputLeftPadH(ctx);
+        const auto in_left_pad_w  = ConvolutionContextInterpreter::GetInputLeftPadW(ctx);
+        const auto in_right_pad_h = ConvolutionContextInterpreter::GetAdjustedInputRightPadH(ctx);
+        const auto in_right_pad_w = ConvolutionContextInterpreter::GetAdjustedInputRightPadW(ctx);
+
+        // GemmN is src vector read dimension, bounded by input tensor global memory layout
+        // TODO this logic need to be more aggresive
+        if(y == 1 && x == 1 && conv_stride_h == 1 && conv_stride_w == 1 && in_left_pad_h == 0 &&
+           in_left_pad_w == 0 && in_right_pad_h == 0 && in_right_pad_w == 0)
+        {
+            SrcDataPerRead_GemmN = gcd(SrcDataPerRead_GemmN, ho * wo);
+        }
+        else if(conv_stride_w == 1 && in_left_pad_w == 0 && in_right_pad_w == 0)
+        {
+            SrcDataPerRead_GemmN = gcd(SrcDataPerRead_GemmN, wo);
+        }
+        else if(conv_stride_w == 1)
+        {
+            SrcDataPerRead_GemmN =
+                gcd(SrcDataPerRead_GemmN, wo, in_left_pad_w, in_right_pad_w, conv_dilation_w);
+        }
+        else
+        {
+            SrcDataPerRead_GemmN = 1;
+        }
+
+        // SrcDataPerRead_GemmN also bounded by GemmNPerBlock
+        SrcDataPerRead_GemmN = gcd(SrcDataPerRead_GemmN, GemmNPerBlock);
+
+        // calculate threadwise copy size
+        auto data_per_thread_copy =
+            std::max(1, (GemmKPerBlock * GemmNPerBlock * GemmKPack) / block_size);
+
+        // make sure a thread can do a full vector load, at the cost that some threads
+        // may not do threadwise copy at all
+        data_per_thread_copy = lcm(data_per_thread_copy, SrcDataPerRead_GemmN);
+
+        const auto data_per_thread_copy_gemmn = SrcDataPerRead_GemmN;
+        const auto tmp                        = data_per_thread_copy / data_per_thread_copy_gemmn;
+
+        int data_per_thread_copy_gemmkpack = -1;
+        int data_per_thread_copy_gemmk     = -1;
+
+        if(GemmBThreadCopyMoreGemmKPack)
+        {
+            data_per_thread_copy_gemmkpack = gcd(GemmKPack, tmp);
+            data_per_thread_copy_gemmk     = tmp / data_per_thread_copy_gemmkpack;
+        }
+        else
+        {
+            data_per_thread_copy_gemmk     = gcd(GemmKPerBlock, tmp);
+            data_per_thread_copy_gemmkpack = tmp / data_per_thread_copy_gemmk;
+        }
+
+        // vector write into LDS
+        DstDataPerWrite_GemmKPack = gcd(DstDataPerWrite_GemmKPack, data_per_thread_copy_gemmkpack);
+
+        if(!(GemmKPerBlock % data_per_thread_copy_gemmk == 0 &&
+             GemmNPerBlock % data_per_thread_copy_gemmn == 0 &&
+             GemmKPack % data_per_thread_copy_gemmkpack == 0))
+            MIOPEN_THROW("invalid performance parameter");
+
+        ClusterLengths_GemmK     = GemmKPerBlock / data_per_thread_copy_gemmk;
+        ClusterLengths_GemmN     = GemmNPerBlock / data_per_thread_copy_gemmn;
+        ClusterLengths_GemmKPack = GemmKPack / data_per_thread_copy_gemmkpack;
+
+        // blockwise-copy support that block_size is larger than thread cluster size, which means
+        // some threads may not do threadwise copy
+        if(block_size < ClusterLengths_GemmK * ClusterLengths_GemmN * ClusterLengths_GemmKPack)
+            MIOPEN_THROW("invalid performance parameter");
+    }
+    catch(...)
+    {
+        return std::make_tuple(-1, -1, -1, -1, -1, false);
+    }
+
+    return std::make_tuple(ClusterLengths_GemmK,
+                           ClusterLengths_GemmN,
+                           ClusterLengths_GemmKPack,
+                           SrcDataPerRead_GemmN,
+                           DstDataPerWrite_GemmKPack,
+                           true);
+}
+
+std::tuple<std::size_t, bool> PerformanceImplicitGemmForwardV4R4Xdlops::CalculateLdsNumberOfByte(
+    const ConvolutionContext& ctx) const
+{
+    const auto a_block_space = GemmKPerBlock * GemmMPerBlock * GemmKPack;
+    const auto b_block_space = GemmKPerBlock * GemmNPerBlock * GemmKPack;
+
+    std::size_t lds_size =
+        (a_block_space + b_block_space) * (ctx.IsFp32() ? sizeof(float) : sizeof(half_float::half));
+
+    return std::make_tuple(lds_size, true);
+}
+
+// Used by IsReallyValid()
+bool PerformanceImplicitGemmForwardV4R4Xdlops::IsValidValue() const
+{
+    // clang-format off
+    return IsTwoPower<4, 256>(GemmMPerBlock)
+        && IsTwoPower<4, 256>(GemmNPerBlock)
+        && IsTwoPower<1, 8>(GemmKPerBlock)
+        && IsTwoPower<4, 128>(GemmMPerWave)
+        && IsTwoPower<4, 128>(GemmNPerWave)
+        && IsTwoPower<1, 8>(GemmKPack);
+    // clang-format on
+}
+
+// Used by EuristicInit() and GenericSearch
+// Only return false if a performance config will violate requirements given by kernel algorithm
+bool PerformanceImplicitGemmForwardV4R4Xdlops::IsReallyValid(const ConvolutionContext& ctx) const
+{
+    if(!IsValidValue())
+        return false;
+
+    if(!IsValidBlockwiseGemmXdlops(
+           ctx, GemmMPerBlock, GemmNPerBlock, GemmKPerBlock, GemmMPerWave, GemmNPerWave, GemmKPack))
+        return false;
+
+    bool valid = false;
+
+    // check blockwise GEMM size
+    {
+        int gemm_m       = -1;
+        int gemm_n       = -1;
+        int gemm_k_total = -1;
+
+        std::tie(std::ignore, gemm_m, gemm_n, gemm_k_total) =
+            ConvHipImplicitGemmForwardV4R4Xdlops::CalculateGemmSize(ctx);
+
+        if(gemm_k_total % GemmKPack != 0)
+            return false;
+
+        const auto gemm_k = gemm_k_total / GemmKPack;
+
+        if(!(gemm_m % GemmMPerBlock == 0 && gemm_n % GemmNPerBlock == 0 &&
+             gemm_k % GemmKPerBlock == 0))
+            return false;
+    }
+
+    // check blockwise copy of A matrix
+    {
+        std::tie(std::ignore, std::ignore, std::ignore, std::ignore, std::ignore, valid) =
+            CalculateGemmABlockCopyPerformanceParameters(ctx);
+
+        if(!valid)
+            return false;
+    }
+
+    // check blockwise copy of B matrix
+    {
+        std::tie(std::ignore, std::ignore, std::ignore, std::ignore, std::ignore, valid) =
+            CalculateGemmBBlockCopyPerformanceParameters(ctx);
+
+        if(!valid)
+            return false;
+    }
+
+    // check LDS allocation
+    std::size_t lds_size = 0;
+    std::tie(lds_size, valid) = CalculateLdsNumberOfByte(ctx);
+
+    return (valid and lds_size <= get_lds_max_number_of_byte());
+}
+
+// Used by GenericSearch, not used by EuristicInit
+// Return false if a performance config is known to be sub-optimal, comparing to other performance
+// config inside tuning range
+bool PerformanceImplicitGemmForwardV4R4Xdlops::IsFastToBeUsedForTuning(
+    const ConvolutionContext& ctx) const
+{
+    // somehow, 128x128 wave-wise GEMM tend to spill register
+    // TODO revisit this when 128x128 wave-wise GEMM become efficient
+    {
+        if(GemmMPerWave * GemmNPerWave > 64 * 128)
+            return false;
+    }
+
+#if WORKAROUND_SWDEV_240356
+    {
+        if(ctx.IsBfp16() && GemmMPerWave * GemmNPerWave > 64 * 64)
+            return false;
+    }
+#endif
+
+    // don't need too many blocks
+    {
+        int gemm_m = 0;
+        int gemm_n = 0;
+
+        std::tie(std::ignore, gemm_m, gemm_n, std::ignore) =
+            ConvHipImplicitGemmForwardV4R4Xdlops::CalculateGemmSize(ctx);
+
+        // this is grid size using current blockwise-GEMM
+        const int grid_size = (gemm_m * gemm_n) / (GemmMPerBlock * GemmNPerBlock);
+
+        // this the the biggest blockwise-GEMM you can do
+        int max_blockwise_gemm_size =
+#if WORKAROUND_SWDEV_240356
+            gcd(128, gemm_m) * gcd(128, gemm_n);
+#else
+            std::max(gcd(256, gemm_m) * gcd(128, gemm_n), gcd(128, gemm_m) * gcd(256, gemm_n));
+#endif
+
+        // this is the grid size using the biggest blockwise-GEMM
+        auto grid_size_max_blockwise_gemm =
+            (std::size_t(gemm_m) * gemm_n) / max_blockwise_gemm_size;
+
+        const float ratio = float(grid_size) / grid_size_max_blockwise_gemm;
+
+        if(grid_size_max_blockwise_gemm > 600)
+        {
+            if(ratio > 1.41)
+                return false;
+        }
+        if(grid_size_max_blockwise_gemm > 480)
+        {
+            if(ratio > 1.81)
+                return false;
+        }
+        if(grid_size_max_blockwise_gemm > 360)
+        {
+            if(ratio > 2.21)
+                return false;
+        }
+        if(grid_size_max_blockwise_gemm > 240)
+        {
+            if(ratio > 3.21)
+                return false;
+        }
+        else if(grid_size_max_blockwise_gemm > 120)
+        {
+            if(ratio > 6.21)
+                return false;
+        }
+    }
+
+    // don't need too many waves per block
+    {
+        const int wave_per_block = (GemmMPerBlock / GemmMPerWave) * (GemmNPerBlock / GemmNPerWave);
+
+        if(!(wave_per_block > 1 && wave_per_block <= 4))
+        {
+            return false;
+        }
+    }
+
+    // avoid skinny blockwise GEMM whenever possible
+    {
+        int gemm_m = 0;
+        int gemm_n = 0;
+
+        std::tie(std::ignore, gemm_m, gemm_n, std::ignore) =
+            ConvHipImplicitGemmForwardV4R4Xdlops::CalculateGemmSize(ctx);
+
+        if(GemmMPerBlock > 2 * GemmNPerBlock)
+        {
+            if(gemm_n % (2 * GemmNPerBlock) == 0)
+                return false;
+        }
+
+        if(GemmNPerBlock > 2 * GemmMPerBlock)
+        {
+            if(gemm_m % (2 * GemmMPerBlock) == 0)
+                return false;
+        }
+    }
+
+    // avoid skinny wavewise GEMM whenever possible
+    {
+        if(GemmMPerWave > 2 * GemmNPerWave)
+        {
+            if(GemmNPerBlock % (2 * GemmNPerWave) == 0)
+                return false;
+        }
+
+        if(GemmNPerWave > 2 * GemmMPerWave)
+        {
+            if(GemmMPerBlock % (2 * GemmMPerWave) == 0)
+                return false;
+        }
+    }
+
+    // each thread should not too much data
+    {
+        const int block_size = (GemmMPerBlock / GemmMPerWave) * (GemmNPerBlock / GemmNPerWave) * 64;
+
+        const int a_data_per_thread_copy = (GemmKPerBlock * GemmMPerBlock * GemmKPack) / block_size;
+        const int b_data_per_thread_copy = (GemmKPerBlock * GemmNPerBlock * GemmKPack) / block_size;
+
+        if(ctx.IsFp32())
+        {
+            if(a_data_per_thread_copy > 16 || b_data_per_thread_copy > 16)
+                return false;
+        }
+        else if(ctx.IsFp16() || ctx.IsBfp16())
+        {
+            if(a_data_per_thread_copy > 32 || b_data_per_thread_copy > 32)
+                return false;
+        }
+    }
+
+    // GemmKPerBlock*GemmKPack should not be too small, otherwise read performance of A matrix would
+    // be bad
+    {
+        if(ctx.IsFp32())
+        {
+            if(GemmKPack > 4)
+                return false;
+
+            if(GemmKPerBlock * GemmKPack < 8)
+                return false;
+        }
+        else if(ctx.IsFp16() || ctx.IsBfp16())
+        {
+            if(GemmKPerBlock * GemmKPack < 16)
+                return false;
+        }
+    }
+
+    return true;
+}
+
+// Used by GenericSearch, not used by EuristicInit
+// Return false, if you don't want to this to be included in tuning range used by generic search
+// A performance config may still be valid w.r.t algorithm correctness, even when IsValid() return
+// false
+bool PerformanceImplicitGemmForwardV4R4Xdlops::IsValid(const ConvolutionContext& ctx) const
+{
+    return IsReallyValid(ctx) && IsFastToBeUsedForTuning(ctx);
+}
+
+// Used by GenericSearch, not used by EuristicInit
+bool ConvHipImplicitGemmForwardV4R4Xdlops::IsValidPerformanceConfig(
+    const ConvolutionContext& ctx, const PerformanceImplicitGemmForwardV4R4Xdlops& c) const
+{
+    return c.IsReallyValid(ctx);
+}
+
+std::tuple<int, int, int, int>
+ConvHipImplicitGemmForwardV4R4Xdlops::CalculateGemmSize(const ConvolutionContext& ctx)
+{
+    const auto g  = ConvolutionContextInterpreter::GetGroupCountG(ctx);
+    const auto n  = ConvolutionContextInterpreter::GetBatchN(ctx);
+    const auto k  = ConvolutionContextInterpreter::GetOutputChannelK(ctx);
+    const auto c  = ConvolutionContextInterpreter::GetInputChannelC(ctx);
+    const auto ho = ConvolutionContextInterpreter::GetOutputHeightHo(ctx);
+    const auto wo = ConvolutionContextInterpreter::GetOutputWidthWo(ctx);
+    const auto y  = ConvolutionContextInterpreter::GetFilterHeightY(ctx);
+    const auto x  = ConvolutionContextInterpreter::GetFilterWidthX(ctx);
+
+    const auto k_per_group = k / g;
+    const auto c_per_group = c / g;
+
+    const auto gemm_g       = g;
+    const auto gemm_m       = k_per_group;
+    const auto gemm_n       = n * ho * wo;
+    const auto gemm_k_total = c_per_group * y * x;
+
+    return std::make_tuple(gemm_g, gemm_m, gemm_n, gemm_k_total);
+}
+
+PerformanceImplicitGemmForwardV4R4Xdlops
+ConvHipImplicitGemmForwardV4R4Xdlops::GetPerformanceConfig(const ConvolutionContext& ctx) const
+{
+    PerformanceImplicitGemmForwardV4R4Xdlops config;
+    config.EuristicInit(ctx);
+    MIOPEN_LOG_I(config.ToString());
+    return config;
+}
+
+ConvSolution ConvHipImplicitGemmForwardV4R4Xdlops::GetSolution(
+    const ConvolutionContext& ctx,
+    const PerformanceImplicitGemmForwardV4R4Xdlops& config,
+    bool) const
+{
+    ConvSolution result;
+    KernelInfo construction_parameters;
+
+    assert(config.IsReallyValid(ctx));
+
+    construction_parameters.kernel_file =
+        "gridwise_convolution_forward_implicit_gemm_v4r4_xdlops_nchw_kcyx_nkhw.cpp";
+
+    construction_parameters.kernel_name =
+        "gridwise_convolution_forward_implicit_gemm_v4r4_xdlops_nchw_kcyx_nkhw";
+
+    int grid_size  = 0;
+    int block_size = 0;
+
+    std::tie(grid_size, std::ignore)  = config.CalculateGridSize(ctx);
+    std::tie(block_size, std::ignore) = config.CalculateBlockSize();
+
+    construction_parameters.l_wk.push_back(block_size);
+    construction_parameters.l_wk.push_back(1);
+    construction_parameters.l_wk.push_back(1);
+
+    construction_parameters.g_wk.push_back(block_size * grid_size);
+    construction_parameters.g_wk.push_back(1);
+    construction_parameters.g_wk.push_back(1);
+
+    int GemmABlockCopyClusterLengths_GemmK      = -1;
+    int GemmABlockCopyClusterLengths_GemmM      = -1;
+    int GemmABlockCopyClusterLengths_GemmKPack  = -1;
+    int GemmABlockCopySrcDataPerRead_GemmKPack  = -1;
+    int GemmABlockCopyDstDataPerWrite_GemmKPack = -1;
+
+    int GemmBBlockCopyClusterLengths_GemmK      = -1;
+    int GemmBBlockCopyClusterLengths_GemmN      = -1;
+    int GemmBBlockCopyClusterLengths_GemmKPack  = -1;
+    int GemmBBlockCopySrcDataPerRead_GemmN      = -1;
+    int GemmBBlockCopyDstDataPerWrite_GemmKPack = -1;
+
+    std::tie(GemmABlockCopyClusterLengths_GemmK,
+             GemmABlockCopyClusterLengths_GemmM,
+             GemmABlockCopyClusterLengths_GemmKPack,
+             GemmABlockCopySrcDataPerRead_GemmKPack,
+             GemmABlockCopyDstDataPerWrite_GemmKPack,
+             std::ignore) = config.CalculateGemmABlockCopyPerformanceParameters(ctx);
+
+    std::tie(GemmBBlockCopyClusterLengths_GemmK,
+             GemmBBlockCopyClusterLengths_GemmN,
+             GemmBBlockCopyClusterLengths_GemmKPack,
+             GemmBBlockCopySrcDataPerRead_GemmN,
+             GemmBBlockCopyDstDataPerWrite_GemmKPack,
+             std::ignore) = config.CalculateGemmBBlockCopyPerformanceParameters(ctx);
+
+    // clang-format off
+    construction_parameters.comp_options =
+        std::string(" -std=c++14 ") +
+        std::string(" -DCK_PARAM_PROBLEM_G=") + std::to_string(ConvolutionContextInterpreter::GetGroupCountG(ctx)) +
+        std::string(" -DCK_PARAM_PROBLEM_N=") + std::to_string(ConvolutionContextInterpreter::GetBatchN(ctx)) +
+        std::string(" -DCK_PARAM_PROBLEM_K=") + std::to_string(ConvolutionContextInterpreter::GetOutputChannelK(ctx)) +
+        std::string(" -DCK_PARAM_PROBLEM_C=") + std::to_string(ConvolutionContextInterpreter::GetInputChannelC(ctx)) +
+        std::string(" -DCK_PARAM_PROBLEM_HI=") + std::to_string(ConvolutionContextInterpreter::GetInputHeightHi(ctx)) +
+        std::string(" -DCK_PARAM_PROBLEM_WI=") + std::to_string(ConvolutionContextInterpreter::GetInputWidthWi(ctx)) +
+        std::string(" -DCK_PARAM_PROBLEM_HO=") + std::to_string(ConvolutionContextInterpreter::GetOutputHeightHo(ctx)) +
+        std::string(" -DCK_PARAM_PROBLEM_WO=") + std::to_string(ConvolutionContextInterpreter::GetOutputWidthWo(ctx)) +
+        std::string(" -DCK_PARAM_PROBLEM_Y=") + std::to_string(ConvolutionContextInterpreter::GetFilterHeightY(ctx)) +
+        std::string(" -DCK_PARAM_PROBLEM_X=") + std::to_string(ConvolutionContextInterpreter::GetFilterWidthX(ctx)) +
+        std::string(" -DCK_PARAM_PROBLEM_CONV_STRIDE_H=") + std::to_string(ConvolutionContextInterpreter::GetAdjustedConvolutionStrideH(ctx)) +
+        std::string(" -DCK_PARAM_PROBLEM_CONV_STRIDE_W=") + std::to_string(ConvolutionContextInterpreter::GetAdjustedConvolutionStrideW(ctx)) +
+        std::string(" -DCK_PARAM_PROBLEM_CONV_DILATION_H=") + std::to_string(ConvolutionContextInterpreter::GetAdjustedConvolutionDilationH(ctx)) +
+        std::string(" -DCK_PARAM_PROBLEM_CONV_DILATION_W=") + std::to_string(ConvolutionContextInterpreter::GetAdjustedConvolutionDilationW(ctx)) +
+        std::string(" -DCK_PARAM_PROBLEM_IN_LEFT_PAD_H=") + std::to_string(ConvolutionContextInterpreter::GetInputLeftPadH(ctx)) +
+        std::string(" -DCK_PARAM_PROBLEM_IN_LEFT_PAD_W=") + std::to_string(ConvolutionContextInterpreter::GetInputLeftPadW(ctx)) +
+        std::string(" -DCK_PARAM_PROBLEM_IN_RIGHT_PAD_H=") + std::to_string(ConvolutionContextInterpreter::GetAdjustedInputRightPadH(ctx)) +
+        std::string(" -DCK_PARAM_PROBLEM_IN_RIGHT_PAD_W=") + std::to_string(ConvolutionContextInterpreter::GetAdjustedInputRightPadW(ctx)) +
+        std::string(" -DCK_PARAM_TUNABLE_GEMM_M_PER_BLOCK=") + std::to_string(config.GemmMPerBlock) +
+        std::string(" -DCK_PARAM_TUNABLE_GEMM_N_PER_BLOCK=") + std::to_string(config.GemmNPerBlock) +
+        std::string(" -DCK_PARAM_TUNABLE_GEMM_K_PER_BLOCK=") + std::to_string(config.GemmKPerBlock) +
+        std::string(" -DCK_PARAM_TUNABLE_GEMM_M_PER_WAVE=") + std::to_string(config.GemmMPerWave) +
+        std::string(" -DCK_PARAM_TUNABLE_GEMM_N_PER_WAVE=") + std::to_string(config.GemmNPerWave) +
+        std::string(" -DCK_PARAM_TUNABLE_GEMM_KPACK=") + std::to_string(config.GemmKPack) +
+        std::string(" -DCK_PARAM_DEPENDENT_BLOCK_SIZE=") + std::to_string(block_size) +
+        std::string(" -DCK_PARAM_DEPENDENT_GRID_SIZE=") + std::to_string(grid_size) +
+        std::string(" -DCK_PARAM_DEPENDENT_GEMM_A_BLOCK_COPY_CLUSTER_LENGTHS_GEMM_K=") + std::to_string(GemmABlockCopyClusterLengths_GemmK) +
+        std::string(" -DCK_PARAM_DEPENDENT_GEMM_A_BLOCK_COPY_CLUSTER_LENGTHS_GEMM_M=") + std::to_string(GemmABlockCopyClusterLengths_GemmM) +
+        std::string(" -DCK_PARAM_DEPENDENT_GEMM_A_BLOCK_COPY_CLUSTER_LENGTHS_GEMM_KPACK=") + std::to_string(GemmABlockCopyClusterLengths_GemmKPack) +
+        std::string(" -DCK_PARAM_DEPENDENT_GEMM_A_BLOCK_COPY_SRC_DATA_PER_READ_GEMM_KPACK=") + std::to_string(GemmABlockCopySrcDataPerRead_GemmKPack) +
+        std::string(" -DCK_PARAM_DEPENDENT_GEMM_A_BLOCK_COPY_DST_DATA_PER_WRITE_GEMM_KPACK=") + std::to_string(GemmABlockCopyDstDataPerWrite_GemmKPack) +
+        std::string(" -DCK_PARAM_DEPENDENT_GEMM_B_BLOCK_COPY_CLUSTER_LENGTHS_GEMM_K=") + std::to_string(GemmBBlockCopyClusterLengths_GemmK) +
+        std::string(" -DCK_PARAM_DEPENDENT_GEMM_B_BLOCK_COPY_CLUSTER_LENGTHS_GEMM_N=") + std::to_string(GemmBBlockCopyClusterLengths_GemmN) +
+        std::string(" -DCK_PARAM_DEPENDENT_GEMM_B_BLOCK_COPY_CLUSTER_LENGTHS_GEMM_KPACK=") + std::to_string(GemmBBlockCopyClusterLengths_GemmKPack) +
+        std::string(" -DCK_PARAM_DEPENDENT_GEMM_B_BLOCK_COPY_SRC_DATA_PER_READ_GEMM_N=") + std::to_string(GemmBBlockCopySrcDataPerRead_GemmN) +
+        std::string(" -DCK_PARAM_DEPENDENT_GEMM_B_BLOCK_COPY_DST_DATA_PER_WRITE_GEMM_KPACK=") + std::to_string(GemmBBlockCopyDstDataPerWrite_GemmKPack) +
+        std::string(" -DCK_USE_AMD_XDLOPS=") + std::to_string(IsXdlopsSupport(ctx) ? 1 : 0) +
+        std::string(" -DCK_USE_AMD_XDLOPS_INLINE_ASM=") + std::to_string(miopen::IsEnabled(MIOPEN_DEBUG_IMPLICIT_GEMM_XDLOPS_INLINE_ASM{}) ? 1 : 0) +
+        std::string(" -DCK_USE_AMD_XDLOPS_EMULATE=") + (miopen::IsEnabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_XDLOPS_EMULATE{}) ? '1' : '0') +
+        std::string(" -DCK_BLOCK_SYNC_LDS_WITHOUT_SYNC_VMEM=") + (miopen::IsDisabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_BLOCK_SYNC_LDS_WITHOUT_SYNC_VMEM{}) ? '0' : '1') +
+        std::string(" -DCK_WORKAROUND_SWDEV_229564=") + std::to_string(WORKAROUND_SWDEV_229564) +
+        std::string(" -DCK_WORKAROUND_SWDEV_231101=") + std::to_string(WORKAROUND_SWDEV_231101) +
+        ctx.general_compile_options;
+    // clang-format on
+
+    result.invoker_factory = conv::MakeImplGemmDataInvokerFactory(ctx);
+    result.construction_params.push_back(construction_parameters);
+    return result;
+}
+
+int ConvHipImplicitGemmForwardV4R4Xdlops::RunAndMeasureSolution(const miopen::Handle& profile_h,
+                                                                ConstData_t bot_buf,
+                                                                Data_t top_buf,
+                                                                ConstData_t wei_buf,
+                                                                ConstData_t bias_buf,
+                                                                const ConvolutionContext& ctx,
+                                                                const ConvSolution& solution,
+                                                                float& elapsed_time) const
+{
+    assert(bias_buf == nullptr);
+    (void)bias_buf;
+
+    return RunAndMeasureSolutionBase(
+        profile_h, bot_buf, top_buf, wei_buf, ctx, solution, elapsed_time);
+}
+
+bool ConvHipImplicitGemmForwardV4R4Xdlops::IsApplicable(const ConvolutionContext& ctx) const
+{
+    if(!IsXdlopsSupport(ctx))
+        return false;
+
+    if(!(ctx.IsFp32() || ctx.IsFp16() || ctx.IsBfp16()))
+        return false;
+
+    if(!ctx.direction.IsForward())
+        return false;
+
+    if(!ctx.Is2d())
+        return false;
+
+    if(!IsIndexRangeLargeEnough(ctx))
+        return false;
+
+#if WORKAROUND_SWDEV_239555
+    if(ctx.IsFp16() || ctx.IsBfp16())
+    {
+        const auto y              = ConvolutionContextInterpreter::GetFilterHeightY(ctx);
+        const auto x              = ConvolutionContextInterpreter::GetFilterWidthX(ctx);
+        const auto in_left_pad_h  = ConvolutionContextInterpreter::GetInputLeftPadH(ctx);
+        const auto in_left_pad_w  = ConvolutionContextInterpreter::GetInputLeftPadW(ctx);
+        const auto in_right_pad_h = ConvolutionContextInterpreter::GetAdjustedInputRightPadH(ctx);
+        const auto in_right_pad_w = ConvolutionContextInterpreter::GetAdjustedInputRightPadW(ctx);
+
+        if((y > 1 || x > 1) &&
+           (in_left_pad_h > 0 || in_left_pad_w > 0 || in_right_pad_h > 0 || in_right_pad_w > 0))
+            return false;
+    }
+#endif
+
+    // gemm size
+    {
+        int gemm_g       = -1;
+        int gemm_m       = -1;
+        int gemm_n       = -1;
+        int gemm_k_total = -1;
+
+        std::tie(gemm_g, gemm_m, gemm_n, gemm_k_total) = CalculateGemmSize(ctx);
+
+        if(!IsValidGridGemmXdlops(gemm_m, gemm_n, gemm_k_total))
+            return false;
+    }
+
+    // this particular EuristicInit is so comprehensive, that if it cannot predict a valid
+    // performance config, the problem is probably not applicable
+    PerformanceImplicitGemmForwardV4R4Xdlops config;
+    config.EuristicInit(ctx);
+
+    return config.IsReallyValid(ctx);
+}
+
+PerformanceImplicitGemmForwardV4R4Xdlops
+ConvHipImplicitGemmForwardV4R4Xdlops::Search(const ConvolutionContext& ctx) const
+
+{
+    return GenericSearchFwd(*this, ctx);
+}
+
+} // namespace solver
+} // namespace miopen

--- a/src/solver/conv_hip_implicit_gemm_v4r4_gen_xdlops_fwd_fp32.cpp
+++ b/src/solver/conv_hip_implicit_gemm_v4r4_gen_xdlops_fwd_fp32.cpp
@@ -249,9 +249,9 @@ bool PerformanceImplicitGemmV4R4GenXdlopsFwdFp32::IsValid(const ConvolutionConte
     // heuristic to reduce search space
     {
         // use largest XdlopsGemm
-        if(GemmMPerBlock >= 64 && GemmMPerWave != 64)
+        if(GemmMPerBlock >= 64 && GemmMPerWave < 64)
             return false;
-        if(GemmNPerBlock >= 64 && GemmNPerWave != 64)
+        if(GemmNPerBlock >= 64 && GemmNPerWave < 64)
             return false;
         if((GemmMPerBlock == 32 || GemmMPerBlock == 16) && GemmMPerWave != GemmMPerBlock)
             return false;
@@ -335,8 +335,8 @@ bool PerformanceImplicitGemmV4R4GenXdlopsFwdFp32::IsValidValue() const
         IsTwoPower<4,128>(GemmMPerBlock)
         && IsTwoPower<16,128>(GemmNPerBlock)
         && IsTwoPower<4,16>(GemmKPerBlock)
-        && IsTwoPower<4,64>(GemmMPerWave)
-        && IsTwoPower<16,64>(GemmNPerWave);
+        && IsTwoPower<4,128>(GemmMPerWave)
+        && IsTwoPower<16,128>(GemmNPerWave);
     // clang-format on
 }
 
@@ -350,9 +350,9 @@ bool PerformanceImplicitGemmV4R4GenXdlopsFwdFp32::SetNextValue()
             break;
         if(!NextTwoPower<4, 16>(GemmKPerBlock))
             break;
-        if(!NextTwoPower<4, 64>(GemmMPerWave))
+        if(!NextTwoPower<4, 128>(GemmMPerWave))
             break;
-        if(!NextTwoPower<16, 64>(GemmNPerWave))
+        if(!NextTwoPower<16, 128>(GemmNPerWave))
             break;
         return false;
     } while(false);

--- a/src/solver/implicitgemm_util.hpp
+++ b/src/solver/implicitgemm_util.hpp
@@ -6,24 +6,34 @@
 #include <miopen/hip_build_utils.hpp>
 #include <miopen/mlo_internal.hpp>
 
-MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_XDLOPS)
-MIOPEN_DECLARE_ENV_VAR(
-    MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_XDLOPS_EMULATE) // For internal debug purposes
-
 MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEBUG_IMPLICIT_GEMM_NON_XDLOPS_INLINE_ASM)
+MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_XDLOPS)
+MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_XDLOPS_EMULATE)
 MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEBUG_IMPLICIT_GEMM_XDLOPS_INLINE_ASM)
+MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_BLOCK_SYNC_LDS_WITHOUT_SYNC_VMEM)
 
 #define WORKAROUND_SWDEV_200782 1
-
 #define WORKAROUND_SWDEV_229277_227616_229195 1
+// workaround for unnecessary VGPA <--> AGRP data movement when using mfma LLVM intrinsic
+#define WORKAROUND_SWDEV_229564 1
+// workaround for buffer load/store fp16/bfp16 intrinsic bug
+#define WORKAROUND_SWDEV_231101 1
+// workaround compiler bug: GPU memory access fault when there is padding in fp16/bfp16 case
+#define WORKAROUND_SWDEV_239555 1
+// LLVM xdlops instrinsic will do unnecessey VGRP <--> AGPR movement, and result in
+// register spill, for bfloat16 datatype, when doing wave-wise GEMM larger than 64x64
+#define WORKAROUND_SWDEV_240356 1
 
 namespace miopen {
+
 namespace solver {
 
 // greatest common divisor, aka highest common factor
 template <typename T>
 T gcd(T x, T y)
 {
+    assert(!(x == 0 && y == 0));
+
     if(x == y || x == 0)
     {
         return y;
@@ -380,6 +390,33 @@ inline static bool NextTwoPower(int& v)
     return false;
 }
 
+template <int L, int H>
+inline static bool PreviousTwoPower(int& v)
+{
+    static_assert((((L - 1) & L) == 0), "L is not power of 2");
+    static_assert((((H - 1) & H) == 0), "H is not power of 2");
+    assert((IsTwoPower<L, H>(v)));
+    if(v == L)
+    {
+        v = H;
+        return true;
+    }
+    v /= 2;
+    return false;
+}
+
+template <bool L, bool H>
+inline static bool NextFlag(bool& v)
+{
+    if(v == H)
+    {
+        v = L;
+        return true;
+    }
+    v = H;
+    return false;
+}
+
 static inline bool IsXdlopsSupport(const ConvolutionContext& c)
 {
     if(miopen::IsEnabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_XDLOPS_EMULATE{}))
@@ -399,11 +436,13 @@ static inline bool IsXdlopsSupport(const ConvolutionContext& c)
 #endif
 }
 
+///\todo remove
 inline static uint32_t GetReadWriteVectorSize(const int v)
 {
     return v % 4 == 0 ? 4 : (v % 2 == 0 ? 2 : 1);
 }
 
+///\todo remove
 inline static uint32_t GetEPackLength(const ConvolutionContext& ctx, bool isXdlopsInvoked)
 {
     // Based on data type, Es are packed
@@ -423,6 +462,7 @@ inline static uint32_t GetEPackLength(const ConvolutionContext& ctx, bool isXdlo
     return EPACK;
 }
 
+///\todo remove
 static inline bool IsValidXdlopsGemm(const int GemmMPerBlock,
                                      const int GemmNPerBlock,
                                      const int GemmKPackedPerBlock, // packed
@@ -442,9 +482,60 @@ static inline bool IsValidXdlopsGemm(const int GemmMPerBlock,
         return false;
     if(GemmMPerWave == 16 && GemmNPerWave == 16 && GemmKPackedPerBlock % 4 != 0)
         return false;
+    if(GemmMPerWave > 64 && GemmNPerWave < 64)
+        return false;
+    if(GemmNPerWave > 64 && GemmMPerWave < 64)
+        return false;
 
-    const auto WaveSize  = 64;
-    const auto BlockSize = GemmNPerBlock * GemmMPerBlock / (GemmMPerWave * GemmNPerWave) * WaveSize;
+    const auto WaveSize = 64;
+    const auto BlockSize =
+        (GemmNPerBlock * GemmMPerBlock) / (GemmMPerWave * GemmNPerWave) * WaveSize;
+
+    if(BlockSize < 64 || BlockSize > 256)
+        return false;
+
+    return (GemmMPerBlock % GemmMPerWave) == 0 && (GemmNPerBlock % GemmNPerWave) == 0;
+}
+
+static inline bool IsIndexRangeLargeEnough(const ConvolutionContext& ctx)
+{
+    // composable kernel use int32_t for memory offset, which covers 2GB of memory maximum
+    const std::size_t max_index_range = std::size_t(2) * 1024 * 1024 * 1024;
+
+    return ctx.bot_sz < max_index_range && ctx.weights_sz < max_index_range &&
+           ctx.top_sz < max_index_range;
+}
+
+static inline bool IsValidBlockwiseGemmXdlops(const ConvolutionContext& ctx,
+                                              const int GemmMPerBlock,
+                                              const int GemmNPerBlock,
+                                              const int GemmKPerBlock,
+                                              const int GemmMPerWave,
+                                              const int GemmNPerWave,
+                                              const int GemmKPack)
+{
+    // unsupported xdlops-gemm
+    if(ctx.IsFp16() && GemmKPack % 4 != 0)
+        return false;
+    if(ctx.IsBfp16() && GemmKPack % 2 != 0)
+        return false;
+
+    if(GemmMPerWave == 16 && GemmNPerWave == 32)
+        return false;
+    if(GemmMPerWave == 32 && GemmNPerWave == 16)
+        return false;
+    if(GemmMPerWave == 8 && GemmNPerWave != 64)
+        return false;
+    if(GemmMPerWave == 4 && GemmNPerWave != 64)
+        return false;
+    if(GemmMPerWave == 32 && GemmNPerWave == 32 && GemmKPerBlock % 2 != 0)
+        return false;
+    if(GemmMPerWave == 16 && GemmNPerWave == 16 && GemmKPerBlock % 4 != 0)
+        return false;
+
+    const auto WaveSize = 64;
+    const auto BlockSize =
+        (GemmNPerBlock * GemmMPerBlock) / (GemmMPerWave * GemmNPerWave) * WaveSize;
 
     if(BlockSize < 64 || BlockSize > 256)
         return false;
@@ -465,6 +556,7 @@ IsValidGridGemmXdlops(const std::size_t GemmM, const std::size_t GemmN, const st
            (GemmK * GemmN) % WaveSize == 0 && GemmN % 16 == 0 && GemmM % 4 == 0 && GemmK % 4 == 0;
 }
 
+///\todo remove
 static inline bool IsApplicableXdlops(const ConvolutionContext& ctx)
 {
     if(!IsXdlopsSupport(ctx))
@@ -516,6 +608,7 @@ static inline bool IsApplicableXdlops(const ConvolutionContext& ctx)
     return IsValidGridGemmXdlops(GemmM, GemmN, GemmK);
 }
 
+///\todo remove
 template <class PerformanceImplicitGemm_t>
 inline static auto GetPerformanceConfigBase(const ConvolutionContext& ctx)
 {
@@ -525,6 +618,7 @@ inline static auto GetPerformanceConfigBase(const ConvolutionContext& ctx)
     return pp;
 }
 
+///\todo remove
 static inline size_t ComputeLDSRequiredSize(const ConvolutionContext& ctx,
                                             const int BPerBlock,
                                             const int KPerBlock,
@@ -633,6 +727,10 @@ int amd_buffer_load_max_length()
     {
         return 4;
     }
+    else if(std::is_same<half_float::half, T>())
+    {
+        return 8;
+    }
     else
     {
         MIOPEN_LOG_I("not implemented");
@@ -646,6 +744,10 @@ int amd_buffer_store_max_length()
     if(std::is_same<float, T>())
     {
         return 4;
+    }
+    else if(std::is_same<half_float::half, T>())
+    {
+        return 8;
     }
     else
     {
@@ -661,6 +763,10 @@ int amd_lds_read_max_length()
     {
         return 4;
     }
+    else if(std::is_same<half_float::half, T>())
+    {
+        return 8;
+    }
     else
     {
         MIOPEN_LOG_I("not implemented");
@@ -675,6 +781,10 @@ int amd_lds_write_max_length()
     {
         return 4;
     }
+    else if(std::is_same<half_float::half, T>())
+    {
+        return 8;
+    }
     else
     {
         MIOPEN_LOG_I("not implemented");
@@ -686,4 +796,5 @@ constexpr std::size_t get_lds_max_number_of_byte() { return 65536; }
 
 } // namespace solver
 } // namespace miopen
+
 #endif

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -186,6 +186,10 @@ struct conv_forward : output_tensor_fixture
         size_t sz_fwd_workspace;
         STATUS(miopenConvolutionForwardGetWorkSpaceSize(
             handle, convFilter, inputTensor, convDesc, outputTensor, &sz_fwd_workspace));
+        // OCL fails to allocate zero workspace. Let's allocate small workspace instead to simplify
+        // subsequent code.
+        if(sz_fwd_workspace == 0)
+            sz_fwd_workspace = 256;
 
         std::vector<float> in(sz_in);
         std::vector<float> wei(sz_wei);
@@ -284,7 +288,7 @@ struct conv_forward : output_tensor_fixture
                                             convFilter,
                                             wei_dev,
                                             convDesc,
-                                            miopenConvolutionFwdAlgoDirect,
+                                            perf.fwd_algo,
                                             &beta,
                                             outputTensor,
                                             out_dev,

--- a/test/network_data.hpp
+++ b/test/network_data.hpp
@@ -436,7 +436,9 @@ get_bn_spatial_inputs(int n = MIOPEN_TEST_DEFAULT_BATCH_SIZE_FACTOR)
         { pick_batch_size(32, n),  256,  28,  28  },
         { pick_batch_size(32, n),  3,    224, 224 },
         { pick_batch_size(32, n),  480,  128, 256 },
-        { pick_batch_size(32, n),  528,  64,  128 }
+        { pick_batch_size(32, n),  528,  64,  128 },
+        { pick_batch_size(770, n),  1,  8,  8 },
+        { pick_batch_size(770, n),  1024,  1,  1 }
     };
     // clang-format on
 }


### PR DESCRIPTION
Following PR #https://github.com/ROCmSoftwarePlatform/MIOpen/pull/302 
This PR provides MIOpenDriver reduce module for generic-reduction. 

The MIOpenDriver reduce module provides testing/verification of the device-based generic_reduction function by comparing with the host-based generic_reduction result.  The reduce module is also able to measure the performance of each reduction operation through its "--time" option. 
