### PR TITLE
[driver] Verification fixes

### DIFF
--- a/driver/conv_driver.hpp
+++ b/driver/conv_driver.hpp
@@ -2837,6 +2837,7 @@ std::string ConvDriver<Tgpu, Tref>::GetVerificationCacheFileName(
         case Direction::WrW: return "conv_bwd_wei";
         case Direction::BwdBias: return "bias_bwd_dat";
         }
+        return "<error in get_basename_string>"; // For gcc.
     };
 
     auto get_datatype_string = [](auto type) {


### PR DESCRIPTION
The main purpose of this is fixing of multiple verification errors in the MIOpenDriver, which is essential for testing.

- Decreased default FP16 tolerance from 7e-2 to 8.2e-3.
- Decreased default BF16 tolerance from 7e-2 to 6.56e-2.
- Doubled tolerance for all WrW convolutions.
- Algorithm-specific adjustments:
  - FP32/FP16/BF16 Fwd/Bwd iGemm: allow 10 times bigger deviation.
  - FP32 WrW iGemm and Winograd: allow 10 times bigger deviation.
  - FP16 WrW iGemm: allow 5 times bigger deviation.
  - FP32 WrW iGemm, added workaround for https://github.com/AMDComputeLibraries/MLOpen/issues/2176
- Printed tolerance after verification failure.
- Some refactors (useful by-products of experimental changes).
