### PR TITLE
Disable faulty compiler option for global addressing using SGPR

### DIFF
--- a/src/hip/hip_build_utils.cpp
+++ b/src/hip/hip_build_utils.cpp
@@ -122,14 +122,13 @@ boost::filesystem::path HipBuild(boost::optional<TmpDir>& tmp_dir,
     params += MIOPEN_STRINGIZE(HIP_COMPILER_FLAGS);
     if(IsHccCompiler())
     {
-        env += std::string("KMOPTLLC=\"-mattr=+enable-ds128 -amdgpu-enable-global-sgpr-addr");
+        env += std::string("KMOPTLLC=\"-mattr=+enable-ds128 ");
         if(miopen::HipCompilerVersion() >= external_tool_version_t{2, 8, 0})
             env += " --amdgpu-spill-vgpr-to-agpr=0";
         env += '\"';
     }
     else if(IsHipClangCompiler())
     {
-        params += " -mllvm -amdgpu-enable-global-sgpr-addr";
         params += " -mllvm --amdgpu-spill-vgpr-to-agpr=0";
     }
 

--- a/src/solver/conv_hip_implicit_gemm_fwd_v4r4_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_fwd_v4r4_xdlops.cpp
@@ -999,22 +999,6 @@ bool ConvHipImplicitGemmForwardV4R4Xdlops::IsApplicable(const ConvolutionContext
     if(!IsIndexRangeLargeEnough(ctx))
         return false;
 
-#if WORKAROUND_SWDEV_239555
-    if(ctx.IsFp16() || ctx.IsBfp16())
-    {
-        const auto y              = ConvolutionContextInterpreter::GetFilterHeightY(ctx);
-        const auto x              = ConvolutionContextInterpreter::GetFilterWidthX(ctx);
-        const auto in_left_pad_h  = ConvolutionContextInterpreter::GetInputLeftPadH(ctx);
-        const auto in_left_pad_w  = ConvolutionContextInterpreter::GetInputLeftPadW(ctx);
-        const auto in_right_pad_h = ConvolutionContextInterpreter::GetAdjustedInputRightPadH(ctx);
-        const auto in_right_pad_w = ConvolutionContextInterpreter::GetAdjustedInputRightPadW(ctx);
-
-        if((y > 1 || x > 1) &&
-           (in_left_pad_h > 0 || in_left_pad_w > 0 || in_right_pad_h > 0 || in_right_pad_w > 0))
-            return false;
-    }
-#endif
-
     // gemm size
     {
         int gemm_g       = -1;

--- a/src/solver/implicitgemm_util.hpp
+++ b/src/solver/implicitgemm_util.hpp
@@ -18,8 +18,6 @@ MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_BLOCK_SYNC_LDS_WITHOUT_SY
 #define WORKAROUND_SWDEV_229564 1
 // workaround for buffer load/store fp16/bfp16 intrinsic bug
 #define WORKAROUND_SWDEV_231101 1
-// workaround compiler bug: GPU memory access fault when there is padding in fp16/bfp16 case
-#define WORKAROUND_SWDEV_239555 1
 // LLVM xdlops instrinsic will do unnecessey VGRP <--> AGPR movement, and result in
 // register spill, for bfloat16 datatype, when doing wave-wise GEMM larger than 64x64
 #define WORKAROUND_SWDEV_240356 1


### PR DESCRIPTION
MIOpen is using "-amdgpu-enable-global-sgpr-addr" option for hip-clang compiler, but the feature has not been correctly implemented in compiler, and can cause GPU core dump in some cases (http://ontrack-internal.amd.com/browse/SWDEV-239555). Currently there is a workaround in MIOpen to prevent this failure. This PR remove this compiler flag and the workaround.


However, disabling the option can result in more than 20% regression in gfx908 fp16 cases.
http://ontrack-internal.amd.com/browse/SWDEV-239555?focusedCommentId=6260190&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-6260190

A JIRA is opened to request proper implementation of SGPR offset for global addressing in compiler, so performance can be restored.
http://ontrack-internal.amd.com/browse/SWDEV-248564