### PR TITLE
Activate NORMAL Find mode when auto-tuning is ENFORCEd

### DIFF
--- a/src/convolution.cpp
+++ b/src/convolution.cpp
@@ -431,7 +431,7 @@ std::size_t ConvolutionDescriptor::ForwardGetWorkSpaceSize(Handle& handle,
     }
 
     /// \ref ffind_special_cases
-    const miopen::FindMode fm;
+    const miopen::FindMode fm(ctx);
     while(fm.IsFast() || fm.IsHybrid())
     {
         /// \section ffind_gwss_why_not_0
@@ -539,7 +539,7 @@ ConvolutionDescriptor::BackwardDataGetWorkSpaceSize(Handle& handle,
     }
 
     /// \ref ffind_special_cases
-    const miopen::FindMode fm;
+    const miopen::FindMode fm(ctx);
     while(fm.IsFast() || fm.IsHybrid())
     {
         /// \ref ffind_gwss_why_not_0
@@ -867,7 +867,8 @@ ConvolutionDescriptor::BackwardWeightsGetWorkSpaceSize(Handle& handle,
                                                        const TensorDescriptor& dwDesc) const
 {
     MIOPEN_LOG_I("");
-    const miopen::FindMode fm;
+    auto ctx = ConvolutionContext(xDesc, dwDesc, dyDesc, *this, conv::Direction::BackwardWeights);
+    const miopen::FindMode fm(ctx);
     while(fm.IsFast() || fm.IsHybrid())
     {
         /// \ref ffind_gwss_why_not_0
@@ -880,7 +881,6 @@ ConvolutionDescriptor::BackwardWeightsGetWorkSpaceSize(Handle& handle,
         return sol.workspace_size;
     }
 
-    auto ctx = ConvolutionContext(xDesc, dwDesc, dyDesc, *this, conv::Direction::BackwardWeights);
     ctx.SetStream(&handle);
     ctx.DetectRocm();
     ctx.SetupFloats();

--- a/src/include/miopen/find_controls.hpp
+++ b/src/include/miopen/find_controls.hpp
@@ -28,6 +28,7 @@
 #define GUARD_MIOPEN_FIND_CONTROLS_HPP_
 
 #include <miopen/solver_id.hpp>
+#include <miopen/conv/context.hpp>
 #include <ostream>
 
 namespace miopen {
@@ -135,7 +136,8 @@ class FindMode
     Values value;
 
     public:
-    FindMode();
+    FindMode(const ConvolutionContext& ctx);
+
     bool IsFast() const { return value == Values::Fast && !debug::FindModeDisable; }
     bool IsHybrid() const { return value == Values::Hybrid && !debug::FindModeDisable; }
     friend std::ostream& operator<<(std::ostream&, const FindMode&);

--- a/src/ocl/convolutionocl.cpp
+++ b/src/ocl/convolutionocl.cpp
@@ -904,7 +904,7 @@ void ConvolutionDescriptor::FindConvFwdAlgorithm(Handle& handle,
 
     std::vector<PerfField> perf_db;
 
-    const miopen::FindMode fm;
+    const miopen::FindMode fm(ctx);
     /// \section ffind_special_cases
     /// Fast Find mode: Let's allow known fast-to-build special cases
     /// (this is only Winograd 3x3 so far) to override switching to Immediate mode.
@@ -2323,7 +2323,7 @@ void ConvolutionDescriptor::FindConvBwdDataAlgorithm(Handle& handle,
 
     std::vector<PerfField> perf_db;
 
-    const miopen::FindMode fm;
+    const miopen::FindMode fm(problem);
     /// \ref ffind_special_cases
     bool use_immediate_solution = false;
     miopenConvSolution_t imm_sol;
@@ -3566,7 +3566,7 @@ void ConvolutionDescriptor::FindConvBwdWeightsAlgorithm(Handle& handle,
         ProblemDescription{xDesc, dwDesc, dyDesc, *this, conv::Direction::BackwardWeights};
 
     std::vector<PerfField> perf_db;
-    const miopen::FindMode fm;
+    const miopen::FindMode fm(problem);
     bool use_immediate_solution = false;
     miopenConvSolution_t imm_sol;
     if(fm.IsFast() || fm.IsHybrid())


### PR DESCRIPTION
This is continuation of #178, the PR promised by @daniellowell:
> We have just merged in the Hybrid mode as default PR. This means that MIOPEN_FIND_MODE=3 by default.
One thing we overlooked is that the MIOPEN_FIND_ENFORCE=2/3/4 is blocked by hybrid and fast find modes. Artem will open a PR to make it so that if MIOPEN_FIND_ENFORCE > 1 then it will drop MIOPEN_FIND_MODE to NORMAL(1). This will make it behave as normal.
>
>Until that PR is merged make sure you set MIOPEN_FIND_MODE=1 if you are attempting to tune MIOpen off of our current develop branch.

Please note that NORMAL Find mode cannot be enforced in the same way when full search is activated by means of the `exhaustiveSearch` parameter `Find()`:
https://github.com/ROCmSoftwarePlatform/MIOpen/blob/da79ca10acb669fd745f5fa65bb24735c54f33ff/include/miopen/miopen.h#L1424
https://github.com/ROCmSoftwarePlatform/MIOpen/blob/da79ca10acb669fd745f5fa65bb24735c54f33ff/include/miopen/miopen.h#L1565
https://github.com/ROCmSoftwarePlatform/MIOpen/blob/da79ca10acb669fd745f5fa65bb24735c54f33ff/include/miopen/miopen.h#L1689
