### PR TITLE
add direction check to ConvOclBwdWrW53  IsApplicable

### DIFF
--- a/src/solver/conv_ocl_dir2D_bwdWrW_53.cpp
+++ b/src/solver/conv_ocl_dir2D_bwdWrW_53.cpp
@@ -52,6 +52,8 @@ bool ConvOclBwdWrW53::IsApplicable(const ConvolutionContext& params) const
         return false;
     if(!(params.IsFp32() || params.IsFp16() || params.IsBfp16()))
         return false;
+    if(!params.direction.IsBackwardWrW())
+        return false;
 
     bool workaround = false;
 


### PR DESCRIPTION
Resolves #353 

The IsApplicable method of ConvOclBwdWrW53 does not check the direction of the context and within the IsApplicable method calls the GetSolution method, which throws an exception if the convolution direction is not acceptable.

Ideally, the IsApplicable method should check the direction of convolution and return false instead of throwing an exception.