### PR TITLE
Fix nan issue in bwd v1r1 kernel

### DIFF
--- a/src/conv/invokers/impl_gemm.cpp
+++ b/src/conv/invokers/impl_gemm.cpp
@@ -60,7 +60,7 @@ InvokerFactory MakeImplGemmDataInvokerFactory(const ConvolutionContext& ctx)
                     bool need_atomic_add = (stride_h < dilation_h * (y - 1) + 1) &&
                                            (stride_w < dilation_w * (x - 1) + 1);
                     bool every_pixel_is_written =
-                        (dilation_h == 1 && stride_h <= Y) && (dilation_w == 1 && stride_w <= X);
+                        (dilation_h == 1 && stride_h <= y) && (dilation_w == 1 && stride_w <= x);
                     bool need_set_zero = need_atomic_add || !(every_pixel_is_written);
                     bool need_cast     = need_atomic_add;
 

--- a/src/conv/invokers/impl_gemm.cpp
+++ b/src/conv/invokers/impl_gemm.cpp
@@ -57,7 +57,7 @@ InvokerFactory MakeImplGemmDataInvokerFactory(const ConvolutionContext& ctx)
                     const auto dilation_h = conv.GetConvDilations()[0];
                     const auto dilation_w = conv.GetConvDilations()[1];
 
-                    bool need_atomic_add = (stride_h < dilation_h * (y - 1) + 1) &&
+                    bool need_atomic_add = (stride_h < dilation_h * (y - 1) + 1) ||
                                            (stride_w < dilation_w * (x - 1) + 1);
                     bool every_pixel_is_written =
                         (dilation_h == 1 && stride_h <= y) && (dilation_w == 1 && stride_w <= x);

--- a/src/conv/invokers/impl_gemm.cpp
+++ b/src/conv/invokers/impl_gemm.cpp
@@ -57,16 +57,26 @@ InvokerFactory MakeImplGemmDataInvokerFactory(const ConvolutionContext& ctx)
                     const auto dilation_h = conv.GetConvDilations()[0];
                     const auto dilation_w = conv.GetConvDilations()[1];
 
-                    if((stride_h >= dilation_h * (y - 1) + 1) &&
-                       (stride_w >= dilation_w * (x - 1) + 1))
-                    {
+                    bool need_atomic_add = (stride_h < dilation_h * (y - 1) + 1) &&
+                                           (stride_w < dilation_w * (x - 1) + 1);
+                    bool every_pixel_is_written =
+                        (dilation_h == 1 && stride_h <= Y) && (dilation_w == 1 && stride_w <= X);
+                    bool need_set_zero = need_atomic_add || !(every_pixel_is_written);
+                    bool need_cast     = need_atomic_add;
 
+                    if(need_set_zero && !need_cast)
+                    {
                         float zero = 0.f;
                         SetTensor(handle, tensors.outDesc, tensors.out, &zero);
-
                         if(handle.IsProfilingEnabled())
                             elapsed += handle.GetKernelTime();
 
+                        kernel(tensors.in, tensors.w, tensors.out);
+                        if(handle.IsProfilingEnabled())
+                            elapsed += handle.GetKernelTime();
+                    }
+                    else if(!need_set_zero && !need_cast)
+                    {
                         kernel(tensors.in, tensors.w, tensors.out);
                         if(handle.IsProfilingEnabled())
                             elapsed += handle.GetKernelTime();

--- a/src/conv/invokers/impl_gemm.cpp
+++ b/src/conv/invokers/impl_gemm.cpp
@@ -60,6 +60,13 @@ InvokerFactory MakeImplGemmDataInvokerFactory(const ConvolutionContext& ctx)
                     if((stride_h >= dilation_h * (y - 1) + 1) &&
                        (stride_w >= dilation_w * (x - 1) + 1))
                     {
+
+                        float zero = 0.f;
+                        SetTensor(handle, tensors.outDesc, tensors.out, &zero);
+
+                        if(handle.IsProfilingEnabled())
+                            elapsed += handle.GetKernelTime();
+
                         kernel(tensors.in, tensors.w, tensors.out);
                         if(handle.IsProfilingEnabled())
                             elapsed += handle.GetKernelTime();


### PR DESCRIPTION
@asroy If we skip settensor, it causes nan in resnext50 as reported by @sunway513 . So, putting it back.

@asroy The assumption we had here in #305 https://github.com/ROCmSoftwarePlatform/MIOpen/pull/305#discussion_r455157461 seemed wrong, causing this nan.

