### PR TITLE
Dynamic OpenCL batch normalization inference.

### DIFF
--- a/src/kernels/MIOpenBatchNormFwdInferPerAct.cl
+++ b/src/kernels/MIOpenBatchNormFwdInferPerAct.cl
@@ -53,8 +53,6 @@ MIOpenBatchNormFwdInferPerActivationEst(const __global _FLOAT* in,
     _FLOAT_PREC invVariance, elemStd, inhat;
     _FLOAT_PREC pvt_scale, pvt_bias;
     unsigned int adjIndex, index;
-
-    // int xgid    = get_global_id(0);
     int ygid    = get_global_id(1);
     int yglb_sz = get_global_size(1);
 
@@ -62,7 +60,7 @@ MIOpenBatchNormFwdInferPerActivationEst(const __global _FLOAT* in,
     {
         for(int img_offset = ygid; img_offset < imageDims; img_offset += yglb_sz)
         {
-            adjIndex    = (cidx * imageDims) + img_offset; // gamma and beta tensor index
+            adjIndex    = (cidx * imageDims) + img_offset;
             mean        = estimatedMean[adjIndex];
             variance    = estimatedVariance[adjIndex];
             invVariance = rsqrt(fabs(variance + epsilon));
@@ -75,7 +73,7 @@ MIOpenBatchNormFwdInferPerActivationEst(const __global _FLOAT* in,
                 elemStd    = (_FLOAT_PREC)(*(in + index)) - mean;
                 inhat      = elemStd * invVariance;
                 out[index] = (_FLOAT)(mad(pvt_scale, inhat, pvt_bias));
-            } // end for
+            }
         }
     }
 }

--- a/src/kernels/MIOpenBatchNormFwdInferPerAct.cl
+++ b/src/kernels/MIOpenBatchNormFwdInferPerAct.cl
@@ -44,8 +44,7 @@ MIOpenBatchNormFwdInferPerActivationEst(const __global _FLOAT* in,
                                         double epsilon,
                                         unsigned int batchSize,
                                         unsigned int imageDims,
-                                        unsigned int batchStride,
-                                        unsigned int channels)
+                                        unsigned int batchStride)
 {
 
     // PER ACTIVATION

--- a/src/kernels/MIOpenBatchNormFwdInferPerAct.cl
+++ b/src/kernels/MIOpenBatchNormFwdInferPerAct.cl
@@ -35,53 +35,49 @@
 #include "batchnorm_functions.h"
 
 __attribute__((reqd_work_group_size(MIO_BN_GRP0, MIO_BN_GRP1, MIO_BN_GRP2))) __kernel void
-MIOpenBatchNormFwdInferPerActivationEst(
-    const __global _FLOAT* in,                      /* x input */
-    __global _FLOAT* __restrict out,                /* y output */
-    __global _FLOAT_PREC* __restrict estimatedMean, /*input and output, same descriptor as bias*/
-    __global _FLOAT_PREC* __restrict estimatedVariance, /*input and output*/
-    const __global _FLOAT_PREC* __restrict scale,       /* gamma 1xCxHxW */
-    const __global _FLOAT_PREC* __restrict bias,        /* beta 1xCxHxW */
-    double epsilon)
+MIOpenBatchNormFwdInferPerActivationEst(const __global _FLOAT* in,
+                                        __global _FLOAT* __restrict out,
+                                        __global _FLOAT_PREC* __restrict estimatedMean,
+                                        __global _FLOAT_PREC* __restrict estimatedVariance,
+                                        const __global _FLOAT_PREC* __restrict scale,
+                                        const __global _FLOAT_PREC* __restrict bias,
+                                        double epsilon,
+                                        unsigned int batchSize,
+                                        unsigned int imageDims,
+                                        unsigned int batchStride,
+                                        unsigned int channels)
 {
 
     // PER ACTIVATION
     _FLOAT_PREC mean, variance;
     _FLOAT_PREC invVariance, elemStd, inhat;
     _FLOAT_PREC pvt_scale, pvt_bias;
-    unsigned int adjIndex, inImgIndex, index;
+    unsigned int adjIndex, index;
 
-    int xgid    = get_global_id(0);
+    // int xgid    = get_global_id(0);
     int ygid    = get_global_id(1);
     int yglb_sz = get_global_size(1);
 
-    int Cidx = MIO_BN_HW * xgid;
-
-    // move across the sections of an image in the mini_batch stack
-    for(int img_offset = 0; img_offset < MIO_BN_HW; img_offset += yglb_sz)
+    for(int cidx = get_group_id(0); cidx < channels; cidx += get_num_groups(0))
     {
-        inImgIndex = img_offset + ygid;
-        if(inImgIndex < MIO_BN_HW)
+        for(int img_offset = ygid; img_offset < imageDims; img_offset += yglb_sz)
         {
-            adjIndex    = Cidx + inImgIndex; // gamma and beta tensor index
+            adjIndex    = (cidx * imageDims) + img_offset; // gamma and beta tensor index
             mean        = estimatedMean[adjIndex];
             variance    = estimatedVariance[adjIndex];
             invVariance = rsqrt(fabs(variance + epsilon));
             pvt_scale   = *(scale + adjIndex);
             pvt_bias    = *(bias + adjIndex);
 
-#pragma unroll
-            for(int n = 0; n < MIO_BN_N; n++)
+            for(int n = 0; n < batchSize; n++)
             {
-                // per (x-dims) channel load a block of data into LDS
-                index   = MIO_BN_CHW * n + adjIndex;
-                elemStd = (_FLOAT_PREC)(*(in + index)) - mean; // (x_i - mean)
-                inhat   = elemStd * invVariance;
-                out[index] =
-                    (_FLOAT)(mad(pvt_scale, inhat, pvt_bias)); //	y_i = gamma*x_hat + beta
-            }                                                  // end for
-        }                                                      // end if
-    } // end for(img_offset) //image mini_batch is processed
+                index      = batchStride * n + adjIndex;
+                elemStd    = (_FLOAT_PREC)(*(in + index)) - mean;
+                inhat      = elemStd * invVariance;
+                out[index] = (_FLOAT)(mad(pvt_scale, inhat, pvt_bias));
+            } // end for
+        }
+    }
 }
 
 // Restore warnings

--- a/src/kernels/MIOpenBatchNormFwdInferSpatial.cl
+++ b/src/kernels/MIOpenBatchNormFwdInferSpatial.cl
@@ -44,8 +44,7 @@ MIOpenBatchNormFwdInferSpatialEst(const __global _FLOAT* __restrict in, /* x inp
                                   double epsilon,
                                   unsigned int batchSize,
                                   unsigned int imageDims,
-                                  unsigned int batchStride,
-                                  unsigned int channels)
+                                  unsigned int batchStride)
 {
 
     int xgid = get_global_id(0);

--- a/src/kernels/MIOpenBatchNormFwdInferSpatial.cl
+++ b/src/kernels/MIOpenBatchNormFwdInferSpatial.cl
@@ -51,32 +51,12 @@ MIOpenBatchNormFwdInferSpatialEst(const __global _FLOAT* __restrict in, /* x inp
     int xgid = get_global_id(0);
     int ygid = get_global_id(1);
 
-    /*     local _FLOAT_PREC lmean;
-        local _FLOAT_PREC lvar;
-        local _FLOAT_PREC lscale;
-        local _FLOAT_PREC lbias; */
-
     unsigned int index;
 
     _FLOAT_PREC mean, variance, invVariance;
     _FLOAT_PREC inhat;
     _FLOAT_PREC pscale, pbias;
 
-    /*     if(get_local_id(1) == 0)
-        {
-            lmean  = *(estimatedMean + xgid);
-            lvar   = *(estimatedVariance + xgid);
-            lscale = *(scale + xgid);
-            lbias  = *(bias + xgid);
-        }
-        barrier(CLK_LOCAL_MEM_FENCE);
-
-        mean        = lmean;
-        variance    = lvar;
-        pscale      = lscale;
-        pbias       = lbias;
-        invVariance = rsqrt(fabs(variance + epsilon));
-     */
     for(int cidx = xgid; cidx < channels; cidx += get_global_size(0))
     {
 

--- a/src/kernels/MIOpenBatchNormFwdInferSpatial.cl
+++ b/src/kernels/MIOpenBatchNormFwdInferSpatial.cl
@@ -41,47 +41,60 @@ MIOpenBatchNormFwdInferSpatialEst(const __global _FLOAT* __restrict in, /* x inp
                                   const __global _FLOAT_PREC* __restrict estimatedVariance,
                                   const __global _FLOAT_PREC* __restrict scale,
                                   const __global _FLOAT_PREC* __restrict bias,
-                                  double epsilon)
+                                  double epsilon,
+                                  unsigned int batchSize,
+                                  unsigned int imageDims,
+                                  unsigned int batchStride,
+                                  unsigned int channels)
 {
 
     int xgid = get_global_id(0);
     int ygid = get_global_id(1);
-    local _FLOAT_PREC lmean;
-    local _FLOAT_PREC lvar;
-    local _FLOAT_PREC lscale;
-    local _FLOAT_PREC lbias;
 
-    unsigned int cidx = xgid * MIO_BN_HW;
+    /*     local _FLOAT_PREC lmean;
+        local _FLOAT_PREC lvar;
+        local _FLOAT_PREC lscale;
+        local _FLOAT_PREC lbias; */
+
     unsigned int index;
 
     _FLOAT_PREC mean, variance, invVariance;
     _FLOAT_PREC inhat;
     _FLOAT_PREC pscale, pbias;
 
-    if(get_local_id(1) == 0)
-    {
-        lmean  = *(estimatedMean + xgid);
-        lvar   = *(estimatedVariance + xgid);
-        lscale = *(scale + xgid); // dims 1xCx1x1
-        lbias  = *(bias + xgid);
-    }
-    barrier(CLK_LOCAL_MEM_FENCE);
-    // move across the sections of the image mini_batch stack
-    if(ygid < MIO_BN_HW)
-    {
+    /*     if(get_local_id(1) == 0)
+        {
+            lmean  = *(estimatedMean + xgid);
+            lvar   = *(estimatedVariance + xgid);
+            lscale = *(scale + xgid);
+            lbias  = *(bias + xgid);
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+
         mean        = lmean;
         variance    = lvar;
         pscale      = lscale;
         pbias       = lbias;
         invVariance = rsqrt(fabs(variance + epsilon));
+     */
+    for(int cidx = xgid; cidx < channels; cidx += get_global_size(0))
+    {
 
-#pragma unroll
-        for(int n = 0; n < MIO_BN_N; n++)
+        mean        = *(estimatedMean + cidx);
+        variance    = *(estimatedVariance + cidx);
+        pscale      = *(scale + cidx);
+        pbias       = *(bias + cidx);
+        invVariance = rsqrt(fabs(variance + epsilon));
+
+        for(int idx = ygid; idx < imageDims; idx += get_global_size(1))
         {
-            index      = n * MIO_BN_CHW + cidx + ygid;
-            inhat      = ((_FLOAT_PREC)(*(in + index)) - mean) * invVariance;
-            out[index] = (_FLOAT)(mad(pscale, inhat, pbias)); // y_i = gamma*x_hat + beta
-        }                                                     // end for(img_offset)
+            for(int n = 0; n < batchSize; n++)
+            {
+                index      = (n * batchStride) + (cidx * imageDims) + idx;
+                inhat      = ((_FLOAT_PREC)(*(in + index)) - mean) * invVariance;
+                out[index] = (_FLOAT)(mad(pscale, inhat, pbias));
+            }
+        }
     }
 } // end spatial norm
 

--- a/src/kernels/batchnorm_functions.h
+++ b/src/kernels/batchnorm_functions.h
@@ -165,27 +165,6 @@ static inline void running_stash(global _FLOAT_PREC* resultRunningMean,
         (_FLOAT_ACCUM)expAvgFactor * adjust);
 }
 
-static inline void running_stash_dyn(global _FLOAT_PREC* resultRunningMean,
-                                     global _FLOAT_PREC* resultRunningVariance,
-                                     double expAvgFactor,
-                                     _FLOAT_ACCUM mean,
-                                     _FLOAT_ACCUM variance,
-                                     uint channel,
-                                     uint NHW)
-{
-    _FLOAT_ACCUM pvt_runMean = (_FLOAT_ACCUM)(*(resultRunningMean + channel));
-    _FLOAT_ACCUM pvt_newRunMean =
-        mad((_FLOAT_ACCUM)-expAvgFactor, pvt_runMean, pvt_runMean); // tmp = oldRunMean*(1-factor)
-    resultRunningMean[channel] =
-        (_FLOAT_PREC)mad(mean, (_FLOAT_ACCUM)expAvgFactor, pvt_newRunMean); // newMean*factor + tmp
-    const _FLOAT_ACCUM adjust = (_FLOAT_ACCUM)(
-        (NHW == 1) ? variance
-                   : variance * ((_FLOAT_ACCUM)NHW / ((_FLOAT_ACCUM)NHW - (_FLOAT_ACCUM)1.0)));
-    resultRunningVariance[channel] = (_FLOAT_PREC)(
-        (1 - (_FLOAT_ACCUM)expAvgFactor) * (_FLOAT_ACCUM)(*(resultRunningVariance + channel)) +
-        (_FLOAT_ACCUM)expAvgFactor * adjust);
-}
-
 static inline void saved_stash(global _FLOAT_PREC* resultSaveMean,
                                global _FLOAT_PREC* resultSaveInvVariance,
                                _FLOAT_ACCUM mean,

--- a/src/kernels/reduction_functions.h
+++ b/src/kernels/reduction_functions.h
@@ -54,6 +54,7 @@ regLDSreduce(_FLOAT_ACCUM* value, local _FLOAT_ACCUM* data, uint localID, _FLOAT
     barrier(CLK_LOCAL_MEM_FENCE);
     *value = data[0] * scale;
 }
+
 #endif
 
 #ifdef __AMDGCN__

--- a/src/ocl/batchnormocl.cpp
+++ b/src/ocl/batchnormocl.cpp
@@ -682,12 +682,15 @@ void BatchNormForwardInference(Handle& handle,
         std::string algo_name      = "miopenBatchNormalizationForwardInference";
         std::string network_config = "fp16" + std::to_string(static_cast<int>(bfp16parm)) + "fp32" +
                                      std::to_string(static_cast<int>(bfp32parm)) + "mode" +
-                                     std::to_string(bn_mode);
+                                     std::to_string(bn_mode) + "HWdims" +
+                                     std::to_string(in_cstride) + "C" + std::to_string(c);
 
         auto&& kernels = handle.GetKernels(algo_name, network_config);
         if(!kernels.empty())
         {
             auto kernel = kernels.front();
+            std::cout << "network_config: " << network_config << std::endl;
+            std::cout << "network_config: " << network_config << std::endl;
             kernel(x,
                    y,
                    estimatedMean,

--- a/src/ocl/batchnormocl.cpp
+++ b/src/ocl/batchnormocl.cpp
@@ -703,9 +703,9 @@ void BatchNormForwardInference(Handle& handle,
         else
         {
             size_t xlocalsize = 1;
-            auto xgridsize    = std::size_t(handle.GetMaxComputeUnits());
+            auto xgridsize    = c;
             size_t ylocalsize = 256;
-            size_t ygridsize  = 4096;
+            size_t ygridsize  = ylocalsize * ((in_cstride + ylocalsize - 1) / ylocalsize);
             size_t zlocalsize = 1;
             size_t zgridsize  = 1;
 

--- a/src/ocl/batchnormocl.cpp
+++ b/src/ocl/batchnormocl.cpp
@@ -697,8 +697,7 @@ void BatchNormForwardInference(Handle& handle,
                    epsilon,
                    n,
                    in_cstride,
-                   in_nstride,
-                   c);
+                   in_nstride);
         }
         else
         {
@@ -750,8 +749,7 @@ void BatchNormForwardInference(Handle& handle,
                 epsilon,
                 n,
                 in_cstride,
-                in_nstride,
-                c);
+                in_nstride);
         }
     }
     else // Need to recalculated everything, let's just call training kernel in that case

--- a/src/ocl/batchnormocl.cpp
+++ b/src/ocl/batchnormocl.cpp
@@ -679,15 +679,6 @@ void BatchNormForwardInference(Handle& handle,
         unsigned int in_nstride = c * h * w;
         unsigned int in_cstride = h * w;
 
-        size_t xlocalsize = 1;
-        size_t ylocalsize = 256;
-
-        std::vector<size_t> vld;
-        std::vector<size_t> vgd;
-
-        auto xgridsize = std::size_t(handle.GetMaxComputeUnits());
-        auto ygridsize = 4096;
-
         std::string algo_name      = "miopenBatchNormalizationForwardInference";
         std::string network_config = "fp16" + std::to_string(static_cast<int>(bfp16parm)) + "fp32" +
                                      std::to_string(static_cast<int>(bfp32parm)) + "mode" +
@@ -712,16 +703,12 @@ void BatchNormForwardInference(Handle& handle,
         else
         {
             size_t xlocalsize = 1;
+            auto xgridsize    = std::size_t(handle.GetMaxComputeUnits());
             size_t ylocalsize = 256;
+            size_t ygridsize  = 4096;
+            size_t zlocalsize = 1;
+            size_t zgridsize  = 1;
 
-            std::vector<size_t> vld;
-            std::vector<size_t> vgd;
-
-            auto xgridsize = std::size_t(handle.GetMaxComputeUnits());
-            auto ygridsize = 4096;
-
-            size_t zlocalsize        = 1;
-            size_t zgridsize         = 1;
             std::string program_name = "MIOpenBatchNormFwdInfer"; // build this up
             std::string kernel_name  = "MIOpenBatchNormFwdInfer";
             if(bn_mode == miopenBNSpatial)
@@ -742,6 +729,8 @@ void BatchNormForwardInference(Handle& handle,
                 " -DMIO_BN_GRP0=" + std::to_string(xlocalsize) + " -DMIO_BN_GRP1=" +
                 std::to_string(ylocalsize) + " -DMIO_BN_GRP2=" + std::to_string(zlocalsize);
 
+            std::vector<size_t> vld;
+            std::vector<size_t> vgd;
             vld.push_back(xlocalsize);
             vld.push_back(ylocalsize);
             vld.push_back(zlocalsize);

--- a/src/ocl/batchnormocl.cpp
+++ b/src/ocl/batchnormocl.cpp
@@ -711,6 +711,15 @@ void BatchNormForwardInference(Handle& handle,
         }
         else
         {
+            size_t xlocalsize = 1;
+            size_t ylocalsize = 256;
+
+            std::vector<size_t> vld;
+            std::vector<size_t> vgd;
+
+            auto xgridsize = std::size_t(handle.GetMaxComputeUnits());
+            auto ygridsize = 4096;
+
             size_t zlocalsize        = 1;
             size_t zgridsize         = 1;
             std::string program_name = "MIOpenBatchNormFwdInfer"; // build this up


### PR DESCRIPTION

This PR is specifically for inference. Low batch sizes do better than what we had previously, high batch sizes do worse.
Since this is for inference I suspect for now we don't have to worry a lot for larger batch sizes. 

Data collected on a MI50.




Batch size 1:

  | spatial PR | spatial dev | runtime ratio | per act PR | per act dev | runtime ratio
-- | -- | -- | -- | -- | -- | --
./bin/MIOpenDriver bnorm -i 10 -t 1 -w 1 -V 0 -n 1 -c 1024 -H 14 -W 14   -m ${1} --forw 2 -s 1 -r 1 | 0.010 | 0.013 | 74% | 0.015 | 0.021 | 69%
./bin/MIOpenDriver bnorm -i 10 -t 1 -w 1 -V 0 -n 1 -c 128 -H 28 -W 28   -m ${1} --forw 2 -s 1 -r 1 | 0.011 | 0.009 | 132% | 0.008 | 0.012 | 66%
./bin/MIOpenDriver bnorm -i 10 -t 1 -w 1 -V 0 -n 1 -c 2048 -H 7 -W 7   -m ${1} --forw 2 -s 1 -r 1 | 0.011 | 0.009 | 115% | 0.014 | 0.013 | 107%
./bin/MIOpenDriver bnorm -i 10 -t 1 -w 1 -V 0 -n 1 -c 256 -H 14 -W 14   -m ${1} --forw 2 -s 1 -r 1 | 0.005 | 0.005 | 94% | 0.008 | 0.008 | 104%
./bin/MIOpenDriver bnorm -i 10 -t 1 -w 1 -V 0 -n 1 -c 256 -H 56 -W 56   -m ${1} --forw 2 -s 1 -r 1 | 0.023 | 0.027 | 83% | 0.065 | 0.072 | 90%
./bin/MIOpenDriver bnorm -i 10 -t 1 -w 1 -V 0 -n 1 -c 512 -H 28 -W 28   -m ${1} --forw 2 -s 1 -r 1 | 0.012 | 0.014 | 86% | 0.038 | 0.038 | 100%
./bin/MIOpenDriver bnorm -i 10 -t 1 -w 1 -V 0 -n 1 -c 512 -H 7 -W 7 -m   ${1} --forw 2 -s 1 -r 1 | 0.005 | 0.005 | 100% | 0.007 | 0.006 | 110%
./bin/MIOpenDriver bnorm -i 10 -t 1 -w 1 -V 0 -n 1 -c 64 -H 112 -W 112   -m ${1} --forw 2 -s 1 -r 1 | 0.016 | 0.025 | 63% | 0.045 | 0.072 | 62%
./bin/MIOpenDriver bnorm -i 10 -t 1 -w 1 -V 0 -n 1 -c 64 -H 56 -W 56   -m ${1} --forw 2 -s 1 -r 1 | 0.007 | 0.009 | 78% | 0.014 | 0.015 | 93%



Batch size 128:

  | spatial PR | spatial dev | runtime ratio | per act PR | per act dev | runtime ratio
-- | -- | -- | -- | -- | -- | --
./bin/MIOpenDriver bnorm -i 10 -t 1 -w 1 -V 0 -n 128 -c 1024 -H 14 -W   14 -m ${1} --forw 2 -s 1 -r 1 | 0.347 | 0.352 | 99% | 0.314 | 0.323 | 97%
./bin/MIOpenDriver bnorm -i 10 -t 1 -w 1 -V 0 -n 128 -c 128 -H 28 -W   28 -m ${1} --forw 2 -s 1 -r 1 | 0.157 | 0.207 | 76% | 0.157 | 0.182 | 86%
./bin/MIOpenDriver bnorm -i 10 -t 1 -w 1 -V 0 -n 128 -c 2048 -H 7 -W 7   -m ${1} --forw 2 -s 1 -r 1 | 0.258 | 0.178 | 145% | 0.263 | 0.166 | 159%
./bin/MIOpenDriver bnorm -i 10 -t 1 -w 1 -V 0 -n 128 -c 256 -H 14 -W   14 -m ${1} --forw 2 -s 1 -r 1 | 0.103 | 0.093 | 111% | 0.104 | 0.127 | 81%
./bin/MIOpenDriver bnorm -i 10 -t 1 -w 1 -V 0 -n 128 -c 256 -H 56 -W   56 -m ${1} --forw 2 -s 1 -r 1 | 1.036 | 1.050 | 99% | 1.040 | 1.053 | 99%
./bin/MIOpenDriver bnorm -i 10 -t 1 -w 1 -V 0 -n 128 -c 512 -H 28 -W   28 -m ${1} --forw 2 -s 1 -r 1 | 0.603 | 0.597 | 101% | 0.611 | 0.609 | 100%
./bin/MIOpenDriver bnorm -i 10 -t 1 -w 1 -V 0 -n 128 -c 512 -H 7 -W 7   -m ${1} --forw 2 -s 1 -r 1 | 0.074 | 0.043 | 173% | 0.075 | 0.102 | 73%
./bin/MIOpenDriver bnorm -i 10 -t 1 -w 1 -V 0 -n 128 -c 64 -H 112 -W   112 -m ${1} --forw 2 -s 1 -r 1 | 1.037 | 1.059 | 98% | 1.053 | 1.046 | 101%
./bin/MIOpenDriver bnorm -i 10 -t 1 -w 1 -V 0 -n 128 -c 64 -H 56 -W 56   -m ${1} --forw 2 -s 1 -r 1 | 0.307 | 0.293 | 105% | 0.332 | 0.300 | 111%