### PR TITLE
Prevent UB in all ASM & OCL kernels that do not anticipate asymmetric padding

### DIFF
--- a/src/solver/conv_asm_1x1u.cpp
+++ b/src/solver/conv_asm_1x1u.cpp
@@ -381,6 +381,8 @@ bool ConvAsm1x1U::IsApplicable(const ConvolutionContext& params) const
         return false;
     if(!params.Is2d())
         return false;
+    if(params.IsAsymmetricPadH() || params.IsAsymmetricPadW())
+        return false;
     if(!params.rmv.IsV2orV3())
         return false;
     if(!(params.IsFp32() || params.IsFp16()))

--- a/src/solver/conv_asm_1x1u_stride2.cpp
+++ b/src/solver/conv_asm_1x1u_stride2.cpp
@@ -480,6 +480,8 @@ bool ConvAsm1x1UV2::IsApplicable(const ConvolutionContext& params) const
         return false;
     if(!params.Is2d())
         return false;
+    if(params.IsAsymmetricPadH() || params.IsAsymmetricPadW())
+        return false;
     if(!params.rmv.IsV2orV3())
         return false;
     if(!params.IsFp32())

--- a/src/solver/conv_asm_3x3u.cpp
+++ b/src/solver/conv_asm_3x3u.cpp
@@ -175,6 +175,8 @@ bool ConvAsm3x3U::IsApplicable(const ConvolutionContext& params) const
         return false;
     if(!params.Is2d())
         return false;
+    if(params.IsAsymmetricPadH() || params.IsAsymmetricPadW())
+        return false;
     if(!params.rmv.IsV2orV3())
         return false;
     const std::string name = params.GetStream().GetDeviceName();

--- a/src/solver/conv_asm_5x10u2v2b1.cpp
+++ b/src/solver/conv_asm_5x10u2v2b1.cpp
@@ -42,6 +42,8 @@ bool ConvAsm5x10u2v2b1::IsApplicable(const ConvolutionContext& params) const
         return false;
     if(!params.Is2d())
         return false;
+    if(params.IsAsymmetricPadH() || params.IsAsymmetricPadW())
+        return false;
     if(!params.rmv.IsV2orV3())
         return false;
 

--- a/src/solver/conv_asm_5x10u2v2f1.cpp
+++ b/src/solver/conv_asm_5x10u2v2f1.cpp
@@ -43,6 +43,8 @@ bool ConvAsm5x10u2v2f1::IsApplicable(const ConvolutionContext& params) const
         return false;
     if(!params.Is2d())
         return false;
+    if(params.IsAsymmetricPadH() || params.IsAsymmetricPadW())
+        return false;
     if(!params.rmv.IsV2orV3())
         return false;
 

--- a/src/solver/conv_asm_7x7c3h224w224k64u2v2p3q3f1.cpp
+++ b/src/solver/conv_asm_7x7c3h224w224k64u2v2p3q3f1.cpp
@@ -43,6 +43,8 @@ bool ConvAsm7x7c3h224w224k64u2v2p3q3f1::IsApplicable(const ConvolutionContext& p
         return false;
     if(!params.Is2d())
         return false;
+    if(params.IsAsymmetricPadH() || params.IsAsymmetricPadW())
+        return false;
     if(!params.rmv.IsV2orV3())
         return false;
 

--- a/src/solver/conv_asm_dir_BwdWrW1x1.cpp
+++ b/src/solver/conv_asm_dir_BwdWrW1x1.cpp
@@ -472,6 +472,8 @@ bool ConvAsmBwdWrW1x1::IsApplicable(const ConvolutionContext& params) const
         return false;
     if(!params.Is2d())
         return false;
+    if(params.IsAsymmetricPadH() || params.IsAsymmetricPadW())
+        return false;
     if(!params.rmv.IsV2orV3())
         return false;
 

--- a/src/solver/conv_asm_dir_BwdWrW3x3.cpp
+++ b/src/solver/conv_asm_dir_BwdWrW3x3.cpp
@@ -344,6 +344,8 @@ bool ConvAsmBwdWrW3x3::IsApplicable(const ConvolutionContext& params) const
         return false;
     if(!params.Is2d())
         return false;
+    if(params.IsAsymmetricPadH() || params.IsAsymmetricPadW())
+        return false;
     if(!params.rmv.IsV2orV3())
         return false;
     const std::string name = params.GetStream().GetDeviceName();

--- a/src/solver/conv_ocl_dir2D11x11.cpp
+++ b/src/solver/conv_ocl_dir2D11x11.cpp
@@ -44,6 +44,8 @@ bool ConvOclDirectFwd11x11::IsApplicable(const ConvolutionContext& params) const
         return false;
     if(!params.Is2d())
         return false;
+    if(params.IsAsymmetricPadH() || params.IsAsymmetricPadW())
+        return false;
     if(!(params.IsFp32() || params.IsFp16() || params.IsBfp16()))
         return false;
 

--- a/src/solver/conv_ocl_dir2D3x3.cpp
+++ b/src/solver/conv_ocl_dir2D3x3.cpp
@@ -42,6 +42,8 @@ bool ConvOclDirectFwd3x3::IsApplicable(const ConvolutionContext& params) const
         return false;
     if(!params.Is2d())
         return false;
+    if(params.IsAsymmetricPadH() || params.IsAsymmetricPadW())
+        return false;
     if(!(params.IsFp32() || params.IsFp16() || params.IsBfp16()))
         return false;
 

--- a/src/solver/conv_ocl_dir2D_bwdWrW_1x1.cpp
+++ b/src/solver/conv_ocl_dir2D_bwdWrW_1x1.cpp
@@ -45,6 +45,8 @@ bool ConvOclBwdWrW1x1::IsApplicable(const ConvolutionContext& params) const
         return false;
     if(!params.Is2d())
         return false;
+    if(params.IsAsymmetricPadH() || params.IsAsymmetricPadW())
+        return false;
     if(!(params.IsFp32() || params.IsFp16() || params.IsBfp16()))
         return false;
 

--- a/src/solver/conv_ocl_dir2D_bwdWrW_53.cpp
+++ b/src/solver/conv_ocl_dir2D_bwdWrW_53.cpp
@@ -48,6 +48,8 @@ bool ConvOclBwdWrW53::IsApplicable(const ConvolutionContext& params) const
         return false;
     if(!params.Is2d())
         return false;
+    if(params.IsAsymmetricPadH() || params.IsAsymmetricPadW())
+        return false;
     if(!(params.IsFp32() || params.IsFp16() || params.IsBfp16()))
         return false;
 

--- a/src/solver/conv_ocl_dir2Dfwd.cpp
+++ b/src/solver/conv_ocl_dir2Dfwd.cpp
@@ -43,6 +43,8 @@ bool ConvOclDirectFwd::IsApplicable(const ConvolutionContext& params) const
         return false;
     if(!params.Is2d())
         return false;
+    if(params.IsAsymmetricPadH() || params.IsAsymmetricPadW())
+        return false;
     if(!(params.IsFp32() || params.IsFp16() || params.IsBfp16()))
         return false;
 

--- a/src/solver/conv_ocl_dir2Dfwd1x1.cpp
+++ b/src/solver/conv_ocl_dir2Dfwd1x1.cpp
@@ -54,6 +54,8 @@ bool ConvOclDirectFwd1x1::IsApplicable(const ConvolutionContext& params) const
         return false;
     if(!params.Is2d())
         return false;
+    if(params.IsAsymmetricPadH() || params.IsAsymmetricPadW())
+        return false;
     if(!(params.IsFp32() || params.IsFp16() || params.IsBfp16()))
         return false;
 

--- a/src/solver/conv_ocl_dir2Dfwdgen.cpp
+++ b/src/solver/conv_ocl_dir2Dfwdgen.cpp
@@ -42,6 +42,8 @@ bool ConvOclDirectFwdGen::IsApplicable(const ConvolutionContext& params) const
         return false;
     if(!params.Is2d())
         return false;
+    if(params.IsAsymmetricPadH() || params.IsAsymmetricPadW())
+        return false;
     if(!(params.IsFp32() || params.IsFp16() || params.IsBfp16()))
         return false;
 


### PR DESCRIPTION
Resolves ASM & OCL leftovers of #142.

Disables configs that have asymmetric padding in all Solvers that do not anticipate it. See https://github.com/ROCmSoftwarePlatform/MIOpen/issues/142#issuecomment-625941366 for details. 

Note that currently asymmetric padding is possible only for even filter sizes. However this PR affects Solvers that support odd filters as well. This is done in order to avoid adding new implicit dependencies (on how we define “asymmetric padding”).