### PR TITLE
workaround issue SWDEV-251757

### DIFF
--- a/src/solver/implicitgemm_util.hpp
+++ b/src/solver/implicitgemm_util.hpp
@@ -21,6 +21,9 @@ MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_BLOCK_SYNC_LDS_WITHOUT_SY
 // LLVM xdlops instrinsic will do unnecessey VGRP <--> AGPR movement, and result in
 // register spill, for bfloat16 datatype, when doing wave-wise GEMM larger than 64x64
 #define WORKAROUND_SWDEV_240356 1
+// due to compiler bug, iGEMM xdlops kernels fail verification in some cases, if using "-O3" flag,
+// (but will pass verification with "-O1" flag)
+#define WORKAROUND_SWDEV_251757 1
 // workaround failure of ConvHipImplicitGemmV4R4GenWrWXdlops with vector load
 #define WORKAROUND_ISSUE_2532 1
 
@@ -514,6 +517,11 @@ static inline bool IsValidBlockwiseGemmXdlops(const ConvolutionContext& ctx,
                                               const int GemmNPerWave,
                                               const int GemmKPack)
 {
+#if WORKAROUND_SWDEV_251757
+    if(ctx.IsFp32() && GemmKPerBlock == 1 && GemmKPack == 8)
+        return false;
+#endif
+
     // check k
     if(ctx.IsFp16() && GemmKPack % 4 != 0)
         return false;


### PR DESCRIPTION
workaround for a compiler bug:
http://ontrack-internal.amd.com/browse/SWDEV-251757

This triggers MIOpen staging failure (solver is ```ConvHipImplicitGemmBwdDataV1R1Xdlops```)

```
MIOpenDriver conv -n 32 -c 128 -H 38 -W 38 -k 256 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -t 1

MIOpen Backward Data Conv. Algorithm: 5, Solution: 57/ConvHipImplicitGemmBwdDataV1R1Xdlops

Backward Convolution Data Failed: 0.205775 > 1e-05

 

MIOpenDriver conv -n 32 -c 256 -H 38 -W 38 -k 256 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -t 1

MIOpen Backward Data Conv. Algorithm: 5, Solution: 57/ConvHipImplicitGemmBwdDataV1R1Xdlops

Backward Convolution Data Failed: 0.218504 > 1e-05

 

MIOpenDriver conv -n 32 -c 256 -H 38 -W 38 -k 512 -y 3 -x 3 -p 1 -q 1 -u 2 -v 2 -l 1 -j 1 -m conv -g 1 -t 1

MIOpen Backward Data Conv. Algorithm: 5, Solution: 57/ConvHipImplicitGemmBwdDataV1R1Xdlops

Backward Convolution Data Failed: 0.156217 > 1e-05

 

MIOpenDriver conv -n 32 -c 512 -H 19 -W 19 -k 256 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -t 1

MIOpen Backward Data Conv. Algorithm: 5, Solution: 57/ConvHipImplicitGemmBwdDataV1R1Xdlops

Backward Convolution Data Failed: 0.201321 > 1e-05

 

MIOpenDriver conv -n 32 -c 256 -H 19 -W 19 -k 512 -y 3 -x 3 -p 1 -q 1 -u 2 -v 2 -l 1 -j 1 -m conv -g 1 -t 1

MIOpen Backward Data Conv. Algorithm: 5, Solution: 57/ConvHipImplicitGemmBwdDataV1R1Xdlops

Backward Convolution Data Failed: 0.169962 > 1e-05

 

MIOpenDriver conv -n 4 -c 64 -H 256 -W 256 -k 256 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -t 1

MIOpen Backward Data Conv. Algorithm: 5, Solution: 57/ConvHipImplicitGemmBwdDataV1R1Xdlops

Backward Convolution Data Failed: 0.109827 > 1e-05

 

MIOpenDriver conv -n 4 -c 256 -H 256 -W 256 -k 64 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -t 1

MIOpen Backward Data Conv. Algorithm: 5, Solution: 57/ConvHipImplicitGemmBwdDataV1R1Xdlops

Backward Convolution Data Failed: 0.0925176 > 1e-05

 

MIOpenDriver conv -n 4 -c 256 -H 256 -W 256 -k 256 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -t 1

MIOpen Backward Data Conv. Algorithm: 5, Solution: 57/ConvHipImplicitGemmBwdDataV1R1Xdlops

Backward Convolution Data Failed: 0.203921 > 1e-05

 

MIOpenDriver conv -n 4 -c 512 -H 128 -W 128 -k 128 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -t 1

MIOpen Backward Data Conv. Algorithm: 5, Solution: 57/ConvHipImplicitGemmBwdDataV1R1Xdlops

Backward Convolution Data Failed: 0.181879 > 1e-05

 

MIOpenDriver conv -n 4 -c 512 -H 128 -W 128 -k 256 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -t 1

MIOpen Backward Data Conv. Algorithm: 5, Solution: 57/ConvHipImplicitGemmBwdDataV1R1Xdlops

Backward Convolution Data Failed: 0.187799 > 1e-05

 

MIOpenDriver conv -n 4 -c 1024 -H 64 -W 64 -k 256 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -t 1

MIOpen Backward Data Conv. Algorithm: 5, Solution: 57/ConvHipImplicitGemmBwdDataV1R1Xdlops

Backward Convolution Data Failed: 0.198568 > 1e-05

 

MIOpenDriver conv -n 4 -c 512 -H 128 -W 128 -k 12 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -t 1

MIOpen Backward Data Conv. Algorithm: 5, Solution: 57/ConvHipImplicitGemmBwdDataV1R1Xdlops

Backward Convolution Data Failed: 0.1117 > 1e-05

 

MIOpenDriver conv -n 800 -c 256 -H 7 -W 7 -k 1024 -y 7 -x 7 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -t 1

MIOpen Backward Data Conv. Algorithm: 5, Solution: 57/ConvHipImplicitGemmBwdDataV1R1Xdlops

Backward Convolution Data Failed: 0.18362 > 1e-05

 

MIOpenDriver conv -n 800 -c 1024 -H 1 -W 1 -k 1024 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -t 1

MIOpen Backward Data Conv. Algorithm: 5, Solution: 57/ConvHipImplicitGemmBwdDataV1R1Xdlops

Backward Convolution Data Failed: 0.210989 > 1e-05

 

MIOpenDriver conv -n 800 -c 256 -H 28 -W 28 -k 256 -y 2 -x 2 -p 0 -q 0 -u 2 -v 2 -l 1 -j 1 -m conv -g 1 -t 1

MIOpen Backward Data Conv. Algorithm: 5, Solution: 57/ConvHipImplicitGemmBwdDataV1R1Xdlops

Backward Convolution Data Failed: 0.19599 > 1e-05
```