### PR TITLE
Workaround performance regression for M/N repeats in xdlops-gemm 

### DIFF
--- a/src/kernels/composable_kernel/include/tensor_operation/blockwise_gemm_xdlops.hpp
+++ b/src/kernels/composable_kernel/include/tensor_operation/blockwise_gemm_xdlops.hpp
@@ -28,16 +28,17 @@ struct BlockwiseGemmBlockABlockBThreadCTransANormalBNormalC_xdlops
         index_t col;
     };
 
+#if CK_WORKAROUND_SWDEV_241664
     static constexpr index_t MRepeats = (GemmMPerWave > 64) ? (GemmMPerWave / 64) : 1;
     static constexpr index_t NRepeats = (GemmNPerWave > 64) ? (GemmNPerWave / 64) : 1;
 
     static constexpr index_t MPerXdlops = (GemmMPerWave > 64) ? 64 : GemmMPerWave;
     static constexpr index_t NPerXdlops = (GemmNPerWave > 64) ? 64 : GemmNPerWave;
 
-#if CK_WORKAROUND_SWDEV_241664
     static constexpr auto XdlopsGemm =
         XdlopsGemm_t<Float, MPerXdlops, NPerXdlops, GemmDataPerReadA, GemmDataPerReadB>{};
 #else
+
 #if CK_USE_AMD_XDLOPS_INLINE_ASM
     static constexpr auto XdlopsGemm =
         XdlopsGemmAsm_t<Float, GemmMPerWave, GemmNPerWave, GemmDataPerReadA, GemmDataPerReadB>{};
@@ -45,6 +46,7 @@ struct BlockwiseGemmBlockABlockBThreadCTransANormalBNormalC_xdlops
     static constexpr auto XdlopsGemm =
         XdlopsGemm_t<Float, GemmMPerWave, GemmNPerWave, GemmDataPerReadA, GemmDataPerReadB>{};
 #endif
+
 #endif
 
     index_t mMyWaveOffsetA;

--- a/src/kernels/composable_kernel/include/tensor_operation/blockwise_gemm_xdlops.hpp
+++ b/src/kernels/composable_kernel/include/tensor_operation/blockwise_gemm_xdlops.hpp
@@ -28,12 +28,23 @@ struct BlockwiseGemmBlockABlockBThreadCTransANormalBNormalC_xdlops
         index_t col;
     };
 
+    static constexpr index_t MRepeats = (GemmMPerWave > 64) ? (GemmMPerWave / 64) : 1;
+    static constexpr index_t NRepeats = (GemmNPerWave > 64) ? (GemmNPerWave / 64) : 1;
+
+    static constexpr index_t MPerXdlops = (GemmMPerWave > 64) ? 64 : GemmMPerWave;
+    static constexpr index_t NPerXdlops = (GemmNPerWave > 64) ? 64 : GemmNPerWave;
+
+#if CK_WORKAROUND_SWDEV_241664
+    static constexpr auto XdlopsGemm =
+        XdlopsGemm_t<Float, MPerXdlops, NPerXdlops, GemmDataPerReadA, GemmDataPerReadB>{};
+#else
 #if CK_USE_AMD_XDLOPS_INLINE_ASM
     static constexpr auto XdlopsGemm =
         XdlopsGemmAsm_t<Float, GemmMPerWave, GemmNPerWave, GemmDataPerReadA, GemmDataPerReadB>{};
 #else
     static constexpr auto XdlopsGemm =
         XdlopsGemm_t<Float, GemmMPerWave, GemmNPerWave, GemmDataPerReadA, GemmDataPerReadB>{};
+#endif
 #endif
 
     index_t mMyWaveOffsetA;
@@ -45,7 +56,11 @@ struct BlockwiseGemmBlockABlockBThreadCTransANormalBNormalC_xdlops
 
     __device__ constexpr auto GetNumBlks() const
     {
+#if CK_WORKAROUND_SWDEV_241664
+        return XdlopsGemm.GetOutputLayout().GetNumBlks() * MRepeats * NRepeats;
+#else
         return XdlopsGemm.GetOutputLayout().GetNumBlks();
+#endif
     }
 
     __device__ constexpr auto GetBlkSize() const
@@ -67,6 +82,11 @@ struct BlockwiseGemmBlockABlockBThreadCTransANormalBNormalC_xdlops
         static_assert(BlockSize == GemmMWaves * GemmNWaves * WaveSize,
                       "BlockSize != GemmMWaves * GemmNWaves * WaveSize\n");
 
+#if CK_WORKAROUND_SWDEV_241664
+        static_assert((MRepeats == 1 && NRepeats == 1) || CK_USE_AMD_XDLOPS_INLINE_ASM == 0,
+                      "do not support xdlops repeat with inline asm");
+#endif
+
         const index_t waveId   = get_thread_local_1d_id() / WaveSize;
         const index_t waveId_m = waveId / GemmNWaves;
         const index_t waveId_n = waveId % GemmNWaves;
@@ -85,8 +105,22 @@ struct BlockwiseGemmBlockABlockBThreadCTransANormalBNormalC_xdlops
         constexpr index_t N = BlockMatrixB::NCol();
         constexpr index_t K = BlockMatrixA::NRow();
 
+#if CK_WORKAROUND_SWDEV_241664
+        constexpr auto reg_size_xdlops = MPerXdlops * NPerXdlops / WaveSize;
+
+        for(index_t m = 0; m < MRepeats; m++)
+        {
+            for(index_t n = 0; n < NRepeats; n++)
+            {
+                XdlopsGemm.template Run<M, N, K>(&p_a_block[mMyWaveOffsetA + MPerXdlops * m],
+                                                 &p_b_block[mMyWaveOffsetB + NPerXdlops * n],
+                                                 p_c_thread + (NRepeats * m + n) * reg_size_xdlops);
+            }
+        }
+#else
         XdlopsGemm.template Run<M, N, K>(
             &p_a_block[mMyWaveOffsetA], &p_b_block[mMyWaveOffsetB], p_c_thread);
+#endif
     }
 
     __device__ static MatrixIndex GetBeginOfThreadMatrixC(index_t i)
@@ -94,10 +128,26 @@ struct BlockwiseGemmBlockABlockBThreadCTransANormalBNormalC_xdlops
 
         const index_t waveId = get_thread_local_1d_id() / WaveSize;
 
+#if CK_WORKAROUND_SWDEV_241664
+        const index_t xdlops_i = i / XdlopsGemm.GetOutputLayout().GetNumBlks();
+        const index_t j        = i % XdlopsGemm.GetOutputLayout().GetNumBlks();
+
+        const index_t m = xdlops_i / NRepeats;
+        const index_t n = xdlops_i % NRepeats;
+
+        const auto thread_mtx_on_blk = XdlopsGemm.GetBeginOfThreadBlk(j);
+
+        const index_t col =
+            (waveId % GemmNWaves) * GemmNPerWave + n * NPerXdlops + thread_mtx_on_blk.col;
+
+        const index_t row =
+            (waveId / GemmNWaves) * GemmMPerWave + m * MPerXdlops + thread_mtx_on_blk.row;
+#else
         const auto thread_mtx_on_blk = XdlopsGemm.GetBeginOfThreadBlk(i);
 
         const index_t col = (waveId % GemmNWaves) * GemmNPerWave + thread_mtx_on_blk.col;
         const index_t row = (waveId / GemmNWaves) * GemmMPerWave + thread_mtx_on_blk.row;
+#endif
 
         return MatrixIndex{row, col};
     }

--- a/src/kernels/composable_kernel/include/utility/config.hpp
+++ b/src/kernels/composable_kernel/include/utility/config.hpp
@@ -73,6 +73,10 @@
 #ifndef CK_WORKAROUND_SWDEV_231101
 #define CK_WORKAROUND_SWDEV_231101 1
 #endif
+// workaround for accvgpr over-allocation
+#ifndef CK_WORKAROUND_SWDEV_241664
+#define CK_WORKAROUND_SWDEV_241664 1
+#endif
 
 namespace ck {
 

--- a/src/kernels/composable_kernel/include/utility/config.hpp
+++ b/src/kernels/composable_kernel/include/utility/config.hpp
@@ -75,7 +75,7 @@
 #endif
 // workaround for accvgpr over-allocation
 #ifndef CK_WORKAROUND_SWDEV_241664
-#define CK_WORKAROUND_SWDEV_241664 1
+#define CK_WORKAROUND_SWDEV_241664 0
 #endif
 
 namespace ck {

--- a/src/kernels/composable_kernel/include/utility/config.hpp
+++ b/src/kernels/composable_kernel/include/utility/config.hpp
@@ -75,7 +75,7 @@
 #endif
 // workaround for accvgpr over-allocation
 #ifndef CK_WORKAROUND_SWDEV_241664
-#define CK_WORKAROUND_SWDEV_241664 0
+#define CK_WORKAROUND_SWDEV_241664 1
 #endif
 
 namespace ck {


### PR DESCRIPTION
- Workaround performance regression issue (Issue #377 ) due to AccVgpr allocation issue (SWDEV_241664)
- Moving M/N repeats from xdlops gemm to blockwise gemm
