### PR TITLE
Refactored XdlopsGemm for M/N Repeats

### DIFF
--- a/src/kernels/composable_kernel/include/tensor_operation/blockwise_gemm_xdlops.hpp
+++ b/src/kernels/composable_kernel/include/tensor_operation/blockwise_gemm_xdlops.hpp
@@ -61,9 +61,6 @@ struct BlockwiseGemmBlockABlockBThreadCTransANormalBNormalC_xdlops
         static_assert(BlockSize == GemmMWaves * GemmNWaves * WaveSize,
                       "BlockSize != GemmMWaves * GemmNWaves * WaveSize\n");
 
-        static_assert((MRepeats == 1 && NRepeats == 1) || CK_USE_AMD_XDLOPS_INLINE_ASM == 0,
-                      "do not support xdlops repeat with inline asm");
-
         const index_t waveId   = get_thread_local_1d_id() / WaveSize;
         const index_t waveId_m = waveId / GemmNWaves;
         const index_t waveId_n = waveId % GemmNWaves;

--- a/src/kernels/composable_kernel/include/tensor_operation/blockwise_gemm_xdlops.hpp
+++ b/src/kernels/composable_kernel/include/tensor_operation/blockwise_gemm_xdlops.hpp
@@ -97,7 +97,6 @@ struct BlockwiseGemmBlockABlockBThreadCTransANormalBNormalC_xdlops
         const auto thread_mtx_on_blk = XdlopsGemm.GetBeginOfThreadBlk(i);
 
         const index_t col = (waveId % GemmNWaves) * GemmNPerWave + thread_mtx_on_blk.col;
-
         const index_t row = (waveId / GemmNWaves) * GemmMPerWave + thread_mtx_on_blk.row;
 
         return MatrixIndex{row, col};

--- a/src/kernels/composable_kernel/include/tensor_operation/blockwise_gemm_xdlops.hpp
+++ b/src/kernels/composable_kernel/include/tensor_operation/blockwise_gemm_xdlops.hpp
@@ -4,6 +4,7 @@
 #include "common_header.hpp"
 #include "ConstantMatrixDescriptor.hpp"
 #include "xdlops_gemm.hpp"
+#include "xdlops_gemm_inline_asm.hpp"
 #include "threadwise_gemm.hpp"
 
 namespace ck {
@@ -27,8 +28,13 @@ struct BlockwiseGemmBlockABlockBThreadCTransANormalBNormalC_xdlops
         index_t col;
     };
 
+#if CK_USE_AMD_XDLOPS_INLINE_ASM
+    static constexpr auto XdlopsGemm =
+        XdlopsGemmAsm_t<Float, GemmMPerWave, GemmNPerWave, GemmDataPerReadA, GemmDataPerReadB>{};
+#else
     static constexpr auto XdlopsGemm =
         XdlopsGemm_t<Float, GemmMPerWave, GemmNPerWave, GemmDataPerReadA, GemmDataPerReadB>{};
+#endif
 
     index_t mMyWaveOffsetA;
     index_t mMyWaveOffsetB;

--- a/src/kernels/composable_kernel/include/tensor_operation/blockwise_gemm_xdlops.hpp
+++ b/src/kernels/composable_kernel/include/tensor_operation/blockwise_gemm_xdlops.hpp
@@ -27,14 +27,8 @@ struct BlockwiseGemmBlockABlockBThreadCTransANormalBNormalC_xdlops
         index_t col;
     };
 
-    static constexpr index_t MRepeats = (GemmMPerWave > 64) ? (GemmMPerWave / 64) : 1;
-    static constexpr index_t NRepeats = (GemmNPerWave > 64) ? (GemmNPerWave / 64) : 1;
-
-    static constexpr index_t MPerXdlops = (GemmMPerWave > 64) ? 64 : GemmMPerWave;
-    static constexpr index_t NPerXdlops = (GemmNPerWave > 64) ? 64 : GemmNPerWave;
-
     static constexpr auto XdlopsGemm =
-        XdlopsGemm_t<Float, MPerXdlops, NPerXdlops, GemmDataPerReadA, GemmDataPerReadB>{};
+        XdlopsGemm_t<Float, GemmMPerWave, GemmNPerWave, GemmDataPerReadA, GemmDataPerReadB>{};
 
     index_t mMyWaveOffsetA;
     index_t mMyWaveOffsetB;
@@ -43,13 +37,9 @@ struct BlockwiseGemmBlockABlockBThreadCTransANormalBNormalC_xdlops
 
     __device__ constexpr auto GetOutputLayout() const { return XdlopsGemm.GetOutputLayout(); }
 
-    __device__ constexpr auto GetMRepeats() const { return MRepeats; }
-
-    __device__ constexpr auto GetNRepeats() const { return NRepeats; }
-
     __device__ constexpr auto GetNumBlks() const
     {
-        return XdlopsGemm.GetOutputLayout().GetNumBlks() * MRepeats * NRepeats;
+        return XdlopsGemm.GetOutputLayout().GetNumBlks();
     }
 
     __device__ constexpr auto GetBlkSize() const
@@ -89,17 +79,8 @@ struct BlockwiseGemmBlockABlockBThreadCTransANormalBNormalC_xdlops
         constexpr index_t N = BlockMatrixB::NCol();
         constexpr index_t K = BlockMatrixA::NRow();
 
-        constexpr auto reg_size_xdlops = MPerXdlops * NPerXdlops / WaveSize;
-
-        for(index_t m = 0; m < MRepeats; m++)
-        {
-            for(index_t n = 0; n < NRepeats; n++)
-            {
-                XdlopsGemm.template Run<M, N, K>(&p_a_block[mMyWaveOffsetA + MPerXdlops * m],
-                                                 &p_b_block[mMyWaveOffsetB + NPerXdlops * n],
-                                                 p_c_thread + (NRepeats * m + n) * reg_size_xdlops);
-            }
-        }
+        XdlopsGemm.template Run<M, N, K>(
+            &p_a_block[mMyWaveOffsetA], &p_b_block[mMyWaveOffsetB], p_c_thread);
     }
 
     __device__ static MatrixIndex GetBeginOfThreadMatrixC(index_t i)
@@ -107,19 +88,11 @@ struct BlockwiseGemmBlockABlockBThreadCTransANormalBNormalC_xdlops
 
         const index_t waveId = get_thread_local_1d_id() / WaveSize;
 
-        const index_t xdlops_i = i / XdlopsGemm.GetOutputLayout().GetNumBlks();
-        const index_t j        = i % XdlopsGemm.GetOutputLayout().GetNumBlks();
+        const auto thread_mtx_on_blk = XdlopsGemm.GetBeginOfThreadBlk(i);
 
-        const index_t m = xdlops_i / NRepeats;
-        const index_t n = xdlops_i % NRepeats;
+        const index_t col = (waveId % GemmNWaves) * GemmNPerWave + thread_mtx_on_blk.col;
 
-        const auto thread_mtx_on_blk = XdlopsGemm.GetBeginOfThreadBlk(j);
-
-        const index_t col =
-            (waveId % GemmNWaves) * GemmNPerWave + n * NPerXdlops + thread_mtx_on_blk.col;
-
-        const index_t row =
-            (waveId / GemmNWaves) * GemmMPerWave + m * MPerXdlops + thread_mtx_on_blk.row;
+        const index_t row = (waveId / GemmNWaves) * GemmMPerWave + thread_mtx_on_blk.row;
 
         return MatrixIndex{row, col};
     }
@@ -130,17 +103,12 @@ struct BlockwiseGemmBlockABlockBThreadCTransANormalBNormalC_xdlops
         return make_ConstantMatrixDescriptor_packed(Number<total_reg_size>{}, Number<1>{});
     }
 
-    __device__ void XdlopsMatrixCSetZero() const
-    {
-        constexpr auto reg_size_xdlops = MPerXdlops * NPerXdlops / WaveSize;
-        XdlopsGemm.SetZeroXdlopsRegs(Number<reg_size_xdlops>{});
-    }
+    __device__ void XdlopsMatrixCSetZero() const { XdlopsGemm.SetZeroXdlopsRegs(); }
 
     template <class FloatC>
     __device__ void XdlopsMatrixCRead(FloatC* __restrict__ p_c_thread) const
     {
-        constexpr auto reg_size_xdlops = MPerXdlops * NPerXdlops / WaveSize;
-        XdlopsGemm.ReadXdlopsRegs(Number<reg_size_xdlops>{}, p_c_thread);
+        XdlopsGemm.ReadXdlopsRegs(p_c_thread);
     }
 };
 

--- a/src/kernels/composable_kernel/include/tensor_operation/gridwise_gemm_xdlops_fp16_bfp16.hpp
+++ b/src/kernels/composable_kernel/include/tensor_operation/gridwise_gemm_xdlops_fp16_bfp16.hpp
@@ -997,7 +997,8 @@ struct GridwiseBatchGemmXdlops_gkmkpack_gknkpack_gmn_v2
 
             constexpr auto c_g_m0_m1_m2_n_global_desc = transform_tensor_descriptor(
                 c_g_m_n_global_desc,
-                make_tuple(PassThrough<G>{}, UnMerge<Sequence<M0, M1, M2>>{}, PassThrough<N>{}),
+                make_tuple(
+                    PassThrough<G>{}, UnMerge<Sequence<M / (M1 * M2), M1, M2>>{}, PassThrough<N>{}),
                 make_tuple(Sequence<0>{}, Sequence<1>{}, Sequence<2>{}),
                 make_tuple(Sequence<0>{}, Sequence<1, 2, 3>{}, Sequence<4>{}));
 

--- a/src/kernels/composable_kernel/include/tensor_operation/xdlops_gemm.hpp
+++ b/src/kernels/composable_kernel/include/tensor_operation/xdlops_gemm.hpp
@@ -704,17 +704,14 @@ struct XdlopsGemm_t
         GetXdlopsInfo<data_type, GemmMPerWave, GemmNPerWave>().MRepeats;
     static constexpr auto NRepeats =
         GetXdlopsInfo<data_type, GemmMPerWave, GemmNPerWave>().NRepeats;
-
     static constexpr auto MPerXdlops =
         GetXdlopsInfo<data_type, GemmMPerWave, GemmNPerWave>().MPerXdlops;
     static constexpr auto NPerXdlops =
         GetXdlopsInfo<data_type, GemmMPerWave, GemmNPerWave>().NPerXdlops;
-
     static constexpr auto IsKReduction =
         GetXdlopsInfo<data_type, GemmMPerWave, GemmNPerWave>().IsKReduction();
     static constexpr auto IsABroadcast =
         GetXdlopsInfo<data_type, GemmMPerWave, GemmNPerWave>().IsABroadcast();
-
     static constexpr auto mfma_type =
         GetXdlopsInfo<data_type, GemmMPerWave, GemmNPerWave>().mfma_type;
 
@@ -866,9 +863,6 @@ struct XdlopsGemm_t
                         const FloatB* const __restrict__ p_b_wave,
                         FloatC* const __restrict__ p_c_thread) const
     {
-
-        static_assert(GemmDataPerReadA == 1 && GemmDataPerReadB == 1, "GemmDataPerReadA/B != 1");
-
         static_assert(is_same<FloatA, FloatB>::value, "FloatA != FloatB");
         static_assert(is_same<FloatC, float>::value, "FloatC != float");
 

--- a/src/kernels/composable_kernel/include/tensor_operation/xdlops_gemm.hpp
+++ b/src/kernels/composable_kernel/include/tensor_operation/xdlops_gemm.hpp
@@ -898,6 +898,18 @@ struct XdlopsGemm_t
     }
 
     template <>
+    static constexpr auto GetXdlopsInfo<half_t, 128, 32>()
+    {
+        return xdlops_info<mfma_instr::mfma_f32_32x32x4f16, 64, 32, 2, 1>{};
+    }
+
+    template <>
+    static constexpr auto GetXdlopsInfo<half_t, 64, 16>()
+    {
+        return xdlops_info<mfma_instr::mfma_f32_16x16x4f16, 64, 16, 2, 1>{};
+    }
+
+    template <>
     static constexpr auto GetXdlopsInfo<half_t, 64, 128>()
     {
         return xdlops_info<mfma_instr::mfma_f32_32x32x4f16, 64, 64, 1, 2>{};
@@ -922,6 +934,12 @@ struct XdlopsGemm_t
     }
 
     template <>
+    static constexpr auto GetXdlopsInfo<half_t, 32, 128>()
+    {
+        return xdlops_info<mfma_instr::mfma_f32_32x32x4f16, 32, 128, 1, 2>{};
+    }
+
+    template <>
     static constexpr auto GetXdlopsInfo<half_t, 32, 64>()
     {
         return xdlops_info<mfma_instr::mfma_f32_32x32x4f16, 32, 64, 1, 1>{};
@@ -931,6 +949,12 @@ struct XdlopsGemm_t
     static constexpr auto GetXdlopsInfo<half_t, 32, 32>()
     {
         return xdlops_info<mfma_instr::mfma_f32_32x32x8f16, 32, 32, 1, 1>{};
+    }
+
+    template <>
+    static constexpr auto GetXdlopsInfo<half_t, 16, 128>()
+    {
+        return xdlops_info<mfma_instr::mfma_f32_16x16x4f16, 16, 64, 1, 2>{};
     }
 
     template <>
@@ -946,9 +970,21 @@ struct XdlopsGemm_t
     }
 
     template <>
+    static constexpr auto GetXdlopsInfo<half_t, 8, 128>()
+    {
+        return xdlops_info<mfma_instr::mfma_f32_4x4x4f16, 8, 64, 1, 2>{};
+    }
+
+    template <>
     static constexpr auto GetXdlopsInfo<half_t, 8, 64>()
     {
         return xdlops_info<mfma_instr::mfma_f32_4x4x4f16, 8, 64, 1, 1>{};
+    }
+
+    template <>
+    static constexpr auto GetXdlopsInfo<half_t, 4, 128>()
+    {
+        return xdlops_info<mfma_instr::mfma_f32_4x4x4f16, 4, 64, 1, 2>{};
     }
 
     template <>
@@ -967,6 +1003,18 @@ struct XdlopsGemm_t
     static constexpr auto GetXdlopsInfo<ushort, 128, 64>()
     {
         return xdlops_info<mfma_instr::mfma_f32_32x32x2bf16, 64, 64, 2, 1>{};
+    }
+
+    template <>
+    static constexpr auto GetXdlopsInfo<ushort, 128, 32>()
+    {
+        return xdlops_info<mfma_instr::mfma_f32_32x32x2bf16, 64, 32, 2, 1>{};
+    }
+
+    template <>
+    static constexpr auto GetXdlopsInfo<ushort, 128, 16>()
+    {
+        return xdlops_info<mfma_instr::mfma_f32_16x16x2bf16, 64, 16, 2, 1>{};
     }
 
     template <>
@@ -994,6 +1042,12 @@ struct XdlopsGemm_t
     }
 
     template <>
+    static constexpr auto GetXdlopsInfo<ushort, 32, 128>()
+    {
+        return xdlops_info<mfma_instr::mfma_f32_32x32x2bf16, 32, 64, 1, 2>{};
+    }
+
+    template <>
     static constexpr auto GetXdlopsInfo<ushort, 32, 64>()
     {
         return xdlops_info<mfma_instr::mfma_f32_32x32x2bf16, 32, 64, 1, 1>{};
@@ -1003,6 +1057,12 @@ struct XdlopsGemm_t
     static constexpr auto GetXdlopsInfo<ushort, 32, 32>()
     {
         return xdlops_info<mfma_instr::mfma_f32_32x32x4bf16, 32, 32, 1, 1>{};
+    }
+
+    template <>
+    static constexpr auto GetXdlopsInfo<ushort, 16, 128>()
+    {
+        return xdlops_info<mfma_instr::mfma_f32_16x16x2bf16, 16, 64, 1, 2>{};
     }
 
     template <>
@@ -1018,9 +1078,21 @@ struct XdlopsGemm_t
     }
 
     template <>
+    static constexpr auto GetXdlopsInfo<ushort, 8, 128>()
+    {
+        return xdlops_info<mfma_instr::mfma_f32_4x4x2bf16, 8, 128, 1, 2>{};
+    }
+
+    template <>
     static constexpr auto GetXdlopsInfo<ushort, 8, 64>()
     {
         return xdlops_info<mfma_instr::mfma_f32_4x4x2bf16, 8, 64, 1, 1>{};
+    }
+
+    template <>
+    static constexpr auto GetXdlopsInfo<ushort, 4, 128>()
+    {
+        return xdlops_info<mfma_instr::mfma_f32_4x4x2bf16, 4, 64, 1, 2>{};
     }
 
     template <>

--- a/src/kernels/composable_kernel/include/tensor_operation/xdlops_gemm.hpp
+++ b/src/kernels/composable_kernel/include/tensor_operation/xdlops_gemm.hpp
@@ -453,6 +453,246 @@ struct mfma_info<mfma_instr::mfma_f32_4x4x2bf16>
     }
 };
 
+template <mfma_instr instr,
+          index_t MPerXdlops_,
+          index_t NPerXdlops_,
+          index_t MRepeats_,
+          index_t NRepeats_>
+struct xdlops_info
+{
+    static constexpr auto mfma_type  = mfma_info<instr>{};
+    static constexpr auto MPerXdlops = MPerXdlops_;
+    static constexpr auto NPerXdlops = NPerXdlops_;
+    static constexpr auto MRepeats   = MRepeats_;
+    static constexpr auto NRepeats   = NRepeats_;
+
+    __device__ static constexpr bool IsABroadcast() { return NPerXdlops >= MPerXdlops; }
+
+    __device__ static constexpr bool IsKReduction()
+    {
+        return (mfma_type.num_output_blks == 1) && (mfma_type.num_input_blks > 1);
+    }
+};
+
+template <class data_type, index_t MPerWave, index_t NPerWave>
+__device__ static constexpr auto GetXdlopsInfo();
+
+template <>
+__device__ static constexpr auto GetXdlopsInfo<float, 128, 128>()
+{
+    return xdlops_info<mfma_instr::mfma_f32_32x32x1xf32, 64, 64, 2, 2>{};
+}
+
+template <>
+__device__ static constexpr auto GetXdlopsInfo<float, 128, 64>()
+{
+    return xdlops_info<mfma_instr::mfma_f32_32x32x1xf32, 64, 64, 2, 1>{};
+}
+
+template <>
+__device__ static constexpr auto GetXdlopsInfo<float, 64, 128>()
+{
+    return xdlops_info<mfma_instr::mfma_f32_32x32x1xf32, 64, 64, 1, 2>{};
+}
+
+template <>
+__device__ static constexpr auto GetXdlopsInfo<float, 64, 64>()
+{
+    return xdlops_info<mfma_instr::mfma_f32_32x32x1xf32, 64, 64, 1, 1>{};
+}
+
+template <>
+__device__ static constexpr auto GetXdlopsInfo<float, 64, 32>()
+{
+    return xdlops_info<mfma_instr::mfma_f32_32x32x1xf32, 64, 32, 1, 1>{};
+}
+
+template <>
+__device__ static constexpr auto GetXdlopsInfo<float, 64, 16>()
+{
+    return xdlops_info<mfma_instr::mfma_f32_16x16x1xf32, 64, 16, 1, 1>{};
+}
+
+template <>
+__device__ static constexpr auto GetXdlopsInfo<float, 32, 64>()
+{
+    return xdlops_info<mfma_instr::mfma_f32_32x32x1xf32, 32, 64, 1, 1>{};
+}
+
+template <>
+__device__ static constexpr auto GetXdlopsInfo<float, 32, 32>()
+{
+    return xdlops_info<mfma_instr::mfma_f32_32x32x2xf32, 32, 32, 1, 1>{};
+}
+
+template <>
+__device__ static constexpr auto GetXdlopsInfo<float, 16, 64>()
+{
+    return xdlops_info<mfma_instr::mfma_f32_16x16x1xf32, 16, 64, 1, 1>{};
+}
+
+template <>
+__device__ static constexpr auto GetXdlopsInfo<float, 16, 16>()
+{
+    return xdlops_info<mfma_instr::mfma_f32_16x16x4xf32, 16, 16, 1, 1>{};
+}
+
+template <>
+__device__ static constexpr auto GetXdlopsInfo<float, 8, 64>()
+{
+    return xdlops_info<mfma_instr::mfma_f32_4x4x1xf32, 8, 64, 1, 1>{};
+}
+
+template <>
+__device__ static constexpr auto GetXdlopsInfo<float, 4, 64>()
+{
+    return xdlops_info<mfma_instr::mfma_f32_4x4x1xf32, 4, 64, 1, 1>{};
+}
+
+template <>
+__device__ static constexpr auto GetXdlopsInfo<half_t, 128, 128>()
+{
+    return xdlops_info<mfma_instr::mfma_f32_32x32x4f16, 64, 64, 2, 2>{};
+}
+
+template <>
+__device__ static constexpr auto GetXdlopsInfo<half_t, 128, 64>()
+{
+    return xdlops_info<mfma_instr::mfma_f32_32x32x4f16, 64, 64, 2, 1>{};
+}
+
+template <>
+__device__ static constexpr auto GetXdlopsInfo<half_t, 64, 128>()
+{
+    return xdlops_info<mfma_instr::mfma_f32_32x32x4f16, 64, 64, 1, 2>{};
+}
+
+template <>
+__device__ static constexpr auto GetXdlopsInfo<half_t, 64, 64>()
+{
+    return xdlops_info<mfma_instr::mfma_f32_32x32x4f16, 64, 64, 1, 1>{};
+}
+
+template <>
+__device__ static constexpr auto GetXdlopsInfo<half_t, 64, 32>()
+{
+    return xdlops_info<mfma_instr::mfma_f32_32x32x4f16, 64, 32, 1, 1>{};
+}
+
+template <>
+__device__ static constexpr auto GetXdlopsInfo<half_t, 64, 16>()
+{
+    return xdlops_info<mfma_instr::mfma_f32_16x16x4f16, 64, 16, 1, 1>{};
+}
+
+template <>
+__device__ static constexpr auto GetXdlopsInfo<half_t, 32, 64>()
+{
+    return xdlops_info<mfma_instr::mfma_f32_32x32x4f16, 32, 64, 1, 1>{};
+}
+
+template <>
+__device__ static constexpr auto GetXdlopsInfo<half_t, 32, 32>()
+{
+    return xdlops_info<mfma_instr::mfma_f32_32x32x8f16, 32, 32, 1, 1>{};
+}
+
+template <>
+__device__ static constexpr auto GetXdlopsInfo<half_t, 16, 64>()
+{
+    return xdlops_info<mfma_instr::mfma_f32_16x16x4f16, 16, 64, 1, 1>{};
+}
+
+template <>
+__device__ static constexpr auto GetXdlopsInfo<half_t, 16, 16>()
+{
+    return xdlops_info<mfma_instr::mfma_f32_16x16x16f16, 16, 16, 1, 1>{};
+}
+
+template <>
+__device__ static constexpr auto GetXdlopsInfo<half_t, 8, 64>()
+{
+    return xdlops_info<mfma_instr::mfma_f32_4x4x4f16, 8, 64, 1, 1>{};
+}
+
+template <>
+__device__ static constexpr auto GetXdlopsInfo<half_t, 4, 64>()
+{
+    return xdlops_info<mfma_instr::mfma_f32_4x4x4f16, 4, 64, 1, 1>{};
+}
+
+template <>
+__device__ static constexpr auto GetXdlopsInfo<ushort, 128, 128>()
+{
+    return xdlops_info<mfma_instr::mfma_f32_32x32x2bf16, 64, 64, 2, 2>{};
+}
+
+template <>
+__device__ static constexpr auto GetXdlopsInfo<ushort, 128, 64>()
+{
+    return xdlops_info<mfma_instr::mfma_f32_32x32x2bf16, 64, 64, 2, 1>{};
+}
+
+template <>
+__device__ static constexpr auto GetXdlopsInfo<ushort, 64, 128>()
+{
+    return xdlops_info<mfma_instr::mfma_f32_32x32x2bf16, 64, 64, 1, 2>{};
+}
+
+template <>
+__device__ static constexpr auto GetXdlopsInfo<ushort, 64, 64>()
+{
+    return xdlops_info<mfma_instr::mfma_f32_32x32x2bf16, 64, 64, 1, 1>{};
+}
+
+template <>
+__device__ static constexpr auto GetXdlopsInfo<ushort, 64, 32>()
+{
+    return xdlops_info<mfma_instr::mfma_f32_32x32x2bf16, 64, 32, 1, 1>{};
+}
+
+template <>
+__device__ static constexpr auto GetXdlopsInfo<ushort, 64, 16>()
+{
+    return xdlops_info<mfma_instr::mfma_f32_16x16x2bf16, 64, 16, 1, 1>{};
+}
+
+template <>
+__device__ static constexpr auto GetXdlopsInfo<ushort, 32, 64>()
+{
+    return xdlops_info<mfma_instr::mfma_f32_32x32x2bf16, 32, 64, 1, 1>{};
+}
+
+template <>
+__device__ static constexpr auto GetXdlopsInfo<ushort, 32, 32>()
+{
+    return xdlops_info<mfma_instr::mfma_f32_32x32x4bf16, 32, 32, 1, 1>{};
+}
+
+template <>
+__device__ static constexpr auto GetXdlopsInfo<ushort, 16, 64>()
+{
+    return xdlops_info<mfma_instr::mfma_f32_16x16x2bf16, 16, 64, 1, 1>{};
+}
+
+template <>
+__device__ static constexpr auto GetXdlopsInfo<ushort, 16, 16>()
+{
+    return xdlops_info<mfma_instr::mfma_f32_16x16x8bf16, 16, 16, 1, 1>{};
+}
+
+template <>
+__device__ static constexpr auto GetXdlopsInfo<ushort, 8, 64>()
+{
+    return xdlops_info<mfma_instr::mfma_f32_4x4x2bf16, 8, 64, 1, 1>{};
+}
+
+template <>
+__device__ static constexpr auto GetXdlopsInfo<ushort, 4, 64>()
+{
+    return xdlops_info<mfma_instr::mfma_f32_4x4x2bf16, 4, 64, 1, 1>{};
+}
+
 template <class data_type,
           index_t GemmMPerWave,
           index_t GemmNPerWave,
@@ -460,11 +700,23 @@ template <class data_type,
           index_t GemmDataPerReadB>
 struct XdlopsGemm_t
 {
-    static constexpr index_t WaveSize = 64;
+    static constexpr auto MRepeats =
+        GetXdlopsInfo<data_type, GemmMPerWave, GemmNPerWave>().MRepeats;
+    static constexpr auto NRepeats =
+        GetXdlopsInfo<data_type, GemmMPerWave, GemmNPerWave>().NRepeats;
 
-    __device__ constexpr auto GetMRepeats() const { return GetXdlopsInfo().MRepeats; }
+    static constexpr auto MPerXdlops =
+        GetXdlopsInfo<data_type, GemmMPerWave, GemmNPerWave>().MPerXdlops;
+    static constexpr auto NPerXdlops =
+        GetXdlopsInfo<data_type, GemmMPerWave, GemmNPerWave>().NPerXdlops;
 
-    __device__ constexpr auto GetNRepeats() const { return GetXdlopsInfo().NRepeats; }
+    static constexpr auto IsKReduction =
+        GetXdlopsInfo<data_type, GemmMPerWave, GemmNPerWave>().IsKReduction();
+    static constexpr auto IsABroadcast =
+        GetXdlopsInfo<data_type, GemmMPerWave, GemmNPerWave>().IsABroadcast();
+
+    static constexpr auto mfma_type =
+        GetXdlopsInfo<data_type, GemmMPerWave, GemmNPerWave>().mfma_type;
 
     struct MatrixIndex
     {
@@ -474,16 +726,11 @@ struct XdlopsGemm_t
 
     __device__ static constexpr index_t GetNumBlksPerXdlops()
     {
-        constexpr auto mfma_type = GetXdlopsInfo().mfma_type;
-        return (GetXdlopsInfo().MPerXdlops * GetXdlopsInfo().NPerXdlops) /
-               (mfma_type.m * mfma_type.n);
+        return (MPerXdlops * NPerXdlops) / (mfma_type.m * mfma_type.n);
     }
 
     __device__ constexpr XdlopsGemm_t()
     {
-        constexpr auto MPerXdlops = GetXdlopsInfo().MPerXdlops;
-        constexpr auto NPerXdlops = GetXdlopsInfo().NPerXdlops;
-
         static_assert(NPerXdlops == 4 || NPerXdlops == 8 || NPerXdlops == 16 || NPerXdlops == 32 ||
                           NPerXdlops == 64,
                       "Only support GemmNPerXdlops == 4, 8, 16, 32 or 64 for xdlops");
@@ -493,8 +740,6 @@ struct XdlopsGemm_t
                       "Only support GemmMPerXdlops == 4, 8, 16, 32 or 64 for xdlops");
 
         static_assert(GemmDataPerReadA == 1 && GemmDataPerReadB == 1, "GemmDataPerReadA/B != 1");
-
-        constexpr auto mfma_type = GetXdlopsInfo().mfma_type;
 
         static_assert(mfma_type.num_threads_blk == mfma_type.n, "n != num_threads_blk");
         static_assert(mfma_type.num_regs_blk * mfma_type.num_input_blks == mfma_type.m,
@@ -510,250 +755,7 @@ struct XdlopsGemm_t
 
     __device__ static constexpr index_t GetRegSizePerXdlops()
     {
-        return GetXdlopsInfo().MPerXdlops * GetXdlopsInfo().NPerXdlops / WaveSize;
-    }
-
-    template <mfma_instr instr,
-              index_t MPerXdlops_,
-              index_t NPerXdlops_,
-              index_t MRepeats_,
-              index_t NRepeats_>
-    struct xdlops_info
-    {
-        static constexpr auto mfma_type  = mfma_info<instr>{};
-        static constexpr auto MPerXdlops = MPerXdlops_;
-        static constexpr auto NPerXdlops = NPerXdlops_;
-        static constexpr auto MRepeats   = MRepeats_;
-        static constexpr auto NRepeats   = NRepeats_;
-
-        __device__ static constexpr bool IsABroadcast() { return NPerXdlops >= MPerXdlops; }
-
-        __device__ static constexpr bool IsKReduction()
-        {
-            constexpr auto mfma_type = GetXdlopsInfo().mfma_type;
-            return (mfma_type.num_output_blks == 1) && (mfma_type.num_input_blks > 1);
-        }
-    };
-
-    template <class data_type_  = data_type,
-              index_t MPerWave_ = GemmMPerWave,
-              index_t NPerWave_ = GemmNPerWave>
-    __device__ static constexpr auto GetXdlopsInfo();
-
-    template <>
-    __device__ static constexpr auto GetXdlopsInfo<float, 128, 128>()
-    {
-        return xdlops_info<mfma_instr::mfma_f32_32x32x1xf32, 64, 64, 2, 2>{};
-    }
-
-    template <>
-    __device__ static constexpr auto GetXdlopsInfo<float, 128, 64>()
-    {
-        return xdlops_info<mfma_instr::mfma_f32_32x32x1xf32, 64, 64, 2, 1>{};
-    }
-
-    template <>
-    __device__ static constexpr auto GetXdlopsInfo<float, 64, 128>()
-    {
-        return xdlops_info<mfma_instr::mfma_f32_32x32x1xf32, 64, 64, 1, 2>{};
-    }
-
-    template <>
-    __device__ static constexpr auto GetXdlopsInfo<float, 64, 64>()
-    {
-        return xdlops_info<mfma_instr::mfma_f32_32x32x1xf32, 64, 64, 1, 1>{};
-    }
-
-    template <>
-    __device__ static constexpr auto GetXdlopsInfo<float, 64, 32>()
-    {
-        return xdlops_info<mfma_instr::mfma_f32_32x32x1xf32, 64, 32, 1, 1>{};
-    }
-
-    template <>
-    __device__ static constexpr auto GetXdlopsInfo<float, 64, 16>()
-    {
-        return xdlops_info<mfma_instr::mfma_f32_16x16x1xf32, 64, 16, 1, 1>{};
-    }
-
-    template <>
-    __device__ static constexpr auto GetXdlopsInfo<float, 32, 64>()
-    {
-        return xdlops_info<mfma_instr::mfma_f32_32x32x1xf32, 32, 64, 1, 1>{};
-    }
-
-    template <>
-    __device__ static constexpr auto GetXdlopsInfo<float, 32, 32>()
-    {
-        return xdlops_info<mfma_instr::mfma_f32_32x32x2xf32, 32, 32, 1, 1>{};
-    }
-
-    template <>
-    __device__ static constexpr auto GetXdlopsInfo<float, 16, 64>()
-    {
-        return xdlops_info<mfma_instr::mfma_f32_16x16x1xf32, 16, 64, 1, 1>{};
-    }
-
-    template <>
-    __device__ static constexpr auto GetXdlopsInfo<float, 16, 16>()
-    {
-        return xdlops_info<mfma_instr::mfma_f32_16x16x4xf32, 16, 16, 1, 1>{};
-    }
-
-    template <>
-    __device__ static constexpr auto GetXdlopsInfo<float, 8, 64>()
-    {
-        return xdlops_info<mfma_instr::mfma_f32_4x4x1xf32, 8, 64, 1, 1>{};
-    }
-
-    template <>
-    __device__ static constexpr auto GetXdlopsInfo<float, 4, 64>()
-    {
-        return xdlops_info<mfma_instr::mfma_f32_4x4x1xf32, 4, 64, 1, 1>{};
-    }
-
-    template <>
-    __device__ static constexpr auto GetXdlopsInfo<half_t, 128, 128>()
-    {
-        return xdlops_info<mfma_instr::mfma_f32_32x32x4f16, 64, 64, 2, 2>{};
-    }
-
-    template <>
-    __device__ static constexpr auto GetXdlopsInfo<half_t, 128, 64>()
-    {
-        return xdlops_info<mfma_instr::mfma_f32_32x32x4f16, 64, 64, 2, 1>{};
-    }
-
-    template <>
-    __device__ static constexpr auto GetXdlopsInfo<half_t, 64, 128>()
-    {
-        return xdlops_info<mfma_instr::mfma_f32_32x32x4f16, 64, 64, 1, 2>{};
-    }
-
-    template <>
-    __device__ static constexpr auto GetXdlopsInfo<half_t, 64, 64>()
-    {
-        return xdlops_info<mfma_instr::mfma_f32_32x32x4f16, 64, 64, 1, 1>{};
-    }
-
-    template <>
-    __device__ static constexpr auto GetXdlopsInfo<half_t, 64, 32>()
-    {
-        return xdlops_info<mfma_instr::mfma_f32_32x32x4f16, 64, 32, 1, 1>{};
-    }
-
-    template <>
-    __device__ static constexpr auto GetXdlopsInfo<half_t, 64, 16>()
-    {
-        return xdlops_info<mfma_instr::mfma_f32_16x16x4f16, 64, 16, 1, 1>{};
-    }
-
-    template <>
-    __device__ static constexpr auto GetXdlopsInfo<half_t, 32, 64>()
-    {
-        return xdlops_info<mfma_instr::mfma_f32_32x32x4f16, 32, 64, 1, 1>{};
-    }
-
-    template <>
-    __device__ static constexpr auto GetXdlopsInfo<half_t, 32, 32>()
-    {
-        return xdlops_info<mfma_instr::mfma_f32_32x32x8f16, 32, 32, 1, 1>{};
-    }
-
-    template <>
-    __device__ static constexpr auto GetXdlopsInfo<half_t, 16, 64>()
-    {
-        return xdlops_info<mfma_instr::mfma_f32_16x16x4f16, 16, 64, 1, 1>{};
-    }
-
-    template <>
-    __device__ static constexpr auto GetXdlopsInfo<half_t, 16, 16>()
-    {
-        return xdlops_info<mfma_instr::mfma_f32_16x16x16f16, 16, 16, 1, 1>{};
-    }
-
-    template <>
-    __device__ static constexpr auto GetXdlopsInfo<half_t, 8, 64>()
-    {
-        return xdlops_info<mfma_instr::mfma_f32_4x4x4f16, 8, 64, 1, 1>{};
-    }
-
-    template <>
-    __device__ static constexpr auto GetXdlopsInfo<half_t, 4, 64>()
-    {
-        return xdlops_info<mfma_instr::mfma_f32_4x4x4f16, 4, 64, 1, 1>{};
-    }
-
-    template <>
-    __device__ static constexpr auto GetXdlopsInfo<ushort, 128, 128>()
-    {
-        return xdlops_info<mfma_instr::mfma_f32_32x32x2bf16, 64, 64, 2, 2>{};
-    }
-
-    template <>
-    __device__ static constexpr auto GetXdlopsInfo<ushort, 128, 64>()
-    {
-        return xdlops_info<mfma_instr::mfma_f32_32x32x2bf16, 64, 64, 2, 1>{};
-    }
-
-    template <>
-    __device__ static constexpr auto GetXdlopsInfo<ushort, 64, 128>()
-    {
-        return xdlops_info<mfma_instr::mfma_f32_32x32x2bf16, 64, 64, 1, 2>{};
-    }
-
-    template <>
-    __device__ static constexpr auto GetXdlopsInfo<ushort, 64, 64>()
-    {
-        return xdlops_info<mfma_instr::mfma_f32_32x32x2bf16, 64, 64, 1, 1>{};
-    }
-
-    template <>
-    __device__ static constexpr auto GetXdlopsInfo<ushort, 64, 32>()
-    {
-        return xdlops_info<mfma_instr::mfma_f32_32x32x2bf16, 64, 32, 1, 1>{};
-    }
-
-    template <>
-    __device__ static constexpr auto GetXdlopsInfo<ushort, 64, 16>()
-    {
-        return xdlops_info<mfma_instr::mfma_f32_16x16x2bf16, 64, 16, 1, 1>{};
-    }
-
-    template <>
-    __device__ static constexpr auto GetXdlopsInfo<ushort, 32, 64>()
-    {
-        return xdlops_info<mfma_instr::mfma_f32_32x32x2bf16, 32, 64, 1, 1>{};
-    }
-
-    template <>
-    __device__ static constexpr auto GetXdlopsInfo<ushort, 32, 32>()
-    {
-        return xdlops_info<mfma_instr::mfma_f32_32x32x4bf16, 32, 32, 1, 1>{};
-    }
-
-    template <>
-    __device__ static constexpr auto GetXdlopsInfo<ushort, 16, 64>()
-    {
-        return xdlops_info<mfma_instr::mfma_f32_16x16x2bf16, 16, 64, 1, 1>{};
-    }
-
-    template <>
-    __device__ static constexpr auto GetXdlopsInfo<ushort, 16, 16>()
-    {
-        return xdlops_info<mfma_instr::mfma_f32_16x16x8bf16, 16, 16, 1, 1>{};
-    }
-
-    template <>
-    __device__ static constexpr auto GetXdlopsInfo<ushort, 8, 64>()
-    {
-        return xdlops_info<mfma_instr::mfma_f32_4x4x2bf16, 8, 64, 1, 1>{};
-    }
-
-    template <>
-    __device__ static constexpr auto GetXdlopsInfo<ushort, 4, 64>()
-    {
-        return xdlops_info<mfma_instr::mfma_f32_4x4x2bf16, 4, 64, 1, 1>{};
+        return MPerXdlops * NPerXdlops / mfma_type.wave_size;
     }
 
 #if CK_USE_AMD_XDLOPS_EMULATE
@@ -763,20 +765,12 @@ struct XdlopsGemm_t
                                   const FloatB* const __restrict__ p_b_wave,
                                   FloatC* const __restrict__ p_c_thread) const
     {
-        constexpr auto mfma_type = GetXdlopsInfo().mfma_type;
-
         const index_t laneId = get_thread_local_1d_id() % mfma_type.wave_size;
         const index_t blk_id = laneId / mfma_type.num_threads_blk;
         const index_t blk_td = laneId % mfma_type.num_threads_blk;
 
-        constexpr auto MRepeats = GetXdlopsInfo().MRepeats;
-        constexpr auto NRepeats = GetXdlopsInfo().NRepeats;
-
-        constexpr auto MPerXdlops = GetXdlopsInfo().MPerXdlops;
-        constexpr auto NPerXdlops = GetXdlopsInfo().NPerXdlops;
-
         // K reduction
-        static_if<GetXdlopsInfo().IsKReduction()>{}([&](auto) {
+        static_if<IsKReduction>{}([&](auto) {
             for(index_t k = 0; k < K; k += mfma_type.num_input_blks)
             {
                 for(index_t n = 0; n < mfma_type.num_input_blks; ++n)
@@ -798,7 +792,7 @@ struct XdlopsGemm_t
             }
 
         }).Else([&](auto) {
-            static_if<GetXdlopsInfo().IsABroadcast()>{}([&](auto) {
+            static_if<IsABroadcast>{}([&](auto) {
 
                 for(index_t m_i = 0; m_i < MRepeats; ++m_i)
                 {
@@ -885,15 +879,7 @@ struct XdlopsGemm_t
 #if CK_USE_AMD_XDLOPS_EMULATE
         XdlopsEmulate<M, N, K>(p_a_wave, p_b_wave, p_c_thread);
 #else
-        constexpr auto mfma_type = GetXdlopsInfo().mfma_type;
-
         const index_t laneId = get_thread_local_1d_id() % mfma_type.wave_size;
-
-        constexpr auto MRepeats = GetXdlopsInfo().MRepeats;
-        constexpr auto NRepeats = GetXdlopsInfo().NRepeats;
-
-        constexpr auto MPerXdlops = GetXdlopsInfo().MPerXdlops;
-        constexpr auto NPerXdlops = GetXdlopsInfo().NPerXdlops;
 
         FloatA a[K * MRepeats];
         FloatB b[K * NRepeats];
@@ -903,16 +889,16 @@ struct XdlopsGemm_t
 
         constexpr index_t nxdlops = sizeof(FloatA) / (sizeof(data_type) * mfma_type.k_base);
 
-        static_assert(!GetXdlopsInfo().IsKReduction() || K % mfma_type.num_input_blks == 0,
+        static_assert(!IsKReduction || K % mfma_type.num_input_blks == 0,
                       "K cannot divided by mfma_type.num_input_blks!");
 
-        static_if<!GetXdlopsInfo().IsKReduction()>{}([&](auto) {
+        static_if<!IsKReduction>{}([&](auto) {
 
-            for(index_t m_i = 0; m_i < GetXdlopsInfo().MRepeats; ++m_i)
+            for(index_t m_i = 0; m_i < MRepeats; ++m_i)
                 for(index_t k_i      = 0; k_i < K; ++k_i)
                     a[k_i + m_i * K] = p_a_wave[k_i * M + laneId + MPerXdlops * m_i];
 
-            for(index_t n_i = 0; n_i < GetXdlopsInfo().NRepeats; ++n_i)
+            for(index_t n_i = 0; n_i < NRepeats; ++n_i)
                 for(index_t k_i      = 0; k_i < K; ++k_i)
                     b[k_i + n_i * K] = p_b_wave[k_i * N + laneId + NPerXdlops * n_i];
 
@@ -920,10 +906,10 @@ struct XdlopsGemm_t
             auto pa = reinterpret_cast<const data_type*>(&a);
             auto pb = reinterpret_cast<const data_type*>(&b);
 
-            for(index_t m_i = 0; m_i < GetXdlopsInfo().MRepeats; ++m_i)
+            for(index_t m_i = 0; m_i < MRepeats; ++m_i)
             {
 
-                for(index_t n_i = 0; n_i < GetXdlopsInfo().NRepeats; ++n_i)
+                for(index_t n_i = 0; n_i < NRepeats; ++n_i)
                 {
 
 #if CK_WORKAROUND_SWDEV_229564
@@ -937,8 +923,7 @@ struct XdlopsGemm_t
                                     m_i * K * nxdlops * mfma_type.k_base],
                                 &pb[(k_i * nxdlops + i) * mfma_type.k_base +
                                     n_i * K * nxdlops * mfma_type.k_base],
-                                p_c_thread +
-                                    (GetXdlopsInfo().NRepeats * m_i + n_i) * GetRegSizePerXdlops());
+                                p_c_thread + (NRepeats * m_i + n_i) * GetRegSizePerXdlops());
                     }
                 }
             }
@@ -977,19 +962,11 @@ struct XdlopsGemm_t
 
     __device__ static MatrixIndex GetBeginOfThreadBlk(index_t i)
     {
-        constexpr auto MPerXdlops = GetXdlopsInfo().MPerXdlops;
-        constexpr auto NPerXdlops = GetXdlopsInfo().NPerXdlops;
-
-        constexpr auto MRepeats = GetXdlopsInfo().MRepeats;
-        constexpr auto NRepeats = GetXdlopsInfo().NRepeats;
-
         const index_t xdlops_i = i / GetNumBlksPerXdlops();
         const index_t j        = i % GetNumBlksPerXdlops();
 
         const index_t m_i = xdlops_i / NRepeats;
         const index_t n_i = xdlops_i % NRepeats;
-
-        constexpr auto mfma_type = GetXdlopsInfo().mfma_type;
 
         const index_t laneId = get_thread_local_1d_id() % mfma_type.wave_size;
         const index_t blk_id = laneId / mfma_type.num_threads_blk;
@@ -998,7 +975,7 @@ struct XdlopsGemm_t
         index_t col_blk = j % mfma_type.num_output_blks;
         index_t row_blk = j / mfma_type.num_output_blks;
 
-        static_if<!GetXdlopsInfo().IsABroadcast()>{}([&](auto) {
+        static_if<!IsABroadcast>{}([&](auto) {
             col_blk = j / mfma_type.num_output_blks;
             row_blk = j % mfma_type.num_output_blks;
         });
@@ -1011,27 +988,16 @@ struct XdlopsGemm_t
 
     struct OutputLayout
     {
-        static constexpr auto mfma_type = GetXdlopsInfo().mfma_type;
-
         __device__ static constexpr index_t M1() { return mfma_type.num_groups_blk; }
-        __device__ static constexpr index_t M0() { return GetXdlopsInfo().mfma_type.group_size; }
-        __device__ static constexpr index_t N1()
-        {
-            return GetXdlopsInfo().mfma_type.num_input_blks;
-        }
-        __device__ static constexpr index_t N0()
-        {
-            return GetXdlopsInfo().mfma_type.num_threads_blk;
-        }
+        __device__ static constexpr index_t M0() { return mfma_type.group_size; }
+        __device__ static constexpr index_t N1() { return mfma_type.num_input_blks; }
+        __device__ static constexpr index_t N0() { return mfma_type.num_threads_blk; }
 
-        __device__ static constexpr index_t GetBlkSize()
-        {
-            return GetXdlopsInfo().mfma_type.num_regs_blk;
-        }
+        __device__ static constexpr index_t GetBlkSize() { return mfma_type.num_regs_blk; }
 
         __device__ static constexpr index_t GetNumBlks()
         {
-            return GetNumBlksPerXdlops() * GetXdlopsInfo().MRepeats * GetXdlopsInfo().NRepeats;
+            return GetNumBlksPerXdlops() * MRepeats * NRepeats;
         }
     };
 

--- a/src/kernels/composable_kernel/include/tensor_operation/xdlops_gemm.hpp
+++ b/src/kernels/composable_kernel/include/tensor_operation/xdlops_gemm.hpp
@@ -462,15 +462,9 @@ struct XdlopsGemm_t
 {
     static constexpr index_t WaveSize = 64;
 
-    static constexpr index_t MRepeats = (GemmMPerWave > 64) ? (GemmMPerWave / 64) : 1;
-    static constexpr index_t NRepeats = (GemmNPerWave > 64) ? (GemmNPerWave / 64) : 1;
+    __device__ constexpr auto GetMRepeats() const { return GetXdlopsInfo().MRepeats; }
 
-    static constexpr index_t MPerXdlops = (GemmMPerWave > 64) ? 64 : GemmMPerWave;
-    static constexpr index_t NPerXdlops = (GemmNPerWave > 64) ? 64 : GemmNPerWave;
-
-    __device__ constexpr auto GetMRepeats() const { return MRepeats; }
-
-    __device__ constexpr auto GetNRepeats() const { return NRepeats; }
+    __device__ constexpr auto GetNRepeats() const { return GetXdlopsInfo().NRepeats; }
 
     struct MatrixIndex
     {
@@ -478,29 +472,18 @@ struct XdlopsGemm_t
         index_t col;
     };
 
-    template <index_t M1_, index_t M0_, index_t N1_, index_t N0_>
-    struct OutputLayout
-    {
-        __device__ static constexpr index_t M1() { return M1_; }
-        __device__ static constexpr index_t M0() { return M0_; }
-        __device__ static constexpr index_t N1() { return N1_; }
-        __device__ static constexpr index_t N0() { return N0_; }
-        __device__ static constexpr index_t GetBlkSize() { return GetMFMAInfo().num_regs_blk; }
-
-        __device__ static constexpr index_t GetNumBlks()
-        {
-            return GetNumBlksPerXdlops() * MRepeats * NRepeats;
-        }
-    };
-
     __device__ static constexpr index_t GetNumBlksPerXdlops()
     {
-        constexpr auto mfma_type = GetMFMAInfo();
-        return (MPerXdlops * NPerXdlops) / (mfma_type.m * mfma_type.n);
+        constexpr auto mfma_type = GetXdlopsInfo().mfma_type;
+        return (GetXdlopsInfo().MPerXdlops * GetXdlopsInfo().NPerXdlops) /
+               (mfma_type.m * mfma_type.n);
     }
 
     __device__ constexpr XdlopsGemm_t()
     {
+        constexpr auto MPerXdlops = GetXdlopsInfo().MPerXdlops;
+        constexpr auto NPerXdlops = GetXdlopsInfo().NPerXdlops;
+
         static_assert(NPerXdlops == 4 || NPerXdlops == 8 || NPerXdlops == 16 || NPerXdlops == 32 ||
                           NPerXdlops == 64,
                       "Only support GemmNPerXdlops == 4, 8, 16, 32 or 64 for xdlops");
@@ -511,7 +494,7 @@ struct XdlopsGemm_t
 
         static_assert(GemmDataPerReadA == 1 && GemmDataPerReadB == 1, "GemmDataPerReadA/B != 1");
 
-        constexpr auto mfma_type = GetMFMAInfo();
+        constexpr auto mfma_type = GetXdlopsInfo().mfma_type;
 
         static_assert(mfma_type.num_threads_blk == mfma_type.n, "n != num_threads_blk");
         static_assert(mfma_type.num_regs_blk * mfma_type.num_input_blks == mfma_type.m,
@@ -527,182 +510,250 @@ struct XdlopsGemm_t
 
     __device__ static constexpr index_t GetRegSizePerXdlops()
     {
-        return MPerXdlops * NPerXdlops / WaveSize;
+        return GetXdlopsInfo().MPerXdlops * GetXdlopsInfo().NPerXdlops / WaveSize;
     }
 
-    __device__ static constexpr bool IsABroadcast() { return NPerXdlops >= MPerXdlops; }
-
-    __device__ static constexpr bool IsKReduction()
+    template <mfma_instr instr,
+              index_t MPerXdlops_,
+              index_t NPerXdlops_,
+              index_t MRepeats_,
+              index_t NRepeats_>
+    struct xdlops_info
     {
-        constexpr auto mfma_type = GetMFMAInfo();
-        return (mfma_type.num_output_blks == 1) && (mfma_type.num_input_blks > 1);
-    }
+        static constexpr auto mfma_type  = mfma_info<instr>{};
+        static constexpr auto MPerXdlops = MPerXdlops_;
+        static constexpr auto NPerXdlops = NPerXdlops_;
+        static constexpr auto MRepeats   = MRepeats_;
+        static constexpr auto NRepeats   = NRepeats_;
 
-    template <class data_type_    = data_type,
-              index_t MPerXdlops_ = MPerXdlops,
-              index_t NPerXdlops_ = NPerXdlops>
-    __device__ static constexpr auto GetMFMAInfo();
+        __device__ static constexpr bool IsABroadcast() { return NPerXdlops >= MPerXdlops; }
+
+        __device__ static constexpr bool IsKReduction()
+        {
+            constexpr auto mfma_type = GetXdlopsInfo().mfma_type;
+            return (mfma_type.num_output_blks == 1) && (mfma_type.num_input_blks > 1);
+        }
+    };
+
+    template <class data_type_  = data_type,
+              index_t MPerWave_ = GemmMPerWave,
+              index_t NPerWave_ = GemmNPerWave>
+    __device__ static constexpr auto GetXdlopsInfo();
 
     template <>
-    __device__ static constexpr auto GetMFMAInfo<float, 32, 64>()
+    __device__ static constexpr auto GetXdlopsInfo<float, 128, 128>()
     {
-        return mfma_info<mfma_instr::mfma_f32_32x32x1xf32>{};
-    }
-
-    template <>
-    __device__ static constexpr auto GetMFMAInfo<float, 64, 64>()
-    {
-        return mfma_info<mfma_instr::mfma_f32_32x32x1xf32>{};
-    }
-
-    template <>
-    __device__ static constexpr auto GetMFMAInfo<float, 64, 32>()
-    {
-        return mfma_info<mfma_instr::mfma_f32_32x32x1xf32>{};
-    }
-
-    template <>
-    __device__ static constexpr auto GetMFMAInfo<float, 32, 32>()
-    {
-        return mfma_info<mfma_instr::mfma_f32_32x32x2xf32>{};
+        return xdlops_info<mfma_instr::mfma_f32_32x32x1xf32, 64, 64, 2, 2>{};
     }
 
     template <>
-    __device__ static constexpr auto GetMFMAInfo<float, 16, 16>()
+    __device__ static constexpr auto GetXdlopsInfo<float, 128, 64>()
     {
-        return mfma_info<mfma_instr::mfma_f32_16x16x4xf32>{};
+        return xdlops_info<mfma_instr::mfma_f32_32x32x1xf32, 64, 64, 2, 1>{};
     }
 
     template <>
-    __device__ static constexpr auto GetMFMAInfo<float, 16, 64>()
+    __device__ static constexpr auto GetXdlopsInfo<float, 64, 128>()
     {
-        return mfma_info<mfma_instr::mfma_f32_16x16x1xf32>{};
+        return xdlops_info<mfma_instr::mfma_f32_32x32x1xf32, 64, 64, 1, 2>{};
     }
 
     template <>
-    __device__ static constexpr auto GetMFMAInfo<float, 64, 16>()
+    __device__ static constexpr auto GetXdlopsInfo<float, 64, 64>()
     {
-        return mfma_info<mfma_instr::mfma_f32_16x16x1xf32>{};
+        return xdlops_info<mfma_instr::mfma_f32_32x32x1xf32, 64, 64, 1, 1>{};
     }
 
     template <>
-    __device__ static constexpr auto GetMFMAInfo<float, 8, 64>()
+    __device__ static constexpr auto GetXdlopsInfo<float, 64, 32>()
     {
-        return mfma_info<mfma_instr::mfma_f32_4x4x1xf32>{};
+        return xdlops_info<mfma_instr::mfma_f32_32x32x1xf32, 64, 32, 1, 1>{};
     }
 
     template <>
-    __device__ static constexpr auto GetMFMAInfo<float, 4, 64>()
+    __device__ static constexpr auto GetXdlopsInfo<float, 64, 16>()
     {
-        return mfma_info<mfma_instr::mfma_f32_4x4x1xf32>{};
+        return xdlops_info<mfma_instr::mfma_f32_16x16x1xf32, 64, 16, 1, 1>{};
     }
 
     template <>
-    __device__ static constexpr auto GetMFMAInfo<half_t, 64, 64>()
+    __device__ static constexpr auto GetXdlopsInfo<float, 32, 64>()
     {
-        return mfma_info<mfma_instr::mfma_f32_32x32x4f16>{};
+        return xdlops_info<mfma_instr::mfma_f32_32x32x1xf32, 32, 64, 1, 1>{};
     }
 
     template <>
-    __device__ static constexpr auto GetMFMAInfo<half_t, 64, 32>()
+    __device__ static constexpr auto GetXdlopsInfo<float, 32, 32>()
     {
-        return mfma_info<mfma_instr::mfma_f32_32x32x4f16>{};
+        return xdlops_info<mfma_instr::mfma_f32_32x32x2xf32, 32, 32, 1, 1>{};
     }
 
     template <>
-    __device__ static constexpr auto GetMFMAInfo<half_t, 32, 64>()
+    __device__ static constexpr auto GetXdlopsInfo<float, 16, 64>()
     {
-        return mfma_info<mfma_instr::mfma_f32_32x32x4f16>{};
+        return xdlops_info<mfma_instr::mfma_f32_16x16x1xf32, 16, 64, 1, 1>{};
     }
 
     template <>
-    __device__ static constexpr auto GetMFMAInfo<half_t, 32, 32>()
+    __device__ static constexpr auto GetXdlopsInfo<float, 16, 16>()
     {
-        return mfma_info<mfma_instr::mfma_f32_32x32x8f16>{};
+        return xdlops_info<mfma_instr::mfma_f32_16x16x4xf32, 16, 16, 1, 1>{};
     }
 
     template <>
-    __device__ static constexpr auto GetMFMAInfo<half_t, 16, 16>()
+    __device__ static constexpr auto GetXdlopsInfo<float, 8, 64>()
     {
-        return mfma_info<mfma_instr::mfma_f32_16x16x16f16>{};
+        return xdlops_info<mfma_instr::mfma_f32_4x4x1xf32, 8, 64, 1, 1>{};
     }
 
     template <>
-    __device__ static constexpr auto GetMFMAInfo<half_t, 16, 64>()
+    __device__ static constexpr auto GetXdlopsInfo<float, 4, 64>()
     {
-        return mfma_info<mfma_instr::mfma_f32_16x16x4f16>{};
+        return xdlops_info<mfma_instr::mfma_f32_4x4x1xf32, 4, 64, 1, 1>{};
     }
 
     template <>
-    __device__ static constexpr auto GetMFMAInfo<half_t, 64, 16>()
+    __device__ static constexpr auto GetXdlopsInfo<half_t, 128, 128>()
     {
-        return mfma_info<mfma_instr::mfma_f32_16x16x4f16>{};
+        return xdlops_info<mfma_instr::mfma_f32_32x32x4f16, 64, 64, 2, 2>{};
     }
 
     template <>
-    __device__ static constexpr auto GetMFMAInfo<half_t, 4, 64>()
+    __device__ static constexpr auto GetXdlopsInfo<half_t, 128, 64>()
     {
-        return mfma_info<mfma_instr::mfma_f32_4x4x4f16>{};
+        return xdlops_info<mfma_instr::mfma_f32_32x32x4f16, 64, 64, 2, 1>{};
     }
 
     template <>
-    __device__ static constexpr auto GetMFMAInfo<half_t, 8, 64>()
+    __device__ static constexpr auto GetXdlopsInfo<half_t, 64, 128>()
     {
-        return mfma_info<mfma_instr::mfma_f32_4x4x4f16>{};
+        return xdlops_info<mfma_instr::mfma_f32_32x32x4f16, 64, 64, 1, 2>{};
     }
 
     template <>
-    __device__ static constexpr auto GetMFMAInfo<ushort, 64, 64>()
+    __device__ static constexpr auto GetXdlopsInfo<half_t, 64, 64>()
     {
-        return mfma_info<mfma_instr::mfma_f32_32x32x2bf16>{};
+        return xdlops_info<mfma_instr::mfma_f32_32x32x4f16, 64, 64, 1, 1>{};
     }
 
     template <>
-    __device__ static constexpr auto GetMFMAInfo<ushort, 64, 32>()
+    __device__ static constexpr auto GetXdlopsInfo<half_t, 64, 32>()
     {
-        return mfma_info<mfma_instr::mfma_f32_32x32x2bf16>{};
+        return xdlops_info<mfma_instr::mfma_f32_32x32x4f16, 64, 32, 1, 1>{};
     }
 
     template <>
-    __device__ static constexpr auto GetMFMAInfo<ushort, 32, 64>()
+    __device__ static constexpr auto GetXdlopsInfo<half_t, 64, 16>()
     {
-        return mfma_info<mfma_instr::mfma_f32_32x32x2bf16>{};
+        return xdlops_info<mfma_instr::mfma_f32_16x16x4f16, 64, 16, 1, 1>{};
     }
 
     template <>
-    __device__ static constexpr auto GetMFMAInfo<ushort, 32, 32>()
+    __device__ static constexpr auto GetXdlopsInfo<half_t, 32, 64>()
     {
-        return mfma_info<mfma_instr::mfma_f32_32x32x4bf16>{};
+        return xdlops_info<mfma_instr::mfma_f32_32x32x4f16, 32, 64, 1, 1>{};
     }
 
     template <>
-    __device__ static constexpr auto GetMFMAInfo<ushort, 16, 16>()
+    __device__ static constexpr auto GetXdlopsInfo<half_t, 32, 32>()
     {
-        return mfma_info<mfma_instr::mfma_f32_16x16x8bf16>{};
+        return xdlops_info<mfma_instr::mfma_f32_32x32x8f16, 32, 32, 1, 1>{};
     }
 
     template <>
-    __device__ static constexpr auto GetMFMAInfo<ushort, 16, 64>()
+    __device__ static constexpr auto GetXdlopsInfo<half_t, 16, 64>()
     {
-        return mfma_info<mfma_instr::mfma_f32_16x16x2bf16>{};
+        return xdlops_info<mfma_instr::mfma_f32_16x16x4f16, 16, 64, 1, 1>{};
     }
 
     template <>
-    __device__ static constexpr auto GetMFMAInfo<ushort, 64, 16>()
+    __device__ static constexpr auto GetXdlopsInfo<half_t, 16, 16>()
     {
-        return mfma_info<mfma_instr::mfma_f32_16x16x2bf16>{};
+        return xdlops_info<mfma_instr::mfma_f32_16x16x16f16, 16, 16, 1, 1>{};
     }
 
     template <>
-    __device__ static constexpr auto GetMFMAInfo<ushort, 4, 64>()
+    __device__ static constexpr auto GetXdlopsInfo<half_t, 8, 64>()
     {
-        return mfma_info<mfma_instr::mfma_f32_4x4x2bf16>{};
+        return xdlops_info<mfma_instr::mfma_f32_4x4x4f16, 8, 64, 1, 1>{};
     }
 
     template <>
-    __device__ static constexpr auto GetMFMAInfo<ushort, 8, 64>()
+    __device__ static constexpr auto GetXdlopsInfo<half_t, 4, 64>()
     {
-        return mfma_info<mfma_instr::mfma_f32_4x4x2bf16>{};
+        return xdlops_info<mfma_instr::mfma_f32_4x4x4f16, 4, 64, 1, 1>{};
+    }
+
+    template <>
+    __device__ static constexpr auto GetXdlopsInfo<ushort, 128, 128>()
+    {
+        return xdlops_info<mfma_instr::mfma_f32_32x32x2bf16, 64, 64, 2, 2>{};
+    }
+
+    template <>
+    __device__ static constexpr auto GetXdlopsInfo<ushort, 128, 64>()
+    {
+        return xdlops_info<mfma_instr::mfma_f32_32x32x2bf16, 64, 64, 2, 1>{};
+    }
+
+    template <>
+    __device__ static constexpr auto GetXdlopsInfo<ushort, 64, 128>()
+    {
+        return xdlops_info<mfma_instr::mfma_f32_32x32x2bf16, 64, 64, 1, 2>{};
+    }
+
+    template <>
+    __device__ static constexpr auto GetXdlopsInfo<ushort, 64, 64>()
+    {
+        return xdlops_info<mfma_instr::mfma_f32_32x32x2bf16, 64, 64, 1, 1>{};
+    }
+
+    template <>
+    __device__ static constexpr auto GetXdlopsInfo<ushort, 64, 32>()
+    {
+        return xdlops_info<mfma_instr::mfma_f32_32x32x2bf16, 64, 32, 1, 1>{};
+    }
+
+    template <>
+    __device__ static constexpr auto GetXdlopsInfo<ushort, 64, 16>()
+    {
+        return xdlops_info<mfma_instr::mfma_f32_16x16x2bf16, 64, 16, 1, 1>{};
+    }
+
+    template <>
+    __device__ static constexpr auto GetXdlopsInfo<ushort, 32, 64>()
+    {
+        return xdlops_info<mfma_instr::mfma_f32_32x32x2bf16, 32, 64, 1, 1>{};
+    }
+
+    template <>
+    __device__ static constexpr auto GetXdlopsInfo<ushort, 32, 32>()
+    {
+        return xdlops_info<mfma_instr::mfma_f32_32x32x4bf16, 32, 32, 1, 1>{};
+    }
+
+    template <>
+    __device__ static constexpr auto GetXdlopsInfo<ushort, 16, 64>()
+    {
+        return xdlops_info<mfma_instr::mfma_f32_16x16x2bf16, 16, 64, 1, 1>{};
+    }
+
+    template <>
+    __device__ static constexpr auto GetXdlopsInfo<ushort, 16, 16>()
+    {
+        return xdlops_info<mfma_instr::mfma_f32_16x16x8bf16, 16, 16, 1, 1>{};
+    }
+
+    template <>
+    __device__ static constexpr auto GetXdlopsInfo<ushort, 8, 64>()
+    {
+        return xdlops_info<mfma_instr::mfma_f32_4x4x2bf16, 8, 64, 1, 1>{};
+    }
+
+    template <>
+    __device__ static constexpr auto GetXdlopsInfo<ushort, 4, 64>()
+    {
+        return xdlops_info<mfma_instr::mfma_f32_4x4x2bf16, 4, 64, 1, 1>{};
     }
 
 #if CK_USE_AMD_XDLOPS_EMULATE
@@ -712,14 +763,20 @@ struct XdlopsGemm_t
                                   const FloatB* const __restrict__ p_b_wave,
                                   FloatC* const __restrict__ p_c_thread) const
     {
-        constexpr auto mfma_type = GetMFMAInfo();
+        constexpr auto mfma_type = GetXdlopsInfo().mfma_type;
 
         const index_t laneId = get_thread_local_1d_id() % mfma_type.wave_size;
         const index_t blk_id = laneId / mfma_type.num_threads_blk;
         const index_t blk_td = laneId % mfma_type.num_threads_blk;
 
+        constexpr auto MRepeats = GetXdlopsInfo().MRepeats;
+        constexpr auto NRepeats = GetXdlopsInfo().NRepeats;
+
+        constexpr auto MPerXdlops = GetXdlopsInfo().MPerXdlops;
+        constexpr auto NPerXdlops = GetXdlopsInfo().NPerXdlops;
+
         // K reduction
-        static_if<IsKReduction()>{}([&](auto) {
+        static_if<GetXdlopsInfo().IsKReduction()>{}([&](auto) {
             for(index_t k = 0; k < K; k += mfma_type.num_input_blks)
             {
                 for(index_t n = 0; n < mfma_type.num_input_blks; ++n)
@@ -741,7 +798,7 @@ struct XdlopsGemm_t
             }
 
         }).Else([&](auto) {
-            static_if<IsABroadcast()>{}([&](auto) {
+            static_if<GetXdlopsInfo().IsABroadcast()>{}([&](auto) {
 
                 for(index_t m_i = 0; m_i < MRepeats; ++m_i)
                 {
@@ -828,9 +885,15 @@ struct XdlopsGemm_t
 #if CK_USE_AMD_XDLOPS_EMULATE
         XdlopsEmulate<M, N, K>(p_a_wave, p_b_wave, p_c_thread);
 #else
-        constexpr auto mfma_type = GetMFMAInfo();
+        constexpr auto mfma_type = GetXdlopsInfo().mfma_type;
 
         const index_t laneId = get_thread_local_1d_id() % mfma_type.wave_size;
+
+        constexpr auto MRepeats = GetXdlopsInfo().MRepeats;
+        constexpr auto NRepeats = GetXdlopsInfo().NRepeats;
+
+        constexpr auto MPerXdlops = GetXdlopsInfo().MPerXdlops;
+        constexpr auto NPerXdlops = GetXdlopsInfo().NPerXdlops;
 
         FloatA a[K * MRepeats];
         FloatB b[K * NRepeats];
@@ -840,19 +903,16 @@ struct XdlopsGemm_t
 
         constexpr index_t nxdlops = sizeof(FloatA) / (sizeof(data_type) * mfma_type.k_base);
 
-        static_assert(!IsKReduction() || K % mfma_type.num_input_blks == 0,
+        static_assert(!GetXdlopsInfo().IsKReduction() || K % mfma_type.num_input_blks == 0,
                       "K cannot divided by mfma_type.num_input_blks!");
 
-        static_assert(!IsKReduction() || (MRepeats == 1 && NRepeats == 1),
-                      "KReduction does not support xdlops repeats");
+        static_if<!GetXdlopsInfo().IsKReduction()>{}([&](auto) {
 
-        static_if<!IsKReduction()>{}([&](auto) {
-
-            for(index_t m_i = 0; m_i < MRepeats; ++m_i)
+            for(index_t m_i = 0; m_i < GetXdlopsInfo().MRepeats; ++m_i)
                 for(index_t k_i      = 0; k_i < K; ++k_i)
                     a[k_i + m_i * K] = p_a_wave[k_i * M + laneId + MPerXdlops * m_i];
 
-            for(index_t n_i = 0; n_i < NRepeats; ++n_i)
+            for(index_t n_i = 0; n_i < GetXdlopsInfo().NRepeats; ++n_i)
                 for(index_t k_i      = 0; k_i < K; ++k_i)
                     b[k_i + n_i * K] = p_b_wave[k_i * N + laneId + NPerXdlops * n_i];
 
@@ -860,10 +920,10 @@ struct XdlopsGemm_t
             auto pa = reinterpret_cast<const data_type*>(&a);
             auto pb = reinterpret_cast<const data_type*>(&b);
 
-            for(index_t m_i = 0; m_i < MRepeats; ++m_i)
+            for(index_t m_i = 0; m_i < GetXdlopsInfo().MRepeats; ++m_i)
             {
 
-                for(index_t n_i = 0; n_i < NRepeats; ++n_i)
+                for(index_t n_i = 0; n_i < GetXdlopsInfo().NRepeats; ++n_i)
                 {
 
 #if CK_WORKAROUND_SWDEV_229564
@@ -877,7 +937,8 @@ struct XdlopsGemm_t
                                     m_i * K * nxdlops * mfma_type.k_base],
                                 &pb[(k_i * nxdlops + i) * mfma_type.k_base +
                                     n_i * K * nxdlops * mfma_type.k_base],
-                                p_c_thread + (NRepeats * m_i + n_i) * GetRegSizePerXdlops());
+                                p_c_thread +
+                                    (GetXdlopsInfo().NRepeats * m_i + n_i) * GetRegSizePerXdlops());
                     }
                 }
             }
@@ -916,13 +977,19 @@ struct XdlopsGemm_t
 
     __device__ static MatrixIndex GetBeginOfThreadBlk(index_t i)
     {
+        constexpr auto MPerXdlops = GetXdlopsInfo().MPerXdlops;
+        constexpr auto NPerXdlops = GetXdlopsInfo().NPerXdlops;
+
+        constexpr auto MRepeats = GetXdlopsInfo().MRepeats;
+        constexpr auto NRepeats = GetXdlopsInfo().NRepeats;
+
         const index_t xdlops_i = i / GetNumBlksPerXdlops();
         const index_t j        = i % GetNumBlksPerXdlops();
 
         const index_t m_i = xdlops_i / NRepeats;
         const index_t n_i = xdlops_i % NRepeats;
 
-        constexpr auto mfma_type = GetMFMAInfo();
+        constexpr auto mfma_type = GetXdlopsInfo().mfma_type;
 
         const index_t laneId = get_thread_local_1d_id() % mfma_type.wave_size;
         const index_t blk_id = laneId / mfma_type.num_threads_blk;
@@ -931,7 +998,7 @@ struct XdlopsGemm_t
         index_t col_blk = j % mfma_type.num_output_blks;
         index_t row_blk = j / mfma_type.num_output_blks;
 
-        static_if<!IsABroadcast()>{}([&](auto) {
+        static_if<!GetXdlopsInfo().IsABroadcast()>{}([&](auto) {
             col_blk = j / mfma_type.num_output_blks;
             row_blk = j % mfma_type.num_output_blks;
         });
@@ -942,17 +1009,33 @@ struct XdlopsGemm_t
         return MatrixIndex{row, col};
     }
 
-    __device__ static constexpr auto GetOutputLayout()
+    struct OutputLayout
     {
-        constexpr auto mfma_type = GetMFMAInfo();
+        static constexpr auto mfma_type = GetXdlopsInfo().mfma_type;
 
-        constexpr auto M1 = mfma_type.num_groups_blk;
-        constexpr auto M0 = mfma_type.group_size;
-        constexpr auto N1 = mfma_type.num_input_blks;
-        constexpr auto N0 = mfma_type.num_threads_blk;
+        __device__ static constexpr index_t M1() { return mfma_type.num_groups_blk; }
+        __device__ static constexpr index_t M0() { return GetXdlopsInfo().mfma_type.group_size; }
+        __device__ static constexpr index_t N1()
+        {
+            return GetXdlopsInfo().mfma_type.num_input_blks;
+        }
+        __device__ static constexpr index_t N0()
+        {
+            return GetXdlopsInfo().mfma_type.num_threads_blk;
+        }
 
-        return OutputLayout<M1, M0, N1, N0>{};
-    }
+        __device__ static constexpr index_t GetBlkSize()
+        {
+            return GetXdlopsInfo().mfma_type.num_regs_blk;
+        }
+
+        __device__ static constexpr index_t GetNumBlks()
+        {
+            return GetNumBlksPerXdlops() * GetXdlopsInfo().MRepeats * GetXdlopsInfo().NRepeats;
+        }
+    };
+
+    __device__ static constexpr auto GetOutputLayout() { return OutputLayout{}; }
 
     __device__ void SetZeroXdlopsRegs() const {}
 

--- a/src/kernels/composable_kernel/include/tensor_operation/xdlops_gemm.hpp
+++ b/src/kernels/composable_kernel/include/tensor_operation/xdlops_gemm.hpp
@@ -467,232 +467,13 @@ struct xdlops_info
     static constexpr index_t MRepeats   = MRepeats_;
     static constexpr index_t NRepeats   = NRepeats_;
 
-    __device__ static constexpr bool IsABroadcast() { return NPerXdlops >= MPerXdlops; }
+    static constexpr bool IsABroadcast() { return NPerXdlops >= MPerXdlops; }
 
-    __device__ static constexpr bool IsKReduction()
+    static constexpr bool IsKReduction()
     {
         return (mfma_type.num_output_blks == 1) && (mfma_type.num_input_blks > 1);
     }
 };
-
-template <class data_type, index_t MPerWave, index_t NPerWave>
-__device__ inline constexpr auto GetXdlopsInfo();
-
-template <>
-__device__ inline constexpr auto GetXdlopsInfo<float, 128, 128>()
-{
-    return xdlops_info<mfma_instr::mfma_f32_32x32x1xf32, 64, 64, 2, 2>{};
-}
-
-template <>
-__device__ inline constexpr auto GetXdlopsInfo<float, 128, 64>()
-{
-    return xdlops_info<mfma_instr::mfma_f32_32x32x1xf32, 64, 64, 2, 1>{};
-}
-
-template <>
-__device__ inline constexpr auto GetXdlopsInfo<float, 64, 128>()
-{
-    return xdlops_info<mfma_instr::mfma_f32_32x32x1xf32, 64, 64, 1, 2>{};
-}
-
-template <>
-__device__ inline constexpr auto GetXdlopsInfo<float, 64, 64>()
-{
-    return xdlops_info<mfma_instr::mfma_f32_32x32x1xf32, 64, 64, 1, 1>{};
-}
-
-template <>
-__device__ inline constexpr auto GetXdlopsInfo<float, 64, 32>()
-{
-    return xdlops_info<mfma_instr::mfma_f32_32x32x1xf32, 64, 32, 1, 1>{};
-}
-
-template <>
-__device__ inline constexpr auto GetXdlopsInfo<float, 64, 16>()
-{
-    return xdlops_info<mfma_instr::mfma_f32_16x16x1xf32, 64, 16, 1, 1>{};
-}
-
-template <>
-__device__ inline constexpr auto GetXdlopsInfo<float, 32, 64>()
-{
-    return xdlops_info<mfma_instr::mfma_f32_32x32x1xf32, 32, 64, 1, 1>{};
-}
-
-template <>
-__device__ inline constexpr auto GetXdlopsInfo<float, 32, 32>()
-{
-    return xdlops_info<mfma_instr::mfma_f32_32x32x2xf32, 32, 32, 1, 1>{};
-}
-
-template <>
-__device__ inline constexpr auto GetXdlopsInfo<float, 16, 64>()
-{
-    return xdlops_info<mfma_instr::mfma_f32_16x16x1xf32, 16, 64, 1, 1>{};
-}
-
-template <>
-__device__ inline constexpr auto GetXdlopsInfo<float, 16, 16>()
-{
-    return xdlops_info<mfma_instr::mfma_f32_16x16x4xf32, 16, 16, 1, 1>{};
-}
-
-template <>
-__device__ inline constexpr auto GetXdlopsInfo<float, 8, 64>()
-{
-    return xdlops_info<mfma_instr::mfma_f32_4x4x1xf32, 8, 64, 1, 1>{};
-}
-
-template <>
-__device__ inline constexpr auto GetXdlopsInfo<float, 4, 64>()
-{
-    return xdlops_info<mfma_instr::mfma_f32_4x4x1xf32, 4, 64, 1, 1>{};
-}
-
-template <>
-__device__ inline constexpr auto GetXdlopsInfo<half_t, 128, 128>()
-{
-    return xdlops_info<mfma_instr::mfma_f32_32x32x4f16, 64, 64, 2, 2>{};
-}
-
-template <>
-__device__ inline constexpr auto GetXdlopsInfo<half_t, 128, 64>()
-{
-    return xdlops_info<mfma_instr::mfma_f32_32x32x4f16, 64, 64, 2, 1>{};
-}
-
-template <>
-__device__ inline constexpr auto GetXdlopsInfo<half_t, 64, 128>()
-{
-    return xdlops_info<mfma_instr::mfma_f32_32x32x4f16, 64, 64, 1, 2>{};
-}
-
-template <>
-__device__ inline constexpr auto GetXdlopsInfo<half_t, 64, 64>()
-{
-    return xdlops_info<mfma_instr::mfma_f32_32x32x4f16, 64, 64, 1, 1>{};
-}
-
-template <>
-__device__ inline constexpr auto GetXdlopsInfo<half_t, 64, 32>()
-{
-    return xdlops_info<mfma_instr::mfma_f32_32x32x4f16, 64, 32, 1, 1>{};
-}
-
-template <>
-__device__ inline constexpr auto GetXdlopsInfo<half_t, 64, 16>()
-{
-    return xdlops_info<mfma_instr::mfma_f32_16x16x4f16, 64, 16, 1, 1>{};
-}
-
-template <>
-__device__ inline constexpr auto GetXdlopsInfo<half_t, 32, 64>()
-{
-    return xdlops_info<mfma_instr::mfma_f32_32x32x4f16, 32, 64, 1, 1>{};
-}
-
-template <>
-__device__ inline constexpr auto GetXdlopsInfo<half_t, 32, 32>()
-{
-    return xdlops_info<mfma_instr::mfma_f32_32x32x8f16, 32, 32, 1, 1>{};
-}
-
-template <>
-__device__ inline constexpr auto GetXdlopsInfo<half_t, 16, 64>()
-{
-    return xdlops_info<mfma_instr::mfma_f32_16x16x4f16, 16, 64, 1, 1>{};
-}
-
-template <>
-__device__ inline constexpr auto GetXdlopsInfo<half_t, 16, 16>()
-{
-    return xdlops_info<mfma_instr::mfma_f32_16x16x16f16, 16, 16, 1, 1>{};
-}
-
-template <>
-__device__ inline constexpr auto GetXdlopsInfo<half_t, 8, 64>()
-{
-    return xdlops_info<mfma_instr::mfma_f32_4x4x4f16, 8, 64, 1, 1>{};
-}
-
-template <>
-__device__ inline constexpr auto GetXdlopsInfo<half_t, 4, 64>()
-{
-    return xdlops_info<mfma_instr::mfma_f32_4x4x4f16, 4, 64, 1, 1>{};
-}
-
-template <>
-__device__ inline constexpr auto GetXdlopsInfo<ushort, 128, 128>()
-{
-    return xdlops_info<mfma_instr::mfma_f32_32x32x2bf16, 64, 64, 2, 2>{};
-}
-
-template <>
-__device__ inline constexpr auto GetXdlopsInfo<ushort, 128, 64>()
-{
-    return xdlops_info<mfma_instr::mfma_f32_32x32x2bf16, 64, 64, 2, 1>{};
-}
-
-template <>
-__device__ inline constexpr auto GetXdlopsInfo<ushort, 64, 128>()
-{
-    return xdlops_info<mfma_instr::mfma_f32_32x32x2bf16, 64, 64, 1, 2>{};
-}
-
-template <>
-__device__ inline constexpr auto GetXdlopsInfo<ushort, 64, 64>()
-{
-    return xdlops_info<mfma_instr::mfma_f32_32x32x2bf16, 64, 64, 1, 1>{};
-}
-
-template <>
-__device__ inline constexpr auto GetXdlopsInfo<ushort, 64, 32>()
-{
-    return xdlops_info<mfma_instr::mfma_f32_32x32x2bf16, 64, 32, 1, 1>{};
-}
-
-template <>
-__device__ inline constexpr auto GetXdlopsInfo<ushort, 64, 16>()
-{
-    return xdlops_info<mfma_instr::mfma_f32_16x16x2bf16, 64, 16, 1, 1>{};
-}
-
-template <>
-__device__ inline constexpr auto GetXdlopsInfo<ushort, 32, 64>()
-{
-    return xdlops_info<mfma_instr::mfma_f32_32x32x2bf16, 32, 64, 1, 1>{};
-}
-
-template <>
-__device__ inline constexpr auto GetXdlopsInfo<ushort, 32, 32>()
-{
-    return xdlops_info<mfma_instr::mfma_f32_32x32x4bf16, 32, 32, 1, 1>{};
-}
-
-template <>
-__device__ inline constexpr auto GetXdlopsInfo<ushort, 16, 64>()
-{
-    return xdlops_info<mfma_instr::mfma_f32_16x16x2bf16, 16, 64, 1, 1>{};
-}
-
-template <>
-__device__ inline constexpr auto GetXdlopsInfo<ushort, 16, 16>()
-{
-    return xdlops_info<mfma_instr::mfma_f32_16x16x8bf16, 16, 16, 1, 1>{};
-}
-
-template <>
-__device__ inline constexpr auto GetXdlopsInfo<ushort, 8, 64>()
-{
-    return xdlops_info<mfma_instr::mfma_f32_4x4x2bf16, 8, 64, 1, 1>{};
-}
-
-template <>
-__device__ inline constexpr auto GetXdlopsInfo<ushort, 4, 64>()
-{
-    return xdlops_info<mfma_instr::mfma_f32_4x4x2bf16, 4, 64, 1, 1>{};
-}
 
 template <class data_type,
           index_t GemmMPerWave,
@@ -701,23 +482,6 @@ template <class data_type,
           index_t GemmDataPerReadB>
 struct XdlopsGemm_t
 {
-    static constexpr index_t MRepeats =
-        GetXdlopsInfo<data_type, GemmMPerWave, GemmNPerWave>().MRepeats;
-    static constexpr index_t NRepeats =
-        GetXdlopsInfo<data_type, GemmMPerWave, GemmNPerWave>().NRepeats;
-    static constexpr index_t MPerXdlops =
-        GetXdlopsInfo<data_type, GemmMPerWave, GemmNPerWave>().MPerXdlops;
-    static constexpr index_t NPerXdlops =
-        GetXdlopsInfo<data_type, GemmMPerWave, GemmNPerWave>().NPerXdlops;
-
-    static constexpr bool IsKReduction =
-        GetXdlopsInfo<data_type, GemmMPerWave, GemmNPerWave>().IsKReduction();
-    static constexpr bool IsABroadcast =
-        GetXdlopsInfo<data_type, GemmMPerWave, GemmNPerWave>().IsABroadcast();
-
-    static constexpr auto mfma_type =
-        GetXdlopsInfo<data_type, GemmMPerWave, GemmNPerWave>().mfma_type;
-
     struct MatrixIndex
     {
         index_t row;
@@ -1006,6 +770,238 @@ struct XdlopsGemm_t
     __device__ void ReadXdlopsRegs(FloatC* const __restrict__) const
     {
     }
+
+    protected:
+    template <class data_type_  = data_type,
+              index_t MPerWave_ = GemmMPerWave,
+              index_t NPerWave_ = GemmNPerWave>
+    static constexpr auto GetXdlopsInfo();
+
+    template <>
+    static constexpr auto GetXdlopsInfo<float, 128, 128>()
+    {
+        return xdlops_info<mfma_instr::mfma_f32_32x32x1xf32, 64, 64, 2, 2>{};
+    }
+
+    template <>
+    static constexpr auto GetXdlopsInfo<float, 128, 64>()
+    {
+        return xdlops_info<mfma_instr::mfma_f32_32x32x1xf32, 64, 64, 2, 1>{};
+    }
+
+    template <>
+    static constexpr auto GetXdlopsInfo<float, 64, 128>()
+    {
+        return xdlops_info<mfma_instr::mfma_f32_32x32x1xf32, 64, 64, 1, 2>{};
+    }
+
+    template <>
+    static constexpr auto GetXdlopsInfo<float, 64, 64>()
+    {
+        return xdlops_info<mfma_instr::mfma_f32_32x32x1xf32, 64, 64, 1, 1>{};
+    }
+
+    template <>
+    static constexpr auto GetXdlopsInfo<float, 64, 32>()
+    {
+        return xdlops_info<mfma_instr::mfma_f32_32x32x1xf32, 64, 32, 1, 1>{};
+    }
+
+    template <>
+    static constexpr auto GetXdlopsInfo<float, 64, 16>()
+    {
+        return xdlops_info<mfma_instr::mfma_f32_16x16x1xf32, 64, 16, 1, 1>{};
+    }
+
+    template <>
+    static constexpr auto GetXdlopsInfo<float, 32, 64>()
+    {
+        return xdlops_info<mfma_instr::mfma_f32_32x32x1xf32, 32, 64, 1, 1>{};
+    }
+
+    template <>
+    static constexpr auto GetXdlopsInfo<float, 32, 32>()
+    {
+        return xdlops_info<mfma_instr::mfma_f32_32x32x2xf32, 32, 32, 1, 1>{};
+    }
+
+    template <>
+    static constexpr auto GetXdlopsInfo<float, 16, 64>()
+    {
+        return xdlops_info<mfma_instr::mfma_f32_16x16x1xf32, 16, 64, 1, 1>{};
+    }
+
+    template <>
+    static constexpr auto GetXdlopsInfo<float, 16, 16>()
+    {
+        return xdlops_info<mfma_instr::mfma_f32_16x16x4xf32, 16, 16, 1, 1>{};
+    }
+
+    template <>
+    static constexpr auto GetXdlopsInfo<float, 8, 64>()
+    {
+        return xdlops_info<mfma_instr::mfma_f32_4x4x1xf32, 8, 64, 1, 1>{};
+    }
+
+    template <>
+    static constexpr auto GetXdlopsInfo<float, 4, 64>()
+    {
+        return xdlops_info<mfma_instr::mfma_f32_4x4x1xf32, 4, 64, 1, 1>{};
+    }
+
+    template <>
+    static constexpr auto GetXdlopsInfo<half_t, 128, 128>()
+    {
+        return xdlops_info<mfma_instr::mfma_f32_32x32x4f16, 64, 64, 2, 2>{};
+    }
+
+    template <>
+    static constexpr auto GetXdlopsInfo<half_t, 128, 64>()
+    {
+        return xdlops_info<mfma_instr::mfma_f32_32x32x4f16, 64, 64, 2, 1>{};
+    }
+
+    template <>
+    static constexpr auto GetXdlopsInfo<half_t, 64, 128>()
+    {
+        return xdlops_info<mfma_instr::mfma_f32_32x32x4f16, 64, 64, 1, 2>{};
+    }
+
+    template <>
+    static constexpr auto GetXdlopsInfo<half_t, 64, 64>()
+    {
+        return xdlops_info<mfma_instr::mfma_f32_32x32x4f16, 64, 64, 1, 1>{};
+    }
+
+    template <>
+    static constexpr auto GetXdlopsInfo<half_t, 64, 32>()
+    {
+        return xdlops_info<mfma_instr::mfma_f32_32x32x4f16, 64, 32, 1, 1>{};
+    }
+
+    template <>
+    static constexpr auto GetXdlopsInfo<half_t, 64, 16>()
+    {
+        return xdlops_info<mfma_instr::mfma_f32_16x16x4f16, 64, 16, 1, 1>{};
+    }
+
+    template <>
+    static constexpr auto GetXdlopsInfo<half_t, 32, 64>()
+    {
+        return xdlops_info<mfma_instr::mfma_f32_32x32x4f16, 32, 64, 1, 1>{};
+    }
+
+    template <>
+    static constexpr auto GetXdlopsInfo<half_t, 32, 32>()
+    {
+        return xdlops_info<mfma_instr::mfma_f32_32x32x8f16, 32, 32, 1, 1>{};
+    }
+
+    template <>
+    static constexpr auto GetXdlopsInfo<half_t, 16, 64>()
+    {
+        return xdlops_info<mfma_instr::mfma_f32_16x16x4f16, 16, 64, 1, 1>{};
+    }
+
+    template <>
+    static constexpr auto GetXdlopsInfo<half_t, 16, 16>()
+    {
+        return xdlops_info<mfma_instr::mfma_f32_16x16x16f16, 16, 16, 1, 1>{};
+    }
+
+    template <>
+    static constexpr auto GetXdlopsInfo<half_t, 8, 64>()
+    {
+        return xdlops_info<mfma_instr::mfma_f32_4x4x4f16, 8, 64, 1, 1>{};
+    }
+
+    template <>
+    static constexpr auto GetXdlopsInfo<half_t, 4, 64>()
+    {
+        return xdlops_info<mfma_instr::mfma_f32_4x4x4f16, 4, 64, 1, 1>{};
+    }
+
+    template <>
+    static constexpr auto GetXdlopsInfo<ushort, 128, 128>()
+    {
+        return xdlops_info<mfma_instr::mfma_f32_32x32x2bf16, 64, 64, 2, 2>{};
+    }
+
+    template <>
+    static constexpr auto GetXdlopsInfo<ushort, 128, 64>()
+    {
+        return xdlops_info<mfma_instr::mfma_f32_32x32x2bf16, 64, 64, 2, 1>{};
+    }
+
+    template <>
+    static constexpr auto GetXdlopsInfo<ushort, 64, 128>()
+    {
+        return xdlops_info<mfma_instr::mfma_f32_32x32x2bf16, 64, 64, 1, 2>{};
+    }
+
+    template <>
+    static constexpr auto GetXdlopsInfo<ushort, 64, 64>()
+    {
+        return xdlops_info<mfma_instr::mfma_f32_32x32x2bf16, 64, 64, 1, 1>{};
+    }
+
+    template <>
+    static constexpr auto GetXdlopsInfo<ushort, 64, 32>()
+    {
+        return xdlops_info<mfma_instr::mfma_f32_32x32x2bf16, 64, 32, 1, 1>{};
+    }
+
+    template <>
+    static constexpr auto GetXdlopsInfo<ushort, 64, 16>()
+    {
+        return xdlops_info<mfma_instr::mfma_f32_16x16x2bf16, 64, 16, 1, 1>{};
+    }
+
+    template <>
+    static constexpr auto GetXdlopsInfo<ushort, 32, 64>()
+    {
+        return xdlops_info<mfma_instr::mfma_f32_32x32x2bf16, 32, 64, 1, 1>{};
+    }
+
+    template <>
+    static constexpr auto GetXdlopsInfo<ushort, 32, 32>()
+    {
+        return xdlops_info<mfma_instr::mfma_f32_32x32x4bf16, 32, 32, 1, 1>{};
+    }
+
+    template <>
+    static constexpr auto GetXdlopsInfo<ushort, 16, 64>()
+    {
+        return xdlops_info<mfma_instr::mfma_f32_16x16x2bf16, 16, 64, 1, 1>{};
+    }
+
+    template <>
+    static constexpr auto GetXdlopsInfo<ushort, 16, 16>()
+    {
+        return xdlops_info<mfma_instr::mfma_f32_16x16x8bf16, 16, 16, 1, 1>{};
+    }
+
+    template <>
+    static constexpr auto GetXdlopsInfo<ushort, 8, 64>()
+    {
+        return xdlops_info<mfma_instr::mfma_f32_4x4x2bf16, 8, 64, 1, 1>{};
+    }
+
+    template <>
+    static constexpr auto GetXdlopsInfo<ushort, 4, 64>()
+    {
+        return xdlops_info<mfma_instr::mfma_f32_4x4x2bf16, 4, 64, 1, 1>{};
+    }
+
+    static constexpr index_t MRepeats   = GetXdlopsInfo().MRepeats;
+    static constexpr index_t NRepeats   = GetXdlopsInfo().NRepeats;
+    static constexpr index_t MPerXdlops = GetXdlopsInfo().MPerXdlops;
+    static constexpr index_t NPerXdlops = GetXdlopsInfo().NPerXdlops;
+
+    static constexpr bool IsKReduction = GetXdlopsInfo().IsKReduction();
+    static constexpr bool IsABroadcast = GetXdlopsInfo().IsABroadcast();
+
+    static constexpr auto mfma_type = GetXdlopsInfo().mfma_type;
 };
 
 } // namespace ck

--- a/src/kernels/composable_kernel/include/tensor_operation/xdlops_gemm.hpp
+++ b/src/kernels/composable_kernel/include/tensor_operation/xdlops_gemm.hpp
@@ -790,6 +790,18 @@ struct XdlopsGemm_t
     }
 
     template <>
+    static constexpr auto GetXdlopsInfo<float, 128, 32>()
+    {
+        return xdlops_info<mfma_instr::mfma_f32_32x32x1xf32, 64, 32, 2, 1>{};
+    }
+
+    template <>
+    static constexpr auto GetXdlopsInfo<float, 128, 16>()
+    {
+        return xdlops_info<mfma_instr::mfma_f32_16x16x1xf32, 64, 16, 2, 1>{};
+    }
+
+    template <>
     static constexpr auto GetXdlopsInfo<float, 64, 128>()
     {
         return xdlops_info<mfma_instr::mfma_f32_32x32x1xf32, 64, 64, 1, 2>{};
@@ -814,6 +826,12 @@ struct XdlopsGemm_t
     }
 
     template <>
+    static constexpr auto GetXdlopsInfo<float, 32, 128>()
+    {
+        return xdlops_info<mfma_instr::mfma_f32_32x32x1xf32, 32, 64, 1, 2>{};
+    }
+
+    template <>
     static constexpr auto GetXdlopsInfo<float, 32, 64>()
     {
         return xdlops_info<mfma_instr::mfma_f32_32x32x1xf32, 32, 64, 1, 1>{};
@@ -823,6 +841,12 @@ struct XdlopsGemm_t
     static constexpr auto GetXdlopsInfo<float, 32, 32>()
     {
         return xdlops_info<mfma_instr::mfma_f32_32x32x2xf32, 32, 32, 1, 1>{};
+    }
+
+    template <>
+    static constexpr auto GetXdlopsInfo<float, 16, 128>()
+    {
+        return xdlops_info<mfma_instr::mfma_f32_16x16x1xf32, 16, 64, 1, 2>{};
     }
 
     template <>
@@ -838,9 +862,21 @@ struct XdlopsGemm_t
     }
 
     template <>
+    static constexpr auto GetXdlopsInfo<float, 8, 128>()
+    {
+        return xdlops_info<mfma_instr::mfma_f32_4x4x1xf32, 8, 64, 1, 2>{};
+    }
+
+    template <>
     static constexpr auto GetXdlopsInfo<float, 8, 64>()
     {
         return xdlops_info<mfma_instr::mfma_f32_4x4x1xf32, 8, 64, 1, 1>{};
+    }
+
+    template <>
+    static constexpr auto GetXdlopsInfo<float, 4, 128>()
+    {
+        return xdlops_info<mfma_instr::mfma_f32_4x4x1xf32, 4, 64, 1, 2>{};
     }
 
     template <>

--- a/src/kernels/composable_kernel/include/tensor_operation/xdlops_gemm.hpp
+++ b/src/kernels/composable_kernel/include/tensor_operation/xdlops_gemm.hpp
@@ -50,8 +50,7 @@ struct mfma_info<mfma_instr::mfma_f32_32x32x1xf32>
     static constexpr index_t k_base          = 1;
 
     template <index_t MPerXdlops, index_t NPerXdlops>
-    __device__ void
-    run(Number<MPerXdlops>, Number<NPerXdlops>, const float* a, const float* b, float* reg_c) const
+    __device__ void run(const float* a, const float* b, float* reg_c) const
     {
         const auto p_a = a;
         const auto p_b = b;
@@ -79,8 +78,7 @@ struct mfma_info<mfma_instr::mfma_f32_32x32x2xf32>
     static constexpr index_t k_base          = 1;
 
     template <index_t MPerXdlops, index_t NPerXdlops>
-    __device__ void
-    run(Number<MPerXdlops>, Number<NPerXdlops>, const float* a, const float* b, float* reg_c) const
+    __device__ void run(const float* a, const float* b, float* reg_c) const
     {
         const auto p_a = a;
         const auto p_b = b;
@@ -108,8 +106,7 @@ struct mfma_info<mfma_instr::mfma_f32_16x16x4xf32>
     static constexpr index_t k_base          = 1;
 
     template <index_t MPerXdlops, index_t NPerXdlops>
-    __device__ void
-    run(Number<MPerXdlops>, Number<NPerXdlops>, const float* a, const float* b, float* reg_c) const
+    __device__ void run(const float* a, const float* b, float* reg_c) const
     {
         const auto p_a = a;
         const auto p_b = b;
@@ -137,8 +134,7 @@ struct mfma_info<mfma_instr::mfma_f32_16x16x1xf32>
     static constexpr index_t k_base          = 1;
 
     template <index_t MPerXdlops, index_t NPerXdlops>
-    __device__ void
-    run(Number<MPerXdlops>, Number<NPerXdlops>, const float* a, const float* b, float* reg_c) const
+    __device__ void run(const float* a, const float* b, float* reg_c) const
     {
         const auto p_a = a;
         const auto p_b = b;
@@ -167,8 +163,7 @@ struct mfma_info<mfma_instr::mfma_f32_4x4x1xf32>
     static constexpr index_t k_base          = 1;
 
     template <index_t MPerXdlops, index_t NPerXdlops>
-    __device__ void
-    run(Number<MPerXdlops>, Number<NPerXdlops>, const float* a, const float* b, float* reg_c) const
+    __device__ void run(const float* a, const float* b, float* reg_c) const
     {
         static_assert((MPerXdlops == 4 || MPerXdlops == 8) && NPerXdlops == 64,
                       "unsupported xdlops gemm");
@@ -199,11 +194,7 @@ struct mfma_info<mfma_instr::mfma_f32_32x32x4f16>
     static constexpr index_t k_base          = 4;
 
     template <index_t MPerXdlops, index_t NPerXdlops>
-    __device__ void run(Number<MPerXdlops>,
-                        Number<NPerXdlops>,
-                        const half_t* a,
-                        const half_t* b,
-                        float* reg_c) const
+    __device__ void run(const half_t* a, const half_t* b, float* reg_c) const
     {
         const auto p_a = reinterpret_cast<const half4_t*>(a);
         const auto p_b = reinterpret_cast<const half4_t*>(b);
@@ -231,11 +222,7 @@ struct mfma_info<mfma_instr::mfma_f32_32x32x8f16>
     static constexpr index_t k_base          = 4;
 
     template <index_t MPerXdlops, index_t NPerXdlops>
-    __device__ void run(Number<MPerXdlops>,
-                        Number<NPerXdlops>,
-                        const half_t* a,
-                        const half_t* b,
-                        float* reg_c) const
+    __device__ void run(const half_t* a, const half_t* b, float* reg_c) const
     {
         const auto p_a = reinterpret_cast<const half4_t*>(a);
         const auto p_b = reinterpret_cast<const half4_t*>(b);
@@ -263,11 +250,7 @@ struct mfma_info<mfma_instr::mfma_f32_16x16x16f16>
     static constexpr index_t k_base          = 4;
 
     template <index_t MPerXdlops, index_t NPerXdlops>
-    __device__ void run(Number<MPerXdlops>,
-                        Number<NPerXdlops>,
-                        const half_t* a,
-                        const half_t* b,
-                        float* reg_c) const
+    __device__ void run(const half_t* a, const half_t* b, float* reg_c) const
     {
         const auto p_a = reinterpret_cast<const half4_t*>(a);
         const auto p_b = reinterpret_cast<const half4_t*>(b);
@@ -295,11 +278,7 @@ struct mfma_info<mfma_instr::mfma_f32_16x16x4f16>
     static constexpr index_t k_base          = 4;
 
     template <index_t MPerXdlops, index_t NPerXdlops>
-    __device__ void run(Number<MPerXdlops>,
-                        Number<NPerXdlops>,
-                        const half_t* a,
-                        const half_t* b,
-                        float* reg_c) const
+    __device__ void run(const half_t* a, const half_t* b, float* reg_c) const
     {
         const auto p_a = reinterpret_cast<const half4_t*>(a);
         const auto p_b = reinterpret_cast<const half4_t*>(b);
@@ -327,11 +306,7 @@ struct mfma_info<mfma_instr::mfma_f32_4x4x4f16>
     static constexpr index_t k_base          = 4;
 
     template <index_t MPerXdlops, index_t NPerXdlops>
-    __device__ void run(Number<MPerXdlops>,
-                        Number<NPerXdlops>,
-                        const half_t* a,
-                        const half_t* b,
-                        float* reg_c) const
+    __device__ void run(const half_t* a, const half_t* b, float* reg_c) const
     {
         const auto p_a = reinterpret_cast<const half4_t*>(a);
         const auto p_b = reinterpret_cast<const half4_t*>(b);
@@ -359,11 +334,7 @@ struct mfma_info<mfma_instr::mfma_f32_32x32x2bf16>
     static constexpr index_t k_base          = 2;
 
     template <index_t MPerXdlops, index_t NPerXdlops>
-    __device__ void run(Number<MPerXdlops>,
-                        Number<NPerXdlops>,
-                        const ushort* a,
-                        const ushort* b,
-                        float* reg_c) const
+    __device__ void run(const ushort* a, const ushort* b, float* reg_c) const
     {
         const auto p_a = reinterpret_cast<const ushort2_t*>(a);
         const auto p_b = reinterpret_cast<const ushort2_t*>(b);
@@ -391,11 +362,7 @@ struct mfma_info<mfma_instr::mfma_f32_32x32x4bf16>
     static constexpr index_t k_base          = 2;
 
     template <index_t MPerXdlops, index_t NPerXdlops>
-    __device__ void run(Number<MPerXdlops>,
-                        Number<NPerXdlops>,
-                        const ushort* a,
-                        const ushort* b,
-                        float* reg_c) const
+    __device__ void run(const ushort* a, const ushort* b, float* reg_c) const
     {
         const auto p_a = reinterpret_cast<const ushort2_t*>(a);
         const auto p_b = reinterpret_cast<const ushort2_t*>(b);
@@ -423,11 +390,7 @@ struct mfma_info<mfma_instr::mfma_f32_16x16x8bf16>
     static constexpr index_t k_base          = 2;
 
     template <index_t MPerXdlops, index_t NPerXdlops>
-    __device__ void run(Number<MPerXdlops>,
-                        Number<NPerXdlops>,
-                        const ushort* a,
-                        const ushort* b,
-                        float* reg_c) const
+    __device__ void run(const ushort* a, const ushort* b, float* reg_c) const
     {
         const auto p_a = reinterpret_cast<const ushort2_t*>(a);
         const auto p_b = reinterpret_cast<const ushort2_t*>(b);
@@ -455,11 +418,7 @@ struct mfma_info<mfma_instr::mfma_f32_16x16x2bf16>
     static constexpr index_t k_base          = 2;
 
     template <index_t MPerXdlops, index_t NPerXdlops>
-    __device__ void run(Number<MPerXdlops>,
-                        Number<NPerXdlops>,
-                        const ushort* a,
-                        const ushort* b,
-                        float* reg_c) const
+    __device__ void run(const ushort* a, const ushort* b, float* reg_c) const
     {
         const auto p_a = reinterpret_cast<const ushort2_t*>(a);
         const auto p_b = reinterpret_cast<const ushort2_t*>(b);
@@ -487,11 +446,7 @@ struct mfma_info<mfma_instr::mfma_f32_4x4x2bf16>
     static constexpr index_t k_base          = 2;
 
     template <index_t MPerXdlops, index_t NPerXdlops>
-    __device__ void run(Number<MPerXdlops>,
-                        Number<NPerXdlops>,
-                        const ushort* a,
-                        const ushort* b,
-                        float* reg_c) const
+    __device__ void run(const ushort* a, const ushort* b, float* reg_c) const
     {
         const auto p_a = reinterpret_cast<const ushort2_t*>(a);
         const auto p_b = reinterpret_cast<const ushort2_t*>(b);
@@ -885,6 +840,9 @@ struct XdlopsGemm_t
                 for(index_t k_i      = 0; k_i < K; ++k_i)
                     b[k_i + n_i * K] = p_b_wave[k_i * N + laneId + NPerXdlops * n_i];
 
+            // constexpr index_t AStride = K * nxdlops;
+            // constexpr index_t BStride = K * nxdlops;
+
             for(index_t m_i = 0; m_i < MRepeats; ++m_i)
             {
 
@@ -900,11 +858,12 @@ struct XdlopsGemm_t
                     for(index_t k_i = 0; k_i < K; ++k_i)
                     {
                         for(index_t i = 0; i < nxdlops; ++i)
-                            mfma_type.run(Number<MPerXdlops>{},
-                                          Number<NPerXdlops>{},
-                                          &pa[((m_i * K + k_i) * nxdlops + i) * mfma_type.k_base],
-                                          &pb[((n_i * K + k_i) * nxdlops + i) * mfma_type.k_base],
-                                          p_c_thread + (NRepeats * m_i + n_i) * GetRegSize());
+                            mfma_type.template run<MPerXdlops, NPerXdlops>(
+                                &pa[(k_i * nxdlops + i) * mfma_type.k_base +
+                                    m_i * K * nxdlops * mfma_type.k_base],
+                                &pb[(k_i * nxdlops + i) * mfma_type.k_base +
+                                    n_i * K * nxdlops * mfma_type.k_base],
+                                p_c_thread + (NRepeats * m_i + n_i) * GetRegSize());
                     }
                 }
             }
@@ -931,11 +890,10 @@ struct XdlopsGemm_t
             for(index_t k_i = 0; k_i < K; k_i += mfma_type.num_input_blks)
             {
                 for(index_t i = 0; i < nxdlops; ++i)
-                    mfma_type.run(Number<MPerXdlops>{},
-                                  Number<NPerXdlops>{},
-                                  &pa[(k_i * nxdlops + i) * mfma_type.k_base],
-                                  &pb[(k_i * nxdlops + i) * mfma_type.k_base],
-                                  p_c_thread);
+                    mfma_type.template run<MPerXdlops, NPerXdlops>(
+                        &pa[(k_i * nxdlops + i) * mfma_type.k_base],
+                        &pb[(k_i * nxdlops + i) * mfma_type.k_base],
+                        p_c_thread);
             }
 
         });

--- a/src/kernels/composable_kernel/include/tensor_operation/xdlops_gemm.hpp
+++ b/src/kernels/composable_kernel/include/tensor_operation/xdlops_gemm.hpp
@@ -165,9 +165,6 @@ struct mfma_info<mfma_instr::mfma_f32_4x4x1xf32>
     template <index_t MPerXdlops, index_t NPerXdlops>
     __device__ void run(const float* a, const float* b, float* reg_c) const
     {
-        static_assert((MPerXdlops == 4 || MPerXdlops == 8) && NPerXdlops == 64,
-                      "unsupported xdlops gemm");
-
         const auto p_a = a;
         const auto p_b = b;
         auto p_c       = reinterpret_cast<float4_t*>(reg_c);

--- a/src/kernels/composable_kernel/include/tensor_operation/xdlops_gemm.hpp
+++ b/src/kernels/composable_kernel/include/tensor_operation/xdlops_gemm.hpp
@@ -930,15 +930,14 @@ struct XdlopsGemm_t
 
         index_t col_blk = j % mfma_type.num_output_blks;
         index_t row_blk = j / mfma_type.num_output_blks;
-        index_t col     = col_blk * mfma_type.n + blk_td + n_i * NPerXdlops;
-        index_t row     = row_blk * mfma_type.m + blk_id * mfma_type.group_size + m_i * MPerXdlops;
 
         static_if<!IsABroadcast()>{}([&](auto) {
             col_blk = j / mfma_type.num_output_blks;
             row_blk = j % mfma_type.num_output_blks;
-            col     = col_blk * mfma_type.n + blk_td + n_i * NPerXdlops;
-            row     = row_blk * mfma_type.m + blk_id * mfma_type.group_size + m_i * MPerXdlops;
         });
+
+        index_t col = col_blk * mfma_type.n + blk_td + n_i * NPerXdlops;
+        index_t row = row_blk * mfma_type.m + blk_id * mfma_type.group_size + m_i * MPerXdlops;
 
         return MatrixIndex{row, col};
     }

--- a/src/kernels/composable_kernel/include/tensor_operation/xdlops_gemm.hpp
+++ b/src/kernels/composable_kernel/include/tensor_operation/xdlops_gemm.hpp
@@ -936,7 +936,7 @@ struct XdlopsGemm_t
     template <>
     static constexpr auto GetXdlopsInfo<half_t, 32, 128>()
     {
-        return xdlops_info<mfma_instr::mfma_f32_32x32x4f16, 32, 128, 1, 2>{};
+        return xdlops_info<mfma_instr::mfma_f32_32x32x4f16, 32, 64, 1, 2>{};
     }
 
     template <>

--- a/src/kernels/composable_kernel/include/tensor_operation/xdlops_gemm.hpp
+++ b/src/kernels/composable_kernel/include/tensor_operation/xdlops_gemm.hpp
@@ -475,220 +475,220 @@ struct xdlops_info
 };
 
 template <class data_type, index_t MPerWave, index_t NPerWave>
-__device__ static constexpr auto GetXdlopsInfo();
+__device__ inline constexpr auto GetXdlopsInfo();
 
 template <>
-__device__ static constexpr auto GetXdlopsInfo<float, 128, 128>()
+__device__ inline constexpr auto GetXdlopsInfo<float, 128, 128>()
 {
     return xdlops_info<mfma_instr::mfma_f32_32x32x1xf32, 64, 64, 2, 2>{};
 }
 
 template <>
-__device__ static constexpr auto GetXdlopsInfo<float, 128, 64>()
+__device__ inline constexpr auto GetXdlopsInfo<float, 128, 64>()
 {
     return xdlops_info<mfma_instr::mfma_f32_32x32x1xf32, 64, 64, 2, 1>{};
 }
 
 template <>
-__device__ static constexpr auto GetXdlopsInfo<float, 64, 128>()
+__device__ inline constexpr auto GetXdlopsInfo<float, 64, 128>()
 {
     return xdlops_info<mfma_instr::mfma_f32_32x32x1xf32, 64, 64, 1, 2>{};
 }
 
 template <>
-__device__ static constexpr auto GetXdlopsInfo<float, 64, 64>()
+__device__ inline constexpr auto GetXdlopsInfo<float, 64, 64>()
 {
     return xdlops_info<mfma_instr::mfma_f32_32x32x1xf32, 64, 64, 1, 1>{};
 }
 
 template <>
-__device__ static constexpr auto GetXdlopsInfo<float, 64, 32>()
+__device__ inline constexpr auto GetXdlopsInfo<float, 64, 32>()
 {
     return xdlops_info<mfma_instr::mfma_f32_32x32x1xf32, 64, 32, 1, 1>{};
 }
 
 template <>
-__device__ static constexpr auto GetXdlopsInfo<float, 64, 16>()
+__device__ inline constexpr auto GetXdlopsInfo<float, 64, 16>()
 {
     return xdlops_info<mfma_instr::mfma_f32_16x16x1xf32, 64, 16, 1, 1>{};
 }
 
 template <>
-__device__ static constexpr auto GetXdlopsInfo<float, 32, 64>()
+__device__ inline constexpr auto GetXdlopsInfo<float, 32, 64>()
 {
     return xdlops_info<mfma_instr::mfma_f32_32x32x1xf32, 32, 64, 1, 1>{};
 }
 
 template <>
-__device__ static constexpr auto GetXdlopsInfo<float, 32, 32>()
+__device__ inline constexpr auto GetXdlopsInfo<float, 32, 32>()
 {
     return xdlops_info<mfma_instr::mfma_f32_32x32x2xf32, 32, 32, 1, 1>{};
 }
 
 template <>
-__device__ static constexpr auto GetXdlopsInfo<float, 16, 64>()
+__device__ inline constexpr auto GetXdlopsInfo<float, 16, 64>()
 {
     return xdlops_info<mfma_instr::mfma_f32_16x16x1xf32, 16, 64, 1, 1>{};
 }
 
 template <>
-__device__ static constexpr auto GetXdlopsInfo<float, 16, 16>()
+__device__ inline constexpr auto GetXdlopsInfo<float, 16, 16>()
 {
     return xdlops_info<mfma_instr::mfma_f32_16x16x4xf32, 16, 16, 1, 1>{};
 }
 
 template <>
-__device__ static constexpr auto GetXdlopsInfo<float, 8, 64>()
+__device__ inline constexpr auto GetXdlopsInfo<float, 8, 64>()
 {
     return xdlops_info<mfma_instr::mfma_f32_4x4x1xf32, 8, 64, 1, 1>{};
 }
 
 template <>
-__device__ static constexpr auto GetXdlopsInfo<float, 4, 64>()
+__device__ inline constexpr auto GetXdlopsInfo<float, 4, 64>()
 {
     return xdlops_info<mfma_instr::mfma_f32_4x4x1xf32, 4, 64, 1, 1>{};
 }
 
 template <>
-__device__ static constexpr auto GetXdlopsInfo<half_t, 128, 128>()
+__device__ inline constexpr auto GetXdlopsInfo<half_t, 128, 128>()
 {
     return xdlops_info<mfma_instr::mfma_f32_32x32x4f16, 64, 64, 2, 2>{};
 }
 
 template <>
-__device__ static constexpr auto GetXdlopsInfo<half_t, 128, 64>()
+__device__ inline constexpr auto GetXdlopsInfo<half_t, 128, 64>()
 {
     return xdlops_info<mfma_instr::mfma_f32_32x32x4f16, 64, 64, 2, 1>{};
 }
 
 template <>
-__device__ static constexpr auto GetXdlopsInfo<half_t, 64, 128>()
+__device__ inline constexpr auto GetXdlopsInfo<half_t, 64, 128>()
 {
     return xdlops_info<mfma_instr::mfma_f32_32x32x4f16, 64, 64, 1, 2>{};
 }
 
 template <>
-__device__ static constexpr auto GetXdlopsInfo<half_t, 64, 64>()
+__device__ inline constexpr auto GetXdlopsInfo<half_t, 64, 64>()
 {
     return xdlops_info<mfma_instr::mfma_f32_32x32x4f16, 64, 64, 1, 1>{};
 }
 
 template <>
-__device__ static constexpr auto GetXdlopsInfo<half_t, 64, 32>()
+__device__ inline constexpr auto GetXdlopsInfo<half_t, 64, 32>()
 {
     return xdlops_info<mfma_instr::mfma_f32_32x32x4f16, 64, 32, 1, 1>{};
 }
 
 template <>
-__device__ static constexpr auto GetXdlopsInfo<half_t, 64, 16>()
+__device__ inline constexpr auto GetXdlopsInfo<half_t, 64, 16>()
 {
     return xdlops_info<mfma_instr::mfma_f32_16x16x4f16, 64, 16, 1, 1>{};
 }
 
 template <>
-__device__ static constexpr auto GetXdlopsInfo<half_t, 32, 64>()
+__device__ inline constexpr auto GetXdlopsInfo<half_t, 32, 64>()
 {
     return xdlops_info<mfma_instr::mfma_f32_32x32x4f16, 32, 64, 1, 1>{};
 }
 
 template <>
-__device__ static constexpr auto GetXdlopsInfo<half_t, 32, 32>()
+__device__ inline constexpr auto GetXdlopsInfo<half_t, 32, 32>()
 {
     return xdlops_info<mfma_instr::mfma_f32_32x32x8f16, 32, 32, 1, 1>{};
 }
 
 template <>
-__device__ static constexpr auto GetXdlopsInfo<half_t, 16, 64>()
+__device__ inline constexpr auto GetXdlopsInfo<half_t, 16, 64>()
 {
     return xdlops_info<mfma_instr::mfma_f32_16x16x4f16, 16, 64, 1, 1>{};
 }
 
 template <>
-__device__ static constexpr auto GetXdlopsInfo<half_t, 16, 16>()
+__device__ inline constexpr auto GetXdlopsInfo<half_t, 16, 16>()
 {
     return xdlops_info<mfma_instr::mfma_f32_16x16x16f16, 16, 16, 1, 1>{};
 }
 
 template <>
-__device__ static constexpr auto GetXdlopsInfo<half_t, 8, 64>()
+__device__ inline constexpr auto GetXdlopsInfo<half_t, 8, 64>()
 {
     return xdlops_info<mfma_instr::mfma_f32_4x4x4f16, 8, 64, 1, 1>{};
 }
 
 template <>
-__device__ static constexpr auto GetXdlopsInfo<half_t, 4, 64>()
+__device__ inline constexpr auto GetXdlopsInfo<half_t, 4, 64>()
 {
     return xdlops_info<mfma_instr::mfma_f32_4x4x4f16, 4, 64, 1, 1>{};
 }
 
 template <>
-__device__ static constexpr auto GetXdlopsInfo<ushort, 128, 128>()
+__device__ inline constexpr auto GetXdlopsInfo<ushort, 128, 128>()
 {
     return xdlops_info<mfma_instr::mfma_f32_32x32x2bf16, 64, 64, 2, 2>{};
 }
 
 template <>
-__device__ static constexpr auto GetXdlopsInfo<ushort, 128, 64>()
+__device__ inline constexpr auto GetXdlopsInfo<ushort, 128, 64>()
 {
     return xdlops_info<mfma_instr::mfma_f32_32x32x2bf16, 64, 64, 2, 1>{};
 }
 
 template <>
-__device__ static constexpr auto GetXdlopsInfo<ushort, 64, 128>()
+__device__ inline constexpr auto GetXdlopsInfo<ushort, 64, 128>()
 {
     return xdlops_info<mfma_instr::mfma_f32_32x32x2bf16, 64, 64, 1, 2>{};
 }
 
 template <>
-__device__ static constexpr auto GetXdlopsInfo<ushort, 64, 64>()
+__device__ inline constexpr auto GetXdlopsInfo<ushort, 64, 64>()
 {
     return xdlops_info<mfma_instr::mfma_f32_32x32x2bf16, 64, 64, 1, 1>{};
 }
 
 template <>
-__device__ static constexpr auto GetXdlopsInfo<ushort, 64, 32>()
+__device__ inline constexpr auto GetXdlopsInfo<ushort, 64, 32>()
 {
     return xdlops_info<mfma_instr::mfma_f32_32x32x2bf16, 64, 32, 1, 1>{};
 }
 
 template <>
-__device__ static constexpr auto GetXdlopsInfo<ushort, 64, 16>()
+__device__ inline constexpr auto GetXdlopsInfo<ushort, 64, 16>()
 {
     return xdlops_info<mfma_instr::mfma_f32_16x16x2bf16, 64, 16, 1, 1>{};
 }
 
 template <>
-__device__ static constexpr auto GetXdlopsInfo<ushort, 32, 64>()
+__device__ inline constexpr auto GetXdlopsInfo<ushort, 32, 64>()
 {
     return xdlops_info<mfma_instr::mfma_f32_32x32x2bf16, 32, 64, 1, 1>{};
 }
 
 template <>
-__device__ static constexpr auto GetXdlopsInfo<ushort, 32, 32>()
+__device__ inline constexpr auto GetXdlopsInfo<ushort, 32, 32>()
 {
     return xdlops_info<mfma_instr::mfma_f32_32x32x4bf16, 32, 32, 1, 1>{};
 }
 
 template <>
-__device__ static constexpr auto GetXdlopsInfo<ushort, 16, 64>()
+__device__ inline constexpr auto GetXdlopsInfo<ushort, 16, 64>()
 {
     return xdlops_info<mfma_instr::mfma_f32_16x16x2bf16, 16, 64, 1, 1>{};
 }
 
 template <>
-__device__ static constexpr auto GetXdlopsInfo<ushort, 16, 16>()
+__device__ inline constexpr auto GetXdlopsInfo<ushort, 16, 16>()
 {
     return xdlops_info<mfma_instr::mfma_f32_16x16x8bf16, 16, 16, 1, 1>{};
 }
 
 template <>
-__device__ static constexpr auto GetXdlopsInfo<ushort, 8, 64>()
+__device__ inline constexpr auto GetXdlopsInfo<ushort, 8, 64>()
 {
     return xdlops_info<mfma_instr::mfma_f32_4x4x2bf16, 8, 64, 1, 1>{};
 }
 
 template <>
-__device__ static constexpr auto GetXdlopsInfo<ushort, 4, 64>()
+__device__ inline constexpr auto GetXdlopsInfo<ushort, 4, 64>()
 {
     return xdlops_info<mfma_instr::mfma_f32_4x4x2bf16, 4, 64, 1, 1>{};
 }

--- a/src/kernels/composable_kernel/include/tensor_operation/xdlops_gemm.hpp
+++ b/src/kernels/composable_kernel/include/tensor_operation/xdlops_gemm.hpp
@@ -53,16 +53,11 @@ struct mfma_info<mfma_instr::mfma_f32_32x32x1xf32>
     __device__ void
     run(Number<MPerXdlops>, Number<NPerXdlops>, const float* a, const float* b, float* reg_c) const
     {
-        static_assert((MPerXdlops == 64 && NPerXdlops == 64) ||
-                          (MPerXdlops == 32 && NPerXdlops == 64) ||
-                          (MPerXdlops == 64 && NPerXdlops == 32),
-                      "unsupported xdlops gemm");
+        const auto p_a = a;
+        const auto p_b = b;
+        auto p_c       = reinterpret_cast<float32_t*>(reg_c);
 
-        const auto reg_a = *a;
-        const auto reg_b = *b;
-
-        auto reg_c_ = reinterpret_cast<float32_t*>(reg_c);
-        gcnasm_mfma_f32_32x32x1f32<MPerXdlops, NPerXdlops>(reg_a, reg_b, reg_c_);
+        gcnasm_mfma_f32_32x32x1f32<MPerXdlops, NPerXdlops>(p_a, p_b, p_c);
     }
 };
 
@@ -87,13 +82,11 @@ struct mfma_info<mfma_instr::mfma_f32_32x32x2xf32>
     __device__ void
     run(Number<MPerXdlops>, Number<NPerXdlops>, const float* a, const float* b, float* reg_c) const
     {
-        static_assert((MPerXdlops == 32 && NPerXdlops == 32), "unsupported xdlops gemm");
+        const auto p_a = a;
+        const auto p_b = b;
+        auto p_c       = reinterpret_cast<float16_t*>(reg_c);
 
-        const auto reg_a = *a;
-        const auto reg_b = *b;
-
-        auto reg_c_ = reinterpret_cast<float16_t*>(reg_c);
-        gcnasm_mfma_f32_32x32x2f32(reg_a, reg_b, reg_c_);
+        gcnasm_mfma_f32_32x32x2f32(p_a, p_b, p_c);
     }
 };
 
@@ -118,13 +111,11 @@ struct mfma_info<mfma_instr::mfma_f32_16x16x4xf32>
     __device__ void
     run(Number<MPerXdlops>, Number<NPerXdlops>, const float* a, const float* b, float* reg_c) const
     {
-        static_assert((MPerXdlops == 16 && NPerXdlops == 16), "unsupported xdlops gemm");
+        const auto p_a = a;
+        const auto p_b = b;
+        auto p_c       = reinterpret_cast<float4_t*>(reg_c);
 
-        const auto reg_a = *a;
-        const auto reg_b = *b;
-
-        auto reg_c_ = reinterpret_cast<float4_t*>(reg_c);
-        gcnasm_mfma_f32_16x16x4f32(reg_a, reg_b, reg_c_);
+        gcnasm_mfma_f32_16x16x4f32(p_a, p_b, p_c);
     }
 };
 
@@ -149,15 +140,11 @@ struct mfma_info<mfma_instr::mfma_f32_16x16x1xf32>
     __device__ void
     run(Number<MPerXdlops>, Number<NPerXdlops>, const float* a, const float* b, float* reg_c) const
     {
-        static_assert((MPerXdlops == 16 && NPerXdlops == 64) ||
-                          (MPerXdlops == 64 && NPerXdlops == 16),
-                      "unsupported xdlops gemm");
+        const auto p_a = a;
+        const auto p_b = b;
+        auto p_c       = reinterpret_cast<float16_t*>(reg_c);
 
-        const auto reg_a = *a;
-        const auto reg_b = *b;
-        auto reg_c_      = reinterpret_cast<float16_t*>(reg_c);
-
-        gcnasm_mfma_f32_16x16x1f32<MPerXdlops, NPerXdlops>(reg_a, reg_b, reg_c_);
+        gcnasm_mfma_f32_16x16x1f32<MPerXdlops, NPerXdlops>(p_a, p_b, p_c);
     }
 };
 
@@ -186,11 +173,11 @@ struct mfma_info<mfma_instr::mfma_f32_4x4x1xf32>
         static_assert((MPerXdlops == 4 || MPerXdlops == 8) && NPerXdlops == 64,
                       "unsupported xdlops gemm");
 
-        const auto reg_a = *a;
-        const auto reg_b = *b;
-        auto reg_c_      = reinterpret_cast<float4_t*>(reg_c);
+        const auto p_a = a;
+        const auto p_b = b;
+        auto p_c       = reinterpret_cast<float4_t*>(reg_c);
 
-        gcnasm_mfma_f32_4x4x1f32<MPerXdlops, NPerXdlops>(reg_a, reg_b, reg_c_);
+        gcnasm_mfma_f32_4x4x1f32<MPerXdlops, NPerXdlops>(p_a, p_b, p_c);
     }
 };
 
@@ -218,16 +205,11 @@ struct mfma_info<mfma_instr::mfma_f32_32x32x4f16>
                         const half_t* b,
                         float* reg_c) const
     {
-        static_assert((MPerXdlops == 64 && NPerXdlops == 64) ||
-                          (MPerXdlops == 32 && NPerXdlops == 64) ||
-                          (MPerXdlops == 64 && NPerXdlops == 32),
-                      "unsupported xdlops gemm");
+        const auto p_a = reinterpret_cast<const half4_t*>(a);
+        const auto p_b = reinterpret_cast<const half4_t*>(b);
+        auto p_c       = reinterpret_cast<float32_t*>(reg_c);
 
-        const auto reg_a = *(reinterpret_cast<const half4_t*>(a));
-        const auto reg_b = *(reinterpret_cast<const half4_t*>(b));
-        auto reg_c_      = reinterpret_cast<float32_t*>(reg_c);
-
-        gcnasm_mfma_f32_32x32x4f16<MPerXdlops, NPerXdlops>(reg_a, reg_b, reg_c_);
+        gcnasm_mfma_f32_32x32x4f16<MPerXdlops, NPerXdlops>(p_a, p_b, p_c);
     }
 };
 
@@ -255,13 +237,11 @@ struct mfma_info<mfma_instr::mfma_f32_32x32x8f16>
                         const half_t* b,
                         float* reg_c) const
     {
-        static_assert((MPerXdlops == 32 && NPerXdlops == 32), "unsupported xdlops gemm");
+        const auto p_a = reinterpret_cast<const half4_t*>(a);
+        const auto p_b = reinterpret_cast<const half4_t*>(b);
+        auto p_c       = reinterpret_cast<float16_t*>(reg_c);
 
-        const auto reg_a = *(reinterpret_cast<const half4_t*>(a));
-        const auto reg_b = *(reinterpret_cast<const half4_t*>(b));
-        auto reg_c_      = reinterpret_cast<float16_t*>(reg_c);
-
-        gcnasm_mfma_f32_32x32x8f16(reg_a, reg_b, reg_c_);
+        gcnasm_mfma_f32_32x32x8f16(p_a, p_b, p_c);
     }
 };
 
@@ -289,13 +269,11 @@ struct mfma_info<mfma_instr::mfma_f32_16x16x16f16>
                         const half_t* b,
                         float* reg_c) const
     {
-        static_assert((MPerXdlops == 16 && NPerXdlops == 16), "unsupported xdlops gemm");
+        const auto p_a = reinterpret_cast<const half4_t*>(a);
+        const auto p_b = reinterpret_cast<const half4_t*>(b);
+        auto p_c       = reinterpret_cast<float4_t*>(reg_c);
 
-        const auto reg_a = *(reinterpret_cast<const half4_t*>(a));
-        const auto reg_b = *(reinterpret_cast<const half4_t*>(b));
-        auto reg_c_      = reinterpret_cast<float4_t*>(reg_c);
-
-        gcnasm_mfma_f32_16x16x16f16(reg_a, reg_b, reg_c_);
+        gcnasm_mfma_f32_16x16x16f16(p_a, p_b, p_c);
     }
 };
 
@@ -323,15 +301,11 @@ struct mfma_info<mfma_instr::mfma_f32_16x16x4f16>
                         const half_t* b,
                         float* reg_c) const
     {
-        static_assert((MPerXdlops == 16 && NPerXdlops == 64) ||
-                          (MPerXdlops == 64 && NPerXdlops == 16),
-                      "unsupported xdlops gemm");
+        const auto p_a = reinterpret_cast<const half4_t*>(a);
+        const auto p_b = reinterpret_cast<const half4_t*>(b);
+        auto p_c       = reinterpret_cast<float16_t*>(reg_c);
 
-        const auto reg_a = *(reinterpret_cast<const half4_t*>(a));
-        const auto reg_b = *(reinterpret_cast<const half4_t*>(b));
-        auto reg_c_      = reinterpret_cast<float16_t*>(reg_c);
-
-        gcnasm_mfma_f32_16x16x4f16<MPerXdlops, NPerXdlops>(reg_a, reg_b, reg_c_);
+        gcnasm_mfma_f32_16x16x4f16<MPerXdlops, NPerXdlops>(p_a, p_b, p_c);
     }
 };
 
@@ -359,14 +333,11 @@ struct mfma_info<mfma_instr::mfma_f32_4x4x4f16>
                         const half_t* b,
                         float* reg_c) const
     {
-        static_assert((MPerXdlops == 4 || MPerXdlops == 8) && NPerXdlops == 64,
-                      "unsupported xdlops gemm");
+        const auto p_a = reinterpret_cast<const half4_t*>(a);
+        const auto p_b = reinterpret_cast<const half4_t*>(b);
+        auto p_c       = reinterpret_cast<float4_t*>(reg_c);
 
-        const auto reg_a = *(reinterpret_cast<const half4_t*>(a));
-        const auto reg_b = *(reinterpret_cast<const half4_t*>(b));
-        auto reg_c_      = reinterpret_cast<float4_t*>(reg_c);
-
-        gcnasm_mfma_f32_4x4x4f16<MPerXdlops, NPerXdlops>(reg_a, reg_b, reg_c_);
+        gcnasm_mfma_f32_4x4x4f16<MPerXdlops, NPerXdlops>(p_a, p_b, p_c);
     }
 };
 
@@ -394,16 +365,11 @@ struct mfma_info<mfma_instr::mfma_f32_32x32x2bf16>
                         const ushort* b,
                         float* reg_c) const
     {
-        static_assert((MPerXdlops == 64 && NPerXdlops == 64) ||
-                          (MPerXdlops == 32 && NPerXdlops == 64) ||
-                          (MPerXdlops == 64 && NPerXdlops == 32),
-                      "unsupported xdlops gemm");
+        const auto p_a = reinterpret_cast<const ushort2_t*>(a);
+        const auto p_b = reinterpret_cast<const ushort2_t*>(b);
+        auto p_c       = reinterpret_cast<float32_t*>(reg_c);
 
-        const auto reg_a = *(reinterpret_cast<const ushort2_t*>(a));
-        const auto reg_b = *(reinterpret_cast<const ushort2_t*>(b));
-        auto reg_c_      = reinterpret_cast<float32_t*>(reg_c);
-
-        gcnasm_mfma_f32_32x32x2bf16<MPerXdlops, NPerXdlops>(reg_a, reg_b, reg_c_);
+        gcnasm_mfma_f32_32x32x2bf16<MPerXdlops, NPerXdlops>(p_a, p_b, p_c);
     }
 };
 
@@ -431,13 +397,11 @@ struct mfma_info<mfma_instr::mfma_f32_32x32x4bf16>
                         const ushort* b,
                         float* reg_c) const
     {
-        static_assert((MPerXdlops == 32 && NPerXdlops == 32), "unsupported xdlops gemm");
+        const auto p_a = reinterpret_cast<const ushort2_t*>(a);
+        const auto p_b = reinterpret_cast<const ushort2_t*>(b);
+        auto p_c       = reinterpret_cast<float16_t*>(reg_c);
 
-        const auto reg_a = *(reinterpret_cast<const ushort2_t*>(a));
-        const auto reg_b = *(reinterpret_cast<const ushort2_t*>(b));
-        auto reg_c_      = reinterpret_cast<float16_t*>(reg_c);
-
-        gcnasm_mfma_f32_32x32x4bf16(reg_a, reg_b, reg_c_);
+        gcnasm_mfma_f32_32x32x4bf16(p_a, p_b, p_c);
     }
 };
 
@@ -465,13 +429,11 @@ struct mfma_info<mfma_instr::mfma_f32_16x16x8bf16>
                         const ushort* b,
                         float* reg_c) const
     {
-        static_assert((MPerXdlops == 16 && NPerXdlops == 16), "unsupported xdlops gemm");
+        const auto p_a = reinterpret_cast<const ushort2_t*>(a);
+        const auto p_b = reinterpret_cast<const ushort2_t*>(b);
+        auto p_c       = reinterpret_cast<float4_t*>(reg_c);
 
-        const auto reg_a = *(reinterpret_cast<const ushort2_t*>(a));
-        const auto reg_b = *(reinterpret_cast<const ushort2_t*>(b));
-        auto reg_c_      = reinterpret_cast<float4_t*>(reg_c);
-
-        gcnasm_mfma_f32_16x16x8bf16(reg_a, reg_b, reg_c_);
+        gcnasm_mfma_f32_16x16x8bf16(p_a, p_b, p_c);
     }
 };
 
@@ -499,15 +461,11 @@ struct mfma_info<mfma_instr::mfma_f32_16x16x2bf16>
                         const ushort* b,
                         float* reg_c) const
     {
-        static_assert((MPerXdlops == 16 && NPerXdlops == 64) ||
-                          (MPerXdlops == 64 && NPerXdlops == 16),
-                      "unsupported xdlops gemm");
+        const auto p_a = reinterpret_cast<const ushort2_t*>(a);
+        const auto p_b = reinterpret_cast<const ushort2_t*>(b);
+        auto p_c       = reinterpret_cast<float16_t*>(reg_c);
 
-        const auto reg_a = *(reinterpret_cast<const ushort2_t*>(a));
-        const auto reg_b = *(reinterpret_cast<const ushort2_t*>(b));
-        auto reg_c_      = reinterpret_cast<float16_t*>(reg_c);
-
-        gcnasm_mfma_f32_16x16x2bf16<MPerXdlops, NPerXdlops>(reg_a, reg_b, reg_c_);
+        gcnasm_mfma_f32_16x16x2bf16<MPerXdlops, NPerXdlops>(p_a, p_b, p_c);
     }
 };
 
@@ -535,14 +493,11 @@ struct mfma_info<mfma_instr::mfma_f32_4x4x2bf16>
                         const ushort* b,
                         float* reg_c) const
     {
-        static_assert((MPerXdlops == 4 || MPerXdlops == 8) && NPerXdlops == 64,
-                      "unsupported xdlops gemm");
+        const auto p_a = reinterpret_cast<const ushort2_t*>(a);
+        const auto p_b = reinterpret_cast<const ushort2_t*>(b);
+        auto p_c       = reinterpret_cast<float4_t*>(reg_c);
 
-        const auto reg_a = *(reinterpret_cast<const ushort2_t*>(a));
-        const auto reg_b = *(reinterpret_cast<const ushort2_t*>(b));
-        auto reg_c_      = reinterpret_cast<float4_t*>(reg_c);
-
-        gcnasm_mfma_f32_4x4x2bf16<MPerXdlops, NPerXdlops>(reg_a, reg_b, reg_c_);
+        gcnasm_mfma_f32_4x4x2bf16<MPerXdlops, NPerXdlops>(p_a, p_b, p_c);
     }
 };
 
@@ -922,14 +877,13 @@ struct XdlopsGemm_t
 
         static_if<!IsKReduction()>{}([&](auto) {
 
-            for(index_t k_i = 0; k_i < K; ++k_i)
-            {
-                for(index_t m_i      = 0; m_i < MRepeats; ++m_i)
+            for(index_t m_i = 0; m_i < MRepeats; ++m_i)
+                for(index_t k_i      = 0; k_i < K; ++k_i)
                     a[k_i + m_i * K] = p_a_wave[k_i * M + laneId + MPerXdlops * m_i];
 
-                for(index_t n_i      = 0; n_i < NRepeats; ++n_i)
+            for(index_t n_i = 0; n_i < NRepeats; ++n_i)
+                for(index_t k_i      = 0; k_i < K; ++k_i)
                     b[k_i + n_i * K] = p_b_wave[k_i * N + laneId + NPerXdlops * n_i];
-            }
 
             for(index_t m_i = 0; m_i < MRepeats; ++m_i)
             {
@@ -948,8 +902,8 @@ struct XdlopsGemm_t
                         for(index_t i = 0; i < nxdlops; ++i)
                             mfma_type.run(Number<MPerXdlops>{},
                                           Number<NPerXdlops>{},
-                                          &pa[(m_i * K + k_i * nxdlops + i) * mfma_type.k_base],
-                                          &pb[(n_i * K + k_i * nxdlops + i) * mfma_type.k_base],
+                                          &pa[((m_i * K + k_i) * nxdlops + i) * mfma_type.k_base],
+                                          &pb[((n_i * K + k_i) * nxdlops + i) * mfma_type.k_base],
                                           p_c_thread + (NRepeats * m_i + n_i) * GetRegSize());
                     }
                 }
@@ -961,10 +915,10 @@ struct XdlopsGemm_t
             const index_t blk_td = laneId % mfma_type.num_threads_blk;
 
             // load into registers
-            for(index_t k = 0; k < K; k += mfma_type.num_input_blks)
+            for(index_t k_i = 0; k_i < K; k_i += mfma_type.num_input_blks)
             {
-                a[k] = p_a_wave[(k + blk_id) * M + blk_td];
-                b[k] = p_b_wave[(k + blk_id) * N + blk_td];
+                a[k_i] = p_a_wave[(k_i + blk_id) * M + blk_td];
+                b[k_i] = p_b_wave[(k_i + blk_id) * N + blk_td];
             }
 
             // get pointer of registers
@@ -974,13 +928,13 @@ struct XdlopsGemm_t
 #if CK_WORKAROUND_SWDEV_229564
 #pragma unroll
 #endif
-            for(index_t k = 0; k < K; k += mfma_type.num_input_blks)
+            for(index_t k_i = 0; k_i < K; k_i += mfma_type.num_input_blks)
             {
                 for(index_t i = 0; i < nxdlops; ++i)
                     mfma_type.run(Number<MPerXdlops>{},
                                   Number<NPerXdlops>{},
-                                  &pa[(k * nxdlops + i) * mfma_type.k_base],
-                                  &pb[(k * nxdlops + i) * mfma_type.k_base],
+                                  &pa[(k_i * nxdlops + i) * mfma_type.k_base],
+                                  &pb[(k_i * nxdlops + i) * mfma_type.k_base],
                                   p_c_thread);
             }
 

--- a/src/kernels/composable_kernel/include/tensor_operation/xdlops_gemm.hpp
+++ b/src/kernels/composable_kernel/include/tensor_operation/xdlops_gemm.hpp
@@ -56,7 +56,7 @@ struct mfma_info<mfma_instr::mfma_f32_32x32x1xf32>
         const auto p_b = b;
         auto p_c       = reinterpret_cast<float32_t*>(reg_c);
 
-        gcnasm_mfma_f32_32x32x1f32<MPerXdlops, NPerXdlops>(p_a, p_b, p_c);
+        intrin_mfma_f32_32x32x1f32<MPerXdlops, NPerXdlops>(p_a, p_b, p_c);
     }
 };
 
@@ -84,7 +84,7 @@ struct mfma_info<mfma_instr::mfma_f32_32x32x2xf32>
         const auto p_b = b;
         auto p_c       = reinterpret_cast<float16_t*>(reg_c);
 
-        gcnasm_mfma_f32_32x32x2f32(p_a, p_b, p_c);
+        intrin_mfma_f32_32x32x2f32(p_a, p_b, p_c);
     }
 };
 
@@ -112,7 +112,7 @@ struct mfma_info<mfma_instr::mfma_f32_16x16x4xf32>
         const auto p_b = b;
         auto p_c       = reinterpret_cast<float4_t*>(reg_c);
 
-        gcnasm_mfma_f32_16x16x4f32(p_a, p_b, p_c);
+        intrin_mfma_f32_16x16x4f32(p_a, p_b, p_c);
     }
 };
 
@@ -140,7 +140,7 @@ struct mfma_info<mfma_instr::mfma_f32_16x16x1xf32>
         const auto p_b = b;
         auto p_c       = reinterpret_cast<float16_t*>(reg_c);
 
-        gcnasm_mfma_f32_16x16x1f32<MPerXdlops, NPerXdlops>(p_a, p_b, p_c);
+        intrin_mfma_f32_16x16x1f32<MPerXdlops, NPerXdlops>(p_a, p_b, p_c);
     }
 };
 
@@ -172,7 +172,7 @@ struct mfma_info<mfma_instr::mfma_f32_4x4x1xf32>
         const auto p_b = b;
         auto p_c       = reinterpret_cast<float4_t*>(reg_c);
 
-        gcnasm_mfma_f32_4x4x1f32<MPerXdlops, NPerXdlops>(p_a, p_b, p_c);
+        intrin_mfma_f32_4x4x1f32<MPerXdlops, NPerXdlops>(p_a, p_b, p_c);
     }
 };
 
@@ -200,7 +200,7 @@ struct mfma_info<mfma_instr::mfma_f32_32x32x4f16>
         const auto p_b = reinterpret_cast<const half4_t*>(b);
         auto p_c       = reinterpret_cast<float32_t*>(reg_c);
 
-        gcnasm_mfma_f32_32x32x4f16<MPerXdlops, NPerXdlops>(p_a, p_b, p_c);
+        intrin_mfma_f32_32x32x4f16<MPerXdlops, NPerXdlops>(p_a, p_b, p_c);
     }
 };
 
@@ -228,7 +228,7 @@ struct mfma_info<mfma_instr::mfma_f32_32x32x8f16>
         const auto p_b = reinterpret_cast<const half4_t*>(b);
         auto p_c       = reinterpret_cast<float16_t*>(reg_c);
 
-        gcnasm_mfma_f32_32x32x8f16(p_a, p_b, p_c);
+        intrin_mfma_f32_32x32x8f16(p_a, p_b, p_c);
     }
 };
 
@@ -256,7 +256,7 @@ struct mfma_info<mfma_instr::mfma_f32_16x16x16f16>
         const auto p_b = reinterpret_cast<const half4_t*>(b);
         auto p_c       = reinterpret_cast<float4_t*>(reg_c);
 
-        gcnasm_mfma_f32_16x16x16f16(p_a, p_b, p_c);
+        intrin_mfma_f32_16x16x16f16(p_a, p_b, p_c);
     }
 };
 
@@ -284,7 +284,7 @@ struct mfma_info<mfma_instr::mfma_f32_16x16x4f16>
         const auto p_b = reinterpret_cast<const half4_t*>(b);
         auto p_c       = reinterpret_cast<float16_t*>(reg_c);
 
-        gcnasm_mfma_f32_16x16x4f16<MPerXdlops, NPerXdlops>(p_a, p_b, p_c);
+        intrin_mfma_f32_16x16x4f16<MPerXdlops, NPerXdlops>(p_a, p_b, p_c);
     }
 };
 
@@ -312,7 +312,7 @@ struct mfma_info<mfma_instr::mfma_f32_4x4x4f16>
         const auto p_b = reinterpret_cast<const half4_t*>(b);
         auto p_c       = reinterpret_cast<float4_t*>(reg_c);
 
-        gcnasm_mfma_f32_4x4x4f16<MPerXdlops, NPerXdlops>(p_a, p_b, p_c);
+        intrin_mfma_f32_4x4x4f16<MPerXdlops, NPerXdlops>(p_a, p_b, p_c);
     }
 };
 
@@ -340,7 +340,7 @@ struct mfma_info<mfma_instr::mfma_f32_32x32x2bf16>
         const auto p_b = reinterpret_cast<const ushort2_t*>(b);
         auto p_c       = reinterpret_cast<float32_t*>(reg_c);
 
-        gcnasm_mfma_f32_32x32x2bf16<MPerXdlops, NPerXdlops>(p_a, p_b, p_c);
+        intrin_mfma_f32_32x32x2bf16<MPerXdlops, NPerXdlops>(p_a, p_b, p_c);
     }
 };
 
@@ -368,7 +368,7 @@ struct mfma_info<mfma_instr::mfma_f32_32x32x4bf16>
         const auto p_b = reinterpret_cast<const ushort2_t*>(b);
         auto p_c       = reinterpret_cast<float16_t*>(reg_c);
 
-        gcnasm_mfma_f32_32x32x4bf16(p_a, p_b, p_c);
+        intrin_mfma_f32_32x32x4bf16(p_a, p_b, p_c);
     }
 };
 
@@ -396,7 +396,7 @@ struct mfma_info<mfma_instr::mfma_f32_16x16x8bf16>
         const auto p_b = reinterpret_cast<const ushort2_t*>(b);
         auto p_c       = reinterpret_cast<float4_t*>(reg_c);
 
-        gcnasm_mfma_f32_16x16x8bf16(p_a, p_b, p_c);
+        intrin_mfma_f32_16x16x8bf16(p_a, p_b, p_c);
     }
 };
 
@@ -424,7 +424,7 @@ struct mfma_info<mfma_instr::mfma_f32_16x16x2bf16>
         const auto p_b = reinterpret_cast<const ushort2_t*>(b);
         auto p_c       = reinterpret_cast<float16_t*>(reg_c);
 
-        gcnasm_mfma_f32_16x16x2bf16<MPerXdlops, NPerXdlops>(p_a, p_b, p_c);
+        intrin_mfma_f32_16x16x2bf16<MPerXdlops, NPerXdlops>(p_a, p_b, p_c);
     }
 };
 
@@ -452,7 +452,7 @@ struct mfma_info<mfma_instr::mfma_f32_4x4x2bf16>
         const auto p_b = reinterpret_cast<const ushort2_t*>(b);
         auto p_c       = reinterpret_cast<float4_t*>(reg_c);
 
-        gcnasm_mfma_f32_4x4x2bf16<MPerXdlops, NPerXdlops>(p_a, p_b, p_c);
+        intrin_mfma_f32_4x4x2bf16<MPerXdlops, NPerXdlops>(p_a, p_b, p_c);
     }
 };
 

--- a/src/kernels/composable_kernel/include/tensor_operation/xdlops_gemm.hpp
+++ b/src/kernels/composable_kernel/include/tensor_operation/xdlops_gemm.hpp
@@ -904,7 +904,7 @@ struct XdlopsGemm_t
     }
 
     template <>
-    static constexpr auto GetXdlopsInfo<half_t, 64, 16>()
+    static constexpr auto GetXdlopsInfo<half_t, 128, 16>()
     {
         return xdlops_info<mfma_instr::mfma_f32_16x16x4f16, 64, 16, 2, 1>{};
     }
@@ -1080,7 +1080,7 @@ struct XdlopsGemm_t
     template <>
     static constexpr auto GetXdlopsInfo<ushort, 8, 128>()
     {
-        return xdlops_info<mfma_instr::mfma_f32_4x4x2bf16, 8, 128, 1, 2>{};
+        return xdlops_info<mfma_instr::mfma_f32_4x4x2bf16, 8, 64, 1, 2>{};
     }
 
     template <>

--- a/src/kernels/composable_kernel/include/tensor_operation/xdlops_gemm.hpp
+++ b/src/kernels/composable_kernel/include/tensor_operation/xdlops_gemm.hpp
@@ -460,11 +460,12 @@ template <mfma_instr instr,
           index_t NRepeats_>
 struct xdlops_info
 {
-    static constexpr auto mfma_type  = mfma_info<instr>{};
-    static constexpr auto MPerXdlops = MPerXdlops_;
-    static constexpr auto NPerXdlops = NPerXdlops_;
-    static constexpr auto MRepeats   = MRepeats_;
-    static constexpr auto NRepeats   = NRepeats_;
+    static constexpr auto mfma_type = mfma_info<instr>{};
+
+    static constexpr index_t MPerXdlops = MPerXdlops_;
+    static constexpr index_t NPerXdlops = NPerXdlops_;
+    static constexpr index_t MRepeats   = MRepeats_;
+    static constexpr index_t NRepeats   = NRepeats_;
 
     __device__ static constexpr bool IsABroadcast() { return NPerXdlops >= MPerXdlops; }
 
@@ -700,18 +701,20 @@ template <class data_type,
           index_t GemmDataPerReadB>
 struct XdlopsGemm_t
 {
-    static constexpr auto MRepeats =
+    static constexpr index_t MRepeats =
         GetXdlopsInfo<data_type, GemmMPerWave, GemmNPerWave>().MRepeats;
-    static constexpr auto NRepeats =
+    static constexpr index_t NRepeats =
         GetXdlopsInfo<data_type, GemmMPerWave, GemmNPerWave>().NRepeats;
-    static constexpr auto MPerXdlops =
+    static constexpr index_t MPerXdlops =
         GetXdlopsInfo<data_type, GemmMPerWave, GemmNPerWave>().MPerXdlops;
-    static constexpr auto NPerXdlops =
+    static constexpr index_t NPerXdlops =
         GetXdlopsInfo<data_type, GemmMPerWave, GemmNPerWave>().NPerXdlops;
-    static constexpr auto IsKReduction =
+
+    static constexpr bool IsKReduction =
         GetXdlopsInfo<data_type, GemmMPerWave, GemmNPerWave>().IsKReduction();
-    static constexpr auto IsABroadcast =
+    static constexpr bool IsABroadcast =
         GetXdlopsInfo<data_type, GemmMPerWave, GemmNPerWave>().IsABroadcast();
+
     static constexpr auto mfma_type =
         GetXdlopsInfo<data_type, GemmMPerWave, GemmNPerWave>().mfma_type;
 

--- a/src/kernels/composable_kernel/include/tensor_operation/xdlops_gemm_inline_asm.hpp
+++ b/src/kernels/composable_kernel/include/tensor_operation/xdlops_gemm_inline_asm.hpp
@@ -143,9 +143,6 @@ struct mfma_info_asm<mfma_instr::mfma_f32_4x4x1xf32>
     template <index_t MPerXdlops, index_t NPerXdlops, index_t AStride = 1, index_t BStride = 1>
     __device__ void run(const float* a, const float* b, float* reg_c) const
     {
-        static_assert((MPerXdlops == 4 || MPerXdlops == 8) && NPerXdlops == 64,
-                      "unsupported xdlops gemm");
-
         const auto p_a = a;
         const auto p_b = b;
         auto p_c       = reinterpret_cast<float4_t*>(reg_c);

--- a/src/kernels/composable_kernel/include/tensor_operation/xdlops_gemm_inline_asm.hpp
+++ b/src/kernels/composable_kernel/include/tensor_operation/xdlops_gemm_inline_asm.hpp
@@ -1,5 +1,5 @@
-#ifndef CK_XDLOPS_GEMM_HPP
-#define CK_XDLOPS_GEMM_HPP
+#ifndef CK_XDLOPS_GEMM_INLINE_ASM_HPP
+#define CK_XDLOPS_GEMM_INLINE_ASM_HPP
 
 #include "common_header.hpp"
 #include "ConstantMatrixDescriptor.hpp"
@@ -7,33 +7,11 @@
 
 namespace ck {
 
-enum struct mfma_instr
-{
-    // fp32
-    mfma_f32_32x32x1xf32 = 0,
-    mfma_f32_16x16x1xf32,
-    mfma_f32_4x4x1xf32,
-    mfma_f32_32x32x2xf32, // k reduction
-    mfma_f32_16x16x4xf32, // k reduction
-    // fp16
-    mfma_f32_32x32x4f16,
-    mfma_f32_16x16x4f16,
-    mfma_f32_4x4x4f16,
-    mfma_f32_32x32x8f16,  // k reduction
-    mfma_f32_16x16x16f16, // k reduction
-    // bfp16
-    mfma_f32_32x32x2bf16,
-    mfma_f32_16x16x2bf16,
-    mfma_f32_4x4x2bf16,
-    mfma_f32_32x32x4bf16, // k reduction
-    mfma_f32_16x16x8bf16, // k reduction
-};
-
 template <mfma_instr instr>
-struct mfma_info;
+struct mfma_info_asm;
 
 template <>
-struct mfma_info<mfma_instr::mfma_f32_32x32x1xf32>
+struct mfma_info_asm<mfma_instr::mfma_f32_32x32x1xf32>
 {
     static constexpr index_t group_size      = 4;
     static constexpr index_t num_groups_blk  = 4;
@@ -61,7 +39,7 @@ struct mfma_info<mfma_instr::mfma_f32_32x32x1xf32>
 };
 
 template <>
-struct mfma_info<mfma_instr::mfma_f32_32x32x2xf32>
+struct mfma_info_asm<mfma_instr::mfma_f32_32x32x2xf32>
 {
     static constexpr index_t group_size      = 4;
     static constexpr index_t num_groups_blk  = 4;
@@ -89,7 +67,7 @@ struct mfma_info<mfma_instr::mfma_f32_32x32x2xf32>
 };
 
 template <>
-struct mfma_info<mfma_instr::mfma_f32_16x16x4xf32>
+struct mfma_info_asm<mfma_instr::mfma_f32_16x16x4xf32>
 {
     static constexpr index_t group_size      = 4;
     static constexpr index_t num_groups_blk  = 1;
@@ -117,7 +95,7 @@ struct mfma_info<mfma_instr::mfma_f32_16x16x4xf32>
 };
 
 template <>
-struct mfma_info<mfma_instr::mfma_f32_16x16x1xf32>
+struct mfma_info_asm<mfma_instr::mfma_f32_16x16x1xf32>
 {
     static constexpr index_t group_size      = 4;
     static constexpr index_t num_groups_blk  = 1;
@@ -146,7 +124,7 @@ struct mfma_info<mfma_instr::mfma_f32_16x16x1xf32>
 
 // treat 4x4x1 as a single-blk 4x64 mfma
 template <>
-struct mfma_info<mfma_instr::mfma_f32_4x4x1xf32>
+struct mfma_info_asm<mfma_instr::mfma_f32_4x4x1xf32>
 {
     static constexpr index_t group_size      = 4;
     static constexpr index_t num_groups_blk  = 1;
@@ -177,7 +155,7 @@ struct mfma_info<mfma_instr::mfma_f32_4x4x1xf32>
 };
 
 template <>
-struct mfma_info<mfma_instr::mfma_f32_32x32x4f16>
+struct mfma_info_asm<mfma_instr::mfma_f32_32x32x4f16>
 {
     static constexpr index_t group_size      = 4;
     static constexpr index_t num_groups_blk  = 4;
@@ -205,7 +183,7 @@ struct mfma_info<mfma_instr::mfma_f32_32x32x4f16>
 };
 
 template <>
-struct mfma_info<mfma_instr::mfma_f32_32x32x8f16>
+struct mfma_info_asm<mfma_instr::mfma_f32_32x32x8f16>
 {
     static constexpr index_t group_size      = 4;
     static constexpr index_t num_groups_blk  = 4;
@@ -233,7 +211,7 @@ struct mfma_info<mfma_instr::mfma_f32_32x32x8f16>
 };
 
 template <>
-struct mfma_info<mfma_instr::mfma_f32_16x16x16f16>
+struct mfma_info_asm<mfma_instr::mfma_f32_16x16x16f16>
 {
     static constexpr index_t group_size      = 4;
     static constexpr index_t num_groups_blk  = 1;
@@ -261,7 +239,7 @@ struct mfma_info<mfma_instr::mfma_f32_16x16x16f16>
 };
 
 template <>
-struct mfma_info<mfma_instr::mfma_f32_16x16x4f16>
+struct mfma_info_asm<mfma_instr::mfma_f32_16x16x4f16>
 {
     static constexpr index_t group_size      = 4;
     static constexpr index_t num_groups_blk  = 1;
@@ -289,7 +267,7 @@ struct mfma_info<mfma_instr::mfma_f32_16x16x4f16>
 };
 
 template <>
-struct mfma_info<mfma_instr::mfma_f32_4x4x4f16>
+struct mfma_info_asm<mfma_instr::mfma_f32_4x4x4f16>
 {
     static constexpr index_t group_size      = 4;
     static constexpr index_t num_groups_blk  = 1;
@@ -317,7 +295,7 @@ struct mfma_info<mfma_instr::mfma_f32_4x4x4f16>
 };
 
 template <>
-struct mfma_info<mfma_instr::mfma_f32_32x32x2bf16>
+struct mfma_info_asm<mfma_instr::mfma_f32_32x32x2bf16>
 {
     static constexpr index_t group_size      = 4;
     static constexpr index_t num_groups_blk  = 4;
@@ -345,7 +323,7 @@ struct mfma_info<mfma_instr::mfma_f32_32x32x2bf16>
 };
 
 template <>
-struct mfma_info<mfma_instr::mfma_f32_32x32x4bf16>
+struct mfma_info_asm<mfma_instr::mfma_f32_32x32x4bf16>
 {
     static constexpr index_t group_size      = 4;
     static constexpr index_t num_groups_blk  = 4;
@@ -373,7 +351,7 @@ struct mfma_info<mfma_instr::mfma_f32_32x32x4bf16>
 };
 
 template <>
-struct mfma_info<mfma_instr::mfma_f32_16x16x8bf16>
+struct mfma_info_asm<mfma_instr::mfma_f32_16x16x8bf16>
 {
     static constexpr index_t group_size      = 4;
     static constexpr index_t num_groups_blk  = 1;
@@ -401,7 +379,7 @@ struct mfma_info<mfma_instr::mfma_f32_16x16x8bf16>
 };
 
 template <>
-struct mfma_info<mfma_instr::mfma_f32_16x16x2bf16>
+struct mfma_info_asm<mfma_instr::mfma_f32_16x16x2bf16>
 {
     static constexpr index_t group_size      = 4;
     static constexpr index_t num_groups_blk  = 1;
@@ -429,7 +407,7 @@ struct mfma_info<mfma_instr::mfma_f32_16x16x2bf16>
 };
 
 template <>
-struct mfma_info<mfma_instr::mfma_f32_4x4x2bf16>
+struct mfma_info_asm<mfma_instr::mfma_f32_4x4x2bf16>
 {
     static constexpr index_t group_size      = 4;
     static constexpr index_t num_groups_blk  = 1;
@@ -461,7 +439,7 @@ template <class data_type,
           index_t GemmNPerWave,
           index_t GemmDataPerReadA,
           index_t GemmDataPerReadB>
-struct XdlopsGemm_t
+struct XdlopsGemmAsm_t
 {
     static constexpr index_t WaveSize = 64;
 
@@ -497,8 +475,11 @@ struct XdlopsGemm_t
         }
     };
 
-    __device__ constexpr XdlopsGemm_t()
+    __device__ constexpr XdlopsGemmAsm_t()
     {
+        static_assert(!(GemmMPerWave == 128 && GemmNPerWave == 128),
+                      "does not support 128x128 xdlops gemm");
+
         static_assert(NPerXdlops == 4 || NPerXdlops == 8 || NPerXdlops == 16 || NPerXdlops == 32 ||
                           NPerXdlops == 64,
                       "Only support GemmNPerXdlops == 4, 8, 16, 32 or 64 for xdlops");
@@ -525,7 +506,7 @@ struct XdlopsGemm_t
 
     __device__ static constexpr index_t GetRegSize()
     {
-        return (GemmMPerWave * GemmNPerWave) / WaveSize;
+        return (MPerXdlops * NPerXdlops) / WaveSize;
     }
 
     __device__ static constexpr bool IsABroadcast() { return NPerXdlops >= MPerXdlops; }
@@ -544,258 +525,164 @@ struct XdlopsGemm_t
     template <>
     __device__ static constexpr auto GetMFMAInfo<float, 32, 64>()
     {
-        return mfma_info<mfma_instr::mfma_f32_32x32x1xf32>{};
+        return mfma_info_asm<mfma_instr::mfma_f32_32x32x1xf32>{};
     }
 
     template <>
     __device__ static constexpr auto GetMFMAInfo<float, 64, 64>()
     {
-        return mfma_info<mfma_instr::mfma_f32_32x32x1xf32>{};
+        return mfma_info_asm<mfma_instr::mfma_f32_32x32x1xf32>{};
     }
 
     template <>
     __device__ static constexpr auto GetMFMAInfo<float, 64, 32>()
     {
-        return mfma_info<mfma_instr::mfma_f32_32x32x1xf32>{};
+        return mfma_info_asm<mfma_instr::mfma_f32_32x32x1xf32>{};
     }
 
     template <>
     __device__ static constexpr auto GetMFMAInfo<float, 32, 32>()
     {
-        return mfma_info<mfma_instr::mfma_f32_32x32x2xf32>{};
+        return mfma_info_asm<mfma_instr::mfma_f32_32x32x2xf32>{};
     }
 
     template <>
     __device__ static constexpr auto GetMFMAInfo<float, 16, 16>()
     {
-        return mfma_info<mfma_instr::mfma_f32_16x16x4xf32>{};
+        return mfma_info_asm<mfma_instr::mfma_f32_16x16x4xf32>{};
     }
 
     template <>
     __device__ static constexpr auto GetMFMAInfo<float, 16, 64>()
     {
-        return mfma_info<mfma_instr::mfma_f32_16x16x1xf32>{};
+        return mfma_info_asm<mfma_instr::mfma_f32_16x16x1xf32>{};
     }
 
     template <>
     __device__ static constexpr auto GetMFMAInfo<float, 64, 16>()
     {
-        return mfma_info<mfma_instr::mfma_f32_16x16x1xf32>{};
+        return mfma_info_asm<mfma_instr::mfma_f32_16x16x1xf32>{};
     }
 
     template <>
     __device__ static constexpr auto GetMFMAInfo<float, 8, 64>()
     {
-        return mfma_info<mfma_instr::mfma_f32_4x4x1xf32>{};
+        return mfma_info_asm<mfma_instr::mfma_f32_4x4x1xf32>{};
     }
 
     template <>
     __device__ static constexpr auto GetMFMAInfo<float, 4, 64>()
     {
-        return mfma_info<mfma_instr::mfma_f32_4x4x1xf32>{};
+        return mfma_info_asm<mfma_instr::mfma_f32_4x4x1xf32>{};
     }
 
     template <>
     __device__ static constexpr auto GetMFMAInfo<half_t, 64, 64>()
     {
-        return mfma_info<mfma_instr::mfma_f32_32x32x4f16>{};
+        return mfma_info_asm<mfma_instr::mfma_f32_32x32x4f16>{};
     }
 
     template <>
     __device__ static constexpr auto GetMFMAInfo<half_t, 64, 32>()
     {
-        return mfma_info<mfma_instr::mfma_f32_32x32x4f16>{};
+        return mfma_info_asm<mfma_instr::mfma_f32_32x32x4f16>{};
     }
 
     template <>
     __device__ static constexpr auto GetMFMAInfo<half_t, 32, 64>()
     {
-        return mfma_info<mfma_instr::mfma_f32_32x32x4f16>{};
+        return mfma_info_asm<mfma_instr::mfma_f32_32x32x4f16>{};
     }
 
     template <>
     __device__ static constexpr auto GetMFMAInfo<half_t, 32, 32>()
     {
-        return mfma_info<mfma_instr::mfma_f32_32x32x8f16>{};
+        return mfma_info_asm<mfma_instr::mfma_f32_32x32x8f16>{};
     }
 
     template <>
     __device__ static constexpr auto GetMFMAInfo<half_t, 16, 16>()
     {
-        return mfma_info<mfma_instr::mfma_f32_16x16x16f16>{};
+        return mfma_info_asm<mfma_instr::mfma_f32_16x16x16f16>{};
     }
 
     template <>
     __device__ static constexpr auto GetMFMAInfo<half_t, 16, 64>()
     {
-        return mfma_info<mfma_instr::mfma_f32_16x16x4f16>{};
+        return mfma_info_asm<mfma_instr::mfma_f32_16x16x4f16>{};
     }
 
     template <>
     __device__ static constexpr auto GetMFMAInfo<half_t, 64, 16>()
     {
-        return mfma_info<mfma_instr::mfma_f32_16x16x4f16>{};
+        return mfma_info_asm<mfma_instr::mfma_f32_16x16x4f16>{};
     }
 
     template <>
     __device__ static constexpr auto GetMFMAInfo<half_t, 4, 64>()
     {
-        return mfma_info<mfma_instr::mfma_f32_4x4x4f16>{};
+        return mfma_info_asm<mfma_instr::mfma_f32_4x4x4f16>{};
     }
 
     template <>
     __device__ static constexpr auto GetMFMAInfo<half_t, 8, 64>()
     {
-        return mfma_info<mfma_instr::mfma_f32_4x4x4f16>{};
+        return mfma_info_asm<mfma_instr::mfma_f32_4x4x4f16>{};
     }
 
     template <>
     __device__ static constexpr auto GetMFMAInfo<ushort, 64, 64>()
     {
-        return mfma_info<mfma_instr::mfma_f32_32x32x2bf16>{};
+        return mfma_info_asm<mfma_instr::mfma_f32_32x32x2bf16>{};
     }
 
     template <>
     __device__ static constexpr auto GetMFMAInfo<ushort, 64, 32>()
     {
-        return mfma_info<mfma_instr::mfma_f32_32x32x2bf16>{};
+        return mfma_info_asm<mfma_instr::mfma_f32_32x32x2bf16>{};
     }
 
     template <>
     __device__ static constexpr auto GetMFMAInfo<ushort, 32, 64>()
     {
-        return mfma_info<mfma_instr::mfma_f32_32x32x2bf16>{};
+        return mfma_info_asm<mfma_instr::mfma_f32_32x32x2bf16>{};
     }
 
     template <>
     __device__ static constexpr auto GetMFMAInfo<ushort, 32, 32>()
     {
-        return mfma_info<mfma_instr::mfma_f32_32x32x4bf16>{};
+        return mfma_info_asm<mfma_instr::mfma_f32_32x32x4bf16>{};
     }
 
     template <>
     __device__ static constexpr auto GetMFMAInfo<ushort, 16, 16>()
     {
-        return mfma_info<mfma_instr::mfma_f32_16x16x8bf16>{};
+        return mfma_info_asm<mfma_instr::mfma_f32_16x16x8bf16>{};
     }
 
     template <>
     __device__ static constexpr auto GetMFMAInfo<ushort, 16, 64>()
     {
-        return mfma_info<mfma_instr::mfma_f32_16x16x2bf16>{};
+        return mfma_info_asm<mfma_instr::mfma_f32_16x16x2bf16>{};
     }
 
     template <>
     __device__ static constexpr auto GetMFMAInfo<ushort, 64, 16>()
     {
-        return mfma_info<mfma_instr::mfma_f32_16x16x2bf16>{};
+        return mfma_info_asm<mfma_instr::mfma_f32_16x16x2bf16>{};
     }
 
     template <>
     __device__ static constexpr auto GetMFMAInfo<ushort, 4, 64>()
     {
-        return mfma_info<mfma_instr::mfma_f32_4x4x2bf16>{};
+        return mfma_info_asm<mfma_instr::mfma_f32_4x4x2bf16>{};
     }
 
     template <>
     __device__ static constexpr auto GetMFMAInfo<ushort, 8, 64>()
     {
-        return mfma_info<mfma_instr::mfma_f32_4x4x2bf16>{};
+        return mfma_info_asm<mfma_instr::mfma_f32_4x4x2bf16>{};
     }
-
-#if CK_USE_AMD_XDLOPS_EMULATE
-    // emulate xdlops
-    template <index_t M, index_t N, index_t K, class FloatA, class FloatB, class FloatC>
-    __device__ void XdlopsEmulate(const FloatA* const __restrict__ p_a_wave,
-                                  const FloatB* const __restrict__ p_b_wave,
-                                  FloatC* const __restrict__ p_c_thread) const
-    {
-        constexpr auto mfma_type = GetMFMAInfo();
-
-        const index_t laneId = get_thread_local_1d_id() % mfma_type.wave_size;
-        const index_t blk_id = laneId / mfma_type.num_threads_blk;
-        const index_t blk_td = laneId % mfma_type.num_threads_blk;
-
-        // K reduction
-        static_if<IsKReduction()>{}([&](auto) {
-            for(index_t k = 0; k < K; k += mfma_type.num_input_blks)
-            {
-                for(index_t n = 0; n < mfma_type.num_input_blks; ++n)
-                {
-                    index_t a_off = (k + n) * M;
-                    index_t b_off = (k + n) * N;
-                    index_t c_off = 0;
-
-                    for(index_t m = 0; m < mfma_type.num_regs_blk; ++m)
-                    {
-                        index_t aindex = m % mfma_type.group_size + blk_id * mfma_type.group_size +
-                                         m / mfma_type.group_size *
-                                             (mfma_type.group_size * mfma_type.num_input_blks);
-                        index_t bindex = blk_td;
-                        p_c_thread[m + c_off] += inner_product_with_conversion<FloatC>{}(
-                            p_a_wave[aindex + a_off], p_b_wave[bindex + b_off]);
-                    }
-                }
-            }
-
-        }).Else([&](auto) {
-            static_if<IsABroadcast()>{}([&](auto) {
-                // ABroadcast
-                for(index_t k = 0; k < K; ++k)
-                {
-                    for(index_t b = 0; b < MPerXdlops / mfma_type.m; ++b)
-                    {
-                        for(index_t n = 0; n < mfma_type.num_input_blks; ++n)
-                        {
-                            index_t a_off = k * M + b * mfma_type.m;
-                            index_t b_off = k * N + n * mfma_type.num_threads_blk;
-                            index_t c_off =
-                                n * mfma_type.num_regs_blk + b * mfma_type.num_regs_xdlops;
-
-                            for(index_t m = 0; m < mfma_type.num_regs_blk; ++m)
-                            {
-                                index_t aindex =
-                                    m % mfma_type.group_size + blk_id * mfma_type.group_size +
-                                    m / mfma_type.group_size *
-                                        (mfma_type.group_size * mfma_type.num_input_blks);
-                                index_t bindex = blk_td;
-                                p_c_thread[m + c_off] += inner_product_with_conversion<FloatC>{}(
-                                    p_a_wave[aindex + a_off], p_b_wave[bindex + b_off]);
-                            }
-                        }
-                    }
-                }
-
-            }).Else([&](auto) {
-                // BBroadcast
-                for(index_t k = 0; k < K; ++k)
-                {
-                    for(index_t b = 0; b < NPerXdlops / mfma_type.n; ++b)
-                    {
-                        for(index_t n = 0; n < mfma_type.num_input_blks; ++n)
-                        {
-                            index_t a_off = k * M + n * mfma_type.m;
-                            index_t b_off = k * N + b * mfma_type.n;
-                            index_t c_off =
-                                n * mfma_type.num_regs_blk + b * mfma_type.num_regs_xdlops;
-
-                            for(index_t m = 0; m < mfma_type.num_regs_blk; ++m)
-                            {
-                                index_t aindex =
-                                    m % mfma_type.group_size + blk_id * mfma_type.group_size +
-                                    m / mfma_type.group_size *
-                                        (mfma_type.group_size * mfma_type.num_input_blks);
-                                index_t bindex = blk_td;
-                                p_c_thread[m + c_off] += inner_product_with_conversion<FloatC>{}(
-                                    p_a_wave[aindex + a_off], p_b_wave[bindex + b_off]);
-                            }
-                        }
-                    }
-                }
-            });
-        });
-    }
-#endif
 
     template <index_t M, index_t N, index_t K, class FloatA, class FloatB, class FloatC>
     __device__ void Run(const FloatA* const __restrict__ p_a_wave,
@@ -812,9 +699,6 @@ struct XdlopsGemm_t
                           is_same<data_type, ushort>::value,
                       "base data_type must be float, half, ushort!");
 
-#if CK_USE_AMD_XDLOPS_EMULATE
-        XdlopsEmulate<M, N, K>(p_a_wave, p_b_wave, p_c_thread);
-#else
         constexpr auto mfma_type = GetMFMAInfo();
 
         const index_t laneId = get_thread_local_1d_id() % mfma_type.wave_size;
@@ -891,7 +775,6 @@ struct XdlopsGemm_t
             }
 
         });
-#endif
     }
 
     __device__ static MatrixIndex GetBeginOfThreadBlk(index_t i)
@@ -937,23 +820,17 @@ struct XdlopsGemm_t
 
     __device__ void SetZeroXdlopsRegs() const
     {
-#if !CK_USE_AMD_XDLOPS_EMULATE
-        constexpr auto reg_size = GetRegSize();
+        constexpr auto reg_size = GetRegSize() * MRepeats * NRepeats;
         gcnasm_accvgpr_zero<reg_size>();
-#endif
     }
 
     template <class FloatC>
     __device__ void ReadXdlopsRegs(FloatC* const __restrict__ p_c_thread) const
     {
-#if !CK_USE_AMD_XDLOPS_EMULATE
         constexpr auto mfma_type = GetMFMAInfo();
-        constexpr auto reg_size  = GetRegSize();
+        constexpr auto reg_size  = GetRegSize() * MRepeats * NRepeats;
         gcnasm_nop<mfma_type.cycles>();
         gcnasm_accvgpr_read<reg_size>(p_c_thread);
-#else
-        (void)p_c_thread;
-#endif
     }
 };
 

--- a/src/kernels/composable_kernel/include/tensor_operation/xdlops_gemm_inline_asm.hpp
+++ b/src/kernels/composable_kernel/include/tensor_operation/xdlops_gemm_inline_asm.hpp
@@ -28,13 +28,12 @@ struct mfma_info_asm<mfma_instr::mfma_f32_32x32x1xf32>
     static constexpr index_t k_base          = 1;
 
     template <index_t MPerXdlops, index_t NPerXdlops, index_t AStride = 1, index_t BStride = 1>
-    __device__ void run(const float* a, const float* b, float* reg_c) const
+    __device__ void run(const float* a, const float* b) const
     {
         const auto p_a = a;
         const auto p_b = b;
-        auto p_c       = reinterpret_cast<float32_t*>(reg_c);
 
-        gcnasm_mfma_f32_32x32x1f32<MPerXdlops, NPerXdlops, AStride, BStride>{}.run(p_a, p_b, p_c);
+        gcnasm_mfma_f32_32x32x1f32<MPerXdlops, NPerXdlops, AStride, BStride>{}.run(p_a, p_b);
     }
 };
 
@@ -56,13 +55,12 @@ struct mfma_info_asm<mfma_instr::mfma_f32_32x32x2xf32>
     static constexpr index_t k_base          = 1;
 
     template <index_t MPerXdlops, index_t NPerXdlops, index_t AStride = 1, index_t BStride = 1>
-    __device__ void run(const float* a, const float* b, float* reg_c) const
+    __device__ void run(const float* a, const float* b) const
     {
         const auto p_a = a;
         const auto p_b = b;
-        auto p_c       = reinterpret_cast<float16_t*>(reg_c);
 
-        gcnasm_mfma_f32_32x32x2f32(p_a, p_b, p_c);
+        gcnasm_mfma_f32_32x32x2f32(p_a, p_b);
     }
 };
 
@@ -84,13 +82,12 @@ struct mfma_info_asm<mfma_instr::mfma_f32_16x16x4xf32>
     static constexpr index_t k_base          = 1;
 
     template <index_t MPerXdlops, index_t NPerXdlops, index_t AStride = 1, index_t BStride = 1>
-    __device__ void run(const float* a, const float* b, float* reg_c) const
+    __device__ void run(const float* a, const float* b) const
     {
         const auto p_a = a;
         const auto p_b = b;
-        auto p_c       = reinterpret_cast<float4_t*>(reg_c);
 
-        gcnasm_mfma_f32_16x16x4f32(p_a, p_b, p_c);
+        gcnasm_mfma_f32_16x16x4f32(p_a, p_b);
     }
 };
 
@@ -112,13 +109,12 @@ struct mfma_info_asm<mfma_instr::mfma_f32_16x16x1xf32>
     static constexpr index_t k_base          = 1;
 
     template <index_t MPerXdlops, index_t NPerXdlops, index_t AStride = 1, index_t BStride = 1>
-    __device__ void run(const float* a, const float* b, float* reg_c) const
+    __device__ void run(const float* a, const float* b) const
     {
         const auto p_a = a;
         const auto p_b = b;
-        auto p_c       = reinterpret_cast<float16_t*>(reg_c);
 
-        gcnasm_mfma_f32_16x16x1f32<MPerXdlops, NPerXdlops>(p_a, p_b, p_c);
+        gcnasm_mfma_f32_16x16x1f32<MPerXdlops, NPerXdlops>(p_a, p_b);
     }
 };
 
@@ -141,13 +137,12 @@ struct mfma_info_asm<mfma_instr::mfma_f32_4x4x1xf32>
     static constexpr index_t k_base          = 1;
 
     template <index_t MPerXdlops, index_t NPerXdlops, index_t AStride = 1, index_t BStride = 1>
-    __device__ void run(const float* a, const float* b, float* reg_c) const
+    __device__ void run(const float* a, const float* b) const
     {
         const auto p_a = a;
         const auto p_b = b;
-        auto p_c       = reinterpret_cast<float4_t*>(reg_c);
 
-        gcnasm_mfma_f32_4x4x1f32<MPerXdlops, NPerXdlops>(p_a, p_b, p_c);
+        gcnasm_mfma_f32_4x4x1f32<MPerXdlops, NPerXdlops>(p_a, p_b);
     }
 };
 
@@ -169,13 +164,12 @@ struct mfma_info_asm<mfma_instr::mfma_f32_32x32x4f16>
     static constexpr index_t k_base          = 4;
 
     template <index_t MPerXdlops, index_t NPerXdlops, index_t AStride = 1, index_t BStride = 1>
-    __device__ void run(const half_t* a, const half_t* b, float* reg_c) const
+    __device__ void run(const half_t* a, const half_t* b) const
     {
         const auto p_a = reinterpret_cast<const half4_t*>(a);
         const auto p_b = reinterpret_cast<const half4_t*>(b);
-        auto p_c       = reinterpret_cast<float32_t*>(reg_c);
 
-        gcnasm_mfma_f32_32x32x4f16<MPerXdlops, NPerXdlops, AStride, BStride>{}.run(p_a, p_b, p_c);
+        gcnasm_mfma_f32_32x32x4f16<MPerXdlops, NPerXdlops, AStride, BStride>{}.run(p_a, p_b);
     }
 };
 
@@ -197,13 +191,12 @@ struct mfma_info_asm<mfma_instr::mfma_f32_32x32x8f16>
     static constexpr index_t k_base          = 4;
 
     template <index_t MPerXdlops, index_t NPerXdlops, index_t AStride = 1, index_t BStride = 1>
-    __device__ void run(const half_t* a, const half_t* b, float* reg_c) const
+    __device__ void run(const half_t* a, const half_t* b) const
     {
         const auto p_a = reinterpret_cast<const half4_t*>(a);
         const auto p_b = reinterpret_cast<const half4_t*>(b);
-        auto p_c       = reinterpret_cast<float16_t*>(reg_c);
 
-        gcnasm_mfma_f32_32x32x8f16(p_a, p_b, p_c);
+        gcnasm_mfma_f32_32x32x8f16(p_a, p_b);
     }
 };
 
@@ -225,13 +218,12 @@ struct mfma_info_asm<mfma_instr::mfma_f32_16x16x16f16>
     static constexpr index_t k_base          = 4;
 
     template <index_t MPerXdlops, index_t NPerXdlops, index_t AStride = 1, index_t BStride = 1>
-    __device__ void run(const half_t* a, const half_t* b, float* reg_c) const
+    __device__ void run(const half_t* a, const half_t* b) const
     {
         const auto p_a = reinterpret_cast<const half4_t*>(a);
         const auto p_b = reinterpret_cast<const half4_t*>(b);
-        auto p_c       = reinterpret_cast<float4_t*>(reg_c);
 
-        gcnasm_mfma_f32_16x16x16f16(p_a, p_b, p_c);
+        gcnasm_mfma_f32_16x16x16f16(p_a, p_b);
     }
 };
 
@@ -253,13 +245,12 @@ struct mfma_info_asm<mfma_instr::mfma_f32_16x16x4f16>
     static constexpr index_t k_base          = 4;
 
     template <index_t MPerXdlops, index_t NPerXdlops, index_t AStride = 1, index_t BStride = 1>
-    __device__ void run(const half_t* a, const half_t* b, float* reg_c) const
+    __device__ void run(const half_t* a, const half_t* b) const
     {
         const auto p_a = reinterpret_cast<const half4_t*>(a);
         const auto p_b = reinterpret_cast<const half4_t*>(b);
-        auto p_c       = reinterpret_cast<float16_t*>(reg_c);
 
-        gcnasm_mfma_f32_16x16x4f16<MPerXdlops, NPerXdlops>(p_a, p_b, p_c);
+        gcnasm_mfma_f32_16x16x4f16<MPerXdlops, NPerXdlops>(p_a, p_b);
     }
 };
 
@@ -281,13 +272,12 @@ struct mfma_info_asm<mfma_instr::mfma_f32_4x4x4f16>
     static constexpr index_t k_base          = 4;
 
     template <index_t MPerXdlops, index_t NPerXdlops, index_t AStride = 1, index_t BStride = 1>
-    __device__ void run(const half_t* a, const half_t* b, float* reg_c) const
+    __device__ void run(const half_t* a, const half_t* b) const
     {
         const auto p_a = reinterpret_cast<const half4_t*>(a);
         const auto p_b = reinterpret_cast<const half4_t*>(b);
-        auto p_c       = reinterpret_cast<float4_t*>(reg_c);
 
-        gcnasm_mfma_f32_4x4x4f16<MPerXdlops, NPerXdlops>(p_a, p_b, p_c);
+        gcnasm_mfma_f32_4x4x4f16<MPerXdlops, NPerXdlops>(p_a, p_b);
     }
 };
 
@@ -309,13 +299,12 @@ struct mfma_info_asm<mfma_instr::mfma_f32_32x32x2bf16>
     static constexpr index_t k_base          = 2;
 
     template <index_t MPerXdlops, index_t NPerXdlops, index_t AStride = 1, index_t BStride = 1>
-    __device__ void run(const ushort* a, const ushort* b, float* reg_c) const
+    __device__ void run(const ushort* a, const ushort* b) const
     {
         const auto p_a = reinterpret_cast<const ushort2_t*>(a);
         const auto p_b = reinterpret_cast<const ushort2_t*>(b);
-        auto p_c       = reinterpret_cast<float32_t*>(reg_c);
 
-        gcnasm_mfma_f32_32x32x2bf16<MPerXdlops, NPerXdlops, AStride, BStride>{}.run(p_a, p_b, p_c);
+        gcnasm_mfma_f32_32x32x2bf16<MPerXdlops, NPerXdlops, AStride, BStride>{}.run(p_a, p_b);
     }
 };
 
@@ -337,13 +326,12 @@ struct mfma_info_asm<mfma_instr::mfma_f32_32x32x4bf16>
     static constexpr index_t k_base          = 2;
 
     template <index_t MPerXdlops, index_t NPerXdlops, index_t AStride = 1, index_t BStride = 1>
-    __device__ void run(const ushort* a, const ushort* b, float* reg_c) const
+    __device__ void run(const ushort* a, const ushort* b) const
     {
         const auto p_a = reinterpret_cast<const ushort2_t*>(a);
         const auto p_b = reinterpret_cast<const ushort2_t*>(b);
-        auto p_c       = reinterpret_cast<float16_t*>(reg_c);
 
-        gcnasm_mfma_f32_32x32x4bf16(p_a, p_b, p_c);
+        gcnasm_mfma_f32_32x32x4bf16(p_a, p_b);
     }
 };
 
@@ -365,13 +353,12 @@ struct mfma_info_asm<mfma_instr::mfma_f32_16x16x8bf16>
     static constexpr index_t k_base          = 2;
 
     template <index_t MPerXdlops, index_t NPerXdlops, index_t AStride = 1, index_t BStride = 1>
-    __device__ void run(const ushort* a, const ushort* b, float* reg_c) const
+    __device__ void run(const ushort* a, const ushort* b) const
     {
         const auto p_a = reinterpret_cast<const ushort2_t*>(a);
         const auto p_b = reinterpret_cast<const ushort2_t*>(b);
-        auto p_c       = reinterpret_cast<float4_t*>(reg_c);
 
-        gcnasm_mfma_f32_16x16x8bf16(p_a, p_b, p_c);
+        gcnasm_mfma_f32_16x16x8bf16(p_a, p_b);
     }
 };
 
@@ -393,13 +380,12 @@ struct mfma_info_asm<mfma_instr::mfma_f32_16x16x2bf16>
     static constexpr index_t k_base          = 2;
 
     template <index_t MPerXdlops, index_t NPerXdlops, index_t AStride = 1, index_t BStride = 1>
-    __device__ void run(const ushort* a, const ushort* b, float* reg_c) const
+    __device__ void run(const ushort* a, const ushort* b) const
     {
         const auto p_a = reinterpret_cast<const ushort2_t*>(a);
         const auto p_b = reinterpret_cast<const ushort2_t*>(b);
-        auto p_c       = reinterpret_cast<float16_t*>(reg_c);
 
-        gcnasm_mfma_f32_16x16x2bf16<MPerXdlops, NPerXdlops>(p_a, p_b, p_c);
+        gcnasm_mfma_f32_16x16x2bf16<MPerXdlops, NPerXdlops>(p_a, p_b);
     }
 };
 
@@ -421,13 +407,12 @@ struct mfma_info_asm<mfma_instr::mfma_f32_4x4x2bf16>
     static constexpr index_t k_base          = 2;
 
     template <index_t MPerXdlops, index_t NPerXdlops, index_t AStride = 1, index_t BStride = 1>
-    __device__ void run(const ushort* a, const ushort* b, float* reg_c) const
+    __device__ void run(const ushort* a, const ushort* b) const
     {
         const auto p_a = reinterpret_cast<const ushort2_t*>(a);
         const auto p_b = reinterpret_cast<const ushort2_t*>(b);
-        auto p_c       = reinterpret_cast<float4_t*>(reg_c);
 
-        gcnasm_mfma_f32_4x4x2bf16<MPerXdlops, NPerXdlops>(p_a, p_b, p_c);
+        gcnasm_mfma_f32_4x4x2bf16<MPerXdlops, NPerXdlops>(p_a, p_b);
     }
 };
 
@@ -689,7 +674,7 @@ struct XdlopsGemmAsm_t
     template <index_t M, index_t N, index_t K, class FloatA, class FloatB, class FloatC>
     __device__ void Run(const FloatA* const __restrict__ p_a_wave,
                         const FloatB* const __restrict__ p_b_wave,
-                        FloatC* const __restrict__ p_c_thread) const
+                        FloatC* const __restrict__) const
     {
 
         static_assert(GemmDataPerReadA == 1 && GemmDataPerReadB == 1, "GemmDataPerReadA/B != 1");
@@ -744,8 +729,7 @@ struct XdlopsGemmAsm_t
                 for(index_t i = 0; i < nxdlops; ++i)
                     mfma_type.template run<GemmMPerWave, GemmNPerWave, AStride, BStride>(
                         &pa[(k_i * nxdlops + i) * mfma_type.k_base],
-                        &pb[(k_i * nxdlops + i) * mfma_type.k_base],
-                        p_c_thread);
+                        &pb[(k_i * nxdlops + i) * mfma_type.k_base]);
             }
 
         }).Else([&](auto) {
@@ -772,8 +756,7 @@ struct XdlopsGemmAsm_t
                 for(index_t i = 0; i < nxdlops; ++i)
                     mfma_type.template run<MPerXdlops, NPerXdlops>(
                         &pa[(k_i * nxdlops + i) * mfma_type.k_base],
-                        &pb[(k_i * nxdlops + i) * mfma_type.k_base],
-                        p_c_thread);
+                        &pb[(k_i * nxdlops + i) * mfma_type.k_base]);
             }
 
         });

--- a/src/kernels/composable_kernel/include/tensor_operation/xdlops_gemm_inline_asm.hpp
+++ b/src/kernels/composable_kernel/include/tensor_operation/xdlops_gemm_inline_asm.hpp
@@ -49,14 +49,14 @@ struct mfma_info<mfma_instr::mfma_f32_32x32x1xf32>
     static constexpr index_t cycles          = 64;
     static constexpr index_t k_base          = 1;
 
-    template <index_t MPerXdlops, index_t NPerXdlops>
+    template <index_t MPerXdlops, index_t NPerXdlops, index_t AStride = 1, index_t BStride = 1>
     __device__ void run(const float* a, const float* b, float* reg_c) const
     {
         const auto p_a = a;
         const auto p_b = b;
         auto p_c       = reinterpret_cast<float32_t*>(reg_c);
 
-        gcnasm_mfma_f32_32x32x1f32<MPerXdlops, NPerXdlops>(p_a, p_b, p_c);
+        gcnasm_mfma_f32_32x32x1f32<MPerXdlops, NPerXdlops, AStride, BStride>{}.run(p_a, p_b, p_c);
     }
 };
 
@@ -77,7 +77,7 @@ struct mfma_info<mfma_instr::mfma_f32_32x32x2xf32>
     static constexpr index_t cycles          = 64;
     static constexpr index_t k_base          = 1;
 
-    template <index_t MPerXdlops, index_t NPerXdlops>
+    template <index_t MPerXdlops, index_t NPerXdlops, index_t AStride = 1, index_t BStride = 1>
     __device__ void run(const float* a, const float* b, float* reg_c) const
     {
         const auto p_a = a;
@@ -105,7 +105,7 @@ struct mfma_info<mfma_instr::mfma_f32_16x16x4xf32>
     static constexpr index_t cycles          = 32;
     static constexpr index_t k_base          = 1;
 
-    template <index_t MPerXdlops, index_t NPerXdlops>
+    template <index_t MPerXdlops, index_t NPerXdlops, index_t AStride = 1, index_t BStride = 1>
     __device__ void run(const float* a, const float* b, float* reg_c) const
     {
         const auto p_a = a;
@@ -133,7 +133,7 @@ struct mfma_info<mfma_instr::mfma_f32_16x16x1xf32>
     static constexpr index_t cycles          = 32;
     static constexpr index_t k_base          = 1;
 
-    template <index_t MPerXdlops, index_t NPerXdlops>
+    template <index_t MPerXdlops, index_t NPerXdlops, index_t AStride = 1, index_t BStride = 1>
     __device__ void run(const float* a, const float* b, float* reg_c) const
     {
         const auto p_a = a;
@@ -162,7 +162,7 @@ struct mfma_info<mfma_instr::mfma_f32_4x4x1xf32>
     static constexpr index_t cycles          = 8;
     static constexpr index_t k_base          = 1;
 
-    template <index_t MPerXdlops, index_t NPerXdlops>
+    template <index_t MPerXdlops, index_t NPerXdlops, index_t AStride = 1, index_t BStride = 1>
     __device__ void run(const float* a, const float* b, float* reg_c) const
     {
         static_assert((MPerXdlops == 4 || MPerXdlops == 8) && NPerXdlops == 64,
@@ -193,14 +193,14 @@ struct mfma_info<mfma_instr::mfma_f32_32x32x4f16>
     static constexpr index_t cycles          = 64;
     static constexpr index_t k_base          = 4;
 
-    template <index_t MPerXdlops, index_t NPerXdlops>
+    template <index_t MPerXdlops, index_t NPerXdlops, index_t AStride = 1, index_t BStride = 1>
     __device__ void run(const half_t* a, const half_t* b, float* reg_c) const
     {
         const auto p_a = reinterpret_cast<const half4_t*>(a);
         const auto p_b = reinterpret_cast<const half4_t*>(b);
         auto p_c       = reinterpret_cast<float32_t*>(reg_c);
 
-        gcnasm_mfma_f32_32x32x4f16<MPerXdlops, NPerXdlops>(p_a, p_b, p_c);
+        gcnasm_mfma_f32_32x32x4f16<MPerXdlops, NPerXdlops, AStride, BStride>{}.run(p_a, p_b, p_c);
     }
 };
 
@@ -221,7 +221,7 @@ struct mfma_info<mfma_instr::mfma_f32_32x32x8f16>
     static constexpr index_t cycles          = 64;
     static constexpr index_t k_base          = 4;
 
-    template <index_t MPerXdlops, index_t NPerXdlops>
+    template <index_t MPerXdlops, index_t NPerXdlops, index_t AStride = 1, index_t BStride = 1>
     __device__ void run(const half_t* a, const half_t* b, float* reg_c) const
     {
         const auto p_a = reinterpret_cast<const half4_t*>(a);
@@ -249,7 +249,7 @@ struct mfma_info<mfma_instr::mfma_f32_16x16x16f16>
     static constexpr index_t cycles          = 32;
     static constexpr index_t k_base          = 4;
 
-    template <index_t MPerXdlops, index_t NPerXdlops>
+    template <index_t MPerXdlops, index_t NPerXdlops, index_t AStride = 1, index_t BStride = 1>
     __device__ void run(const half_t* a, const half_t* b, float* reg_c) const
     {
         const auto p_a = reinterpret_cast<const half4_t*>(a);
@@ -277,7 +277,7 @@ struct mfma_info<mfma_instr::mfma_f32_16x16x4f16>
     static constexpr index_t cycles          = 32;
     static constexpr index_t k_base          = 4;
 
-    template <index_t MPerXdlops, index_t NPerXdlops>
+    template <index_t MPerXdlops, index_t NPerXdlops, index_t AStride = 1, index_t BStride = 1>
     __device__ void run(const half_t* a, const half_t* b, float* reg_c) const
     {
         const auto p_a = reinterpret_cast<const half4_t*>(a);
@@ -305,7 +305,7 @@ struct mfma_info<mfma_instr::mfma_f32_4x4x4f16>
     static constexpr index_t cycles          = 8;
     static constexpr index_t k_base          = 4;
 
-    template <index_t MPerXdlops, index_t NPerXdlops>
+    template <index_t MPerXdlops, index_t NPerXdlops, index_t AStride = 1, index_t BStride = 1>
     __device__ void run(const half_t* a, const half_t* b, float* reg_c) const
     {
         const auto p_a = reinterpret_cast<const half4_t*>(a);
@@ -333,14 +333,14 @@ struct mfma_info<mfma_instr::mfma_f32_32x32x2bf16>
     static constexpr index_t cycles          = 64;
     static constexpr index_t k_base          = 2;
 
-    template <index_t MPerXdlops, index_t NPerXdlops>
+    template <index_t MPerXdlops, index_t NPerXdlops, index_t AStride = 1, index_t BStride = 1>
     __device__ void run(const ushort* a, const ushort* b, float* reg_c) const
     {
         const auto p_a = reinterpret_cast<const ushort2_t*>(a);
         const auto p_b = reinterpret_cast<const ushort2_t*>(b);
         auto p_c       = reinterpret_cast<float32_t*>(reg_c);
 
-        gcnasm_mfma_f32_32x32x2bf16<MPerXdlops, NPerXdlops>(p_a, p_b, p_c);
+        gcnasm_mfma_f32_32x32x2bf16<MPerXdlops, NPerXdlops, AStride, BStride>{}.run(p_a, p_b, p_c);
     }
 };
 
@@ -361,7 +361,7 @@ struct mfma_info<mfma_instr::mfma_f32_32x32x4bf16>
     static constexpr index_t cycles          = 64;
     static constexpr index_t k_base          = 2;
 
-    template <index_t MPerXdlops, index_t NPerXdlops>
+    template <index_t MPerXdlops, index_t NPerXdlops, index_t AStride = 1, index_t BStride = 1>
     __device__ void run(const ushort* a, const ushort* b, float* reg_c) const
     {
         const auto p_a = reinterpret_cast<const ushort2_t*>(a);
@@ -389,7 +389,7 @@ struct mfma_info<mfma_instr::mfma_f32_16x16x8bf16>
     static constexpr index_t cycles          = 32;
     static constexpr index_t k_base          = 2;
 
-    template <index_t MPerXdlops, index_t NPerXdlops>
+    template <index_t MPerXdlops, index_t NPerXdlops, index_t AStride = 1, index_t BStride = 1>
     __device__ void run(const ushort* a, const ushort* b, float* reg_c) const
     {
         const auto p_a = reinterpret_cast<const ushort2_t*>(a);
@@ -417,7 +417,7 @@ struct mfma_info<mfma_instr::mfma_f32_16x16x2bf16>
     static constexpr index_t cycles          = 32;
     static constexpr index_t k_base          = 2;
 
-    template <index_t MPerXdlops, index_t NPerXdlops>
+    template <index_t MPerXdlops, index_t NPerXdlops, index_t AStride = 1, index_t BStride = 1>
     __device__ void run(const ushort* a, const ushort* b, float* reg_c) const
     {
         const auto p_a = reinterpret_cast<const ushort2_t*>(a);
@@ -445,7 +445,7 @@ struct mfma_info<mfma_instr::mfma_f32_4x4x2bf16>
     static constexpr index_t cycles          = 8;
     static constexpr index_t k_base          = 2;
 
-    template <index_t MPerXdlops, index_t NPerXdlops>
+    template <index_t MPerXdlops, index_t NPerXdlops, index_t AStride = 1, index_t BStride = 1>
     __device__ void run(const ushort* a, const ushort* b, float* reg_c) const
     {
         const auto p_a = reinterpret_cast<const ushort2_t*>(a);
@@ -523,7 +523,10 @@ struct XdlopsGemm_t
         static_assert(mfma_type.k % mfma_type.k_base == 0, "k and k_base is inconsistent!");
     }
 
-    __device__ static constexpr index_t GetRegSize() { return MPerXdlops * NPerXdlops / WaveSize; }
+    __device__ static constexpr index_t GetRegSize()
+    {
+        return (GemmMPerWave * GemmNPerWave) / WaveSize;
+    }
 
     __device__ static constexpr bool IsABroadcast() { return NPerXdlops >= MPerXdlops; }
 
@@ -832,6 +835,9 @@ struct XdlopsGemm_t
 
         static_if<!IsKReduction()>{}([&](auto) {
 
+            constexpr index_t AStride = K * nxdlops;
+            constexpr index_t BStride = K * nxdlops;
+
             for(index_t m_i = 0; m_i < MRepeats; ++m_i)
                 for(index_t k_i      = 0; k_i < K; ++k_i)
                     a[k_i + m_i * K] = p_a_wave[k_i * M + laneId + MPerXdlops * m_i];
@@ -840,32 +846,20 @@ struct XdlopsGemm_t
                 for(index_t k_i      = 0; k_i < K; ++k_i)
                     b[k_i + n_i * K] = p_b_wave[k_i * N + laneId + NPerXdlops * n_i];
 
-            // constexpr index_t AStride = K * nxdlops;
-            // constexpr index_t BStride = K * nxdlops;
-
-            for(index_t m_i = 0; m_i < MRepeats; ++m_i)
-            {
-
-                for(index_t n_i = 0; n_i < NRepeats; ++n_i)
-                {
-                    // get pointer of registers
-                    auto pa = reinterpret_cast<const data_type*>(&a);
-                    auto pb = reinterpret_cast<const data_type*>(&b);
+            // get pointer of registers
+            auto pa = reinterpret_cast<const data_type*>(&a);
+            auto pb = reinterpret_cast<const data_type*>(&b);
 
 #if CK_WORKAROUND_SWDEV_229564
 #pragma unroll
 #endif
-                    for(index_t k_i = 0; k_i < K; ++k_i)
-                    {
-                        for(index_t i = 0; i < nxdlops; ++i)
-                            mfma_type.template run<MPerXdlops, NPerXdlops>(
-                                &pa[(k_i * nxdlops + i) * mfma_type.k_base +
-                                    m_i * K * nxdlops * mfma_type.k_base],
-                                &pb[(k_i * nxdlops + i) * mfma_type.k_base +
-                                    n_i * K * nxdlops * mfma_type.k_base],
-                                p_c_thread + (NRepeats * m_i + n_i) * GetRegSize());
-                    }
-                }
+            for(index_t k_i = 0; k_i < K; ++k_i)
+            {
+                for(index_t i = 0; i < nxdlops; ++i)
+                    mfma_type.template run<GemmMPerWave, GemmNPerWave, AStride, BStride>(
+                        &pa[(k_i * nxdlops + i) * mfma_type.k_base],
+                        &pb[(k_i * nxdlops + i) * mfma_type.k_base],
+                        p_c_thread);
             }
 
         }).Else([&](auto) {
@@ -941,11 +935,25 @@ struct XdlopsGemm_t
         return OutputLayout<M1, M0, N1, N0>{};
     }
 
-    __device__ void SetZeroXdlopsRegs() const {}
+    __device__ void SetZeroXdlopsRegs() const
+    {
+#if !CK_USE_AMD_XDLOPS_EMULATE
+        constexpr auto reg_size = GetRegSize();
+        gcnasm_accvgpr_zero<reg_size>();
+#endif
+    }
 
     template <class FloatC>
-    __device__ void ReadXdlopsRegs(FloatC* const __restrict__) const
+    __device__ void ReadXdlopsRegs(FloatC* const __restrict__ p_c_thread) const
     {
+#if !CK_USE_AMD_XDLOPS_EMULATE
+        constexpr auto mfma_type = GetMFMAInfo();
+        constexpr auto reg_size  = GetRegSize();
+        gcnasm_nop<mfma_type.cycles>();
+        gcnasm_accvgpr_read<reg_size>(p_c_thread);
+#else
+        (void)p_c_thread;
+#endif
     }
 };
 

--- a/src/kernels/composable_kernel/include/utility/amd_xdlops.hpp
+++ b/src/kernels/composable_kernel/include/utility/amd_xdlops.hpp
@@ -50,848 +50,232 @@ extern "C" __device__ float16_t llvm_intrin_amdgcn_mfma_f32_16x16x2bf16(
 
 extern "C" __device__ float4_t llvm_intrin_amdgcn_mfma_f32_4x4x2bf16(
     ushort2_t, ushort2_t, float4_t, int, int, int) __asm("llvm.amdgcn.mfma.f32.4x4x2bf16");
-// clang-format off
-
-#define REPEATx4(f, off) f(off) f(off + 1) f(off + 2) f(off + 3)
-
-#define REPEATx16(f, off) \
-    REPEATx4(f, off) REPEATx4(f, off + 4) REPEATx4(f, off + 8) REPEATx4(f, off + 12)
-
-#define REPEATx64(f, off) \
-    REPEATx16(f, off) REPEATx16(f, off + 16) REPEATx16(f, off + 32) REPEATx16(f, off + 48)
-
-#define REPEAT_STRIDEx4(f, stride, off) \
-    f(off) f(off + 1 * stride) f(off + 2 * stride) f(off + 3 * stride)
-
-#define REPEAT_STRIDEx16(f, stride, off)                                             \
-    REPEAT_STRIDEx4(f, stride, off) REPEAT_STRIDEx4(f, stride, off + 1 * stride * 4) \
-        REPEAT_STRIDEx4(f, stride, off + 2 * stride * 4)                             \
-            REPEAT_STRIDEx4(f, stride, off + 3 * stride * 4)
-
-#define REPEAT_STRIDEx64(f, stride, off)                                                \
-    REPEAT_STRIDEx16(f, stride, off) REPEAT_STRIDEx16(f, stride, off + 1 * stride * 16) \
-        REPEAT_STRIDEx16(f, stride, off + 2 * stride * 16)                              \
-            REPEAT_STRIDEx16(f, stride, off + 3 * stride * 16)
-
-#define S_NOP(n) \
-    static_assert((n) >=0 && (n) <= 15, "s_nop operand must be within [0..15]"); \
-    asm volatile("\n s_nop " #n " " : :);
-
-#define MFMA_F32_32x32x1F32(acc, reg_a, reg_b, cbsz, abid, blgp)                           \
-    asm volatile("v_mfma_f32_32x32x1f32 a[" #acc ":" #acc "+31], %0, %1, a[" #acc ":" #acc \
-                 "+31] cbsz: " #cbsz " abid: " #abid " blgp:" #blgp " "                    \
-                 :                                                                         \
-                 : "v"(reg_a), "v"(reg_b));
-
-#define MFMA_F32_32x32x2F32(acc, reg_a, reg_b, cbsz, abid, blgp)                           \
-    asm volatile("v_mfma_f32_32x32x2f32 a[" #acc ":" #acc "+15], %0, %1, a[" #acc ":" #acc \
-                 "+15] cbsz: " #cbsz " abid: " #abid " blgp:" #blgp " "                    \
-                 :                                                                         \
-                 : "v"(reg_a), "v"(reg_b));
-
-#define MFMA_F32_16x16x4F32(acc, reg_a, reg_b, cbsz, abid, blgp)                           \
-    asm volatile("v_mfma_f32_16x16x4f32 a[" #acc ":" #acc "+3], %0, %1, a[" #acc ":" #acc \
-                 "+3] cbsz: " #cbsz " abid: " #abid " blgp:" #blgp " "                    \
-                 :                                                                         \
-                 : "v"(reg_a), "v"(reg_b));
-
-#define MFMA_F32_16x16x1F32(acc, reg_a, reg_b, cbsz, abid, blgp)                           \
-    asm volatile("v_mfma_f32_16x16x1f32 a[" #acc ":" #acc "+15], %0, %1, a[" #acc ":" #acc \
-                 "+15] cbsz: " #cbsz " abid: " #abid " blgp:" #blgp " "                    \
-                 :                                                                         \
-                 : "v"(reg_a), "v"(reg_b));
-
-#define MFMA_F32_4x4x1F32(acc, reg_a, reg_b, cbsz, abid, blgp)                           \
-    asm volatile("v_mfma_f32_4x4x1f32 a[" #acc ":" #acc "+3], %0, %1, a[" #acc ":" #acc \
-                 "+3] cbsz: " #cbsz " abid: " #abid " blgp:" #blgp " "                    \
-                 :                                                                         \
-                 : "v"(reg_a), "v"(reg_b));
-
-#define MFMA_F32_32x32x4F16(acc, reg_a, reg_b, cbsz, abid, blgp)                           \
-    asm volatile("v_mfma_f32_32x32x4f16 a[" #acc ":" #acc "+31], %0, %1, a[" #acc ":" #acc \
-                 "+31] cbsz: " #cbsz " abid: " #abid " blgp:" #blgp " "                    \
-                 :                                                                         \
-                 : "v"(reg_a), "v"(reg_b));
-
-#define MFMA_F32_32x32x8F16(acc, reg_a, reg_b, cbsz, abid, blgp)                           \
-    asm volatile("v_mfma_f32_32x32x8f16 a[" #acc ":" #acc "+15], %0, %1, a[" #acc ":" #acc \
-                 "+15] cbsz: " #cbsz " abid: " #abid " blgp:" #blgp " "                    \
-                 :                                                                         \
-                 : "v"(reg_a), "v"(reg_b));
-
-#define MFMA_F32_16x16x16F16(acc, reg_a, reg_b, cbsz, abid, blgp)                           \
-    asm volatile("v_mfma_f32_16x16x16f16 a[" #acc ":" #acc "+3], %0, %1, a[" #acc ":" #acc \
-                 "+3] cbsz: " #cbsz " abid: " #abid " blgp:" #blgp " "                    \
-                 :                                                                         \
-                 : "v"(reg_a), "v"(reg_b));
-
-#define MFMA_F32_16x16x4F16(acc, reg_a, reg_b, cbsz, abid, blgp)                           \
-    asm volatile("v_mfma_f32_16x16x4f16 a[" #acc ":" #acc "+15], %0, %1, a[" #acc ":" #acc \
-                 "+15] cbsz: " #cbsz " abid: " #abid " blgp:" #blgp " "                    \
-                 :                                                                         \
-                 : "v"(reg_a), "v"(reg_b));
-
-#define MFMA_F32_4x4x4F16(acc, reg_a, reg_b, cbsz, abid, blgp)                           \
-    asm volatile("v_mfma_f32_4x4x4f16 a[" #acc ":" #acc "+3], %0, %1, a[" #acc ":" #acc \
-                 "+3] cbsz: " #cbsz " abid: " #abid " blgp:" #blgp " "                    \
-                 :                                                                         \
-                 : "v"(reg_a), "v"(reg_b));
-
-#define MFMA_F32_32x32x2BF16(acc, reg_a, reg_b, cbsz, abid, blgp)                           \
-    asm volatile("v_mfma_f32_32x32x2bf16 a[" #acc ":" #acc "+31], %0, %1, a[" #acc ":" #acc \
-                 "+31] cbsz: " #cbsz " abid: " #abid " blgp:" #blgp " "                     \
-                 :                                                                          \
-                 : "v"(reg_a), "v"(reg_b));
-
-#define MFMA_F32_32x32x4BF16(acc, reg_a, reg_b, cbsz, abid, blgp)                           \
-    asm volatile("v_mfma_f32_32x32x4bf16 a[" #acc ":" #acc "+15], %0, %1, a[" #acc ":" #acc \
-                 "+15] cbsz: " #cbsz " abid: " #abid " blgp:" #blgp " "                     \
-                 :                                                                          \
-                 : "v"(reg_a), "v"(reg_b));
-
-#define MFMA_F32_16x16x8BF16(acc, reg_a, reg_b, cbsz, abid, blgp)                           \
-    asm volatile("v_mfma_f32_16x16x8bf16 a[" #acc ":" #acc "+3], %0, %1, a[" #acc ":" #acc \
-                 "+3] cbsz: " #cbsz " abid: " #abid " blgp:" #blgp " "                     \
-                 :                                                                          \
-                 : "v"(reg_a), "v"(reg_b));
-
-#define MFMA_F32_16x16x2BF16(acc, reg_a, reg_b, cbsz, abid, blgp)                           \
-    asm volatile("v_mfma_f32_16x16x2bf16 a[" #acc ":" #acc "+15], %0, %1, a[" #acc ":" #acc \
-                 "+15] cbsz: " #cbsz " abid: " #abid " blgp:" #blgp " "                     \
-                 :                                                                          \
-                 : "v"(reg_a), "v"(reg_b));
-
-#define MFMA_F32_4x4x2BF16(acc, reg_a, reg_b, cbsz, abid, blgp)                           \
-    asm volatile("v_mfma_f32_4x4x2bf16 a[" #acc ":" #acc "+3], %0, %1, a[" #acc ":" #acc \
-                 "+3] cbsz: " #cbsz " abid: " #abid " blgp:" #blgp " "                     \
-                 :                                                                          \
-                 : "v"(reg_a), "v"(reg_b));
-
-#define ACCVGPR_READ(acc_reg_id) \
-    asm volatile("v_accvgpr_read_b32 %0, a[" #acc_reg_id "]" : "=v"(arch_reg[acc_reg_id]) :);
-
-#define ACCVGPR_WRITE(acc_reg_id) \
-    asm volatile("v_accvgpr_write_b32 a[" #acc_reg_id "], %0" : : "v"(arch_reg[acc_reg_id]));
-
-#define ACCVGPR_ZERO(acc_reg_id) \
-    asm volatile("v_accvgpr_write_b32 a[" #acc_reg_id "], 0" : :);
-
-template <index_t Size>
-__device__ void gcnasm_accvgpr_read(float*);
-
-template <>
-__device__ void gcnasm_accvgpr_read<4>(float* arch_reg)
-{
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
-    REPEATx4(ACCVGPR_READ, 0)
-#else
-    (void)arch_reg;
-#endif
-}
-
-template <>
-__device__ void gcnasm_accvgpr_read<8>(float* arch_reg)
-{
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
-  asm volatile("\
-      v_accvgpr_read_b32 %0,  a[ 0] \n \
-      v_accvgpr_read_b32 %1,  a[ 1] \n \
-      v_accvgpr_read_b32 %2,  a[ 2] \n \
-      v_accvgpr_read_b32 %3,  a[ 3] \n \
-      v_accvgpr_read_b32 %4,  a[ 4] \n \
-      v_accvgpr_read_b32 %5,  a[ 5] \n \
-      v_accvgpr_read_b32 %6,  a[ 6] \n \
-      v_accvgpr_read_b32 %7,  a[ 7] \n \
-      "
-      :
-      "=v"(arch_reg[ 0]),
-      "=v"(arch_reg[ 1]),
-      "=v"(arch_reg[ 2]),
-      "=v"(arch_reg[ 3]),
-      "=v"(arch_reg[ 4]),
-      "=v"(arch_reg[ 5]),
-      "=v"(arch_reg[ 6]),
-      "=v"(arch_reg[ 7])
-      :);
-
-#else
-    (void)arch_reg;
-#endif
-}
-
-template <>
-__device__ void gcnasm_accvgpr_read<16>(float* arch_reg)
-{
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
-    asm volatile("\
-      v_accvgpr_read_b32 %0,  a[ 0] \n \
-      v_accvgpr_read_b32 %1,  a[ 1] \n \
-      v_accvgpr_read_b32 %2,  a[ 2] \n \
-      v_accvgpr_read_b32 %3,  a[ 3] \n \
-      v_accvgpr_read_b32 %4,  a[ 4] \n \
-      v_accvgpr_read_b32 %5,  a[ 5] \n \
-      v_accvgpr_read_b32 %6,  a[ 6] \n \
-      v_accvgpr_read_b32 %7,  a[ 7] \n \
-      v_accvgpr_read_b32 %8,  a[ 8] \n \
-      v_accvgpr_read_b32 %9,  a[ 9] \n \
-      v_accvgpr_read_b32 %10, a[10] \n \
-      v_accvgpr_read_b32 %11, a[11] \n \
-      v_accvgpr_read_b32 %12, a[12] \n \
-      v_accvgpr_read_b32 %13, a[13] \n \
-      v_accvgpr_read_b32 %14, a[14] \n \
-      v_accvgpr_read_b32 %15, a[15] \n \
-      "
-      :
-      "=v"(arch_reg[ 0]),
-      "=v"(arch_reg[ 1]),
-      "=v"(arch_reg[ 2]),
-      "=v"(arch_reg[ 3]),
-      "=v"(arch_reg[ 4]),
-      "=v"(arch_reg[ 5]),
-      "=v"(arch_reg[ 6]),
-      "=v"(arch_reg[ 7]),
-      "=v"(arch_reg[ 8]),
-      "=v"(arch_reg[ 9]),
-      "=v"(arch_reg[10]),
-      "=v"(arch_reg[11]),
-      "=v"(arch_reg[12]),
-      "=v"(arch_reg[13]),
-      "=v"(arch_reg[14]),
-      "=v"(arch_reg[15])
-      :);
-
-#else
-    (void)arch_reg;
-#endif
-}
-
-template <>
-__device__ void gcnasm_accvgpr_read<32>(float* arch_reg)
-{
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
-    asm volatile("\
-      v_accvgpr_read_b32 %0,  a[ 0] \n \
-      v_accvgpr_read_b32 %1,  a[ 1] \n \
-      v_accvgpr_read_b32 %2,  a[ 2] \n \
-      v_accvgpr_read_b32 %3,  a[ 3] \n \
-      v_accvgpr_read_b32 %4,  a[ 4] \n \
-      v_accvgpr_read_b32 %5,  a[ 5] \n \
-      v_accvgpr_read_b32 %6,  a[ 6] \n \
-      v_accvgpr_read_b32 %7,  a[ 7] \n \
-      v_accvgpr_read_b32 %8,  a[ 8] \n \
-      v_accvgpr_read_b32 %9,  a[ 9] \n \
-      v_accvgpr_read_b32 %10, a[10] \n \
-      v_accvgpr_read_b32 %11, a[11] \n \
-      v_accvgpr_read_b32 %12, a[12] \n \
-      v_accvgpr_read_b32 %13, a[13] \n \
-      v_accvgpr_read_b32 %14, a[14] \n \
-      v_accvgpr_read_b32 %15, a[15] \n \
-      v_accvgpr_read_b32 %16, a[16] \n \
-      v_accvgpr_read_b32 %17, a[17] \n \
-      v_accvgpr_read_b32 %18, a[18] \n \
-      v_accvgpr_read_b32 %19, a[19] \n \
-      v_accvgpr_read_b32 %20, a[20] \n \
-      v_accvgpr_read_b32 %21, a[21] \n \
-      v_accvgpr_read_b32 %22, a[22] \n \
-      v_accvgpr_read_b32 %23, a[23] \n \
-      v_accvgpr_read_b32 %24, a[24] \n \
-      v_accvgpr_read_b32 %25, a[25] \n \
-      v_accvgpr_read_b32 %26, a[26] \n \
-      v_accvgpr_read_b32 %27, a[27] \n \
-      v_accvgpr_read_b32 %28, a[28] \n \
-      v_accvgpr_read_b32 %29, a[29] \n \
-      v_accvgpr_read_b32 %30, a[30] \n \
-      v_accvgpr_read_b32 %31, a[31] \n \
-      "
-      :
-      "=v"(arch_reg[ 0]),
-      "=v"(arch_reg[ 1]),
-      "=v"(arch_reg[ 2]),
-      "=v"(arch_reg[ 3]),
-      "=v"(arch_reg[ 4]),
-      "=v"(arch_reg[ 5]),
-      "=v"(arch_reg[ 6]),
-      "=v"(arch_reg[ 7]),
-      "=v"(arch_reg[ 8]),
-      "=v"(arch_reg[ 9]),
-      "=v"(arch_reg[10]),
-      "=v"(arch_reg[11]),
-      "=v"(arch_reg[12]),
-      "=v"(arch_reg[13]),
-      "=v"(arch_reg[14]),
-      "=v"(arch_reg[15]),
-      "=v"(arch_reg[16]),
-      "=v"(arch_reg[17]),
-      "=v"(arch_reg[18]),
-      "=v"(arch_reg[19]),
-      "=v"(arch_reg[20]),
-      "=v"(arch_reg[21]),
-      "=v"(arch_reg[22]),
-      "=v"(arch_reg[23]),
-      "=v"(arch_reg[24]),
-      "=v"(arch_reg[25]),
-      "=v"(arch_reg[26]),
-      "=v"(arch_reg[27]),
-      "=v"(arch_reg[28]),
-      "=v"(arch_reg[29]),
-      "=v"(arch_reg[30]),
-      "=v"(arch_reg[31])
-      :);
-#else
-    (void)arch_reg;
-#endif
-}
-
-template <>
-__device__ void gcnasm_accvgpr_read<64>(float* arch_reg)
-{
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
-    asm volatile("\
-      v_accvgpr_read_b32 %0,  a[ 0] \n \
-      v_accvgpr_read_b32 %1,  a[ 1] \n \
-      v_accvgpr_read_b32 %2,  a[ 2] \n \
-      v_accvgpr_read_b32 %3,  a[ 3] \n \
-      v_accvgpr_read_b32 %4,  a[ 4] \n \
-      v_accvgpr_read_b32 %5,  a[ 5] \n \
-      v_accvgpr_read_b32 %6,  a[ 6] \n \
-      v_accvgpr_read_b32 %7,  a[ 7] \n \
-      v_accvgpr_read_b32 %8,  a[ 8] \n \
-      v_accvgpr_read_b32 %9,  a[ 9] \n \
-      v_accvgpr_read_b32 %10, a[10] \n \
-      v_accvgpr_read_b32 %11, a[11] \n \
-      v_accvgpr_read_b32 %12, a[12] \n \
-      v_accvgpr_read_b32 %13, a[13] \n \
-      v_accvgpr_read_b32 %14, a[14] \n \
-      v_accvgpr_read_b32 %15, a[15] \n \
-      v_accvgpr_read_b32 %16, a[16] \n \
-      v_accvgpr_read_b32 %17, a[17] \n \
-      v_accvgpr_read_b32 %18, a[18] \n \
-      v_accvgpr_read_b32 %19, a[19] \n \
-      v_accvgpr_read_b32 %20, a[20] \n \
-      v_accvgpr_read_b32 %21, a[21] \n \
-      v_accvgpr_read_b32 %22, a[22] \n \
-      v_accvgpr_read_b32 %23, a[23] \n \
-      v_accvgpr_read_b32 %24, a[24] \n \
-      v_accvgpr_read_b32 %25, a[25] \n \
-      v_accvgpr_read_b32 %26, a[26] \n \
-      v_accvgpr_read_b32 %27, a[27] \n \
-      v_accvgpr_read_b32 %28, a[28] \n \
-      v_accvgpr_read_b32 %29, a[29] \n \
-      v_accvgpr_read_b32 %30, a[30] \n \
-      v_accvgpr_read_b32 %31, a[31] \n \
-      v_accvgpr_read_b32 %32, a[32] \n \
-      v_accvgpr_read_b32 %33, a[33] \n \
-      v_accvgpr_read_b32 %34, a[34] \n \
-      v_accvgpr_read_b32 %35, a[35] \n \
-      v_accvgpr_read_b32 %36, a[36] \n \
-      v_accvgpr_read_b32 %37, a[37] \n \
-      v_accvgpr_read_b32 %38, a[38] \n \
-      v_accvgpr_read_b32 %39, a[39] \n \
-      v_accvgpr_read_b32 %40, a[40] \n \
-      v_accvgpr_read_b32 %41, a[41] \n \
-      v_accvgpr_read_b32 %42, a[42] \n \
-      v_accvgpr_read_b32 %43, a[43] \n \
-      v_accvgpr_read_b32 %44, a[44] \n \
-      v_accvgpr_read_b32 %45, a[45] \n \
-      v_accvgpr_read_b32 %46, a[46] \n \
-      v_accvgpr_read_b32 %47, a[47] \n \
-      v_accvgpr_read_b32 %48, a[48] \n \
-      v_accvgpr_read_b32 %49, a[49] \n \
-      v_accvgpr_read_b32 %50, a[50] \n \
-      v_accvgpr_read_b32 %51, a[51] \n \
-      v_accvgpr_read_b32 %52, a[52] \n \
-      v_accvgpr_read_b32 %53, a[53] \n \
-      v_accvgpr_read_b32 %54, a[54] \n \
-      v_accvgpr_read_b32 %55, a[55] \n \
-      v_accvgpr_read_b32 %56, a[56] \n \
-      v_accvgpr_read_b32 %57, a[57] \n \
-      v_accvgpr_read_b32 %58, a[58] \n \
-      v_accvgpr_read_b32 %59, a[59] \n \
-      v_accvgpr_read_b32 %60, a[60] \n \
-      v_accvgpr_read_b32 %61, a[61] \n \
-      v_accvgpr_read_b32 %62, a[62] \n \
-      v_accvgpr_read_b32 %63, a[63] \n \
-      "
-      :
-      "=v"(arch_reg[ 0]),
-      "=v"(arch_reg[ 1]),
-      "=v"(arch_reg[ 2]),
-      "=v"(arch_reg[ 3]),
-      "=v"(arch_reg[ 4]),
-      "=v"(arch_reg[ 5]),
-      "=v"(arch_reg[ 6]),
-      "=v"(arch_reg[ 7]),
-      "=v"(arch_reg[ 8]),
-      "=v"(arch_reg[ 9]),
-      "=v"(arch_reg[10]),
-      "=v"(arch_reg[11]),
-      "=v"(arch_reg[12]),
-      "=v"(arch_reg[13]),
-      "=v"(arch_reg[14]),
-      "=v"(arch_reg[15]),
-      "=v"(arch_reg[16]),
-      "=v"(arch_reg[17]),
-      "=v"(arch_reg[18]),
-      "=v"(arch_reg[19]),
-      "=v"(arch_reg[20]),
-      "=v"(arch_reg[21]),
-      "=v"(arch_reg[22]),
-      "=v"(arch_reg[23]),
-      "=v"(arch_reg[24]),
-      "=v"(arch_reg[25]),
-      "=v"(arch_reg[26]),
-      "=v"(arch_reg[27]),
-      "=v"(arch_reg[28]),
-      "=v"(arch_reg[29]),
-      "=v"(arch_reg[30]),
-      "=v"(arch_reg[31]),
-      "=v"(arch_reg[32]),
-      "=v"(arch_reg[33]),
-      "=v"(arch_reg[34]),
-      "=v"(arch_reg[35]),
-      "=v"(arch_reg[36]),
-      "=v"(arch_reg[37]),
-      "=v"(arch_reg[38]),
-      "=v"(arch_reg[39]),
-      "=v"(arch_reg[40]),
-      "=v"(arch_reg[41]),
-      "=v"(arch_reg[42]),
-      "=v"(arch_reg[43]),
-      "=v"(arch_reg[44]),
-      "=v"(arch_reg[45]),
-      "=v"(arch_reg[46]),
-      "=v"(arch_reg[47]),
-      "=v"(arch_reg[48]),
-      "=v"(arch_reg[49]),
-      "=v"(arch_reg[50]),
-      "=v"(arch_reg[51]),
-      "=v"(arch_reg[52]),
-      "=v"(arch_reg[53]),
-      "=v"(arch_reg[54]),
-      "=v"(arch_reg[55]),
-      "=v"(arch_reg[56]),
-      "=v"(arch_reg[57]),
-      "=v"(arch_reg[58]),
-      "=v"(arch_reg[59]),
-      "=v"(arch_reg[60]),
-      "=v"(arch_reg[61]),
-      "=v"(arch_reg[62]),
-      "=v"(arch_reg[63])
-      :);
-#else
-    (void)arch_reg;
-#endif
-}
-
-template <index_t MPerWave>
-__device__ void gcnasm_accvgpr_zero();
-
-template <>
-__device__ void gcnasm_accvgpr_zero<4>()
-{
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
-    REPEATx4(ACCVGPR_ZERO, 0)
-    S_NOP(1)
-#endif
-}
-
-template <>
-__device__ void gcnasm_accvgpr_zero<8>()
-{
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
-    REPEATx4(ACCVGPR_ZERO, 0)
-    REPEATx4(ACCVGPR_ZERO, 4)
-    S_NOP(1)
-#endif
-}
-
-template <>
-__device__ void gcnasm_accvgpr_zero<16>()
-{
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
-    REPEATx16(ACCVGPR_ZERO, 0)
-    S_NOP(1)
-#endif
-}
-
-template <>
-__device__ void gcnasm_accvgpr_zero<32>()
-{
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
-    REPEATx16(ACCVGPR_ZERO, 0)
-    REPEATx16(ACCVGPR_ZERO, 16)
-    S_NOP(1)
-#endif
-}
-
-template <>
-__device__ void gcnasm_accvgpr_zero<64>()
-{
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
-    REPEATx64(ACCVGPR_ZERO, 0)
-    S_NOP(1)
-#endif
-}
-
-template <index_t Cycles>
-__device__ void gcnasm_nop();
-
-template <>
-__device__ void gcnasm_nop<8>()
-{
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
-    S_NOP(3)
-#endif
-}
-
-template <>
-__device__ void gcnasm_nop<32>()
-{
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
-    S_NOP(9)
-#endif
-}
-
-template <>
-__device__ void gcnasm_nop<64>()
-{
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
-    S_NOP(8)
-    S_NOP(8)
-#endif
-}
 
 template <index_t MPerWave, index_t NPerWave>
-__device__ void gcnasm_mfma_f32_32x32x1f32(const float* reg_a, const float* reg_b, float32_t* reg_c);
+__device__ void
+gcnasm_mfma_f32_32x32x1f32(const float* reg_a, const float* reg_b, float32_t* reg_c);
 
 template <>
-__device__ void gcnasm_mfma_f32_32x32x1f32<64, 64>(const float* reg_a, const float* reg_b, float32_t* reg_c)
+__device__ void
+gcnasm_mfma_f32_32x32x1f32<64, 64>(const float* reg_a, const float* reg_b, float32_t* reg_c)
 {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
-    (void)reg_c;
-    MFMA_F32_32x32x1F32(0, reg_a[0], reg_b[0], 1, 0, 0)
-    MFMA_F32_32x32x1F32(32, reg_a[0], reg_b[0], 1, 1, 0)
-#else
     reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x1f32(reg_a[0], reg_b[0], reg_c[0], 1, 0, 0);
     reg_c[1] = llvm_intrin_amdgcn_mfma_f32_32x32x1f32(reg_a[0], reg_b[0], reg_c[1], 1, 1, 0);
-#endif
 }
 
 template <>
-__device__ void gcnasm_mfma_f32_32x32x1f32<32, 64>(const float* reg_a, const float* reg_b, float32_t* reg_c)
+__device__ void
+gcnasm_mfma_f32_32x32x1f32<32, 64>(const float* reg_a, const float* reg_b, float32_t* reg_c)
 {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
-    (void)reg_c;
-    MFMA_F32_32x32x1F32(0, reg_a[0], reg_b[0], 1, 0, 0)
-#else
     reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x1f32(reg_a[0], reg_b[0], reg_c[0], 1, 0, 0);
-#endif
 }
 
 template <>
-__device__ void gcnasm_mfma_f32_32x32x1f32<64, 32>(const float* reg_a, const float* reg_b, float32_t* reg_c)
+__device__ void
+gcnasm_mfma_f32_32x32x1f32<64, 32>(const float* reg_a, const float* reg_b, float32_t* reg_c)
 {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
-    (void)reg_c;
-    MFMA_F32_32x32x1F32(0, reg_a[0], reg_b[0], 0, 0, 1)
-#else
     reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x1f32(reg_a[0], reg_b[0], reg_c[0], 0, 0, 1);
-#endif
 }
 
 __device__ void gcnasm_mfma_f32_32x32x2f32(const float* reg_a, const float* reg_b, float16_t* reg_c)
 {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
-    (void)reg_c;
-    MFMA_F32_32x32x2F32(0, reg_a[0], reg_b[0], 0, 0, 0)
-#else
     reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x2f32(reg_a[0], reg_b[0], reg_c[0], 0, 0, 0);
-#endif
 }
 
 __device__ void gcnasm_mfma_f32_16x16x4f32(const float* reg_a, const float* reg_b, float4_t* reg_c)
 {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
-    (void)reg_c;
-    MFMA_F32_16x16x4F32(0, reg_a[0], reg_b[0], 0, 0, 0)
-#else
     reg_c[0] = llvm_intrin_amdgcn_mfma_f32_16x16x4f32(reg_a[0], reg_b[0], reg_c[0], 0, 0, 0);
-#endif
 }
 
 template <index_t MPerWave, index_t NPerWave>
-__device__ void gcnasm_mfma_f32_16x16x1f32(const float* reg_a, const float* reg_b, float16_t* reg_c);
+__device__ void
+gcnasm_mfma_f32_16x16x1f32(const float* reg_a, const float* reg_b, float16_t* reg_c);
 
 template <>
-__device__ void gcnasm_mfma_f32_16x16x1f32<16, 64>(const float* reg_a, const float* reg_b, float16_t* reg_c)
+__device__ void
+gcnasm_mfma_f32_16x16x1f32<16, 64>(const float* reg_a, const float* reg_b, float16_t* reg_c)
 {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
-    (void)reg_c;
-    MFMA_F32_16x16x1F32(0, reg_a[0], reg_b[0], 2, 0, 0)
-#else
     reg_c[0] = llvm_intrin_amdgcn_mfma_f32_16x16x1f32(reg_a[0], reg_b[0], reg_c[0], 2, 0, 0);
-#endif
 }
 
 template <>
-__device__ void gcnasm_mfma_f32_16x16x1f32<64, 16>(const float* reg_a, const float* reg_b, float16_t* reg_c)
+__device__ void
+gcnasm_mfma_f32_16x16x1f32<64, 16>(const float* reg_a, const float* reg_b, float16_t* reg_c)
 {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
-    (void)reg_c;
-    MFMA_F32_16x16x1F32(0, reg_a[0], reg_b[0], 0, 0, 4)
-#else
     reg_c[0] = llvm_intrin_amdgcn_mfma_f32_16x16x1f32(reg_a[0], reg_b[0], reg_c[0], 0, 0, 4);
-#endif
 }
 
 template <index_t MPerWave, index_t NPerWave>
 __device__ void gcnasm_mfma_f32_4x4x1f32(const float* reg_a, const float* reg_b, float4_t* reg_c);
 
 template <>
-__device__ void gcnasm_mfma_f32_4x4x1f32<4, 64>(const float* reg_a, const float* reg_b, float4_t* reg_c)
+__device__ void
+gcnasm_mfma_f32_4x4x1f32<4, 64>(const float* reg_a, const float* reg_b, float4_t* reg_c)
 {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
-    (void)reg_c;
-    MFMA_F32_4x4x1F32(0, reg_a[0], reg_b[0], 4, 0, 0)
-#else
     reg_c[0] = llvm_intrin_amdgcn_mfma_f32_4x4x1f32(reg_a[0], reg_b[0], reg_c[0], 4, 0, 0);
-#endif
 }
 
 template <>
-__device__ void gcnasm_mfma_f32_4x4x1f32<8, 64>(const float* reg_a, const float* reg_b, float4_t* reg_c)
+__device__ void
+gcnasm_mfma_f32_4x4x1f32<8, 64>(const float* reg_a, const float* reg_b, float4_t* reg_c)
 {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
-    (void)reg_c;
-    MFMA_F32_4x4x1F32(0, reg_a[0], reg_b[0], 4, 0, 0)
-    MFMA_F32_4x4x1F32(4, reg_a[0], reg_b[0], 4, 1, 0)
-#else
     reg_c[0] = llvm_intrin_amdgcn_mfma_f32_4x4x1f32(reg_a[0], reg_b[0], reg_c[0], 4, 0, 0);
     reg_c[1] = llvm_intrin_amdgcn_mfma_f32_4x4x1f32(reg_a[0], reg_b[0], reg_c[1], 4, 1, 0);
-#endif
 }
 
 template <index_t MPerWave, index_t NPerWave>
-__device__ void gcnasm_mfma_f32_32x32x4f16(const half4_t* reg_a,
-                                           const half4_t* reg_b,
-                                           float32_t* reg_c);
+__device__ void
+gcnasm_mfma_f32_32x32x4f16(const half4_t* reg_a, const half4_t* reg_b, float32_t* reg_c);
 template <>
-__device__ void gcnasm_mfma_f32_32x32x4f16<64, 64>(const half4_t* reg_a, const half4_t* reg_b, float32_t* reg_c)
+__device__ void
+gcnasm_mfma_f32_32x32x4f16<64, 64>(const half4_t* reg_a, const half4_t* reg_b, float32_t* reg_c)
 {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
-    (void)reg_c;
-    MFMA_F32_32x32x4F16(0, reg_a[0], reg_b[0], 1, 0, 0)
-    MFMA_F32_32x32x4F16(32, reg_a[0], reg_b[0], 1, 1, 0)
-#else
     reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x4f16(reg_a[0], reg_b[0], reg_c[0], 1, 0, 0);
     reg_c[1] = llvm_intrin_amdgcn_mfma_f32_32x32x4f16(reg_a[0], reg_b[0], reg_c[1], 1, 1, 0);
-#endif
 }
 
 template <>
-__device__ void gcnasm_mfma_f32_32x32x4f16<32, 64>(const half4_t* reg_a, const half4_t* reg_b, float32_t* reg_c)
+__device__ void
+gcnasm_mfma_f32_32x32x4f16<32, 64>(const half4_t* reg_a, const half4_t* reg_b, float32_t* reg_c)
 {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
-    (void)reg_c;
-    MFMA_F32_32x32x4F16(0, reg_a[0], reg_b[0], 1, 0, 0)
-#else
     reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x4f16(reg_a[0], reg_b[0], reg_c[0], 1, 0, 0);
-#endif
 }
 
 template <>
-__device__ void gcnasm_mfma_f32_32x32x4f16<64, 32>(const half4_t* reg_a, const half4_t* reg_b, float32_t* reg_c)
+__device__ void
+gcnasm_mfma_f32_32x32x4f16<64, 32>(const half4_t* reg_a, const half4_t* reg_b, float32_t* reg_c)
 {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
-    (void)reg_c;
-    MFMA_F32_32x32x4F16(0, reg_a[0], reg_b[0], 0, 0, 1)
-#else
     reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x4f16(reg_a[0], reg_b[0], reg_c[0], 0, 0, 1);
-#endif
 }
 
-__device__ void gcnasm_mfma_f32_32x32x8f16(const half4_t* reg_a, const half4_t* reg_b, float16_t* reg_c)
+__device__ void
+gcnasm_mfma_f32_32x32x8f16(const half4_t* reg_a, const half4_t* reg_b, float16_t* reg_c)
 {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
-    (void)reg_c;
-    MFMA_F32_32x32x8F16(0, reg_a[0], reg_b[0], 0, 0, 0)
-#else
     reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x8f16(reg_a[0], reg_b[0], reg_c[0], 0, 0, 0);
-#endif
 }
 
-__device__ void gcnasm_mfma_f32_16x16x16f16(const half4_t* reg_a, const half4_t* reg_b, float4_t* reg_c)
+__device__ void
+gcnasm_mfma_f32_16x16x16f16(const half4_t* reg_a, const half4_t* reg_b, float4_t* reg_c)
 {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
-    (void)reg_c;
-    MFMA_F32_16x16x16F16(0, reg_a[0], reg_b[0], 0, 0, 0)
-#else
     reg_c[0] = llvm_intrin_amdgcn_mfma_f32_16x16x16f16(reg_a[0], reg_b[0], reg_c[0], 0, 0, 0);
-#endif
 }
 
 template <index_t MPerWave, index_t NPerWave>
-__device__ void gcnasm_mfma_f32_16x16x4f16(const half4_t* reg_a, const half4_t* reg_b, float16_t* reg_c);
+__device__ void
+gcnasm_mfma_f32_16x16x4f16(const half4_t* reg_a, const half4_t* reg_b, float16_t* reg_c);
 
 template <>
-__device__ void gcnasm_mfma_f32_16x16x4f16<16, 64>(const half4_t* reg_a, const half4_t* reg_b, float16_t* reg_c)
+__device__ void
+gcnasm_mfma_f32_16x16x4f16<16, 64>(const half4_t* reg_a, const half4_t* reg_b, float16_t* reg_c)
 {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
-    (void)reg_c;
-    MFMA_F32_16x16x4F16(0, reg_a[0], reg_b[0], 2, 0, 0)
-#else
     reg_c[0] = llvm_intrin_amdgcn_mfma_f32_16x16x4f16(reg_a[0], reg_b[0], reg_c[0], 2, 0, 0);
-#endif
 }
 
 template <>
-__device__ void gcnasm_mfma_f32_16x16x4f16<64, 16>(const half4_t* reg_a, const half4_t* reg_b, float16_t* reg_c)
+__device__ void
+gcnasm_mfma_f32_16x16x4f16<64, 16>(const half4_t* reg_a, const half4_t* reg_b, float16_t* reg_c)
 
 {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
-    (void)reg_c;
-    MFMA_F32_16x16x4F16(0, reg_a[0], reg_b[0], 0, 0, 4)
-#else
     reg_c[0] = llvm_intrin_amdgcn_mfma_f32_16x16x4f16(reg_a[0], reg_b[0], reg_c[0], 0, 0, 4);
-#endif
 }
 
 template <index_t MPerWave, index_t NPerWave>
-__device__ void gcnasm_mfma_f32_4x4x4f16(const half4_t* reg_a, const half4_t* reg_b, float4_t* reg_c);
+__device__ void
+gcnasm_mfma_f32_4x4x4f16(const half4_t* reg_a, const half4_t* reg_b, float4_t* reg_c);
 
 template <>
-__device__ void gcnasm_mfma_f32_4x4x4f16<4, 64>(const half4_t* reg_a, const half4_t* reg_b, float4_t* reg_c)
+__device__ void
+gcnasm_mfma_f32_4x4x4f16<4, 64>(const half4_t* reg_a, const half4_t* reg_b, float4_t* reg_c)
 {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
-    (void)reg_c;
-    MFMA_F32_4x4x4F16(0, reg_a[0], reg_b[0], 4, 0, 0)
-#else
     reg_c[0] = llvm_intrin_amdgcn_mfma_f32_4x4x4f16(reg_a[0], reg_b[0], reg_c[0], 4, 0, 0);
-#endif
 }
 
 template <>
-__device__ void gcnasm_mfma_f32_4x4x4f16<8, 64>(const half4_t* reg_a, const half4_t* reg_b, float4_t* reg_c)
+__device__ void
+gcnasm_mfma_f32_4x4x4f16<8, 64>(const half4_t* reg_a, const half4_t* reg_b, float4_t* reg_c)
 {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
-    (void)reg_c;
-    MFMA_F32_4x4x4F16(0, reg_a[0], reg_b[0], 4, 0, 0)
-    MFMA_F32_4x4x4F16(4, reg_a[0], reg_b[0], 4, 1, 0)
-#else
     reg_c[0] = llvm_intrin_amdgcn_mfma_f32_4x4x4f16(reg_a[0], reg_b[0], reg_c[0], 4, 0, 0);
     reg_c[1] = llvm_intrin_amdgcn_mfma_f32_4x4x4f16(reg_a[0], reg_b[0], reg_c[1], 4, 1, 0);
-#endif
 }
 
 template <index_t MPerWave, index_t NPerWave>
-__device__ void gcnasm_mfma_f32_32x32x2bf16(const ushort2_t* reg_a, const ushort2_t* reg_b, float32_t* reg_c);
+__device__ void
+gcnasm_mfma_f32_32x32x2bf16(const ushort2_t* reg_a, const ushort2_t* reg_b, float32_t* reg_c);
 
 template <>
-__device__ void gcnasm_mfma_f32_32x32x2bf16<64, 64>(const ushort2_t* reg_a, const ushort2_t* reg_b, float32_t* reg_c)
+__device__ void gcnasm_mfma_f32_32x32x2bf16<64, 64>(const ushort2_t* reg_a,
+                                                    const ushort2_t* reg_b,
+                                                    float32_t* reg_c)
 {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
-    (void)reg_c;
-    MFMA_F32_32x32x2BF16(0, reg_a[0], reg_b[0], 1, 0, 0)
-    MFMA_F32_32x32x2BF16(32, reg_a[0], reg_b[0], 1, 1, 0)
-#else
     reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x2bf16(reg_a[0], reg_b[0], reg_c[0], 1, 0, 0);
     reg_c[1] = llvm_intrin_amdgcn_mfma_f32_32x32x2bf16(reg_a[0], reg_b[0], reg_c[1], 1, 1, 0);
-#endif
 }
 
 template <>
-__device__ void gcnasm_mfma_f32_32x32x2bf16<32, 64>(const ushort2_t* reg_a, const ushort2_t* reg_b, float32_t* reg_c)
+__device__ void gcnasm_mfma_f32_32x32x2bf16<32, 64>(const ushort2_t* reg_a,
+                                                    const ushort2_t* reg_b,
+                                                    float32_t* reg_c)
 {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
-    (void)reg_c;
-    MFMA_F32_32x32x2BF16(0, reg_a[0], reg_b[0], 1, 0, 0)
-#else
     reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x2bf16(reg_a[0], reg_b[0], reg_c[0], 1, 0, 0);
-#endif
 }
 
 template <>
-__device__ void gcnasm_mfma_f32_32x32x2bf16<64, 32>(const ushort2_t* reg_a, const ushort2_t* reg_b, float32_t* reg_c)
+__device__ void gcnasm_mfma_f32_32x32x2bf16<64, 32>(const ushort2_t* reg_a,
+                                                    const ushort2_t* reg_b,
+                                                    float32_t* reg_c)
 {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
-    (void)reg_c;
-    MFMA_F32_32x32x2BF16(0, reg_a[0], reg_b[0], 0, 0, 1)
-#else
     reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x2bf16(reg_a[0], reg_b[0], reg_c[0], 0, 0, 1);
-#endif
 }
 
-__device__ void gcnasm_mfma_f32_32x32x4bf16(const ushort2_t* reg_a, const ushort2_t* reg_b, float16_t* reg_c)
+__device__ void
+gcnasm_mfma_f32_32x32x4bf16(const ushort2_t* reg_a, const ushort2_t* reg_b, float16_t* reg_c)
 {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
-    (void)reg_c;
-    MFMA_F32_32x32x4BF16(0, reg_a[0], reg_b[0], 0, 0, 0)
-#else
     reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x4bf16(reg_a[0], reg_b[0], reg_c[0], 0, 0, 0);
-#endif
 }
 
-__device__ void gcnasm_mfma_f32_16x16x8bf16(const ushort2_t* reg_a, const ushort2_t* reg_b, float4_t* reg_c)
+__device__ void
+gcnasm_mfma_f32_16x16x8bf16(const ushort2_t* reg_a, const ushort2_t* reg_b, float4_t* reg_c)
 {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
-    (void)reg_c;
-    MFMA_F32_16x16x8BF16(0, reg_a[0], reg_b[0], 0, 0, 0)
-#else
     reg_c[0] = llvm_intrin_amdgcn_mfma_f32_16x16x8bf16(reg_a[0], reg_b[0], reg_c[0], 0, 0, 0);
-#endif
 }
 
 template <index_t MPerWave, index_t NPerWave>
-__device__ void gcnasm_mfma_f32_16x16x2bf16(const ushort2_t* reg_a, const ushort2_t* reg_b, float16_t* reg_c);
+__device__ void
+gcnasm_mfma_f32_16x16x2bf16(const ushort2_t* reg_a, const ushort2_t* reg_b, float16_t* reg_c);
 
 template <>
-__device__ void gcnasm_mfma_f32_16x16x2bf16<16, 64>(const ushort2_t* reg_a, const ushort2_t* reg_b, float16_t* reg_c)
+__device__ void gcnasm_mfma_f32_16x16x2bf16<16, 64>(const ushort2_t* reg_a,
+                                                    const ushort2_t* reg_b,
+                                                    float16_t* reg_c)
 {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
-    (void)reg_c;
-    MFMA_F32_16x16x2BF16(0, reg_a[0], reg_b[0], 2, 0, 0)
-#else
     reg_c[0] = llvm_intrin_amdgcn_mfma_f32_16x16x2bf16(reg_a[0], reg_b[0], reg_c[0], 2, 0, 0);
-#endif
 }
 
 template <>
-__device__ void gcnasm_mfma_f32_16x16x2bf16<64, 16>(const ushort2_t* reg_a, const ushort2_t* reg_b, float16_t* reg_c)
+__device__ void gcnasm_mfma_f32_16x16x2bf16<64, 16>(const ushort2_t* reg_a,
+                                                    const ushort2_t* reg_b,
+                                                    float16_t* reg_c)
 {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
-    (void)reg_c;
-    MFMA_F32_16x16x2BF16(0, reg_a[0], reg_b[0], 0, 0, 4)
-#else
     reg_c[0] = llvm_intrin_amdgcn_mfma_f32_16x16x2bf16(reg_a[0], reg_b[0], reg_c[0], 0, 0, 4);
-#endif
 }
 
 template <index_t MPerWave, index_t NPerWave>
-__device__ void gcnasm_mfma_f32_4x4x2bf16(const ushort2_t* reg_a, const ushort2_t* reg_b, float4_t* reg_c);
+__device__ void
+gcnasm_mfma_f32_4x4x2bf16(const ushort2_t* reg_a, const ushort2_t* reg_b, float4_t* reg_c);
 
 template <>
-__device__ void gcnasm_mfma_f32_4x4x2bf16<4, 64>(const ushort2_t* reg_a, const ushort2_t* reg_b, float4_t* reg_c)
+__device__ void
+gcnasm_mfma_f32_4x4x2bf16<4, 64>(const ushort2_t* reg_a, const ushort2_t* reg_b, float4_t* reg_c)
 {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
-    (void)reg_c;
-    MFMA_F32_4x4x2BF16(0, reg_a[0], reg_b[0], 4, 0, 0)
-#else
     reg_c[0] = llvm_intrin_amdgcn_mfma_f32_4x4x2bf16(reg_a[0], reg_b[0], reg_c[0], 4, 0, 0);
-#endif
 }
 
 template <>
-__device__ void gcnasm_mfma_f32_4x4x2bf16<8, 64>(const ushort2_t* reg_a, const ushort2_t* reg_b, float4_t* reg_c)
+__device__ void
+gcnasm_mfma_f32_4x4x2bf16<8, 64>(const ushort2_t* reg_a, const ushort2_t* reg_b, float4_t* reg_c)
 {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
-    (void)reg_c;
-    MFMA_F32_4x4x2BF16(0, reg_a[0], reg_b[0], 4, 0, 0)
-    MFMA_F32_4x4x2BF16(4, reg_a[0], reg_b[0], 4, 1, 0)
-#else
     reg_c[0] = llvm_intrin_amdgcn_mfma_f32_4x4x2bf16(reg_a[0], reg_b[0], reg_c[0], 4, 0, 0);
     reg_c[1] = llvm_intrin_amdgcn_mfma_f32_4x4x2bf16(reg_a[0], reg_b[0], reg_c[1], 4, 1, 0);
-#endif
 }
-// clang-format on
 }
 #endif

--- a/src/kernels/composable_kernel/include/utility/amd_xdlops.hpp
+++ b/src/kernels/composable_kernel/include/utility/amd_xdlops.hpp
@@ -53,11 +53,11 @@ extern "C" __device__ float4_t llvm_intrin_amdgcn_mfma_f32_4x4x2bf16(
 
 template <index_t MPerWave, index_t NPerWave>
 __device__ void
-gcnasm_mfma_f32_32x32x1f32(const float* reg_a, const float* reg_b, float32_t* reg_c);
+intrin_mfma_f32_32x32x1f32(const float* reg_a, const float* reg_b, float32_t* reg_c);
 
 template <>
 __device__ void
-gcnasm_mfma_f32_32x32x1f32<64, 64>(const float* reg_a, const float* reg_b, float32_t* reg_c)
+intrin_mfma_f32_32x32x1f32<64, 64>(const float* reg_a, const float* reg_b, float32_t* reg_c)
 {
     reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x1f32(reg_a[0], reg_b[0], reg_c[0], 1, 0, 0);
     reg_c[1] = llvm_intrin_amdgcn_mfma_f32_32x32x1f32(reg_a[0], reg_b[0], reg_c[1], 1, 1, 0);
@@ -65,59 +65,59 @@ gcnasm_mfma_f32_32x32x1f32<64, 64>(const float* reg_a, const float* reg_b, float
 
 template <>
 __device__ void
-gcnasm_mfma_f32_32x32x1f32<32, 64>(const float* reg_a, const float* reg_b, float32_t* reg_c)
+intrin_mfma_f32_32x32x1f32<32, 64>(const float* reg_a, const float* reg_b, float32_t* reg_c)
 {
     reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x1f32(reg_a[0], reg_b[0], reg_c[0], 1, 0, 0);
 }
 
 template <>
 __device__ void
-gcnasm_mfma_f32_32x32x1f32<64, 32>(const float* reg_a, const float* reg_b, float32_t* reg_c)
+intrin_mfma_f32_32x32x1f32<64, 32>(const float* reg_a, const float* reg_b, float32_t* reg_c)
 {
     reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x1f32(reg_a[0], reg_b[0], reg_c[0], 0, 0, 1);
 }
 
-__device__ void gcnasm_mfma_f32_32x32x2f32(const float* reg_a, const float* reg_b, float16_t* reg_c)
+__device__ void intrin_mfma_f32_32x32x2f32(const float* reg_a, const float* reg_b, float16_t* reg_c)
 {
     reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x2f32(reg_a[0], reg_b[0], reg_c[0], 0, 0, 0);
 }
 
-__device__ void gcnasm_mfma_f32_16x16x4f32(const float* reg_a, const float* reg_b, float4_t* reg_c)
+__device__ void intrin_mfma_f32_16x16x4f32(const float* reg_a, const float* reg_b, float4_t* reg_c)
 {
     reg_c[0] = llvm_intrin_amdgcn_mfma_f32_16x16x4f32(reg_a[0], reg_b[0], reg_c[0], 0, 0, 0);
 }
 
 template <index_t MPerWave, index_t NPerWave>
 __device__ void
-gcnasm_mfma_f32_16x16x1f32(const float* reg_a, const float* reg_b, float16_t* reg_c);
+intrin_mfma_f32_16x16x1f32(const float* reg_a, const float* reg_b, float16_t* reg_c);
 
 template <>
 __device__ void
-gcnasm_mfma_f32_16x16x1f32<16, 64>(const float* reg_a, const float* reg_b, float16_t* reg_c)
+intrin_mfma_f32_16x16x1f32<16, 64>(const float* reg_a, const float* reg_b, float16_t* reg_c)
 {
     reg_c[0] = llvm_intrin_amdgcn_mfma_f32_16x16x1f32(reg_a[0], reg_b[0], reg_c[0], 2, 0, 0);
 }
 
 template <>
 __device__ void
-gcnasm_mfma_f32_16x16x1f32<64, 16>(const float* reg_a, const float* reg_b, float16_t* reg_c)
+intrin_mfma_f32_16x16x1f32<64, 16>(const float* reg_a, const float* reg_b, float16_t* reg_c)
 {
     reg_c[0] = llvm_intrin_amdgcn_mfma_f32_16x16x1f32(reg_a[0], reg_b[0], reg_c[0], 0, 0, 4);
 }
 
 template <index_t MPerWave, index_t NPerWave>
-__device__ void gcnasm_mfma_f32_4x4x1f32(const float* reg_a, const float* reg_b, float4_t* reg_c);
+__device__ void intrin_mfma_f32_4x4x1f32(const float* reg_a, const float* reg_b, float4_t* reg_c);
 
 template <>
 __device__ void
-gcnasm_mfma_f32_4x4x1f32<4, 64>(const float* reg_a, const float* reg_b, float4_t* reg_c)
+intrin_mfma_f32_4x4x1f32<4, 64>(const float* reg_a, const float* reg_b, float4_t* reg_c)
 {
     reg_c[0] = llvm_intrin_amdgcn_mfma_f32_4x4x1f32(reg_a[0], reg_b[0], reg_c[0], 4, 0, 0);
 }
 
 template <>
 __device__ void
-gcnasm_mfma_f32_4x4x1f32<8, 64>(const float* reg_a, const float* reg_b, float4_t* reg_c)
+intrin_mfma_f32_4x4x1f32<8, 64>(const float* reg_a, const float* reg_b, float4_t* reg_c)
 {
     reg_c[0] = llvm_intrin_amdgcn_mfma_f32_4x4x1f32(reg_a[0], reg_b[0], reg_c[0], 4, 0, 0);
     reg_c[1] = llvm_intrin_amdgcn_mfma_f32_4x4x1f32(reg_a[0], reg_b[0], reg_c[1], 4, 1, 0);
@@ -125,10 +125,10 @@ gcnasm_mfma_f32_4x4x1f32<8, 64>(const float* reg_a, const float* reg_b, float4_t
 
 template <index_t MPerWave, index_t NPerWave>
 __device__ void
-gcnasm_mfma_f32_32x32x4f16(const half4_t* reg_a, const half4_t* reg_b, float32_t* reg_c);
+intrin_mfma_f32_32x32x4f16(const half4_t* reg_a, const half4_t* reg_b, float32_t* reg_c);
 template <>
 __device__ void
-gcnasm_mfma_f32_32x32x4f16<64, 64>(const half4_t* reg_a, const half4_t* reg_b, float32_t* reg_c)
+intrin_mfma_f32_32x32x4f16<64, 64>(const half4_t* reg_a, const half4_t* reg_b, float32_t* reg_c)
 {
     reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x4f16(reg_a[0], reg_b[0], reg_c[0], 1, 0, 0);
     reg_c[1] = llvm_intrin_amdgcn_mfma_f32_32x32x4f16(reg_a[0], reg_b[0], reg_c[1], 1, 1, 0);
@@ -136,44 +136,44 @@ gcnasm_mfma_f32_32x32x4f16<64, 64>(const half4_t* reg_a, const half4_t* reg_b, f
 
 template <>
 __device__ void
-gcnasm_mfma_f32_32x32x4f16<32, 64>(const half4_t* reg_a, const half4_t* reg_b, float32_t* reg_c)
+intrin_mfma_f32_32x32x4f16<32, 64>(const half4_t* reg_a, const half4_t* reg_b, float32_t* reg_c)
 {
     reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x4f16(reg_a[0], reg_b[0], reg_c[0], 1, 0, 0);
 }
 
 template <>
 __device__ void
-gcnasm_mfma_f32_32x32x4f16<64, 32>(const half4_t* reg_a, const half4_t* reg_b, float32_t* reg_c)
+intrin_mfma_f32_32x32x4f16<64, 32>(const half4_t* reg_a, const half4_t* reg_b, float32_t* reg_c)
 {
     reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x4f16(reg_a[0], reg_b[0], reg_c[0], 0, 0, 1);
 }
 
 __device__ void
-gcnasm_mfma_f32_32x32x8f16(const half4_t* reg_a, const half4_t* reg_b, float16_t* reg_c)
+intrin_mfma_f32_32x32x8f16(const half4_t* reg_a, const half4_t* reg_b, float16_t* reg_c)
 {
     reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x8f16(reg_a[0], reg_b[0], reg_c[0], 0, 0, 0);
 }
 
 __device__ void
-gcnasm_mfma_f32_16x16x16f16(const half4_t* reg_a, const half4_t* reg_b, float4_t* reg_c)
+intrin_mfma_f32_16x16x16f16(const half4_t* reg_a, const half4_t* reg_b, float4_t* reg_c)
 {
     reg_c[0] = llvm_intrin_amdgcn_mfma_f32_16x16x16f16(reg_a[0], reg_b[0], reg_c[0], 0, 0, 0);
 }
 
 template <index_t MPerWave, index_t NPerWave>
 __device__ void
-gcnasm_mfma_f32_16x16x4f16(const half4_t* reg_a, const half4_t* reg_b, float16_t* reg_c);
+intrin_mfma_f32_16x16x4f16(const half4_t* reg_a, const half4_t* reg_b, float16_t* reg_c);
 
 template <>
 __device__ void
-gcnasm_mfma_f32_16x16x4f16<16, 64>(const half4_t* reg_a, const half4_t* reg_b, float16_t* reg_c)
+intrin_mfma_f32_16x16x4f16<16, 64>(const half4_t* reg_a, const half4_t* reg_b, float16_t* reg_c)
 {
     reg_c[0] = llvm_intrin_amdgcn_mfma_f32_16x16x4f16(reg_a[0], reg_b[0], reg_c[0], 2, 0, 0);
 }
 
 template <>
 __device__ void
-gcnasm_mfma_f32_16x16x4f16<64, 16>(const half4_t* reg_a, const half4_t* reg_b, float16_t* reg_c)
+intrin_mfma_f32_16x16x4f16<64, 16>(const half4_t* reg_a, const half4_t* reg_b, float16_t* reg_c)
 
 {
     reg_c[0] = llvm_intrin_amdgcn_mfma_f32_16x16x4f16(reg_a[0], reg_b[0], reg_c[0], 0, 0, 4);
@@ -181,18 +181,18 @@ gcnasm_mfma_f32_16x16x4f16<64, 16>(const half4_t* reg_a, const half4_t* reg_b, f
 
 template <index_t MPerWave, index_t NPerWave>
 __device__ void
-gcnasm_mfma_f32_4x4x4f16(const half4_t* reg_a, const half4_t* reg_b, float4_t* reg_c);
+intrin_mfma_f32_4x4x4f16(const half4_t* reg_a, const half4_t* reg_b, float4_t* reg_c);
 
 template <>
 __device__ void
-gcnasm_mfma_f32_4x4x4f16<4, 64>(const half4_t* reg_a, const half4_t* reg_b, float4_t* reg_c)
+intrin_mfma_f32_4x4x4f16<4, 64>(const half4_t* reg_a, const half4_t* reg_b, float4_t* reg_c)
 {
     reg_c[0] = llvm_intrin_amdgcn_mfma_f32_4x4x4f16(reg_a[0], reg_b[0], reg_c[0], 4, 0, 0);
 }
 
 template <>
 __device__ void
-gcnasm_mfma_f32_4x4x4f16<8, 64>(const half4_t* reg_a, const half4_t* reg_b, float4_t* reg_c)
+intrin_mfma_f32_4x4x4f16<8, 64>(const half4_t* reg_a, const half4_t* reg_b, float4_t* reg_c)
 {
     reg_c[0] = llvm_intrin_amdgcn_mfma_f32_4x4x4f16(reg_a[0], reg_b[0], reg_c[0], 4, 0, 0);
     reg_c[1] = llvm_intrin_amdgcn_mfma_f32_4x4x4f16(reg_a[0], reg_b[0], reg_c[1], 4, 1, 0);
@@ -200,10 +200,10 @@ gcnasm_mfma_f32_4x4x4f16<8, 64>(const half4_t* reg_a, const half4_t* reg_b, floa
 
 template <index_t MPerWave, index_t NPerWave>
 __device__ void
-gcnasm_mfma_f32_32x32x2bf16(const ushort2_t* reg_a, const ushort2_t* reg_b, float32_t* reg_c);
+intrin_mfma_f32_32x32x2bf16(const ushort2_t* reg_a, const ushort2_t* reg_b, float32_t* reg_c);
 
 template <>
-__device__ void gcnasm_mfma_f32_32x32x2bf16<64, 64>(const ushort2_t* reg_a,
+__device__ void intrin_mfma_f32_32x32x2bf16<64, 64>(const ushort2_t* reg_a,
                                                     const ushort2_t* reg_b,
                                                     float32_t* reg_c)
 {
@@ -212,7 +212,7 @@ __device__ void gcnasm_mfma_f32_32x32x2bf16<64, 64>(const ushort2_t* reg_a,
 }
 
 template <>
-__device__ void gcnasm_mfma_f32_32x32x2bf16<32, 64>(const ushort2_t* reg_a,
+__device__ void intrin_mfma_f32_32x32x2bf16<32, 64>(const ushort2_t* reg_a,
                                                     const ushort2_t* reg_b,
                                                     float32_t* reg_c)
 {
@@ -220,7 +220,7 @@ __device__ void gcnasm_mfma_f32_32x32x2bf16<32, 64>(const ushort2_t* reg_a,
 }
 
 template <>
-__device__ void gcnasm_mfma_f32_32x32x2bf16<64, 32>(const ushort2_t* reg_a,
+__device__ void intrin_mfma_f32_32x32x2bf16<64, 32>(const ushort2_t* reg_a,
                                                     const ushort2_t* reg_b,
                                                     float32_t* reg_c)
 {
@@ -228,23 +228,23 @@ __device__ void gcnasm_mfma_f32_32x32x2bf16<64, 32>(const ushort2_t* reg_a,
 }
 
 __device__ void
-gcnasm_mfma_f32_32x32x4bf16(const ushort2_t* reg_a, const ushort2_t* reg_b, float16_t* reg_c)
+intrin_mfma_f32_32x32x4bf16(const ushort2_t* reg_a, const ushort2_t* reg_b, float16_t* reg_c)
 {
     reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x4bf16(reg_a[0], reg_b[0], reg_c[0], 0, 0, 0);
 }
 
 __device__ void
-gcnasm_mfma_f32_16x16x8bf16(const ushort2_t* reg_a, const ushort2_t* reg_b, float4_t* reg_c)
+intrin_mfma_f32_16x16x8bf16(const ushort2_t* reg_a, const ushort2_t* reg_b, float4_t* reg_c)
 {
     reg_c[0] = llvm_intrin_amdgcn_mfma_f32_16x16x8bf16(reg_a[0], reg_b[0], reg_c[0], 0, 0, 0);
 }
 
 template <index_t MPerWave, index_t NPerWave>
 __device__ void
-gcnasm_mfma_f32_16x16x2bf16(const ushort2_t* reg_a, const ushort2_t* reg_b, float16_t* reg_c);
+intrin_mfma_f32_16x16x2bf16(const ushort2_t* reg_a, const ushort2_t* reg_b, float16_t* reg_c);
 
 template <>
-__device__ void gcnasm_mfma_f32_16x16x2bf16<16, 64>(const ushort2_t* reg_a,
+__device__ void intrin_mfma_f32_16x16x2bf16<16, 64>(const ushort2_t* reg_a,
                                                     const ushort2_t* reg_b,
                                                     float16_t* reg_c)
 {
@@ -252,7 +252,7 @@ __device__ void gcnasm_mfma_f32_16x16x2bf16<16, 64>(const ushort2_t* reg_a,
 }
 
 template <>
-__device__ void gcnasm_mfma_f32_16x16x2bf16<64, 16>(const ushort2_t* reg_a,
+__device__ void intrin_mfma_f32_16x16x2bf16<64, 16>(const ushort2_t* reg_a,
                                                     const ushort2_t* reg_b,
                                                     float16_t* reg_c)
 {
@@ -261,18 +261,18 @@ __device__ void gcnasm_mfma_f32_16x16x2bf16<64, 16>(const ushort2_t* reg_a,
 
 template <index_t MPerWave, index_t NPerWave>
 __device__ void
-gcnasm_mfma_f32_4x4x2bf16(const ushort2_t* reg_a, const ushort2_t* reg_b, float4_t* reg_c);
+intrin_mfma_f32_4x4x2bf16(const ushort2_t* reg_a, const ushort2_t* reg_b, float4_t* reg_c);
 
 template <>
 __device__ void
-gcnasm_mfma_f32_4x4x2bf16<4, 64>(const ushort2_t* reg_a, const ushort2_t* reg_b, float4_t* reg_c)
+intrin_mfma_f32_4x4x2bf16<4, 64>(const ushort2_t* reg_a, const ushort2_t* reg_b, float4_t* reg_c)
 {
     reg_c[0] = llvm_intrin_amdgcn_mfma_f32_4x4x2bf16(reg_a[0], reg_b[0], reg_c[0], 4, 0, 0);
 }
 
 template <>
 __device__ void
-gcnasm_mfma_f32_4x4x2bf16<8, 64>(const ushort2_t* reg_a, const ushort2_t* reg_b, float4_t* reg_c)
+intrin_mfma_f32_4x4x2bf16<8, 64>(const ushort2_t* reg_a, const ushort2_t* reg_b, float4_t* reg_c)
 {
     reg_c[0] = llvm_intrin_amdgcn_mfma_f32_4x4x2bf16(reg_a[0], reg_b[0], reg_c[0], 4, 0, 0);
     reg_c[1] = llvm_intrin_amdgcn_mfma_f32_4x4x2bf16(reg_a[0], reg_b[0], reg_c[1], 4, 1, 0);

--- a/src/kernels/composable_kernel/include/utility/amd_xdlops.hpp
+++ b/src/kernels/composable_kernel/include/utility/amd_xdlops.hpp
@@ -562,334 +562,334 @@ __device__ void gcnasm_nop<64>()
 }
 
 template <index_t MPerWave, index_t NPerWave>
-__device__ void gcnasm_mfma_f32_32x32x1f32(const float&, const float&, float32_t*);
+__device__ void gcnasm_mfma_f32_32x32x1f32(const float* reg_a, const float* reg_b, float32_t* reg_c);
 
 template <>
-__device__ void gcnasm_mfma_f32_32x32x1f32<64, 64>(const float& reg_a, const float& reg_b, float32_t* reg_c)
+__device__ void gcnasm_mfma_f32_32x32x1f32<64, 64>(const float* reg_a, const float* reg_b, float32_t* reg_c)
 {
 #if CK_USE_AMD_XDLOPS_INLINE_ASM
     (void)reg_c;
-    MFMA_F32_32x32x1F32(0, reg_a, reg_b, 1, 0, 0)
-    MFMA_F32_32x32x1F32(32, reg_a, reg_b, 1, 1, 0)
+    MFMA_F32_32x32x1F32(0, reg_a[0], reg_b[0], 1, 0, 0)
+    MFMA_F32_32x32x1F32(32, reg_a[0], reg_b[0], 1, 1, 0)
 #else
-    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x1f32(reg_a, reg_b, reg_c[0], 1, 0, 0);
-    reg_c[1] = llvm_intrin_amdgcn_mfma_f32_32x32x1f32(reg_a, reg_b, reg_c[1], 1, 1, 0);
-#endif
-}
-
-template <>
-__device__ void gcnasm_mfma_f32_32x32x1f32<32, 64>(const float& reg_a, const float& reg_b, float32_t* reg_c)
-{
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
-    (void)reg_c;
-    MFMA_F32_32x32x1F32(0, reg_a, reg_b, 1, 0, 0)
-#else
-    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x1f32(reg_a, reg_b, reg_c[0], 1, 0, 0);
+    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x1f32(reg_a[0], reg_b[0], reg_c[0], 1, 0, 0);
+    reg_c[1] = llvm_intrin_amdgcn_mfma_f32_32x32x1f32(reg_a[0], reg_b[0], reg_c[1], 1, 1, 0);
 #endif
 }
 
 template <>
-__device__ void gcnasm_mfma_f32_32x32x1f32<64, 32>(const float& reg_a, const float& reg_b, float32_t* reg_c)
+__device__ void gcnasm_mfma_f32_32x32x1f32<32, 64>(const float* reg_a, const float* reg_b, float32_t* reg_c)
 {
 #if CK_USE_AMD_XDLOPS_INLINE_ASM
     (void)reg_c;
-    MFMA_F32_32x32x1F32(0, reg_a, reg_b, 0, 0, 1)
+    MFMA_F32_32x32x1F32(0, reg_a[0], reg_b[0], 1, 0, 0)
 #else
-    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x1f32(reg_a, reg_b, reg_c[0], 0, 0, 1);
+    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x1f32(reg_a[0], reg_b[0], reg_c[0], 1, 0, 0);
 #endif
 }
 
-__device__ void gcnasm_mfma_f32_32x32x2f32(const float& reg_a, const float& reg_b, float16_t* reg_c)
+template <>
+__device__ void gcnasm_mfma_f32_32x32x1f32<64, 32>(const float* reg_a, const float* reg_b, float32_t* reg_c)
 {
 #if CK_USE_AMD_XDLOPS_INLINE_ASM
     (void)reg_c;
-    MFMA_F32_32x32x2F32(0, reg_a, reg_b, 0, 0, 0)
+    MFMA_F32_32x32x1F32(0, reg_a[0], reg_b[0], 0, 0, 1)
 #else
-    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x2f32(reg_a, reg_b, reg_c[0], 0, 0, 0);
+    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x1f32(reg_a[0], reg_b[0], reg_c[0], 0, 0, 1);
 #endif
 }
 
-__device__ void gcnasm_mfma_f32_16x16x4f32(const float& reg_a, const float& reg_b, float4_t* reg_c)
+__device__ void gcnasm_mfma_f32_32x32x2f32(const float* reg_a, const float* reg_b, float16_t* reg_c)
 {
 #if CK_USE_AMD_XDLOPS_INLINE_ASM
     (void)reg_c;
-    MFMA_F32_16x16x4F32(0, reg_a, reg_b, 0, 0, 0)
+    MFMA_F32_32x32x2F32(0, reg_a[0], reg_b[0], 0, 0, 0)
 #else
-    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_16x16x4f32(reg_a, reg_b, reg_c[0], 0, 0, 0);
+    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x2f32(reg_a[0], reg_b[0], reg_c[0], 0, 0, 0);
+#endif
+}
+
+__device__ void gcnasm_mfma_f32_16x16x4f32(const float* reg_a, const float* reg_b, float4_t* reg_c)
+{
+#if CK_USE_AMD_XDLOPS_INLINE_ASM
+    (void)reg_c;
+    MFMA_F32_16x16x4F32(0, reg_a[0], reg_b[0], 0, 0, 0)
+#else
+    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_16x16x4f32(reg_a[0], reg_b[0], reg_c[0], 0, 0, 0);
 #endif
 }
 
 template <index_t MPerWave, index_t NPerWave>
-__device__ void gcnasm_mfma_f32_16x16x1f32(const float&, const float&, float16_t*);
+__device__ void gcnasm_mfma_f32_16x16x1f32(const float* reg_a, const float* reg_b, float16_t* reg_c);
 
 template <>
-__device__ void gcnasm_mfma_f32_16x16x1f32<16, 64>(const float& reg_a, const float& reg_b, float16_t* reg_c)
+__device__ void gcnasm_mfma_f32_16x16x1f32<16, 64>(const float* reg_a, const float* reg_b, float16_t* reg_c)
 {
 #if CK_USE_AMD_XDLOPS_INLINE_ASM
     (void)reg_c;
-    MFMA_F32_16x16x1F32(0, reg_a, reg_b, 2, 0, 0)
+    MFMA_F32_16x16x1F32(0, reg_a[0], reg_b[0], 2, 0, 0)
 #else
-    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_16x16x1f32(reg_a, reg_b, reg_c[0], 2, 0, 0);
+    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_16x16x1f32(reg_a[0], reg_b[0], reg_c[0], 2, 0, 0);
 #endif
 }
 
 template <>
-__device__ void gcnasm_mfma_f32_16x16x1f32<64, 16>(const float& reg_a, const float& reg_b, float16_t* reg_c)
+__device__ void gcnasm_mfma_f32_16x16x1f32<64, 16>(const float* reg_a, const float* reg_b, float16_t* reg_c)
 {
 #if CK_USE_AMD_XDLOPS_INLINE_ASM
     (void)reg_c;
-    MFMA_F32_16x16x1F32(0, reg_a, reg_b, 0, 0, 4)
+    MFMA_F32_16x16x1F32(0, reg_a[0], reg_b[0], 0, 0, 4)
 #else
-    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_16x16x1f32(reg_a, reg_b, reg_c[0], 0, 0, 4);
+    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_16x16x1f32(reg_a[0], reg_b[0], reg_c[0], 0, 0, 4);
 #endif
 }
 
 template <index_t MPerWave, index_t NPerWave>
-__device__ void gcnasm_mfma_f32_4x4x1f32(const float& reg_a, const float& reg_b, float4_t* reg_c);
+__device__ void gcnasm_mfma_f32_4x4x1f32(const float* reg_a, const float* reg_b, float4_t* reg_c);
 
 template <>
-__device__ void gcnasm_mfma_f32_4x4x1f32<4, 64>(const float& reg_a, const float& reg_b, float4_t* reg_c)
+__device__ void gcnasm_mfma_f32_4x4x1f32<4, 64>(const float* reg_a, const float* reg_b, float4_t* reg_c)
 {
 #if CK_USE_AMD_XDLOPS_INLINE_ASM
     (void)reg_c;
-    MFMA_F32_4x4x1F32(0, reg_a, reg_b, 4, 0, 0)
+    MFMA_F32_4x4x1F32(0, reg_a[0], reg_b[0], 4, 0, 0)
 #else
-    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_4x4x1f32(reg_a, reg_b, reg_c[0], 4, 0, 0);
+    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_4x4x1f32(reg_a[0], reg_b[0], reg_c[0], 4, 0, 0);
 #endif
 }
 
 template <>
-__device__ void gcnasm_mfma_f32_4x4x1f32<8, 64>(const float& reg_a, const float& reg_b, float4_t* reg_c)
+__device__ void gcnasm_mfma_f32_4x4x1f32<8, 64>(const float* reg_a, const float* reg_b, float4_t* reg_c)
 {
 #if CK_USE_AMD_XDLOPS_INLINE_ASM
     (void)reg_c;
-    MFMA_F32_4x4x1F32(0, reg_a, reg_b, 4, 0, 0)
-    MFMA_F32_4x4x1F32(4, reg_a, reg_b, 4, 1, 0)
+    MFMA_F32_4x4x1F32(0, reg_a[0], reg_b[0], 4, 0, 0)
+    MFMA_F32_4x4x1F32(4, reg_a[0], reg_b[0], 4, 1, 0)
 #else
-    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_4x4x1f32(reg_a, reg_b, reg_c[0], 4, 0, 0);
-    reg_c[1] = llvm_intrin_amdgcn_mfma_f32_4x4x1f32(reg_a, reg_b, reg_c[1], 4, 1, 0);
+    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_4x4x1f32(reg_a[0], reg_b[0], reg_c[0], 4, 0, 0);
+    reg_c[1] = llvm_intrin_amdgcn_mfma_f32_4x4x1f32(reg_a[0], reg_b[0], reg_c[1], 4, 1, 0);
 #endif
 }
 
 template <index_t MPerWave, index_t NPerWave>
-__device__ void gcnasm_mfma_f32_32x32x4f16(const half4_t&,
-                                           const half4_t&,
-                                           float32_t*);
+__device__ void gcnasm_mfma_f32_32x32x4f16(const half4_t* reg_a,
+                                           const half4_t* reg_b,
+                                           float32_t* reg_c);
 template <>
-__device__ void gcnasm_mfma_f32_32x32x4f16<64, 64>(const half4_t& reg_a, const half4_t& reg_b, float32_t* reg_c)
+__device__ void gcnasm_mfma_f32_32x32x4f16<64, 64>(const half4_t* reg_a, const half4_t* reg_b, float32_t* reg_c)
 {
 #if CK_USE_AMD_XDLOPS_INLINE_ASM
     (void)reg_c;
-    MFMA_F32_32x32x4F16(0, reg_a, reg_b, 1, 0, 0)
-    MFMA_F32_32x32x4F16(32, reg_a, reg_b, 1, 1, 0)
+    MFMA_F32_32x32x4F16(0, reg_a[0], reg_b[0], 1, 0, 0)
+    MFMA_F32_32x32x4F16(32, reg_a[0], reg_b[0], 1, 1, 0)
 #else
-    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x4f16(reg_a, reg_b, reg_c[0], 1, 0, 0);
-    reg_c[1] = llvm_intrin_amdgcn_mfma_f32_32x32x4f16(reg_a, reg_b, reg_c[1], 1, 1, 0);
-#endif
-}
-
-template <>
-__device__ void gcnasm_mfma_f32_32x32x4f16<32, 64>(const half4_t& reg_a, const half4_t& reg_b, float32_t* reg_c)
-{
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
-    (void)reg_c;
-    MFMA_F32_32x32x4F16(0, reg_a, reg_b, 1, 0, 0)
-#else
-    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x4f16(reg_a, reg_b, reg_c[0], 1, 0, 0);
+    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x4f16(reg_a[0], reg_b[0], reg_c[0], 1, 0, 0);
+    reg_c[1] = llvm_intrin_amdgcn_mfma_f32_32x32x4f16(reg_a[0], reg_b[0], reg_c[1], 1, 1, 0);
 #endif
 }
 
 template <>
-__device__ void gcnasm_mfma_f32_32x32x4f16<64, 32>(const half4_t& reg_a, const half4_t& reg_b, float32_t* reg_c)
+__device__ void gcnasm_mfma_f32_32x32x4f16<32, 64>(const half4_t* reg_a, const half4_t* reg_b, float32_t* reg_c)
 {
 #if CK_USE_AMD_XDLOPS_INLINE_ASM
     (void)reg_c;
-    MFMA_F32_32x32x4F16(0, reg_a, reg_b, 0, 0, 1)
+    MFMA_F32_32x32x4F16(0, reg_a[0], reg_b[0], 1, 0, 0)
 #else
-    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x4f16(reg_a, reg_b, reg_c[0], 0, 0, 1);
+    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x4f16(reg_a[0], reg_b[0], reg_c[0], 1, 0, 0);
 #endif
 }
 
-__device__ void gcnasm_mfma_f32_32x32x8f16(const half4_t& reg_a, const half4_t& reg_b, float16_t* reg_c)
+template <>
+__device__ void gcnasm_mfma_f32_32x32x4f16<64, 32>(const half4_t* reg_a, const half4_t* reg_b, float32_t* reg_c)
 {
 #if CK_USE_AMD_XDLOPS_INLINE_ASM
     (void)reg_c;
-    MFMA_F32_32x32x8F16(0, reg_a, reg_b, 0, 0, 0)
+    MFMA_F32_32x32x4F16(0, reg_a[0], reg_b[0], 0, 0, 1)
 #else
-    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x8f16(reg_a, reg_b, reg_c[0], 0, 0, 0);
+    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x4f16(reg_a[0], reg_b[0], reg_c[0], 0, 0, 1);
 #endif
 }
 
-__device__ void gcnasm_mfma_f32_16x16x16f16(const half4_t& reg_a, const half4_t& reg_b, float4_t* reg_c)
+__device__ void gcnasm_mfma_f32_32x32x8f16(const half4_t* reg_a, const half4_t* reg_b, float16_t* reg_c)
 {
 #if CK_USE_AMD_XDLOPS_INLINE_ASM
     (void)reg_c;
-    MFMA_F32_16x16x16F16(0, reg_a, reg_b, 0, 0, 0)
+    MFMA_F32_32x32x8F16(0, reg_a[0], reg_b[0], 0, 0, 0)
 #else
-    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_16x16x16f16(reg_a, reg_b, reg_c[0], 0, 0, 0);
+    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x8f16(reg_a[0], reg_b[0], reg_c[0], 0, 0, 0);
+#endif
+}
+
+__device__ void gcnasm_mfma_f32_16x16x16f16(const half4_t* reg_a, const half4_t* reg_b, float4_t* reg_c)
+{
+#if CK_USE_AMD_XDLOPS_INLINE_ASM
+    (void)reg_c;
+    MFMA_F32_16x16x16F16(0, reg_a[0], reg_b[0], 0, 0, 0)
+#else
+    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_16x16x16f16(reg_a[0], reg_b[0], reg_c[0], 0, 0, 0);
 #endif
 }
 
 template <index_t MPerWave, index_t NPerWave>
-__device__ void gcnasm_mfma_f32_16x16x4f16(const half4_t& reg_a, const half4_t& reg_b, float16_t* reg_c);
+__device__ void gcnasm_mfma_f32_16x16x4f16(const half4_t* reg_a, const half4_t* reg_b, float16_t* reg_c);
 
 template <>
-__device__ void gcnasm_mfma_f32_16x16x4f16<16, 64>(const half4_t& reg_a, const half4_t& reg_b, float16_t* reg_c)
+__device__ void gcnasm_mfma_f32_16x16x4f16<16, 64>(const half4_t* reg_a, const half4_t* reg_b, float16_t* reg_c)
 {
 #if CK_USE_AMD_XDLOPS_INLINE_ASM
     (void)reg_c;
-    MFMA_F32_16x16x4F16(0, reg_a, reg_b, 2, 0, 0)
+    MFMA_F32_16x16x4F16(0, reg_a[0], reg_b[0], 2, 0, 0)
 #else
-    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_16x16x4f16(reg_a, reg_b, reg_c[0], 2, 0, 0);
+    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_16x16x4f16(reg_a[0], reg_b[0], reg_c[0], 2, 0, 0);
 #endif
 }
 
 template <>
-__device__ void gcnasm_mfma_f32_16x16x4f16<64, 16>(const half4_t& reg_a, const half4_t& reg_b, float16_t* reg_c)
+__device__ void gcnasm_mfma_f32_16x16x4f16<64, 16>(const half4_t* reg_a, const half4_t* reg_b, float16_t* reg_c)
 
 {
 #if CK_USE_AMD_XDLOPS_INLINE_ASM
     (void)reg_c;
-    MFMA_F32_16x16x4F16(0, reg_a, reg_b, 0, 0, 4)
+    MFMA_F32_16x16x4F16(0, reg_a[0], reg_b[0], 0, 0, 4)
 #else
-    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_16x16x4f16(reg_a, reg_b, reg_c[0], 0, 0, 4);
+    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_16x16x4f16(reg_a[0], reg_b[0], reg_c[0], 0, 0, 4);
 #endif
 }
 
 template <index_t MPerWave, index_t NPerWave>
-__device__ void gcnasm_mfma_f32_4x4x4f16(const half4_t& reg_a, const half4_t& reg_b, float4_t* reg_c);
+__device__ void gcnasm_mfma_f32_4x4x4f16(const half4_t* reg_a, const half4_t* reg_b, float4_t* reg_c);
 
 template <>
-__device__ void gcnasm_mfma_f32_4x4x4f16<4, 64>(const half4_t& reg_a, const half4_t& reg_b, float4_t* reg_c)
+__device__ void gcnasm_mfma_f32_4x4x4f16<4, 64>(const half4_t* reg_a, const half4_t* reg_b, float4_t* reg_c)
 {
 #if CK_USE_AMD_XDLOPS_INLINE_ASM
     (void)reg_c;
-    MFMA_F32_4x4x4F16(0, reg_a, reg_b, 4, 0, 0)
+    MFMA_F32_4x4x4F16(0, reg_a[0], reg_b[0], 4, 0, 0)
 #else
-    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_4x4x4f16(reg_a, reg_b, reg_c[0], 4, 0, 0);
+    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_4x4x4f16(reg_a[0], reg_b[0], reg_c[0], 4, 0, 0);
 #endif
 }
 
 template <>
-__device__ void gcnasm_mfma_f32_4x4x4f16<8, 64>(const half4_t& reg_a, const half4_t& reg_b, float4_t* reg_c)
+__device__ void gcnasm_mfma_f32_4x4x4f16<8, 64>(const half4_t* reg_a, const half4_t* reg_b, float4_t* reg_c)
 {
 #if CK_USE_AMD_XDLOPS_INLINE_ASM
     (void)reg_c;
-    MFMA_F32_4x4x4F16(0, reg_a, reg_b, 4, 0, 0)
-    MFMA_F32_4x4x4F16(4, reg_a, reg_b, 4, 1, 0)
+    MFMA_F32_4x4x4F16(0, reg_a[0], reg_b[0], 4, 0, 0)
+    MFMA_F32_4x4x4F16(4, reg_a[0], reg_b[0], 4, 1, 0)
 #else
-    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_4x4x4f16(reg_a, reg_b, reg_c[0], 4, 0, 0);
-    reg_c[1] = llvm_intrin_amdgcn_mfma_f32_4x4x4f16(reg_a, reg_b, reg_c[1], 4, 1, 0);
+    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_4x4x4f16(reg_a[0], reg_b[0], reg_c[0], 4, 0, 0);
+    reg_c[1] = llvm_intrin_amdgcn_mfma_f32_4x4x4f16(reg_a[0], reg_b[0], reg_c[1], 4, 1, 0);
 #endif
 }
 
 template <index_t MPerWave, index_t NPerWave>
-__device__ void gcnasm_mfma_f32_32x32x2bf16(const ushort2_t&, const ushort2_t&, float32_t*);
+__device__ void gcnasm_mfma_f32_32x32x2bf16(const ushort2_t* reg_a, const ushort2_t* reg_b, float32_t* reg_c);
 
 template <>
-__device__ void gcnasm_mfma_f32_32x32x2bf16<64, 64>(const ushort2_t& reg_a, const ushort2_t& reg_b, float32_t* reg_c)
+__device__ void gcnasm_mfma_f32_32x32x2bf16<64, 64>(const ushort2_t* reg_a, const ushort2_t* reg_b, float32_t* reg_c)
 {
 #if CK_USE_AMD_XDLOPS_INLINE_ASM
     (void)reg_c;
-    MFMA_F32_32x32x2BF16(0, reg_a, reg_b, 1, 0, 0)
-    MFMA_F32_32x32x2BF16(32, reg_a, reg_b, 1, 1, 0)
+    MFMA_F32_32x32x2BF16(0, reg_a[0], reg_b[0], 1, 0, 0)
+    MFMA_F32_32x32x2BF16(32, reg_a[0], reg_b[0], 1, 1, 0)
 #else
-    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x2bf16(reg_a, reg_b, reg_c[0], 1, 0, 0);
-    reg_c[1] = llvm_intrin_amdgcn_mfma_f32_32x32x2bf16(reg_a, reg_b, reg_c[1], 1, 1, 0);
-#endif
-}
-
-template <>
-__device__ void gcnasm_mfma_f32_32x32x2bf16<32, 64>(const ushort2_t& reg_a, const ushort2_t& reg_b, float32_t* reg_c)
-{
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
-    (void)reg_c;
-    MFMA_F32_32x32x2BF16(0, reg_a, reg_b, 1, 0, 0)
-#else
-    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x2bf16(reg_a, reg_b, reg_c[0], 1, 0, 0);
+    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x2bf16(reg_a[0], reg_b[0], reg_c[0], 1, 0, 0);
+    reg_c[1] = llvm_intrin_amdgcn_mfma_f32_32x32x2bf16(reg_a[0], reg_b[0], reg_c[1], 1, 1, 0);
 #endif
 }
 
 template <>
-__device__ void gcnasm_mfma_f32_32x32x2bf16<64, 32>(const ushort2_t& reg_a, const ushort2_t& reg_b, float32_t* reg_c)
+__device__ void gcnasm_mfma_f32_32x32x2bf16<32, 64>(const ushort2_t* reg_a, const ushort2_t* reg_b, float32_t* reg_c)
 {
 #if CK_USE_AMD_XDLOPS_INLINE_ASM
     (void)reg_c;
-    MFMA_F32_32x32x2BF16(0, reg_a, reg_b, 0, 0, 1)
+    MFMA_F32_32x32x2BF16(0, reg_a[0], reg_b[0], 1, 0, 0)
 #else
-    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x2bf16(reg_a, reg_b, reg_c[0], 0, 0, 1);
+    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x2bf16(reg_a[0], reg_b[0], reg_c[0], 1, 0, 0);
 #endif
 }
 
-__device__ void gcnasm_mfma_f32_32x32x4bf16(const ushort2_t& reg_a, const ushort2_t& reg_b, float16_t* reg_c)
+template <>
+__device__ void gcnasm_mfma_f32_32x32x2bf16<64, 32>(const ushort2_t* reg_a, const ushort2_t* reg_b, float32_t* reg_c)
 {
 #if CK_USE_AMD_XDLOPS_INLINE_ASM
     (void)reg_c;
-    MFMA_F32_32x32x4BF16(0, reg_a, reg_b, 0, 0, 0)
+    MFMA_F32_32x32x2BF16(0, reg_a[0], reg_b[0], 0, 0, 1)
 #else
-    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x4bf16(reg_a, reg_b, reg_c[0], 0, 0, 0);
+    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x2bf16(reg_a[0], reg_b[0], reg_c[0], 0, 0, 1);
 #endif
 }
 
-__device__ void gcnasm_mfma_f32_16x16x8bf16(const ushort2_t& reg_a, const ushort2_t& reg_b, float4_t* reg_c)
+__device__ void gcnasm_mfma_f32_32x32x4bf16(const ushort2_t* reg_a, const ushort2_t* reg_b, float16_t* reg_c)
 {
 #if CK_USE_AMD_XDLOPS_INLINE_ASM
     (void)reg_c;
-    MFMA_F32_16x16x8BF16(0, reg_a, reg_b, 0, 0, 0)
+    MFMA_F32_32x32x4BF16(0, reg_a[0], reg_b[0], 0, 0, 0)
 #else
-    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_16x16x8bf16(reg_a, reg_b, reg_c[0], 0, 0, 0);
+    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x4bf16(reg_a[0], reg_b[0], reg_c[0], 0, 0, 0);
+#endif
+}
+
+__device__ void gcnasm_mfma_f32_16x16x8bf16(const ushort2_t* reg_a, const ushort2_t* reg_b, float4_t* reg_c)
+{
+#if CK_USE_AMD_XDLOPS_INLINE_ASM
+    (void)reg_c;
+    MFMA_F32_16x16x8BF16(0, reg_a[0], reg_b[0], 0, 0, 0)
+#else
+    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_16x16x8bf16(reg_a[0], reg_b[0], reg_c[0], 0, 0, 0);
 #endif
 }
 
 template <index_t MPerWave, index_t NPerWave>
-__device__ void gcnasm_mfma_f32_16x16x2bf16(const ushort2_t& reg_a, const ushort2_t& reg_b, float16_t* reg_c);
+__device__ void gcnasm_mfma_f32_16x16x2bf16(const ushort2_t* reg_a, const ushort2_t* reg_b, float16_t* reg_c);
 
 template <>
-__device__ void gcnasm_mfma_f32_16x16x2bf16<16, 64>(const ushort2_t& reg_a, const ushort2_t& reg_b, float16_t* reg_c)
+__device__ void gcnasm_mfma_f32_16x16x2bf16<16, 64>(const ushort2_t* reg_a, const ushort2_t* reg_b, float16_t* reg_c)
 {
 #if CK_USE_AMD_XDLOPS_INLINE_ASM
     (void)reg_c;
-    MFMA_F32_16x16x2BF16(0, reg_a, reg_b, 2, 0, 0)
+    MFMA_F32_16x16x2BF16(0, reg_a[0], reg_b[0], 2, 0, 0)
 #else
-    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_16x16x2bf16(reg_a, reg_b, reg_c[0], 2, 0, 0);
+    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_16x16x2bf16(reg_a[0], reg_b[0], reg_c[0], 2, 0, 0);
 #endif
 }
 
 template <>
-__device__ void gcnasm_mfma_f32_16x16x2bf16<64, 16>(const ushort2_t& reg_a, const ushort2_t& reg_b, float16_t* reg_c)
+__device__ void gcnasm_mfma_f32_16x16x2bf16<64, 16>(const ushort2_t* reg_a, const ushort2_t* reg_b, float16_t* reg_c)
 {
 #if CK_USE_AMD_XDLOPS_INLINE_ASM
     (void)reg_c;
-    MFMA_F32_16x16x2BF16(0, reg_a, reg_b, 0, 0, 4)
+    MFMA_F32_16x16x2BF16(0, reg_a[0], reg_b[0], 0, 0, 4)
 #else
-    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_16x16x2bf16(reg_a, reg_b, reg_c[0], 0, 0, 4);
+    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_16x16x2bf16(reg_a[0], reg_b[0], reg_c[0], 0, 0, 4);
 #endif
 }
 
 template <index_t MPerWave, index_t NPerWave>
-__device__ void gcnasm_mfma_f32_4x4x2bf16(const ushort2_t& reg_a, const ushort2_t& reg_b, float4_t* reg_c);
+__device__ void gcnasm_mfma_f32_4x4x2bf16(const ushort2_t* reg_a, const ushort2_t* reg_b, float4_t* reg_c);
 
 template <>
-__device__ void gcnasm_mfma_f32_4x4x2bf16<4, 64>(const ushort2_t& reg_a, const ushort2_t& reg_b, float4_t* reg_c)
+__device__ void gcnasm_mfma_f32_4x4x2bf16<4, 64>(const ushort2_t* reg_a, const ushort2_t* reg_b, float4_t* reg_c)
 {
 #if CK_USE_AMD_XDLOPS_INLINE_ASM
     (void)reg_c;
-    MFMA_F32_4x4x2BF16(0, reg_a, reg_b, 4, 0, 0)
+    MFMA_F32_4x4x2BF16(0, reg_a[0], reg_b[0], 4, 0, 0)
 #else
-    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_4x4x2bf16(reg_a, reg_b, reg_c[0], 4, 0, 0);
+    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_4x4x2bf16(reg_a[0], reg_b[0], reg_c[0], 4, 0, 0);
 #endif
 }
 
 template <>
-__device__ void gcnasm_mfma_f32_4x4x2bf16<8, 64>(const ushort2_t& reg_a, const ushort2_t& reg_b, float4_t* reg_c)
+__device__ void gcnasm_mfma_f32_4x4x2bf16<8, 64>(const ushort2_t* reg_a, const ushort2_t* reg_b, float4_t* reg_c)
 {
 #if CK_USE_AMD_XDLOPS_INLINE_ASM
     (void)reg_c;
-    MFMA_F32_4x4x2BF16(0, reg_a, reg_b, 4, 0, 0)
-    MFMA_F32_4x4x2BF16(4, reg_a, reg_b, 4, 1, 0)
+    MFMA_F32_4x4x2BF16(0, reg_a[0], reg_b[0], 4, 0, 0)
+    MFMA_F32_4x4x2BF16(4, reg_a[0], reg_b[0], 4, 1, 0)
 #else
-    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_4x4x2bf16(reg_a, reg_b, reg_c[0], 4, 0, 0);
-    reg_c[1] = llvm_intrin_amdgcn_mfma_f32_4x4x2bf16(reg_a, reg_b, reg_c[1], 4, 1, 0);
+    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_4x4x2bf16(reg_a[0], reg_b[0], reg_c[0], 4, 0, 0);
+    reg_c[1] = llvm_intrin_amdgcn_mfma_f32_4x4x2bf16(reg_a[0], reg_b[0], reg_c[1], 4, 1, 0);
 #endif
 }
 // clang-format on

--- a/src/kernels/composable_kernel/include/utility/amd_xdlops_inline_asm.hpp
+++ b/src/kernels/composable_kernel/include/utility/amd_xdlops_inline_asm.hpp
@@ -4,9 +4,7 @@
 #include "float_type.hpp"
 
 namespace ck {
-
 // clang-format off
-
 #define REPEATx4(f, off) f(off) f(off + 1) f(off + 2) f(off + 3)
 
 #define REPEATx16(f, off) \
@@ -249,9 +247,8 @@ struct gcnasm_mfma_f32_32x32x1f32;
 template <index_t AStride, index_t BStride>
 struct gcnasm_mfma_f32_32x32x1f32<128, 128, AStride, BStride>
 {
-    __device__ void run(const float* reg_a, const float* reg_b, float32_t* reg_c)
+    __device__ void run(const float* reg_a, const float* reg_b)
     {
-        (void)reg_c;
         MFMA_F32_32x32x1F32(0,  reg_a[0],       reg_b[0], 1, 0, 0)
         MFMA_F32_32x32x1F32(32, reg_a[0],       reg_b[0], 1, 1, 0)
         MFMA_F32_32x32x1F32(64, reg_a[AStride], reg_b[0], 1, 0, 0)
@@ -267,9 +264,8 @@ struct gcnasm_mfma_f32_32x32x1f32<128, 128, AStride, BStride>
 template <index_t AStride, index_t BStride>
 struct gcnasm_mfma_f32_32x32x1f32<128, 64, AStride, BStride>
 {
-    __device__ void run(const float* reg_a, const float* reg_b, float32_t* reg_c)
+    __device__ void run(const float* reg_a, const float* reg_b)
     {
-        (void)reg_c;
         MFMA_F32_32x32x1F32(0,  reg_a[0], reg_b[0], 1, 0, 0)
         MFMA_F32_32x32x1F32(32, reg_a[0], reg_b[0], 1, 1, 0)
         MFMA_F32_32x32x1F32(64, reg_a[AStride], reg_b[0], 1, 0, 0)
@@ -280,9 +276,8 @@ struct gcnasm_mfma_f32_32x32x1f32<128, 64, AStride, BStride>
 template <index_t AStride, index_t BStride>
 struct gcnasm_mfma_f32_32x32x1f32<64, 128, AStride, BStride>
 {
-    __device__ void run(const float* reg_a, const float* reg_b, float32_t* reg_c)
+    __device__ void run(const float* reg_a, const float* reg_b)
     {
-        (void)reg_c;
         MFMA_F32_32x32x1F32(0,  reg_a[0], reg_b[0], 1, 0, 0)
         MFMA_F32_32x32x1F32(32, reg_a[0], reg_b[0], 1, 1, 0)
         MFMA_F32_32x32x1F32(64, reg_a[0], reg_b[BStride], 1, 0, 0)
@@ -293,9 +288,8 @@ struct gcnasm_mfma_f32_32x32x1f32<64, 128, AStride, BStride>
 template <index_t AStride, index_t BStride>
 struct gcnasm_mfma_f32_32x32x1f32<64, 64, AStride, BStride>
 {
-    __device__ void run(const float* reg_a, const float* reg_b, float32_t* reg_c)
+    __device__ void run(const float* reg_a, const float* reg_b)
     {
-        (void)reg_c;
         MFMA_F32_32x32x1F32(0, reg_a[0], reg_b[0], 1, 0, 0)
         MFMA_F32_32x32x1F32(32, reg_a[0], reg_b[0], 1, 1, 0)
     }
@@ -304,9 +298,8 @@ struct gcnasm_mfma_f32_32x32x1f32<64, 64, AStride, BStride>
 template <index_t AStride, index_t BStride>
 struct gcnasm_mfma_f32_32x32x1f32<32, 64, AStride, BStride>
 {
-    __device__ void run(const float* reg_a, const float* reg_b, float32_t* reg_c)
+    __device__ void run(const float* reg_a, const float* reg_b)
     {
-        (void)reg_c;
         MFMA_F32_32x32x1F32(0, reg_a[0], reg_b[0], 1, 0, 0)
     }
 };
@@ -314,56 +307,49 @@ struct gcnasm_mfma_f32_32x32x1f32<32, 64, AStride, BStride>
 template <index_t AStride, index_t BStride>
 struct gcnasm_mfma_f32_32x32x1f32<64, 32, AStride, BStride>
 {
-    __device__ void run(const float* reg_a, const float* reg_b, float32_t* reg_c)
+    __device__ void run(const float* reg_a, const float* reg_b)
     {
-        (void)reg_c;
         MFMA_F32_32x32x1F32(0, reg_a[0], reg_b[0], 0, 0, 1)
     }
 };
 
-__device__ void gcnasm_mfma_f32_32x32x2f32(const float* reg_a, const float* reg_b, float16_t* reg_c)
+__device__ void gcnasm_mfma_f32_32x32x2f32(const float* reg_a, const float* reg_b)
 {
-    (void)reg_c;
     MFMA_F32_32x32x2F32(0, reg_a[0], reg_b[0], 0, 0, 0)
 }
 
-__device__ void gcnasm_mfma_f32_16x16x4f32(const float* reg_a, const float* reg_b, float4_t* reg_c)
+__device__ void gcnasm_mfma_f32_16x16x4f32(const float* reg_a, const float* reg_b)
 {
-    (void)reg_c;
     MFMA_F32_16x16x4F32(0, reg_a[0], reg_b[0], 0, 0, 0)
 }
 
 template <index_t MPerWave, index_t NPerWave>
-__device__ void gcnasm_mfma_f32_16x16x1f32(const float* reg_a, const float* reg_b, float16_t* reg_c);
+__device__ void gcnasm_mfma_f32_16x16x1f32(const float* reg_a, const float* reg_b);
 
 template <>
-__device__ void gcnasm_mfma_f32_16x16x1f32<16, 64>(const float* reg_a, const float* reg_b, float16_t* reg_c)
+__device__ void gcnasm_mfma_f32_16x16x1f32<16, 64>(const float* reg_a, const float* reg_b)
 {
-    (void)reg_c;
     MFMA_F32_16x16x1F32(0, reg_a[0], reg_b[0], 2, 0, 0)
 }
 
 template <>
-__device__ void gcnasm_mfma_f32_16x16x1f32<64, 16>(const float* reg_a, const float* reg_b, float16_t* reg_c)
+__device__ void gcnasm_mfma_f32_16x16x1f32<64, 16>(const float* reg_a, const float* reg_b)
 {
-    (void)reg_c;
     MFMA_F32_16x16x1F32(0, reg_a[0], reg_b[0], 0, 0, 4)
 }
 
 template <index_t MPerWave, index_t NPerWave>
-__device__ void gcnasm_mfma_f32_4x4x1f32(const float* reg_a, const float* reg_b, float4_t* reg_c);
+__device__ void gcnasm_mfma_f32_4x4x1f32(const float* reg_a, const float* reg_b);
 
 template <>
-__device__ void gcnasm_mfma_f32_4x4x1f32<4, 64>(const float* reg_a, const float* reg_b, float4_t* reg_c)
+__device__ void gcnasm_mfma_f32_4x4x1f32<4, 64>(const float* reg_a, const float* reg_b)
 {
-    (void)reg_c;
     MFMA_F32_4x4x1F32(0, reg_a[0], reg_b[0], 4, 0, 0)
 }
 
 template <>
-__device__ void gcnasm_mfma_f32_4x4x1f32<8, 64>(const float* reg_a, const float* reg_b, float4_t* reg_c)
+__device__ void gcnasm_mfma_f32_4x4x1f32<8, 64>(const float* reg_a, const float* reg_b)
 {
-    (void)reg_c;
     MFMA_F32_4x4x1F32(0, reg_a[0], reg_b[0], 4, 0, 0)
     MFMA_F32_4x4x1F32(4, reg_a[0], reg_b[0], 4, 1, 0)
 }
@@ -374,9 +360,8 @@ struct gcnasm_mfma_f32_32x32x4f16;
 template <index_t AStride, index_t BStride>
 struct gcnasm_mfma_f32_32x32x4f16<128, 128, AStride, BStride>
 {
-    __device__ void run(const half4_t* reg_a, const half4_t* reg_b, float32_t* reg_c)
+    __device__ void run(const half4_t* reg_a, const half4_t* reg_b)
     {
-        (void)reg_c;
         MFMA_F32_32x32x4F16(0,  reg_a[0],       reg_b[0], 1, 0, 0)
         MFMA_F32_32x32x4F16(32, reg_a[0],       reg_b[0], 1, 1, 0)
         MFMA_F32_32x32x4F16(64, reg_a[AStride], reg_b[0], 1, 0, 0)
@@ -392,9 +377,8 @@ struct gcnasm_mfma_f32_32x32x4f16<128, 128, AStride, BStride>
 template <index_t AStride, index_t BStride>
 struct gcnasm_mfma_f32_32x32x4f16<128, 64, AStride, BStride>
 {
-    __device__ void run(const half4_t* reg_a, const half4_t* reg_b, float32_t* reg_c)
+    __device__ void run(const half4_t* reg_a, const half4_t* reg_b)
     {
-        (void)reg_c;
         MFMA_F32_32x32x4F16(0,  reg_a[0],       reg_b[0], 1, 0, 0)
         MFMA_F32_32x32x4F16(32, reg_a[0],       reg_b[0], 1, 1, 0)
         MFMA_F32_32x32x4F16(64, reg_a[AStride], reg_b[0], 1, 0, 0)
@@ -405,9 +389,8 @@ struct gcnasm_mfma_f32_32x32x4f16<128, 64, AStride, BStride>
 template <index_t AStride, index_t BStride>
 struct gcnasm_mfma_f32_32x32x4f16<64, 128, AStride, BStride>
 {
-    __device__ void run(const half4_t* reg_a, const half4_t* reg_b, float32_t* reg_c)
+    __device__ void run(const half4_t* reg_a, const half4_t* reg_b)
     {
-        (void)reg_c;
         MFMA_F32_32x32x4F16(0,  reg_a[0], reg_b[0], 1, 0, 0)
         MFMA_F32_32x32x4F16(32, reg_a[0], reg_b[0], 1, 1, 0)
         MFMA_F32_32x32x4F16(64, reg_a[0], reg_b[BStride], 1, 0, 0)
@@ -418,9 +401,8 @@ struct gcnasm_mfma_f32_32x32x4f16<64, 128, AStride, BStride>
 template <index_t AStride, index_t BStride>
 struct gcnasm_mfma_f32_32x32x4f16<64, 64, AStride, BStride>
 {
-    __device__ void run(const half4_t* reg_a, const half4_t* reg_b, float32_t* reg_c)
+    __device__ void run(const half4_t* reg_a, const half4_t* reg_b)
     {
-        (void)reg_c;
         MFMA_F32_32x32x4F16(0, reg_a[0], reg_b[0], 1, 0, 0)
         MFMA_F32_32x32x4F16(32, reg_a[0], reg_b[0], 1, 1, 0)
     }
@@ -429,9 +411,8 @@ struct gcnasm_mfma_f32_32x32x4f16<64, 64, AStride, BStride>
 template <index_t AStride, index_t BStride>
 struct gcnasm_mfma_f32_32x32x4f16<32, 64, AStride, BStride>
 {
-    __device__ void run(const half4_t* reg_a, const half4_t* reg_b, float32_t* reg_c)
+    __device__ void run(const half4_t* reg_a, const half4_t* reg_b)
     {
-        (void)reg_c;
         MFMA_F32_32x32x4F16(0, reg_a[0], reg_b[0], 1, 0, 0)
     }
 };
@@ -439,57 +420,50 @@ struct gcnasm_mfma_f32_32x32x4f16<32, 64, AStride, BStride>
 template <index_t AStride, index_t BStride>
 struct gcnasm_mfma_f32_32x32x4f16<64, 32, AStride, BStride>
 {
-    __device__ void run(const half4_t* reg_a, const half4_t* reg_b, float32_t* reg_c)
+    __device__ void run(const half4_t* reg_a, const half4_t* reg_b)
     {
-        (void)reg_c;
         MFMA_F32_32x32x4F16(0, reg_a[0], reg_b[0], 0, 0, 1)
     }
 };
 
-__device__ void gcnasm_mfma_f32_32x32x8f16(const half4_t* reg_a, const half4_t* reg_b, float16_t* reg_c)
+__device__ void gcnasm_mfma_f32_32x32x8f16(const half4_t* reg_a, const half4_t* reg_b)
 {
-    (void)reg_c;
     MFMA_F32_32x32x8F16(0, reg_a[0], reg_b[0], 0, 0, 0)
 }
 
-__device__ void gcnasm_mfma_f32_16x16x16f16(const half4_t* reg_a, const half4_t* reg_b, float4_t* reg_c)
+__device__ void gcnasm_mfma_f32_16x16x16f16(const half4_t* reg_a, const half4_t* reg_b)
 {
-    (void)reg_c;
     MFMA_F32_16x16x16F16(0, reg_a[0], reg_b[0], 0, 0, 0)
 }
 
 template <index_t MPerWave, index_t NPerWave>
-__device__ void gcnasm_mfma_f32_16x16x4f16(const half4_t* reg_a, const half4_t* reg_b, float16_t* reg_c);
+__device__ void gcnasm_mfma_f32_16x16x4f16(const half4_t* reg_a, const half4_t* reg_b);
 
 template <>
-__device__ void gcnasm_mfma_f32_16x16x4f16<16, 64>(const half4_t* reg_a, const half4_t* reg_b, float16_t* reg_c)
+__device__ void gcnasm_mfma_f32_16x16x4f16<16, 64>(const half4_t* reg_a, const half4_t* reg_b)
 {
-    (void)reg_c;
     MFMA_F32_16x16x4F16(0, reg_a[0], reg_b[0], 2, 0, 0)
 }
 
 template <>
-__device__ void gcnasm_mfma_f32_16x16x4f16<64, 16>(const half4_t* reg_a, const half4_t* reg_b, float16_t* reg_c)
+__device__ void gcnasm_mfma_f32_16x16x4f16<64, 16>(const half4_t* reg_a, const half4_t* reg_b)
 
 {
-    (void)reg_c;
     MFMA_F32_16x16x4F16(0, reg_a[0], reg_b[0], 0, 0, 4)
 }
 
 template <index_t MPerWave, index_t NPerWave>
-__device__ void gcnasm_mfma_f32_4x4x4f16(const half4_t* reg_a, const half4_t* reg_b, float4_t* reg_c);
+__device__ void gcnasm_mfma_f32_4x4x4f16(const half4_t* reg_a, const half4_t* reg_b);
 
 template <>
-__device__ void gcnasm_mfma_f32_4x4x4f16<4, 64>(const half4_t* reg_a, const half4_t* reg_b, float4_t* reg_c)
+__device__ void gcnasm_mfma_f32_4x4x4f16<4, 64>(const half4_t* reg_a, const half4_t* reg_b)
 {
-    (void)reg_c;
     MFMA_F32_4x4x4F16(0, reg_a[0], reg_b[0], 4, 0, 0)
 }
 
 template <>
-__device__ void gcnasm_mfma_f32_4x4x4f16<8, 64>(const half4_t* reg_a, const half4_t* reg_b, float4_t* reg_c)
+__device__ void gcnasm_mfma_f32_4x4x4f16<8, 64>(const half4_t* reg_a, const half4_t* reg_b)
 {
-    (void)reg_c;
     MFMA_F32_4x4x4F16(0, reg_a[0], reg_b[0], 4, 0, 0)
     MFMA_F32_4x4x4F16(4, reg_a[0], reg_b[0], 4, 1, 0)
 }
@@ -500,9 +474,8 @@ struct gcnasm_mfma_f32_32x32x2bf16;
 template <index_t AStride, index_t BStride>
 struct gcnasm_mfma_f32_32x32x2bf16<128, 128, AStride, BStride>
 {
-    __device__ void run(const ushort2_t* reg_a, const ushort2_t* reg_b, float32_t* reg_c)
+    __device__ void run(const ushort2_t* reg_a, const ushort2_t* reg_b)
     {
-        (void)reg_c;
         MFMA_F32_32x32x2BF16(0,  reg_a[0],       reg_b[0], 1, 0, 0)
         MFMA_F32_32x32x2BF16(32, reg_a[0],       reg_b[0], 1, 1, 0)
         MFMA_F32_32x32x2BF16(64, reg_a[AStride], reg_b[0], 1, 0, 0)
@@ -518,9 +491,8 @@ struct gcnasm_mfma_f32_32x32x2bf16<128, 128, AStride, BStride>
 template <index_t AStride, index_t BStride>
 struct gcnasm_mfma_f32_32x32x2bf16<128, 64, AStride, BStride>
 {
-    __device__ void run(const ushort2_t* reg_a, const ushort2_t* reg_b, float32_t* reg_c)
+    __device__ void run(const ushort2_t* reg_a, const ushort2_t* reg_b)
     {
-        (void)reg_c;
         MFMA_F32_32x32x2BF16(0,  reg_a[0],       reg_b[0], 1, 0, 0)
         MFMA_F32_32x32x2BF16(32, reg_a[0],       reg_b[0], 1, 1, 0)
         MFMA_F32_32x32x2BF16(64, reg_a[AStride], reg_b[0], 1, 0, 0)
@@ -531,9 +503,8 @@ struct gcnasm_mfma_f32_32x32x2bf16<128, 64, AStride, BStride>
 template <index_t AStride, index_t BStride>
 struct gcnasm_mfma_f32_32x32x2bf16<64, 128, AStride, BStride>
 {
-    __device__ void run(const ushort2_t* reg_a, const ushort2_t* reg_b, float32_t* reg_c)
+    __device__ void run(const ushort2_t* reg_a, const ushort2_t* reg_b)
     {
-        (void)reg_c;
         MFMA_F32_32x32x2BF16(0,  reg_a[0], reg_b[0], 1, 0, 0)
         MFMA_F32_32x32x2BF16(32, reg_a[0], reg_b[0], 1, 1, 0)
         MFMA_F32_32x32x2BF16(64, reg_a[0], reg_b[BStride], 1, 0, 0)
@@ -544,9 +515,8 @@ struct gcnasm_mfma_f32_32x32x2bf16<64, 128, AStride, BStride>
 template <index_t AStride, index_t BStride>
 struct gcnasm_mfma_f32_32x32x2bf16<64, 64, AStride, BStride>
 {
-    __device__ void run(const ushort2_t* reg_a, const ushort2_t* reg_b, float32_t* reg_c)
+    __device__ void run(const ushort2_t* reg_a, const ushort2_t* reg_b)
     {
-        (void)reg_c;
         MFMA_F32_32x32x2BF16(0, reg_a[0], reg_b[0], 1, 0, 0)
         MFMA_F32_32x32x2BF16(32, reg_a[0], reg_b[0], 1, 1, 0)
     }
@@ -555,9 +525,8 @@ struct gcnasm_mfma_f32_32x32x2bf16<64, 64, AStride, BStride>
 template <index_t AStride, index_t BStride>
 struct gcnasm_mfma_f32_32x32x2bf16<32, 64, AStride, BStride>
 {
-    __device__ void run(const ushort2_t* reg_a, const ushort2_t* reg_b, float32_t* reg_c)
+    __device__ void run(const ushort2_t* reg_a, const ushort2_t* reg_b)
     {
-        (void)reg_c;
         MFMA_F32_32x32x2BF16(0, reg_a[0], reg_b[0], 1, 0, 0)
     }
 };
@@ -565,60 +534,52 @@ struct gcnasm_mfma_f32_32x32x2bf16<32, 64, AStride, BStride>
 template <index_t AStride, index_t BStride>
 struct gcnasm_mfma_f32_32x32x2bf16<64, 32, AStride, BStride>
 {
-    __device__ void run(const ushort2_t* reg_a, const ushort2_t* reg_b, float32_t* reg_c)
+    __device__ void run(const ushort2_t* reg_a, const ushort2_t* reg_b)
     {
-        (void)reg_c;
         MFMA_F32_32x32x2BF16(0, reg_a[0], reg_b[0], 0, 0, 1)
     }
 };
 
-__device__ void gcnasm_mfma_f32_32x32x4bf16(const ushort2_t* reg_a, const ushort2_t* reg_b, float16_t* reg_c)
+__device__ void gcnasm_mfma_f32_32x32x4bf16(const ushort2_t* reg_a, const ushort2_t* reg_b)
 {
-    (void)reg_c;
     MFMA_F32_32x32x4BF16(0, reg_a[0], reg_b[0], 0, 0, 0)
 }
 
-__device__ void gcnasm_mfma_f32_16x16x8bf16(const ushort2_t* reg_a, const ushort2_t* reg_b, float4_t* reg_c)
+__device__ void gcnasm_mfma_f32_16x16x8bf16(const ushort2_t* reg_a, const ushort2_t* reg_b)
 {
-    (void)reg_c;
     MFMA_F32_16x16x8BF16(0, reg_a[0], reg_b[0], 0, 0, 0)
 }
 
 template <index_t MPerWave, index_t NPerWave>
-__device__ void gcnasm_mfma_f32_16x16x2bf16(const ushort2_t* reg_a, const ushort2_t* reg_b, float16_t* reg_c);
+__device__ void gcnasm_mfma_f32_16x16x2bf16(const ushort2_t* reg_a, const ushort2_t* reg_b);
 
 template <>
-__device__ void gcnasm_mfma_f32_16x16x2bf16<16, 64>(const ushort2_t* reg_a, const ushort2_t* reg_b, float16_t* reg_c)
+__device__ void gcnasm_mfma_f32_16x16x2bf16<16, 64>(const ushort2_t* reg_a, const ushort2_t* reg_b)
 {
-    (void)reg_c;
     MFMA_F32_16x16x2BF16(0, reg_a[0], reg_b[0], 2, 0, 0)
 }
 
 template <>
-__device__ void gcnasm_mfma_f32_16x16x2bf16<64, 16>(const ushort2_t* reg_a, const ushort2_t* reg_b, float16_t* reg_c)
+__device__ void gcnasm_mfma_f32_16x16x2bf16<64, 16>(const ushort2_t* reg_a, const ushort2_t* reg_b)
 {
-    (void)reg_c;
     MFMA_F32_16x16x2BF16(0, reg_a[0], reg_b[0], 0, 0, 4)
 }
 
 template <index_t MPerWave, index_t NPerWave>
-__device__ void gcnasm_mfma_f32_4x4x2bf16(const ushort2_t* reg_a, const ushort2_t* reg_b, float4_t* reg_c);
+__device__ void gcnasm_mfma_f32_4x4x2bf16(const ushort2_t* reg_a, const ushort2_t* reg_b);
 
 template <>
-__device__ void gcnasm_mfma_f32_4x4x2bf16<4, 64>(const ushort2_t* reg_a, const ushort2_t* reg_b, float4_t* reg_c)
+__device__ void gcnasm_mfma_f32_4x4x2bf16<4, 64>(const ushort2_t* reg_a, const ushort2_t* reg_b)
 {
-    (void)reg_c;
     MFMA_F32_4x4x2BF16(0, reg_a[0], reg_b[0], 4, 0, 0)
 }
 
 template <>
-__device__ void gcnasm_mfma_f32_4x4x2bf16<8, 64>(const ushort2_t* reg_a, const ushort2_t* reg_b, float4_t* reg_c)
+__device__ void gcnasm_mfma_f32_4x4x2bf16<8, 64>(const ushort2_t* reg_a, const ushort2_t* reg_b)
 {
-    (void)reg_c;
     MFMA_F32_4x4x2BF16(0, reg_a[0], reg_b[0], 4, 0, 0)
     MFMA_F32_4x4x2BF16(4, reg_a[0], reg_b[0], 4, 1, 0)
 }
-
 // clang-format on
 }
 #endif

--- a/src/kernels/composable_kernel/include/utility/amd_xdlops_inline_asm.hpp
+++ b/src/kernels/composable_kernel/include/utility/amd_xdlops_inline_asm.hpp
@@ -1,55 +1,9 @@
-#ifndef CK_AMD_XDLOPS_HPP
-#define CK_AMD_XDLOPS_HPP
+#ifndef CK_AMD_XDLOPS_INLINE_ASM_HPP
+#define CK_AMD_XDLOPS_INLINE_ASM_HPP
 
 #include "float_type.hpp"
 
 namespace ck {
-
-// A, B, C, cbsz, abid, blgp
-extern "C" __device__ float32_t llvm_intrin_amdgcn_mfma_f32_32x32x1f32(
-    float, float, float32_t, int, int, int) __asm("llvm.amdgcn.mfma.f32.32x32x1f32");
-
-extern "C" __device__ float16_t llvm_intrin_amdgcn_mfma_f32_32x32x2f32(
-    float, float, float16_t, int, int, int) __asm("llvm.amdgcn.mfma.f32.32x32x2f32");
-
-extern "C" __device__ float4_t llvm_intrin_amdgcn_mfma_f32_16x16x4f32(
-    float, float, float4_t, int, int, int) __asm("llvm.amdgcn.mfma.f32.16x16x4f32");
-
-extern "C" __device__ float16_t llvm_intrin_amdgcn_mfma_f32_16x16x1f32(
-    float, float, float16_t, int, int, int) __asm("llvm.amdgcn.mfma.f32.16x16x1f32");
-
-extern "C" __device__ float4_t llvm_intrin_amdgcn_mfma_f32_4x4x1f32(
-    float, float, float4_t, int, int, int) __asm("llvm.amdgcn.mfma.f32.4x4x1f32");
-
-extern "C" __device__ float32_t llvm_intrin_amdgcn_mfma_f32_32x32x4f16(
-    half4_t, half4_t, float32_t, int, int, int) __asm("llvm.amdgcn.mfma.f32.32x32x4f16");
-
-extern "C" __device__ float16_t llvm_intrin_amdgcn_mfma_f32_32x32x8f16(
-    half4_t, half4_t, float16_t, int, int, int) __asm("llvm.amdgcn.mfma.f32.32x32x8f16");
-
-extern "C" __device__ float4_t llvm_intrin_amdgcn_mfma_f32_16x16x16f16(
-    half4_t, half4_t, float4_t, int, int, int) __asm("llvm.amdgcn.mfma.f32.16x16x16f16");
-
-extern "C" __device__ float16_t llvm_intrin_amdgcn_mfma_f32_16x16x4f16(
-    half4_t, half4_t, float16_t, int, int, int) __asm("llvm.amdgcn.mfma.f32.16x16x4f16");
-
-extern "C" __device__ float4_t llvm_intrin_amdgcn_mfma_f32_4x4x4f16(
-    half4_t, half4_t, float4_t, int, int, int) __asm("llvm.amdgcn.mfma.f32.4x4x4f16");
-
-extern "C" __device__ float32_t llvm_intrin_amdgcn_mfma_f32_32x32x2bf16(
-    ushort2_t, ushort2_t, float32_t, int, int, int) __asm("llvm.amdgcn.mfma.f32.32x32x2bf16");
-
-extern "C" __device__ float16_t llvm_intrin_amdgcn_mfma_f32_32x32x4bf16(
-    ushort2_t, ushort2_t, float16_t, int, int, int) __asm("llvm.amdgcn.mfma.f32.32x32x4bf16");
-
-extern "C" __device__ float4_t llvm_intrin_amdgcn_mfma_f32_16x16x8bf16(
-    ushort2_t, ushort2_t, float4_t, int, int, int) __asm("llvm.amdgcn.mfma.f32.16x16x8bf16");
-
-extern "C" __device__ float16_t llvm_intrin_amdgcn_mfma_f32_16x16x2bf16(
-    ushort2_t, ushort2_t, float16_t, int, int, int) __asm("llvm.amdgcn.mfma.f32.16x16x2bf16");
-
-extern "C" __device__ float4_t llvm_intrin_amdgcn_mfma_f32_4x4x2bf16(
-    ushort2_t, ushort2_t, float4_t, int, int, int) __asm("llvm.amdgcn.mfma.f32.4x4x2bf16");
 
 // clang-format off
 
@@ -183,345 +137,40 @@ __device__ void gcnasm_accvgpr_read(float*);
 template <>
 __device__ void gcnasm_accvgpr_read<4>(float* arch_reg)
 {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
     REPEATx4(ACCVGPR_READ, 0)
-#else
-    (void)arch_reg;
-#endif
 }
 
 template <>
 __device__ void gcnasm_accvgpr_read<8>(float* arch_reg)
 {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
-#if 1
     REPEATx4(ACCVGPR_READ, 0)
     REPEATx4(ACCVGPR_READ, 4)
-#else
-  asm volatile("\
-      v_accvgpr_read_b32 %0,  a[ 0] \n \
-      v_accvgpr_read_b32 %1,  a[ 1] \n \
-      v_accvgpr_read_b32 %2,  a[ 2] \n \
-      v_accvgpr_read_b32 %3,  a[ 3] \n \
-      v_accvgpr_read_b32 %4,  a[ 4] \n \
-      v_accvgpr_read_b32 %5,  a[ 5] \n \
-      v_accvgpr_read_b32 %6,  a[ 6] \n \
-      v_accvgpr_read_b32 %7,  a[ 7] \n \
-      "
-      :
-      "=v"(arch_reg[ 0]),
-      "=v"(arch_reg[ 1]),
-      "=v"(arch_reg[ 2]),
-      "=v"(arch_reg[ 3]),
-      "=v"(arch_reg[ 4]),
-      "=v"(arch_reg[ 5]),
-      "=v"(arch_reg[ 6]),
-      "=v"(arch_reg[ 7])
-      :);
-#endif
-#else
-    (void)arch_reg;
-#endif
 }
 
 template <>
 __device__ void gcnasm_accvgpr_read<16>(float* arch_reg)
 {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
-#if 1
     REPEATx16(ACCVGPR_READ, 0)
-#else
-    asm volatile("\
-      v_accvgpr_read_b32 %0,  a[ 0] \n \
-      v_accvgpr_read_b32 %1,  a[ 1] \n \
-      v_accvgpr_read_b32 %2,  a[ 2] \n \
-      v_accvgpr_read_b32 %3,  a[ 3] \n \
-      v_accvgpr_read_b32 %4,  a[ 4] \n \
-      v_accvgpr_read_b32 %5,  a[ 5] \n \
-      v_accvgpr_read_b32 %6,  a[ 6] \n \
-      v_accvgpr_read_b32 %7,  a[ 7] \n \
-      v_accvgpr_read_b32 %8,  a[ 8] \n \
-      v_accvgpr_read_b32 %9,  a[ 9] \n \
-      v_accvgpr_read_b32 %10, a[10] \n \
-      v_accvgpr_read_b32 %11, a[11] \n \
-      v_accvgpr_read_b32 %12, a[12] \n \
-      v_accvgpr_read_b32 %13, a[13] \n \
-      v_accvgpr_read_b32 %14, a[14] \n \
-      v_accvgpr_read_b32 %15, a[15] \n \
-      "
-      :
-      "=v"(arch_reg[ 0]),
-      "=v"(arch_reg[ 1]),
-      "=v"(arch_reg[ 2]),
-      "=v"(arch_reg[ 3]),
-      "=v"(arch_reg[ 4]),
-      "=v"(arch_reg[ 5]),
-      "=v"(arch_reg[ 6]),
-      "=v"(arch_reg[ 7]),
-      "=v"(arch_reg[ 8]),
-      "=v"(arch_reg[ 9]),
-      "=v"(arch_reg[10]),
-      "=v"(arch_reg[11]),
-      "=v"(arch_reg[12]),
-      "=v"(arch_reg[13]),
-      "=v"(arch_reg[14]),
-      "=v"(arch_reg[15])
-      :);
-#endif
-#else
-    (void)arch_reg;
-#endif
 }
 
 template <>
 __device__ void gcnasm_accvgpr_read<32>(float* arch_reg)
 {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
-#if 1
     REPEATx16(ACCVGPR_READ, 0)
     REPEATx16(ACCVGPR_READ, 16)
-#else
-    asm volatile("\
-      v_accvgpr_read_b32 %0,  a[ 0] \n \
-      v_accvgpr_read_b32 %1,  a[ 1] \n \
-      v_accvgpr_read_b32 %2,  a[ 2] \n \
-      v_accvgpr_read_b32 %3,  a[ 3] \n \
-      v_accvgpr_read_b32 %4,  a[ 4] \n \
-      v_accvgpr_read_b32 %5,  a[ 5] \n \
-      v_accvgpr_read_b32 %6,  a[ 6] \n \
-      v_accvgpr_read_b32 %7,  a[ 7] \n \
-      v_accvgpr_read_b32 %8,  a[ 8] \n \
-      v_accvgpr_read_b32 %9,  a[ 9] \n \
-      v_accvgpr_read_b32 %10, a[10] \n \
-      v_accvgpr_read_b32 %11, a[11] \n \
-      v_accvgpr_read_b32 %12, a[12] \n \
-      v_accvgpr_read_b32 %13, a[13] \n \
-      v_accvgpr_read_b32 %14, a[14] \n \
-      v_accvgpr_read_b32 %15, a[15] \n \
-      v_accvgpr_read_b32 %16, a[16] \n \
-      v_accvgpr_read_b32 %17, a[17] \n \
-      v_accvgpr_read_b32 %18, a[18] \n \
-      v_accvgpr_read_b32 %19, a[19] \n \
-      v_accvgpr_read_b32 %20, a[20] \n \
-      v_accvgpr_read_b32 %21, a[21] \n \
-      v_accvgpr_read_b32 %22, a[22] \n \
-      v_accvgpr_read_b32 %23, a[23] \n \
-      v_accvgpr_read_b32 %24, a[24] \n \
-      v_accvgpr_read_b32 %25, a[25] \n \
-      v_accvgpr_read_b32 %26, a[26] \n \
-      v_accvgpr_read_b32 %27, a[27] \n \
-      v_accvgpr_read_b32 %28, a[28] \n \
-      v_accvgpr_read_b32 %29, a[29] \n \
-      v_accvgpr_read_b32 %30, a[30] \n \
-      v_accvgpr_read_b32 %31, a[31] \n \
-      "
-      :
-      "=v"(arch_reg[ 0]),
-      "=v"(arch_reg[ 1]),
-      "=v"(arch_reg[ 2]),
-      "=v"(arch_reg[ 3]),
-      "=v"(arch_reg[ 4]),
-      "=v"(arch_reg[ 5]),
-      "=v"(arch_reg[ 6]),
-      "=v"(arch_reg[ 7]),
-      "=v"(arch_reg[ 8]),
-      "=v"(arch_reg[ 9]),
-      "=v"(arch_reg[10]),
-      "=v"(arch_reg[11]),
-      "=v"(arch_reg[12]),
-      "=v"(arch_reg[13]),
-      "=v"(arch_reg[14]),
-      "=v"(arch_reg[15]),
-      "=v"(arch_reg[16]),
-      "=v"(arch_reg[17]),
-      "=v"(arch_reg[18]),
-      "=v"(arch_reg[19]),
-      "=v"(arch_reg[20]),
-      "=v"(arch_reg[21]),
-      "=v"(arch_reg[22]),
-      "=v"(arch_reg[23]),
-      "=v"(arch_reg[24]),
-      "=v"(arch_reg[25]),
-      "=v"(arch_reg[26]),
-      "=v"(arch_reg[27]),
-      "=v"(arch_reg[28]),
-      "=v"(arch_reg[29]),
-      "=v"(arch_reg[30]),
-      "=v"(arch_reg[31])
-      :);
-#endif
-#else
-    (void)arch_reg;
-#endif
 }
 
 template <>
 __device__ void gcnasm_accvgpr_read<64>(float* arch_reg)
 {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
-#if 1
     REPEATx64(ACCVGPR_READ, 0)
-#else
-    asm volatile("\
-      v_accvgpr_read_b32 %0,  a[ 0] \n \
-      v_accvgpr_read_b32 %1,  a[ 1] \n \
-      v_accvgpr_read_b32 %2,  a[ 2] \n \
-      v_accvgpr_read_b32 %3,  a[ 3] \n \
-      v_accvgpr_read_b32 %4,  a[ 4] \n \
-      v_accvgpr_read_b32 %5,  a[ 5] \n \
-      v_accvgpr_read_b32 %6,  a[ 6] \n \
-      v_accvgpr_read_b32 %7,  a[ 7] \n \
-      v_accvgpr_read_b32 %8,  a[ 8] \n \
-      v_accvgpr_read_b32 %9,  a[ 9] \n \
-      v_accvgpr_read_b32 %10, a[10] \n \
-      v_accvgpr_read_b32 %11, a[11] \n \
-      v_accvgpr_read_b32 %12, a[12] \n \
-      v_accvgpr_read_b32 %13, a[13] \n \
-      v_accvgpr_read_b32 %14, a[14] \n \
-      v_accvgpr_read_b32 %15, a[15] \n \
-      v_accvgpr_read_b32 %16, a[16] \n \
-      v_accvgpr_read_b32 %17, a[17] \n \
-      v_accvgpr_read_b32 %18, a[18] \n \
-      v_accvgpr_read_b32 %19, a[19] \n \
-      v_accvgpr_read_b32 %20, a[20] \n \
-      v_accvgpr_read_b32 %21, a[21] \n \
-      v_accvgpr_read_b32 %22, a[22] \n \
-      v_accvgpr_read_b32 %23, a[23] \n \
-      v_accvgpr_read_b32 %24, a[24] \n \
-      v_accvgpr_read_b32 %25, a[25] \n \
-      v_accvgpr_read_b32 %26, a[26] \n \
-      v_accvgpr_read_b32 %27, a[27] \n \
-      v_accvgpr_read_b32 %28, a[28] \n \
-      v_accvgpr_read_b32 %29, a[29] \n \
-      v_accvgpr_read_b32 %30, a[30] \n \
-      v_accvgpr_read_b32 %31, a[31] \n \
-      v_accvgpr_read_b32 %32, a[32] \n \
-      v_accvgpr_read_b32 %33, a[33] \n \
-      v_accvgpr_read_b32 %34, a[34] \n \
-      v_accvgpr_read_b32 %35, a[35] \n \
-      v_accvgpr_read_b32 %36, a[36] \n \
-      v_accvgpr_read_b32 %37, a[37] \n \
-      v_accvgpr_read_b32 %38, a[38] \n \
-      v_accvgpr_read_b32 %39, a[39] \n \
-      v_accvgpr_read_b32 %40, a[40] \n \
-      v_accvgpr_read_b32 %41, a[41] \n \
-      v_accvgpr_read_b32 %42, a[42] \n \
-      v_accvgpr_read_b32 %43, a[43] \n \
-      v_accvgpr_read_b32 %44, a[44] \n \
-      v_accvgpr_read_b32 %45, a[45] \n \
-      v_accvgpr_read_b32 %46, a[46] \n \
-      v_accvgpr_read_b32 %47, a[47] \n \
-      v_accvgpr_read_b32 %48, a[48] \n \
-      v_accvgpr_read_b32 %49, a[49] \n \
-      v_accvgpr_read_b32 %50, a[50] \n \
-      v_accvgpr_read_b32 %51, a[51] \n \
-      v_accvgpr_read_b32 %52, a[52] \n \
-      v_accvgpr_read_b32 %53, a[53] \n \
-      v_accvgpr_read_b32 %54, a[54] \n \
-      v_accvgpr_read_b32 %55, a[55] \n \
-      v_accvgpr_read_b32 %56, a[56] \n \
-      v_accvgpr_read_b32 %57, a[57] \n \
-      v_accvgpr_read_b32 %58, a[58] \n \
-      v_accvgpr_read_b32 %59, a[59] \n \
-      v_accvgpr_read_b32 %60, a[60] \n \
-      v_accvgpr_read_b32 %61, a[61] \n \
-      v_accvgpr_read_b32 %62, a[62] \n \
-      v_accvgpr_read_b32 %63, a[63] \n \
-      "
-      :
-      "=v"(arch_reg[ 0]),
-      "=v"(arch_reg[ 1]),
-      "=v"(arch_reg[ 2]),
-      "=v"(arch_reg[ 3]),
-      "=v"(arch_reg[ 4]),
-      "=v"(arch_reg[ 5]),
-      "=v"(arch_reg[ 6]),
-      "=v"(arch_reg[ 7]),
-      "=v"(arch_reg[ 8]),
-      "=v"(arch_reg[ 9]),
-      "=v"(arch_reg[10]),
-      "=v"(arch_reg[11]),
-      "=v"(arch_reg[12]),
-      "=v"(arch_reg[13]),
-      "=v"(arch_reg[14]),
-      "=v"(arch_reg[15]),
-      "=v"(arch_reg[16]),
-      "=v"(arch_reg[17]),
-      "=v"(arch_reg[18]),
-      "=v"(arch_reg[19]),
-      "=v"(arch_reg[20]),
-      "=v"(arch_reg[21]),
-      "=v"(arch_reg[22]),
-      "=v"(arch_reg[23]),
-      "=v"(arch_reg[24]),
-      "=v"(arch_reg[25]),
-      "=v"(arch_reg[26]),
-      "=v"(arch_reg[27]),
-      "=v"(arch_reg[28]),
-      "=v"(arch_reg[29]),
-      "=v"(arch_reg[30]),
-      "=v"(arch_reg[31]),
-      "=v"(arch_reg[32]),
-      "=v"(arch_reg[33]),
-      "=v"(arch_reg[34]),
-      "=v"(arch_reg[35]),
-      "=v"(arch_reg[36]),
-      "=v"(arch_reg[37]),
-      "=v"(arch_reg[38]),
-      "=v"(arch_reg[39]),
-      "=v"(arch_reg[40]),
-      "=v"(arch_reg[41]),
-      "=v"(arch_reg[42]),
-      "=v"(arch_reg[43]),
-      "=v"(arch_reg[44]),
-      "=v"(arch_reg[45]),
-      "=v"(arch_reg[46]),
-      "=v"(arch_reg[47]),
-      "=v"(arch_reg[48]),
-      "=v"(arch_reg[49]),
-      "=v"(arch_reg[50]),
-      "=v"(arch_reg[51]),
-      "=v"(arch_reg[52]),
-      "=v"(arch_reg[53]),
-      "=v"(arch_reg[54]),
-      "=v"(arch_reg[55]),
-      "=v"(arch_reg[56]),
-      "=v"(arch_reg[57]),
-      "=v"(arch_reg[58]),
-      "=v"(arch_reg[59]),
-      "=v"(arch_reg[60]),
-      "=v"(arch_reg[61]),
-      "=v"(arch_reg[62]),
-      "=v"(arch_reg[63])
-      :);
-#endif
-#else
-    (void)arch_reg;
-#endif
 }
 
 template <>
 __device__ void gcnasm_accvgpr_read<128>(float* arch_reg)
 {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
     REPEATx64(ACCVGPR_READ, 0)
     REPEATx64(ACCVGPR_READ, 64)
-#else
-    (void)arch_reg;
-#endif
-}
-
-template <>
-__device__ void gcnasm_accvgpr_read<256>(float* arch_reg)
-{
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
-    REPEATx64(ACCVGPR_READ, 0)
-    REPEATx64(ACCVGPR_READ, 64)
-    REPEATx64(ACCVGPR_READ, 128)
-    REPEATx64(ACCVGPR_READ, 192)
-#else
-    (void)arch_reg;
-#endif
 }
 
 template <index_t MPerWave>
@@ -530,70 +179,46 @@ __device__ void gcnasm_accvgpr_zero();
 template <>
 __device__ void gcnasm_accvgpr_zero<4>()
 {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
     REPEATx4(ACCVGPR_ZERO, 0)
     S_NOP(1)
-#endif
 }
 
 template <>
 __device__ void gcnasm_accvgpr_zero<8>()
 {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
     REPEATx4(ACCVGPR_ZERO, 0)
     REPEATx4(ACCVGPR_ZERO, 4)
     S_NOP(1)
-#endif
 }
 
 template <>
 __device__ void gcnasm_accvgpr_zero<16>()
 {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
     REPEATx16(ACCVGPR_ZERO, 0)
     S_NOP(1)
-#endif
 }
 
 template <>
 __device__ void gcnasm_accvgpr_zero<32>()
 {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
     REPEATx16(ACCVGPR_ZERO, 0)
     REPEATx16(ACCVGPR_ZERO, 16)
     S_NOP(1)
-#endif
 }
 
 template <>
 __device__ void gcnasm_accvgpr_zero<64>()
 {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
     REPEATx64(ACCVGPR_ZERO, 0)
     S_NOP(1)
-#endif
 }
 
 template <>
 __device__ void gcnasm_accvgpr_zero<128>()
 {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
     REPEATx64(ACCVGPR_ZERO, 0)
     REPEATx64(ACCVGPR_ZERO, 64)
     S_NOP(1)
-#endif
-}
-
-template <>
-__device__ void gcnasm_accvgpr_zero<256>()
-{
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
-    REPEATx64(ACCVGPR_ZERO, 0)
-    REPEATx64(ACCVGPR_ZERO, 64)
-    REPEATx64(ACCVGPR_ZERO, 128)
-    REPEATx64(ACCVGPR_ZERO, 196)
-    S_NOP(1)
-#endif
 }
 
 template <index_t Cycles>
@@ -602,26 +227,20 @@ __device__ void gcnasm_nop();
 template <>
 __device__ void gcnasm_nop<8>()
 {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
     S_NOP(3)
-#endif
 }
 
 template <>
 __device__ void gcnasm_nop<32>()
 {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
     S_NOP(9)
-#endif
 }
 
 template <>
 __device__ void gcnasm_nop<64>()
 {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
     S_NOP(8)
     S_NOP(8)
-#endif
 }
 
 template <index_t MPerWave, index_t NPerWave, index_t AStride, index_t BStride>
@@ -632,7 +251,6 @@ struct gcnasm_mfma_f32_32x32x1f32<128, 128, AStride, BStride>
 {
     __device__ void run(const float* reg_a, const float* reg_b, float32_t* reg_c)
     {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
         (void)reg_c;
         MFMA_F32_32x32x1F32(0,  reg_a[0],       reg_b[0], 1, 0, 0)
         MFMA_F32_32x32x1F32(32, reg_a[0],       reg_b[0], 1, 1, 0)
@@ -643,17 +261,6 @@ struct gcnasm_mfma_f32_32x32x1f32<128, 128, AStride, BStride>
         MFMA_F32_32x32x1F32(160, reg_a[0],       reg_b[BStride], 1, 1, 0)
         MFMA_F32_32x32x1F32(192, reg_a[AStride], reg_b[BStride], 1, 0, 0)
         MFMA_F32_32x32x1F32(224, reg_a[AStride], reg_b[BStride], 1, 1, 0)
-#else
-        reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x1f32(reg_a[0],       reg_b[0], reg_c[0], 1, 0, 0);
-        reg_c[1] = llvm_intrin_amdgcn_mfma_f32_32x32x1f32(reg_a[0],       reg_b[0], reg_c[1], 1, 1, 0);
-        reg_c[2] = llvm_intrin_amdgcn_mfma_f32_32x32x1f32(reg_a[AStride], reg_b[0], reg_c[2], 1, 0, 0);
-        reg_c[3] = llvm_intrin_amdgcn_mfma_f32_32x32x1f32(reg_a[BStride], reg_b[0], reg_c[3], 1, 1, 0);
-
-        reg_c[4] = llvm_intrin_amdgcn_mfma_f32_32x32x1f32(reg_a[0],       reg_b[BStride], reg_c[4], 1, 0, 0);
-        reg_c[5] = llvm_intrin_amdgcn_mfma_f32_32x32x1f32(reg_a[0],       reg_b[BStride], reg_c[5], 1, 1, 0);
-        reg_c[6] = llvm_intrin_amdgcn_mfma_f32_32x32x1f32(reg_a[AStride], reg_b[BStride], reg_c[6], 1, 0, 0);
-        reg_c[7] = llvm_intrin_amdgcn_mfma_f32_32x32x1f32(reg_a[BStride], reg_b[BStride], reg_c[7], 1, 1, 0);
-#endif
     }
 };
 
@@ -662,18 +269,11 @@ struct gcnasm_mfma_f32_32x32x1f32<128, 64, AStride, BStride>
 {
     __device__ void run(const float* reg_a, const float* reg_b, float32_t* reg_c)
     {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
         (void)reg_c;
         MFMA_F32_32x32x1F32(0,  reg_a[0], reg_b[0], 1, 0, 0)
         MFMA_F32_32x32x1F32(32, reg_a[0], reg_b[0], 1, 1, 0)
         MFMA_F32_32x32x1F32(64, reg_a[AStride], reg_b[0], 1, 0, 0)
         MFMA_F32_32x32x1F32(96, reg_a[AStride], reg_b[0], 1, 1, 0)
-#else
-        reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x1f32(reg_a[0], reg_b[0], reg_c[0], 1, 0, 0);
-        reg_c[1] = llvm_intrin_amdgcn_mfma_f32_32x32x1f32(reg_a[0], reg_b[0], reg_c[1], 1, 1, 0);
-        reg_c[2] = llvm_intrin_amdgcn_mfma_f32_32x32x1f32(reg_a[AStride], reg_b[0], reg_c[2], 1, 0, 0);
-        reg_c[3] = llvm_intrin_amdgcn_mfma_f32_32x32x1f32(reg_a[BStride], reg_b[0], reg_c[3], 1, 1, 0);
-#endif
     }
 };
 
@@ -682,18 +282,11 @@ struct gcnasm_mfma_f32_32x32x1f32<64, 128, AStride, BStride>
 {
     __device__ void run(const float* reg_a, const float* reg_b, float32_t* reg_c)
     {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
         (void)reg_c;
         MFMA_F32_32x32x1F32(0,  reg_a[0], reg_b[0], 1, 0, 0)
         MFMA_F32_32x32x1F32(32, reg_a[0], reg_b[0], 1, 1, 0)
         MFMA_F32_32x32x1F32(64, reg_a[0], reg_b[BStride], 1, 0, 0)
         MFMA_F32_32x32x1F32(96, reg_a[0], reg_b[BStride], 1, 1, 0)
-#else
-        reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x1f32(reg_a[0], reg_b[0], reg_c[0], 1, 0, 0);
-        reg_c[1] = llvm_intrin_amdgcn_mfma_f32_32x32x1f32(reg_a[0], reg_b[0], reg_c[1], 1, 1, 0);
-        reg_c[2] = llvm_intrin_amdgcn_mfma_f32_32x32x1f32(reg_a[0], reg_b[BStride], reg_c[2], 1, 0, 0);
-        reg_c[3] = llvm_intrin_amdgcn_mfma_f32_32x32x1f32(reg_a[0], reg_b[BStride], reg_c[3], 1, 1, 0);
-#endif
     }
 };
 
@@ -702,14 +295,9 @@ struct gcnasm_mfma_f32_32x32x1f32<64, 64, AStride, BStride>
 {
     __device__ void run(const float* reg_a, const float* reg_b, float32_t* reg_c)
     {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
         (void)reg_c;
         MFMA_F32_32x32x1F32(0, reg_a[0], reg_b[0], 1, 0, 0)
         MFMA_F32_32x32x1F32(32, reg_a[0], reg_b[0], 1, 1, 0)
-#else
-        reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x1f32(reg_a[0], reg_b[0], reg_c[0], 1, 0, 0);
-        reg_c[1] = llvm_intrin_amdgcn_mfma_f32_32x32x1f32(reg_a[0], reg_b[0], reg_c[1], 1, 1, 0);
-#endif
     }
 };
 
@@ -718,12 +306,8 @@ struct gcnasm_mfma_f32_32x32x1f32<32, 64, AStride, BStride>
 {
     __device__ void run(const float* reg_a, const float* reg_b, float32_t* reg_c)
     {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
         (void)reg_c;
         MFMA_F32_32x32x1F32(0, reg_a[0], reg_b[0], 1, 0, 0)
-#else
-        reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x1f32(reg_a[0], reg_b[0], reg_c[0], 1, 0, 0);
-#endif
     }
 };
 
@@ -732,33 +316,21 @@ struct gcnasm_mfma_f32_32x32x1f32<64, 32, AStride, BStride>
 {
     __device__ void run(const float* reg_a, const float* reg_b, float32_t* reg_c)
     {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
         (void)reg_c;
         MFMA_F32_32x32x1F32(0, reg_a[0], reg_b[0], 0, 0, 1)
-#else
-        reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x1f32(reg_a[0], reg_b[0], reg_c[0], 0, 0, 1);
-#endif
     }
 };
 
 __device__ void gcnasm_mfma_f32_32x32x2f32(const float* reg_a, const float* reg_b, float16_t* reg_c)
 {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
     (void)reg_c;
     MFMA_F32_32x32x2F32(0, reg_a[0], reg_b[0], 0, 0, 0)
-#else
-    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x2f32(reg_a[0], reg_b[0], reg_c[0], 0, 0, 0);
-#endif
 }
 
 __device__ void gcnasm_mfma_f32_16x16x4f32(const float* reg_a, const float* reg_b, float4_t* reg_c)
 {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
     (void)reg_c;
     MFMA_F32_16x16x4F32(0, reg_a[0], reg_b[0], 0, 0, 0)
-#else
-    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_16x16x4f32(reg_a[0], reg_b[0], reg_c[0], 0, 0, 0);
-#endif
 }
 
 template <index_t MPerWave, index_t NPerWave>
@@ -767,23 +339,15 @@ __device__ void gcnasm_mfma_f32_16x16x1f32(const float* reg_a, const float* reg_
 template <>
 __device__ void gcnasm_mfma_f32_16x16x1f32<16, 64>(const float* reg_a, const float* reg_b, float16_t* reg_c)
 {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
     (void)reg_c;
     MFMA_F32_16x16x1F32(0, reg_a[0], reg_b[0], 2, 0, 0)
-#else
-    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_16x16x1f32(reg_a[0], reg_b[0], reg_c[0], 2, 0, 0);
-#endif
 }
 
 template <>
 __device__ void gcnasm_mfma_f32_16x16x1f32<64, 16>(const float* reg_a, const float* reg_b, float16_t* reg_c)
 {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
     (void)reg_c;
     MFMA_F32_16x16x1F32(0, reg_a[0], reg_b[0], 0, 0, 4)
-#else
-    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_16x16x1f32(reg_a[0], reg_b[0], reg_c[0], 0, 0, 4);
-#endif
 }
 
 template <index_t MPerWave, index_t NPerWave>
@@ -792,25 +356,16 @@ __device__ void gcnasm_mfma_f32_4x4x1f32(const float* reg_a, const float* reg_b,
 template <>
 __device__ void gcnasm_mfma_f32_4x4x1f32<4, 64>(const float* reg_a, const float* reg_b, float4_t* reg_c)
 {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
     (void)reg_c;
     MFMA_F32_4x4x1F32(0, reg_a[0], reg_b[0], 4, 0, 0)
-#else
-    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_4x4x1f32(reg_a[0], reg_b[0], reg_c[0], 4, 0, 0);
-#endif
 }
 
 template <>
 __device__ void gcnasm_mfma_f32_4x4x1f32<8, 64>(const float* reg_a, const float* reg_b, float4_t* reg_c)
 {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
     (void)reg_c;
     MFMA_F32_4x4x1F32(0, reg_a[0], reg_b[0], 4, 0, 0)
     MFMA_F32_4x4x1F32(4, reg_a[0], reg_b[0], 4, 1, 0)
-#else
-    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_4x4x1f32(reg_a[0], reg_b[0], reg_c[0], 4, 0, 0);
-    reg_c[1] = llvm_intrin_amdgcn_mfma_f32_4x4x1f32(reg_a[0], reg_b[0], reg_c[1], 4, 1, 0);
-#endif
 }
 
 template <index_t MPerWave, index_t NPerWave, index_t AStride, index_t BStride>
@@ -821,7 +376,6 @@ struct gcnasm_mfma_f32_32x32x4f16<128, 128, AStride, BStride>
 {
     __device__ void run(const half4_t* reg_a, const half4_t* reg_b, float32_t* reg_c)
     {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
         (void)reg_c;
         MFMA_F32_32x32x4F16(0,  reg_a[0],       reg_b[0], 1, 0, 0)
         MFMA_F32_32x32x4F16(32, reg_a[0],       reg_b[0], 1, 1, 0)
@@ -832,17 +386,6 @@ struct gcnasm_mfma_f32_32x32x4f16<128, 128, AStride, BStride>
         MFMA_F32_32x32x4F16(160, reg_a[0],       reg_b[BStride], 1, 1, 0)
         MFMA_F32_32x32x4F16(192, reg_a[AStride], reg_b[BStride], 1, 0, 0)
         MFMA_F32_32x32x4F16(224, reg_a[AStride], reg_b[BStride], 1, 1, 0)
-#else
-        reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x4f16(reg_a[0],       reg_b[0], reg_c[0], 1, 0, 0);
-        reg_c[1] = llvm_intrin_amdgcn_mfma_f32_32x32x4f16(reg_a[0],       reg_b[0], reg_c[1], 1, 1, 0);
-        reg_c[2] = llvm_intrin_amdgcn_mfma_f32_32x32x4f16(reg_a[AStride], reg_b[0], reg_c[2], 1, 0, 0);
-        reg_c[3] = llvm_intrin_amdgcn_mfma_f32_32x32x4f16(reg_a[AStride], reg_b[0], reg_c[3], 1, 1, 0);
-
-        reg_c[4] = llvm_intrin_amdgcn_mfma_f32_32x32x4f16(reg_a[0],       reg_b[BStride], reg_c[4], 1, 0, 0);
-        reg_c[5] = llvm_intrin_amdgcn_mfma_f32_32x32x4f16(reg_a[0],       reg_b[BStride], reg_c[5], 1, 1, 0);
-        reg_c[6] = llvm_intrin_amdgcn_mfma_f32_32x32x4f16(reg_a[AStride], reg_b[BStride], reg_c[6], 1, 0, 0);
-        reg_c[7] = llvm_intrin_amdgcn_mfma_f32_32x32x4f16(reg_a[AStride], reg_b[BStride], reg_c[7], 1, 1, 0);
-#endif
     }
 };
 
@@ -851,18 +394,11 @@ struct gcnasm_mfma_f32_32x32x4f16<128, 64, AStride, BStride>
 {
     __device__ void run(const half4_t* reg_a, const half4_t* reg_b, float32_t* reg_c)
     {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
         (void)reg_c;
         MFMA_F32_32x32x4F16(0,  reg_a[0],       reg_b[0], 1, 0, 0)
         MFMA_F32_32x32x4F16(32, reg_a[0],       reg_b[0], 1, 1, 0)
         MFMA_F32_32x32x4F16(64, reg_a[AStride], reg_b[0], 1, 0, 0)
         MFMA_F32_32x32x4F16(96, reg_a[AStride], reg_b[0], 1, 1, 0)
-#else
-        reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x4f16(reg_a[0],       reg_b[0], reg_c[0], 1, 0, 0);
-        reg_c[1] = llvm_intrin_amdgcn_mfma_f32_32x32x4f16(reg_a[0],       reg_b[0], reg_c[1], 1, 1, 0);
-        reg_c[2] = llvm_intrin_amdgcn_mfma_f32_32x32x4f16(reg_a[AStride], reg_b[0], reg_c[2], 1, 0, 0);
-        reg_c[3] = llvm_intrin_amdgcn_mfma_f32_32x32x4f16(reg_a[AStride], reg_b[0], reg_c[3], 1, 1, 0);
-#endif
     }
 };
 
@@ -871,18 +407,11 @@ struct gcnasm_mfma_f32_32x32x4f16<64, 128, AStride, BStride>
 {
     __device__ void run(const half4_t* reg_a, const half4_t* reg_b, float32_t* reg_c)
     {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
         (void)reg_c;
         MFMA_F32_32x32x4F16(0,  reg_a[0], reg_b[0], 1, 0, 0)
         MFMA_F32_32x32x4F16(32, reg_a[0], reg_b[0], 1, 1, 0)
         MFMA_F32_32x32x4F16(64, reg_a[0], reg_b[BStride], 1, 0, 0)
         MFMA_F32_32x32x4F16(96, reg_a[0], reg_b[BStride], 1, 1, 0)
-#else
-        reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x4f16(reg_a[0], reg_b[0], reg_c[0], 1, 0, 0);
-        reg_c[1] = llvm_intrin_amdgcn_mfma_f32_32x32x4f16(reg_a[0], reg_b[0], reg_c[1], 1, 1, 0);
-        reg_c[2] = llvm_intrin_amdgcn_mfma_f32_32x32x4f16(reg_a[0], reg_b[BStride], reg_c[2], 1, 0, 0);
-        reg_c[3] = llvm_intrin_amdgcn_mfma_f32_32x32x4f16(reg_a[0], reg_b[BStride], reg_c[3], 1, 1, 0);
-#endif
     }
 };
 
@@ -891,14 +420,9 @@ struct gcnasm_mfma_f32_32x32x4f16<64, 64, AStride, BStride>
 {
     __device__ void run(const half4_t* reg_a, const half4_t* reg_b, float32_t* reg_c)
     {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
         (void)reg_c;
         MFMA_F32_32x32x4F16(0, reg_a[0], reg_b[0], 1, 0, 0)
         MFMA_F32_32x32x4F16(32, reg_a[0], reg_b[0], 1, 1, 0)
-#else
-        reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x4f16(reg_a[0], reg_b[0], reg_c[0], 1, 0, 0);
-        reg_c[1] = llvm_intrin_amdgcn_mfma_f32_32x32x4f16(reg_a[0], reg_b[0], reg_c[1], 1, 1, 0);
-#endif
     }
 };
 
@@ -907,12 +431,8 @@ struct gcnasm_mfma_f32_32x32x4f16<32, 64, AStride, BStride>
 {
     __device__ void run(const half4_t* reg_a, const half4_t* reg_b, float32_t* reg_c)
     {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
         (void)reg_c;
         MFMA_F32_32x32x4F16(0, reg_a[0], reg_b[0], 1, 0, 0)
-#else
-        reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x4f16(reg_a[0], reg_b[0], reg_c[0], 1, 0, 0);
-#endif
     }
 };
 
@@ -921,33 +441,21 @@ struct gcnasm_mfma_f32_32x32x4f16<64, 32, AStride, BStride>
 {
     __device__ void run(const half4_t* reg_a, const half4_t* reg_b, float32_t* reg_c)
     {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
         (void)reg_c;
         MFMA_F32_32x32x4F16(0, reg_a[0], reg_b[0], 0, 0, 1)
-#else
-        reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x4f16(reg_a[0], reg_b[0], reg_c[0], 0, 0, 1);
-#endif
     }
 };
 
 __device__ void gcnasm_mfma_f32_32x32x8f16(const half4_t* reg_a, const half4_t* reg_b, float16_t* reg_c)
 {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
     (void)reg_c;
     MFMA_F32_32x32x8F16(0, reg_a[0], reg_b[0], 0, 0, 0)
-#else
-    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x8f16(reg_a[0], reg_b[0], reg_c[0], 0, 0, 0);
-#endif
 }
 
 __device__ void gcnasm_mfma_f32_16x16x16f16(const half4_t* reg_a, const half4_t* reg_b, float4_t* reg_c)
 {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
     (void)reg_c;
     MFMA_F32_16x16x16F16(0, reg_a[0], reg_b[0], 0, 0, 0)
-#else
-    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_16x16x16f16(reg_a[0], reg_b[0], reg_c[0], 0, 0, 0);
-#endif
 }
 
 template <index_t MPerWave, index_t NPerWave>
@@ -956,24 +464,16 @@ __device__ void gcnasm_mfma_f32_16x16x4f16(const half4_t* reg_a, const half4_t* 
 template <>
 __device__ void gcnasm_mfma_f32_16x16x4f16<16, 64>(const half4_t* reg_a, const half4_t* reg_b, float16_t* reg_c)
 {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
     (void)reg_c;
     MFMA_F32_16x16x4F16(0, reg_a[0], reg_b[0], 2, 0, 0)
-#else
-    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_16x16x4f16(reg_a[0], reg_b[0], reg_c[0], 2, 0, 0);
-#endif
 }
 
 template <>
 __device__ void gcnasm_mfma_f32_16x16x4f16<64, 16>(const half4_t* reg_a, const half4_t* reg_b, float16_t* reg_c)
 
 {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
     (void)reg_c;
     MFMA_F32_16x16x4F16(0, reg_a[0], reg_b[0], 0, 0, 4)
-#else
-    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_16x16x4f16(reg_a[0], reg_b[0], reg_c[0], 0, 0, 4);
-#endif
 }
 
 template <index_t MPerWave, index_t NPerWave>
@@ -982,25 +482,16 @@ __device__ void gcnasm_mfma_f32_4x4x4f16(const half4_t* reg_a, const half4_t* re
 template <>
 __device__ void gcnasm_mfma_f32_4x4x4f16<4, 64>(const half4_t* reg_a, const half4_t* reg_b, float4_t* reg_c)
 {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
     (void)reg_c;
     MFMA_F32_4x4x4F16(0, reg_a[0], reg_b[0], 4, 0, 0)
-#else
-    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_4x4x4f16(reg_a[0], reg_b[0], reg_c[0], 4, 0, 0);
-#endif
 }
 
 template <>
 __device__ void gcnasm_mfma_f32_4x4x4f16<8, 64>(const half4_t* reg_a, const half4_t* reg_b, float4_t* reg_c)
 {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
     (void)reg_c;
     MFMA_F32_4x4x4F16(0, reg_a[0], reg_b[0], 4, 0, 0)
     MFMA_F32_4x4x4F16(4, reg_a[0], reg_b[0], 4, 1, 0)
-#else
-    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_4x4x4f16(reg_a[0], reg_b[0], reg_c[0], 4, 0, 0);
-    reg_c[1] = llvm_intrin_amdgcn_mfma_f32_4x4x4f16(reg_a[0], reg_b[0], reg_c[1], 4, 1, 0);
-#endif
 }
 
 template <index_t MPerWave, index_t NPerWave, index_t AStride, index_t BStride>
@@ -1011,7 +502,6 @@ struct gcnasm_mfma_f32_32x32x2bf16<128, 128, AStride, BStride>
 {
     __device__ void run(const ushort2_t* reg_a, const ushort2_t* reg_b, float32_t* reg_c)
     {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
         (void)reg_c;
         MFMA_F32_32x32x2BF16(0,  reg_a[0],       reg_b[0], 1, 0, 0)
         MFMA_F32_32x32x2BF16(32, reg_a[0],       reg_b[0], 1, 1, 0)
@@ -1022,17 +512,6 @@ struct gcnasm_mfma_f32_32x32x2bf16<128, 128, AStride, BStride>
         MFMA_F32_32x32x2BF16(160, reg_a[0],       reg_b[BStride], 1, 1, 0)
         MFMA_F32_32x32x2BF16(192, reg_a[AStride], reg_b[BStride], 1, 0, 0)
         MFMA_F32_32x32x2BF16(224, reg_a[AStride], reg_b[BStride], 1, 1, 0)
-#else
-        reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x2bf16(reg_a[0],       reg_b[0], reg_c[0], 1, 0, 0);
-        reg_c[1] = llvm_intrin_amdgcn_mfma_f32_32x32x2bf16(reg_a[0],       reg_b[0], reg_c[1], 1, 1, 0);
-        reg_c[2] = llvm_intrin_amdgcn_mfma_f32_32x32x2bf16(reg_a[AStride], reg_b[0], reg_c[2], 1, 0, 0);
-        reg_c[3] = llvm_intrin_amdgcn_mfma_f32_32x32x2bf16(reg_a[AStride], reg_b[0], reg_c[3], 1, 1, 0);
-
-        reg_c[4] = llvm_intrin_amdgcn_mfma_f32_32x32x2bf16(reg_a[0],       reg_b[BStride], reg_c[4], 1, 0, 0);
-        reg_c[5] = llvm_intrin_amdgcn_mfma_f32_32x32x2bf16(reg_a[0],       reg_b[BStride], reg_c[5], 1, 1, 0);
-        reg_c[6] = llvm_intrin_amdgcn_mfma_f32_32x32x2bf16(reg_a[AStride], reg_b[BStride], reg_c[6], 1, 0, 0);
-        reg_c[7] = llvm_intrin_amdgcn_mfma_f32_32x32x2bf16(reg_a[AStride], reg_b[BStride], reg_c[7], 1, 1, 0);
-#endif
     }
 };
 
@@ -1041,18 +520,11 @@ struct gcnasm_mfma_f32_32x32x2bf16<128, 64, AStride, BStride>
 {
     __device__ void run(const ushort2_t* reg_a, const ushort2_t* reg_b, float32_t* reg_c)
     {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
         (void)reg_c;
         MFMA_F32_32x32x2BF16(0,  reg_a[0],       reg_b[0], 1, 0, 0)
         MFMA_F32_32x32x2BF16(32, reg_a[0],       reg_b[0], 1, 1, 0)
         MFMA_F32_32x32x2BF16(64, reg_a[AStride], reg_b[0], 1, 0, 0)
         MFMA_F32_32x32x2BF16(96, reg_a[AStride], reg_b[0], 1, 1, 0)
-#else
-        reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x2bf16(reg_a[0],       reg_b[0], reg_c[0], 1, 0, 0);
-        reg_c[1] = llvm_intrin_amdgcn_mfma_f32_32x32x2bf16(reg_a[0],       reg_b[0], reg_c[1], 1, 1, 0);
-        reg_c[2] = llvm_intrin_amdgcn_mfma_f32_32x32x2bf16(reg_a[AStride], reg_b[0], reg_c[2], 1, 0, 0);
-        reg_c[3] = llvm_intrin_amdgcn_mfma_f32_32x32x2bf16(reg_a[AStride], reg_b[0], reg_c[3], 1, 1, 0);
-#endif
     }
 };
 
@@ -1061,18 +533,11 @@ struct gcnasm_mfma_f32_32x32x2bf16<64, 128, AStride, BStride>
 {
     __device__ void run(const ushort2_t* reg_a, const ushort2_t* reg_b, float32_t* reg_c)
     {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
         (void)reg_c;
         MFMA_F32_32x32x2BF16(0,  reg_a[0], reg_b[0], 1, 0, 0)
         MFMA_F32_32x32x2BF16(32, reg_a[0], reg_b[0], 1, 1, 0)
         MFMA_F32_32x32x2BF16(64, reg_a[0], reg_b[BStride], 1, 0, 0)
         MFMA_F32_32x32x2BF16(96, reg_a[0], reg_b[BStride], 1, 1, 0)
-#else
-        reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x2bf16(reg_a[0], reg_b[0], reg_c[0], 1, 0, 0);
-        reg_c[1] = llvm_intrin_amdgcn_mfma_f32_32x32x2bf16(reg_a[0], reg_b[0], reg_c[1], 1, 1, 0);
-        reg_c[2] = llvm_intrin_amdgcn_mfma_f32_32x32x2bf16(reg_a[0], reg_b[BStride], reg_c[2], 1, 0, 0);
-        reg_c[3] = llvm_intrin_amdgcn_mfma_f32_32x32x2bf16(reg_a[0], reg_b[BStride], reg_c[3], 1, 1, 0);
-#endif
     }
 };
 
@@ -1081,14 +546,9 @@ struct gcnasm_mfma_f32_32x32x2bf16<64, 64, AStride, BStride>
 {
     __device__ void run(const ushort2_t* reg_a, const ushort2_t* reg_b, float32_t* reg_c)
     {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
         (void)reg_c;
         MFMA_F32_32x32x2BF16(0, reg_a[0], reg_b[0], 1, 0, 0)
         MFMA_F32_32x32x2BF16(32, reg_a[0], reg_b[0], 1, 1, 0)
-#else
-        reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x2bf16(reg_a[0], reg_b[0], reg_c[0], 1, 0, 0);
-        reg_c[1] = llvm_intrin_amdgcn_mfma_f32_32x32x2bf16(reg_a[0], reg_b[0], reg_c[1], 1, 1, 0);
-#endif
     }
 };
 
@@ -1097,12 +557,8 @@ struct gcnasm_mfma_f32_32x32x2bf16<32, 64, AStride, BStride>
 {
     __device__ void run(const ushort2_t* reg_a, const ushort2_t* reg_b, float32_t* reg_c)
     {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
         (void)reg_c;
         MFMA_F32_32x32x2BF16(0, reg_a[0], reg_b[0], 1, 0, 0)
-#else
-        reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x2bf16(reg_a[0], reg_b[0], reg_c[0], 1, 0, 0);
-#endif
     }
 };
 
@@ -1111,33 +567,21 @@ struct gcnasm_mfma_f32_32x32x2bf16<64, 32, AStride, BStride>
 {
     __device__ void run(const ushort2_t* reg_a, const ushort2_t* reg_b, float32_t* reg_c)
     {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
         (void)reg_c;
         MFMA_F32_32x32x2BF16(0, reg_a[0], reg_b[0], 0, 0, 1)
-#else
-        reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x2bf16(reg_a[0], reg_b[0], reg_c[0], 0, 0, 1);
-#endif
     }
 };
 
 __device__ void gcnasm_mfma_f32_32x32x4bf16(const ushort2_t* reg_a, const ushort2_t* reg_b, float16_t* reg_c)
 {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
     (void)reg_c;
     MFMA_F32_32x32x4BF16(0, reg_a[0], reg_b[0], 0, 0, 0)
-#else
-    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x4bf16(reg_a[0], reg_b[0], reg_c[0], 0, 0, 0);
-#endif
 }
 
 __device__ void gcnasm_mfma_f32_16x16x8bf16(const ushort2_t* reg_a, const ushort2_t* reg_b, float4_t* reg_c)
 {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
     (void)reg_c;
     MFMA_F32_16x16x8BF16(0, reg_a[0], reg_b[0], 0, 0, 0)
-#else
-    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_16x16x8bf16(reg_a[0], reg_b[0], reg_c[0], 0, 0, 0);
-#endif
 }
 
 template <index_t MPerWave, index_t NPerWave>
@@ -1146,23 +590,15 @@ __device__ void gcnasm_mfma_f32_16x16x2bf16(const ushort2_t* reg_a, const ushort
 template <>
 __device__ void gcnasm_mfma_f32_16x16x2bf16<16, 64>(const ushort2_t* reg_a, const ushort2_t* reg_b, float16_t* reg_c)
 {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
     (void)reg_c;
     MFMA_F32_16x16x2BF16(0, reg_a[0], reg_b[0], 2, 0, 0)
-#else
-    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_16x16x2bf16(reg_a[0], reg_b[0], reg_c[0], 2, 0, 0);
-#endif
 }
 
 template <>
 __device__ void gcnasm_mfma_f32_16x16x2bf16<64, 16>(const ushort2_t* reg_a, const ushort2_t* reg_b, float16_t* reg_c)
 {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
     (void)reg_c;
     MFMA_F32_16x16x2BF16(0, reg_a[0], reg_b[0], 0, 0, 4)
-#else
-    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_16x16x2bf16(reg_a[0], reg_b[0], reg_c[0], 0, 0, 4);
-#endif
 }
 
 template <index_t MPerWave, index_t NPerWave>
@@ -1171,26 +607,18 @@ __device__ void gcnasm_mfma_f32_4x4x2bf16(const ushort2_t* reg_a, const ushort2_
 template <>
 __device__ void gcnasm_mfma_f32_4x4x2bf16<4, 64>(const ushort2_t* reg_a, const ushort2_t* reg_b, float4_t* reg_c)
 {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
     (void)reg_c;
     MFMA_F32_4x4x2BF16(0, reg_a[0], reg_b[0], 4, 0, 0)
-#else
-    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_4x4x2bf16(reg_a[0], reg_b[0], reg_c[0], 4, 0, 0);
-#endif
 }
 
 template <>
 __device__ void gcnasm_mfma_f32_4x4x2bf16<8, 64>(const ushort2_t* reg_a, const ushort2_t* reg_b, float4_t* reg_c)
 {
-#if CK_USE_AMD_XDLOPS_INLINE_ASM
     (void)reg_c;
     MFMA_F32_4x4x2BF16(0, reg_a[0], reg_b[0], 4, 0, 0)
     MFMA_F32_4x4x2BF16(4, reg_a[0], reg_b[0], 4, 1, 0)
-#else
-    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_4x4x2bf16(reg_a[0], reg_b[0], reg_c[0], 4, 0, 0);
-    reg_c[1] = llvm_intrin_amdgcn_mfma_f32_4x4x2bf16(reg_a[0], reg_b[0], reg_c[1], 4, 1, 0);
-#endif
 }
+
 // clang-format on
 }
 #endif

--- a/src/kernels/composable_kernel/include/utility/amd_xdlops_inline_asm.hpp
+++ b/src/kernels/composable_kernel/include/utility/amd_xdlops_inline_asm.hpp
@@ -1,0 +1,1196 @@
+#ifndef CK_AMD_XDLOPS_HPP
+#define CK_AMD_XDLOPS_HPP
+
+#include "float_type.hpp"
+
+namespace ck {
+
+// A, B, C, cbsz, abid, blgp
+extern "C" __device__ float32_t llvm_intrin_amdgcn_mfma_f32_32x32x1f32(
+    float, float, float32_t, int, int, int) __asm("llvm.amdgcn.mfma.f32.32x32x1f32");
+
+extern "C" __device__ float16_t llvm_intrin_amdgcn_mfma_f32_32x32x2f32(
+    float, float, float16_t, int, int, int) __asm("llvm.amdgcn.mfma.f32.32x32x2f32");
+
+extern "C" __device__ float4_t llvm_intrin_amdgcn_mfma_f32_16x16x4f32(
+    float, float, float4_t, int, int, int) __asm("llvm.amdgcn.mfma.f32.16x16x4f32");
+
+extern "C" __device__ float16_t llvm_intrin_amdgcn_mfma_f32_16x16x1f32(
+    float, float, float16_t, int, int, int) __asm("llvm.amdgcn.mfma.f32.16x16x1f32");
+
+extern "C" __device__ float4_t llvm_intrin_amdgcn_mfma_f32_4x4x1f32(
+    float, float, float4_t, int, int, int) __asm("llvm.amdgcn.mfma.f32.4x4x1f32");
+
+extern "C" __device__ float32_t llvm_intrin_amdgcn_mfma_f32_32x32x4f16(
+    half4_t, half4_t, float32_t, int, int, int) __asm("llvm.amdgcn.mfma.f32.32x32x4f16");
+
+extern "C" __device__ float16_t llvm_intrin_amdgcn_mfma_f32_32x32x8f16(
+    half4_t, half4_t, float16_t, int, int, int) __asm("llvm.amdgcn.mfma.f32.32x32x8f16");
+
+extern "C" __device__ float4_t llvm_intrin_amdgcn_mfma_f32_16x16x16f16(
+    half4_t, half4_t, float4_t, int, int, int) __asm("llvm.amdgcn.mfma.f32.16x16x16f16");
+
+extern "C" __device__ float16_t llvm_intrin_amdgcn_mfma_f32_16x16x4f16(
+    half4_t, half4_t, float16_t, int, int, int) __asm("llvm.amdgcn.mfma.f32.16x16x4f16");
+
+extern "C" __device__ float4_t llvm_intrin_amdgcn_mfma_f32_4x4x4f16(
+    half4_t, half4_t, float4_t, int, int, int) __asm("llvm.amdgcn.mfma.f32.4x4x4f16");
+
+extern "C" __device__ float32_t llvm_intrin_amdgcn_mfma_f32_32x32x2bf16(
+    ushort2_t, ushort2_t, float32_t, int, int, int) __asm("llvm.amdgcn.mfma.f32.32x32x2bf16");
+
+extern "C" __device__ float16_t llvm_intrin_amdgcn_mfma_f32_32x32x4bf16(
+    ushort2_t, ushort2_t, float16_t, int, int, int) __asm("llvm.amdgcn.mfma.f32.32x32x4bf16");
+
+extern "C" __device__ float4_t llvm_intrin_amdgcn_mfma_f32_16x16x8bf16(
+    ushort2_t, ushort2_t, float4_t, int, int, int) __asm("llvm.amdgcn.mfma.f32.16x16x8bf16");
+
+extern "C" __device__ float16_t llvm_intrin_amdgcn_mfma_f32_16x16x2bf16(
+    ushort2_t, ushort2_t, float16_t, int, int, int) __asm("llvm.amdgcn.mfma.f32.16x16x2bf16");
+
+extern "C" __device__ float4_t llvm_intrin_amdgcn_mfma_f32_4x4x2bf16(
+    ushort2_t, ushort2_t, float4_t, int, int, int) __asm("llvm.amdgcn.mfma.f32.4x4x2bf16");
+
+// clang-format off
+
+#define REPEATx4(f, off) f(off) f(off + 1) f(off + 2) f(off + 3)
+
+#define REPEATx16(f, off) \
+    REPEATx4(f, off) REPEATx4(f, off + 4) REPEATx4(f, off + 8) REPEATx4(f, off + 12)
+
+#define REPEATx64(f, off) \
+    REPEATx16(f, off) REPEATx16(f, off + 16) REPEATx16(f, off + 32) REPEATx16(f, off + 48)
+
+#define REPEAT_STRIDEx4(f, stride, off) \
+    f(off) f(off + 1 * stride) f(off + 2 * stride) f(off + 3 * stride)
+
+#define REPEAT_STRIDEx16(f, stride, off)                                             \
+    REPEAT_STRIDEx4(f, stride, off) REPEAT_STRIDEx4(f, stride, off + 1 * stride * 4) \
+        REPEAT_STRIDEx4(f, stride, off + 2 * stride * 4)                             \
+            REPEAT_STRIDEx4(f, stride, off + 3 * stride * 4)
+
+#define REPEAT_STRIDEx64(f, stride, off)                                                \
+    REPEAT_STRIDEx16(f, stride, off) REPEAT_STRIDEx16(f, stride, off + 1 * stride * 16) \
+        REPEAT_STRIDEx16(f, stride, off + 2 * stride * 16)                              \
+            REPEAT_STRIDEx16(f, stride, off + 3 * stride * 16)
+
+#define S_NOP(n) \
+    static_assert((n) >=0 && (n) <= 15, "s_nop operand must be within [0..15]"); \
+    asm volatile("\n s_nop " #n " " : :);
+
+#define MFMA_F32_32x32x1F32(acc, reg_a, reg_b, cbsz, abid, blgp)                           \
+    asm volatile("v_mfma_f32_32x32x1f32 a[" #acc ":" #acc "+31], %0, %1, a[" #acc ":" #acc \
+                 "+31] cbsz: " #cbsz " abid: " #abid " blgp:" #blgp " "                    \
+                 :                                                                         \
+                 : "v"(reg_a), "v"(reg_b));
+
+#define MFMA_F32_32x32x2F32(acc, reg_a, reg_b, cbsz, abid, blgp)                           \
+    asm volatile("v_mfma_f32_32x32x2f32 a[" #acc ":" #acc "+15], %0, %1, a[" #acc ":" #acc \
+                 "+15] cbsz: " #cbsz " abid: " #abid " blgp:" #blgp " "                    \
+                 :                                                                         \
+                 : "v"(reg_a), "v"(reg_b));
+
+#define MFMA_F32_16x16x4F32(acc, reg_a, reg_b, cbsz, abid, blgp)                           \
+    asm volatile("v_mfma_f32_16x16x4f32 a[" #acc ":" #acc "+3], %0, %1, a[" #acc ":" #acc \
+                 "+3] cbsz: " #cbsz " abid: " #abid " blgp:" #blgp " "                    \
+                 :                                                                         \
+                 : "v"(reg_a), "v"(reg_b));
+
+#define MFMA_F32_16x16x1F32(acc, reg_a, reg_b, cbsz, abid, blgp)                           \
+    asm volatile("v_mfma_f32_16x16x1f32 a[" #acc ":" #acc "+15], %0, %1, a[" #acc ":" #acc \
+                 "+15] cbsz: " #cbsz " abid: " #abid " blgp:" #blgp " "                    \
+                 :                                                                         \
+                 : "v"(reg_a), "v"(reg_b));
+
+#define MFMA_F32_4x4x1F32(acc, reg_a, reg_b, cbsz, abid, blgp)                           \
+    asm volatile("v_mfma_f32_4x4x1f32 a[" #acc ":" #acc "+3], %0, %1, a[" #acc ":" #acc \
+                 "+3] cbsz: " #cbsz " abid: " #abid " blgp:" #blgp " "                    \
+                 :                                                                         \
+                 : "v"(reg_a), "v"(reg_b));
+
+#define MFMA_F32_32x32x4F16(acc, reg_a, reg_b, cbsz, abid, blgp)                           \
+    asm volatile("v_mfma_f32_32x32x4f16 a[" #acc ":" #acc "+31], %0, %1, a[" #acc ":" #acc \
+                 "+31] cbsz: " #cbsz " abid: " #abid " blgp:" #blgp " "                    \
+                 :                                                                         \
+                 : "v"(reg_a), "v"(reg_b));
+
+#define MFMA_F32_32x32x8F16(acc, reg_a, reg_b, cbsz, abid, blgp)                           \
+    asm volatile("v_mfma_f32_32x32x8f16 a[" #acc ":" #acc "+15], %0, %1, a[" #acc ":" #acc \
+                 "+15] cbsz: " #cbsz " abid: " #abid " blgp:" #blgp " "                    \
+                 :                                                                         \
+                 : "v"(reg_a), "v"(reg_b));
+
+#define MFMA_F32_16x16x16F16(acc, reg_a, reg_b, cbsz, abid, blgp)                           \
+    asm volatile("v_mfma_f32_16x16x16f16 a[" #acc ":" #acc "+3], %0, %1, a[" #acc ":" #acc \
+                 "+3] cbsz: " #cbsz " abid: " #abid " blgp:" #blgp " "                    \
+                 :                                                                         \
+                 : "v"(reg_a), "v"(reg_b));
+
+#define MFMA_F32_16x16x4F16(acc, reg_a, reg_b, cbsz, abid, blgp)                           \
+    asm volatile("v_mfma_f32_16x16x4f16 a[" #acc ":" #acc "+15], %0, %1, a[" #acc ":" #acc \
+                 "+15] cbsz: " #cbsz " abid: " #abid " blgp:" #blgp " "                    \
+                 :                                                                         \
+                 : "v"(reg_a), "v"(reg_b));
+
+#define MFMA_F32_4x4x4F16(acc, reg_a, reg_b, cbsz, abid, blgp)                           \
+    asm volatile("v_mfma_f32_4x4x4f16 a[" #acc ":" #acc "+3], %0, %1, a[" #acc ":" #acc \
+                 "+3] cbsz: " #cbsz " abid: " #abid " blgp:" #blgp " "                    \
+                 :                                                                         \
+                 : "v"(reg_a), "v"(reg_b));
+
+#define MFMA_F32_32x32x2BF16(acc, reg_a, reg_b, cbsz, abid, blgp)                           \
+    asm volatile("v_mfma_f32_32x32x2bf16 a[" #acc ":" #acc "+31], %0, %1, a[" #acc ":" #acc \
+                 "+31] cbsz: " #cbsz " abid: " #abid " blgp:" #blgp " "                     \
+                 :                                                                          \
+                 : "v"(reg_a), "v"(reg_b));
+
+#define MFMA_F32_32x32x4BF16(acc, reg_a, reg_b, cbsz, abid, blgp)                           \
+    asm volatile("v_mfma_f32_32x32x4bf16 a[" #acc ":" #acc "+15], %0, %1, a[" #acc ":" #acc \
+                 "+15] cbsz: " #cbsz " abid: " #abid " blgp:" #blgp " "                     \
+                 :                                                                          \
+                 : "v"(reg_a), "v"(reg_b));
+
+#define MFMA_F32_16x16x8BF16(acc, reg_a, reg_b, cbsz, abid, blgp)                           \
+    asm volatile("v_mfma_f32_16x16x8bf16 a[" #acc ":" #acc "+3], %0, %1, a[" #acc ":" #acc \
+                 "+3] cbsz: " #cbsz " abid: " #abid " blgp:" #blgp " "                     \
+                 :                                                                          \
+                 : "v"(reg_a), "v"(reg_b));
+
+#define MFMA_F32_16x16x2BF16(acc, reg_a, reg_b, cbsz, abid, blgp)                           \
+    asm volatile("v_mfma_f32_16x16x2bf16 a[" #acc ":" #acc "+15], %0, %1, a[" #acc ":" #acc \
+                 "+15] cbsz: " #cbsz " abid: " #abid " blgp:" #blgp " "                     \
+                 :                                                                          \
+                 : "v"(reg_a), "v"(reg_b));
+
+#define MFMA_F32_4x4x2BF16(acc, reg_a, reg_b, cbsz, abid, blgp)                           \
+    asm volatile("v_mfma_f32_4x4x2bf16 a[" #acc ":" #acc "+3], %0, %1, a[" #acc ":" #acc \
+                 "+3] cbsz: " #cbsz " abid: " #abid " blgp:" #blgp " "                     \
+                 :                                                                          \
+                 : "v"(reg_a), "v"(reg_b));
+
+#define ACCVGPR_READ(acc_reg_id) \
+    asm volatile("v_accvgpr_read_b32 %0, a[" #acc_reg_id "]" : "=v"(arch_reg[acc_reg_id]) :);
+
+#define ACCVGPR_WRITE(acc_reg_id) \
+    asm volatile("v_accvgpr_write_b32 a[" #acc_reg_id "], %0" : : "v"(arch_reg[acc_reg_id]));
+
+#define ACCVGPR_ZERO(acc_reg_id) \
+    asm volatile("v_accvgpr_write_b32 a[" #acc_reg_id "], 0" : :);
+
+template <index_t Size>
+__device__ void gcnasm_accvgpr_read(float*);
+
+template <>
+__device__ void gcnasm_accvgpr_read<4>(float* arch_reg)
+{
+#if CK_USE_AMD_XDLOPS_INLINE_ASM
+    REPEATx4(ACCVGPR_READ, 0)
+#else
+    (void)arch_reg;
+#endif
+}
+
+template <>
+__device__ void gcnasm_accvgpr_read<8>(float* arch_reg)
+{
+#if CK_USE_AMD_XDLOPS_INLINE_ASM
+#if 1
+    REPEATx4(ACCVGPR_READ, 0)
+    REPEATx4(ACCVGPR_READ, 4)
+#else
+  asm volatile("\
+      v_accvgpr_read_b32 %0,  a[ 0] \n \
+      v_accvgpr_read_b32 %1,  a[ 1] \n \
+      v_accvgpr_read_b32 %2,  a[ 2] \n \
+      v_accvgpr_read_b32 %3,  a[ 3] \n \
+      v_accvgpr_read_b32 %4,  a[ 4] \n \
+      v_accvgpr_read_b32 %5,  a[ 5] \n \
+      v_accvgpr_read_b32 %6,  a[ 6] \n \
+      v_accvgpr_read_b32 %7,  a[ 7] \n \
+      "
+      :
+      "=v"(arch_reg[ 0]),
+      "=v"(arch_reg[ 1]),
+      "=v"(arch_reg[ 2]),
+      "=v"(arch_reg[ 3]),
+      "=v"(arch_reg[ 4]),
+      "=v"(arch_reg[ 5]),
+      "=v"(arch_reg[ 6]),
+      "=v"(arch_reg[ 7])
+      :);
+#endif
+#else
+    (void)arch_reg;
+#endif
+}
+
+template <>
+__device__ void gcnasm_accvgpr_read<16>(float* arch_reg)
+{
+#if CK_USE_AMD_XDLOPS_INLINE_ASM
+#if 1
+    REPEATx16(ACCVGPR_READ, 0)
+#else
+    asm volatile("\
+      v_accvgpr_read_b32 %0,  a[ 0] \n \
+      v_accvgpr_read_b32 %1,  a[ 1] \n \
+      v_accvgpr_read_b32 %2,  a[ 2] \n \
+      v_accvgpr_read_b32 %3,  a[ 3] \n \
+      v_accvgpr_read_b32 %4,  a[ 4] \n \
+      v_accvgpr_read_b32 %5,  a[ 5] \n \
+      v_accvgpr_read_b32 %6,  a[ 6] \n \
+      v_accvgpr_read_b32 %7,  a[ 7] \n \
+      v_accvgpr_read_b32 %8,  a[ 8] \n \
+      v_accvgpr_read_b32 %9,  a[ 9] \n \
+      v_accvgpr_read_b32 %10, a[10] \n \
+      v_accvgpr_read_b32 %11, a[11] \n \
+      v_accvgpr_read_b32 %12, a[12] \n \
+      v_accvgpr_read_b32 %13, a[13] \n \
+      v_accvgpr_read_b32 %14, a[14] \n \
+      v_accvgpr_read_b32 %15, a[15] \n \
+      "
+      :
+      "=v"(arch_reg[ 0]),
+      "=v"(arch_reg[ 1]),
+      "=v"(arch_reg[ 2]),
+      "=v"(arch_reg[ 3]),
+      "=v"(arch_reg[ 4]),
+      "=v"(arch_reg[ 5]),
+      "=v"(arch_reg[ 6]),
+      "=v"(arch_reg[ 7]),
+      "=v"(arch_reg[ 8]),
+      "=v"(arch_reg[ 9]),
+      "=v"(arch_reg[10]),
+      "=v"(arch_reg[11]),
+      "=v"(arch_reg[12]),
+      "=v"(arch_reg[13]),
+      "=v"(arch_reg[14]),
+      "=v"(arch_reg[15])
+      :);
+#endif
+#else
+    (void)arch_reg;
+#endif
+}
+
+template <>
+__device__ void gcnasm_accvgpr_read<32>(float* arch_reg)
+{
+#if CK_USE_AMD_XDLOPS_INLINE_ASM
+#if 1
+    REPEATx16(ACCVGPR_READ, 0)
+    REPEATx16(ACCVGPR_READ, 16)
+#else
+    asm volatile("\
+      v_accvgpr_read_b32 %0,  a[ 0] \n \
+      v_accvgpr_read_b32 %1,  a[ 1] \n \
+      v_accvgpr_read_b32 %2,  a[ 2] \n \
+      v_accvgpr_read_b32 %3,  a[ 3] \n \
+      v_accvgpr_read_b32 %4,  a[ 4] \n \
+      v_accvgpr_read_b32 %5,  a[ 5] \n \
+      v_accvgpr_read_b32 %6,  a[ 6] \n \
+      v_accvgpr_read_b32 %7,  a[ 7] \n \
+      v_accvgpr_read_b32 %8,  a[ 8] \n \
+      v_accvgpr_read_b32 %9,  a[ 9] \n \
+      v_accvgpr_read_b32 %10, a[10] \n \
+      v_accvgpr_read_b32 %11, a[11] \n \
+      v_accvgpr_read_b32 %12, a[12] \n \
+      v_accvgpr_read_b32 %13, a[13] \n \
+      v_accvgpr_read_b32 %14, a[14] \n \
+      v_accvgpr_read_b32 %15, a[15] \n \
+      v_accvgpr_read_b32 %16, a[16] \n \
+      v_accvgpr_read_b32 %17, a[17] \n \
+      v_accvgpr_read_b32 %18, a[18] \n \
+      v_accvgpr_read_b32 %19, a[19] \n \
+      v_accvgpr_read_b32 %20, a[20] \n \
+      v_accvgpr_read_b32 %21, a[21] \n \
+      v_accvgpr_read_b32 %22, a[22] \n \
+      v_accvgpr_read_b32 %23, a[23] \n \
+      v_accvgpr_read_b32 %24, a[24] \n \
+      v_accvgpr_read_b32 %25, a[25] \n \
+      v_accvgpr_read_b32 %26, a[26] \n \
+      v_accvgpr_read_b32 %27, a[27] \n \
+      v_accvgpr_read_b32 %28, a[28] \n \
+      v_accvgpr_read_b32 %29, a[29] \n \
+      v_accvgpr_read_b32 %30, a[30] \n \
+      v_accvgpr_read_b32 %31, a[31] \n \
+      "
+      :
+      "=v"(arch_reg[ 0]),
+      "=v"(arch_reg[ 1]),
+      "=v"(arch_reg[ 2]),
+      "=v"(arch_reg[ 3]),
+      "=v"(arch_reg[ 4]),
+      "=v"(arch_reg[ 5]),
+      "=v"(arch_reg[ 6]),
+      "=v"(arch_reg[ 7]),
+      "=v"(arch_reg[ 8]),
+      "=v"(arch_reg[ 9]),
+      "=v"(arch_reg[10]),
+      "=v"(arch_reg[11]),
+      "=v"(arch_reg[12]),
+      "=v"(arch_reg[13]),
+      "=v"(arch_reg[14]),
+      "=v"(arch_reg[15]),
+      "=v"(arch_reg[16]),
+      "=v"(arch_reg[17]),
+      "=v"(arch_reg[18]),
+      "=v"(arch_reg[19]),
+      "=v"(arch_reg[20]),
+      "=v"(arch_reg[21]),
+      "=v"(arch_reg[22]),
+      "=v"(arch_reg[23]),
+      "=v"(arch_reg[24]),
+      "=v"(arch_reg[25]),
+      "=v"(arch_reg[26]),
+      "=v"(arch_reg[27]),
+      "=v"(arch_reg[28]),
+      "=v"(arch_reg[29]),
+      "=v"(arch_reg[30]),
+      "=v"(arch_reg[31])
+      :);
+#endif
+#else
+    (void)arch_reg;
+#endif
+}
+
+template <>
+__device__ void gcnasm_accvgpr_read<64>(float* arch_reg)
+{
+#if CK_USE_AMD_XDLOPS_INLINE_ASM
+#if 1
+    REPEATx64(ACCVGPR_READ, 0)
+#else
+    asm volatile("\
+      v_accvgpr_read_b32 %0,  a[ 0] \n \
+      v_accvgpr_read_b32 %1,  a[ 1] \n \
+      v_accvgpr_read_b32 %2,  a[ 2] \n \
+      v_accvgpr_read_b32 %3,  a[ 3] \n \
+      v_accvgpr_read_b32 %4,  a[ 4] \n \
+      v_accvgpr_read_b32 %5,  a[ 5] \n \
+      v_accvgpr_read_b32 %6,  a[ 6] \n \
+      v_accvgpr_read_b32 %7,  a[ 7] \n \
+      v_accvgpr_read_b32 %8,  a[ 8] \n \
+      v_accvgpr_read_b32 %9,  a[ 9] \n \
+      v_accvgpr_read_b32 %10, a[10] \n \
+      v_accvgpr_read_b32 %11, a[11] \n \
+      v_accvgpr_read_b32 %12, a[12] \n \
+      v_accvgpr_read_b32 %13, a[13] \n \
+      v_accvgpr_read_b32 %14, a[14] \n \
+      v_accvgpr_read_b32 %15, a[15] \n \
+      v_accvgpr_read_b32 %16, a[16] \n \
+      v_accvgpr_read_b32 %17, a[17] \n \
+      v_accvgpr_read_b32 %18, a[18] \n \
+      v_accvgpr_read_b32 %19, a[19] \n \
+      v_accvgpr_read_b32 %20, a[20] \n \
+      v_accvgpr_read_b32 %21, a[21] \n \
+      v_accvgpr_read_b32 %22, a[22] \n \
+      v_accvgpr_read_b32 %23, a[23] \n \
+      v_accvgpr_read_b32 %24, a[24] \n \
+      v_accvgpr_read_b32 %25, a[25] \n \
+      v_accvgpr_read_b32 %26, a[26] \n \
+      v_accvgpr_read_b32 %27, a[27] \n \
+      v_accvgpr_read_b32 %28, a[28] \n \
+      v_accvgpr_read_b32 %29, a[29] \n \
+      v_accvgpr_read_b32 %30, a[30] \n \
+      v_accvgpr_read_b32 %31, a[31] \n \
+      v_accvgpr_read_b32 %32, a[32] \n \
+      v_accvgpr_read_b32 %33, a[33] \n \
+      v_accvgpr_read_b32 %34, a[34] \n \
+      v_accvgpr_read_b32 %35, a[35] \n \
+      v_accvgpr_read_b32 %36, a[36] \n \
+      v_accvgpr_read_b32 %37, a[37] \n \
+      v_accvgpr_read_b32 %38, a[38] \n \
+      v_accvgpr_read_b32 %39, a[39] \n \
+      v_accvgpr_read_b32 %40, a[40] \n \
+      v_accvgpr_read_b32 %41, a[41] \n \
+      v_accvgpr_read_b32 %42, a[42] \n \
+      v_accvgpr_read_b32 %43, a[43] \n \
+      v_accvgpr_read_b32 %44, a[44] \n \
+      v_accvgpr_read_b32 %45, a[45] \n \
+      v_accvgpr_read_b32 %46, a[46] \n \
+      v_accvgpr_read_b32 %47, a[47] \n \
+      v_accvgpr_read_b32 %48, a[48] \n \
+      v_accvgpr_read_b32 %49, a[49] \n \
+      v_accvgpr_read_b32 %50, a[50] \n \
+      v_accvgpr_read_b32 %51, a[51] \n \
+      v_accvgpr_read_b32 %52, a[52] \n \
+      v_accvgpr_read_b32 %53, a[53] \n \
+      v_accvgpr_read_b32 %54, a[54] \n \
+      v_accvgpr_read_b32 %55, a[55] \n \
+      v_accvgpr_read_b32 %56, a[56] \n \
+      v_accvgpr_read_b32 %57, a[57] \n \
+      v_accvgpr_read_b32 %58, a[58] \n \
+      v_accvgpr_read_b32 %59, a[59] \n \
+      v_accvgpr_read_b32 %60, a[60] \n \
+      v_accvgpr_read_b32 %61, a[61] \n \
+      v_accvgpr_read_b32 %62, a[62] \n \
+      v_accvgpr_read_b32 %63, a[63] \n \
+      "
+      :
+      "=v"(arch_reg[ 0]),
+      "=v"(arch_reg[ 1]),
+      "=v"(arch_reg[ 2]),
+      "=v"(arch_reg[ 3]),
+      "=v"(arch_reg[ 4]),
+      "=v"(arch_reg[ 5]),
+      "=v"(arch_reg[ 6]),
+      "=v"(arch_reg[ 7]),
+      "=v"(arch_reg[ 8]),
+      "=v"(arch_reg[ 9]),
+      "=v"(arch_reg[10]),
+      "=v"(arch_reg[11]),
+      "=v"(arch_reg[12]),
+      "=v"(arch_reg[13]),
+      "=v"(arch_reg[14]),
+      "=v"(arch_reg[15]),
+      "=v"(arch_reg[16]),
+      "=v"(arch_reg[17]),
+      "=v"(arch_reg[18]),
+      "=v"(arch_reg[19]),
+      "=v"(arch_reg[20]),
+      "=v"(arch_reg[21]),
+      "=v"(arch_reg[22]),
+      "=v"(arch_reg[23]),
+      "=v"(arch_reg[24]),
+      "=v"(arch_reg[25]),
+      "=v"(arch_reg[26]),
+      "=v"(arch_reg[27]),
+      "=v"(arch_reg[28]),
+      "=v"(arch_reg[29]),
+      "=v"(arch_reg[30]),
+      "=v"(arch_reg[31]),
+      "=v"(arch_reg[32]),
+      "=v"(arch_reg[33]),
+      "=v"(arch_reg[34]),
+      "=v"(arch_reg[35]),
+      "=v"(arch_reg[36]),
+      "=v"(arch_reg[37]),
+      "=v"(arch_reg[38]),
+      "=v"(arch_reg[39]),
+      "=v"(arch_reg[40]),
+      "=v"(arch_reg[41]),
+      "=v"(arch_reg[42]),
+      "=v"(arch_reg[43]),
+      "=v"(arch_reg[44]),
+      "=v"(arch_reg[45]),
+      "=v"(arch_reg[46]),
+      "=v"(arch_reg[47]),
+      "=v"(arch_reg[48]),
+      "=v"(arch_reg[49]),
+      "=v"(arch_reg[50]),
+      "=v"(arch_reg[51]),
+      "=v"(arch_reg[52]),
+      "=v"(arch_reg[53]),
+      "=v"(arch_reg[54]),
+      "=v"(arch_reg[55]),
+      "=v"(arch_reg[56]),
+      "=v"(arch_reg[57]),
+      "=v"(arch_reg[58]),
+      "=v"(arch_reg[59]),
+      "=v"(arch_reg[60]),
+      "=v"(arch_reg[61]),
+      "=v"(arch_reg[62]),
+      "=v"(arch_reg[63])
+      :);
+#endif
+#else
+    (void)arch_reg;
+#endif
+}
+
+template <>
+__device__ void gcnasm_accvgpr_read<128>(float* arch_reg)
+{
+#if CK_USE_AMD_XDLOPS_INLINE_ASM
+    REPEATx64(ACCVGPR_READ, 0)
+    REPEATx64(ACCVGPR_READ, 64)
+#else
+    (void)arch_reg;
+#endif
+}
+
+template <>
+__device__ void gcnasm_accvgpr_read<256>(float* arch_reg)
+{
+#if CK_USE_AMD_XDLOPS_INLINE_ASM
+    REPEATx64(ACCVGPR_READ, 0)
+    REPEATx64(ACCVGPR_READ, 64)
+    REPEATx64(ACCVGPR_READ, 128)
+    REPEATx64(ACCVGPR_READ, 192)
+#else
+    (void)arch_reg;
+#endif
+}
+
+template <index_t MPerWave>
+__device__ void gcnasm_accvgpr_zero();
+
+template <>
+__device__ void gcnasm_accvgpr_zero<4>()
+{
+#if CK_USE_AMD_XDLOPS_INLINE_ASM
+    REPEATx4(ACCVGPR_ZERO, 0)
+    S_NOP(1)
+#endif
+}
+
+template <>
+__device__ void gcnasm_accvgpr_zero<8>()
+{
+#if CK_USE_AMD_XDLOPS_INLINE_ASM
+    REPEATx4(ACCVGPR_ZERO, 0)
+    REPEATx4(ACCVGPR_ZERO, 4)
+    S_NOP(1)
+#endif
+}
+
+template <>
+__device__ void gcnasm_accvgpr_zero<16>()
+{
+#if CK_USE_AMD_XDLOPS_INLINE_ASM
+    REPEATx16(ACCVGPR_ZERO, 0)
+    S_NOP(1)
+#endif
+}
+
+template <>
+__device__ void gcnasm_accvgpr_zero<32>()
+{
+#if CK_USE_AMD_XDLOPS_INLINE_ASM
+    REPEATx16(ACCVGPR_ZERO, 0)
+    REPEATx16(ACCVGPR_ZERO, 16)
+    S_NOP(1)
+#endif
+}
+
+template <>
+__device__ void gcnasm_accvgpr_zero<64>()
+{
+#if CK_USE_AMD_XDLOPS_INLINE_ASM
+    REPEATx64(ACCVGPR_ZERO, 0)
+    S_NOP(1)
+#endif
+}
+
+template <>
+__device__ void gcnasm_accvgpr_zero<128>()
+{
+#if CK_USE_AMD_XDLOPS_INLINE_ASM
+    REPEATx64(ACCVGPR_ZERO, 0)
+    REPEATx64(ACCVGPR_ZERO, 64)
+    S_NOP(1)
+#endif
+}
+
+template <>
+__device__ void gcnasm_accvgpr_zero<256>()
+{
+#if CK_USE_AMD_XDLOPS_INLINE_ASM
+    REPEATx64(ACCVGPR_ZERO, 0)
+    REPEATx64(ACCVGPR_ZERO, 64)
+    REPEATx64(ACCVGPR_ZERO, 128)
+    REPEATx64(ACCVGPR_ZERO, 196)
+    S_NOP(1)
+#endif
+}
+
+template <index_t Cycles>
+__device__ void gcnasm_nop();
+
+template <>
+__device__ void gcnasm_nop<8>()
+{
+#if CK_USE_AMD_XDLOPS_INLINE_ASM
+    S_NOP(3)
+#endif
+}
+
+template <>
+__device__ void gcnasm_nop<32>()
+{
+#if CK_USE_AMD_XDLOPS_INLINE_ASM
+    S_NOP(9)
+#endif
+}
+
+template <>
+__device__ void gcnasm_nop<64>()
+{
+#if CK_USE_AMD_XDLOPS_INLINE_ASM
+    S_NOP(8)
+    S_NOP(8)
+#endif
+}
+
+template <index_t MPerWave, index_t NPerWave, index_t AStride, index_t BStride>
+struct gcnasm_mfma_f32_32x32x1f32;
+
+template <index_t AStride, index_t BStride>
+struct gcnasm_mfma_f32_32x32x1f32<128, 128, AStride, BStride>
+{
+    __device__ void run(const float* reg_a, const float* reg_b, float32_t* reg_c)
+    {
+#if CK_USE_AMD_XDLOPS_INLINE_ASM
+        (void)reg_c;
+        MFMA_F32_32x32x1F32(0,  reg_a[0],       reg_b[0], 1, 0, 0)
+        MFMA_F32_32x32x1F32(32, reg_a[0],       reg_b[0], 1, 1, 0)
+        MFMA_F32_32x32x1F32(64, reg_a[AStride], reg_b[0], 1, 0, 0)
+        MFMA_F32_32x32x1F32(96, reg_a[AStride], reg_b[0], 1, 1, 0)
+
+        MFMA_F32_32x32x1F32(128, reg_a[0],       reg_b[BStride], 1, 0, 0)
+        MFMA_F32_32x32x1F32(160, reg_a[0],       reg_b[BStride], 1, 1, 0)
+        MFMA_F32_32x32x1F32(192, reg_a[AStride], reg_b[BStride], 1, 0, 0)
+        MFMA_F32_32x32x1F32(224, reg_a[AStride], reg_b[BStride], 1, 1, 0)
+#else
+        reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x1f32(reg_a[0],       reg_b[0], reg_c[0], 1, 0, 0);
+        reg_c[1] = llvm_intrin_amdgcn_mfma_f32_32x32x1f32(reg_a[0],       reg_b[0], reg_c[1], 1, 1, 0);
+        reg_c[2] = llvm_intrin_amdgcn_mfma_f32_32x32x1f32(reg_a[AStride], reg_b[0], reg_c[2], 1, 0, 0);
+        reg_c[3] = llvm_intrin_amdgcn_mfma_f32_32x32x1f32(reg_a[BStride], reg_b[0], reg_c[3], 1, 1, 0);
+
+        reg_c[4] = llvm_intrin_amdgcn_mfma_f32_32x32x1f32(reg_a[0],       reg_b[BStride], reg_c[4], 1, 0, 0);
+        reg_c[5] = llvm_intrin_amdgcn_mfma_f32_32x32x1f32(reg_a[0],       reg_b[BStride], reg_c[5], 1, 1, 0);
+        reg_c[6] = llvm_intrin_amdgcn_mfma_f32_32x32x1f32(reg_a[AStride], reg_b[BStride], reg_c[6], 1, 0, 0);
+        reg_c[7] = llvm_intrin_amdgcn_mfma_f32_32x32x1f32(reg_a[BStride], reg_b[BStride], reg_c[7], 1, 1, 0);
+#endif
+    }
+};
+
+template <index_t AStride, index_t BStride>
+struct gcnasm_mfma_f32_32x32x1f32<128, 64, AStride, BStride>
+{
+    __device__ void run(const float* reg_a, const float* reg_b, float32_t* reg_c)
+    {
+#if CK_USE_AMD_XDLOPS_INLINE_ASM
+        (void)reg_c;
+        MFMA_F32_32x32x1F32(0,  reg_a[0], reg_b[0], 1, 0, 0)
+        MFMA_F32_32x32x1F32(32, reg_a[0], reg_b[0], 1, 1, 0)
+        MFMA_F32_32x32x1F32(64, reg_a[AStride], reg_b[0], 1, 0, 0)
+        MFMA_F32_32x32x1F32(96, reg_a[AStride], reg_b[0], 1, 1, 0)
+#else
+        reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x1f32(reg_a[0], reg_b[0], reg_c[0], 1, 0, 0);
+        reg_c[1] = llvm_intrin_amdgcn_mfma_f32_32x32x1f32(reg_a[0], reg_b[0], reg_c[1], 1, 1, 0);
+        reg_c[2] = llvm_intrin_amdgcn_mfma_f32_32x32x1f32(reg_a[AStride], reg_b[0], reg_c[2], 1, 0, 0);
+        reg_c[3] = llvm_intrin_amdgcn_mfma_f32_32x32x1f32(reg_a[BStride], reg_b[0], reg_c[3], 1, 1, 0);
+#endif
+    }
+};
+
+template <index_t AStride, index_t BStride>
+struct gcnasm_mfma_f32_32x32x1f32<64, 128, AStride, BStride>
+{
+    __device__ void run(const float* reg_a, const float* reg_b, float32_t* reg_c)
+    {
+#if CK_USE_AMD_XDLOPS_INLINE_ASM
+        (void)reg_c;
+        MFMA_F32_32x32x1F32(0,  reg_a[0], reg_b[0], 1, 0, 0)
+        MFMA_F32_32x32x1F32(32, reg_a[0], reg_b[0], 1, 1, 0)
+        MFMA_F32_32x32x1F32(64, reg_a[0], reg_b[BStride], 1, 0, 0)
+        MFMA_F32_32x32x1F32(96, reg_a[0], reg_b[BStride], 1, 1, 0)
+#else
+        reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x1f32(reg_a[0], reg_b[0], reg_c[0], 1, 0, 0);
+        reg_c[1] = llvm_intrin_amdgcn_mfma_f32_32x32x1f32(reg_a[0], reg_b[0], reg_c[1], 1, 1, 0);
+        reg_c[2] = llvm_intrin_amdgcn_mfma_f32_32x32x1f32(reg_a[0], reg_b[BStride], reg_c[2], 1, 0, 0);
+        reg_c[3] = llvm_intrin_amdgcn_mfma_f32_32x32x1f32(reg_a[0], reg_b[BStride], reg_c[3], 1, 1, 0);
+#endif
+    }
+};
+
+template <index_t AStride, index_t BStride>
+struct gcnasm_mfma_f32_32x32x1f32<64, 64, AStride, BStride>
+{
+    __device__ void run(const float* reg_a, const float* reg_b, float32_t* reg_c)
+    {
+#if CK_USE_AMD_XDLOPS_INLINE_ASM
+        (void)reg_c;
+        MFMA_F32_32x32x1F32(0, reg_a[0], reg_b[0], 1, 0, 0)
+        MFMA_F32_32x32x1F32(32, reg_a[0], reg_b[0], 1, 1, 0)
+#else
+        reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x1f32(reg_a[0], reg_b[0], reg_c[0], 1, 0, 0);
+        reg_c[1] = llvm_intrin_amdgcn_mfma_f32_32x32x1f32(reg_a[0], reg_b[0], reg_c[1], 1, 1, 0);
+#endif
+    }
+};
+
+template <index_t AStride, index_t BStride>
+struct gcnasm_mfma_f32_32x32x1f32<32, 64, AStride, BStride>
+{
+    __device__ void run(const float* reg_a, const float* reg_b, float32_t* reg_c)
+    {
+#if CK_USE_AMD_XDLOPS_INLINE_ASM
+        (void)reg_c;
+        MFMA_F32_32x32x1F32(0, reg_a[0], reg_b[0], 1, 0, 0)
+#else
+        reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x1f32(reg_a[0], reg_b[0], reg_c[0], 1, 0, 0);
+#endif
+    }
+};
+
+template <index_t AStride, index_t BStride>
+struct gcnasm_mfma_f32_32x32x1f32<64, 32, AStride, BStride>
+{
+    __device__ void run(const float* reg_a, const float* reg_b, float32_t* reg_c)
+    {
+#if CK_USE_AMD_XDLOPS_INLINE_ASM
+        (void)reg_c;
+        MFMA_F32_32x32x1F32(0, reg_a[0], reg_b[0], 0, 0, 1)
+#else
+        reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x1f32(reg_a[0], reg_b[0], reg_c[0], 0, 0, 1);
+#endif
+    }
+};
+
+__device__ void gcnasm_mfma_f32_32x32x2f32(const float* reg_a, const float* reg_b, float16_t* reg_c)
+{
+#if CK_USE_AMD_XDLOPS_INLINE_ASM
+    (void)reg_c;
+    MFMA_F32_32x32x2F32(0, reg_a[0], reg_b[0], 0, 0, 0)
+#else
+    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x2f32(reg_a[0], reg_b[0], reg_c[0], 0, 0, 0);
+#endif
+}
+
+__device__ void gcnasm_mfma_f32_16x16x4f32(const float* reg_a, const float* reg_b, float4_t* reg_c)
+{
+#if CK_USE_AMD_XDLOPS_INLINE_ASM
+    (void)reg_c;
+    MFMA_F32_16x16x4F32(0, reg_a[0], reg_b[0], 0, 0, 0)
+#else
+    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_16x16x4f32(reg_a[0], reg_b[0], reg_c[0], 0, 0, 0);
+#endif
+}
+
+template <index_t MPerWave, index_t NPerWave>
+__device__ void gcnasm_mfma_f32_16x16x1f32(const float* reg_a, const float* reg_b, float16_t* reg_c);
+
+template <>
+__device__ void gcnasm_mfma_f32_16x16x1f32<16, 64>(const float* reg_a, const float* reg_b, float16_t* reg_c)
+{
+#if CK_USE_AMD_XDLOPS_INLINE_ASM
+    (void)reg_c;
+    MFMA_F32_16x16x1F32(0, reg_a[0], reg_b[0], 2, 0, 0)
+#else
+    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_16x16x1f32(reg_a[0], reg_b[0], reg_c[0], 2, 0, 0);
+#endif
+}
+
+template <>
+__device__ void gcnasm_mfma_f32_16x16x1f32<64, 16>(const float* reg_a, const float* reg_b, float16_t* reg_c)
+{
+#if CK_USE_AMD_XDLOPS_INLINE_ASM
+    (void)reg_c;
+    MFMA_F32_16x16x1F32(0, reg_a[0], reg_b[0], 0, 0, 4)
+#else
+    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_16x16x1f32(reg_a[0], reg_b[0], reg_c[0], 0, 0, 4);
+#endif
+}
+
+template <index_t MPerWave, index_t NPerWave>
+__device__ void gcnasm_mfma_f32_4x4x1f32(const float* reg_a, const float* reg_b, float4_t* reg_c);
+
+template <>
+__device__ void gcnasm_mfma_f32_4x4x1f32<4, 64>(const float* reg_a, const float* reg_b, float4_t* reg_c)
+{
+#if CK_USE_AMD_XDLOPS_INLINE_ASM
+    (void)reg_c;
+    MFMA_F32_4x4x1F32(0, reg_a[0], reg_b[0], 4, 0, 0)
+#else
+    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_4x4x1f32(reg_a[0], reg_b[0], reg_c[0], 4, 0, 0);
+#endif
+}
+
+template <>
+__device__ void gcnasm_mfma_f32_4x4x1f32<8, 64>(const float* reg_a, const float* reg_b, float4_t* reg_c)
+{
+#if CK_USE_AMD_XDLOPS_INLINE_ASM
+    (void)reg_c;
+    MFMA_F32_4x4x1F32(0, reg_a[0], reg_b[0], 4, 0, 0)
+    MFMA_F32_4x4x1F32(4, reg_a[0], reg_b[0], 4, 1, 0)
+#else
+    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_4x4x1f32(reg_a[0], reg_b[0], reg_c[0], 4, 0, 0);
+    reg_c[1] = llvm_intrin_amdgcn_mfma_f32_4x4x1f32(reg_a[0], reg_b[0], reg_c[1], 4, 1, 0);
+#endif
+}
+
+template <index_t MPerWave, index_t NPerWave, index_t AStride, index_t BStride>
+struct gcnasm_mfma_f32_32x32x4f16;
+
+template <index_t AStride, index_t BStride>
+struct gcnasm_mfma_f32_32x32x4f16<128, 128, AStride, BStride>
+{
+    __device__ void run(const half4_t* reg_a, const half4_t* reg_b, float32_t* reg_c)
+    {
+#if CK_USE_AMD_XDLOPS_INLINE_ASM
+        (void)reg_c;
+        MFMA_F32_32x32x4F16(0,  reg_a[0],       reg_b[0], 1, 0, 0)
+        MFMA_F32_32x32x4F16(32, reg_a[0],       reg_b[0], 1, 1, 0)
+        MFMA_F32_32x32x4F16(64, reg_a[AStride], reg_b[0], 1, 0, 0)
+        MFMA_F32_32x32x4F16(96, reg_a[AStride], reg_b[0], 1, 1, 0)
+
+        MFMA_F32_32x32x4F16(128, reg_a[0],       reg_b[BStride], 1, 0, 0)
+        MFMA_F32_32x32x4F16(160, reg_a[0],       reg_b[BStride], 1, 1, 0)
+        MFMA_F32_32x32x4F16(192, reg_a[AStride], reg_b[BStride], 1, 0, 0)
+        MFMA_F32_32x32x4F16(224, reg_a[AStride], reg_b[BStride], 1, 1, 0)
+#else
+        reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x4f16(reg_a[0],       reg_b[0], reg_c[0], 1, 0, 0);
+        reg_c[1] = llvm_intrin_amdgcn_mfma_f32_32x32x4f16(reg_a[0],       reg_b[0], reg_c[1], 1, 1, 0);
+        reg_c[2] = llvm_intrin_amdgcn_mfma_f32_32x32x4f16(reg_a[AStride], reg_b[0], reg_c[2], 1, 0, 0);
+        reg_c[3] = llvm_intrin_amdgcn_mfma_f32_32x32x4f16(reg_a[AStride], reg_b[0], reg_c[3], 1, 1, 0);
+
+        reg_c[4] = llvm_intrin_amdgcn_mfma_f32_32x32x4f16(reg_a[0],       reg_b[BStride], reg_c[4], 1, 0, 0);
+        reg_c[5] = llvm_intrin_amdgcn_mfma_f32_32x32x4f16(reg_a[0],       reg_b[BStride], reg_c[5], 1, 1, 0);
+        reg_c[6] = llvm_intrin_amdgcn_mfma_f32_32x32x4f16(reg_a[AStride], reg_b[BStride], reg_c[6], 1, 0, 0);
+        reg_c[7] = llvm_intrin_amdgcn_mfma_f32_32x32x4f16(reg_a[AStride], reg_b[BStride], reg_c[7], 1, 1, 0);
+#endif
+    }
+};
+
+template <index_t AStride, index_t BStride>
+struct gcnasm_mfma_f32_32x32x4f16<128, 64, AStride, BStride>
+{
+    __device__ void run(const half4_t* reg_a, const half4_t* reg_b, float32_t* reg_c)
+    {
+#if CK_USE_AMD_XDLOPS_INLINE_ASM
+        (void)reg_c;
+        MFMA_F32_32x32x4F16(0,  reg_a[0],       reg_b[0], 1, 0, 0)
+        MFMA_F32_32x32x4F16(32, reg_a[0],       reg_b[0], 1, 1, 0)
+        MFMA_F32_32x32x4F16(64, reg_a[AStride], reg_b[0], 1, 0, 0)
+        MFMA_F32_32x32x4F16(96, reg_a[AStride], reg_b[0], 1, 1, 0)
+#else
+        reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x4f16(reg_a[0],       reg_b[0], reg_c[0], 1, 0, 0);
+        reg_c[1] = llvm_intrin_amdgcn_mfma_f32_32x32x4f16(reg_a[0],       reg_b[0], reg_c[1], 1, 1, 0);
+        reg_c[2] = llvm_intrin_amdgcn_mfma_f32_32x32x4f16(reg_a[AStride], reg_b[0], reg_c[2], 1, 0, 0);
+        reg_c[3] = llvm_intrin_amdgcn_mfma_f32_32x32x4f16(reg_a[AStride], reg_b[0], reg_c[3], 1, 1, 0);
+#endif
+    }
+};
+
+template <index_t AStride, index_t BStride>
+struct gcnasm_mfma_f32_32x32x4f16<64, 128, AStride, BStride>
+{
+    __device__ void run(const half4_t* reg_a, const half4_t* reg_b, float32_t* reg_c)
+    {
+#if CK_USE_AMD_XDLOPS_INLINE_ASM
+        (void)reg_c;
+        MFMA_F32_32x32x4F16(0,  reg_a[0], reg_b[0], 1, 0, 0)
+        MFMA_F32_32x32x4F16(32, reg_a[0], reg_b[0], 1, 1, 0)
+        MFMA_F32_32x32x4F16(64, reg_a[0], reg_b[BStride], 1, 0, 0)
+        MFMA_F32_32x32x4F16(96, reg_a[0], reg_b[BStride], 1, 1, 0)
+#else
+        reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x4f16(reg_a[0], reg_b[0], reg_c[0], 1, 0, 0);
+        reg_c[1] = llvm_intrin_amdgcn_mfma_f32_32x32x4f16(reg_a[0], reg_b[0], reg_c[1], 1, 1, 0);
+        reg_c[2] = llvm_intrin_amdgcn_mfma_f32_32x32x4f16(reg_a[0], reg_b[BStride], reg_c[2], 1, 0, 0);
+        reg_c[3] = llvm_intrin_amdgcn_mfma_f32_32x32x4f16(reg_a[0], reg_b[BStride], reg_c[3], 1, 1, 0);
+#endif
+    }
+};
+
+template <index_t AStride, index_t BStride>
+struct gcnasm_mfma_f32_32x32x4f16<64, 64, AStride, BStride>
+{
+    __device__ void run(const half4_t* reg_a, const half4_t* reg_b, float32_t* reg_c)
+    {
+#if CK_USE_AMD_XDLOPS_INLINE_ASM
+        (void)reg_c;
+        MFMA_F32_32x32x4F16(0, reg_a[0], reg_b[0], 1, 0, 0)
+        MFMA_F32_32x32x4F16(32, reg_a[0], reg_b[0], 1, 1, 0)
+#else
+        reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x4f16(reg_a[0], reg_b[0], reg_c[0], 1, 0, 0);
+        reg_c[1] = llvm_intrin_amdgcn_mfma_f32_32x32x4f16(reg_a[0], reg_b[0], reg_c[1], 1, 1, 0);
+#endif
+    }
+};
+
+template <index_t AStride, index_t BStride>
+struct gcnasm_mfma_f32_32x32x4f16<32, 64, AStride, BStride>
+{
+    __device__ void run(const half4_t* reg_a, const half4_t* reg_b, float32_t* reg_c)
+    {
+#if CK_USE_AMD_XDLOPS_INLINE_ASM
+        (void)reg_c;
+        MFMA_F32_32x32x4F16(0, reg_a[0], reg_b[0], 1, 0, 0)
+#else
+        reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x4f16(reg_a[0], reg_b[0], reg_c[0], 1, 0, 0);
+#endif
+    }
+};
+
+template <index_t AStride, index_t BStride>
+struct gcnasm_mfma_f32_32x32x4f16<64, 32, AStride, BStride>
+{
+    __device__ void run(const half4_t* reg_a, const half4_t* reg_b, float32_t* reg_c)
+    {
+#if CK_USE_AMD_XDLOPS_INLINE_ASM
+        (void)reg_c;
+        MFMA_F32_32x32x4F16(0, reg_a[0], reg_b[0], 0, 0, 1)
+#else
+        reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x4f16(reg_a[0], reg_b[0], reg_c[0], 0, 0, 1);
+#endif
+    }
+};
+
+__device__ void gcnasm_mfma_f32_32x32x8f16(const half4_t* reg_a, const half4_t* reg_b, float16_t* reg_c)
+{
+#if CK_USE_AMD_XDLOPS_INLINE_ASM
+    (void)reg_c;
+    MFMA_F32_32x32x8F16(0, reg_a[0], reg_b[0], 0, 0, 0)
+#else
+    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x8f16(reg_a[0], reg_b[0], reg_c[0], 0, 0, 0);
+#endif
+}
+
+__device__ void gcnasm_mfma_f32_16x16x16f16(const half4_t* reg_a, const half4_t* reg_b, float4_t* reg_c)
+{
+#if CK_USE_AMD_XDLOPS_INLINE_ASM
+    (void)reg_c;
+    MFMA_F32_16x16x16F16(0, reg_a[0], reg_b[0], 0, 0, 0)
+#else
+    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_16x16x16f16(reg_a[0], reg_b[0], reg_c[0], 0, 0, 0);
+#endif
+}
+
+template <index_t MPerWave, index_t NPerWave>
+__device__ void gcnasm_mfma_f32_16x16x4f16(const half4_t* reg_a, const half4_t* reg_b, float16_t* reg_c);
+
+template <>
+__device__ void gcnasm_mfma_f32_16x16x4f16<16, 64>(const half4_t* reg_a, const half4_t* reg_b, float16_t* reg_c)
+{
+#if CK_USE_AMD_XDLOPS_INLINE_ASM
+    (void)reg_c;
+    MFMA_F32_16x16x4F16(0, reg_a[0], reg_b[0], 2, 0, 0)
+#else
+    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_16x16x4f16(reg_a[0], reg_b[0], reg_c[0], 2, 0, 0);
+#endif
+}
+
+template <>
+__device__ void gcnasm_mfma_f32_16x16x4f16<64, 16>(const half4_t* reg_a, const half4_t* reg_b, float16_t* reg_c)
+
+{
+#if CK_USE_AMD_XDLOPS_INLINE_ASM
+    (void)reg_c;
+    MFMA_F32_16x16x4F16(0, reg_a[0], reg_b[0], 0, 0, 4)
+#else
+    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_16x16x4f16(reg_a[0], reg_b[0], reg_c[0], 0, 0, 4);
+#endif
+}
+
+template <index_t MPerWave, index_t NPerWave>
+__device__ void gcnasm_mfma_f32_4x4x4f16(const half4_t* reg_a, const half4_t* reg_b, float4_t* reg_c);
+
+template <>
+__device__ void gcnasm_mfma_f32_4x4x4f16<4, 64>(const half4_t* reg_a, const half4_t* reg_b, float4_t* reg_c)
+{
+#if CK_USE_AMD_XDLOPS_INLINE_ASM
+    (void)reg_c;
+    MFMA_F32_4x4x4F16(0, reg_a[0], reg_b[0], 4, 0, 0)
+#else
+    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_4x4x4f16(reg_a[0], reg_b[0], reg_c[0], 4, 0, 0);
+#endif
+}
+
+template <>
+__device__ void gcnasm_mfma_f32_4x4x4f16<8, 64>(const half4_t* reg_a, const half4_t* reg_b, float4_t* reg_c)
+{
+#if CK_USE_AMD_XDLOPS_INLINE_ASM
+    (void)reg_c;
+    MFMA_F32_4x4x4F16(0, reg_a[0], reg_b[0], 4, 0, 0)
+    MFMA_F32_4x4x4F16(4, reg_a[0], reg_b[0], 4, 1, 0)
+#else
+    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_4x4x4f16(reg_a[0], reg_b[0], reg_c[0], 4, 0, 0);
+    reg_c[1] = llvm_intrin_amdgcn_mfma_f32_4x4x4f16(reg_a[0], reg_b[0], reg_c[1], 4, 1, 0);
+#endif
+}
+
+template <index_t MPerWave, index_t NPerWave, index_t AStride, index_t BStride>
+struct gcnasm_mfma_f32_32x32x2bf16;
+
+template <index_t AStride, index_t BStride>
+struct gcnasm_mfma_f32_32x32x2bf16<128, 128, AStride, BStride>
+{
+    __device__ void run(const ushort2_t* reg_a, const ushort2_t* reg_b, float32_t* reg_c)
+    {
+#if CK_USE_AMD_XDLOPS_INLINE_ASM
+        (void)reg_c;
+        MFMA_F32_32x32x2BF16(0,  reg_a[0],       reg_b[0], 1, 0, 0)
+        MFMA_F32_32x32x2BF16(32, reg_a[0],       reg_b[0], 1, 1, 0)
+        MFMA_F32_32x32x2BF16(64, reg_a[AStride], reg_b[0], 1, 0, 0)
+        MFMA_F32_32x32x2BF16(96, reg_a[AStride], reg_b[0], 1, 1, 0)
+
+        MFMA_F32_32x32x2BF16(128, reg_a[0],       reg_b[BStride], 1, 0, 0)
+        MFMA_F32_32x32x2BF16(160, reg_a[0],       reg_b[BStride], 1, 1, 0)
+        MFMA_F32_32x32x2BF16(192, reg_a[AStride], reg_b[BStride], 1, 0, 0)
+        MFMA_F32_32x32x2BF16(224, reg_a[AStride], reg_b[BStride], 1, 1, 0)
+#else
+        reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x2bf16(reg_a[0],       reg_b[0], reg_c[0], 1, 0, 0);
+        reg_c[1] = llvm_intrin_amdgcn_mfma_f32_32x32x2bf16(reg_a[0],       reg_b[0], reg_c[1], 1, 1, 0);
+        reg_c[2] = llvm_intrin_amdgcn_mfma_f32_32x32x2bf16(reg_a[AStride], reg_b[0], reg_c[2], 1, 0, 0);
+        reg_c[3] = llvm_intrin_amdgcn_mfma_f32_32x32x2bf16(reg_a[AStride], reg_b[0], reg_c[3], 1, 1, 0);
+
+        reg_c[4] = llvm_intrin_amdgcn_mfma_f32_32x32x2bf16(reg_a[0],       reg_b[BStride], reg_c[4], 1, 0, 0);
+        reg_c[5] = llvm_intrin_amdgcn_mfma_f32_32x32x2bf16(reg_a[0],       reg_b[BStride], reg_c[5], 1, 1, 0);
+        reg_c[6] = llvm_intrin_amdgcn_mfma_f32_32x32x2bf16(reg_a[AStride], reg_b[BStride], reg_c[6], 1, 0, 0);
+        reg_c[7] = llvm_intrin_amdgcn_mfma_f32_32x32x2bf16(reg_a[AStride], reg_b[BStride], reg_c[7], 1, 1, 0);
+#endif
+    }
+};
+
+template <index_t AStride, index_t BStride>
+struct gcnasm_mfma_f32_32x32x2bf16<128, 64, AStride, BStride>
+{
+    __device__ void run(const ushort2_t* reg_a, const ushort2_t* reg_b, float32_t* reg_c)
+    {
+#if CK_USE_AMD_XDLOPS_INLINE_ASM
+        (void)reg_c;
+        MFMA_F32_32x32x2BF16(0,  reg_a[0],       reg_b[0], 1, 0, 0)
+        MFMA_F32_32x32x2BF16(32, reg_a[0],       reg_b[0], 1, 1, 0)
+        MFMA_F32_32x32x2BF16(64, reg_a[AStride], reg_b[0], 1, 0, 0)
+        MFMA_F32_32x32x2BF16(96, reg_a[AStride], reg_b[0], 1, 1, 0)
+#else
+        reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x2bf16(reg_a[0],       reg_b[0], reg_c[0], 1, 0, 0);
+        reg_c[1] = llvm_intrin_amdgcn_mfma_f32_32x32x2bf16(reg_a[0],       reg_b[0], reg_c[1], 1, 1, 0);
+        reg_c[2] = llvm_intrin_amdgcn_mfma_f32_32x32x2bf16(reg_a[AStride], reg_b[0], reg_c[2], 1, 0, 0);
+        reg_c[3] = llvm_intrin_amdgcn_mfma_f32_32x32x2bf16(reg_a[AStride], reg_b[0], reg_c[3], 1, 1, 0);
+#endif
+    }
+};
+
+template <index_t AStride, index_t BStride>
+struct gcnasm_mfma_f32_32x32x2bf16<64, 128, AStride, BStride>
+{
+    __device__ void run(const ushort2_t* reg_a, const ushort2_t* reg_b, float32_t* reg_c)
+    {
+#if CK_USE_AMD_XDLOPS_INLINE_ASM
+        (void)reg_c;
+        MFMA_F32_32x32x2BF16(0,  reg_a[0], reg_b[0], 1, 0, 0)
+        MFMA_F32_32x32x2BF16(32, reg_a[0], reg_b[0], 1, 1, 0)
+        MFMA_F32_32x32x2BF16(64, reg_a[0], reg_b[BStride], 1, 0, 0)
+        MFMA_F32_32x32x2BF16(96, reg_a[0], reg_b[BStride], 1, 1, 0)
+#else
+        reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x2bf16(reg_a[0], reg_b[0], reg_c[0], 1, 0, 0);
+        reg_c[1] = llvm_intrin_amdgcn_mfma_f32_32x32x2bf16(reg_a[0], reg_b[0], reg_c[1], 1, 1, 0);
+        reg_c[2] = llvm_intrin_amdgcn_mfma_f32_32x32x2bf16(reg_a[0], reg_b[BStride], reg_c[2], 1, 0, 0);
+        reg_c[3] = llvm_intrin_amdgcn_mfma_f32_32x32x2bf16(reg_a[0], reg_b[BStride], reg_c[3], 1, 1, 0);
+#endif
+    }
+};
+
+template <index_t AStride, index_t BStride>
+struct gcnasm_mfma_f32_32x32x2bf16<64, 64, AStride, BStride>
+{
+    __device__ void run(const ushort2_t* reg_a, const ushort2_t* reg_b, float32_t* reg_c)
+    {
+#if CK_USE_AMD_XDLOPS_INLINE_ASM
+        (void)reg_c;
+        MFMA_F32_32x32x2BF16(0, reg_a[0], reg_b[0], 1, 0, 0)
+        MFMA_F32_32x32x2BF16(32, reg_a[0], reg_b[0], 1, 1, 0)
+#else
+        reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x2bf16(reg_a[0], reg_b[0], reg_c[0], 1, 0, 0);
+        reg_c[1] = llvm_intrin_amdgcn_mfma_f32_32x32x2bf16(reg_a[0], reg_b[0], reg_c[1], 1, 1, 0);
+#endif
+    }
+};
+
+template <index_t AStride, index_t BStride>
+struct gcnasm_mfma_f32_32x32x2bf16<32, 64, AStride, BStride>
+{
+    __device__ void run(const ushort2_t* reg_a, const ushort2_t* reg_b, float32_t* reg_c)
+    {
+#if CK_USE_AMD_XDLOPS_INLINE_ASM
+        (void)reg_c;
+        MFMA_F32_32x32x2BF16(0, reg_a[0], reg_b[0], 1, 0, 0)
+#else
+        reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x2bf16(reg_a[0], reg_b[0], reg_c[0], 1, 0, 0);
+#endif
+    }
+};
+
+template <index_t AStride, index_t BStride>
+struct gcnasm_mfma_f32_32x32x2bf16<64, 32, AStride, BStride>
+{
+    __device__ void run(const ushort2_t* reg_a, const ushort2_t* reg_b, float32_t* reg_c)
+    {
+#if CK_USE_AMD_XDLOPS_INLINE_ASM
+        (void)reg_c;
+        MFMA_F32_32x32x2BF16(0, reg_a[0], reg_b[0], 0, 0, 1)
+#else
+        reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x2bf16(reg_a[0], reg_b[0], reg_c[0], 0, 0, 1);
+#endif
+    }
+};
+
+__device__ void gcnasm_mfma_f32_32x32x4bf16(const ushort2_t* reg_a, const ushort2_t* reg_b, float16_t* reg_c)
+{
+#if CK_USE_AMD_XDLOPS_INLINE_ASM
+    (void)reg_c;
+    MFMA_F32_32x32x4BF16(0, reg_a[0], reg_b[0], 0, 0, 0)
+#else
+    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_32x32x4bf16(reg_a[0], reg_b[0], reg_c[0], 0, 0, 0);
+#endif
+}
+
+__device__ void gcnasm_mfma_f32_16x16x8bf16(const ushort2_t* reg_a, const ushort2_t* reg_b, float4_t* reg_c)
+{
+#if CK_USE_AMD_XDLOPS_INLINE_ASM
+    (void)reg_c;
+    MFMA_F32_16x16x8BF16(0, reg_a[0], reg_b[0], 0, 0, 0)
+#else
+    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_16x16x8bf16(reg_a[0], reg_b[0], reg_c[0], 0, 0, 0);
+#endif
+}
+
+template <index_t MPerWave, index_t NPerWave>
+__device__ void gcnasm_mfma_f32_16x16x2bf16(const ushort2_t* reg_a, const ushort2_t* reg_b, float16_t* reg_c);
+
+template <>
+__device__ void gcnasm_mfma_f32_16x16x2bf16<16, 64>(const ushort2_t* reg_a, const ushort2_t* reg_b, float16_t* reg_c)
+{
+#if CK_USE_AMD_XDLOPS_INLINE_ASM
+    (void)reg_c;
+    MFMA_F32_16x16x2BF16(0, reg_a[0], reg_b[0], 2, 0, 0)
+#else
+    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_16x16x2bf16(reg_a[0], reg_b[0], reg_c[0], 2, 0, 0);
+#endif
+}
+
+template <>
+__device__ void gcnasm_mfma_f32_16x16x2bf16<64, 16>(const ushort2_t* reg_a, const ushort2_t* reg_b, float16_t* reg_c)
+{
+#if CK_USE_AMD_XDLOPS_INLINE_ASM
+    (void)reg_c;
+    MFMA_F32_16x16x2BF16(0, reg_a[0], reg_b[0], 0, 0, 4)
+#else
+    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_16x16x2bf16(reg_a[0], reg_b[0], reg_c[0], 0, 0, 4);
+#endif
+}
+
+template <index_t MPerWave, index_t NPerWave>
+__device__ void gcnasm_mfma_f32_4x4x2bf16(const ushort2_t* reg_a, const ushort2_t* reg_b, float4_t* reg_c);
+
+template <>
+__device__ void gcnasm_mfma_f32_4x4x2bf16<4, 64>(const ushort2_t* reg_a, const ushort2_t* reg_b, float4_t* reg_c)
+{
+#if CK_USE_AMD_XDLOPS_INLINE_ASM
+    (void)reg_c;
+    MFMA_F32_4x4x2BF16(0, reg_a[0], reg_b[0], 4, 0, 0)
+#else
+    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_4x4x2bf16(reg_a[0], reg_b[0], reg_c[0], 4, 0, 0);
+#endif
+}
+
+template <>
+__device__ void gcnasm_mfma_f32_4x4x2bf16<8, 64>(const ushort2_t* reg_a, const ushort2_t* reg_b, float4_t* reg_c)
+{
+#if CK_USE_AMD_XDLOPS_INLINE_ASM
+    (void)reg_c;
+    MFMA_F32_4x4x2BF16(0, reg_a[0], reg_b[0], 4, 0, 0)
+    MFMA_F32_4x4x2BF16(4, reg_a[0], reg_b[0], 4, 1, 0)
+#else
+    reg_c[0] = llvm_intrin_amdgcn_mfma_f32_4x4x2bf16(reg_a[0], reg_b[0], reg_c[0], 4, 0, 0);
+    reg_c[1] = llvm_intrin_amdgcn_mfma_f32_4x4x2bf16(reg_a[0], reg_b[0], reg_c[1], 4, 1, 0);
+#endif
+}
+// clang-format on
+}
+#endif

--- a/src/kernels/composable_kernel/include/utility/common_header.hpp
+++ b/src/kernels/composable_kernel/include/utility/common_header.hpp
@@ -24,6 +24,7 @@
 
 #if CK_USE_AMD_XDLOPS
 #include "amd_xdlops.hpp"
+#include "amd_xdlops_inline_asm.hpp"
 #endif
 
 #endif

--- a/src/solver/conv_hip_implicit_gemm_fwd_v4r4_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_fwd_v4r4_xdlops.cpp
@@ -656,6 +656,7 @@ bool PerformanceImplicitGemmForwardV4R4Xdlops::IsFastToBeUsedForTuning(
         }
     }
 
+#if 0
     // avoid skinny blockwise GEMM whenever possible
     {
         int gemm_m = 0;
@@ -691,6 +692,7 @@ bool PerformanceImplicitGemmForwardV4R4Xdlops::IsFastToBeUsedForTuning(
                 return false;
         }
     }
+#endif
 
     // each thread should not too much data
     {

--- a/src/solver/conv_hip_implicit_gemm_fwd_v4r4_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_fwd_v4r4_xdlops.cpp
@@ -656,7 +656,6 @@ bool PerformanceImplicitGemmForwardV4R4Xdlops::IsFastToBeUsedForTuning(
         }
     }
 
-#if 0
     // avoid skinny blockwise GEMM whenever possible
     {
         int gemm_m = 0;
@@ -692,7 +691,6 @@ bool PerformanceImplicitGemmForwardV4R4Xdlops::IsFastToBeUsedForTuning(
                 return false;
         }
     }
-#endif
 
     // each thread should not too much data
     {

--- a/src/solver/implicitgemm_util.hpp
+++ b/src/solver/implicitgemm_util.hpp
@@ -539,21 +539,14 @@ static inline bool IsValidBlockwiseGemmXdlops(const ConvolutionContext& ctx,
                                                                 std::make_tuple(4, 128, 1),
                                                                 std::make_tuple(4, 64, 1)};
 
-    bool IsValidWaveGemm = false;
-
-    for(auto& it : validWaveGemmSize)
-    {
-        int validGemmMPerWave, validGemmNPerWave, validGemmKPerWave;
-        std::tie(validGemmMPerWave, validGemmNPerWave, validGemmKPerWave) = it;
-        if(validGemmMPerWave == GemmMPerWave && validGemmNPerWave == GemmNPerWave &&
-           GemmKPerBlock % validGemmKPerWave == 0)
-        {
-            IsValidWaveGemm = true;
-            break;
-        }
-    }
-
-    if(!IsValidWaveGemm)
+    if(!std::any_of(validWaveGemmSize.cbegin(),
+                    validWaveGemmSize.cend(),
+                    [ GemmMPerWave, GemmNPerWave, GemmKPerBlock ](const auto it) noexcept->bool {
+                        int validMPerWave, validNPerWave, validKPerWave;
+                        std::tie(validMPerWave, validNPerWave, validKPerWave) = it;
+                        return (GemmMPerWave == validMPerWave) && (GemmNPerWave == validNPerWave) &&
+                               (GemmKPerBlock % validKPerWave == 0);
+                    }))
         return false;
 
     const auto WaveSize = 64;

--- a/src/solver/implicitgemm_util.hpp
+++ b/src/solver/implicitgemm_util.hpp
@@ -526,7 +526,9 @@ static inline bool IsValidBlockwiseGemmXdlops(const ConvolutionContext& ctx,
         return false;
 
     // check M and N
-    std::vector<std::tuple<int, int>> validWaveGemmSize = {std::make_tuple(64, 64),
+    std::vector<std::tuple<int, int>> validWaveGemmSize = {std::make_tuple(128, 64),
+                                                           std::make_tuple(64, 128),
+                                                           std::make_tuple(64, 64),
                                                            std::make_tuple(64, 32),
                                                            std::make_tuple(64, 16),
                                                            std::make_tuple(32, 64),
@@ -535,14 +537,6 @@ static inline bool IsValidBlockwiseGemmXdlops(const ConvolutionContext& ctx,
                                                            std::make_tuple(16, 16),
                                                            std::make_tuple(8, 64),
                                                            std::make_tuple(4, 64)};
-
-    // xdlops repeat only supported by llvm intrinsic
-    // if(!miopen::IsEnabled(MIOPEN_DEBUG_IMPLICIT_GEMM_XDLOPS_INLINE_ASM{}))
-    {
-        validWaveGemmSize.emplace_back(std::make_tuple(128, 128));
-        validWaveGemmSize.emplace_back(std::make_tuple(128, 64));
-        validWaveGemmSize.emplace_back(std::make_tuple(64, 128));
-    }
 
     bool IsValidWaveGemm = false;
 

--- a/src/solver/implicitgemm_util.hpp
+++ b/src/solver/implicitgemm_util.hpp
@@ -520,31 +520,29 @@ static inline bool IsValidBlockwiseGemmXdlops(const ConvolutionContext& ctx,
     if(ctx.IsBfp16() && GemmKPack % 2 != 0)
         return false;
 
-    if(GemmMPerWave == 32 && GemmNPerWave == 32 && GemmKPerBlock % 2 != 0)
-        return false;
-    if(GemmMPerWave == 16 && GemmNPerWave == 16 && GemmKPerBlock % 4 != 0)
-        return false;
-
-    // check M and N
-    std::vector<std::tuple<int, int>> validWaveGemmSize = {std::make_tuple(128, 64),
-                                                           std::make_tuple(64, 128),
-                                                           std::make_tuple(64, 64),
-                                                           std::make_tuple(64, 32),
-                                                           std::make_tuple(64, 16),
-                                                           std::make_tuple(32, 64),
-                                                           std::make_tuple(32, 32),
-                                                           std::make_tuple(16, 64),
-                                                           std::make_tuple(16, 16),
-                                                           std::make_tuple(8, 64),
-                                                           std::make_tuple(4, 64)};
+    // check M, N and K
+    std::vector<std::tuple<int, int, int>> validWaveGemmSize = {std::make_tuple(128, 64, 1),
+                                                                std::make_tuple(128, 32, 1),
+                                                                std::make_tuple(128, 16, 1),
+                                                                std::make_tuple(64, 128, 1),
+                                                                std::make_tuple(64, 64, 1),
+                                                                std::make_tuple(64, 32, 1),
+                                                                std::make_tuple(64, 16, 1),
+                                                                std::make_tuple(32, 64, 1),
+                                                                std::make_tuple(32, 32, 2),
+                                                                std::make_tuple(16, 64, 1),
+                                                                std::make_tuple(16, 16, 4),
+                                                                std::make_tuple(8, 64, 1),
+                                                                std::make_tuple(4, 64, 1)};
 
     bool IsValidWaveGemm = false;
 
     for(auto& it : validWaveGemmSize)
     {
-        int validGemmMPerWave, validGemmNPerWave;
-        std::tie(validGemmMPerWave, validGemmNPerWave) = it;
-        if(validGemmMPerWave == GemmMPerWave && validGemmNPerWave == GemmNPerWave)
+        int validGemmMPerWave, validGemmNPerWave, validGemmKPerWave;
+        std::tie(validGemmMPerWave, validGemmNPerWave, validGemmKPerWave) = it;
+        if(validGemmMPerWave == GemmMPerWave && validGemmNPerWave == GemmNPerWave &&
+           GemmKPerBlock % validGemmKPerWave == 0)
         {
             IsValidWaveGemm = true;
             break;

--- a/src/solver/implicitgemm_util.hpp
+++ b/src/solver/implicitgemm_util.hpp
@@ -537,7 +537,7 @@ static inline bool IsValidBlockwiseGemmXdlops(const ConvolutionContext& ctx,
                                                            std::make_tuple(4, 64)};
 
     // xdlops repeat only supported by llvm intrinsic
-    if(!miopen::IsEnabled(MIOPEN_DEBUG_IMPLICIT_GEMM_XDLOPS_INLINE_ASM{}))
+    // if(!miopen::IsEnabled(MIOPEN_DEBUG_IMPLICIT_GEMM_XDLOPS_INLINE_ASM{}))
     {
         validWaveGemmSize.emplace_back(std::make_tuple(128, 128));
         validWaveGemmSize.emplace_back(std::make_tuple(128, 64));

--- a/src/solver/implicitgemm_util.hpp
+++ b/src/solver/implicitgemm_util.hpp
@@ -528,11 +528,15 @@ static inline bool IsValidBlockwiseGemmXdlops(const ConvolutionContext& ctx,
                                                                 std::make_tuple(64, 64, 1),
                                                                 std::make_tuple(64, 32, 1),
                                                                 std::make_tuple(64, 16, 1),
+                                                                std::make_tuple(32, 128, 1),
                                                                 std::make_tuple(32, 64, 1),
                                                                 std::make_tuple(32, 32, 2),
+                                                                std::make_tuple(16, 128, 1),
                                                                 std::make_tuple(16, 64, 1),
                                                                 std::make_tuple(16, 16, 4),
+                                                                std::make_tuple(8, 128, 1),
                                                                 std::make_tuple(8, 64, 1),
+                                                                std::make_tuple(4, 128, 1),
                                                                 std::make_tuple(4, 64, 1)};
 
     bool IsValidWaveGemm = false;


### PR DESCRIPTION
- Moved M/NRepeats inside XdlopsGemm to avoid redundant data loads
- Added M/NRepeats support into xdlops inline asm (do not support 128x128 due to failed allocation of 256 acc_reg)
- Added more M/N gemm size with repeats, such as `128*32/32*128`, `16*128/128*16`, ...
- Separated inline asm and llvm intrinsic