### PR TITLE
Core implementation of generic-reduction

### DIFF
--- a/include/miopen/miopen.h
+++ b/include/miopen/miopen.h
@@ -59,8 +59,9 @@
  * @defgroup RNN
  * @defgroup fusion
  * @defgroup LossFunction
+ * @defgroup TensorReduce
  *
-*/
+ */
 
 /*! Constructs type name from a struct */
 #define MIOPEN_DECLARE_OBJECT(name) \
@@ -91,7 +92,7 @@ MIOPEN_DECLARE_OBJECT(miopenHandle);
 
 /*! @enum miopenStatus_t
  * Error codes that are returned by all MIOpen API calls.
-*/
+ */
 typedef enum {
     miopenStatusSuccess        = 0, /*!< No errors */
     miopenStatusNotInitialized = 1, /*!< Data not initialized. */
@@ -110,7 +111,7 @@ typedef enum {
  *
  * @param error  miopenStatus_t type error status (input)
  * @return       errorString
-*/
+ */
 MIOPEN_EXPORT const char* miopenGetErrorString(miopenStatus_t error);
 
 /*! @brief Custom allocator function
@@ -120,7 +121,7 @@ MIOPEN_EXPORT const char* miopenGetErrorString(miopenStatus_t error);
  * @param context     A pointer a context (input)
  * @param sizeBytes   Number of bytes to allocate (input)
  *
-*/
+ */
 typedef void* (*miopenAllocatorFunction)(void* context, size_t sizeBytes);
 
 /*! @brief Custom deallocator function
@@ -130,7 +131,7 @@ typedef void* (*miopenAllocatorFunction)(void* context, size_t sizeBytes);
  * @param context     A pointer context (input)
  * @param memory      A pointer allocated memory (input)
  *
-*/
+ */
 typedef void (*miopenDeallocatorFunction)(void* context, void* memory);
 
 /*! @brief Method to return version of MIOpen
@@ -145,7 +146,7 @@ typedef void (*miopenDeallocatorFunction)(void* context, void* memory);
  * @param patch     Patch version number (output)
  *
  * @return          miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenGetVersion(size_t* major, size_t* minor, size_t* patch);
 
 /*! @brief Method to create the MIOpen handle object.
@@ -155,7 +156,7 @@ MIOPEN_EXPORT miopenStatus_t miopenGetVersion(size_t* major, size_t* minor, size
  * @param handle     A pointer to a MIOpen handle type (output)
  *
  * @return           miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenCreate(miopenHandle_t* handle);
 
 /*! @brief Create a MIOpen handle with an accelerator stream.
@@ -168,7 +169,7 @@ MIOPEN_EXPORT miopenStatus_t miopenCreate(miopenHandle_t* handle);
  * @param stream      An accelerator queue type (input)
  *
  * @return           miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenCreateWithStream(miopenHandle_t* handle,
                                                     miopenAcceleratorQueue_t stream);
 
@@ -177,7 +178,7 @@ MIOPEN_EXPORT miopenStatus_t miopenCreateWithStream(miopenHandle_t* handle,
  * This is called when breaking down the MIOpen environment.
  * @param handle     MIOpen handle (input)
  * @return           miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenDestroy(miopenHandle_t handle);
 
 /*! @brief Set accelerator command queue previously created
@@ -186,7 +187,7 @@ MIOPEN_EXPORT miopenStatus_t miopenDestroy(miopenHandle_t handle);
  * @param handle     MIOpen handle (input)
  * @param streamID   An accelerator queue type (input)
  * @return           miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenSetStream(miopenHandle_t handle,
                                              miopenAcceleratorQueue_t streamID);
 
@@ -196,7 +197,7 @@ MIOPEN_EXPORT miopenStatus_t miopenSetStream(miopenHandle_t handle,
  * @param handle     MIOpen handle (input)
  * @param streamID   Pointer to a accelerator queue type (output)
  * @return           miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenGetStream(miopenHandle_t handle,
                                              miopenAcceleratorQueue_t* streamID);
 
@@ -215,7 +216,7 @@ MIOPEN_EXPORT miopenStatus_t miopenGetStream(miopenHandle_t handle,
  *      This allows the callback function to access state set by the caller to this function,
  *      for example a stateful heap allocator or a c++ class.
  * @return           miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenSetAllocator(miopenHandle_t handle,
                                                 miopenAllocatorFunction allocator,
                                                 miopenDeallocatorFunction deallocator,
@@ -231,7 +232,7 @@ MIOPEN_EXPORT miopenStatus_t miopenSetAllocator(miopenHandle_t handle,
  * @param handle     MIOpen handle (input)
  * @param time       Pointer to a float type to contain kernel time in milliseconds (output)
  * @return           miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenGetKernelTime(miopenHandle_t handle, float* time);
 
 /*! @brief Enable profiling to retrieve kernel time
@@ -240,7 +241,7 @@ MIOPEN_EXPORT miopenStatus_t miopenGetKernelTime(miopenHandle_t handle, float* t
  * @param handle     MIOpen handle (input)
  * @param enable     Boolean to toggle profiling (input)
  * @return           miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenEnableProfiling(miopenHandle_t handle, bool enable);
 /** @} */
 // CLOSEOUT HANDLE DOXYGEN GROUP
@@ -264,7 +265,7 @@ MIOPEN_DECLARE_OBJECT(miopenFusionOpDescriptor);
 MIOPEN_DECLARE_OBJECT(miopenTensorDescriptor);
 
 /*! @ingroup convolutions
-* @brief Creates the miopenConvolutionDescriptor_t type
+ * @brief Creates the miopenConvolutionDescriptor_t type
  *
  * Convolution descriptor is an object that allows the user to specify a layer's padding, stride,
  * and dilation of the convolutional filter. Parameters must all be non-negative.
@@ -299,24 +300,29 @@ MIOPEN_DECLARE_OBJECT(miopenLRNDescriptor);
 MIOPEN_DECLARE_OBJECT(miopenActivationDescriptor);
 
 /*! @ingroup RNN
-* @brief Creates the miopenRNNDescriptor_t type
-*/
+ * @brief Creates the miopenRNNDescriptor_t type
+ */
 MIOPEN_DECLARE_OBJECT(miopenRNNDescriptor);
 
 /*! @ingroup LossFunction
-* @brief Creates the miopenCTCLossDescriptor_t type
-*/
+ * @brief Creates the miopenCTCLossDescriptor_t type
+ */
 MIOPEN_DECLARE_OBJECT(miopenCTCLossDescriptor);
 
 /*! @ingroup Dropout
-* @brief Creates the miopenDropoutDescriptor_t type
-*/
+ * @brief Creates the miopenDropoutDescriptor_t type
+ */
 MIOPEN_DECLARE_OBJECT(miopenDropoutDescriptor);
+
+/*! @ingroup TensorReduce
+ * @brief Creates the miopenReduceTensorDescriptor_t type
+ */
+MIOPEN_DECLARE_OBJECT(miopenReduceTensorDescriptor);
 
 /*! @ingroup tensor
  * @enum miopenDataType_t
  * MIOpen floating point datatypes. Both 32-bit and 16-bit floats are supported in MIOpen.
-*/
+ */
 typedef enum {
     miopenHalf  = 0, /*!< 16-bit floating point (Fully supported) */
     miopenFloat = 1, /*!< 32-bit floating point (Fully supported) */
@@ -331,7 +337,7 @@ typedef enum {
 /*! @ingroup pooling
  * @enum miopenIndexType_t
  * MIOpen index datatypes.
-*/
+ */
 typedef enum {
     miopenIndexUint8  = 0, /*!<  8-bit unsigned */
     miopenIndexUint16 = 1, /*!< 16-bit unsigned */
@@ -342,7 +348,7 @@ typedef enum {
 /*! @ingroup tensor
  * @enum miopenTensorOp_t
  * Element-wise tensor operation modes
-*/
+ */
 typedef enum {
     miopenTensorOpAdd = 0, /*!< Add tensors element-wise */
     miopenTensorOpMul = 1, /*!< Multiply two tensors element-wise */
@@ -353,7 +359,7 @@ typedef enum {
 /*! @ingroup convolutions
  *  @enum miopenConvolutionMode_t
  * Convolution mode selection for convolution layer preference.
-*/
+ */
 typedef enum {
     miopenConvolution = 0, /*!< Cross-Correlation convolution */
     miopenTranspose   = 1, /*!< Transpose convolutions -- deconvolution */
@@ -364,7 +370,7 @@ typedef enum {
 /*! @ingroup padding
  *  @enum miopenPaddingMode_t
  * Padding mode selection for convolution/Pooling layer preference
-*/
+ */
 typedef enum {
     miopenPaddingDefault = 0, /*!< MIOPEN Default Padding */
     miopenPaddingSame    = 1, /*!< Tensorflow SAME Padding */
@@ -374,7 +380,7 @@ typedef enum {
 /*! @ingroup pooling
  * @enum miopenPoolingMode_t
  * Pooling layer mode
-*/
+ */
 typedef enum {
     miopenPoolingMax              = 0, /*!< Maximum pooling */
     miopenPoolingAverage          = 1, /*!< Average pooling */
@@ -395,7 +401,7 @@ typedef enum {
 /*! @ingroup LRN
  * @enum miopenLRNMode_t
  * Local Response Normalization layer mode
-*/
+ */
 typedef enum {
     miopenLRNWithinChannel = 0, /*!< Channel independent */
     miopenLRNCrossChannel  = 1, /*!< Cross Channel */
@@ -404,7 +410,7 @@ typedef enum {
 /*! @ingroup batchnorm
  * @enum miopenBatchNormMode_t
  * Batch Normalization layer mode
-*/
+ */
 typedef enum {
     miopenBNPerActivation = 0, /*!< Element-wise normalization for fully connected layer */
     miopenBNSpatial       = 1, /*!< Mini-batch spatial normalization for convolutional layers */
@@ -428,13 +434,13 @@ typedef enum {
         8, /*!< Leaky Rectified Linear Unit \f$ \alpha * x | x <= 0; x | x > 0 \f$ */
     miopenActivationELU =
         9, /*!< Exponential Rectified Linear Unit \f$ \alpha * (e^{x} - 1) | x <= 0; x | x > 0 \f$
-              */
+            */
 } miopenActivationMode_t;
 
 /*! @ingroup softmax
  * @enum miopenSoftmaxAlgorithm_t
  * Softmax implementation algorithms
-*/
+ */
 typedef enum {
     MIOPEN_SOFTMAX_FAST     = 0, /*!< straightforward softmax */
     MIOPEN_SOFTMAX_ACCURATE = 1, /*!< scaled softmax by maximum value in input domain */
@@ -444,12 +450,65 @@ typedef enum {
 /*! @ingroup softmax
  * @enum miopenSoftmaxMode_t
  * Softmax modes
-*/
+ */
 typedef enum {
     MIOPEN_SOFTMAX_MODE_INSTANCE = 0, /*!< compute per image (N) across C, H, W */
     MIOPEN_SOFTMAX_MODE_CHANNEL =
         1, /*!< compute per spatial location (H, W) per image (N) across C */
 } miopenSoftmaxMode_t;
+
+/*! @ingroup TensorReduce
+ * @enum miopenReduceTensorOp_t
+ * Tensor Reduction operation types
+ */
+typedef enum {
+    MIOPEN_REDUCE_TENSOR_ADD = 0, /*!< the operation is adding the values of the reduced elements */
+    MIOPEN_REDUCE_TENSOR_MUL =
+        1, /*!< the operation is multiplying the values of the reduced elements */
+    MIOPEN_REDUCE_TENSOR_MIN =
+        2, /*!< the operation is getting the minimum value of the reduced elements */
+    MIOPEN_REDUCE_TENSOR_MAX =
+        3, /*!< the operation is getting the maximum value of the reduced elements */
+    // MIOPEN_REDUCE_TENSOR_AMAX =
+    //    4, /*!< the operation is getting the maximum absolute value of the reduced elements */
+    // MIOPEN_REDUCE_TENSOR_AVG =
+    //    5, /*!< the operation is getting the averaged value of the reduced elements */
+    // MIOPEN_REDUCE_TENSOR_NORM1 =
+    //    6, /*!< the operation is adding the absolute values of the reduced elements */
+    // MIOPEN_REDUCE_TENSOR_NORM2 = 7, /*!< the operation is getting the square root of the sum of
+    //                                   squares of the reduced elements */
+    // MIOPEN_REDUCE_TENSOR_MUL_NO_ZEROS =
+    //    8, /*!< the operation is same as MUL, but does not have the zero values considered */
+} miopenReduceTensorOp_t;
+
+/*! @ingroup TensorReduce
+ * @enum miopenReduceTensorOp_t
+ * Nan numbers propagation modes
+ */
+typedef enum {
+    MIOPEN_NOT_PROPAGATE_NAN = 0, /*!< does not propagate Nan number */
+    MIOPEN_PROPAGATE_NAN     = 1, /*!< propagate the Nan number by the Reduction operation */
+} miopenNanPropagation_t;
+
+/*! @ingroup TensorReduce
+ * @enum miopenReduceTensorIndices_t
+ * Reduction Indices computation modes
+ */
+typedef enum {
+    MIOPEN_REDUCE_TENSOR_NO_INDICES        = 0, /*!< Does not compuate indices */
+    MIOPEN_REDUCE_TENSOR_FLATTENED_INDICES = 1, /*!< Compute the relative, flatted indices */
+} miopenReduceTensorIndices_t;
+
+/*! @ingroup TensorReduce
+ * @enum miopenIndicesType_t
+ * Reduction Indices types
+ */
+typedef enum {
+    MIOPEN_32BIT_INDICES = 0, /*!< unsigned integer indices */
+    MIOPEN_64BIT_INDICES = 1, /*!< unsigned long indices */
+    MIOPEN_16BIT_INDICES = 2, /*!< unsigned short indices */
+    MIOPEN_8BIT_INDICES  = 3, /*!< unsigned char indices */
+} miopenIndicesType_t;
 
 /** @addtogroup tensor
  *
@@ -461,7 +520,7 @@ typedef enum {
  * API for creating an uninitialized tensor descriptor.
  * @param tensorDesc Pointer to a tensor descriptor type (output)
  * @return           miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenCreateTensorDescriptor(miopenTensorDescriptor_t* tensorDesc);
 
 /*! @brief Set shape of 4D tensor
@@ -475,7 +534,7 @@ MIOPEN_EXPORT miopenStatus_t miopenCreateTensorDescriptor(miopenTensorDescriptor
  * @param h          Data height dimension size (input)
  * @param w          Data width dimension size (input)
  * @return           miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenSet4dTensorDescriptor(
     miopenTensorDescriptor_t tensorDesc, miopenDataType_t dataType, int n, int c, int h, int w);
 
@@ -494,7 +553,7 @@ MIOPEN_EXPORT miopenStatus_t miopenSet4dTensorDescriptor(
  * @param hStride    Height dimension stride (output)
  * @param wStride    Width dimension stride (output)
  * @return           miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenGet4dTensorDescriptor(miopenTensorDescriptor_t tensorDesc,
                                                          miopenDataType_t* dataType,
                                                          int* n,
@@ -516,7 +575,7 @@ MIOPEN_EXPORT miopenStatus_t miopenGet4dTensorDescriptor(miopenTensorDescriptor_
  * @param dimsA        Array containing the size of dimensions (input)
  * @param stridesA     Array containing the size of stride (input)
  * @return             miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenSetTensorDescriptor(miopenTensorDescriptor_t tensorDesc,
                                                        miopenDataType_t dataType,
                                                        int nbDims,
@@ -530,7 +589,7 @@ MIOPEN_EXPORT miopenStatus_t miopenSetTensorDescriptor(miopenTensorDescriptor_t 
  * @param tensorDesc   Tensor descriptor type (input)
  * @param size         number of elements in tensor described by the descriptor (output)
  * @return             miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenGetTensorDescriptorSize(miopenTensorDescriptor_t tensorDesc,
                                                            int* size);
 
@@ -551,7 +610,7 @@ MIOPEN_EXPORT miopenStatus_t miopenGetTensorDescriptor(miopenTensorDescriptor_t 
  *
  * @param tensorDesc Tensor descriptor type (input)
  * @return           miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenDestroyTensorDescriptor(miopenTensorDescriptor_t tensorDesc);
 
 /*! @brief Execute element-wise tensor operations
@@ -752,48 +811,48 @@ miopenGetConvolutionNdDescriptor(miopenConvolutionDescriptor_t convDesc,
                                  miopenConvolutionMode_t* c_mode);
 
 /*! @brief Set the number of groups to be used in Group/Depthwise convolution
-*
-* Must be called before all computational APIs of group/depthwise convolution, it is preferable to
-* call miopenInitConvolutionDescriptor() first, then miopenSetConvolutionGroupCount() to fully
-* initialize group convolutions. Both Convolution Mode and Transpose Convolution Mode support
-* group/depthwise convolution. To run depthwise convolution, set groupCount value equal to number of
-* channels.
-*
-* @param convDesc   Convolution layer descriptor (output)
-* @param groupCount      number of groups, in depthwise conv using filter_number/channel_multiplier
-* (input)
-* @return           miopenStatus_t
-*/
+ *
+ * Must be called before all computational APIs of group/depthwise convolution, it is preferable to
+ * call miopenInitConvolutionDescriptor() first, then miopenSetConvolutionGroupCount() to fully
+ * initialize group convolutions. Both Convolution Mode and Transpose Convolution Mode support
+ * group/depthwise convolution. To run depthwise convolution, set groupCount value equal to number
+ * of channels.
+ *
+ * @param convDesc   Convolution layer descriptor (output)
+ * @param groupCount      number of groups, in depthwise conv using filter_number/channel_multiplier
+ * (input)
+ * @return           miopenStatus_t
+ */
 MIOPEN_EXPORT miopenStatus_t miopenSetConvolutionGroupCount(miopenConvolutionDescriptor_t convDesc,
                                                             int groupCount);
 
 /*! @brief Set the output padding to be used in 2-D Transpose convolution
-*
-* This function is optional for initialization of Transpose convolution. If applicable, it must be
-* called before all computational APIs of Transpose convolution. It is preferable to call
-* miopenInitConvolutionDescriptor() first, then miopenSetTransposeConvOutputPadding() to fully
-* initialize transpose convolutions.
-*
-* @param convDesc   Convolution layer descriptor (output)
-* @param adj_h      output padding for the height of output data (input)
-* @param adj_w      output padding for the width of output data (input)
-* @return           miopenStatus_t
-*/
+ *
+ * This function is optional for initialization of Transpose convolution. If applicable, it must be
+ * called before all computational APIs of Transpose convolution. It is preferable to call
+ * miopenInitConvolutionDescriptor() first, then miopenSetTransposeConvOutputPadding() to fully
+ * initialize transpose convolutions.
+ *
+ * @param convDesc   Convolution layer descriptor (output)
+ * @param adj_h      output padding for the height of output data (input)
+ * @param adj_w      output padding for the width of output data (input)
+ * @return           miopenStatus_t
+ */
 MIOPEN_EXPORT miopenStatus_t
 miopenSetTransposeConvOutputPadding(miopenConvolutionDescriptor_t convDesc, int adj_h, int adj_w);
 
 /*! @brief Set the output padding to be used in N-dimensional Transpose convolution
-*
-* This function is optional for initialization of Transpose convolution. If applicable, it must be
-* called before all computational APIs of Transpose convolution. It is preferable to call
-* miopenInitConvolutionNdDescriptor() first, then miopenSetTransposeConvNdOutputPadding() to fully
-* initialize transpose convolutions. Currently, 2-D and 3-D convolutions are supported.
-*
-* @param convDesc      Convolution layer descriptor (output)
-* @param spatialDim    Convolutional spatial dimension (input)
-* @param adjA          array of output padding for output data (input)
-* @return              miopenStatus_t
-*/
+ *
+ * This function is optional for initialization of Transpose convolution. If applicable, it must be
+ * called before all computational APIs of Transpose convolution. It is preferable to call
+ * miopenInitConvolutionNdDescriptor() first, then miopenSetTransposeConvNdOutputPadding() to fully
+ * initialize transpose convolutions. Currently, 2-D and 3-D convolutions are supported.
+ *
+ * @param convDesc      Convolution layer descriptor (output)
+ * @param spatialDim    Convolutional spatial dimension (input)
+ * @param adjA          array of output padding for output data (input)
+ * @return              miopenStatus_t
+ */
 MIOPEN_EXPORT miopenStatus_t miopenSetTransposeConvNdOutputPadding(
     miopenConvolutionDescriptor_t convDesc, int spatialDim, int* adjA);
 
@@ -847,7 +906,7 @@ miopenGetConvolutionNdForwardOutputDim(miopenConvolutionDescriptor_t convDesc,
  *
  * @param convDesc Convolution tensor descriptor type (input)
  * @return           miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t
 miopenDestroyConvolutionDescriptor(miopenConvolutionDescriptor_t convDesc);
 
@@ -1518,7 +1577,7 @@ MIOPEN_EXPORT miopenStatus_t miopenConvolutionForwardBias(miopenHandle_t handle,
  * @param dxDesc         Tensor descriptor for output data tensor dx (input)
  * @param workSpaceSize  Size in bytes of the memory required (output)
  * @return               miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t
 miopenConvolutionBackwardDataGetWorkSpaceSize(miopenHandle_t handle,
                                               const miopenTensorDescriptor_t dyDesc,
@@ -1642,7 +1701,7 @@ miopenConvolutionBackwardData(miopenHandle_t handle,
  * @param dwDesc         Tensor descriptor for output weights tensor dw (input)
  * @param workSpaceSize  Size in bytes of the memory required (output)
  * @return               miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t
 miopenConvolutionBackwardWeightsGetWorkSpaceSize(miopenHandle_t handle,
                                                  const miopenTensorDescriptor_t dyDesc,
@@ -2057,7 +2116,7 @@ MIOPEN_EXPORT miopenStatus_t miopenPoolingBackward(miopenHandle_t handle,
  *
  * @param poolDesc Pooling tensor descriptor type (input)
  * @return           miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenDestroyPoolingDescriptor(miopenPoolingDescriptor_t poolDesc);
 
 /** @} */
@@ -2190,7 +2249,7 @@ MIOPEN_EXPORT miopenStatus_t miopenLRNBackward(miopenHandle_t handle,
  *
  * @param lrnDesc   LRN tensor descriptor type (input)
  * @return          miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenDestroyLRNDescriptor(miopenLRNDescriptor_t lrnDesc);
 
 /** @} */
@@ -2217,7 +2276,7 @@ MIOPEN_EXPORT miopenStatus_t miopenDestroyLRNDescriptor(miopenLRNDescriptor_t lr
  * @param xDesc           Input tensor descriptor (input)
  * @param bn_mode         Batch Normalization mode (input)
  * @return                miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenDeriveBNTensorDescriptor(miopenTensorDescriptor_t derivedBnDesc,
                                                             const miopenTensorDescriptor_t xDesc,
                                                             miopenBatchNormMode_t bn_mode);
@@ -2259,7 +2318,7 @@ MIOPEN_EXPORT miopenStatus_t miopenDeriveBNTensorDescriptor(miopenTensorDescript
  * @param resultSaveMean            Saved mini-batch mean for backwards pass (output)
  * @param resultSaveInvVariance     Saved mini-batch inverse variance for backwards pass (output)
  * @return                          miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t
 miopenBatchNormalizationForwardTraining(miopenHandle_t handle,
                                         miopenBatchNormMode_t bn_mode,
@@ -2304,7 +2363,7 @@ miopenBatchNormalizationForwardTraining(miopenHandle_t handle,
  * @param estimatedVariance         Running variance saved during forward training (input)
  * @param epsilon                   Value to stabilize inverse variance calculation (input)
  * @return                          miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t
 miopenBatchNormalizationForwardInference(miopenHandle_t handle,
                                          miopenBatchNormMode_t bn_mode,
@@ -2354,7 +2413,7 @@ miopenBatchNormalizationForwardInference(miopenHandle_t handle,
  * @param savedMean                 Saved mini-batch mean for backwards pass (input)
  * @param savedInvVariance          Saved mini-bathc inverse variance for backwards pass (input)
  * @return                          miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t
 miopenBatchNormalizationBackward(miopenHandle_t handle,
                                  miopenBatchNormMode_t bn_mode,
@@ -2388,7 +2447,7 @@ miopenBatchNormalizationBackward(miopenHandle_t handle,
  *
  * @param activDesc Pointer to an activation tensor descriptor type
  * @return          miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t
 miopenCreateActivationDescriptor(miopenActivationDescriptor_t* activDesc);
 
@@ -2482,7 +2541,7 @@ MIOPEN_EXPORT miopenStatus_t miopenActivationBackward(miopenHandle_t handle,
  *
  * @param activDesc   Activation tensor descriptor type (input)
  * @return            miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t
 miopenDestroyActivationDescriptor(miopenActivationDescriptor_t activDesc);
 
@@ -2594,49 +2653,49 @@ MIOPEN_EXPORT miopenStatus_t miopenSoftmaxBackward_V2(miopenHandle_t handle,
 // CLOSEOUT SOFTMAX DOXYGEN GROUP
 
 /*! @ingroup FUSION
-* @brief MIOpen fusion interface
-*/
+ * @brief MIOpen fusion interface
+ */
 MIOPEN_DECLARE_OBJECT(miopenFusionPlanDescriptor);
 MIOPEN_DECLARE_OBJECT(miopenOperatorDescriptor);
 MIOPEN_DECLARE_OBJECT(miopenOperatorArgs);
 
 /** @addtogroup FUSION
-*
-*  @{
-*/
+ *
+ *  @{
+ */
 
 /*! @enum miopenFusionDirection_t
-* @brief Kernel fusion direction in the network
-*/
+ * @brief Kernel fusion direction in the network
+ */
 typedef enum {
     miopenVerticalFusion   = 0, /*!< fuses layers vertically, current the only supported mode */
     miopenHorizontalFusion = 1, /*!< fuses layers horizontally, this is unimplemented */
 } miopenFusionDirection_t;
 
 /*! @brief Creates the kenrel fusion plan descriptor object
-*
-* @param fusePlanDesc  Pointer to a fusion plan (output)
-* @param fuseDirection Horizontal or Vertical fusion (input)
-* @param inputDesc     Descriptor to tensor for the input (input)
-* @return              miopenStatus_t
-*/
+ *
+ * @param fusePlanDesc  Pointer to a fusion plan (output)
+ * @param fuseDirection Horizontal or Vertical fusion (input)
+ * @param inputDesc     Descriptor to tensor for the input (input)
+ * @return              miopenStatus_t
+ */
 MIOPEN_EXPORT miopenStatus_t miopenCreateFusionPlan(miopenFusionPlanDescriptor_t* fusePlanDesc,
                                                     const miopenFusionDirection_t fuseDirection,
                                                     const miopenTensorDescriptor_t inputDesc);
 
 /*! @brief Destroy the fusion plan descriptor object
-*
-* @param fusePlanDesc  A fusion plan descriptor type
-* @return              miopenStatus_t
-*/
+ *
+ * @param fusePlanDesc  A fusion plan descriptor type
+ * @return              miopenStatus_t
+ */
 MIOPEN_EXPORT miopenStatus_t miopenDestroyFusionPlan(miopenFusionPlanDescriptor_t fusePlanDesc);
 
 /*! @brief Compiles the fusion plan
-*
-* @param handle           MIOpen handle (input)
-* @param fusePlanDesc A fusion plan descriptor (input)
-* @return             miopenStatus_t
-*/
+ *
+ * @param handle           MIOpen handle (input)
+ * @param fusePlanDesc A fusion plan descriptor (input)
+ * @return             miopenStatus_t
+ */
 MIOPEN_EXPORT miopenStatus_t miopenCompileFusionPlan(miopenHandle_t handle,
                                                      miopenFusionPlanDescriptor_t fusePlanDesc);
 
@@ -2656,10 +2715,10 @@ MIOPEN_EXPORT miopenStatus_t miopenFusionPlanGetOp(miopenFusionPlanDescriptor_t 
 
 /*! @brief Query the workspace size required for the fusion plan
  *
-* @param fusePlanDesc   A fusion plan descriptor (input)
-* @param workSpaceSize  Pointer to memory to return size in bytes (output)
-* @return               miopenStatus_t
-*/
+ * @param fusePlanDesc   A fusion plan descriptor (input)
+ * @param workSpaceSize  Pointer to memory to return size in bytes (output)
+ * @return               miopenStatus_t
+ */
 MIOPEN_EXPORT miopenStatus_t
 miopenFusionPlanGetWorkSpaceSize(miopenHandle_t handle,
                                  miopenFusionPlanDescriptor_t fusePlanDesc,
@@ -2702,13 +2761,13 @@ MIOPEN_EXPORT miopenStatus_t miopenFusionPlanConvolutionSetAlgo(
     miopenFusionPlanDescriptor_t fusePlanDesc, miopenConvFwdAlgorithm_t algo);
 
 /*! @brief Creates forward convolution operator.
-*
-* @param fusePlanDesc   A fusion plan descriptor (input)
-* @param convOp         Pointer to an operator type (output)
-* @param convDesc       Convolution layer descriptor (input)
-* @param wDesc          Descriptor for the weights tensor (input)
-* @return               miopenStatus_t
-*/
+ *
+ * @param fusePlanDesc   A fusion plan descriptor (input)
+ * @param convOp         Pointer to an operator type (output)
+ * @param convDesc       Convolution layer descriptor (input)
+ * @param wDesc          Descriptor for the weights tensor (input)
+ * @return               miopenStatus_t
+ */
 MIOPEN_EXPORT miopenStatus_t miopenCreateOpConvForward(miopenFusionPlanDescriptor_t fusePlanDesc,
                                                        miopenFusionOpDescriptor_t* convOp,
                                                        miopenConvolutionDescriptor_t convDesc,
@@ -2718,12 +2777,12 @@ MIOPEN_EXPORT miopenStatus_t miopenCreateOpConvForward(miopenFusionPlanDescripto
 
 // Activation forward create ops ---
 /*! @brief Creates a forward activation operator.
-*
-* @param fusePlanDesc    A fusion plan descriptor (input)
-* @param activFwdOp         Pointer to an operator type (output)
-* @param mode            Activation version (input)
-* @return                miopenStatus_t
-*/
+ *
+ * @param fusePlanDesc    A fusion plan descriptor (input)
+ * @param activFwdOp         Pointer to an operator type (output)
+ * @param mode            Activation version (input)
+ * @return                miopenStatus_t
+ */
 MIOPEN_EXPORT miopenStatus_t
 miopenCreateOpActivationForward(miopenFusionPlanDescriptor_t fusePlanDesc,
                                 miopenFusionOpDescriptor_t* activFwdOp,
@@ -2731,12 +2790,12 @@ miopenCreateOpActivationForward(miopenFusionPlanDescriptor_t fusePlanDesc,
 
 // Activation backward create ops ---
 /*! @brief Creates a backward activation operator.
-*
-* @param fusePlanDesc    A fusion plan descriptor (input)
-* @param activBwdOp         Pointer to an operator type (output)
-* @param mode            Activation version (input)
-* @return                miopenStatus_t
-*/
+ *
+ * @param fusePlanDesc    A fusion plan descriptor (input)
+ * @param activBwdOp         Pointer to an operator type (output)
+ * @param mode            Activation version (input)
+ * @return                miopenStatus_t
+ */
 MIOPEN_EXPORT miopenStatus_t
 miopenCreateOpActivationBackward(miopenFusionPlanDescriptor_t fusePlanDesc,
                                  miopenFusionOpDescriptor_t* activBwdOp,
@@ -2744,25 +2803,25 @@ miopenCreateOpActivationBackward(miopenFusionPlanDescriptor_t fusePlanDesc,
 
 // Bias create ops ---
 /*! @brief Creates a forward bias operator.
-*
-* @param fusePlanDesc   A fusion plan descriptor (input)
-* @param biasOp         Pointer to an operator type (output)
-* @param bDesc          bias tensor descriptor (input)
-* @return               miopenStatus_t
-*/
+ *
+ * @param fusePlanDesc   A fusion plan descriptor (input)
+ * @param biasOp         Pointer to an operator type (output)
+ * @param bDesc          bias tensor descriptor (input)
+ * @return               miopenStatus_t
+ */
 MIOPEN_EXPORT miopenStatus_t miopenCreateOpBiasForward(miopenFusionPlanDescriptor_t fusePlanDesc,
                                                        miopenFusionOpDescriptor_t* biasOp,
                                                        const miopenTensorDescriptor_t bDesc);
 
 // Batch normalization create ops ---
 /*! @brief Creates a forward inference batch normalization operator.
-*
-* @param fusePlanDesc           A fusion plan descriptor (input)
-* @param bnOp                   Pointer to an operator type (output)
-* @param bn_mode                Batch normalization layer mode (input)
-* @param bnScaleBiasMeanVarDesc Gamma, beta, mean, variance tensor descriptor (input)
-* @return                       miopenStatus_t
-*/
+ *
+ * @param fusePlanDesc           A fusion plan descriptor (input)
+ * @param bnOp                   Pointer to an operator type (output)
+ * @param bn_mode                Batch normalization layer mode (input)
+ * @param bnScaleBiasMeanVarDesc Gamma, beta, mean, variance tensor descriptor (input)
+ * @return                       miopenStatus_t
+ */
 MIOPEN_EXPORT miopenStatus_t
 miopenCreateOpBatchNormInference(miopenFusionPlanDescriptor_t fusePlanDesc,
                                  miopenFusionOpDescriptor_t* bnOp,
@@ -2770,14 +2829,14 @@ miopenCreateOpBatchNormInference(miopenFusionPlanDescriptor_t fusePlanDesc,
                                  const miopenTensorDescriptor_t bnScaleBiasMeanVarDesc);
 
 /*! @brief Creates a forward training batch normalization operator.
-*
-* @param fusePlanDesc           A fusion plan descriptor (input)
-* @param bnFwdOp                   Pointer to an operator type (output)
-* @param bn_mode                Batch normalization layer mode (input)
-* @param runningMeanVariance    Toggles whether or not to save population statistics for inference;
-* batch statistic are required (input)
-* @return                       miopenStatus_t
-*/
+ *
+ * @param fusePlanDesc           A fusion plan descriptor (input)
+ * @param bnFwdOp                   Pointer to an operator type (output)
+ * @param bn_mode                Batch normalization layer mode (input)
+ * @param runningMeanVariance    Toggles whether or not to save population statistics for inference;
+ * batch statistic are required (input)
+ * @return                       miopenStatus_t
+ */
 MIOPEN_EXPORT miopenStatus_t
 miopenCreateOpBatchNormForward(miopenFusionPlanDescriptor_t fusePlanDesc,
                                miopenFusionOpDescriptor_t* bnFwdOp,
@@ -2785,12 +2844,12 @@ miopenCreateOpBatchNormForward(miopenFusionPlanDescriptor_t fusePlanDesc,
                                bool runningMeanVariance);
 
 /*! @brief Creates a back propagation batch normalization operator.
-*
-* @param fusePlanDesc           A fusion plan descriptor (input)
-* @param bnBwdOp                   Pointer to an operator type (output)
-* @param bn_mode                Batch normalization layer mode (input)
-* @return                       miopenStatus_t
-*/
+ *
+ * @param fusePlanDesc           A fusion plan descriptor (input)
+ * @param bnBwdOp                   Pointer to an operator type (output)
+ * @param bn_mode                Batch normalization layer mode (input)
+ * @return                       miopenStatus_t
+ */
 MIOPEN_EXPORT miopenStatus_t
 miopenCreateOpBatchNormBackward(miopenFusionPlanDescriptor_t fusePlanDesc,
                                 miopenFusionOpDescriptor_t* bnBwdOp,
@@ -2798,29 +2857,29 @@ miopenCreateOpBatchNormBackward(miopenFusionPlanDescriptor_t fusePlanDesc,
 
 //---
 /*! @brief Creates an operator argument object
-*
-* @param args        Pointer to an operator argument type (output)
-* @return            miopenStatus_t
-*/
+ *
+ * @param args        Pointer to an operator argument type (output)
+ * @return            miopenStatus_t
+ */
 MIOPEN_EXPORT miopenStatus_t miopenCreateOperatorArgs(miopenOperatorArgs_t* args);
 
 /*! @brief Destroys an operator argument object
-*
-* @param args        An operator argument type (output)
-* @return            miopenStatus_t
-*/
+ *
+ * @param args        An operator argument type (output)
+ * @return            miopenStatus_t
+ */
 MIOPEN_EXPORT miopenStatus_t miopenDestroyOperatorArgs(miopenOperatorArgs_t args);
 
 // Convolution set arguments ---
 /*! @brief Sets the arguments for forward convolution op
-*
-* @param args    An arguments object type (output)
-* @param convOp  Forward convolution operator (input)
-* @param alpha   Floating point scaling factor, allocated on the host (input)
-* @param beta    Floating point shift factor, allocated on the host (input)
-* @param w       Pointer to tensor memory  (input)
-* @return        miopenStatus_t
-*/
+ *
+ * @param args    An arguments object type (output)
+ * @param convOp  Forward convolution operator (input)
+ * @param alpha   Floating point scaling factor, allocated on the host (input)
+ * @param beta    Floating point shift factor, allocated on the host (input)
+ * @param w       Pointer to tensor memory  (input)
+ * @return        miopenStatus_t
+ */
 MIOPEN_EXPORT miopenStatus_t miopenSetOpArgsConvForward(miopenOperatorArgs_t args,
                                                         const miopenFusionOpDescriptor_t convOp,
                                                         const void* alpha,
@@ -2828,16 +2887,16 @@ MIOPEN_EXPORT miopenStatus_t miopenSetOpArgsConvForward(miopenOperatorArgs_t arg
                                                         const void* w);
 // Activation set arguments ---
 /*! @brief Sets the arguments for forward activation op
-*
-* @param args    An arguments object type (output)
-* @param activFwdOp   Activation backwards operator (input)
-* @param alpha   Floating point scaling factor, allocated on the host (input)
-* @param beta    Floating point shift factor, allocated on the host (input)
-* @param activAlpha  Double precision activation parameter which depends on activation mode (input)
-* @param activBeta   Double precision activation parameter which depends on activation mode (input)
-* @param activGamma  Double precision activation parameter which depends on activation mode (input)
-* @return        miopenStatus_t
-*/
+ *
+ * @param args    An arguments object type (output)
+ * @param activFwdOp   Activation backwards operator (input)
+ * @param alpha   Floating point scaling factor, allocated on the host (input)
+ * @param beta    Floating point shift factor, allocated on the host (input)
+ * @param activAlpha  Double precision activation parameter which depends on activation mode (input)
+ * @param activBeta   Double precision activation parameter which depends on activation mode (input)
+ * @param activGamma  Double precision activation parameter which depends on activation mode (input)
+ * @return        miopenStatus_t
+ */
 MIOPEN_EXPORT miopenStatus_t
 miopenSetOpArgsActivForward(miopenOperatorArgs_t args,
                             const miopenFusionOpDescriptor_t activFwdOp,
@@ -2848,18 +2907,18 @@ miopenSetOpArgsActivForward(miopenOperatorArgs_t args,
                             double activGamma);
 
 /*! @brief Sets the arguments for backward activation op
-*
-* @param args    An arguments object type (output)
-* @param activBwdOp   Activation backwards operator (input)
-* @param alpha   Floating point scaling factor, allocated on the host (input)
-* @param beta    Floating point shift factor, allocated on the host (input)
-* @param y        Data tensor y, output of activations in the forward direction (input)
-* @param reserved    Data tensor reserved memory space; currently should be nullptr (input)
-* @param activAlpha  Double precision activation parameter which depends on activation mode (input)
-* @param activBeta   Double precision activation parameter which depends on activation mode (input)
-* @param activGamma  Double precision activation parameter which depends on activation mode (input)
-* @return        miopenStatus_t
-*/
+ *
+ * @param args    An arguments object type (output)
+ * @param activBwdOp   Activation backwards operator (input)
+ * @param alpha   Floating point scaling factor, allocated on the host (input)
+ * @param beta    Floating point shift factor, allocated on the host (input)
+ * @param y        Data tensor y, output of activations in the forward direction (input)
+ * @param reserved    Data tensor reserved memory space; currently should be nullptr (input)
+ * @param activAlpha  Double precision activation parameter which depends on activation mode (input)
+ * @param activBeta   Double precision activation parameter which depends on activation mode (input)
+ * @param activGamma  Double precision activation parameter which depends on activation mode (input)
+ * @return        miopenStatus_t
+ */
 MIOPEN_EXPORT miopenStatus_t
 miopenSetOpArgsActivBackward(miopenOperatorArgs_t args,
                              const miopenFusionOpDescriptor_t activBwdOp,
@@ -2873,18 +2932,18 @@ miopenSetOpArgsActivBackward(miopenOperatorArgs_t args,
 
 // Batch Normalization set arguments ---
 /*! @brief Sets the arguments for inference batch normalization op
-*
-* @param args               An arguments object type (output)
-* @param bnOp               Batch normalization inference operator (input)
-* @param alpha              Floating point scaling factor, allocated on the host (input)
-* @param beta               Floating point shift factor, allocated on the host (input)
-* @param bnScale            Pointer to the gamma tensor memory  (input)
-* @param bnBias             Pointer to the beta tensor memory  (input)
-* @param estimatedMean      Pointer to population mean memory  (input)
-* @param estimatedVariance  Pointer to population variance memory  (input)
-* @param epsilon            Scalar value for numerical stability (input)
-* @return                   miopenStatus_t
-*/
+ *
+ * @param args               An arguments object type (output)
+ * @param bnOp               Batch normalization inference operator (input)
+ * @param alpha              Floating point scaling factor, allocated on the host (input)
+ * @param beta               Floating point shift factor, allocated on the host (input)
+ * @param bnScale            Pointer to the gamma tensor memory  (input)
+ * @param bnBias             Pointer to the beta tensor memory  (input)
+ * @param estimatedMean      Pointer to population mean memory  (input)
+ * @param estimatedVariance  Pointer to population variance memory  (input)
+ * @param epsilon            Scalar value for numerical stability (input)
+ * @return                   miopenStatus_t
+ */
 MIOPEN_EXPORT miopenStatus_t
 miopenSetOpArgsBatchNormInference(miopenOperatorArgs_t args,
                                   const miopenFusionOpDescriptor_t bnOp,
@@ -2897,21 +2956,21 @@ miopenSetOpArgsBatchNormInference(miopenOperatorArgs_t args,
                                   double epsilon);
 
 /*! @brief Sets the arguments for forward batch normalization op
-*
-* @param args               An arguments object type (output)
-* @param bnOp               Batch normalization forward operator (input)
-* @param alpha              Floating point scaling factor, allocated on the host (input)
-* @param beta               Floating point shift factor, allocated on the host (input)
-* @param bnScale            Pointer to the gamma tensor memory  (input)
-* @param bnBias             Pointer to the beta tensor memory  (input)
-* @param savedMean          Pointer to batch mean memory  (input)
-* @param savedInvVariance   Pointer to batch inverse variance memory  (input)
-* @param runningMean        Pointer to population mean memory  (input)
-* @param runningVariance    Pointer to population variance memory  (input)
-* @param expAvgFactor       Scalar value for control of population statistics (input)
-* @param epsilon            Scalar value for numerical stability (input)
-* @return                   miopenStatus_t
-*/
+ *
+ * @param args               An arguments object type (output)
+ * @param bnOp               Batch normalization forward operator (input)
+ * @param alpha              Floating point scaling factor, allocated on the host (input)
+ * @param beta               Floating point shift factor, allocated on the host (input)
+ * @param bnScale            Pointer to the gamma tensor memory  (input)
+ * @param bnBias             Pointer to the beta tensor memory  (input)
+ * @param savedMean          Pointer to batch mean memory  (input)
+ * @param savedInvVariance   Pointer to batch inverse variance memory  (input)
+ * @param runningMean        Pointer to population mean memory  (input)
+ * @param runningVariance    Pointer to population variance memory  (input)
+ * @param expAvgFactor       Scalar value for control of population statistics (input)
+ * @param epsilon            Scalar value for numerical stability (input)
+ * @return                   miopenStatus_t
+ */
 MIOPEN_EXPORT miopenStatus_t miopenSetOpArgsBatchNormForward(miopenOperatorArgs_t args,
                                                              const miopenFusionOpDescriptor_t bnOp,
                                                              const void* alpha,
@@ -2926,20 +2985,20 @@ MIOPEN_EXPORT miopenStatus_t miopenSetOpArgsBatchNormForward(miopenOperatorArgs_
                                                              double epsilon);
 
 /*! @brief Sets the arguments for backward batch normalization op
-*
-* @param args               An arguments object type (output)
-* @param bnOp               Batch normalization forward operator (input)
-* @param alpha              Floating point scaling factor, allocated on the host (input)
-* @param beta               Floating point shift factor, allocated on the host (input)
-* @param x                  Pointer to the forward input tensor memory  (input)
-* @param bnScale            Pointer to the gamma tensor memory  (input)
-* @param bnBias             Pointer to the beta tensor memory  (input)
-* @param resultBnScaleDiff  Pointer to the gamma gradient tensor memory  (output)
-* @param resultBnBiasDiff   Pointer to the beta gradient tensor memory  (output)
-* @param savedMean          Pointer to batch mean memory  (input)
-* @param savedInvVariance   Pointer to batch inverse variance memory  (input)
-* @return                   miopenStatus_t
-*/
+ *
+ * @param args               An arguments object type (output)
+ * @param bnOp               Batch normalization forward operator (input)
+ * @param alpha              Floating point scaling factor, allocated on the host (input)
+ * @param beta               Floating point shift factor, allocated on the host (input)
+ * @param x                  Pointer to the forward input tensor memory  (input)
+ * @param bnScale            Pointer to the gamma tensor memory  (input)
+ * @param bnBias             Pointer to the beta tensor memory  (input)
+ * @param resultBnScaleDiff  Pointer to the gamma gradient tensor memory  (output)
+ * @param resultBnBiasDiff   Pointer to the beta gradient tensor memory  (output)
+ * @param savedMean          Pointer to batch mean memory  (input)
+ * @param savedInvVariance   Pointer to batch inverse variance memory  (input)
+ * @return                   miopenStatus_t
+ */
 MIOPEN_EXPORT miopenStatus_t miopenSetOpArgsBatchNormBackward(miopenOperatorArgs_t args,
                                                               const miopenFusionOpDescriptor_t bnOp,
                                                               const void* alpha,
@@ -2954,31 +3013,31 @@ MIOPEN_EXPORT miopenStatus_t miopenSetOpArgsBatchNormBackward(miopenOperatorArgs
 
 // Bias forward set arguments ---
 /*! @brief Sets the arguments for forward bias op
-*
-* @param args           An arguments object type (output)
-* @param biasOp         Forward bias operator (input)
-* @param alpha          Floating point scaling factor, allocated on the host (input)
-* @param beta           Floating point shift factor, allocated on the host (input)
-* @param bias           Pointer to the forward bias input tensor memory  (input)
-* @return               miopenStatus_t
-*/
+ *
+ * @param args           An arguments object type (output)
+ * @param biasOp         Forward bias operator (input)
+ * @param alpha          Floating point scaling factor, allocated on the host (input)
+ * @param beta           Floating point shift factor, allocated on the host (input)
+ * @param bias           Pointer to the forward bias input tensor memory  (input)
+ * @return               miopenStatus_t
+ */
 MIOPEN_EXPORT miopenStatus_t miopenSetOpArgsBiasForward(miopenOperatorArgs_t args,
                                                         const miopenFusionOpDescriptor_t biasOp,
                                                         const void* alpha,
                                                         const void* beta,
                                                         const void* bias);
 /*! @brief Executes the fusion plan
-*
-*
-* @param handle           MIOpen handle (input)
-* @param fusePlanDesc     fused plan descriptor (input)
-* @param inputDesc        Descriptor of the input tensor (input)
-* @param input            Source data tensor  (input)
-* @param outputDesc       Decriptor of the output tensor (input)
-* @param output           Destination data tensor  (output)
-* @param args             An argument object of the fused kernel (input)
-* @return           miopenStatus_t
-*/
+ *
+ *
+ * @param handle           MIOpen handle (input)
+ * @param fusePlanDesc     fused plan descriptor (input)
+ * @param inputDesc        Descriptor of the input tensor (input)
+ * @param input            Source data tensor  (input)
+ * @param outputDesc       Decriptor of the output tensor (input)
+ * @param output           Destination data tensor  (output)
+ * @param args             An argument object of the fused kernel (input)
+ * @return           miopenStatus_t
+ */
 MIOPEN_EXPORT miopenStatus_t
 miopenExecuteFusionPlan(const miopenHandle_t handle,
                         const miopenFusionPlanDescriptor_t fusePlanDesc,
@@ -2991,13 +3050,13 @@ miopenExecuteFusionPlan(const miopenHandle_t handle,
 // CLOSEOUT FUSION DOXYGEN GROUP
 
 /** @addtogroup RNN
-*
-*  @{
-*/
+ *
+ *  @{
+ */
 
 /*!  @enum miopenRNNMode_t
-* RNN mode selection for rnn layer preference
-*/
+ * RNN mode selection for rnn layer preference
+ */
 typedef enum {
     miopenRNNRELU = 0, /*!< RNN with ReLU activation */
     miopenRNNTANH = 1, /*!< RNN with tanh activation */
@@ -3007,7 +3066,7 @@ typedef enum {
 
 /*! @enum miopenRNNInputMode_t
  * Recurrent Neural Network layer initial input mode
-*/
+ */
 typedef enum {
     miopenRNNlinear = 0, /*!< Matrix multiplication at the input of the first layer */
     miopenRNNskip   = 1, /*!< No operation is performed at the input of the first layer. */
@@ -3015,7 +3074,7 @@ typedef enum {
 
 /*! @enum miopenRNNAlgo_t
  * Recurrent Neural Network algorithm mode
-*/
+ */
 typedef enum {
     miopenRNNdefault = 0, /*!< Use dedicated gate-operation kernel for LSTM and fundamental
                              algorithm for vanilla RNN & GRU */
@@ -3025,7 +3084,7 @@ typedef enum {
 
 /*! @enum miopenRNNDirectionMode_t
  * Recurrent Neural Network bi-directional behavior
-*/
+ */
 typedef enum {
     miopenRNNunidirection = 0, /*!< Forward in time only. */
     miopenRNNbidirection  = 1, /*!< Forward and backwards in time. */
@@ -3033,7 +3092,7 @@ typedef enum {
 
 /*! @enum miopenRNNBiasMode_t
  * Recurrent Neural Network add on bias
-*/
+ */
 typedef enum {
     miopenRNNNoBias   = 0, /*!< No Biases will be applied to GEMM operations */
     miopenRNNwithBias = 1, /*!< Biases will be applied to GEMM operations */
@@ -3041,7 +3100,7 @@ typedef enum {
 
 /*! @enum miopenRNNGEMMalgoMode_t
  * Recurrent Neural Network add on bias
-*/
+ */
 typedef enum {
     miopenRNNAlgoGEMM = 0,
 } miopenRNNGEMMalgoMode_t;
@@ -3051,21 +3110,21 @@ typedef enum {
  * API for creating an uninitialized RNN layer descriptor.
  * @param rnnDesc    Pointer to a tensor descriptor type
  * @return           miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenCreateRNNDescriptor(miopenRNNDescriptor_t* rnnDesc);
 
 /*! @brief Retrieves a RNN layer descriptor's details
-*
-* @param rnnDesc    RNN layer descriptor (input)
-* @param rnnMode    RNN mode (output)
-* @param algoMode   RNN algorithm mode (output)
-* @param inputMode  RNN data input mode (output)
-* @param dirMode    Uni or bi direction mode (output)
-* @param biasMode   Bias used (output)
-* @param hiddenSize Size of hidden state (output)
-* @param layer      Number of stacked layers (output)
-* @return           miopenStatus_t
-*/
+ *
+ * @param rnnDesc    RNN layer descriptor (input)
+ * @param rnnMode    RNN mode (output)
+ * @param algoMode   RNN algorithm mode (output)
+ * @param inputMode  RNN data input mode (output)
+ * @param dirMode    Uni or bi direction mode (output)
+ * @param biasMode   Bias used (output)
+ * @param hiddenSize Size of hidden state (output)
+ * @param layer      Number of stacked layers (output)
+ * @return           miopenStatus_t
+ */
 MIOPEN_EXPORT miopenStatus_t miopenGetRNNDescriptor(miopenRNNDescriptor_t rnnDesc,
                                                     miopenRNNMode_t* rnnMode,
                                                     miopenRNNAlgo_t* algoMode,
@@ -3076,21 +3135,21 @@ MIOPEN_EXPORT miopenStatus_t miopenGetRNNDescriptor(miopenRNNDescriptor_t rnnDes
                                                     int* layer);
 
 /*! @brief Retrieves a RNN layer descriptor's details version 2. This version enables retrieving
-* information of the dropout descriptor of the rnn descriptor.
-*
-* @param rnnDesc     RNN layer descriptor (input)
-* @param hiddenSize  Size of hidden state (output)
-* @param layer       Number of stacked layers (output)
-* @param dropoutDesc Pre-configured dropout descriptor for dropout layer in between RNN layers
-* (output)
-* @param inputMode   RNN data input mode (output)
-* @param dirMode     Uni or bi direction mode (output)
-* @param rnnMode     RNN mode (output)
-* @param biasMode    Bias used (output)
-* @param algoMode    RNN algorithm mode (output)
-* @param dataType    Data type of RNN (output)
-* @return            miopenStatus_t
-*/
+ * information of the dropout descriptor of the rnn descriptor.
+ *
+ * @param rnnDesc     RNN layer descriptor (input)
+ * @param hiddenSize  Size of hidden state (output)
+ * @param layer       Number of stacked layers (output)
+ * @param dropoutDesc Pre-configured dropout descriptor for dropout layer in between RNN layers
+ * (output)
+ * @param inputMode   RNN data input mode (output)
+ * @param dirMode     Uni or bi direction mode (output)
+ * @param rnnMode     RNN mode (output)
+ * @param biasMode    Bias used (output)
+ * @param algoMode    RNN algorithm mode (output)
+ * @param dataType    Data type of RNN (output)
+ * @return            miopenStatus_t
+ */
 MIOPEN_EXPORT miopenStatus_t miopenGetRNNDescriptor_V2(miopenRNNDescriptor_t rnnDesc,
                                                        int* hiddenSize,
                                                        int* layer,
@@ -3103,10 +3162,10 @@ MIOPEN_EXPORT miopenStatus_t miopenGetRNNDescriptor_V2(miopenRNNDescriptor_t rnn
                                                        miopenDataType_t* dataType);
 
 /*! @brief Destroys the tensor descriptor object
-*
-* @param rnnDesc RNN tensor descriptor type (input)
-* @return           miopenStatus_t
-*/
+ *
+ * @param rnnDesc RNN tensor descriptor type (input)
+ * @return           miopenStatus_t
+ */
 MIOPEN_EXPORT miopenStatus_t miopenDestroyRNNDescriptor(miopenRNNDescriptor_t rnnDesc);
 
 /*! @brief Set the details of the RNN descriptor
@@ -3123,7 +3182,7 @@ MIOPEN_EXPORT miopenStatus_t miopenDestroyRNNDescriptor(miopenRNNDescriptor_t rn
  * @param algo         RNN algorithm selected (input)
  * @param dataType     Only fp32 currently supported for RNNs (input)
  * @return             miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenSetRNNDescriptor(miopenRNNDescriptor_t rnnDesc,
                                                     const int hsize,
                                                     const int nlayers,
@@ -3151,7 +3210,7 @@ MIOPEN_EXPORT miopenStatus_t miopenSetRNNDescriptor(miopenRNNDescriptor_t rnnDes
  * @param algo         RNN algorithm selected (input)
  * @param dataType     Only fp32 currently supported for RNNs (input)
  * @return             miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenSetRNNDescriptor_V2(miopenRNNDescriptor_t rnnDesc,
                                                        const int hsize,
                                                        const int nlayers,
@@ -3178,7 +3237,7 @@ MIOPEN_EXPORT miopenStatus_t miopenSetRNNDescriptor_V2(miopenRNNDescriptor_t rnn
  * vector length. (input)
  * @param numBytes        Number of bytes required for RNN layer execution (output)
  * @return                miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenGetRNNWorkspaceSize(miopenHandle_t handle,
                                                        const miopenRNNDescriptor_t rnnDesc,
                                                        const int sequenceLen,
@@ -3200,7 +3259,7 @@ MIOPEN_EXPORT miopenStatus_t miopenGetRNNWorkspaceSize(miopenHandle_t handle,
  * vector length. (input)
  * @param numBytes        Number of bytes required for RNN layer execution (output)
  * @return                miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenGetRNNTrainingReserveSize(miopenHandle_t handle,
                                                              miopenRNNDescriptor_t rnnDesc,
                                                              const int sequenceLen,
@@ -3218,7 +3277,7 @@ MIOPEN_EXPORT miopenStatus_t miopenGetRNNTrainingReserveSize(miopenHandle_t hand
  * @param numBytes        Number of bytes required for RNN layer execution (output)
  * @param dtype           MIOpen data type enum (input)
  * @return                miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenGetRNNParamsSize(miopenHandle_t handle,
                                                     miopenRNNDescriptor_t rnnDesc,
                                                     miopenTensorDescriptor_t xDesc,
@@ -3236,7 +3295,7 @@ MIOPEN_EXPORT miopenStatus_t miopenGetRNNParamsSize(miopenHandle_t handle,
  * @param wDesc           A previously allocated tensor descriptor (output)
  * @param dtype           MIOpen data type enum, currently only fp32 is supported (input)
  * @return                miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenGetRNNParamsDescriptor(miopenHandle_t handle,
                                                           miopenRNNDescriptor_t rnnDesc,
                                                           miopenTensorDescriptor_t xDesc,
@@ -3259,7 +3318,7 @@ MIOPEN_EXPORT miopenStatus_t miopenGetRNNParamsDescriptor(miopenHandle_t handle,
  * vector length. (input)
  * @param numBytes        Number of bytes required for input tensor (output)
  * @return                miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenGetRNNInputTensorSize(miopenHandle_t handle,
                                                          miopenRNNDescriptor_t rnnDesc,
                                                          const int seqLen,
@@ -3277,7 +3336,7 @@ MIOPEN_EXPORT miopenStatus_t miopenGetRNNInputTensorSize(miopenHandle_t handle,
  * @param xDesc           An array of previously populated tensor descriptors (input)
  * @param numBytes        Number of bytes required for input tensor (output)
  * @return                miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenGetRNNHiddenTensorSize(miopenHandle_t handle,
                                                           miopenRNNDescriptor_t rnnDesc,
                                                           const int seqLen,
@@ -3323,7 +3382,7 @@ MIOPEN_EXPORT miopenStatus_t miopenGetRNNHiddenTensorSize(miopenHandle_t handle,
  * @param paramID         ID of the internal parameter tensor (input)
  * @param numBytes        The number of bytes of the layer's parameter matrix (output)
  * @return                miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenGetRNNLayerParamSize(miopenHandle_t handle,
                                                         miopenRNNDescriptor_t rnnDesc,
                                                         const int layer,
@@ -3367,7 +3426,7 @@ MIOPEN_EXPORT miopenStatus_t miopenGetRNNLayerParamSize(miopenHandle_t handle,
  * @param biasID          ID of the internal parameter tensor (input)
  * @param numBytes        The number of bytes of the layer's bias (output)
  * @return                miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenGetRNNLayerBiasSize(miopenHandle_t handle,
                                                        miopenRNNDescriptor_t rnnDesc,
                                                        const int layer,
@@ -3431,7 +3490,7 @@ MIOPEN_EXPORT miopenStatus_t miopenGetRNNLayerBiasSize(miopenHandle_t handle,
  * @param paramDesc       Tensor descriptor for the fully packed output parameter tensor (output)
  * @param layerParam      Pointer to the memory location of the parameter tensor (output)
  * @return                miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenGetRNNLayerParam(miopenHandle_t handle,
                                                     miopenRNNDescriptor_t rnnDesc,
                                                     const int layer,
@@ -3498,7 +3557,7 @@ MIOPEN_EXPORT miopenStatus_t miopenGetRNNLayerParam(miopenHandle_t handle,
  * @param biasDesc        Descriptor of the parameter tensor (output)
  * @param layerBias       Pointer to the memory location of the bias tensor (output)
  * @return                miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenGetRNNLayerBias(miopenHandle_t handle,
                                                    miopenRNNDescriptor_t rnnDesc,
                                                    const int layer,
@@ -3562,7 +3621,7 @@ MIOPEN_EXPORT miopenStatus_t miopenGetRNNLayerBias(miopenHandle_t handle,
  * @param paramDesc         Tensor descriptor for the fully packed output parameter tensor (output)
  * @param layerParamOffset  Location for the parameter offset (output)
  * @return                  miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenGetRNNLayerParamOffset(miopenRNNDescriptor_t rnnDesc,
                                                           const int layer,
                                                           miopenTensorDescriptor_t xDesc,
@@ -3619,7 +3678,7 @@ MIOPEN_EXPORT miopenStatus_t miopenGetRNNLayerParamOffset(miopenRNNDescriptor_t 
  * @param biasDesc        Descriptor of the parameter tensor (output)
  * @param layerBiasOffset Pointer to the memory location of the bias tensor (output)
  * @return                miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenGetRNNLayerBiasOffset(miopenRNNDescriptor_t rnnDesc,
                                                          const int layer,
                                                          miopenTensorDescriptor_t xDesc,
@@ -3678,7 +3737,7 @@ MIOPEN_EXPORT miopenStatus_t miopenGetRNNLayerBiasOffset(miopenRNNDescriptor_t r
  * @param paramDesc       Descriptor of the parameter tensor (input)
  * @param layerParam      Pointer to the memory location of the parameter tensor (input)
  * @return                miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenSetRNNLayerParam(miopenHandle_t handle,
                                                     miopenRNNDescriptor_t rnnDesc,
                                                     const int layer,
@@ -3738,7 +3797,7 @@ MIOPEN_EXPORT miopenStatus_t miopenSetRNNLayerParam(miopenHandle_t handle,
  * @param biasDesc        Descriptor of the bias tensor (output)
  * @param layerBias       Pointer to the memory location of the bias tensor (output)
  * @return                miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenSetRNNLayerBias(miopenHandle_t handle,
                                                    miopenRNNDescriptor_t rnnDesc,
                                                    const int layer,
@@ -3805,7 +3864,7 @@ MIOPEN_EXPORT miopenStatus_t miopenSetRNNLayerBias(miopenHandle_t handle,
  * @param reserveSpace          Pointer to memory allocated for random states (input / output)
  * @param reserveSpaceNumBytes  Number of allocated bytes in memory for use in the forward  (input)
  * @return                      miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenRNNForwardTraining(miopenHandle_t handle,
                                                       const miopenRNNDescriptor_t rnnDesc,
                                                       const int sequenceLen,
@@ -3899,7 +3958,7 @@ MIOPEN_EXPORT miopenStatus_t miopenRNNForwardTraining(miopenHandle_t handle,
  * @param reserveSpace          Pointer to memory allocated for random states (input / output)
  * @param reserveSpaceNumBytes  Number of allocated bytes in memory for use in the forward (input)
  * @return                      miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenRNNBackwardData(miopenHandle_t handle,
                                                    const miopenRNNDescriptor_t rnnDesc,
                                                    const int sequenceLen,
@@ -3963,7 +4022,7 @@ MIOPEN_EXPORT miopenStatus_t miopenRNNBackwardData(miopenHandle_t handle,
  * @param reserveSpace          Pointer to memory allocated for random states (input)
  * @param reserveSpaceNumBytes  Number of allocated bytes in memory for use in the forward (input)
  * @return                      miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenRNNBackwardWeights(miopenHandle_t handle,
                                                       const miopenRNNDescriptor_t rnnDesc,
                                                       const int sequenceLen,
@@ -4034,7 +4093,7 @@ MIOPEN_EXPORT miopenStatus_t miopenRNNBackwardWeights(miopenHandle_t handle,
  * @param workSpace             Pointer to memory allocated for forward training (input)
  * @param workSpaceNumBytes     Number of allocated bytes in memory for the workspace (input)
  * @return                      miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenRNNForwardInference(miopenHandle_t handle,
                                                        miopenRNNDescriptor_t rnnDesc,
                                                        const int sequenceLen,
@@ -4059,13 +4118,13 @@ MIOPEN_EXPORT miopenStatus_t miopenRNNForwardInference(miopenHandle_t handle,
 // CLOSEOUT RNN DOXYGEN GROUP
 
 /** @addtogroup LossFunction
-*
-*  @{
-*/
+ *
+ *  @{
+ */
 
 /*! @enum miopenCTCLossAlgo_t
  * Algorithms available to execute the CTC loss operation
-*/
+ */
 typedef enum {
     MIOPEN_CTC_LOSS_ALGO_DETERMINISTIC = 0, /*!< Results are guaranteed to be reproducible */
 } miopenCTCLossAlgo_t;
@@ -4075,7 +4134,7 @@ typedef enum {
  * API for creating an uninitialized CTC loss function descriptor.
  * @param ctcLossDesc  Pointer to the CTC loss function descriptor type (output)
  * @return             miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenCreateCTCLossDescriptor(miopenCTCLossDescriptor_t* ctcLossDesc);
 
 /*! @brief Retrieves a CTC loss function descriptor's details
@@ -4086,7 +4145,7 @@ MIOPEN_EXPORT miopenStatus_t miopenCreateCTCLossDescriptor(miopenCTCLossDescript
  * @param blank_label_id       User defined index for blank label (output)
  * @param apply_softmax_layer  Boolean to toggle input layer property (output)
  * @return                     miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenGetCTCLossDescriptor(miopenCTCLossDescriptor_t ctcLossDesc,
                                                         miopenDataType_t* dataType,
                                                         int* blank_label_id,
@@ -4096,7 +4155,7 @@ MIOPEN_EXPORT miopenStatus_t miopenGetCTCLossDescriptor(miopenCTCLossDescriptor_
  *
  * @param ctcLossDesc  CTC loss function descriptor type (input)
  * @return             miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenDestroyCTCLossDescriptor(miopenCTCLossDescriptor_t ctcLossDesc);
 
 /*! @brief Set the details of a CTC loss function descriptor
@@ -4107,7 +4166,7 @@ MIOPEN_EXPORT miopenStatus_t miopenDestroyCTCLossDescriptor(miopenCTCLossDescrip
  * @param blank_label_id       User defined index for blank label, default 0 (input)
  * @param apply_softmax_layer  Boolean to toggle input layer property (input)
  * @return             miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenSetCTCLossDescriptor(miopenCTCLossDescriptor_t ctcLossDesc,
                                                         miopenDataType_t dataType,
                                                         const int blank_label_id,
@@ -4128,7 +4187,7 @@ MIOPEN_EXPORT miopenStatus_t miopenSetCTCLossDescriptor(miopenCTCLossDescriptor_
  * @param workSpaceSize  Number of bytes of workspace required for CTC loss operation with selected
  * algorithm (output)
  * @return               miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t
 miopenGetCTCLossWorkspaceSize(miopenHandle_t handle,
                               const miopenTensorDescriptor_t probsDesc,
@@ -4158,7 +4217,7 @@ miopenGetCTCLossWorkspaceSize(miopenHandle_t handle,
  * @param workSpaceSize  Number of bytes of workspace required for CTC loss operation with selected
  * algorithm (input)
  * @return               miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenCTCLoss(miopenHandle_t handle,
                                            const miopenTensorDescriptor_t probsDesc,
                                            const void* probs,
@@ -4183,8 +4242,8 @@ MIOPEN_EXPORT miopenStatus_t miopenCTCLoss(miopenHandle_t handle,
  */
 
 /*!  @enum miopenRNGType_t
-* random number generator type
-*/
+ * random number generator type
+ */
 typedef enum {
     MIOPEN_RNG_PSEUDO_XORWOW = 0, /*!< XORWOW pseudorandom generator */
 } miopenRNGType_t;
@@ -4193,14 +4252,14 @@ typedef enum {
  *
  * @param dropoutDesc Pointer to a dropout descriptor type
  * @return            miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenCreateDropoutDescriptor(miopenDropoutDescriptor_t* dropoutDesc);
 
 /*! @brief Destroys the dropout descriptor object
  *
  * @param dropoutDesc Dropout descriptor type (input)
  * @return            miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenDestroyDropoutDescriptor(miopenDropoutDescriptor_t dropoutDesc);
 
 /*! @brief Query the amount of memory required to run dropout
@@ -4210,7 +4269,7 @@ MIOPEN_EXPORT miopenStatus_t miopenDestroyDropoutDescriptor(miopenDropoutDescrip
  * @param reserveSpaceSizeInBytes  Number of bytes of reservespace required for executing dropout
  * (Output)
  * @return                         miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenDropoutGetReserveSpaceSize(const miopenTensorDescriptor_t xDesc,
                                                               size_t* reserveSpaceSizeInBytes);
 
@@ -4221,7 +4280,7 @@ MIOPEN_EXPORT miopenStatus_t miopenDropoutGetReserveSpaceSize(const miopenTensor
  * @param handle            MIOpen handle (input)
  * @param stateSizeInBytes  Number of bytes required to store random generator states (Output)
  * @return                  miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenDropoutGetStatesSize(miopenHandle_t handle,
                                                         size_t* stateSizeInBytes);
 
@@ -4240,7 +4299,7 @@ MIOPEN_EXPORT miopenStatus_t miopenDropoutGetStatesSize(miopenHandle_t handle,
  * @param rng_mode     Random number generator used to generate parallel random number sequences
  * (Output)
  * @return             miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenGetDropoutDescriptor(miopenDropoutDescriptor_t dropoutDesc,
                                                         miopenHandle_t handle,
                                                         float* dropout,
@@ -4271,7 +4330,7 @@ MIOPEN_EXPORT miopenStatus_t miopenGetDropoutDescriptor(miopenDropoutDescriptor_
  * @param rng_mode          Random number generator used to generate parallel random number
  * sequences (input)
  * @return                  miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenRestoreDropoutDescriptor(miopenDropoutDescriptor_t dropoutDesc,
                                                             miopenHandle_t handle,
                                                             float dropout,
@@ -4300,7 +4359,7 @@ MIOPEN_EXPORT miopenStatus_t miopenRestoreDropoutDescriptor(miopenDropoutDescrip
  * @param rng_mode          Random number generator used to generate parallel random number
  * sequences (input)
  * @return                  miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenSetDropoutDescriptor(miopenDropoutDescriptor_t dropoutDesc,
                                                         miopenHandle_t handle,
                                                         float dropout,
@@ -4327,7 +4386,7 @@ MIOPEN_EXPORT miopenStatus_t miopenSetDropoutDescriptor(miopenDropoutDescriptor_
  * @param reserveSpaceSizeInBytes  Number of bytes of reservespace required for executing forward
  * dropout (input)
  * @return                         miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenDropoutForward(miopenHandle_t handle,
                                                   const miopenDropoutDescriptor_t dropoutDesc,
                                                   const miopenTensorDescriptor_t noise_shape,
@@ -4354,7 +4413,7 @@ MIOPEN_EXPORT miopenStatus_t miopenDropoutForward(miopenHandle_t handle,
  * @param reserveSpaceSizeInBytes  Number of bytes of reservespace required for executing backward
  * dropout (input)
  * @return                         miopenStatus_t
-*/
+ */
 MIOPEN_EXPORT miopenStatus_t miopenDropoutBackward(miopenHandle_t handle,
                                                    const miopenDropoutDescriptor_t dropoutDesc,
                                                    const miopenTensorDescriptor_t noise_shape,
@@ -4367,6 +4426,143 @@ MIOPEN_EXPORT miopenStatus_t miopenDropoutBackward(miopenHandle_t handle,
 
 /** @} */
 // CLOSEOUT DROPOUT DOXYGEN GROUP
+
+// TensorReduce APIs
+/** @addtogroup TensorReduce
+ *
+ *  @{
+ */
+
+/*! @brief Creates the ReduceTensor descriptor object
+ *
+ * @param reduceTensorDesc Pointer to a ReduceTensor descriptor type
+ * @return            miopenStatus_t
+ */
+MIOPEN_EXPORT miopenStatus_t
+miopenCreateReduceTensorDescriptor(miopenReduceTensorDescriptor_t* reduceTensorDesc);
+
+/*! @brief Destroy the ReduceTensor descriptor object
+ *
+ * @param reduceTensorDesc  ReduceTensor descriptor type (input)
+ * @return            miopenStatus_t
+ */
+MIOPEN_EXPORT miopenStatus_t
+miopenDestroyReduceTensorDescriptor(miopenReduceTensorDescriptor_t reduceTensorDesc);
+
+/*! @brief Initialize a ReduceTensor descriptor object
+ *
+ * @param reduceTensorDesc         Pointer to the ReduceTensor descriptor object (output)
+ * @param reduceTensorOp           Enumerant specifying the operation used by ReduceTensor (input)
+ * @param reduceTensorCompType     Enumerant specifying the data type used with ReduceTensor
+ * operation (input)
+ * @param reduceTensorNanOpt       Enumerant specifying the Nan number propagation mode (input)
+ * @param reduceTensorIndices      Enumerant specifying the indices modes used by ReduceTensor
+ * (input)
+ * @param reduceTensorIndicesType  Enumerant specifying the data type of the indices (input)
+ * @return           miopenStatus_t
+ */
+MIOPEN_EXPORT miopenStatus_t
+miopenSetReduceTensorDescriptor(miopenReduceTensorDescriptor_t reduceTensorDesc,
+                                miopenReduceTensorOp_t reduceTensorOp,
+                                miopenDataType_t reduceTensorCompType,
+                                miopenNanPropagation_t reduceTensorNanOpt,
+                                miopenReduceTensorIndices_t reduceTensorIndices,
+                                miopenIndicesType_t reduceTensorIndicesType);
+
+/*! @brief Query a ReduceTensor descriptor object
+ *
+ * @param reduceTensorDesc         Pointer to the ReduceTensor descriptor object (input)
+ * @param reduceTensorOp           Pointer to enumerant specifying the operation used by
+ * ReduceTensor (output)
+ * @param reduceTensorCompType     Pointer to enumerant specifying the data type used with
+ * ReduceTensor operation (output)
+ * @param reduceTensorNanOpt       Pointer to enumerant specifying the Nan number propagation mode
+ * (output)
+ * @param reduceTensorIndices      Pointer to enumerant specifying the indices modes used by
+ * ReduceTensor (output)
+ * @param reduceTensorIndicesType  Pointer to enumerant specifying the data type of the indices
+ * (output)
+ * @return           miopenStatus_t
+ */
+MIOPEN_EXPORT miopenStatus_t
+miopenGetReduceTensorDescriptor(const miopenReduceTensorDescriptor_t reduceTensorDesc,
+                                miopenReduceTensorOp_t* reduceTensorOp,
+                                miopenDataType_t* reduceTensorCompType,
+                                miopenNanPropagation_t* reduceTensorNanOpt,
+                                miopenReduceTensorIndices_t* reduceTensorIndices,
+                                miopenIndicesType_t* reduceTensorIndicesType);
+
+/*! @brief Helper function to query the minimum index space size required by the ReduceTensor call
+ *
+ * @param handle                   MIOpen Handle (input)
+ * @param reduceTensorDesc         Pointer to the ReduceTensor descriptor object (input)
+ * @param aDesc                    Pointer to the input tensor descriptor (input)
+ * @param cDesc                    Pointer to the output tensor descriptor (input)
+ * @param sizeInBytes              Pointer to data to return the minimum index space size
+ * @return           miopenStatus_t
+ */
+MIOPEN_EXPORT miopenStatus_t
+miopenGetReductionIndicesSize(miopenHandle_t handle,
+                              const miopenReduceTensorDescriptor_t reduceTensorDesc,
+                              const miopenTensorDescriptor_t aDesc,
+                              const miopenTensorDescriptor_t cDesc,
+                              size_t* sizeInBytes);
+
+/*! @brief Helper function to query the minimum workspace size required by the ReduceTensor call
+ *
+ * @param handle                   MIOpen Handle (input)
+ * @param reduceTensorDesc         Pointer to the ReduceTensor descriptor object (input)
+ * @param aDesc                    Pointer to the input tensor descriptor (input)
+ * @param cDesc                    Pointer to the output tensor descriptor (input)
+ * @param sizeInBytes              Pointer to data to return the minimum workspace size
+ * @return           miopenStatus_t
+ */
+MIOPEN_EXPORT miopenStatus_t
+miopenGetReductionWorkspaceSize(miopenHandle_t handle,
+                                const miopenReduceTensorDescriptor_t reduceTensorDesc,
+                                const miopenTensorDescriptor_t aDesc,
+                                const miopenTensorDescriptor_t cDesc,
+                                size_t* sizeInBytes);
+
+/*! @brief TensorReduce function doing reduction on tensor A by implementing C = alpha * reduceOp(A)
+ * + beta * C
+ *
+ * The length of each dimension of output tensor C must match the length of the corresponding
+ * dimension of
+ * input tensor A or must be equal to 1. The dimensions with length equal to 1 indicate the
+ * dimensions
+ * of A to be reduced.
+ *
+ * @param handle                   MIOpen Handle (input)
+ * @param reduceTensorDesc         Pointer to the ReduceTensor descriptor object (input)
+ * @param indices                  Address of the allocated indices data space (output)
+ * @param indicesSizeInBytes       Size in bytes of the allocated indices data space (input)
+ * @param workspace                Address of the allocated workspace data (input)
+ * @param workspaceSizeInBytes     Size in bytes of the allocated workspace data (input)
+ * @param alpha                    Pointer to scale factor for data in input tensor A (input)
+ * @param aDesc                    Pointer to the tensor descriptor for input tensor A (input)
+ * @param A                        Pointer to the data of input tensor A (input)
+ * @param beta                     Pointer to scale factor for data in output tensor C (input)
+ * @param cDesc                    Pointer to the tensor descriptor for output tensor C (input)
+ * @param C                        Pointer to the data of output tensor C (output)
+ * @return           miopenStatus_t
+ */
+MIOPEN_EXPORT miopenStatus_t
+miopenReduceTensor(miopenHandle_t handle,
+                   const miopenReduceTensorDescriptor_t reduceTensorDesc,
+                   void* indices,
+                   size_t indicesSizeInBytes,
+                   void* workspace,
+                   size_t workspaceSizeInBytes,
+                   const void* alpha,
+                   const miopenTensorDescriptor_t aDesc,
+                   const void* A,
+                   const void* beta,
+                   const miopenTensorDescriptor_t cDesc,
+                   void* C);
+
+/** @} */
+// CLOSEOUT TensorReduce DOXYGEN GROUP
 
 #ifdef __cplusplus
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -126,6 +126,7 @@ set( MIOpen_Source
     execution_context.cpp
     kern_db.cpp
     bz2.cpp
+    reducetensor.cpp
     include/miopen/buffer_info.hpp
     include/miopen/temp_file.hpp
     include/miopen/bfloat16.hpp
@@ -175,6 +176,8 @@ set( MIOpen_Source
     include/miopen/rnn_util.hpp
     include/miopen/bz2.hpp
     include/miopen/comgr.hpp
+    include/miopen/reducetensor.hpp
+    include/miopen/reduce_common.hpp
     md_graph.cpp
     mdg_expr.cpp
     conv/invokers/gcn_asm_1x1u.cpp

--- a/src/include/miopen/reduce_common.hpp
+++ b/src/include/miopen/reduce_common.hpp
@@ -1,0 +1,311 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2020 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#ifndef GUARD_MIOPEN_REDUCE_COMMON_HPP
+#define GUARD_MIOPEN_REDUCE_COMMON_HPP
+
+#include <half.hpp>
+#include <limits>
+#include <cmath>
+#include <miopen/miopen.h>
+#include <miopen/float_equal.hpp>
+
+#include "bfloat16.hpp"
+
+namespace reduce {
+
+enum ReductionMethod_t
+{
+    Reduce_DirectThreadWise = 1,
+    Reduce_DirectWarpWise   = 2,
+    Reduce_BlockWise        = 3,
+    Reduce_MultiBlock       = 4
+};
+
+// data type conversion
+template <typename T>
+struct type_convert
+{
+    template <typename X>
+    T operator()(X x) const
+    {
+        return static_cast<T>(x);
+    }
+};
+
+template <>
+template <>
+inline float type_convert<float>::operator()<half_float::half>(half_float::half x) const
+{
+    return half_float::half_cast<float>(x);
+};
+
+template <>
+template <>
+inline half_float::half type_convert<half_float::half>::operator()<float>(float x) const
+{
+    return half_float::half_cast<half_float::half>(x);
+};
+
+template <>
+template <>
+inline float type_convert<float>::operator()<bfloat16>(bfloat16 x) const
+{
+    return float(x);
+};
+
+template <>
+template <>
+inline bfloat16 type_convert<bfloat16>::operator()<float>(float x) const
+{
+    return bfloat16(x);
+};
+
+template <typename compType>
+static inline std::function<void(compType&, compType)> ReduceOpFn(miopenReduceTensorOp_t op_)
+{
+    switch(op_)
+    {
+    case MIOPEN_REDUCE_TENSOR_ADD: return ([&](compType& a_, compType b_) { a_ = a_ + b_; });
+
+    case MIOPEN_REDUCE_TENSOR_MUL: return ([&](compType& a_, compType b_) { a_ = a_ * b_; });
+
+    case MIOPEN_REDUCE_TENSOR_MIN:
+        return ([&](compType& a_, compType b_) {
+            if(a_ > b_)
+                a_ = b_;
+        });
+
+    case MIOPEN_REDUCE_TENSOR_MAX:
+        return ([&](compType& a_, compType b_) {
+            if(a_ < b_)
+                a_ = b_;
+        });
+    }
+
+    return (std::function<void(compType&, compType)>{});
+};
+
+template <typename compType>
+static inline std::function<void(compType&, compType, bool& changed)>
+ReduceOpFn2(miopenReduceTensorOp_t op_)
+{
+    switch(op_)
+    {
+    case MIOPEN_REDUCE_TENSOR_MIN:
+        return ([&](compType& a_, compType b_, bool& changed) {
+            if(a_ > b_)
+            {
+                a_      = b_;
+                changed = true;
+            }
+            else
+                changed = false;
+        });
+
+    case MIOPEN_REDUCE_TENSOR_MAX:
+        return ([&](compType& a_, compType b_, bool& changed) {
+            if(a_ < b_)
+            {
+                a_      = b_;
+                changed = true;
+            }
+            else
+                changed = false;
+        });
+
+    case MIOPEN_REDUCE_TENSOR_ADD:
+    case MIOPEN_REDUCE_TENSOR_MUL: return (std::function<void(compType&, compType, bool&)>{});
+    };
+
+    return (std::function<void(compType&, compType, bool&)>{});
+};
+
+template <typename compType>
+static inline compType ReduceOpZeroVal(miopenReduceTensorOp_t op_)
+{
+    switch(op_)
+    {
+    case MIOPEN_REDUCE_TENSOR_ADD: return (type_convert<compType>{}(0.0));
+
+    case MIOPEN_REDUCE_TENSOR_MUL: return (type_convert<compType>{}(1.0));
+
+    case MIOPEN_REDUCE_TENSOR_MIN: return (std::numeric_limits<compType>::max());
+
+    case MIOPEN_REDUCE_TENSOR_MAX: return (std::numeric_limits<compType>::min());
+    }
+
+    return (type_convert<compType>{}(0.0));
+};
+
+template <>
+inline half_float::half ReduceOpZeroVal<half_float::half>(miopenReduceTensorOp_t op_)
+{
+    switch(op_)
+    {
+    case MIOPEN_REDUCE_TENSOR_ADD: return (type_convert<half_float::half>{}(0.0));
+
+    case MIOPEN_REDUCE_TENSOR_MUL: return (type_convert<half_float::half>{}(1.0));
+
+    case MIOPEN_REDUCE_TENSOR_MIN:
+        return (type_convert<half_float::half>{}(std::numeric_limits<float>::max()));
+
+    case MIOPEN_REDUCE_TENSOR_MAX:
+        return (type_convert<half_float::half>{}(std::numeric_limits<float>::min()));
+    }
+
+    return (type_convert<half_float::half>{}(0.0));
+};
+
+template <typename T>
+static inline bool IsNan(T x)
+{
+    // C++ isnan() is used for float and double
+    return (std::isnan(x));
+};
+
+template <>
+inline bool IsNan<half_float::half>(half_float::half x)
+{
+    return (half_float::isnan(x));
+};
+
+template <typename T>
+static inline bool IsFinite(T x)
+{
+    // C++ isfinite() is used for float and double
+    return (std::isfinite(x));
+};
+
+template <>
+inline bool IsFinite<half_float::half>(half_float::half x)
+{
+    return (half_float::isfinite(x));
+};
+
+struct float_equal_one
+{
+    template <class T>
+    static bool apply(T x)
+    {
+        return std::isfinite(x) and
+               std::nextafter(x, std::numeric_limits<T>::lowest()) <= static_cast<T>(1.0) and
+               std::nextafter(x, std::numeric_limits<T>::max()) >= static_cast<T>(1.0);
+    }
+
+    template <class T>
+    bool operator()(T x)
+    {
+        return (float_equal_one::apply(x));
+    };
+};
+
+struct float_equal_zero
+{
+    template <class T>
+    static bool apply(T x)
+    {
+        return std::isfinite(x) and
+               std::nextafter(x, std::numeric_limits<T>::lowest()) <= static_cast<T>(0.0) and
+               std::nextafter(x, std::numeric_limits<T>::max()) >= static_cast<T>(0.0);
+    }
+
+    template <class T>
+    bool operator()(T x)
+    {
+        return (float_equal_zero::apply(x));
+    };
+};
+
+template <>
+inline bool float_equal_one::apply<half_float::half>(half_float::half x)
+{
+    return half_float::isfinite(x) and x <= type_convert<half_float::half>{}(1.0) and
+           x >= type_convert<half_float::half>{}(1.0);
+};
+
+template <>
+inline bool float_equal_zero::apply<half_float::half>(half_float::half x)
+{
+    return half_float::isfinite(x) and x <= type_convert<half_float::half>{}(0.0) and
+           x >= type_convert<half_float::half>{}(0.0);
+};
+
+template <typename compType>
+static inline void binop_with_nan_check(miopenNanPropagation_t nanOpt,
+                                        std::function<void(compType&, compType)> opReduce,
+                                        compType& accuVal,
+                                        compType currVal)
+{
+    if(nanOpt == MIOPEN_NOT_PROPAGATE_NAN)
+        opReduce(accuVal, currVal);
+    else
+    {
+        if(reduce::IsNan(currVal))
+            accuVal = currVal;
+        else
+            opReduce(accuVal, currVal);
+    };
+};
+
+template <typename compType>
+static inline void binop_with_nan_check2(miopenNanPropagation_t nanOpt,
+                                         std::function<void(compType&, compType, bool&)> opReduce,
+                                         compType& accuVal,
+                                         compType currVal,
+                                         int& accuIndex,
+                                         int currIndex)
+{
+    if(nanOpt == MIOPEN_NOT_PROPAGATE_NAN)
+    {
+        bool changed;
+
+        opReduce(accuVal, currVal, changed);
+
+        if(changed)
+            accuIndex = currIndex;
+    }
+    else
+    {
+        if(reduce::IsNan(currVal))
+        {
+            accuVal   = currVal;
+            accuIndex = currIndex;
+        }
+        else
+        {
+            bool changed;
+
+            opReduce(accuVal, currVal, changed);
+
+            if(changed)
+                accuIndex = currIndex;
+        };
+    };
+};
+
+}; // end of namespace reduce
+
+#endif

--- a/src/include/miopen/reducetensor.hpp
+++ b/src/include/miopen/reducetensor.hpp
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2017 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#ifndef GUARD_MIOPEN_REDUCETENSOR_HPP
+#define GUARD_MIOPEN_REDUCETENSOR_HPP
+
+#include <miopen/common.hpp>
+#include <miopen/kernel.hpp>
+#include <miopen/miopen.h>
+#include <miopen/object.hpp>
+#include <miopen/solver_id.hpp>
+#include <miopen/names.hpp>
+#include <miopen/tensor.hpp>
+#include <miopen/handle.hpp>
+
+#include <string>
+#include <tuple>
+#include <vector>
+
+namespace miopen {
+
+struct ReduceTensorDescriptor : miopenReduceTensorDescriptor
+{
+    ReduceTensorDescriptor() = default;
+    ReduceTensorDescriptor(miopenReduceTensorOp_t reduceTensorOp,
+                           miopenDataType_t reduceTensorCompType,
+                           miopenNanPropagation_t reduceTensorNanOpt,
+                           miopenReduceTensorIndices_t reduceTensorIndices,
+                           miopenIndicesType_t reduceTensorIndicesType);
+
+    miopenReduceTensorOp_t reduceTensorOp_;
+    miopenDataType_t reduceTensorCompType_;
+    miopenNanPropagation_t reduceTensorNanOpt_;
+    miopenReduceTensorIndices_t reduceTensorIndices_;
+    miopenIndicesType_t reduceTensorIndicesType_;
+
+    std::size_t GetWorkspaceSize(const Handle& handle,
+                                 const TensorDescriptor& inDesc,
+                                 const TensorDescriptor& outDesc) const;
+    std::size_t GetIndicesSize(const TensorDescriptor& inDesc,
+                               const TensorDescriptor& outDesc) const;
+    void ReduceTensor(const Handle& handle,
+                      Data_t indices,
+                      size_t indicesSizeInBytes,
+                      Data_t workspace,
+                      size_t workspaceSizeInBytes,
+                      const void* alpha,
+                      const TensorDescriptor& aDesc,
+                      ConstData_t A,
+                      const void* beta,
+                      const TensorDescriptor& cDesc,
+                      Data_t C) const;
+};
+
+std::ostream& operator<<(std::ostream& stream, const ReduceTensorDescriptor& c);
+
+} // namespace miopen
+MIOPEN_DEFINE_OBJECT(miopenReduceTensorDescriptor, miopen::ReduceTensorDescriptor);
+
+#endif // GUARD_MIOPEN_CONVOLUTION_HPP_

--- a/src/kernels/composable_kernel/include/kernel_algorithm/gridwise_generic_2d_reduction_blockwise.hpp
+++ b/src/kernels/composable_kernel/include/kernel_algorithm/gridwise_generic_2d_reduction_blockwise.hpp
@@ -1,0 +1,462 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2020 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#ifndef CK_GRIDWISE_GENERIC_2D_REDUCTION_BLOCKWISE_HPP
+#define CK_GRIDWISE_GENERIC_2D_REDUCTION_BLOCKWISE_HPP
+
+#include "float_type.hpp"
+#include "reduction_operator.hpp"
+#include "reduction_functions.hpp"
+#include "reduction_common.hpp"
+
+#include "blockwise_generic_tensor_slice_copy.hpp"
+#include "ConstantMatrixDescriptor.hpp"
+
+namespace ck {
+
+template <int BlockSize,
+          typename srcDataType,
+          typename dstDataType,
+          typename src2dDesc,
+          typename dst1dDesc,
+          typename compType,
+          ckReduceTensorOp_t op,
+          ckNanPropagation_t nanPropaOpt,
+          ckReduceTensorIndices_t reduceIndicesOpt,
+          int callId,
+          int GredAccessesPerThreadInBlock>
+struct Gridwise_generic_reduction_xy_to_x_blockwise
+{
+    static constexpr bool indexable = reduce_binary_operator<compType, op>::indexable;
+    static constexpr bool need_indices =
+        indexable && (reduceIndicesOpt != CK_REDUCE_TENSOR_NO_INDICES);
+    static constexpr bool firstCall = (callId == 0) ? true : false;
+
+    static constexpr int BlockBufferSize = BlockSize * GredAccessesPerThreadInBlock;
+
+    using opReduce = typename reduce_binary_operator<compType, op>::opType;
+
+    __device__ void Run(srcDataType alpha,
+                        const srcDataType* const __restrict__ p_src_global,
+                        dstDataType beta,
+                        dstDataType* const __restrict__ p_dst_global,
+                        int* const __restrict__ ws_indices_global,
+                        int* const __restrict__ indices_global)
+    {
+        static_if<need_indices>{}([&](auto) {
+            static_if<firstCall>{}([&](auto) {
+                RunImpl2(alpha, p_src_global, beta, p_dst_global, indices_global);
+            }).Else([&](auto) {
+                RunImpl3(
+                    alpha, p_src_global, beta, p_dst_global, ws_indices_global, indices_global);
+            });
+        }).Else([&](auto) { RunImpl1(alpha, p_src_global, beta, p_dst_global); });
+    };
+
+    __device__ static void RunImpl1(srcDataType alpha,
+                                    const srcDataType* const __restrict__ p_src_global,
+                                    dstDataType beta,
+                                    dstDataType* const __restrict__ p_dst_global)
+    {
+        // LDS
+        __shared__ compType p_in_block_buffer[BlockBufferSize];
+
+        // VGPR, only useful for thread 0
+        auto zeroVal       = opReduce::getZeroVal();
+        compType accuValue = zeroVal;
+
+        const int thread_local_id    = get_thread_local_1d_id();
+        const int block_global_1d_id = get_block_1d_id();
+
+        constexpr auto in_block_desc =
+            make_native_tensor_descriptor_packed(Sequence<1, BlockBufferSize>{});
+
+        using ThreadSliceLengths   = Sequence<1, GredAccessesPerThreadInBlock>;
+        using ThreadClusterLengths = Sequence<1, BlockSize>;
+
+        auto blockwise_src_load =
+            BlockwiseGenericTensorSliceCopy_v4<BlockSize,
+                                               src2dDesc,
+                                               decltype(in_block_desc),
+                                               decltype(in_block_desc.GetLengths()),
+                                               ThreadSliceLengths,
+                                               ThreadClusterLengths,
+                                               Sequence<0, 1>,
+                                               Sequence<0, 1>,
+                                               Sequence<0, 1>,
+                                               1,
+                                               1,
+                                               1,
+                                               1,
+                                               AddressSpace::Global,
+                                               AddressSpace::Vgpr,
+                                               AddressSpace::Lds,
+                                               InMemoryDataOperation::Set>({block_global_1d_id, 0},
+                                                                           {0, 0});
+
+        constexpr auto block_buff_2d_desc = make_native_tensor_descriptor_packed(
+            Sequence<GredAccessesPerThreadInBlock, BlockSize>{});
+
+        using blockwise_reduce = BlockwiseReduction_2d_block_buffer<decltype(block_buff_2d_desc),
+                                                                    compType,
+                                                                    true,
+                                                                    opReduce,
+                                                                    nanPropaOpt>;
+
+        const int toReduceBlocks = (src2dDesc::GetLengths()[1] + BlockSize - 1) / BlockSize;
+
+        for(int reducedBlocks = 0; reducedBlocks < toReduceBlocks;
+            reducedBlocks += GredAccessesPerThreadInBlock)
+        {
+            blockwise_reduce::set_buffer_value(p_in_block_buffer, zeroVal);
+
+            // load block data from global to LDS, no use of double buffers (to be improved)
+            blockwise_src_load.Run(
+                p_src_global, p_in_block_buffer, type_convert<srcDataType>{}(zeroVal));
+
+            __syncthreads();
+
+            int BlocksInOneOp = (reducedBlocks < toReduceBlocks - GredAccessesPerThreadInBlock)
+                                    ? GredAccessesPerThreadInBlock
+                                    : toReduceBlocks - reducedBlocks;
+            blockwise_reduce::reduce(p_in_block_buffer, BlocksInOneOp, accuValue);
+
+            constexpr auto True = integral_constant<bool, true>{};
+            blockwise_src_load.MoveSrcSliceWindow(Sequence<0, BlockBufferSize>{}, True);
+        }
+
+        using ReducedDataLengths       = Sequence<1>;
+        constexpr auto ReducedDataDesc = make_native_tensor_descriptor_packed(ReducedDataLengths{});
+
+        // The first thread in the block stores the reduced result to the global location
+        // representing the block
+        if(thread_local_id == 0)
+        {
+            if(!float_equal_one{}(alpha))
+                accuValue *= type_convert<compType>{}(alpha);
+
+            if(!float_equal_zero{}(beta))
+            {
+                auto threadwise_dst_load =
+                    ThreadwiseGenericTensorSliceCopy_v4r2<dst1dDesc,
+                                                          decltype(ReducedDataDesc),
+                                                          ReducedDataLengths,
+                                                          Sequence<0>,
+                                                          0,
+                                                          1,
+                                                          1,
+                                                          AddressSpace::Global,
+                                                          AddressSpace::Vgpr,
+                                                          InMemoryDataOperation::Set>(
+                        {block_global_1d_id}, {0});
+                dstDataType priorDstValue;
+
+                threadwise_dst_load.Run(
+                    p_dst_global, &priorDstValue, type_convert<dstDataType>{}(zeroVal));
+
+                accuValue += type_convert<compType>{}(priorDstValue * beta);
+            }
+
+            auto threadwise_dst_store =
+                ThreadwiseGenericTensorSliceCopy_v4r2<decltype(ReducedDataDesc),
+                                                      dst1dDesc,
+                                                      ReducedDataLengths,
+                                                      Sequence<0>,
+                                                      0,
+                                                      1,
+                                                      1,
+                                                      AddressSpace::Vgpr,
+                                                      AddressSpace::Global,
+                                                      InMemoryDataOperation::Set>(
+                    {0}, {block_global_1d_id});
+            threadwise_dst_store.Run(&accuValue, p_dst_global, zeroVal);
+        }
+    };
+
+    __device__ static void RunImpl2(srcDataType alpha,
+                                    const srcDataType* const __restrict__ p_src_global,
+                                    dstDataType beta,
+                                    dstDataType* const __restrict__ p_dst_global,
+                                    int* const __restrict__ indices_global)
+    {
+        // LDS
+        __shared__ compType p_in_block_buffer[BlockBufferSize];
+        __shared__ int block_indices_buffer[BlockBufferSize];
+
+        // VGPR, only useful for thread 0
+        auto zeroVal       = opReduce::getZeroVal();
+        compType accuValue = zeroVal;
+        int accuIndex      = 0;
+
+        const int thread_local_id    = get_thread_local_1d_id();
+        const int block_global_1d_id = get_block_1d_id();
+
+        constexpr auto in_block_desc =
+            make_native_tensor_descriptor_packed(Sequence<1, BlockBufferSize>{});
+
+        using ThreadSliceLengths   = Sequence<1, GredAccessesPerThreadInBlock>;
+        using ThreadClusterLengths = Sequence<1, BlockSize>;
+
+        auto blockwise_src_load =
+            BlockwiseGenericTensorSliceCopy_v4<BlockSize,
+                                               src2dDesc,
+                                               decltype(in_block_desc),
+                                               decltype(in_block_desc.GetLengths()),
+                                               ThreadSliceLengths,
+                                               ThreadClusterLengths,
+                                               Sequence<0, 1>,
+                                               Sequence<0, 1>,
+                                               Sequence<0, 1>,
+                                               1,
+                                               1,
+                                               1,
+                                               1,
+                                               AddressSpace::Global,
+                                               AddressSpace::Vgpr,
+                                               AddressSpace::Lds,
+                                               InMemoryDataOperation::Set>({block_global_1d_id, 0},
+                                                                           {0, 0});
+
+        constexpr auto block_buff_2d_desc = make_native_tensor_descriptor_packed(
+            Sequence<GredAccessesPerThreadInBlock, BlockSize>{});
+
+        using blockwise_reduce = BlockwiseReduction_2d_block_buffer<decltype(block_buff_2d_desc),
+                                                                    compType,
+                                                                    true,
+                                                                    opReduce,
+                                                                    nanPropaOpt>;
+
+        const int toReduceBlocks = (src2dDesc::GetLengths()[1] + BlockSize - 1) / BlockSize;
+
+        int indexOffset = 0;
+
+        for(int reducedBlocks = 0; reducedBlocks < toReduceBlocks;
+            reducedBlocks += GredAccessesPerThreadInBlock)
+        {
+            blockwise_reduce::set_buffer_value(p_in_block_buffer, zeroVal);
+
+            // load block data from global to LDS, no use of double buffers (to be improved)
+            blockwise_src_load.Run(
+                p_src_global, p_in_block_buffer, type_convert<srcDataType>{}(zeroVal));
+
+            __syncthreads();
+
+            // construct the indices for the current toReduce blocks
+            blockwise_reduce::init_buffer_indices(block_indices_buffer, indexOffset);
+
+            int BlocksInOneOp = (reducedBlocks < toReduceBlocks - GredAccessesPerThreadInBlock)
+                                    ? GredAccessesPerThreadInBlock
+                                    : toReduceBlocks - reducedBlocks;
+
+            blockwise_reduce::reduce2(
+                p_in_block_buffer, block_indices_buffer, BlocksInOneOp, accuValue, accuIndex);
+
+            indexOffset += BlockBufferSize;
+
+            constexpr auto True = integral_constant<bool, true>{};
+            blockwise_src_load.MoveSrcSliceWindow(Sequence<0, BlockBufferSize>{}, True);
+        }
+
+        using ReducedDataLengths       = Sequence<1>;
+        constexpr auto ReducedDataDesc = make_native_tensor_descriptor_packed(ReducedDataLengths{});
+
+        // The first thread in the block stores the reduced result to the global location
+        // representing the block
+        if(thread_local_id == 0)
+        {
+            if(!float_equal_one{}(alpha))
+                accuValue *= type_convert<compType>{}(alpha);
+
+            if(!float_equal_zero{}(beta))
+            {
+                auto threadwise_dst_load =
+                    ThreadwiseGenericTensorSliceCopy_v4r2<dst1dDesc,
+                                                          decltype(ReducedDataDesc),
+                                                          ReducedDataLengths,
+                                                          Sequence<0>,
+                                                          0,
+                                                          1,
+                                                          1,
+                                                          AddressSpace::Global,
+                                                          AddressSpace::Vgpr,
+                                                          InMemoryDataOperation::Set>(
+                        {block_global_1d_id}, {0});
+                dstDataType priorDstValue;
+
+                threadwise_dst_load.Run(
+                    p_dst_global, &priorDstValue, type_convert<dstDataType>{}(zeroVal));
+
+                accuValue += type_convert<compType>{}(priorDstValue * beta);
+            }
+
+            auto threadwise_dst_store =
+                ThreadwiseGenericTensorSliceCopy_v4r2<decltype(ReducedDataDesc),
+                                                      dst1dDesc,
+                                                      ReducedDataLengths,
+                                                      Sequence<0>,
+                                                      0,
+                                                      1,
+                                                      1,
+                                                      AddressSpace::Vgpr,
+                                                      AddressSpace::Global,
+                                                      InMemoryDataOperation::Set>(
+                    {0}, {block_global_1d_id});
+            threadwise_dst_store.Run(&accuValue, p_dst_global, zeroVal);
+            threadwise_dst_store.Run(&accuIndex, indices_global, 0);
+        }
+    };
+
+    __device__ static void RunImpl3(srcDataType alpha,
+                                    const srcDataType* const __restrict__ p_src_global,
+                                    dstDataType beta,
+                                    dstDataType* const __restrict__ p_dst_global,
+                                    int* const __restrict__ ws_indices_global,
+                                    int* const __restrict__ indices_global)
+    {
+        // LDS
+        __shared__ compType p_in_block_buffer[BlockBufferSize];
+        __shared__ int block_indices_buffer[BlockBufferSize];
+
+        // VGPR, only useful for thread 0
+        auto zeroVal       = opReduce::getZeroVal();
+        compType accuValue = zeroVal;
+        int accuIndex      = 0;
+
+        const int thread_local_id    = get_thread_local_1d_id();
+        const int block_global_1d_id = get_block_1d_id();
+
+        constexpr auto in_block_desc =
+            make_native_tensor_descriptor_packed(Sequence<1, BlockBufferSize>{});
+
+        using ThreadSliceLengths   = Sequence<1, GredAccessesPerThreadInBlock>;
+        using ThreadClusterLengths = Sequence<1, BlockSize>;
+
+        auto blockwise_src_load =
+            BlockwiseGenericTensorSliceCopy_v4<BlockSize,
+                                               src2dDesc,
+                                               decltype(in_block_desc),
+                                               decltype(in_block_desc.GetLengths()),
+                                               ThreadSliceLengths,
+                                               ThreadClusterLengths,
+                                               Sequence<0, 1>,
+                                               Sequence<0, 1>,
+                                               Sequence<0, 1>,
+                                               1,
+                                               1,
+                                               1,
+                                               1,
+                                               AddressSpace::Global,
+                                               AddressSpace::Vgpr,
+                                               AddressSpace::Lds,
+                                               InMemoryDataOperation::Set>({block_global_1d_id, 0},
+                                                                           {0, 0});
+
+        constexpr auto block_buff_2d_desc = make_native_tensor_descriptor_packed(
+            Sequence<GredAccessesPerThreadInBlock, BlockSize>{});
+
+        using blockwise_reduce = BlockwiseReduction_2d_block_buffer<decltype(block_buff_2d_desc),
+                                                                    compType,
+                                                                    true,
+                                                                    opReduce,
+                                                                    nanPropaOpt>;
+
+        const int toReduceBlocks = (src2dDesc::GetLengths()[1] + BlockSize - 1) / BlockSize;
+
+        for(int reducedBlocks = 0; reducedBlocks < toReduceBlocks;
+            reducedBlocks += GredAccessesPerThreadInBlock)
+        {
+            blockwise_reduce::set_buffer_value(p_in_block_buffer, zeroVal);
+
+            // load block data from global to LDS, no use of double buffers (to be improved)
+            blockwise_src_load.Run(
+                p_src_global, p_in_block_buffer, type_convert<srcDataType>{}(zeroVal));
+            blockwise_src_load.Run(ws_indices_global, block_indices_buffer, static_cast<int>(0));
+
+            __syncthreads();
+
+            int BlocksInOneOp = (reducedBlocks < toReduceBlocks - GredAccessesPerThreadInBlock)
+                                    ? GredAccessesPerThreadInBlock
+                                    : toReduceBlocks - reducedBlocks;
+
+            blockwise_reduce::reduce2(
+                p_in_block_buffer, block_indices_buffer, BlocksInOneOp, accuValue, accuIndex);
+
+            constexpr auto True = integral_constant<bool, true>{};
+            blockwise_src_load.MoveSrcSliceWindow(
+                Sequence<0, BlockSize * GredAccessesPerThreadInBlock>{}, True);
+        }
+
+        using ReducedDataLengths       = Sequence<1>;
+        constexpr auto ReducedDataDesc = make_native_tensor_descriptor_packed(ReducedDataLengths{});
+
+        // The first thread in the block stores the reduced result to the global location
+        // representing the block
+        if(thread_local_id == 0)
+        {
+            if(!float_equal_one{}(alpha))
+                accuValue *= type_convert<compType>{}(alpha);
+
+            if(!float_equal_zero{}(beta))
+            {
+                auto threadwise_dst_load =
+                    ThreadwiseGenericTensorSliceCopy_v4r2<dst1dDesc,
+                                                          decltype(ReducedDataDesc),
+                                                          ReducedDataLengths,
+                                                          Sequence<0>,
+                                                          0,
+                                                          1,
+                                                          1,
+                                                          AddressSpace::Global,
+                                                          AddressSpace::Vgpr,
+                                                          InMemoryDataOperation::Set>(
+                        {block_global_1d_id}, {0});
+                dstDataType priorDstValue;
+
+                threadwise_dst_load.Run(
+                    p_dst_global, &priorDstValue, type_convert<dstDataType>{}(zeroVal));
+
+                accuValue += type_convert<compType>{}(priorDstValue * beta);
+            }
+
+            auto threadwise_dst_store =
+                ThreadwiseGenericTensorSliceCopy_v4r2<decltype(ReducedDataDesc),
+                                                      dst1dDesc,
+                                                      ReducedDataLengths,
+                                                      Sequence<0>,
+                                                      0,
+                                                      1,
+                                                      1,
+                                                      AddressSpace::Vgpr,
+                                                      AddressSpace::Global,
+                                                      InMemoryDataOperation::Set>(
+                    {0}, {block_global_1d_id});
+            threadwise_dst_store.Run(&accuValue, p_dst_global, zeroVal);
+            threadwise_dst_store.Run(&accuIndex, indices_global, 0);
+        }
+    };
+};
+
+} // namespace ck
+#endif

--- a/src/kernels/composable_kernel/include/kernel_algorithm/gridwise_generic_2d_reduction_direct_threadwise.hpp
+++ b/src/kernels/composable_kernel/include/kernel_algorithm/gridwise_generic_2d_reduction_direct_threadwise.hpp
@@ -1,0 +1,364 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2020 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#ifndef CK_GRIDWISE_GENERIC_2D_REDUCTION_DIRECT_THREADWISE_HPP
+#define CK_GRIDWISE_GENERIC_2D_REDUCTION_DIRECT_THREADWISE_HPP
+
+#include "float_type.hpp"
+#include "reduction_operator.hpp"
+#include "reduction_functions.hpp"
+#include "reduction_common.hpp"
+
+#include "threadwise_generic_tensor_slice_copy.hpp"
+
+namespace ck {
+
+template <int BlockSize,
+          typename srcDataType,
+          typename dstDataType,
+          typename src2dDesc,
+          typename dst1dDesc,
+          typename compType,
+          ckReduceTensorOp_t op,
+          ckNanPropagation_t nanPropaOpt,
+          ckReduceTensorIndices_t reduceIndicesOpt,
+          int callId,
+          int GredThreadBufferLength>
+struct Gridwise_generic_reduction_xy_to_x_direct_threadwise
+{
+    static constexpr bool indexable = reduce_binary_operator<compType, op>::indexable;
+    static constexpr bool need_indices =
+        indexable && (reduceIndicesOpt != CK_REDUCE_TENSOR_NO_INDICES);
+    static constexpr bool firstCall = (callId == 0) ? true : false;
+
+    static constexpr auto toReduceLength = src2dDesc::GetLength(Number<1>{});
+
+    using opReduce = typename reduce_binary_operator<compType, op>::opType;
+
+    __device__ void Run(srcDataType alpha,
+                        const srcDataType* const __restrict__ p_src_global,
+                        dstDataType beta,
+                        dstDataType* const __restrict__ p_dst_global,
+                        int* const __restrict__ ws_indices_global,
+                        int* const __restrict__ indices_global)
+    {
+        static_if<need_indices>{}([&](auto) {
+            static_if<firstCall>{}([&](auto) {
+                RunImpl2(alpha, p_src_global, beta, p_dst_global, indices_global);
+            }).Else([&](auto) {
+                RunImpl3(
+                    alpha, p_src_global, beta, p_dst_global, ws_indices_global, indices_global);
+            });
+        }).Else([&](auto) { RunImpl1(alpha, p_src_global, beta, p_dst_global); });
+    };
+
+    __device__ static void RunImpl1(srcDataType alpha,
+                                    const srcDataType* const __restrict__ p_src_global,
+                                    dstDataType beta,
+                                    dstDataType* const __restrict__ p_dst_global)
+    {
+        compType p_in_thread_buffer[GredThreadBufferLength];
+
+        auto zeroVal       = opReduce::getZeroVal();
+        compType accuValue = zeroVal;
+
+        using ThreadBufferLengths = Sequence<1, GredThreadBufferLength>;
+        constexpr auto ThreadBufferDesc =
+            make_native_tensor_descriptor_packed(ThreadBufferLengths{});
+
+        int thread_global_1d_id = get_block_1d_id() * BlockSize + get_thread_local_1d_id();
+
+        auto threadwise_src_load =
+            ThreadwiseGenericTensorSliceCopy_v4r2<src2dDesc,
+                                                  decltype(ThreadBufferDesc),
+                                                  ThreadBufferLengths,
+                                                  Sequence<0, 1>,
+                                                  1,
+                                                  1,
+                                                  1,
+                                                  AddressSpace::Global,
+                                                  AddressSpace::Vgpr,
+                                                  InMemoryDataOperation::Set>(
+                {thread_global_1d_id, 0}, {0, 0});
+        using threadwise_reduce =
+            thread_reduce<compType, GredThreadBufferLength, opReduce, nanPropaOpt>;
+
+        for(int reducedLength = 0; reducedLength < toReduceLength;
+            reducedLength += GredThreadBufferLength)
+        {
+            // zero the data on the Thread Buffer
+            threadwise_reduce::set_buffer_value(p_in_thread_buffer, zeroVal);
+
+            threadwise_src_load.Run(
+                p_src_global, p_in_thread_buffer, type_convert<srcDataType>{}(zeroVal));
+
+            // do the reduction on the Thread Buffer
+            threadwise_reduce::reduce(p_in_thread_buffer, accuValue);
+
+            constexpr auto True = integral_constant<bool, true>{};
+            threadwise_src_load.MoveSrcSliceWindow(Sequence<0, GredThreadBufferLength>{}, True);
+        }
+
+        using ReducedDataLengths       = Sequence<1>;
+        constexpr auto ReducedDataDesc = make_native_tensor_descriptor_packed(ReducedDataLengths{});
+
+        if(!float_equal_one{}(alpha))
+            accuValue *= type_convert<compType>{}(alpha);
+
+        if(!float_equal_zero{}(beta))
+        {
+            auto threadwise_dst_load =
+                ThreadwiseGenericTensorSliceCopy_v4r2<dst1dDesc,
+                                                      decltype(ReducedDataDesc),
+                                                      ReducedDataLengths,
+                                                      Sequence<0>,
+                                                      0,
+                                                      1,
+                                                      1,
+                                                      AddressSpace::Global,
+                                                      AddressSpace::Vgpr,
+                                                      InMemoryDataOperation::Set>(
+                    {thread_global_1d_id}, {0});
+            dstDataType priorDstValue;
+
+            threadwise_dst_load.Run(
+                p_dst_global, &priorDstValue, type_convert<dstDataType>{}(zeroVal));
+
+            accuValue += type_convert<compType>{}(priorDstValue * beta);
+        }
+
+        auto threadwise_dst_store =
+            ThreadwiseGenericTensorSliceCopy_v4r2<decltype(ReducedDataDesc),
+                                                  dst1dDesc,
+                                                  ReducedDataLengths,
+                                                  Sequence<0>,
+                                                  0,
+                                                  1,
+                                                  1,
+                                                  AddressSpace::Vgpr,
+                                                  AddressSpace::Global,
+                                                  InMemoryDataOperation::Set>(
+                {0}, {thread_global_1d_id});
+
+        threadwise_dst_store.Run(&accuValue, p_dst_global, zeroVal);
+    };
+
+    __device__ static void RunImpl2(srcDataType alpha,
+                                    const srcDataType* const __restrict__ p_src_global,
+                                    dstDataType beta,
+                                    dstDataType* const __restrict__ p_dst_global,
+                                    int* const __restrict__ indices_global)
+    {
+        compType p_in_thread_buffer[GredThreadBufferLength];
+
+        auto zeroVal       = opReduce::getZeroVal();
+        compType accuValue = zeroVal;
+        int accuIndex      = 0;
+
+        using ThreadBufferLengths = Sequence<1, GredThreadBufferLength>;
+        constexpr auto ThreadBufferDesc =
+            make_native_tensor_descriptor_packed(ThreadBufferLengths{});
+
+        int thread_global_1d_id = get_block_1d_id() * BlockSize + get_thread_local_1d_id();
+
+        auto threadwise_src_load =
+            ThreadwiseGenericTensorSliceCopy_v4r2<src2dDesc,
+                                                  decltype(ThreadBufferDesc),
+                                                  ThreadBufferLengths,
+                                                  Sequence<0, 1>,
+                                                  1,
+                                                  1,
+                                                  1,
+                                                  AddressSpace::Global,
+                                                  AddressSpace::Vgpr,
+                                                  InMemoryDataOperation::Set>(
+                {thread_global_1d_id, 0}, {0, 0});
+        using threadwise_reduce =
+            thread_reduce<compType, GredThreadBufferLength, opReduce, nanPropaOpt>;
+
+        int indexStart = 0;
+        for(int reducedLength = 0; reducedLength < toReduceLength;
+            reducedLength += GredThreadBufferLength)
+        {
+            // zero the data on the Thread Buffer
+            threadwise_reduce::set_buffer_value(p_in_thread_buffer, zeroVal);
+
+            threadwise_src_load.Run(
+                p_src_global, p_in_thread_buffer, type_convert<srcDataType>{}(zeroVal));
+
+            // do the reduction on the Thread Buffer
+            threadwise_reduce::reduce2(p_in_thread_buffer, accuValue, accuIndex, indexStart);
+
+            indexStart += GredThreadBufferLength;
+
+            constexpr auto True = integral_constant<bool, true>{};
+            threadwise_src_load.MoveSrcSliceWindow(Sequence<0, GredThreadBufferLength>{}, True);
+        }
+
+        using ReducedDataLengths       = Sequence<1>;
+        constexpr auto ReducedDataDesc = make_native_tensor_descriptor_packed(ReducedDataLengths{});
+
+        if(!float_equal_one{}(alpha))
+            accuValue *= type_convert<compType>{}(alpha);
+
+        if(!float_equal_zero{}(beta))
+        {
+            auto threadwise_dst_load =
+                ThreadwiseGenericTensorSliceCopy_v4r2<dst1dDesc,
+                                                      decltype(ReducedDataDesc),
+                                                      ReducedDataLengths,
+                                                      Sequence<0>,
+                                                      0,
+                                                      1,
+                                                      1,
+                                                      AddressSpace::Global,
+                                                      AddressSpace::Vgpr,
+                                                      InMemoryDataOperation::Set>(
+                    {thread_global_1d_id}, {0});
+            dstDataType priorDstValue;
+
+            threadwise_dst_load.Run(
+                p_dst_global, &priorDstValue, type_convert<dstDataType>{}(zeroVal));
+
+            accuValue += type_convert<compType>{}(priorDstValue * beta);
+        }
+
+        auto threadwise_dst_store =
+            ThreadwiseGenericTensorSliceCopy_v4r2<decltype(ReducedDataDesc),
+                                                  dst1dDesc,
+                                                  ReducedDataLengths,
+                                                  Sequence<0>,
+                                                  0,
+                                                  1,
+                                                  1,
+                                                  AddressSpace::Vgpr,
+                                                  AddressSpace::Global,
+                                                  InMemoryDataOperation::Set>(
+                {0}, {thread_global_1d_id});
+        threadwise_dst_store.Run(&accuValue, p_dst_global, zeroVal);
+        threadwise_dst_store.Run(&accuIndex, indices_global, 0);
+    };
+
+    __device__ static void RunImpl3(srcDataType alpha,
+                                    const srcDataType* const __restrict__ p_src_global,
+                                    dstDataType beta,
+                                    dstDataType* const __restrict__ p_dst_global,
+                                    int* const __restrict__ ws_indices_global,
+                                    int* const __restrict__ indices_global)
+    {
+        compType p_in_thread_buffer[GredThreadBufferLength];
+        int thread_indices_buffer[GredThreadBufferLength]; // for store the indices from previous
+                                                           // reduction
+
+        auto zeroVal       = opReduce::getZeroVal();
+        compType accuValue = zeroVal;
+        int accuIndex      = 0;
+
+        using ThreadBufferLengths = Sequence<1, GredThreadBufferLength>;
+        constexpr auto ThreadBufferDesc =
+            make_native_tensor_descriptor_packed(ThreadBufferLengths{});
+
+        int thread_global_1d_id = get_block_1d_id() * BlockSize + get_thread_local_1d_id();
+
+        auto threadwise_src_load =
+            ThreadwiseGenericTensorSliceCopy_v4r2<src2dDesc,
+                                                  decltype(ThreadBufferDesc),
+                                                  ThreadBufferLengths,
+                                                  Sequence<0, 1>,
+                                                  1,
+                                                  1,
+                                                  1,
+                                                  AddressSpace::Global,
+                                                  AddressSpace::Vgpr,
+                                                  InMemoryDataOperation::Set>(
+                {thread_global_1d_id, 0}, {0, 0});
+        using threadwise_reduce =
+            thread_reduce<compType, GredThreadBufferLength, opReduce, nanPropaOpt>;
+
+        for(int reducedLength = 0; reducedLength < toReduceLength;
+            reducedLength += GredThreadBufferLength)
+        {
+            // zero the data on the Thread Buffer
+            threadwise_reduce::set_buffer_value(p_in_thread_buffer, zeroVal);
+
+            threadwise_src_load.Run(
+                p_src_global, p_in_thread_buffer, type_convert<srcDataType>{}(zeroVal));
+            threadwise_src_load.Run(ws_indices_global, thread_indices_buffer, static_cast<int>(0));
+
+            // do the reduction on the Thread Buffer
+            threadwise_reduce::reduce3(
+                p_in_thread_buffer, thread_indices_buffer, accuValue, accuIndex);
+
+            constexpr auto True = integral_constant<bool, true>{};
+            threadwise_src_load.MoveSrcSliceWindow(Sequence<0, GredThreadBufferLength>{}, True);
+        }
+
+        using ReducedDataLengths       = Sequence<1>;
+        constexpr auto ReducedDataDesc = make_native_tensor_descriptor_packed(ReducedDataLengths{});
+
+        if(!float_equal_one{}(alpha))
+            accuValue *= type_convert<compType>{}(alpha);
+
+        if(!float_equal_zero{}(beta))
+        {
+            auto threadwise_dst_load =
+                ThreadwiseGenericTensorSliceCopy_v4r2<dst1dDesc,
+                                                      decltype(ReducedDataDesc),
+                                                      ReducedDataLengths,
+                                                      Sequence<0>,
+                                                      0,
+                                                      1,
+                                                      1,
+                                                      AddressSpace::Global,
+                                                      AddressSpace::Vgpr,
+                                                      InMemoryDataOperation::Set>(
+                    {thread_global_1d_id}, {0});
+            dstDataType priorDstValue;
+
+            threadwise_dst_load.Run(
+                p_dst_global, &priorDstValue, type_convert<dstDataType>{}(zeroVal));
+
+            accuValue += type_convert<compType>{}(priorDstValue * beta);
+        }
+
+        auto threadwise_dst_store =
+            ThreadwiseGenericTensorSliceCopy_v4r2<decltype(ReducedDataDesc),
+                                                  dst1dDesc,
+                                                  ReducedDataLengths,
+                                                  Sequence<0>,
+                                                  0,
+                                                  1,
+                                                  1,
+                                                  AddressSpace::Vgpr,
+                                                  AddressSpace::Global,
+                                                  InMemoryDataOperation::Set>(
+                {0}, {thread_global_1d_id});
+        threadwise_dst_store.Run(&accuValue, p_dst_global, zeroVal);
+        threadwise_dst_store.Run(&accuIndex, indices_global, 0);
+    };
+};
+
+} // namespace ck
+#endif

--- a/src/kernels/composable_kernel/include/kernel_algorithm/gridwise_generic_2d_reduction_direct_warpwise.hpp
+++ b/src/kernels/composable_kernel/include/kernel_algorithm/gridwise_generic_2d_reduction_direct_warpwise.hpp
@@ -1,0 +1,397 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2020 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#ifndef CK_GRIDWISE_GENERIC_2D_REDUCTION_DIRECT_WARPWISE_HPP
+#define CK_GRIDWISE_GENERIC_2D_REDUCTION_DIRECT_WARPWISE_HPP
+
+#include "float_type.hpp"
+#include "reduction_operator.hpp"
+#include "reduction_functions.hpp"
+#include "reduction_common.hpp"
+
+#include "threadwise_generic_tensor_slice_copy.hpp"
+
+namespace ck {
+
+template <int BlockSize,
+          typename srcDataType,
+          typename dstDataType,
+          typename src2dDesc,
+          typename dst1dDesc,
+          typename compType,
+          ckReduceTensorOp_t op,
+          ckNanPropagation_t nanPropaOpt,
+          ckReduceTensorIndices_t reduceIndicesOpt,
+          int callId,
+          int GredAccessesPerThreadInWarp>
+struct Gridwise_generic_reduction_xy_to_x_direct_warpwise
+{
+    static constexpr bool indexable = reduce_binary_operator<compType, op>::indexable;
+    static constexpr bool need_indices =
+        indexable && (reduceIndicesOpt != CK_REDUCE_TENSOR_NO_INDICES);
+    static constexpr bool firstCall = (callId == 0) ? true : false;
+
+    static constexpr auto toReduceLength = src2dDesc::GetLengths()[1];
+
+    using opReduce = typename reduce_binary_operator<compType, op>::opType;
+
+    __device__ void Run(srcDataType alpha,
+                        const srcDataType* const __restrict__ p_src_global,
+                        dstDataType beta,
+                        dstDataType* const __restrict__ p_dst_global,
+                        int* const __restrict__ ws_indices_global,
+                        int* const __restrict__ indices_global)
+    {
+        static_if<need_indices>{}([&](auto) {
+            static_if<firstCall>{}([&](auto) {
+                RunImpl2(alpha, p_src_global, beta, p_dst_global, indices_global);
+            }).Else([&](auto) {
+                RunImpl3(alpha,
+                         p_src_global,
+                         beta,
+                         p_dst_global,
+                         ws_indices_global,
+                         indices_global); // wc_indices_global is needed to read the indices
+                                          // from last reduction
+            });
+        }).Else([&](auto) { RunImpl1(alpha, p_src_global, beta, p_dst_global); });
+    };
+
+    __device__ static void RunImpl1(srcDataType alpha,
+                                    const srcDataType* const __restrict__ p_src_global,
+                                    dstDataType beta,
+                                    dstDataType* const __restrict__ p_dst_global)
+    {
+        compType p_in_thread_buffer[GredAccessesPerThreadInWarp];
+
+        auto zeroVal       = opReduce::getZeroVal();
+        compType accuValue = zeroVal;
+
+        using ThreadBufferLengths = Sequence<1, GredAccessesPerThreadInWarp>;
+        constexpr auto ThreadBufferDesc =
+            make_native_tensor_descriptor_packed(ThreadBufferLengths{});
+
+        int thread_global_1d_id = get_block_1d_id() * BlockSize + get_thread_local_1d_id();
+        int warp_global_1d_id   = thread_global_1d_id / warpSize;
+        int thread_inwarp_id    = thread_global_1d_id % warpSize;
+
+        auto threadwise_src_load =
+            ThreadwiseGenericTensorSliceCopy_v4r2<src2dDesc,
+                                                  decltype(ThreadBufferDesc),
+                                                  ThreadBufferLengths,
+                                                  Sequence<0, 1>,
+                                                  1,
+                                                  1,
+                                                  1,
+                                                  AddressSpace::Global,
+                                                  AddressSpace::Vgpr,
+                                                  InMemoryDataOperation::Set>(
+                {warp_global_1d_id, thread_inwarp_id * GredAccessesPerThreadInWarp}, {0, 0});
+        using warpwise_reduce =
+            warp_reduce<compType, BlockSize, GredAccessesPerThreadInWarp, opReduce, nanPropaOpt>;
+
+        for(int reducedLength = 0; reducedLength < toReduceLength;
+            reducedLength += warpSize * GredAccessesPerThreadInWarp)
+        {
+            // zero the data on the Thread Buffer
+            warpwise_reduce::set_buffer_value(p_in_thread_buffer, zeroVal);
+
+            threadwise_src_load.Run(
+                p_src_global, p_in_thread_buffer, type_convert<srcDataType>{}(zeroVal));
+
+            // do the warp-wise reduction on data of all thread buffers
+            warpwise_reduce::reduce(p_in_thread_buffer, accuValue);
+
+            constexpr auto True = integral_constant<bool, true>{};
+            threadwise_src_load.MoveSrcSliceWindow(
+                Sequence<0, warpSize * GredAccessesPerThreadInWarp>{}, True);
+        }
+
+        using ReducedDataLengths       = Sequence<1>;
+        constexpr auto ReducedDataDesc = make_native_tensor_descriptor_packed(ReducedDataLengths{});
+
+        // The first thread in the warp stores the reduced result to the global location
+        // representing the Warp
+        if(thread_inwarp_id == 0)
+        {
+            if(!float_equal_one{}(alpha))
+                accuValue *= type_convert<compType>{}(alpha);
+
+            if(!float_equal_zero{}(beta))
+            {
+                auto threadwise_dst_load =
+                    ThreadwiseGenericTensorSliceCopy_v4r2<dst1dDesc,
+                                                          decltype(ReducedDataDesc),
+                                                          ReducedDataLengths,
+                                                          Sequence<0>,
+                                                          0,
+                                                          1,
+                                                          1,
+                                                          AddressSpace::Global,
+                                                          AddressSpace::Vgpr,
+                                                          InMemoryDataOperation::Set>(
+                        {warp_global_1d_id}, {0});
+                dstDataType priorDstValue;
+
+                threadwise_dst_load.Run(
+                    p_dst_global, &priorDstValue, type_convert<dstDataType>{}(zeroVal));
+
+                accuValue += type_convert<compType>{}(priorDstValue * beta);
+            }
+
+            auto threadwise_dst_store =
+                ThreadwiseGenericTensorSliceCopy_v4r2<decltype(ReducedDataDesc),
+                                                      dst1dDesc,
+                                                      ReducedDataLengths,
+                                                      Sequence<0>,
+                                                      0,
+                                                      1,
+                                                      1,
+                                                      AddressSpace::Vgpr,
+                                                      AddressSpace::Global,
+                                                      InMemoryDataOperation::Set>(
+                    {0}, {warp_global_1d_id});
+
+            threadwise_dst_store.Run(&accuValue, p_dst_global, zeroVal);
+        }
+    };
+
+    __device__ static void RunImpl2(srcDataType alpha,
+                                    const srcDataType* const __restrict__ p_src_global,
+                                    dstDataType beta,
+                                    dstDataType* const __restrict__ p_dst_global,
+                                    int* const __restrict__ indices_global)
+    {
+        compType p_in_thread_buffer[GredAccessesPerThreadInWarp];
+
+        auto zeroVal       = opReduce::getZeroVal();
+        compType accuValue = zeroVal;
+        int accuIndex      = 0;
+
+        using ThreadBufferLengths = Sequence<1, GredAccessesPerThreadInWarp>;
+        constexpr auto ThreadBufferDesc =
+            make_native_tensor_descriptor_packed(ThreadBufferLengths{});
+
+        int thread_global_1d_id = get_block_1d_id() * BlockSize + get_thread_local_1d_id();
+        int warp_global_1d_id   = thread_global_1d_id / warpSize;
+        int thread_inwarp_id    = thread_global_1d_id % warpSize;
+
+        auto threadwise_src_load =
+            ThreadwiseGenericTensorSliceCopy_v4r2<src2dDesc,
+                                                  decltype(ThreadBufferDesc),
+                                                  ThreadBufferLengths,
+                                                  Sequence<0, 1>,
+                                                  1,
+                                                  1,
+                                                  1,
+                                                  AddressSpace::Global,
+                                                  AddressSpace::Vgpr,
+                                                  InMemoryDataOperation::Set>(
+                {warp_global_1d_id, thread_inwarp_id * GredAccessesPerThreadInWarp}, {0, 0});
+        using warpwise_reduce =
+            warp_reduce<compType, BlockSize, GredAccessesPerThreadInWarp, opReduce, nanPropaOpt>;
+
+        int indexOffset = 0;
+        for(int reducedLength = 0; reducedLength < toReduceLength;
+            reducedLength += warpSize * GredAccessesPerThreadInWarp)
+        {
+            // zero the data on the Thread Buffer
+            warpwise_reduce::set_buffer_value(p_in_thread_buffer, zeroVal);
+
+            threadwise_src_load.Run(
+                p_src_global, p_in_thread_buffer, type_convert<srcDataType>{}(zeroVal));
+
+            // do the warp-wise reduction on data of all thread buffers
+            warpwise_reduce::reduce2(p_in_thread_buffer, accuValue, accuIndex, indexOffset);
+
+            indexOffset += warpSize * GredAccessesPerThreadInWarp;
+
+            constexpr auto True = integral_constant<bool, true>{};
+            threadwise_src_load.MoveSrcSliceWindow(
+                Sequence<0, warpSize * GredAccessesPerThreadInWarp>{}, True);
+        }
+
+        using ReducedDataLengths       = Sequence<1>;
+        constexpr auto ReducedDataDesc = make_native_tensor_descriptor_packed(ReducedDataLengths{});
+
+        // The first thread in the warp stores the reduced result to the global location
+        // representing the Warp
+        if(thread_inwarp_id == 0)
+        {
+            if(!float_equal_one{}(alpha))
+                accuValue *= type_convert<compType>{}(alpha);
+
+            if(!float_equal_zero{}(beta))
+            {
+                auto threadwise_dst_load =
+                    ThreadwiseGenericTensorSliceCopy_v4r2<dst1dDesc,
+                                                          decltype(ReducedDataDesc),
+                                                          ReducedDataLengths,
+                                                          Sequence<0>,
+                                                          0,
+                                                          1,
+                                                          1,
+                                                          AddressSpace::Global,
+                                                          AddressSpace::Vgpr,
+                                                          InMemoryDataOperation::Set>(
+                        {warp_global_1d_id}, {0});
+                dstDataType priorDstValue;
+
+                threadwise_dst_load.Run(
+                    p_dst_global, &priorDstValue, type_convert<dstDataType>{}(zeroVal));
+
+                accuValue += type_convert<compType>{}(priorDstValue * beta);
+            }
+
+            auto threadwise_dst_store =
+                ThreadwiseGenericTensorSliceCopy_v4r2<decltype(ReducedDataDesc),
+                                                      dst1dDesc,
+                                                      ReducedDataLengths,
+                                                      Sequence<0>,
+                                                      0,
+                                                      1,
+                                                      1,
+                                                      AddressSpace::Vgpr,
+                                                      AddressSpace::Global,
+                                                      InMemoryDataOperation::Set>(
+                    {0}, {warp_global_1d_id});
+
+            threadwise_dst_store.Run(&accuValue, p_dst_global, zeroVal);
+            threadwise_dst_store.Run(&accuIndex, indices_global, 0);
+        }
+    };
+
+    __device__ static void RunImpl3(srcDataType alpha,
+                                    const srcDataType* const __restrict__ p_src_global,
+                                    dstDataType beta,
+                                    dstDataType* const __restrict__ p_dst_global,
+                                    int* const __restrict__ ws_indices_global,
+                                    int* const __restrict__ indices_global)
+    {
+        compType p_in_thread_buffer[GredAccessesPerThreadInWarp];
+        int thread_indices_buffer[GredAccessesPerThreadInWarp];
+
+        auto zeroVal       = opReduce::getZeroVal();
+        compType accuValue = zeroVal;
+        int accuIndex      = 0;
+
+        using ThreadBufferLengths = Sequence<1, GredAccessesPerThreadInWarp>;
+        constexpr auto ThreadBufferDesc =
+            make_native_tensor_descriptor_packed(ThreadBufferLengths{});
+
+        int thread_global_1d_id = get_block_1d_id() * BlockSize + get_thread_local_1d_id();
+        int warp_global_1d_id   = thread_global_1d_id / warpSize;
+        int thread_inwarp_id    = thread_global_1d_id % warpSize;
+
+        auto threadwise_src_load =
+            ThreadwiseGenericTensorSliceCopy_v4r2<src2dDesc,
+                                                  decltype(ThreadBufferDesc),
+                                                  ThreadBufferLengths,
+                                                  Sequence<0, 1>,
+                                                  1,
+                                                  1,
+                                                  1,
+                                                  AddressSpace::Global,
+                                                  AddressSpace::Vgpr,
+                                                  InMemoryDataOperation::Set>(
+                {warp_global_1d_id, thread_inwarp_id * GredAccessesPerThreadInWarp}, {0, 0});
+        using warpwise_reduce =
+            warp_reduce<compType, BlockSize, GredAccessesPerThreadInWarp, opReduce, nanPropaOpt>;
+
+        // zero the data on the Thread Buffer
+        warpwise_reduce::set_buffer_value(p_in_thread_buffer, zeroVal);
+
+        for(int reducedLength = 0; reducedLength < toReduceLength;
+            reducedLength += warpSize * GredAccessesPerThreadInWarp)
+        {
+            threadwise_src_load.Run(
+                p_src_global, p_in_thread_buffer, type_convert<srcDataType>{}(zeroVal));
+            threadwise_src_load.Run(ws_indices_global, thread_indices_buffer, static_cast<int>(0));
+
+            // do the warp-wise reduction on data of all thread buffers
+            warpwise_reduce::reduce3(
+                p_in_thread_buffer, thread_indices_buffer, accuValue, accuIndex);
+
+            // zero the data on the Thread Buffer
+            warpwise_reduce::set_buffer_value(p_in_thread_buffer, zeroVal);
+
+            constexpr auto True = integral_constant<bool, true>{};
+            threadwise_src_load.MoveSrcSliceWindow(
+                Sequence<0, warpSize * GredAccessesPerThreadInWarp>{}, True);
+        }
+
+        using ReducedDataLengths       = Sequence<1>;
+        constexpr auto ReducedDataDesc = make_native_tensor_descriptor_packed(ReducedDataLengths{});
+
+        // The first thread in the warp stores the reduced result to the global location
+        // representing the Warp
+        if(thread_inwarp_id == 0)
+        {
+            if(!float_equal_one{}(alpha))
+                accuValue *= type_convert<compType>{}(alpha);
+
+            if(!float_equal_zero{}(beta))
+            {
+                auto threadwise_dst_load =
+                    ThreadwiseGenericTensorSliceCopy_v4r2<dst1dDesc,
+                                                          decltype(ReducedDataDesc),
+                                                          ReducedDataLengths,
+                                                          Sequence<0>,
+                                                          0,
+                                                          1,
+                                                          1,
+                                                          AddressSpace::Global,
+                                                          AddressSpace::Vgpr,
+                                                          InMemoryDataOperation::Set>(
+                        {warp_global_1d_id}, {0});
+                dstDataType priorDstValue;
+
+                threadwise_dst_load.Run(
+                    p_dst_global, &priorDstValue, type_convert<dstDataType>{}(zeroVal));
+
+                accuValue += type_convert<compType>{}(priorDstValue * beta);
+            }
+
+            auto threadwise_dst_store =
+                ThreadwiseGenericTensorSliceCopy_v4r2<decltype(ReducedDataDesc),
+                                                      dst1dDesc,
+                                                      ReducedDataLengths,
+                                                      Sequence<0>,
+                                                      0,
+                                                      1,
+                                                      1,
+                                                      AddressSpace::Vgpr,
+                                                      AddressSpace::Global,
+                                                      InMemoryDataOperation::Set>(
+                    {0}, {warp_global_1d_id});
+
+            threadwise_dst_store.Run(&accuValue, p_dst_global, zeroVal);
+            threadwise_dst_store.Run(&accuIndex, indices_global, 0);
+        }
+    };
+};
+
+} // namespace ck
+#endif

--- a/src/kernels/composable_kernel/include/kernel_algorithm/gridwise_generic_2d_reduction_multiblock.hpp
+++ b/src/kernels/composable_kernel/include/kernel_algorithm/gridwise_generic_2d_reduction_multiblock.hpp
@@ -1,0 +1,305 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2020 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#ifndef CK_GRIDWISE_GENERIC_2D_REDUCTION_MULTIBLOCK_HPP
+#define CK_GRIDWISE_GENERIC_2D_REDUCTION_MULTIBLOCK_HPP
+
+#include "float_type.hpp"
+#include "reduction_operator.hpp"
+#include "reduction_functions.hpp"
+#include "reduction_common.hpp"
+
+#include "blockwise_generic_tensor_slice_copy.hpp"
+#include "ConstantMatrixDescriptor.hpp"
+
+namespace ck {
+
+template <int BlockSize,
+          typename srcDataType,
+          typename dstDataType, // not used together with the beta input
+          typename src2dDesc,
+          typename dst1dDesc,
+          typename compType,
+          ckReduceTensorOp_t op,
+          ckNanPropagation_t nanPropaOpt,
+          ckReduceTensorIndices_t reduceIndicesOpt,
+          int blkGroupSize, // The number of blocks for doing each reduction
+          int GredAccessesPerThreadInBlock>
+struct Gridwise_generic_reduction_xy_to_x_multiblock
+{
+    static constexpr bool indexable = reduce_binary_operator<compType, op>::indexable;
+    static constexpr bool need_indices =
+        indexable && (reduceIndicesOpt != CK_REDUCE_TENSOR_NO_INDICES);
+
+    using opReduce = typename reduce_binary_operator<compType, op>::opType;
+
+    __device__ void Run(srcDataType alpha,
+                        const srcDataType* const __restrict__ p_src_global,
+                        dstDataType beta,
+                        srcDataType* const __restrict__ workspace_global,
+                        int* const __restrict__ ws_indices_global)
+    {
+        static_if<need_indices>{}([&](auto) {
+            RunImpl2(alpha, p_src_global, beta, workspace_global, ws_indices_global);
+        }).Else([&](auto) { RunImpl1(alpha, p_src_global, beta, workspace_global); });
+    };
+
+    __device__ static void RunImpl1(srcDataType alpha,
+                                    const srcDataType* const __restrict__ p_src_global,
+                                    dstDataType beta,
+                                    srcDataType* const __restrict__ workspace_global)
+    {
+        (void)alpha; // unused
+        (void)beta;  // unused
+
+        constexpr int BlockBufferSize = BlockSize * GredAccessesPerThreadInBlock;
+
+        // LDS
+        __shared__ compType p_in_block_buffer[BlockBufferSize];
+
+        // VGPR, only useful for thread 0
+        auto zeroVal       = opReduce::getZeroVal();
+        compType accuValue = zeroVal;
+
+        const int thread_local_id = get_thread_local_1d_id();
+        const int block_global_id = get_block_1d_id();
+        const int blkgroup_id     = block_global_id / blkGroupSize;
+        const int block_local_id  = block_global_id % blkGroupSize;
+
+        const int reduceSizePerBlock =
+            (((src2dDesc::GetLengths()[1] + blkGroupSize - 1) / blkGroupSize + BlockBufferSize -
+              1) /
+             BlockBufferSize) *
+            BlockBufferSize;
+
+        constexpr auto in_block_desc = make_native_tensor_descriptor_packed(
+            Sequence<1, BlockSize * GredAccessesPerThreadInBlock>{});
+
+        using ThreadSliceLengths   = Sequence<1, GredAccessesPerThreadInBlock>;
+        using ThreadClusterLengths = Sequence<1, BlockSize>;
+
+        auto blockwise_src_load =
+            BlockwiseGenericTensorSliceCopy_v4<BlockSize,
+                                               src2dDesc,
+                                               decltype(in_block_desc),
+                                               decltype(in_block_desc.GetLengths()),
+                                               ThreadSliceLengths,
+                                               ThreadClusterLengths,
+                                               Sequence<0, 1>,
+                                               Sequence<0, 1>,
+                                               Sequence<0, 1>,
+                                               1,
+                                               1,
+                                               1,
+                                               1,
+                                               AddressSpace::Global,
+                                               AddressSpace::Vgpr,
+                                               AddressSpace::Lds,
+                                               InMemoryDataOperation::Set>(
+                {blkgroup_id, block_local_id * reduceSizePerBlock}, {0, 0});
+
+        constexpr auto block_buff_2d_desc = make_native_tensor_descriptor_packed(
+            Sequence<GredAccessesPerThreadInBlock, BlockSize>{});
+
+        using blockwise_reduce = BlockwiseReduction_2d_block_buffer<decltype(block_buff_2d_desc),
+                                                                    compType,
+                                                                    true,
+                                                                    opReduce,
+                                                                    nanPropaOpt>;
+
+        const int toReduceBlocks = (reduceSizePerBlock + BlockSize - 1) / BlockSize;
+
+        for(int reducedBlocks = 0; reducedBlocks < toReduceBlocks;
+            reducedBlocks += GredAccessesPerThreadInBlock)
+        {
+            blockwise_reduce::set_buffer_value(p_in_block_buffer, zeroVal);
+
+            // load block data from global to LDS, no use of double buffers (to be improved)
+            blockwise_src_load.Run(
+                p_src_global, p_in_block_buffer, type_convert<srcDataType>{}(zeroVal));
+            __syncthreads();
+
+            int BlocksInOneOp = (reducedBlocks < toReduceBlocks - GredAccessesPerThreadInBlock)
+                                    ? GredAccessesPerThreadInBlock
+                                    : toReduceBlocks - reducedBlocks;
+            blockwise_reduce::reduce(p_in_block_buffer, BlocksInOneOp, accuValue);
+
+            constexpr auto True = integral_constant<bool, true>{};
+            blockwise_src_load.MoveSrcSliceWindow(Sequence<0, BlockBufferSize>{}, True);
+        }
+
+        using ReducedDataLengths       = Sequence<1>;
+        constexpr auto ReducedDataDesc = make_native_tensor_descriptor_packed(ReducedDataLengths{});
+
+        constexpr auto workspace_desc = make_native_tensor_descriptor_packed(
+            Sequence<dst1dDesc::GetLengths()[0] * blkGroupSize>{});
+
+        // The first thread in the block stores the reduced result to the global location
+        // representing the block
+        if(thread_local_id == 0)
+        {
+            auto threadwise_workspace_store =
+                ThreadwiseGenericTensorSliceCopy_v4r2<decltype(ReducedDataDesc),
+                                                      decltype(workspace_desc),
+                                                      ReducedDataLengths,
+                                                      Sequence<0>,
+                                                      0,
+                                                      1,
+                                                      1,
+                                                      AddressSpace::Vgpr,
+                                                      AddressSpace::Global,
+                                                      InMemoryDataOperation::Set>(
+                    {0}, {block_global_id});
+            threadwise_workspace_store.Run(&accuValue, workspace_global, zeroVal);
+        }
+    };
+
+    __device__ static void RunImpl2(srcDataType alpha,
+                                    const srcDataType* const __restrict__ p_src_global,
+                                    dstDataType beta,
+                                    srcDataType* const __restrict__ workspace_global,
+                                    int* const __restrict__ ws_indices_global)
+    {
+        (void)alpha; // unused
+        (void)beta;  // unused
+
+        constexpr int BlockBufferSize = BlockSize * GredAccessesPerThreadInBlock;
+
+        // LDS
+        __shared__ compType p_in_block_buffer[BlockBufferSize];
+        __shared__ int block_indices_buffer[BlockBufferSize];
+
+        // VGPR, only useful for thread 0
+        auto zeroVal       = opReduce::getZeroVal();
+        compType accuValue = zeroVal;
+        int accuIndex      = 0;
+
+        const int thread_local_id = get_thread_local_1d_id();
+        const int block_global_id = get_block_1d_id();
+        const int blkgroup_id     = block_global_id / blkGroupSize;
+        const int block_local_id  = block_global_id % blkGroupSize;
+
+        const int reduceSizePerBlock =
+            (((src2dDesc::GetLengths()[1] + blkGroupSize - 1) / blkGroupSize + BlockBufferSize -
+              1) /
+             BlockBufferSize) *
+            BlockBufferSize;
+
+        constexpr auto in_block_desc = make_native_tensor_descriptor_packed(
+            Sequence<1, BlockSize * GredAccessesPerThreadInBlock>{});
+
+        using ThreadSliceLengths   = Sequence<1, GredAccessesPerThreadInBlock>;
+        using ThreadClusterLengths = Sequence<1, BlockSize>;
+
+        auto blockwise_src_load =
+            BlockwiseGenericTensorSliceCopy_v4<BlockSize,
+                                               src2dDesc,
+                                               decltype(in_block_desc),
+                                               decltype(in_block_desc.GetLengths()),
+                                               ThreadSliceLengths,
+                                               ThreadClusterLengths,
+                                               Sequence<0, 1>,
+                                               Sequence<0, 1>,
+                                               Sequence<0, 1>,
+                                               1,
+                                               1,
+                                               1,
+                                               1,
+                                               AddressSpace::Global,
+                                               AddressSpace::Vgpr,
+                                               AddressSpace::Lds,
+                                               InMemoryDataOperation::Set>(
+                {blkgroup_id, block_local_id * reduceSizePerBlock}, {0, 0});
+
+        constexpr auto block_buff_2d_desc = make_native_tensor_descriptor_packed(
+            Sequence<GredAccessesPerThreadInBlock, BlockSize>{});
+
+        using blockwise_reduce = BlockwiseReduction_2d_block_buffer<decltype(block_buff_2d_desc),
+                                                                    compType,
+                                                                    true,
+                                                                    opReduce,
+                                                                    nanPropaOpt>;
+
+        const int toReduceBlocks = (reduceSizePerBlock + BlockSize - 1) / BlockSize;
+
+        blockwise_reduce::set_buffer_value(p_in_block_buffer, zeroVal);
+
+        int indexOffset = block_local_id * reduceSizePerBlock;
+
+        for(int reducedBlocks = 0; reducedBlocks < toReduceBlocks;
+            reducedBlocks += GredAccessesPerThreadInBlock)
+        {
+            blockwise_reduce::init_buffer_indices(block_indices_buffer, indexOffset);
+
+            // load block data from global to LDS, no use of double buffers (to be improved)
+            blockwise_src_load.Run(
+                p_src_global, p_in_block_buffer, type_convert<srcDataType>{}(zeroVal));
+            __syncthreads();
+
+            int BlocksInOneOp = (reducedBlocks < toReduceBlocks - GredAccessesPerThreadInBlock)
+                                    ? GredAccessesPerThreadInBlock
+                                    : toReduceBlocks - reducedBlocks;
+
+            blockwise_reduce::reduce2(
+                p_in_block_buffer, block_indices_buffer, BlocksInOneOp, accuValue, accuIndex);
+
+            blockwise_reduce::set_buffer_value(p_in_block_buffer, zeroVal);
+
+            indexOffset += BlockBufferSize;
+
+            constexpr auto True = integral_constant<bool, true>{};
+            blockwise_src_load.MoveSrcSliceWindow(Sequence<0, BlockBufferSize>{}, True);
+        }
+
+        using ReducedDataLengths       = Sequence<1>;
+        constexpr auto ReducedDataDesc = make_native_tensor_descriptor_packed(ReducedDataLengths{});
+
+        constexpr auto workspace_desc = make_native_tensor_descriptor_packed(
+            Sequence<dst1dDesc::GetLengths()[0] * blkGroupSize>{});
+
+        // The first thread in the block stores the reduced result to the global location
+        // representing the block
+        if(thread_local_id == 0)
+        {
+            auto threadwise_workspace_store =
+                ThreadwiseGenericTensorSliceCopy_v4r2<decltype(ReducedDataDesc),
+                                                      decltype(workspace_desc),
+                                                      ReducedDataLengths,
+                                                      Sequence<0>,
+                                                      0,
+                                                      1,
+                                                      1,
+                                                      AddressSpace::Vgpr,
+                                                      AddressSpace::Global,
+                                                      InMemoryDataOperation::Set>(
+                    {0}, {block_global_id});
+            threadwise_workspace_store.Run(&accuValue, workspace_global, zeroVal);
+            threadwise_workspace_store.Run(&accuIndex, ws_indices_global, 0);
+        }
+    };
+};
+
+} // namespace ck
+#endif

--- a/src/kernels/composable_kernel/include/kernel_algorithm/gridwise_generic_reduction.hpp
+++ b/src/kernels/composable_kernel/include/kernel_algorithm/gridwise_generic_reduction.hpp
@@ -1,0 +1,466 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2020 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#ifndef CK_GRIDWISE_GENERIC_REDUCTION_HPP
+#define CK_GRIDWISE_GENERIC_REDUCTION_HPP
+
+#include "float_type.hpp"
+#include "reduction_common.hpp"
+#include "reduction_operator.hpp"
+#include "reduction_kernel_simple_configurator.hpp"
+
+#include "tuple_ext.hpp"
+
+#include "gridwise_generic_2d_reduction_direct_threadwise.hpp"
+#include "gridwise_generic_2d_reduction_direct_warpwise.hpp"
+#include "gridwise_generic_2d_reduction_blockwise.hpp"
+#include "gridwise_generic_2d_reduction_multiblock.hpp"
+
+namespace ck {
+
+template <int BlkGroupSize,
+          int BlockSize,
+          typename srcDataType,  // the type with which the data of the source tensor are stored
+          typename dstDataType,  // the type with which the data of the destintion tensor are stored
+          typename compType,     // the type used by the reduce binary operator
+          typename srcDesc,      // the descriptor representing the source tensor to be reduced
+          typename toReduceDims, // the Sequence<...> consists of the indexes of toReduce dimensions
+                                 // in the source tensor descriptor
+          typename invariantDims, // the Sequence<...> consists of the indexes of invariant
+                                  // dimensions in the source tensor descriptor (can be empty)
+          typename dstDesc,  // the descriptor representing the destination tensor where the reduced
+                             // tensor data are saved/added
+          int op_I,          // the enumerate value representing the operation used in Reduction
+          int reduceImpl_I,  // the enumerate value representing the ReductionMethod
+          int nanPropaOpt_I, // the enumerate value representing the NanPropagation Option
+          int reduceIndicesOpt_I, // the enumerate value representing the Reduce Indices Option
+          int GredThreadBufferLength,
+          int GredAccessesPerThreadInBlock,
+          int GredAccessesPerThreadInWarp>
+struct Gridwise_generic_reduction
+{
+    static constexpr auto reduceImpl = static_cast<ckReductionMethod_t>(reduceImpl_I);
+    static constexpr bool is_method_multiblock =
+        (reduceImpl == CK_Reduce_MultiBlock) ? true : false;
+    static constexpr auto op          = static_cast<ckReduceTensorOp_t>(op_I);
+    static constexpr auto nanPropaOpt = static_cast<ckNanPropagation_t>(nanPropaOpt_I);
+    static constexpr auto reduceIndicesOpt =
+        static_cast<ckReduceTensorIndices_t>(reduceIndicesOpt_I);
+
+    template <ckReductionMethod_t impl, int callId>
+    struct Gridwise_generic_2d_reduction_wrapper;
+
+    // wrapper for switching to the Reduce_DirectThreadWise method
+    template <int callId>
+    struct Gridwise_generic_2d_reduction_wrapper<CK_Reduce_DirectThreadWise, callId>
+    {
+        template <typename src2dDesc, typename dst1dDesc>
+        __device__ static void Run(src2dDesc,
+                                   dst1dDesc,
+                                   srcDataType alpha,
+                                   const srcDataType* const __restrict__ p_src_global,
+                                   dstDataType beta,
+                                   dstDataType* const __restrict__ p_dst_global,
+                                   srcDataType* const __restrict__ ws_buf1_global,
+                                   int* const __restrict__ ws_buf2_global,
+                                   int* const __restrict__ indices_global)
+        {
+            (void)ws_buf1_global; // unused
+
+            constexpr auto invariantLen = src2dDesc::GetLengths()[0];
+            constexpr auto toReduceLen  = src2dDesc::GetLengths()[1];
+            constexpr auto copySliceLen = GredThreadBufferLength;
+            constexpr bool need_padding = (toReduceLen % copySliceLen > 0) ? true : false;
+            constexpr auto rPad =
+                ((toReduceLen + copySliceLen - 1) / copySliceLen) * copySliceLen - toReduceLen;
+
+            constexpr auto src2dDesc_2 = transform_tensor_descriptor(
+                src2dDesc{},
+                make_tuple(PassThrough<invariantLen>{},
+                           Pad<Sequence<toReduceLen>, Sequence<0>, Sequence<rPad>>{}),
+                make_tuple(Sequence<0>{}, Sequence<1>{}),
+                make_tuple(Sequence<0>{}, Sequence<1>{}));
+
+            using src2dDesc_touse =
+                typename std::conditional<need_padding, decltype(src2dDesc_2), src2dDesc>::type;
+
+            using gridwise_reduce = Gridwise_generic_reduction_xy_to_x_direct_threadwise<
+                BlockSize,
+                srcDataType,
+                dstDataType,
+                src2dDesc_touse,
+                dst1dDesc,
+                compType,
+                op,
+                nanPropaOpt,
+                reduceIndicesOpt,
+                callId,
+                GredThreadBufferLength>; // the callId indicates the first or second-time reduction
+            gridwise_reduce{}.Run(alpha,
+                                  p_src_global,
+                                  beta,
+                                  p_dst_global,
+                                  ws_buf2_global,
+                                  indices_global); // ws_buf2_global will be read at the second-time
+        };
+    };
+
+    // wrapper for switching to the Reduce_DirectWarpdWise method
+    template <int callId>
+    struct Gridwise_generic_2d_reduction_wrapper<CK_Reduce_DirectWarpWise, callId>
+    {
+        template <typename src2dDesc, typename dst1dDesc>
+        __device__ static void Run(src2dDesc,
+                                   dst1dDesc,
+                                   srcDataType alpha,
+                                   const srcDataType* const __restrict__ p_src_global,
+                                   dstDataType beta,
+                                   dstDataType* const __restrict__ p_dst_global,
+                                   srcDataType* const __restrict__ ws_buf1_global,
+                                   int* const __restrict__ ws_buf2_global,
+                                   int* const __restrict__ indices_global)
+        {
+            (void)ws_buf1_global; // unused
+
+            constexpr auto invariantLen = src2dDesc::GetLengths()[0];
+            constexpr auto toReduceLen  = src2dDesc::GetLengths()[1];
+            constexpr auto copySliceLen = warpSize * GredAccessesPerThreadInWarp;
+            constexpr bool need_padding = (toReduceLen % copySliceLen > 0) ? true : false;
+            constexpr auto rPad =
+                ((toReduceLen + copySliceLen - 1) / copySliceLen) * copySliceLen - toReduceLen;
+
+            constexpr auto src2dDesc_2 = transform_tensor_descriptor(
+                src2dDesc{},
+                make_tuple(PassThrough<invariantLen>{},
+                           Pad<Sequence<toReduceLen>, Sequence<0>, Sequence<rPad>>{}),
+                make_tuple(Sequence<0>{}, Sequence<1>{}),
+                make_tuple(Sequence<0>{}, Sequence<1>{}));
+
+            using src2dDesc_touse =
+                typename std::conditional<need_padding, decltype(src2dDesc_2), src2dDesc>::type;
+
+            using gridwise_reduce = Gridwise_generic_reduction_xy_to_x_direct_warpwise<
+                BlockSize,
+                srcDataType,
+                dstDataType,
+                src2dDesc_touse,
+                dst1dDesc,
+                compType,
+                op,
+                nanPropaOpt,
+                reduceIndicesOpt,
+                callId,
+                GredAccessesPerThreadInWarp>; // the callId indicates the first or second-time
+                                              // reduction
+            gridwise_reduce{}.Run(alpha,
+                                  p_src_global,
+                                  beta,
+                                  p_dst_global,
+                                  ws_buf2_global,
+                                  indices_global); // ws_buf2_global will be read at the second-time
+        };
+    };
+
+    // wrapper for switching to the Reduce_BlockWise method
+    template <int callId>
+    struct Gridwise_generic_2d_reduction_wrapper<CK_Reduce_BlockWise, callId>
+    {
+        template <typename src2dDesc, typename dst1dDesc>
+        __device__ static void Run(src2dDesc,
+                                   dst1dDesc,
+                                   srcDataType alpha,
+                                   const srcDataType* const __restrict__ p_src_global,
+                                   dstDataType beta,
+                                   dstDataType* const __restrict__ p_dst_global,
+                                   srcDataType* const __restrict__ ws_buf1_global,
+                                   int* const __restrict__ ws_buf2_global,
+                                   int* const __restrict__ indices_global)
+        {
+            (void)ws_buf1_global; // unused
+
+            constexpr auto invariantLen = src2dDesc::GetLengths()[0];
+            constexpr auto toReduceLen  = src2dDesc::GetLengths()[1];
+            constexpr auto copySliceLen = BlockSize * GredAccessesPerThreadInBlock;
+            constexpr bool need_padding = (toReduceLen % copySliceLen > 0) ? true : false;
+            constexpr auto rPad =
+                ((toReduceLen + copySliceLen - 1) / copySliceLen) * copySliceLen - toReduceLen;
+
+            constexpr auto src2dDesc_2 = transform_tensor_descriptor(
+                src2dDesc{},
+                make_tuple(PassThrough<invariantLen>{},
+                           Pad<Sequence<toReduceLen>, Sequence<0>, Sequence<rPad>>{}),
+                make_tuple(Sequence<0>{}, Sequence<1>{}),
+                make_tuple(Sequence<0>{}, Sequence<1>{}));
+
+            using src2dDesc_touse =
+                typename std::conditional<need_padding, decltype(src2dDesc_2), src2dDesc>::type;
+
+            using gridwise_reduce = Gridwise_generic_reduction_xy_to_x_blockwise<
+                BlockSize,
+                srcDataType,
+                dstDataType,
+                src2dDesc_touse,
+                dst1dDesc,
+                compType,
+                op,
+                nanPropaOpt,
+                reduceIndicesOpt,
+                callId,
+                GredAccessesPerThreadInBlock>; // the callId indicates the first or second-time
+                                               // reduction
+
+            gridwise_reduce{}.Run(alpha,
+                                  p_src_global,
+                                  beta,
+                                  p_dst_global,
+                                  ws_buf2_global,
+                                  indices_global); // ws_buf2_global will be read at the second-time
+        };
+    };
+
+    // wrapper for switching to the Reduce_MultiBlock method
+    template <int callId>
+    struct Gridwise_generic_2d_reduction_wrapper<CK_Reduce_MultiBlock, callId>
+    {
+        template <typename src2dDesc, typename dst1dDesc>
+        __device__ static void Run(src2dDesc,
+                                   dst1dDesc,
+                                   srcDataType alpha,
+                                   const srcDataType* const __restrict__ p_src_global,
+                                   dstDataType beta,
+                                   dstDataType* const __restrict__ p_dst_global,
+                                   srcDataType* const __restrict__ ws_buf1_global,
+                                   int* const __restrict__ ws_buf2_global,
+                                   int* const __restrict__ indices_global)
+        {
+            (void)p_dst_global;   // unused
+            (void)indices_global; // unused
+
+            constexpr auto invariantLen = src2dDesc::GetLengths()[0];
+            constexpr auto toReduceLen  = src2dDesc::GetLengths()[1];
+            constexpr auto copySliceLen = BlockSize * GredAccessesPerThreadInBlock;
+            const int reduceSizePerBlock =
+                (((toReduceLen + BlkGroupSize - 1) / BlkGroupSize + copySliceLen - 1) /
+                 copySliceLen) *
+                copySliceLen;
+            constexpr bool need_padding =
+                (toReduceLen < reduceSizePerBlock * BlkGroupSize) ? true : false;
+            constexpr auto rPad = reduceSizePerBlock * BlkGroupSize - toReduceLen;
+
+            constexpr auto src2dDesc_2 = transform_tensor_descriptor(
+                src2dDesc{},
+                make_tuple(PassThrough<invariantLen>{},
+                           Pad<Sequence<toReduceLen>, Sequence<0>, Sequence<rPad>>{}),
+                make_tuple(Sequence<0>{}, Sequence<1>{}),
+                make_tuple(Sequence<0>{}, Sequence<1>{}));
+
+            using gridwise_reduce = Gridwise_generic_reduction_xy_to_x_multiblock<
+                BlockSize,
+                srcDataType,
+                dstDataType,
+                typename std::conditional<need_padding, decltype(src2dDesc_2), src2dDesc>::type,
+                dst1dDesc,
+                compType,
+                op,
+                nanPropaOpt,
+                reduceIndicesOpt,
+                BlkGroupSize,
+                GredAccessesPerThreadInBlock>; // MultiBlock case is not used by second-time
+                                               // reduction
+
+            gridwise_reduce{}.Run(alpha,
+                                  p_src_global,
+                                  beta,
+                                  ws_buf1_global,
+                                  ws_buf2_global); // ws_buf1_global instead of p_dst_global,
+                                                   // ws_buf2_global instead of indices_global
+        };
+    };
+
+    __device__ static void Run(float alpha,
+                               const void* const __restrict__ p_src_global,
+                               float beta,
+                               void* const __restrict__ p_dst_global,
+                               void* const __restrict__ ws_buf1_global,
+                               long ws_buf2_bytes_offset,
+                               void* const __restrict__ indices_global)
+    {
+        using srcLengths = decltype(srcDesc::GetLengths());
+        using dstLengths = decltype(dstDesc::GetLengths());
+
+        using specDims = typename sequence_merge<invariantDims, toReduceDims>::type;
+        static_assert(is_valid_sequence_map<specDims>::value &&
+                          specDims::Size() == srcLengths::Size(),
+                      "Wrong invariant and/or toReduce dimensions!");
+
+        static_assert(toReduceDims::Size() >= 1,
+                      "Wrong specification of source mode, We should at "
+                      "least to have one dimension to be reduced !!");
+
+        // The number of invariant dimensions can be zero if all dimension are to be reduced
+        static_assert(
+            invariantDims::Size() > 0 || (dstLengths::Size() == 1 && dstLengths{}[0] == 1),
+            "If all source dimensions are reduced, the dest should have only one dimension !!");
+
+        constexpr bool reduceAllDims = (invariantDims::Size() == 0) ? true : false;
+
+        void* const ws_buf2_global =
+            ws_buf2_bytes_offset > 0
+                ? static_cast<void*>(static_cast<char*>(ws_buf1_global) + ws_buf2_bytes_offset)
+                : nullptr;
+
+        static_if<!reduceAllDims>{}([&](auto) { // not all dimensions are to be reduced
+            using toReduceDimLengths  = decltype(srcLengths::Extract(toReduceDims{}));
+            using invariantDimLengths = decltype(srcLengths::Extract(invariantDims{}));
+
+            // for re-ordering the tensor dimensions
+            using lowDimSeq  = typename sequence_merge<invariantDims, toReduceDims>::type;
+            using highDimSeq = typename arithmetic_sequence_gen<0, srcLengths::Size(), 1>::type;
+
+            // construct the reordered tensor descriptor according to the srcMode and dstMode
+            // mapping
+            constexpr auto reordered_srcDesc = transform_tensor_descriptor(
+                srcDesc{},
+                make_passthrough_tuple(srcLengths::Extract(lowDimSeq{})),
+                make_dimensions_tuple(lowDimSeq{}),
+                make_dimensions_tuple(highDimSeq{}));
+            constexpr auto two_dim_srcDesc = transform_tensor_descriptor(
+                reordered_srcDesc,
+                make_2d_merge_transform_tuple(invariantDimLengths{}, toReduceDimLengths{}),
+                make_tuple(typename arithmetic_sequence_gen<0, dstLengths::Size(), 1>::type{},
+                           typename arithmetic_sequence_gen<dstLengths::Size(),
+                                                            srcLengths::Size(),
+                                                            1>::type{}),
+                make_tuple(Sequence<0>{}, Sequence<1>{}));
+
+            constexpr auto one_dim_dstDesc = transform_tensor_descriptor(
+                dstDesc{},
+                make_1d_merge_transform_tuple(dstLengths{}),
+                make_tuple(typename arithmetic_sequence_gen<0, dstLengths::Size(), 1>::type{}),
+                make_tuple(Sequence<0>{}));
+
+            using gridwise_2d_reduce = Gridwise_generic_2d_reduction_wrapper<reduceImpl, 0>;
+
+            gridwise_2d_reduce{}.Run(two_dim_srcDesc,
+                                     one_dim_dstDesc,
+                                     type_convert<srcDataType>{}(alpha),
+                                     const_cast<const srcDataType* const __restrict__>(
+                                         static_cast<const srcDataType*>(p_src_global)),
+                                     type_convert<dstDataType>{}(beta),
+                                     const_cast<dstDataType* const __restrict__>(
+                                         static_cast<dstDataType*>(p_dst_global)),
+                                     static_cast<srcDataType* const __restrict__>(ws_buf1_global),
+                                     static_cast<int* const __restrict__>(ws_buf2_global),
+                                     static_cast<int* const __restrict__>(indices_global));
+        }).Else([&](auto) { // All dimensions are to be reduced
+            constexpr auto one_dim_srcDesc = transform_tensor_descriptor(
+                srcDesc{},
+                make_1d_merge_transform_tuple(srcLengths{}),
+                make_tuple(typename arithmetic_sequence_gen<0, srcLengths::Size(), 1>::type{}),
+                make_tuple(Sequence<0>{}));
+
+            constexpr auto dim_length = one_dim_srcDesc.GetLengths()[0];
+
+            constexpr auto two_dim_srcDesc =
+                transform_tensor_descriptor(one_dim_srcDesc,
+                                            make_tuple(UnMerge<Sequence<1, dim_length>>{}),
+                                            make_tuple(Sequence<0>{}),
+                                            make_tuple(Sequence<0, 1>{}));
+
+            constexpr auto one_dim_dstDesc = transform_tensor_descriptor(
+                dstDesc{},
+                make_1d_merge_transform_tuple(dstLengths{}),
+                make_tuple(typename arithmetic_sequence_gen<0, dstLengths::Size(), 1>::type{}),
+                make_tuple(Sequence<0>{}));
+
+            using gridwise_2d_reduce = Gridwise_generic_2d_reduction_wrapper<reduceImpl, 0>;
+
+            gridwise_2d_reduce{}.Run(two_dim_srcDesc,
+                                     one_dim_dstDesc,
+                                     type_convert<srcDataType>{}(alpha),
+                                     const_cast<const srcDataType* const __restrict__>(
+                                         static_cast<const srcDataType*>(p_src_global)),
+                                     type_convert<dstDataType>{}(beta),
+                                     const_cast<dstDataType* const __restrict__>(
+                                         static_cast<dstDataType*>(p_dst_global)),
+                                     static_cast<srcDataType* const __restrict__>(ws_buf1_global),
+                                     static_cast<int* const __restrict__>(ws_buf2_global),
+                                     static_cast<int* const __restrict__>(indices_global));
+        });
+    };
+
+    __device__ static void Run_2(float alpha,
+                                 const void* const __restrict__ p_src_global,
+                                 float beta,
+                                 void* const __restrict__ p_dst_global,
+                                 void* const __restrict__ ws_buf1_global,
+                                 long ws_buf2_bytes_offset,
+                                 void* const __restrict__ indices_global)
+    {
+        (void)p_src_global; // unused
+
+        using dstLengths = decltype(dstDesc::GetLengths());
+
+        constexpr auto one_dim_dstDesc = transform_tensor_descriptor(
+            dstDesc{},
+            make_1d_merge_transform_tuple(dstLengths{}),
+            make_tuple(typename arithmetic_sequence_gen<0, dstLengths::Size(), 1>::type{}),
+            make_tuple(Sequence<0>{}));
+        constexpr index_t invariantLength = one_dim_dstDesc.GetLengths()[0];
+        constexpr index_t toReduceLength  = BlkGroupSize;
+
+        constexpr auto workspace_2d_desc =
+            make_native_tensor_descriptor_packed(Sequence<invariantLength, toReduceLength>{});
+
+        void* const ws_buf2_global =
+            ws_buf2_bytes_offset > 0
+                ? static_cast<void*>(static_cast<char*>(ws_buf1_global) + ws_buf2_bytes_offset)
+                : nullptr;
+
+        static_if<is_method_multiblock>{}([&](auto) {
+            constexpr ckReductionMethod_t reduceImpl2 =
+                reduce_kernel_simple_configurator<BlockSize, warpSize>::getReductionMethod(
+                    Number<invariantLength>{}, Number<toReduceLength>{});
+
+            using gridwise_2d_reduce = Gridwise_generic_2d_reduction_wrapper<reduceImpl2, 1>;
+
+            gridwise_2d_reduce{}.Run(
+                workspace_2d_desc,
+                one_dim_dstDesc,
+                type_convert<srcDataType>{}(alpha),
+                const_cast<const srcDataType* const __restrict__>(
+                    static_cast<srcDataType*>(ws_buf1_global)),
+                type_convert<dstDataType>{}(beta),
+                const_cast<dstDataType* const __restrict__>(
+                    static_cast<dstDataType*>(p_dst_global)),
+                const_cast<dstDataType* const __restrict__>(static_cast<dstDataType*>(nullptr)),
+                static_cast<int* const __restrict__>(ws_buf2_global),
+                static_cast<int* const __restrict__>(indices_global));
+        }).Else([&](auto) {});
+    };
+};
+
+} // namespace ck
+#endif

--- a/src/kernels/composable_kernel/include/kernel_algorithm/reduction_functions.hpp
+++ b/src/kernels/composable_kernel/include/kernel_algorithm/reduction_functions.hpp
@@ -1,0 +1,623 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2020 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#ifndef CK_REDUCTION_FUNCTIONS_HPP
+#define CK_REDUCTION_FUNCTIONS_HPP
+
+#include <config.hpp>
+
+#include "reduction_common.hpp"
+#include "reduction_operator.hpp"
+
+namespace ck {
+namespace detail {
+
+template <typename T>
+__device__ bool IsNan(T x)
+{
+    // for float and double, use the builtin hip kernel functions
+    return (isnan(x));
+};
+
+template <>
+__device__ bool IsNan<half>(half x)
+{
+    return (__hisnan(x));
+};
+
+template <ckNanPropagation_t nanPropaOpt, typename opReduce, typename compType>
+struct binop_with_nan_check;
+
+template <typename opReduce, typename compType>
+struct binop_with_nan_check<CK_NOT_PROPAGATE_NAN, opReduce, compType>
+{
+    __device__ static inline void calculate(const compType& accuVal, compType currVal)
+    {
+        opReduce{}(const_cast<compType&>(accuVal), currVal);
+    };
+
+    // this method can only be called when the opReduce is indexable
+    __device__ static inline void
+    calculate(const compType& accuVal, compType currVal, int& accuIndex, int currIndex)
+    {
+        bool changed = false;
+
+        opReduce{}(const_cast<compType&>(accuVal), currVal, changed);
+
+        if(changed)
+            accuIndex = currIndex;
+    };
+};
+
+template <typename opReduce, typename compType>
+struct binop_with_nan_check<CK_PROPAGATE_NAN, opReduce, compType>
+{
+    __device__ static inline void calculate(compType& accuVal, compType currVal)
+    {
+        if(IsNan(currVal))
+            accuVal = currVal;
+        else
+            opReduce{}(accuVal, currVal);
+    };
+
+    // this method can only be called when the opReduce is indexable
+    __device__ static inline void
+    calculate(compType& accuVal, compType currVal, int& accuIndex, int currIndex)
+    {
+        if(IsNan(currVal))
+        {
+            accuVal   = currVal;
+            accuIndex = currIndex;
+        }
+        else
+        {
+            bool changed = false;
+
+            opReduce{}(accuVal, currVal, changed);
+
+            if(changed)
+                accuIndex = currIndex;
+        }
+    };
+};
+}; // namespace detail
+
+template <typename DataType, int ThreadBufferLen, typename opReduce, ckNanPropagation_t nanPropaOpt>
+struct thread_reduce
+{
+    using compType = typename opReduce::dataType;
+    using binop    = detail::binop_with_nan_check<nanPropaOpt, opReduce, compType>;
+
+    __device__ static void reduce(const DataType* p_thread_buffer, compType& accuData)
+    {
+        for(int i = 0; i < ThreadBufferLen; i++)
+        {
+            compType currVal = type_convert<compType>{}(p_thread_buffer[i]);
+            binop::calculate(accuData, currVal);
+        }
+    };
+
+    // This operator is used by Direct_ThreadWise reduction method at first-time reduction
+    __device__ static void
+    reduce2(const DataType* p_thread_buffer, compType& accuData, int& accuIndex, int indexStart)
+    {
+        for(int i = 0; i < ThreadBufferLen; i++)
+        {
+            compType currVal = type_convert<compType>{}(p_thread_buffer[i]);
+            int currIndex    = i + indexStart;
+            binop::calculate(accuData, currVal, accuIndex, currIndex);
+        }
+    };
+
+    // This operator is used by Direct_ThreadWise reduction method at second-time reduction
+    __device__ static void reduce3(const DataType* p_thread_buffer,
+                                   const int* thread_indices_buffer,
+                                   compType& accuData,
+                                   int& accuIndex)
+    {
+        for(int i = 0; i < ThreadBufferLen; i++)
+        {
+            compType currVal = type_convert<compType>{}(p_thread_buffer[i]);
+            int currIndex    = thread_indices_buffer[i];
+            binop::calculate(accuData, currVal, accuIndex, currIndex);
+        }
+    };
+
+    __device__ static void set_buffer_value(DataType* p_thread_buffer, DataType value)
+    {
+        for(int i              = 0; i < ThreadBufferLen; i++)
+            p_thread_buffer[i] = value;
+    };
+};
+
+template <typename DataType,
+          int BlockSize,
+          int ThreadBufferLen,
+          typename opReduce,
+          ckNanPropagation_t nanPropaOpt>
+struct warp_reduce
+{
+    using compType = typename opReduce::dataType;
+    using binop    = detail::binop_with_nan_check<nanPropaOpt, opReduce, compType>;
+    constexpr static bool have_builtin_shuffle = std::is_same<compType, float>::value;
+
+    __device__ static void reduce(const DataType* p_thread_buffer, compType& accuData)
+    {
+        static_if<have_builtin_shuffle>{}([&](auto) {
+            reduceImpl1(p_thread_buffer, accuData);
+        }).Else([&](auto) { reduceImpl2(p_thread_buffer, accuData); });
+    };
+
+    __device__ static void reduceImpl1(const DataType* p_thread_buffer, compType& accuData)
+    {
+        compType lAccuData = opReduce::getZeroVal();
+
+        for(int i = 0; i < ThreadBufferLen; i++)
+        {
+            compType currVal = type_convert<compType>{}(p_thread_buffer[i]);
+            binop::calculate(lAccuData, currVal);
+        }
+
+        // synchronize among all threads in this warp
+        __all(1);
+
+        for(int stride = warpSize / 2; stride > 0; stride /= 2)
+        {
+            compType tmpVal = __shfl_down(lAccuData, stride, warpSize);
+            binop::calculate(lAccuData, tmpVal);
+            __all(1);
+        }
+
+        binop::calculate(accuData, lAccuData);
+    };
+
+    __device__ static void reduceImpl2(const DataType* p_thread_buffer, compType& accuData)
+    {
+        compType lAccuData = opReduce::getZeroVal();
+
+        for(int i = 0; i < ThreadBufferLen; i++)
+        {
+            compType currVal = type_convert<compType>{}(p_thread_buffer[i]);
+            binop::calculate(lAccuData, currVal);
+        }
+
+        __syncthreads();
+
+        int thread_id        = get_thread_local_1d_id();
+        int warpId           = thread_id / warpSize;
+        int thread_inwarp_id = thread_id % warpSize;
+
+        __shared__ compType shuffle_buffer[BlockSize];
+
+        compType* myBuffer = &shuffle_buffer[warpId * warpSize];
+
+        myBuffer[thread_inwarp_id] = lAccuData;
+
+        __syncthreads();
+
+        for(int stride = warpSize / 2; stride > 0; stride /= 2)
+        {
+            if(thread_inwarp_id < warpSize)
+            {
+                compType currVal1 = myBuffer[thread_inwarp_id];
+                compType currVal2 = myBuffer[thread_inwarp_id + stride];
+
+                binop::calculate(currVal1, currVal2);
+
+                myBuffer[thread_inwarp_id] = currVal1;
+            }
+
+            __syncthreads();
+        }
+        if(thread_inwarp_id == 0)
+            binop::calculate(accuData, myBuffer[0]);
+    };
+
+    __device__ static void
+    reduce2(const DataType* p_thread_buffer, compType& accuData, int& accuIndex, int indexStart)
+    {
+        static_if<have_builtin_shuffle>{}([&](auto) {
+            reduce2Impl1(p_thread_buffer, accuData, accuIndex, indexStart);
+        }).Else([&](auto) { reduce2Impl2(p_thread_buffer, accuData, accuIndex, indexStart); });
+    };
+
+    __device__ static void reduce2Impl1(const DataType* p_thread_buffer,
+                                        compType& accuData,
+                                        int& accuIndex,
+                                        int indexStart)
+    {
+        compType lAccuData   = opReduce::getZeroVal();
+        int lAccuIndex       = 0;
+        int thread_inwarp_id = get_thread_local_1d_id() % warpSize;
+
+        for(int i = 0; i < ThreadBufferLen; i++)
+        {
+            compType currVal = type_convert<compType>{}(p_thread_buffer[i]);
+            int currIndex    = thread_inwarp_id * ThreadBufferLen + i + indexStart;
+            binop::calculate(lAccuData, currVal, lAccuIndex, currIndex);
+        }
+
+        // synchronize among all threads in this warp
+        __all(1);
+
+        for(int stride = 1; stride < warpSize; stride *= 2)
+        {
+            compType tmpVal = __shfl_down(lAccuData, stride, warpSize);
+            int tmpIndex    = __shfl_down(lAccuIndex, stride, warpSize);
+
+            binop::calculate(lAccuData, tmpVal, lAccuIndex, tmpIndex);
+            __all(1);
+        }
+
+        if(thread_inwarp_id == 0)
+            binop::calculate(accuData, lAccuData, accuIndex, lAccuIndex);
+    };
+
+    __device__ static void reduce2Impl2(const DataType* p_thread_buffer,
+                                        compType& accuData,
+                                        int& accuIndex,
+                                        int indexStart)
+    {
+        compType lAccuData   = opReduce::getZeroVal();
+        int lAccuIndex       = 0;
+        int thread_id        = get_thread_local_1d_id();
+        int warpId           = thread_id / warpSize;
+        int thread_inwarp_id = thread_id % warpSize;
+
+        for(int i = 0; i < ThreadBufferLen; i++)
+        {
+            compType currVal = type_convert<compType>{}(p_thread_buffer[i]);
+            int currIndex    = thread_inwarp_id * ThreadBufferLen + i + indexStart;
+            binop::calculate(lAccuData, currVal, lAccuIndex, currIndex);
+        }
+
+        __shared__ compType shuffle_data_buffer[BlockSize];
+        __shared__ int shuffle_indices_buffer[BlockSize];
+
+        compType* myDataBuffer = &shuffle_data_buffer[warpId * warpSize];
+        int* myIndicesBuffer   = &shuffle_indices_buffer[warpId * warpSize];
+
+        myDataBuffer[thread_inwarp_id]    = lAccuData;
+        myIndicesBuffer[thread_inwarp_id] = lAccuIndex;
+
+        __syncthreads();
+
+        for(int stride = 1; stride < warpSize; stride *= 2)
+        {
+            if(thread_inwarp_id < warpSize)
+            {
+                compType currVal1 = myDataBuffer[thread_inwarp_id];
+                compType currVal2 = myDataBuffer[thread_inwarp_id + stride];
+                int currIndex1    = myIndicesBuffer[thread_inwarp_id];
+                int currIndex2    = myIndicesBuffer[thread_inwarp_id + stride];
+
+                binop::calculate(currVal1, currVal2, currIndex1, currIndex2);
+
+                myDataBuffer[thread_inwarp_id]    = currVal1;
+                myIndicesBuffer[thread_inwarp_id] = currIndex1;
+            }
+            __syncthreads();
+        }
+
+        if(thread_inwarp_id == 0)
+            binop::calculate(accuData, myDataBuffer[0], accuIndex, myIndicesBuffer[0]);
+    };
+
+    __device__ static void reduce3(const DataType* p_thread_buffer,
+                                   const int* thread_indices_buffer,
+                                   compType& accuData,
+                                   int& accuIndex)
+    {
+        static_if<have_builtin_shuffle>{}([&](auto) {
+            reduce3Impl1(p_thread_buffer, thread_indices_buffer, accuData, accuIndex);
+        }).Else([&](auto) {
+            reduce3Impl2(p_thread_buffer, thread_indices_buffer, accuData, accuIndex);
+        });
+    };
+
+    __device__ static void reduce3Impl1(const DataType* p_thread_buffer,
+                                        const int* thread_indices_buffer,
+                                        compType& accuData,
+                                        int& accuIndex)
+    {
+        compType lAccuData = opReduce::getZeroVal();
+        int lAccuIndex     = 0;
+
+        for(int i = 0; i < ThreadBufferLen; i++)
+        {
+            compType currVal   = type_convert<compType>{}(p_thread_buffer[i]);
+            compType currIndex = thread_indices_buffer[i];
+            binop::calculate(lAccuData, currVal, lAccuIndex, currIndex);
+        }
+
+        // synchronize among all threads in this warp
+        __all(1);
+
+        for(int stride = 1; stride < warpSize; stride *= 2)
+        {
+            compType tmpVal = __shfl_down(lAccuData, stride, warpSize);
+            int tmpIndex    = __shfl_down(lAccuIndex, stride, warpSize);
+
+            binop::calculate(lAccuData, tmpVal, lAccuIndex, tmpIndex);
+            __all(1);
+        }
+
+        binop::calculate(accuData, lAccuData, accuIndex, lAccuIndex);
+    };
+
+    __device__ static void reduce3Impl2(const DataType* p_thread_buffer,
+                                        const int* thread_indices_buffer,
+                                        compType& accuData,
+                                        int& accuIndex)
+    {
+        compType lAccuData   = opReduce::getZeroVal();
+        int lAccuIndex       = 0;
+        int thread_id        = get_thread_local_1d_id();
+        int warpId           = thread_id / warpSize;
+        int thread_inwarp_id = thread_id % warpSize;
+
+        for(int i = 0; i < ThreadBufferLen; i++)
+        {
+            compType currVal   = type_convert<compType>{}(p_thread_buffer[i]);
+            compType currIndex = thread_indices_buffer[i];
+            binop::calculate(lAccuData, currVal, lAccuIndex, currIndex);
+        }
+
+        __shared__ compType shuffle_data_buffer[BlockSize];
+        __shared__ int shuffle_indices_buffer[BlockSize];
+
+        compType* myDataBuffer = &shuffle_data_buffer[warpId * warpSize];
+        int* myIndicesBuffer   = &shuffle_indices_buffer[warpId * warpSize];
+
+        myDataBuffer[thread_inwarp_id]    = lAccuData;
+        myIndicesBuffer[thread_inwarp_id] = lAccuIndex;
+
+        __syncthreads();
+
+        for(int stride = 1; stride < warpSize; stride *= 2)
+        {
+            if(thread_inwarp_id < warpSize)
+            {
+                compType currVal1 = myDataBuffer[thread_inwarp_id];
+                compType currVal2 = myDataBuffer[thread_inwarp_id + stride];
+                int currIndex1    = myIndicesBuffer[thread_inwarp_id];
+                int currIndex2    = myIndicesBuffer[thread_inwarp_id + stride];
+
+                binop::calculate(currVal1, currVal2, currIndex1, currIndex2);
+
+                myDataBuffer[thread_inwarp_id]    = currVal1;
+                myIndicesBuffer[thread_inwarp_id] = currIndex1;
+            }
+            __syncthreads();
+        }
+
+        if(thread_inwarp_id == 0)
+            binop::calculate(accuData, myDataBuffer[0], accuIndex, myIndicesBuffer[0]);
+    };
+
+    __device__ static void set_buffer_value(DataType* p_thread_buffer, DataType value)
+    {
+        for(int i              = 0; i < ThreadBufferLen; i++)
+            p_thread_buffer[i] = value;
+
+        __all(1);
+    };
+};
+
+template <typename buffer2dDesc,
+          typename DataType,
+          bool blockIsOneRow,
+          typename opReduce,
+          ckNanPropagation_t nanPropaOpt>
+struct BlockwiseReduction_2d_block_buffer
+{
+    using compType = typename opReduce::dataType;
+    constexpr static int BlockSize =
+        blockIsOneRow ? buffer2dDesc::GetLengths()[1] : buffer2dDesc::GetLengths()[0];
+    constexpr static int NumBlocks =
+        blockIsOneRow ? buffer2dDesc::GetLengths()[0] : buffer2dDesc::GetLengths()[1];
+    using binop = detail::binop_with_nan_check<nanPropaOpt, opReduce, compType>;
+
+    __device__ static void reduce(DataType* p_block_buffer, int toReduceBlocks, compType& accuData)
+    {
+        const int thread_local_id = get_thread_local_1d_id();
+        compType lAccuData        = opReduce::getZeroVal();
+
+        int offset;
+        for(int otherDimInd = 0; otherDimInd < toReduceBlocks; otherDimInd++)
+        {
+            offset = blockIsOneRow ? buffer2dDesc::CalculateOffset({otherDimInd, thread_local_id})
+                                   : buffer2dDesc::CalculateOffset({thread_local_id, otherDimInd});
+            compType opData = type_convert<compType>{}(p_block_buffer[offset]);
+
+            binop::calculate(lAccuData, opData);
+        }
+
+        offset = blockIsOneRow ? buffer2dDesc::CalculateOffset({0, thread_local_id})
+                               : buffer2dDesc::CalculateOffset({thread_local_id, 0});
+
+        p_block_buffer[offset] = lAccuData;
+
+        __syncthreads();
+
+        for(int indOffset = BlockSize / 2; indOffset > 0; indOffset /= 2)
+        {
+            if(thread_local_id < indOffset)
+            {
+                int offset1 = blockIsOneRow ? buffer2dDesc::CalculateOffset({0, thread_local_id})
+                                            : buffer2dDesc::CalculateOffset({thread_local_id, 0});
+
+                int offset2 = blockIsOneRow
+                                  ? buffer2dDesc::CalculateOffset({0, thread_local_id + indOffset})
+                                  : buffer2dDesc::CalculateOffset({thread_local_id + indOffset, 0});
+
+                compType opData1 = type_convert<compType>{}(p_block_buffer[offset1]);
+                compType opData2 = type_convert<compType>{}(p_block_buffer[offset2]);
+                binop::calculate(opData1, opData2);
+                p_block_buffer[offset1] = type_convert<DataType>{}(opData1);
+            }
+
+            __syncthreads();
+        }
+
+        if(thread_local_id == 0)
+        {
+            compType tmpVal = type_convert<compType>{}(p_block_buffer[0]);
+
+            binop::calculate(accuData, tmpVal);
+        }
+    };
+
+    __device__ static void reduce2(DataType* p_block_buffer,
+                                   int* block_indices_buffer,
+                                   int toReduceBlocks,
+                                   compType& accuData,
+                                   int& accuIndex)
+    {
+        const int thread_local_id = get_thread_local_1d_id();
+        compType lAccuData        = opReduce::getZeroVal();
+        int lAccuIndex            = 0;
+
+        static_if<blockIsOneRow>{}([&](auto) {
+            for(int otherDimInd = 0; otherDimInd < toReduceBlocks; otherDimInd++)
+            {
+                for(int indOffset = 1; indOffset < BlockSize; indOffset *= 2)
+                {
+                    if(thread_local_id % (indOffset * 2) == 0)
+                    {
+                        int offset1 = buffer2dDesc::CalculateOffset({otherDimInd, thread_local_id});
+                        int offset2 = buffer2dDesc::CalculateOffset(
+                            {otherDimInd, thread_local_id + indOffset});
+
+                        compType currVal1 = type_convert<compType>{}(p_block_buffer[offset1]);
+                        compType currVal2 = type_convert<compType>{}(p_block_buffer[offset2]);
+                        int currIndex1    = block_indices_buffer[offset1];
+                        int currIndex2    = block_indices_buffer[offset2];
+
+                        binop::calculate(currVal1, currVal2, currIndex1, currIndex2);
+                        p_block_buffer[offset1]       = type_convert<DataType>{}(currVal1);
+                        block_indices_buffer[offset1] = currIndex1;
+                    }
+                }
+                __syncthreads();
+            }
+
+            if(thread_local_id == 0)
+            {
+                for(int otherDimInd = 0; otherDimInd < toReduceBlocks; otherDimInd++)
+                {
+                    int offset = buffer2dDesc::CalculateOffset({otherDimInd, 0});
+
+                    compType tmpVal = type_convert<compType>{}(p_block_buffer[offset]);
+                    int tmpIndex    = block_indices_buffer[offset];
+
+                    binop::calculate(lAccuData, tmpVal, lAccuIndex, tmpIndex);
+                }
+
+                binop::calculate(accuData, lAccuData, accuIndex, lAccuIndex);
+            }
+        }).Else([&](auto) {
+            int offset;
+
+            for(int otherDimInd = 0; otherDimInd < toReduceBlocks; otherDimInd++)
+            {
+                offset           = buffer2dDesc::CalculateOffset({thread_local_id, otherDimInd});
+                compType currVal = type_convert<compType>{}(p_block_buffer[offset]);
+                int currIndex    = block_indices_buffer[offset];
+
+                binop::calculate(lAccuData, currVal, lAccuIndex, currIndex);
+            }
+
+            offset = buffer2dDesc::CalculateOffset({thread_local_id, 0});
+
+            p_block_buffer[offset]       = lAccuData;
+            block_indices_buffer[offset] = lAccuIndex;
+
+            __syncthreads();
+
+            for(int indOffset = 1; indOffset < BlockSize; indOffset *= 2)
+            {
+                if(thread_local_id % (indOffset * 2) == 0)
+                {
+                    int offset1 = buffer2dDesc::CalculateOffset({thread_local_id, 0});
+                    int offset2 = buffer2dDesc::CalculateOffset({thread_local_id + indOffset, 0});
+
+                    compType currVal1 = type_convert<compType>{}(p_block_buffer[offset1]);
+                    compType currVal2 = type_convert<compType>{}(p_block_buffer[offset2]);
+                    int currIndex1    = block_indices_buffer[offset1];
+                    int currIndex2    = block_indices_buffer[offset2];
+
+                    binop::calculate(currVal1, currVal2, currIndex1, currIndex2);
+                    p_block_buffer[offset1]       = type_convert<DataType>{}(currVal1);
+                    block_indices_buffer[offset1] = currIndex1;
+                }
+
+                __syncthreads();
+            }
+
+            if(thread_local_id == 0)
+            {
+                compType tmpVal = type_convert<compType>{}(p_block_buffer[0]);
+                int tmpIndex    = block_indices_buffer[0];
+
+                binop::calculate(accuData, tmpVal, accuIndex, tmpIndex);
+            }
+        });
+    };
+
+    __device__ static void set_buffer_value(DataType* p_block_buffer, DataType value)
+    {
+        int thread_id = get_thread_local_1d_id();
+
+        for(int otherDimInd = 0; otherDimInd < NumBlocks; otherDimInd++)
+        {
+            int offset = blockIsOneRow ? buffer2dDesc::CalculateOffset({otherDimInd, thread_id})
+                                       : buffer2dDesc::CalculateOffset({thread_id, otherDimInd});
+
+            p_block_buffer[offset] = value;
+
+            __syncthreads();
+        }
+    };
+
+    __device__ static void init_buffer_indices(int* block_indices_buffer, int indexStart)
+    {
+        int thread_id = get_thread_local_1d_id();
+
+        for(int otherDimInd = 0; otherDimInd < NumBlocks; otherDimInd++)
+        {
+            int offset = blockIsOneRow ? buffer2dDesc::CalculateOffset({otherDimInd, thread_id})
+                                       : buffer2dDesc::CalculateOffset({thread_id, otherDimInd});
+
+            block_indices_buffer[offset] = offset + indexStart;
+
+            __syncthreads();
+        }
+    };
+};
+
+}; // end of namespace ck
+
+#endif

--- a/src/kernels/composable_kernel/include/kernel_algorithm/reduction_kernel_simple_configurator.hpp
+++ b/src/kernels/composable_kernel/include/kernel_algorithm/reduction_kernel_simple_configurator.hpp
@@ -1,0 +1,42 @@
+#ifndef REDUCTION_KERNEL_SIMPLE_CONFIGURATOR_HPP_
+#define REDUCTION_KERNEL_SIMPLE_CONFIGURATOR_HPP_ 1
+
+#include "number.hpp"
+#include "reduction_common.hpp"
+
+namespace ck {
+
+// The simple configurator does not consider the "Reduce_MultiBlock" method, since it is usually
+// called to do the second reduction after the first calling of a "Reduce_MultiBlock" reduction.
+template <int BlockSize, int warpSize>
+struct reduce_kernel_simple_configurator
+{
+    static constexpr int numWarpsPerBlock = BlockSize / warpSize;
+
+    template <index_t invariantLength, index_t toReduceLength>
+    __device__ static constexpr int getGridSize(Number<invariantLength>, Number<toReduceLength>)
+    {
+        if(toReduceLength < warpSize / 4) // let one thread to do each reduction
+            return ((invariantLength + BlockSize - 1) / BlockSize);
+        else if(toReduceLength < BlockSize) // let one warp to do each reduction
+            return ((invariantLength + numWarpsPerBlock - 1) / numWarpsPerBlock);
+        else
+            return (invariantLength); // let one block to do each reduction
+    };
+
+    template <index_t invariantLength, index_t toReduceLength>
+    __device__ static constexpr ckReductionMethod_t getReductionMethod(Number<invariantLength>,
+                                                                       Number<toReduceLength>)
+    {
+        if(toReduceLength < warpSize / 4) // let one thread to do each reduction
+            return (CK_Reduce_DirectThreadWise);
+        else if(toReduceLength < BlockSize) // let one warp to do each reduction
+            return (CK_Reduce_DirectWarpWise);
+        else
+            return (CK_Reduce_BlockWise);
+    };
+};
+
+}; // namespace ck
+
+#endif

--- a/src/kernels/composable_kernel/include/tensor_description/tensor_descriptor.hpp
+++ b/src/kernels/composable_kernel/include/tensor_description/tensor_descriptor.hpp
@@ -475,7 +475,7 @@ struct TransformedTensorDescriptor
 #endif
 
     // a multi-index is valid if there is a corresponding point for it in the tensor
-    __host__ __device__ constexpr bool IsUpperIndexValid(const UpperIndex& idx_up) const
+    __host__ __device__ static constexpr bool IsUpperIndexValid(const UpperIndex& idx_up)
     {
         bool flag = true;
 

--- a/src/kernels/composable_kernel/include/tensor_operation/blockwise_generic_tensor_slice_copy.hpp
+++ b/src/kernels/composable_kernel/include/tensor_operation/blockwise_generic_tensor_slice_copy.hpp
@@ -82,7 +82,8 @@ struct BlockwiseGenericTensorSliceCopy_v4
 
     template <typename BlockSrcData, typename ThreadBufferData>
     __device__ void RunLoadThreadBuffer(const BlockSrcData* p_block_src,
-                                        ThreadBufferData* p_thread_buffer) const
+                                        ThreadBufferData* p_thread_buffer,
+                                        BlockSrcData zeroVal = static_cast<BlockSrcData>(0.0)) const
     {
         constexpr bool has_optimized_address_calculation =
             decltype(mThreadwiseStore)::HasWorkingOptimizedAddressCalculation();
@@ -93,18 +94,21 @@ struct BlockwiseGenericTensorSliceCopy_v4
             // TODO: threadwise copy is still being tweaked
             if(has_optimized_address_calculation)
             {
-                mThreadwiseLoad.Run_optimized_src_address_calculation(p_block_src, p_thread_buffer);
+                mThreadwiseLoad.Run_optimized_src_address_calculation(
+                    p_block_src, p_thread_buffer, zeroVal);
             }
             else
             {
-                mThreadwiseLoad.Run(p_block_src, p_thread_buffer);
+                mThreadwiseLoad.Run(p_block_src, p_thread_buffer, zeroVal);
             }
         }
     }
 
     template <typename ThreadBufferData, typename BlockDstData>
-    __device__ void RunStoreThreadBuffer(const ThreadBufferData* p_thread_buffer,
-                                         BlockDstData* p_block_dst) const
+    __device__ void
+    RunStoreThreadBuffer(const ThreadBufferData* p_thread_buffer,
+                         BlockDstData* p_block_dst,
+                         ThreadBufferData zeroVal = static_cast<ThreadBufferData>(0.0)) const
     {
         constexpr bool has_optimized_address_calculation =
             decltype(mThreadwiseStore)::HasWorkingOptimizedAddressCalculation();
@@ -115,18 +119,20 @@ struct BlockwiseGenericTensorSliceCopy_v4
             // TODO: threadwise copy is still being tweaked
             if(has_optimized_address_calculation)
             {
-                mThreadwiseStore.Run_optimized_dst_address_calculation(p_thread_buffer,
-                                                                       p_block_dst);
+                mThreadwiseStore.Run_optimized_dst_address_calculation(
+                    p_thread_buffer, p_block_dst, zeroVal);
             }
             else
             {
-                mThreadwiseStore.Run(p_thread_buffer, p_block_dst);
+                mThreadwiseStore.Run(p_thread_buffer, p_block_dst, zeroVal);
             }
         }
     }
 
     template <typename BlockSrcData, typename BlockDstData>
-    __device__ void Run(const BlockSrcData* p_block_src, BlockDstData* p_block_dst) const
+    __device__ void Run(const BlockSrcData* p_block_src,
+                        BlockDstData* p_block_dst,
+                        BlockSrcData zeroVal = static_cast<BlockSrcData>(0.0)) const
     {
         static_assert(ThreadBufferAddressSpace == AddressSpace::Vgpr,
                       "wrong! This function use vgpr as its thread "
@@ -139,10 +145,10 @@ struct BlockwiseGenericTensorSliceCopy_v4
         if(BlockSize == mThreadClusterDesc.GetElementSize() or
            get_thread_local_1d_id() < mThreadClusterDesc.GetElementSize())
         {
-            RunLoadThreadBuffer(p_block_src, p_thread_buffer);
+            RunLoadThreadBuffer(p_block_src, p_thread_buffer, zeroVal);
 
             // if there is type conversion, it's done during store
-            RunStoreThreadBuffer(p_thread_buffer, p_block_dst);
+            RunStoreThreadBuffer(p_thread_buffer, p_block_dst, zeroVal);
         }
     }
 

--- a/src/kernels/composable_kernel/include/tensor_operation/threadwise_generic_tensor_slice_copy.hpp
+++ b/src/kernels/composable_kernel/include/tensor_operation/threadwise_generic_tensor_slice_copy.hpp
@@ -70,7 +70,8 @@ struct ThreadwiseGenericTensorSliceCopy_v4r2
     }
 
     template <typename SrcData, typename DstData>
-    __device__ void Run(const SrcData* p_src, DstData* p_dst) const
+    __device__ void
+    Run(const SrcData* p_src, DstData* p_dst, SrcData zeroVal = static_cast<SrcData>(0.0)) const
     {
         constexpr auto vector_access_dim = Number<SrcDstVectorReadWriteDim>{};
 
@@ -96,7 +97,7 @@ struct ThreadwiseGenericTensorSliceCopy_v4r2
             // zero out buffer
             for(index_t i = 0; i < long_vector_size; ++i)
             {
-                p_src_long_vector[i] = 0;
+                p_src_long_vector[i] = zeroVal;
             }
 
             // load data from src to the long-vector buffer
@@ -174,8 +175,8 @@ struct ThreadwiseGenericTensorSliceCopy_v4r2
     // This version is optimized for address calculation of src tensor
     // TODO: this function is not compiled to expected ISA
     template <typename SrcData, typename DstData>
-    __device__ void Run_optimized_src_address_calculation(const SrcData* p_src,
-                                                          DstData* p_dst) const
+    __device__ void Run_optimized_src_address_calculation(
+        const SrcData* p_src, DstData* p_dst, SrcData zeroVal = static_cast<SrcData>(0.0)) const
     {
         constexpr auto vector_access_dim = Number<SrcDstVectorReadWriteDim>{};
 
@@ -231,7 +232,7 @@ struct ThreadwiseGenericTensorSliceCopy_v4r2
                 // zero out buffer
                 for(index_t i = 0; i < long_vector_size; ++i)
                 {
-                    p_src_long_vector[i] = 0;
+                    p_src_long_vector[i] = zeroVal;
                 }
 
                 // Loop over SrcDstVectorReadWriteDim, and load data from src to the
@@ -322,8 +323,8 @@ struct ThreadwiseGenericTensorSliceCopy_v4r2
     // This version is optimized for address calculation of dst tensor
     // TODO: this function is not compiled to expected ISA
     template <typename SrcData, typename DstData>
-    __device__ void Run_optimized_dst_address_calculation(const SrcData* p_src,
-                                                          DstData* p_dst) const
+    __device__ void Run_optimized_dst_address_calculation(
+        const SrcData* p_src, DstData* p_dst, SrcData zeroVal = static_cast<SrcData>(0.0)) const
     {
         constexpr auto vector_access_dim = Number<SrcDstVectorReadWriteDim>{};
 
@@ -379,7 +380,7 @@ struct ThreadwiseGenericTensorSliceCopy_v4r2
                 // zero out buffer
                 for(index_t i = 0; i < long_vector_size; ++i)
                 {
-                    p_src_long_vector[i] = 0;
+                    p_src_long_vector[i] = zeroVal;
                 }
 
                 // Loop over SrcDstVectorReadWriteDim, and load data from src to the

--- a/src/kernels/composable_kernel/include/utility/float_type.hpp
+++ b/src/kernels/composable_kernel/include/utility/float_type.hpp
@@ -274,6 +274,20 @@ struct type_convert
 
 template <>
 template <>
+__device__ float type_convert<float>::operator()<half>(half x) const
+{
+    return __half2float(x);
+};
+
+template <>
+template <>
+__device__ half type_convert<half>::operator()<float>(float x) const
+{
+    return __float2half(x);
+};
+
+template <>
+template <>
 __device__ float type_convert<float>::operator()<ushort>(ushort x) const
 {
     return bfloat16_to_float(x);

--- a/src/kernels/composable_kernel/include/utility/in_memory_operation.hpp
+++ b/src/kernels/composable_kernel/include/utility/in_memory_operation.hpp
@@ -83,6 +83,20 @@ struct SetData
 #endif
 };
 
+template <index_t DataPerAccess>
+struct SetData<int, DataPerAccess>
+{
+    using vector_t = typename vector_type<int, DataPerAccess>::MemoryType;
+
+    // This version is only for compatibility, don't use this version if possible
+    template <AddressSpace SrcAddressSpace, AddressSpace DstAddressSpace>
+    __device__ void Run(const int* p_src, index_t src_offset, int* p_dst, index_t dst_offset) const
+    {
+        *reinterpret_cast<vector_t*>(&p_dst[dst_offset]) =
+            *reinterpret_cast<const vector_t*>(&p_src[src_offset]);
+    }
+};
+
 template <typename T, index_t DataPerAccess>
 struct AtomicAddData
 {

--- a/src/kernels/composable_kernel/include/utility/reduction_common.hpp
+++ b/src/kernels/composable_kernel/include/utility/reduction_common.hpp
@@ -1,0 +1,161 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2020 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#ifndef CK_REDUCTION_COMMON_HPP
+#define CK_REDUCTION_COMMON_HPP
+
+#include "config.hpp"
+
+// this enumerate should be synchronized with include/miopen/reduce_common.hpp
+namespace ck {
+typedef enum {
+    CK_Reduce_DirectThreadWise = 1,
+    CK_Reduce_DirectWarpWise   = 2,
+    CK_Reduce_BlockWise        = 3,
+    CK_Reduce_MultiBlock       = 4
+} ckReductionMethod_t; // end of namespace ck
+
+// this enumerate should be synchronized with include/miopen.h
+typedef enum {
+    CK_REDUCE_TENSOR_ADD = 0,
+    CK_REDUCE_TENSOR_MUL = 1,
+    CK_REDUCE_TENSOR_MIN = 2,
+    CK_REDUCE_TENSOR_MAX = 3,
+    // CK_REDUCE_TENSOR_AMAX = 4,
+    // CK_REDUCE_TENSOR_AVG =  5,
+    // CK_REDUCE_TENSOR_NORM1 = 6,
+    // CK_REDUCE_TENSOR_NORM2 = 7,
+    // CK_REDUCE_TENSOR_MUL_NO_ZEROS = 8,
+} ckReduceTensorOp_t;
+
+typedef enum {
+    CK_NOT_PROPAGATE_NAN = 0,
+    CK_PROPAGATE_NAN     = 1,
+} ckNanPropagation_t;
+
+typedef enum {
+    CK_REDUCE_TENSOR_NO_INDICES        = 0,
+    CK_REDUCE_TENSOR_FLATTENED_INDICES = 1,
+} ckReduceTensorIndices_t;
+
+typedef enum {
+    CK_32BIT_INDICES = 0,
+    CK_64BIT_INDICES = 1,
+    CK_16BIT_INDICES = 2,
+    CK_8BIT_INDICES  = 3,
+} ckIndicesType_t;
+
+// this enumerate should be synchronized with include/miopen.h
+typedef enum {
+    ckHalf     = 0,
+    ckFloat    = 1,
+    ckInt32    = 2,
+    ckInt8     = 3,
+    ckInt8x4   = 4,
+    ckBFloat16 = 5,
+    ckDouble   = 6,
+} ckDataType_t;
+
+template <ckDataType_t typeNum>
+struct get_type_from_type_enum;
+
+template <>
+struct get_type_from_type_enum<ckHalf>
+{
+    using type = half;
+};
+
+template <>
+struct get_type_from_type_enum<ckBFloat16>
+{
+    using type = ushort;
+};
+
+template <>
+struct get_type_from_type_enum<ckFloat>
+{
+    using type = float;
+};
+
+template <>
+struct get_type_from_type_enum<ckDouble>
+{
+    using type = double;
+};
+
+template <>
+struct get_type_from_type_enum<ckInt32>
+{
+    using type = int;
+};
+
+struct float_equal
+{
+    template <class T>
+    __device__ static inline bool apply(T x, T y)
+    {
+        return x <= y and x >= y;
+    }
+
+    template <class T>
+    __device__ inline bool operator()(T x, T y)
+    {
+        return (float_equal::apply(x, y));
+    };
+};
+
+struct float_equal_one
+{
+    template <class T>
+    __device__ static inline bool apply(T x)
+    {
+        return x <= type_convert<T>{}(1.0f) and x >= type_convert<T>{}(1.0f);
+    }
+
+    template <class T>
+    __device__ inline bool operator()(T x)
+    {
+        return (float_equal_one::apply(x));
+    };
+};
+
+struct float_equal_zero
+{
+    template <class T>
+    __device__ static inline bool apply(T x)
+    {
+        return x <= type_convert<T>{}(0.0f) and x >= type_convert<T>{}(0.0f);
+    }
+
+    template <class T>
+    __device__ inline bool operator()(T x)
+    {
+        return (float_equal_zero::apply(x));
+    };
+};
+
+}; // end of namespace ck
+
+#endif

--- a/src/kernels/composable_kernel/include/utility/reduction_operator.hpp
+++ b/src/kernels/composable_kernel/include/utility/reduction_operator.hpp
@@ -1,0 +1,177 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2020 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#ifndef CK_REDUCTION_OPERATOR_HPP
+#define CK_REDUCTION_OPERATOR_HPP
+
+#include <limits>
+#include "reduction_common.hpp"
+
+namespace ck {
+
+namespace reduce {
+
+template <class T>
+struct Add
+{
+    using dataType = T;
+
+    __device__ static T getZeroVal() { return type_convert<T>{}(0.0f); };
+
+    __device__ inline constexpr void operator()(T& a, T b) const { a = a + b; }
+
+    static constexpr bool indexable = false;
+};
+
+template <class T>
+struct Mul
+{
+    using dataType = T;
+
+    __device__ static T getZeroVal() { return type_convert<T>{}(1.0f); };
+
+    __device__ inline constexpr void operator()(T& a, T b) const { a = a * b; }
+
+    static constexpr bool indexable = false;
+};
+
+template <class T>
+struct Max
+{
+    using dataType = T;
+
+    __device__ static T getZeroVal() { return std::numeric_limits<T>::min(); };
+
+    __device__ inline constexpr void operator()(T& a, T b) const
+    {
+        if(a < b)
+            a = b;
+    }
+
+    __device__ inline constexpr void operator()(T& a, T b, bool& changed) const
+    {
+        if(a < b)
+        {
+            a       = b;
+            changed = true;
+        }
+        else
+            changed = false;
+    }
+
+    static constexpr bool indexable = true;
+};
+
+template <class T>
+struct Min
+{
+    using dataType = T;
+
+    __device__ static T getZeroVal() { return std::numeric_limits<T>::max(); };
+
+    __device__ inline constexpr void operator()(T& a, T b) const
+    {
+        if(a > b)
+            a = b;
+    }
+
+    __device__ inline constexpr void operator()(T& a, T b, bool& changed) const
+    {
+        if(a > b)
+        {
+            a       = b;
+            changed = true;
+        }
+        else
+            changed = false;
+    }
+
+    static constexpr bool indexable = true;
+};
+
+template <>
+__device__ half Max<half>::getZeroVal()
+{
+    return type_convert<half>{}(std::numeric_limits<float>::min());
+};
+
+template <>
+__device__ half Min<half>::getZeroVal()
+{
+    return type_convert<half>{}(std::numeric_limits<float>::max());
+};
+
+}; // end of namespace reduce
+
+template <typename T, ckReduceTensorOp_t op>
+struct reduce_binary_operator;
+
+template <typename T>
+struct reduce_binary_operator<T, CK_REDUCE_TENSOR_ADD>
+{
+    using opType   = reduce::Add<T>;
+    using dataType = T;
+
+    __device__ static T getZeroVal() { return reduce::Add<T>::getZeroVal(); };
+
+    static constexpr bool indexable = reduce::Add<T>::indexable;
+};
+
+template <typename T>
+struct reduce_binary_operator<T, CK_REDUCE_TENSOR_MUL>
+{
+    using opType   = reduce::Mul<T>;
+    using dataType = T;
+
+    __device__ static T getZeroVal() { return reduce::Mul<T>::getZeroVal(); };
+
+    static constexpr bool indexable = reduce::Mul<T>::indexable;
+};
+
+template <typename T>
+struct reduce_binary_operator<T, CK_REDUCE_TENSOR_MIN>
+{
+    using opType   = reduce::Min<T>;
+    using dataType = T;
+
+    __device__ static T getZeroVal() { return reduce::Min<T>::getZeroVal(); };
+
+    static constexpr bool indexable = reduce::Min<T>::indexable;
+};
+
+template <typename T>
+struct reduce_binary_operator<T, CK_REDUCE_TENSOR_MAX>
+{
+    using opType   = reduce::Max<T>;
+    using dataType = T;
+
+    __device__ static T getZeroVal() { return reduce::Max<T>::getZeroVal(); };
+
+    static constexpr bool indexable = reduce::Max<T>::indexable;
+};
+
+} // end of namespace ck
+
+#endif

--- a/src/kernels/composable_kernel/include/utility/tuple_ext.hpp
+++ b/src/kernels/composable_kernel/include/utility/tuple_ext.hpp
@@ -1,0 +1,36 @@
+#ifndef CK_TUPLE_EXT_HPP_
+#define CK_TUPLE_EXT_HPP_
+
+#include "sequence.hpp"
+#include "tuple.hpp"
+#include "multi_index_transform.hpp"
+
+namespace ck {
+
+template <index_t... Ns>
+__host__ __device__ constexpr auto make_passthrough_tuple(Sequence<Ns...>)
+{
+    return make_tuple(PassThrough<Ns>{}...);
+};
+
+template <index_t... Ids>
+__host__ __device__ constexpr auto make_dimensions_tuple(Sequence<Ids...>)
+{
+    return make_tuple(Sequence<Ids>{}...);
+};
+
+template <typename Seq1, typename Seq2>
+__host__ __device__ constexpr auto make_2d_merge_transform_tuple(Seq1, Seq2)
+{
+    return make_tuple(Merge<Seq1>{}, Merge<Seq2>{});
+};
+
+template <typename Seq>
+__host__ __device__ constexpr auto make_1d_merge_transform_tuple(Seq)
+{
+    return make_tuple(Merge<Seq>{});
+};
+
+}; // end of namespace ck
+
+#endif

--- a/src/kernels/composable_kernel/src/kernel_wrapper/gridwise_generic_reduction.cpp
+++ b/src/kernels/composable_kernel/src/kernel_wrapper/gridwise_generic_reduction.cpp
@@ -1,0 +1,125 @@
+#include "config.hpp"
+#include "number.hpp"
+#include "sequence.hpp"
+#include "tensor_descriptor_helper.hpp"
+#include "reduction_common.hpp"
+#include "gridwise_generic_reduction.hpp"
+
+using namespace ck;
+
+using srcDataType =
+    typename get_type_from_type_enum<static_cast<ckDataType_t>(CK_PARAM_SRC_DATATYPE)>::type;
+using dstDataType =
+    typename get_type_from_type_enum<static_cast<ckDataType_t>(CK_PARAM_DST_DATATYPE)>::type;
+using compType =
+    typename get_type_from_type_enum<static_cast<ckDataType_t>(CK_PARAM_REDUCE_COMPTYPE)>::type;
+
+constexpr int blockSize = CK_PARAM_BLOCKSIZE; // tunable
+constexpr int blkGroupSize =
+    CK_PARAM_BLKGROUPSIZE; // determined by the problem and the selected BlockSize
+
+using srcLengths = Sequence<CK_PARAM_SRC_DESC_LENGTHS>;
+using srcStrides = Sequence<CK_PARAM_SRC_DESC_STRIDES>;
+using dstLengths = Sequence<CK_PARAM_DST_DESC_LENGTHS>;
+using dstStrides = Sequence<CK_PARAM_DST_DESC_STRIDES>;
+
+using toReduceDims  = Sequence<CK_PARAM_TOREDUCE_DIMS>;
+using invariantDims = Sequence<CK_PARAM_INVARIANT_DIMS>;
+
+constexpr ckReduceTensorOp_t op          = static_cast<ckReduceTensorOp_t>(CK_PARAM_REDUCE_OP);
+constexpr ckReductionMethod_t reduceImpl = static_cast<ckReductionMethod_t>(CK_PARAM_REDUCE_IMPL);
+constexpr ckNanPropagation_t nanPropaOpt = static_cast<ckNanPropagation_t>(CK_PARAM_NAN_PROPAGATE);
+constexpr ckReduceTensorIndices_t reduceIndicesOpt =
+    static_cast<ckReduceTensorIndices_t>(CK_PARAM_REDUCE_INDICES);
+
+constexpr int GredThreadBufferLength       = CK_PARAM_THREAD_BUFFER_LENGTH;        // tunable
+constexpr int GredAccessesPerThreadInBlock = CK_PARAM_ACCESSES_PER_THREAD_INBLOCK; // tunable
+constexpr int GredAccessesPerThreadInWarp  = CK_PARAM_ACCESSES_PER_THREAD_INWARP;  // tunable
+
+extern "C" __global__ void gridwise_generic_reduce_1(float alpha,
+                                                     const void* p_src_global,
+                                                     float beta,
+                                                     void* p_dst_global,
+                                                     void* ws_buf1_global,
+                                                     long ws_buf2_bytes_offset,
+                                                     void* indices_global)
+{
+    static_assert(srcLengths::Size() > 0 && srcLengths::Size() == srcStrides::Size(),
+                  "The source desc specification is invalid!");
+    static_assert(dstLengths::Size() > 0 && dstLengths::Size() == dstStrides::Size(),
+                  "The destination desc specification is invalid!");
+    static_assert(dstLengths::Size() <= srcLengths::Size(),
+                  "The destination lengths should be less than source lengths!");
+
+    constexpr auto srcDesc = make_native_tensor_descriptor(srcLengths{}, srcStrides{});
+    constexpr auto dstDesc = make_native_tensor_descriptor(dstLengths{}, dstStrides{});
+
+    constexpr auto gridwise_reduce = Gridwise_generic_reduction<blkGroupSize,
+                                                                blockSize,
+                                                                srcDataType,
+                                                                dstDataType,
+                                                                compType,
+                                                                decltype(srcDesc),
+                                                                toReduceDims,
+                                                                invariantDims,
+                                                                decltype(dstDesc),
+                                                                static_cast<int>(op),
+                                                                static_cast<int>(reduceImpl),
+                                                                static_cast<int>(nanPropaOpt),
+                                                                static_cast<int>(reduceIndicesOpt),
+                                                                GredThreadBufferLength,
+                                                                GredAccessesPerThreadInBlock,
+                                                                GredAccessesPerThreadInWarp>{};
+
+    gridwise_reduce.Run(alpha,
+                        const_cast<const void* const __restrict__>(p_src_global),
+                        beta,
+                        const_cast<void* const __restrict__>(p_dst_global),
+                        const_cast<void* const __restrict__>(ws_buf1_global),
+                        ws_buf2_bytes_offset,
+                        const_cast<void* const __restrict__>(indices_global));
+};
+
+extern "C" __global__ void gridwise_generic_reduce_2(float alpha,
+                                                     const void* p_src_global,
+                                                     float beta,
+                                                     void* p_dst_global,
+                                                     void* ws_buf1_global,
+                                                     long ws_buf2_bytes_offset,
+                                                     void* indices_global)
+{
+    static_assert(srcLengths::Size() > 0 && srcLengths::Size() == srcStrides::Size(),
+                  "The source desc specification is invalid!");
+    static_assert(dstLengths::Size() > 0 && dstLengths::Size() == dstStrides::Size(),
+                  "The destination desc specification is invalid!");
+    static_assert(dstLengths::Size() <= srcLengths::Size(),
+                  "The destination lengths should be less than source lengths!");
+
+    constexpr auto srcDesc = make_native_tensor_descriptor(srcLengths{}, srcStrides{});
+    constexpr auto dstDesc = make_native_tensor_descriptor(dstLengths{}, dstStrides{});
+
+    constexpr auto gridwise_reduce = Gridwise_generic_reduction<blkGroupSize,
+                                                                blockSize,
+                                                                srcDataType,
+                                                                dstDataType,
+                                                                compType,
+                                                                decltype(srcDesc),
+                                                                toReduceDims,
+                                                                invariantDims,
+                                                                decltype(dstDesc),
+                                                                static_cast<int>(op),
+                                                                static_cast<int>(reduceImpl),
+                                                                static_cast<int>(nanPropaOpt),
+                                                                static_cast<int>(reduceIndicesOpt),
+                                                                GredThreadBufferLength,
+                                                                GredAccessesPerThreadInBlock,
+                                                                GredAccessesPerThreadInWarp>{};
+
+    gridwise_reduce.Run_2(alpha,
+                          const_cast<const void* const __restrict__>(p_src_global),
+                          beta,
+                          const_cast<void* const __restrict__>(p_dst_global),
+                          const_cast<void* const __restrict__>(ws_buf1_global),
+                          ws_buf2_bytes_offset,
+                          const_cast<void* const __restrict__>(indices_global));
+};

--- a/src/reducetensor.cpp
+++ b/src/reducetensor.cpp
@@ -1,0 +1,585 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2020 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#include <miopen/config.h>
+#include <miopen/errors.hpp>
+#include <miopen/miopen.h>
+#include <miopen/visit_float.hpp>
+#include <miopen/reduce_common.hpp>
+#include <miopen/handle.hpp>
+#include <miopen/reducetensor.hpp>
+
+#include <cassert>
+#include <cstddef>
+#include <algorithm>
+#include <cmath>
+#include <ostream>
+#include <iostream>
+
+namespace miopen {
+
+using reduce::ReductionMethod_t;
+using reduce::Reduce_DirectThreadWise;
+using reduce::Reduce_DirectWarpWise;
+using reduce::Reduce_BlockWise;
+using reduce::Reduce_MultiBlock;
+
+using reduce::type_convert;
+
+namespace detail {
+
+struct get_tunable_reduction_kernel_constants
+{
+    int GredThreadBufferLength;
+    int GredAccessesPerThreadInBlock;
+    int GredAccessesPerThreadInWarp;
+
+    get_tunable_reduction_kernel_constants(ReductionMethod_t reduceImpl)
+    {
+        switch(reduceImpl)
+        {
+        case Reduce_DirectThreadWise:
+            GredThreadBufferLength       = 8;
+            GredAccessesPerThreadInBlock = 0;
+            GredAccessesPerThreadInWarp  = 0;
+            break;
+        case Reduce_BlockWise:
+            GredThreadBufferLength       = 0;
+            GredAccessesPerThreadInBlock = 2;
+            GredAccessesPerThreadInWarp  = 0;
+            break;
+        case Reduce_DirectWarpWise:
+            GredThreadBufferLength       = 0;
+            GredAccessesPerThreadInBlock = 0;
+            GredAccessesPerThreadInWarp  = 2;
+            break;
+        case Reduce_MultiBlock:
+            GredThreadBufferLength =
+                8; // needed since the second-time reduction could be DirectThreadWise
+            GredAccessesPerThreadInBlock =
+                2; // needed since the second-time reduction could be BlockWise
+            GredAccessesPerThreadInWarp =
+                2; // needed since the second-time reduction could be DirectWarpWise
+            break;
+        };
+    };
+};
+
+struct ReductionKernelConfigurator
+{
+    ReductionKernelConfigurator() = default;
+
+    ReductionKernelConfigurator(int blockSize, int warpSize)
+        : blockSize_(blockSize), warpSize_(warpSize)
+    {
+        GredDirectThreadWiseUpperReductionLen = warpSize;
+        GredDirectWarpWiseUpperReductionLen   = blockSize;
+        GredBlockWiseUpperReductionLen        = blockSize * 4;
+        GredUpperNumBlocksPerReduction        = 32;
+
+        numWarpsPerBlock = blockSize / warpSize;
+    };
+
+    int blockSize_;
+    int warpSize_;
+    int numWarpsPerBlock;
+
+    std::size_t GredDirectThreadWiseUpperReductionLen;
+    std::size_t GredDirectWarpWiseUpperReductionLen;
+    std::size_t GredBlockWiseUpperReductionLen;
+    std::size_t GredUpperNumBlocksPerReduction;
+
+    std::size_t getGridSize(std::size_t invariantLength, std::size_t toReduceLength) const
+    {
+        assert(invariantLength > 0 && toReduceLength > 1);
+
+        if(invariantLength == 1)
+        {
+            if(toReduceLength <
+               GredBlockWiseUpperReductionLen) // let one block to do this only reduction
+                return (1);
+            else
+                return ((toReduceLength + blockSize_ - 1) /
+                        blockSize_); // let multiple blocks to do this only reduction
+        }
+        else
+        {
+            if(toReduceLength <
+               GredDirectThreadWiseUpperReductionLen) // let one thread to do each reduction
+                return ((invariantLength + blockSize_ - 1) / blockSize_);
+            else if(toReduceLength <
+                    GredDirectWarpWiseUpperReductionLen) // let one warp to do each reduction
+                return ((invariantLength + numWarpsPerBlock - 1) / numWarpsPerBlock);
+            else if(toReduceLength <
+                    GredBlockWiseUpperReductionLen) // let one block to do each reduction
+                return (invariantLength);
+            else
+            { // let multiple blocks to do each reduction
+                std::size_t expBlocksPerReduction =
+                    (toReduceLength + GredBlockWiseUpperReductionLen - 1) /
+                    GredBlockWiseUpperReductionLen;
+
+                if(expBlocksPerReduction > GredUpperNumBlocksPerReduction)
+                    return (invariantLength * GredUpperNumBlocksPerReduction);
+                else
+                    return (invariantLength * expBlocksPerReduction);
+            };
+        };
+    };
+
+    ReductionMethod_t getReductionMethod(std::size_t invariantLength,
+                                         std::size_t toReduceLength) const
+    {
+        assert(invariantLength > 0 && toReduceLength > 1);
+
+        if(invariantLength == 1)
+        {
+            if(toReduceLength <
+               GredBlockWiseUpperReductionLen) // let one block to do this only reduction
+                return (Reduce_BlockWise);
+            else // let multiple blocks to do this only reduction
+                return (Reduce_MultiBlock);
+        }
+        else
+        {
+            if(toReduceLength <
+               GredDirectThreadWiseUpperReductionLen) // let one thread to do each reduction
+                return (Reduce_DirectThreadWise);
+            else if(toReduceLength <
+                    GredDirectWarpWiseUpperReductionLen) // let one warp to do each reduction
+                return (Reduce_DirectWarpWise);
+            else if(toReduceLength <
+                    GredBlockWiseUpperReductionLen) // let one block to do each reduction
+                return (Reduce_BlockWise);
+            else
+                return (Reduce_MultiBlock); // let multiple blocks to do each reduction
+        };
+    };
+
+    std::size_t getWorkspaceSize(std::size_t invariantLength, std::size_t toReduceLength) const
+    {
+        assert(invariantLength > 0 && toReduceLength > 1);
+
+        if(getReductionMethod(invariantLength, toReduceLength) == Reduce_MultiBlock)
+        {
+            auto gridSize = getGridSize(invariantLength, toReduceLength);
+
+            return (gridSize);
+        };
+
+        return (0);
+    };
+
+    std::size_t getGridSize_2(std::size_t invariantLength, std::size_t toReduceLength) const
+    {
+        if(toReduceLength < warpSize_ / 4) // let one thread to do each reduction
+            return ((invariantLength + blockSize_ - 1) / blockSize_);
+        else if(toReduceLength < blockSize_) // let one warp to do each reduction
+            return ((invariantLength + numWarpsPerBlock - 1) / numWarpsPerBlock);
+        else
+            return (invariantLength); // let one block to do each reduction
+    };
+};
+
+inline int GetIndicesTypeSize(miopenIndicesType_t t)
+{
+    switch(t)
+    {
+    case MIOPEN_32BIT_INDICES: return (4);
+    case MIOPEN_64BIT_INDICES: return (8);
+    case MIOPEN_16BIT_INDICES: return (2);
+    case MIOPEN_8BIT_INDICES: return (1);
+    }
+    MIOPEN_THROW("Unknown data type");
+}
+
+inline int GetDataTypeSize(miopenDataType_t t)
+{
+    switch(t)
+    {
+    case miopenHalf: return (2);
+    case miopenFloat: return (4);
+    case miopenInt8: return (1);
+    case miopenInt8x4: return (4);
+    case miopenBFloat16: return (2);
+    case miopenInt32: return (4);
+    default:
+        MIOPEN_THROW("Only float, half, bfloat16, int8, int8x4 data type is supported.");
+        break;
+    };
+};
+
+}; // end of namespace detail
+
+ReduceTensorDescriptor::ReduceTensorDescriptor(miopenReduceTensorOp_t reduceTensorOp,
+                                               miopenDataType_t reduceTensorCompType,
+                                               miopenNanPropagation_t reduceTensorNanOpt,
+                                               miopenReduceTensorIndices_t reduceTensorIndices,
+                                               miopenIndicesType_t reduceTensorIndicesType)
+    : reduceTensorOp_(reduceTensorOp),
+      reduceTensorCompType_(reduceTensorCompType),
+      reduceTensorNanOpt_(reduceTensorNanOpt),
+      reduceTensorIndices_(reduceTensorIndices),
+      reduceTensorIndicesType_(reduceTensorIndicesType)
+{
+    if(reduceTensorIndices == MIOPEN_REDUCE_TENSOR_FLATTENED_INDICES &&
+       reduceTensorIndicesType != MIOPEN_32BIT_INDICES)
+        MIOPEN_THROW("Only int32 type is supported for ReduceTensor indices.");
+};
+
+// return the size of the workspace in bytes, so that the workspace buffer can be prepared by the
+// user
+std::size_t ReduceTensorDescriptor::GetWorkspaceSize(const Handle& handle,
+                                                     const TensorDescriptor& inDesc,
+                                                     const TensorDescriptor& outDesc) const
+{
+    const auto& inDescLengths  = inDesc.GetLengths();
+    const auto& outDescLengths = outDesc.GetLengths();
+
+    if(inDescLengths.size() != outDescLengths.size())
+        MIOPEN_THROW("The number of dimensions of the input and output tensor should match.");
+
+    for(int i = 0; i < inDescLengths.size(); i++)
+    {
+        if(outDescLengths[i] != 1 && outDescLengths[i] != inDescLengths[i])
+            MIOPEN_THROW("The length of the output tensor dimension should either be 1 or be equal "
+                         "to the length of the corresponding dimension of the input tensor.");
+    };
+
+    auto invariantLength = outDesc.GetElementSize();
+    auto toReduceLength  = inDesc.GetElementSize() / invariantLength;
+
+    detail::ReductionKernelConfigurator configurator(256, handle.GetWavefrontWidth());
+
+    auto workspace_size = configurator.getWorkspaceSize(invariantLength, toReduceLength);
+
+    auto reduceIndicesOpt = this->reduceTensorIndices_;
+    auto reduceOp         = this->reduceTensorOp_;
+    bool need_indices =
+        (reduceIndicesOpt == MIOPEN_REDUCE_TENSOR_FLATTENED_INDICES) &&
+        (reduceOp == MIOPEN_REDUCE_TENSOR_MIN || reduceOp == MIOPEN_REDUCE_TENSOR_MAX);
+
+    std::size_t wsSizeInBytes =
+        !need_indices ? workspace_size * detail::GetDataTypeSize(inDesc.GetType())
+                      : workspace_size * (detail::GetDataTypeSize(inDesc.GetType()) + sizeof(int)) +
+                            64 + sizeof(int);
+
+    return (wsSizeInBytes);
+};
+
+// return the size of the reduction indices in bytes, so that the indices buffer can be prepared by
+// the user
+std::size_t ReduceTensorDescriptor::GetIndicesSize(const TensorDescriptor& inDesc,
+                                                   const TensorDescriptor& outDesc) const
+{
+    const auto& inDescLengths  = inDesc.GetLengths();
+    const auto& outDescLengths = outDesc.GetLengths();
+
+    if(inDescLengths.size() != outDescLengths.size())
+        MIOPEN_THROW("The number of dimensions of the input and output tensor should match.");
+
+    for(int i = 0; i < inDescLengths.size(); i++)
+    {
+        if(outDescLengths[i] != 1 && outDescLengths[i] != inDescLengths[i])
+            MIOPEN_THROW("The length of the output tensor dimension should either be 1 or be equal "
+                         "to the length of the corresponding dimension of the input tensor.");
+    };
+
+    auto reduceIndicesOpt = this->reduceTensorIndices_;
+    auto reduceOp         = this->reduceTensorOp_;
+    bool need_indices =
+        (reduceIndicesOpt == MIOPEN_REDUCE_TENSOR_FLATTENED_INDICES) &&
+        (reduceOp == MIOPEN_REDUCE_TENSOR_MIN || reduceOp == MIOPEN_REDUCE_TENSOR_MAX);
+
+    if(!need_indices)
+        return (0);
+
+    return (outDesc.GetElementSize() * sizeof(int));
+};
+
+void ReduceTensorDescriptor::ReduceTensor(const Handle& handle,
+                                          Data_t indices,
+                                          size_t indicesSizeInBytes,
+                                          Data_t workspace,
+                                          size_t workspaceSizeInBytes,
+                                          const void* alpha,
+                                          const TensorDescriptor& aDesc,
+                                          ConstData_t A,
+                                          const void* beta,
+                                          const TensorDescriptor& cDesc,
+                                          Data_t C) const
+{
+    const auto srcDataType       = aDesc.GetType();
+    const auto dstDataType       = cDesc.GetType();
+    const auto compType          = this->reduceTensorCompType_;
+    const auto reduceOp          = this->reduceTensorOp_;
+    const auto nanPropaOpt       = this->reduceTensorNanOpt_;
+    const auto reduceIndicesOpt  = this->reduceTensorIndices_;
+    const auto reduceIndicesType = this->reduceTensorIndicesType_;
+
+    const auto& inDescLengths  = aDesc.GetLengths();
+    const auto& inDescStrides  = aDesc.GetStrides();
+    const auto& outDescLengths = cDesc.GetLengths();
+    const auto& outDescStrides = cDesc.GetStrides();
+
+    bool need_indices =
+        (reduceIndicesOpt == MIOPEN_REDUCE_TENSOR_FLATTENED_INDICES) &&
+        (reduceOp == MIOPEN_REDUCE_TENSOR_MIN || reduceOp == MIOPEN_REDUCE_TENSOR_MAX);
+
+    if(inDescLengths.size() > 6)
+        MIOPEN_THROW("Invalid TensorDescriptor, at most number of dimensions of 6 is supported.");
+
+    if(need_indices && (reduceIndicesType != MIOPEN_32BIT_INDICES))
+        MIOPEN_THROW("Only int32 type can be used for ReduceTensor indices.");
+
+    if(inDescLengths.size() != outDescLengths.size())
+        MIOPEN_THROW("The number of dimensions of the input and output tensor should match.");
+
+    for(int i = 0; i < inDescLengths.size(); i++)
+    {
+        if(outDescLengths[i] != 1 && outDescLengths[i] != inDescLengths[i])
+            MIOPEN_THROW("The length of the output tensor dimension should either be 1 or be equal "
+                         "to the length of the corresponding dimension of the input tensor.");
+    };
+
+    std::size_t ws_sizeInBytes      = this->GetWorkspaceSize(handle, aDesc, cDesc);
+    std::size_t indices_sizeInBytes = this->GetIndicesSize(aDesc, cDesc);
+
+    if(ws_sizeInBytes > workspaceSizeInBytes)
+        MIOPEN_THROW("The workspace size allocated is not enough!");
+
+    if(indices_sizeInBytes > indicesSizeInBytes)
+        MIOPEN_THROW("The indices size allocated is not enough!");
+
+    // void* ws_buf1_global = static_cast<void*>(workspace);
+    Data_t ws_buf1_global     = workspace;
+    long ws_buf2_bytes_offset = 0;
+
+    if(need_indices && workspace != nullptr)
+    {
+        std::size_t aTypeSize = detail::GetDataTypeSize(aDesc.GetType());
+
+        long byteOffset =
+            static_cast<long>((workspaceSizeInBytes / (aTypeSize + sizeof(int))) * aTypeSize);
+
+        ws_buf2_bytes_offset = ((byteOffset + 63) / 64) * 64;
+    };
+
+    // invariantLength and toReduceLength are used to determine the kernel configuration
+    auto invariantLength = cDesc.GetElementSize();
+    auto toReduceLength  = aDesc.GetElementSize() / invariantLength;
+
+    std::vector<std::size_t> invariantLengths;
+    std::vector<std::size_t>
+        invariantStrides; // for construct the compressed destinaton descriptor used for Reduction
+    std::vector<int> toReduceDims;
+    std::vector<int> invariantDims;
+
+    for(int i = 0; i < inDescLengths.size(); i++)
+    {
+        if(outDescLengths[i] == inDescLengths[i])
+        { //  this dimension is invariant
+            invariantDims.push_back(i);
+            invariantLengths.push_back(inDescLengths[i]);
+            invariantStrides.push_back(outDescStrides[i]);
+        }
+        else
+        { // this dimension is toReduce
+            toReduceDims.push_back(i);
+        }
+    };
+
+    if(toReduceDims.empty())
+        MIOPEN_THROW("Invalid TensorDescriptor, at least one dimension of the input tensor should "
+                     "be reduced.");
+
+    const int blockSize = 256; // tunable
+    detail::ReductionKernelConfigurator configurator(blockSize, handle.GetWavefrontWidth());
+
+    ReductionMethod_t reduceImpl = configurator.getReductionMethod(invariantLength, toReduceLength);
+    auto gridSize                = configurator.getGridSize(invariantLength, toReduceLength);
+    int blkGroupSize =
+        (reduceImpl == Reduce_MultiBlock) ? static_cast<int>(gridSize / invariantLength) : 0;
+
+    bool useTwoCalls = (reduceImpl == Reduce_MultiBlock);
+
+    bool reduceAllDims = invariantDims.empty();
+
+    detail::get_tunable_reduction_kernel_constants get_constants(reduceImpl);
+
+    int GredThreadBufferLength       = get_constants.GredThreadBufferLength;
+    int GredAccessesPerThreadInBlock = get_constants.GredAccessesPerThreadInBlock;
+    int GredAccessesPerThreadInWarp  = get_constants.GredAccessesPerThreadInWarp;
+
+    std::string param;
+
+    param = std::string(" -std=c++14 ");
+    param += " -DCK_PARAM_BLOCKSIZE=" + std::to_string(blockSize);
+    param += " -DCK_PARAM_BLKGROUPSIZE=" + std::to_string(blkGroupSize);
+    param += " -DCK_PARAM_SRC_DATATYPE=" + std::to_string(static_cast<int>(srcDataType));
+    param += " -DCK_PARAM_DST_DATATYPE=" + std::to_string(static_cast<int>(dstDataType));
+    param += " -DCK_PARAM_REDUCE_COMPTYPE=" + std::to_string(static_cast<int>(compType));
+
+    param += " -DCK_PARAM_SRC_DESC_LENGTHS=";
+    for(int i = 0; i < inDescLengths.size(); i++)
+    {
+        param += std::to_string(inDescLengths[i]);
+        if(i < inDescLengths.size() - 1)
+            param += ",";
+    };
+
+    param += " -DCK_PARAM_SRC_DESC_STRIDES=";
+    for(int i = 0; i < inDescStrides.size(); i++)
+    {
+        param += std::to_string(inDescStrides[i]);
+        if(i < inDescStrides.size() - 1)
+            param += ",";
+    };
+
+    if(!reduceAllDims)
+    {
+        param += " -DCK_PARAM_DST_DESC_LENGTHS=";
+        for(int i = 0; i < invariantLengths.size(); i++)
+        {
+            param += std::to_string(invariantLengths[i]);
+            if(i < invariantLengths.size() - 1)
+                param += ",";
+        };
+
+        param += " -DCK_PARAM_DST_DESC_STRIDES=";
+        for(int i = 0; i < invariantStrides.size(); i++)
+        {
+            param += std::to_string(invariantStrides[i]);
+            if(i < invariantLengths.size() - 1)
+                param += ",";
+        };
+    }
+    else
+    {
+        param += " -DCK_PARAM_DST_DESC_LENGTHS=1";
+        param += " -DCK_PARAM_DST_DESC_STRIDES=1";
+    };
+
+    param += " -DCK_PARAM_TOREDUCE_DIMS=";
+    for(int i = 0; i < toReduceDims.size(); i++)
+    {
+        param += std::to_string(toReduceDims[i]);
+        if(i < toReduceDims.size() - 1)
+            param += ",";
+    };
+
+    if(!reduceAllDims)
+    {
+        param += " -DCK_PARAM_INVARIANT_DIMS=";
+        for(int i = 0; i < invariantDims.size(); i++)
+        {
+            param += std::to_string(invariantDims[i]);
+            if(i < invariantDims.size() - 1)
+                param += ",";
+        };
+    }
+    else
+        param += " -DCK_PARAM_INVARIANT_DIMS= ";
+
+    param += " -DCK_PARAM_REDUCE_OP=" + std::to_string(static_cast<int>(reduceOp));
+    param += " -DCK_PARAM_NAN_PROPAGATE=" + std::to_string(static_cast<int>(nanPropaOpt));
+    param += " -DCK_PARAM_REDUCE_INDICES=" + std::to_string(static_cast<int>(reduceIndicesOpt));
+
+    param += " -DCK_PARAM_THREAD_BUFFER_LENGTH=" + std::to_string(GredThreadBufferLength);
+    param +=
+        " -DCK_PARAM_ACCESSES_PER_THREAD_INBLOCK=" + std::to_string(GredAccessesPerThreadInBlock);
+    param +=
+        " -DCK_PARAM_ACCESSES_PER_THREAD_INWARP=" + std::to_string(GredAccessesPerThreadInWarp);
+
+    param += " -DCK_PARAM_REDUCE_IMPL=" + std::to_string(static_cast<int>(reduceImpl));
+
+    // to remove the warning from clang-tidy checking
+    param += " -DMIOPEN_USE_FP32=0 -DMIOPEN_USE_FP16=0 ";
+
+    std::string program_name = "gridwise_generic_reduction.cpp";
+    std::string algo_name    = "generic_reduce_tensor";
+    std::string network_config;
+
+    network_config = "reduce_T" + std::to_string(srcDataType) + std::to_string(dstDataType) +
+                     std::to_string(compType) + "IN";
+    for(auto dimLen : inDescLengths)
+        network_config += std::to_string(dimLen) + "_";
+    network_config += "OUT";
+    for(auto dimLen : outDescLengths)
+        network_config += std::to_string(dimLen) + "_";
+    network_config += "BSIZE_" + std::to_string(blockSize);
+
+    // kernel for the first call
+    std::string kernel_name1 = "gridwise_generic_reduce_1";
+
+    const std::vector<size_t> vld_1 = {static_cast<size_t>(blockSize), size_t{1}, size_t{1}};
+    const std::vector<size_t> vgd_1 = {
+        static_cast<size_t>(gridSize * blockSize), size_t{1}, size_t{1}};
+
+    visit_float(srcDataType, [&](auto as_float) {
+        float alphaVal = type_convert<float>{}(*as_float(alpha));
+        float betaVal  = type_convert<float>{}(*as_float(beta));
+
+        handle.AddKernel(
+            algo_name, network_config, program_name, kernel_name1, vld_1, vgd_1, param)(
+            alphaVal, A, betaVal, C, ws_buf1_global, ws_buf2_bytes_offset, indices);
+    });
+
+    if(useTwoCalls)
+    {
+        int toReduceLength_2 = blkGroupSize;
+        int gridSize_2       = configurator.getGridSize_2(invariantLength, toReduceLength_2);
+
+        // compile option and network config for the second-time call
+        const std::vector<size_t> vld_2 = {static_cast<size_t>(blockSize), size_t{1}, size_t{1}};
+        const std::vector<size_t> vgd_2 = {
+            static_cast<size_t>(gridSize_2 * blockSize), size_t{1}, size_t{1}};
+
+        // kernel for the second call
+        std::string kernel_name2 = "gridwise_generic_reduce_2";
+
+        visit_float(srcDataType, [&](auto as_float) {
+            float alphaVal = type_convert<float>{}(*as_float(alpha));
+            float betaVal  = type_convert<float>{}(*as_float(beta));
+
+            handle.AddKernel(
+                algo_name, network_config, program_name, kernel_name2, vld_2, vgd_2, param)(
+                alphaVal, A, betaVal, C, ws_buf1_global, ws_buf2_bytes_offset, indices);
+        });
+    };
+};
+
+std::ostream& operator<<(std::ostream& stream, const ReduceTensorDescriptor& desc)
+{
+    stream << "ReduceTensor Descriptor : " << std::endl;
+    stream << "Reduction Operation Type : " << desc.reduceTensorOp_ << std::endl;
+    stream << "Reduction CompType : " << desc.reduceTensorCompType_ << std::endl;
+    stream << "NanPropagation Option : " << desc.reduceTensorNanOpt_ << std::endl;
+    stream << "Indices Option : " << desc.reduceTensorIndices_ << std::endl;
+
+    return (stream);
+};
+
+} // end of namespace miopen

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -151,6 +151,27 @@ function(add_sanitize_test TEST_SOURCE)
 endfunction()
 
 file(GLOB TESTS *.cpp)
+# All the tests are manually sorted in descending order of durations taken from
+# Jenkins, "Full long tests"/"HIP Release All". This is to exploit ctest's 
+# parallelizm as much as possible. Before this change, there were some long
+# jobs at the end, utilizing only one CPU core. This order can potentially
+# save up to ~23 minutes (20%) of total time of "HIP Release All".
+#
+# We use two lists, LONG_TESTS and SHORT_TESTS to implement the sorting
+# mentioned above. If you would like to add a new test, insert it into the
+# LONG_TESTS if it takes more than 800 seconds, or to SHORT_TESTS otherwise.
+# Please notice that each list is also sorted and it is highly recommended
+# to keep this sorting when adding new tests.
+
+set( LONG_TESTS
+    pooling2d.cpp
+    dropout.cpp
+    conv2d.cpp
+    pooling3d.cpp
+    soft_max.cpp
+    lrn_test.cpp
+    reduce_test.cpp
+    )
 
 foreach(TEST ${TESTS})
     get_filename_component(BASE_NAME ${TEST} NAME_WE)

--- a/test/reduce_test.cpp
+++ b/test/reduce_test.cpp
@@ -1,0 +1,826 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2020 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#include "driver.hpp"
+#include "test.hpp"
+#include "verify.hpp"
+#include "get_handle.hpp"
+#include "tensor_holder.hpp"
+#include <miopen/miopen.h>
+#include <miopen/tensor.hpp>
+#include <miopen/stringutils.hpp>
+#include <miopen/reducetensor.hpp>
+#include <random>
+#include <algorithm>
+#include <iterator>
+#include <limits>
+#include <iostream>
+
+#include <miopen/reduce_common.hpp>
+
+static void get_all_indexes(const std::vector<std::size_t>& dimLengths,
+                            int dim,
+                            std::vector<std::vector<std::size_t>>& indexes)
+{
+    if(dim < dimLengths.size())
+    {
+        std::vector<std::vector<std::size_t>> updated_indexes;
+
+        if(dim == 0)
+        {
+            assert(indexes.size() == 0);
+            assert(dimLengths[dim] > 0);
+            for(std::size_t i = 0; i < dimLengths[dim]; i++)
+            {
+                std::vector<std::size_t> index = {i};
+
+                updated_indexes.push_back(index);
+            };
+        }
+        else
+        {
+            // go through all the current indexes
+            for(const auto& index : indexes)
+                for(std::size_t i = 0; i < dimLengths[dim]; i++)
+                {
+                    auto index_new = index;
+                    index_new.push_back(i);
+
+                    updated_indexes.push_back(index_new);
+                };
+        };
+
+        // update to the indexes (output)
+        indexes = updated_indexes;
+
+        // further to construct the indexes from the updated status
+        get_all_indexes(dimLengths, dim + 1, indexes);
+    };
+};
+
+static std::size_t get_offset_from_index(const std::vector<std::size_t>& strides,
+                                         const std::vector<std::size_t>& index)
+{
+    std::size_t offset = 0;
+
+    assert(strides.size() == index.size());
+
+    for(int i = 0; i < index.size(); i++)
+        offset += strides[i] * index[i];
+
+    return (offset);
+};
+
+static std::size_t get_flatten_offset(const std::vector<std::size_t>& lengths,
+                                      const std::vector<std::size_t>& index)
+{
+    std::size_t offset = 0;
+
+    assert(lengths.size() == index.size() && lengths.size() > 0);
+
+    int len            = lengths.size();
+    std::size_t stride = 1;
+
+    // for len==1, the loop is not executed
+    for(int i = len - 1; i > 0; i--)
+    {
+        offset += stride * index[i];
+
+        stride *= lengths[i];
+    };
+
+    offset += stride * index[0];
+
+    return (offset);
+};
+
+template <class T, bool toVerifyData>
+struct verify_reduce_with_indices
+{
+    miopen::ReduceTensorDescriptor reduce;
+    tensor<T> input;
+    tensor<T> output;
+    tensor<T> workspace;
+    tensor<int> indices;
+    T alpha;
+    T beta;
+
+    miopenReduceTensorOp_t reduceOp;
+    miopenDataType_t compTypeVal;
+    miopenNanPropagation_t nanOpt;
+    miopenReduceTensorIndices_t indicesOpt;
+    miopenIndicesType_t indicesType;
+
+    verify_reduce_with_indices(const miopen::ReduceTensorDescriptor& reduce_,
+                               const tensor<T>& input_,
+                               const tensor<T>& output_,
+                               const tensor<T>& workspace_,
+                               const tensor<int>& indices_,
+                               T alpha_,
+                               T beta_)
+    {
+        reduce    = reduce_;
+        input     = input_;
+        output    = output_;
+        workspace = workspace_;
+        indices   = indices_;
+        alpha     = alpha_;
+        beta      = beta_;
+
+        reduceOp    = reduce.reduceTensorOp_;
+        compTypeVal = reduce.reduceTensorCompType_;
+        nanOpt      = reduce.reduceTensorNanOpt_;
+        indicesOpt  = reduce.reduceTensorIndices_;
+        indicesType = reduce.reduceTensorIndicesType_;
+    }
+
+    tensor<float> cpu() const
+    {
+        using reduce::type_convert;
+
+        std::tuple<tensor<T>, tensor<int>> results;
+
+        if(compTypeVal == miopenFloat)
+        {
+            if(std::is_same<T, double>::value)
+                results = cpuImpl<double>();
+            else
+                results = cpuImpl<float>();
+        }
+        else if(compTypeVal == miopenHalf)
+        {
+            if(std::is_same<T, double>::value)
+                results = cpuImpl<double>();
+            else
+                results = cpuImpl<float>();
+        };
+
+        if(toVerifyData)
+        {
+            const auto dimLengths = output.desc.GetLengths();
+
+            auto result_dataFloat = make_tensor<float>(dimLengths);
+
+            auto& result_dataT = std::get<0>(results);
+
+            for(size_t i                 = 0; i < result_dataT.data.size(); i++)
+                result_dataFloat.data[i] = type_convert<float>{}(result_dataT.data[i]);
+
+            return (result_dataFloat);
+        }
+        else
+        {
+            const auto dimLengths = indices.desc.GetLengths();
+
+            auto result_indicesFloat = make_tensor<float>(dimLengths);
+
+            auto& result_indices = std::get<1>(results);
+
+            for(size_t i                    = 0; i < result_indices.data.size(); i++)
+                result_indicesFloat.data[i] = static_cast<float>(result_indices.data[i]);
+
+            return (result_indicesFloat);
+        };
+    };
+
+    tensor<float> gpu() const
+    {
+        using reduce::type_convert;
+
+        std::tuple<tensor<T>, tensor<int>> results;
+
+        results = gpuImpl();
+
+        if(toVerifyData)
+        {
+            const auto dimLengths = output.desc.GetLengths();
+
+            auto result_dataFloat = make_tensor<float>(dimLengths);
+
+            tensor<T>& result_dataT = std::get<0>(results);
+
+            for(size_t i                 = 0; i < result_dataT.data.size(); i++)
+                result_dataFloat.data[i] = type_convert<float>{}(result_dataT.data[i]);
+
+            return (result_dataFloat);
+        }
+        else
+        {
+            const auto dimLengths = indices.desc.GetLengths();
+
+            auto result_indicesFloat = make_tensor<float>(dimLengths);
+
+            tensor<int>& result_indices = std::get<1>(results);
+
+            for(size_t i                    = 0; i < result_indices.data.size(); i++)
+                result_indicesFloat.data[i] = static_cast<float>(result_indices.data[i]);
+
+            return (result_indicesFloat);
+        };
+    };
+
+    template <typename compType>
+    std::tuple<tensor<T>, tensor<int>> cpuImpl() const
+    {
+        using reduce::ReduceOpFn2;
+        using reduce::ReduceOpZeroVal;
+        using reduce::float_equal_one;
+        using reduce::float_equal_zero;
+        using reduce::type_convert;
+        using reduce::binop_with_nan_check;
+        using reduce::binop_with_nan_check2;
+
+        auto inLengths  = input.desc.GetLengths();
+        auto outLengths = output.desc.GetLengths();
+        auto inStrides  = input.desc.GetStrides();
+        auto outStrides = output.desc.GetStrides();
+
+        // replicate
+        auto res         = output;
+        auto res_indices = indices;
+
+        std::vector<std::size_t> invariantLengths;
+        std::vector<std::size_t> toReduceLengths;
+
+        std::vector<int> invariantDims;
+        std::vector<int> toReduceDims;
+
+        for(int i = 0; i < inLengths.size(); i++)
+            if(inLengths[i] == outLengths[i])
+                invariantDims.push_back(i);
+            else
+                toReduceDims.push_back(i);
+
+        invariantLengths.resize(invariantDims.size());
+        for(int i               = 0; i < invariantDims.size(); i++)
+            invariantLengths[i] = inLengths[invariantDims[i]];
+
+        toReduceLengths.resize(toReduceDims.size());
+        for(int i              = 0; i < toReduceDims.size(); i++)
+            toReduceLengths[i] = inLengths[toReduceDims[i]];
+
+        bool reduceAllDims = invariantDims.empty();
+
+        auto opReduce = ReduceOpFn2<compType>(reduceOp);
+
+        if(reduceAllDims)
+        {
+            std::vector<std::vector<std::size_t>> indexes_1;
+
+            get_all_indexes(inLengths, 0, indexes_1);
+
+            compType accuVal = ReduceOpZeroVal<compType>(reduceOp);
+            int accuIndex    = 0;
+
+            // go through indexes of the invariant dimensions
+            for(const auto& src_index : indexes_1)
+            {
+                auto src_offset = get_offset_from_index(inStrides, src_index);
+
+                auto currVal = type_convert<compType>{}(input.data[src_offset]);
+
+                int currIndex = get_flatten_offset(inLengths, src_index);
+                binop_with_nan_check2(nanOpt, opReduce, accuVal, currVal, accuIndex, currIndex);
+            };
+
+            // scale the accumulated value
+            if(!float_equal_one{}(alpha))
+                accuVal *= type_convert<compType>{}(alpha);
+
+            // scale the prior dst value and add it to the accumulated value
+            if(!float_equal_zero{}(beta))
+            {
+                accuVal += type_convert<compType>{}(output.data[0] * beta);
+            };
+
+            // store the reduced value to dst location
+            res.data[0]         = type_convert<T>{}(accuVal);
+            res_indices.data[0] = accuIndex;
+        }
+        else
+        {
+            std::vector<std::vector<std::size_t>> indexes_1, indexes_2;
+
+            get_all_indexes(invariantLengths, 0, indexes_1);
+            get_all_indexes(toReduceLengths, 0, indexes_2);
+
+            // go through indexes of the invariant dimensions
+            for(const auto& index_1 : indexes_1)
+            {
+                std::vector<std::size_t> src_index;
+                std::vector<std::size_t> dst_index;
+
+                src_index.resize(inLengths.size());
+                dst_index.resize(inLengths.size());
+
+                std::fill(dst_index.begin(), dst_index.end(), 0);
+
+                for(int k                       = 0; k < invariantDims.size(); k++)
+                    dst_index[invariantDims[k]] = index_1[k];
+
+                int dst_offset = get_offset_from_index(outStrides, dst_index);
+
+                // generate the part of the index belonging to the invariant dims
+                for(int k                       = 0; k < invariantDims.size(); k++)
+                    src_index[invariantDims[k]] = index_1[k];
+
+                compType accuVal = ReduceOpZeroVal<compType>(reduceOp);
+                int accuIndex    = 0;
+
+                // go through indexes of the toReduce dimensions
+                for(const auto& index_2 : indexes_2)
+                {
+                    // generate the part of the index belonging to the toReduce dims
+                    for(int k                      = 0; k < toReduceDims.size(); k++)
+                        src_index[toReduceDims[k]] = index_2[k];
+
+                    auto src_offset = get_offset_from_index(inStrides, src_index);
+
+                    auto currVal = type_convert<compType>{}(input.data[src_offset]);
+
+                    auto currIndex = get_flatten_offset(toReduceLengths, index_2);
+                    binop_with_nan_check2(nanOpt, opReduce, accuVal, currVal, accuIndex, currIndex);
+                };
+
+                // scale the accumulated value
+                if(!float_equal_one{}(alpha))
+                    accuVal *= type_convert<compType>{}(alpha);
+
+                // scale the prior dst value and add it to the accumulated value
+                if(!float_equal_zero{}(beta))
+                    accuVal += type_convert<compType>{}(output.data[dst_offset] * beta);
+
+                // store the reduced value to dst location
+                res.data[dst_offset]         = type_convert<T>{}(accuVal);
+                res_indices.data[dst_offset] = accuIndex; // store the index
+            };
+        };
+
+        return (std::make_tuple(res, res_indices));
+    }
+
+    std::tuple<tensor<T>, tensor<int>> gpuImpl() const
+    {
+        auto&& handle   = get_handle();
+        auto input_dev  = handle.Write(input.data);
+        auto output_dev = handle.Write(output.data);
+
+        // replicate
+        auto res         = output;
+        auto res_indices = indices;
+
+        auto indices_dev = handle.Write(indices.data);
+
+        std::size_t ws_sizeInBytes      = workspace.desc.GetElementSize() * sizeof(T);
+        std::size_t indices_sizeInBytes = indices.desc.GetElementSize() * sizeof(int);
+
+        if(ws_sizeInBytes > 0)
+        {
+            auto workspace_dev = handle.Write(workspace.data);
+
+            reduce.ReduceTensor(get_handle(),
+                                indices_dev.get(),
+                                indices_sizeInBytes,
+                                workspace_dev.get(),
+                                ws_sizeInBytes,
+                                static_cast<const void*>(&alpha),
+                                input.desc,
+                                input_dev.get(),
+                                static_cast<const void*>(&beta),
+                                output.desc,
+                                output_dev.get());
+        }
+        else
+        {
+            reduce.ReduceTensor(get_handle(),
+                                indices_dev.get(),
+                                indices_sizeInBytes,
+                                nullptr,
+                                0,
+                                static_cast<const void*>(&alpha),
+                                input.desc,
+                                input_dev.get(),
+                                static_cast<const void*>(&beta),
+                                output.desc,
+                                output_dev.get());
+        };
+
+        res.data         = handle.Read<T>(output_dev, res.data.size());
+        res_indices.data = handle.Read<int>(indices_dev, res_indices.data.size());
+
+        return (std::make_tuple(res, res_indices));
+    }
+
+    void fail(int) const
+    {
+        std::cout << "verify_reduce_with_indices failed" << std::endl;
+        std::cout << "Input Tensor"
+                  << " " << input.desc.ToString() << std::endl;
+    }
+};
+
+template <class T>
+struct verify_reduce_no_indices
+{
+    miopen::ReduceTensorDescriptor reduce;
+    tensor<T> input;
+    tensor<T> output;
+    tensor<T> workspace;
+    T alpha;
+    T beta;
+
+    miopenReduceTensorOp_t reduceOp;
+    miopenDataType_t compTypeVal;
+    miopenNanPropagation_t nanOpt;
+
+    verify_reduce_no_indices(const miopen::ReduceTensorDescriptor& reduce_,
+                             const tensor<T>& input_,
+                             const tensor<T>& output_,
+                             const tensor<T>& workspace_,
+                             T alpha_,
+                             T beta_)
+    {
+        reduce    = reduce_;
+        input     = input_;
+        output    = output_;
+        workspace = workspace_;
+        alpha     = alpha_;
+        beta      = beta_;
+
+        reduceOp    = reduce.reduceTensorOp_;
+        compTypeVal = reduce.reduceTensorCompType_;
+        nanOpt      = reduce.reduceTensorNanOpt_;
+    }
+
+    tensor<T> cpu()
+    {
+        if(compTypeVal == miopenFloat)
+        {
+            if(std::is_same<T, double>::value)
+                return (cpuImpl<double>());
+            else
+                return (cpuImpl<float>());
+        }
+        else if(compTypeVal == miopenHalf || compTypeVal == miopenBFloat16)
+        {
+            if(std::is_same<T, double>::value)
+                return (cpuImpl<double>());
+            else
+                return (cpuImpl<float>());
+        };
+
+        return (tensor<T>{});
+    };
+
+    template <typename compType>
+    tensor<T> cpuImpl() const
+    {
+        using reduce::ReduceOpFn;
+        using reduce::ReduceOpZeroVal;
+        using reduce::float_equal_one;
+        using reduce::float_equal_zero;
+        using reduce::type_convert;
+        using reduce::binop_with_nan_check;
+        using reduce::binop_with_nan_check2;
+
+        auto inLengths  = input.desc.GetLengths();
+        auto outLengths = output.desc.GetLengths();
+        auto inStrides  = input.desc.GetStrides();
+        auto outStrides = output.desc.GetStrides();
+
+        // replicate
+        auto res = output;
+
+        std::vector<std::size_t> invariantLengths;
+        std::vector<std::size_t> toReduceLengths;
+
+        std::vector<int> invariantDims;
+        std::vector<int> toReduceDims;
+
+        for(int i = 0; i < inLengths.size(); i++)
+            if(inLengths[i] == outLengths[i])
+                invariantDims.push_back(i);
+            else
+                toReduceDims.push_back(i);
+
+        invariantLengths.resize(invariantDims.size());
+        for(int i               = 0; i < invariantDims.size(); i++)
+            invariantLengths[i] = inLengths[invariantDims[i]];
+
+        toReduceLengths.resize(toReduceDims.size());
+        for(int i              = 0; i < toReduceDims.size(); i++)
+            toReduceLengths[i] = inLengths[toReduceDims[i]];
+
+        bool reduceAllDims = invariantDims.empty();
+
+        auto opReduce = ReduceOpFn<compType>(reduceOp);
+
+        if(reduceAllDims)
+        {
+            std::vector<std::vector<std::size_t>> indexes_1;
+
+            get_all_indexes(inLengths, 0, indexes_1);
+
+            compType accuVal = ReduceOpZeroVal<compType>(reduceOp);
+
+            // go through indexes of the invariant dimensions
+            for(const auto& src_index : indexes_1)
+            {
+                auto src_offset = get_offset_from_index(inStrides, src_index);
+
+                auto currVal = type_convert<compType>{}(input.data[src_offset]);
+
+                binop_with_nan_check(nanOpt, opReduce, accuVal, currVal);
+            };
+
+            // scale the accumulated value
+            if(!float_equal_one{}(alpha))
+                accuVal *= type_convert<compType>{}(alpha);
+
+            // scale the prior dst value and add it to the accumulated value
+            if(!float_equal_one{}(beta))
+                accuVal += type_convert<compType>{}(output.data[0] * beta);
+
+            // store the reduced value to dst location
+            res.data[0] = type_convert<T>{}(accuVal);
+        }
+        else
+        {
+            std::vector<std::vector<std::size_t>> indexes_1, indexes_2;
+
+            get_all_indexes(invariantLengths, 0, indexes_1);
+            get_all_indexes(toReduceLengths, 0, indexes_2);
+
+            // go through indexes of the invariant dimensions
+            for(const auto& index_1 : indexes_1)
+            {
+                std::vector<std::size_t> src_index;
+                std::vector<std::size_t> dst_index;
+
+                src_index.resize(inLengths.size());
+                dst_index.resize(inLengths.size());
+
+                std::fill(dst_index.begin(), dst_index.end(), 0);
+
+                for(int k                       = 0; k < invariantDims.size(); k++)
+                    dst_index[invariantDims[k]] = index_1[k];
+
+                int dst_offset = get_offset_from_index(outStrides, dst_index);
+
+                // generate the part of the index belonging to the invariant dims
+                for(int k                       = 0; k < invariantDims.size(); k++)
+                    src_index[invariantDims[k]] = index_1[k];
+
+                compType accuVal = ReduceOpZeroVal<compType>(reduceOp);
+
+                // go through indexes of the toReduce dimensions
+                for(const auto& index_2 : indexes_2)
+                {
+                    // generate the part of the index belonging to the toReduce dims
+                    for(int k                      = 0; k < toReduceDims.size(); k++)
+                        src_index[toReduceDims[k]] = index_2[k];
+
+                    auto src_offset = get_offset_from_index(inStrides, src_index);
+
+                    auto currVal = type_convert<compType>{}(input.data[src_offset]);
+
+                    binop_with_nan_check(nanOpt, opReduce, accuVal, currVal);
+                };
+
+                // scale the accumulated value
+                if(!float_equal_one{}(alpha))
+                    accuVal *= type_convert<compType>{}(alpha);
+
+                // scale the prior dst value and add it to the accumulated value
+                if(!float_equal_zero{}(beta))
+                    accuVal += type_convert<compType>{}(output.data[dst_offset] * beta);
+
+                // store the reduced value to dst location
+                res.data[dst_offset] = type_convert<T>{}(accuVal);
+            };
+        };
+
+        return (res);
+    }
+
+    tensor<T> gpu() const
+    {
+        auto&& handle   = get_handle();
+        auto input_dev  = handle.Write(input.data);
+        auto output_dev = handle.Write(output.data);
+
+        // replicate
+        auto res = output;
+
+        std::size_t ws_sizeInBytes = workspace.desc.GetElementSize() * sizeof(T);
+
+        if(ws_sizeInBytes > 0)
+        {
+            auto workspace_dev = handle.Write(workspace.data);
+
+            reduce.ReduceTensor(get_handle(),
+                                nullptr,
+                                0,
+                                workspace_dev.get(),
+                                ws_sizeInBytes,
+                                static_cast<const void*>(&alpha),
+                                input.desc,
+                                input_dev.get(),
+                                static_cast<const void*>(&beta),
+                                output.desc,
+                                output_dev.get());
+        }
+        else
+        {
+            reduce.ReduceTensor(get_handle(),
+                                nullptr,
+                                0,
+                                nullptr,
+                                0,
+                                static_cast<const void*>(&alpha),
+                                input.desc,
+                                input_dev.get(),
+                                static_cast<const void*>(&beta),
+                                output.desc,
+                                output_dev.get());
+        };
+
+        res.data = handle.Read<T>(output_dev, res.data.size());
+
+        return (res);
+    }
+
+    void fail(int) const
+    {
+        std::cout << "verify_reduce_no_indices failed" << std::endl;
+        std::cout << "Input Tensor"
+                  << " " << input.desc.ToString() << std::endl;
+    }
+};
+
+template <class T>
+struct reduce_driver : test_driver
+{
+    int reduceOp                    = 0; //  miopenReduceTensorOp_t reduceOp;
+    int compTypeVal                 = 1; //  miopenDataType_t compTypeVal;
+    int nanOpt                      = 0; //  miopenNanPropagation_t nanOpt;
+    int indicesOpt                  = 0; //  miopenReduceTensorIndices_t indicesOpt;
+    miopenIndicesType_t indicesType = MIOPEN_32BIT_INDICES;
+
+    std::vector<std::size_t> inLengths; // the lengths of the input tensor's dimensions
+    std::vector<int>
+        toReduceDims; // the indexes of the dimensions to be reduced in the input tensor
+
+    std::vector<float> scales;
+    float alpha = 1.0f;
+    float beta  = 0.0f;
+
+    std::vector<std::vector<std::size_t>> get_tensor_lengths()
+    {
+        return {
+            {64, 3, 280, 81},
+        };
+    }
+
+    std::vector<std::vector<int>> get_toreduce_dims()
+    {
+        return {
+            {0},
+            {1},
+            {2},
+            {3},
+            {0, 1},
+            {1, 2},
+            {0, 3},
+            {1, 3},
+            {0, 2},
+            {2, 3},
+            {0, 1, 3},
+            {1, 2, 3},
+            {0, 1, 2, 3},
+        };
+    }
+
+    reduce_driver()
+    {
+        add(inLengths, "D", generate_data(get_tensor_lengths()));
+        add(toReduceDims, "R", generate_data(get_toreduce_dims()));
+        add(reduceOp, "ReduceOp", generate_data({0, 2}));
+        add(compTypeVal, "CompType", generate_data({1}));
+        add(nanOpt, "N", generate_data({0}));
+        add(indicesOpt, "I", generate_data({0, 1}));
+
+        add(scales, "scales", generate_data({{1.0f, 0.0f}, {0.5f, 0.5f}}));
+
+        auto&& handle = get_handle();
+        handle.EnableProfiling();
+    }
+
+    void run()
+    {
+        using reduce::type_convert;
+
+        miopen::ReduceTensorDescriptor reduceDesc(
+            static_cast<miopenReduceTensorOp_t>(reduceOp),
+            static_cast<miopenDataType_t>(compTypeVal),
+            static_cast<miopenNanPropagation_t>(nanOpt),
+            static_cast<miopenReduceTensorIndices_t>(indicesOpt),
+            indicesType);
+
+        alpha = scales[0];
+        beta  = scales[1];
+
+        auto outLengths = this->inLengths;
+
+        assert(toReduceDims.size() <= outLengths.size());
+        for(int i = 0; i < toReduceDims.size(); i++)
+            assert(toReduceDims[i] < inLengths.size());
+
+        // set the lengths of the dimensions to be reduced to 1 to represent the output Tensor
+        for(int i                       = 0; i < toReduceDims.size(); i++)
+            outLengths[toReduceDims[i]] = static_cast<std::size_t>(1);
+
+        unsigned long max_value =
+            miopen_type<T>{} == miopenHalf ? 5 : miopen_type<T>{} == miopenInt8 ? 127 : 17;
+
+        auto gen_value = [&](auto... is) {
+            return (tensor_elem_gen_integer{max_value}(is...) *
+                    tensor_elem_gen_checkboard_sign{}(is...));
+        };
+
+        auto inputTensor  = tensor<T>{this->inLengths}.generate(gen_value);
+        auto outputTensor = tensor<T>{outLengths};
+
+        std::fill(outputTensor.begin(), outputTensor.end(), type_convert<T>{}(0.0f));
+
+        auto indices_nelem =
+            reduceDesc.GetIndicesSize(inputTensor.desc, outputTensor.desc) / sizeof(int);
+
+        auto ws_sizeInBytes =
+            reduceDesc.GetWorkspaceSize(get_handle(), inputTensor.desc, outputTensor.desc);
+        auto workspace_nelem = (indices_nelem == 0) ? ws_sizeInBytes / sizeof(T)
+                                                    : (ws_sizeInBytes + sizeof(T) - 1) / sizeof(T);
+
+        std::vector<std::size_t> wsLengths = {static_cast<std::size_t>(workspace_nelem), 1};
+        auto workspaceTensor               = tensor<T>{wsLengths};
+
+        std::fill(workspaceTensor.begin(), workspaceTensor.end(), type_convert<T>{}(0.0f));
+
+        if(indices_nelem > 0)
+        {
+            std::vector<std::size_t> indicesLengths = {static_cast<std::size_t>(indices_nelem), 1};
+            auto indicesTensor                      = tensor<int>{indicesLengths};
+
+            std::fill(indicesTensor.begin(), indicesTensor.end(), 1);
+
+            verify(verify_reduce_with_indices<T, true>(reduceDesc,
+                                                       inputTensor,
+                                                       outputTensor,
+                                                       workspaceTensor,
+                                                       indicesTensor,
+                                                       type_convert<T>{}(1.0),
+                                                       type_convert<T>{}(0.0)));
+
+            verify_equals(verify_reduce_with_indices<T, false>(reduceDesc,
+                                                               inputTensor,
+                                                               outputTensor,
+                                                               workspaceTensor,
+                                                               indicesTensor,
+                                                               type_convert<T>{}(1.0),
+                                                               type_convert<T>{}(0.0)));
+        }
+        else
+        {
+            verify(verify_reduce_no_indices<T>(reduceDesc,
+                                               inputTensor,
+                                               outputTensor,
+                                               workspaceTensor,
+                                               type_convert<T>{}(alpha),
+                                               type_convert<T>{}(beta)));
+        };
+    };
+};
+
+int main(int argc, const char* argv[]) { test_drive<reduce_driver<float>>(argc, argv); };

--- a/test/tensor_holder.hpp
+++ b/test/tensor_holder.hpp
@@ -329,6 +329,22 @@ tensor<T> make_tensor(std::initializer_list<std::size_t> dims, G g)
     return tensor<T>{miopen::TensorDescriptor{miopen_type<T>{}, dims}}.generate(g);
 }
 
+// This is needed since there is no TensorDescriptor(miopenDataType_t t, const size_t* plens, int
+// size) constructor
+template <class T>
+tensor<T> make_tensor(const std::vector<std::size_t>& dims)
+{
+    std::vector<int> tmpDims;
+
+    tmpDims.resize(dims.size());
+
+    for(int i      = 0; i < tmpDims.size(); i++)
+        tmpDims[i] = static_cast<int>(dims[i]);
+
+    return tensor<T>{miopen::TensorDescriptor{
+        miopen_type<T>{}, tmpDims.data(), static_cast<int>(tmpDims.size())}};
+};
+
 template <class T, class X>
 tensor<T> make_tensor(const std::vector<X>& dims)
 {


### PR DESCRIPTION
     Core implementation of the generic-reduction. Generic-reduction provides the functionality of generic tensor reduction similar to what provided by cudnnReduceTensor(), and it is based on the composible-kernel facility available with MIOpen. The core implementation include four commits:

1. Tiny adding/changes to composible_kernel to support generic-reduction.
2. Kernel-layer implementation of generic-reduction, which includes the source of four kernels. kernel wrapper and some common helper functions.
3.  Implementation of host-layer C++ interface (miopenReduceTensorDescriptor class) for generic-reduction.
4.  Auto-test support (#>make check) for generic-reduction, which include an C++ file providing verifying testing of the generic-function function and also some host-layer helper functions.

     Four reduction methods are implemented by the kernels which are called DirectThreadwise, DirectWarpwise, Blockwise and MultBlockwise. The selection of which reduction method is based on the specification of the reduction problem(the input tensor description and the dimensions to reduce). And the reduction process is hierarchical (at most two layers), where the first-call of MultiBlockwise reduction will be followed by one of the three other reduction methods as second-call.

     The following are some important source files explained:

1. src/reducetensor.cpp -- the host c++ interfaces for generic_reduction, in which the host-side codes compile, cache, find and launch the kernels
2. src/kernels/composable_kernel/include/kernel_algorithms/gridwise_generic_reduction.hpp -- the top layer kernel, which does tensor transformation and call one of the four xy_to_x kernels to do 2d to 1d tensor reduction
3. src/kernels/composable_kernel/include/kernel_algorithms gridwise_generic_2d_reduction_.hpp -- the four xy_to_x kernels representing four different reduction methods respectively
4. src/kernels/composable_kernel/src/kernel_wrapper/gridwise_generic_reduction.cpp -- the "global" entry of the all kernels, in which the compiler definitions are received and tensor descriptors are created to represent the reduction task.
5. test/reduce_test.cpp -- the auto-tester called by "#make check". The verification is done by comparing the device-based reduction result with that of host-based one. Various reduction cases are covered.
