### PR TITLE
Add code coverage reports

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,13 +19,13 @@ def rocmnode(name) {
 
 
 
-def cmake_build(compiler, flags, env4make, prefixpath){
+def cmake_build(compiler, flags, env4make, extradebugflags, prefixpath){
     def workspace_dir = pwd()
     def vcache = "/var/jenkins/.cache/miopen/vcache"
     def archive = (flags == '-DCMAKE_BUILD_TYPE=release')
     def config_targets = "check doc MIOpenDriver"
     def test_flags = "--disable-verification-cache"
-    def debug_flags = "-g -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined"
+    def debug_flags = "-g ${extradebugflags} -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined"
     def compilerpath = ""
     def configargs = ""
     if (prefixpath == "/usr/local")
@@ -59,14 +59,21 @@ def cmake_build(compiler, flags, env4make, prefixpath){
 def buildJob(Map conf, compiler){
 
         env.HSA_ENABLE_SDMA=0 
+        env.CODECOV_TOKEN="aec031be-7673-43b5-9840-d8fb71a2354e"
         checkout scm
         def prefixpath = conf.get("prefixpath", "/usr/local")
         def flags = conf.get("flags", "")
         def env4make = conf.get("env4make", "")
         def image = conf.get("image", "miopen")
         def cmd = conf.get("cmd", "")
+        def codecov = conf.get("codecov", false)
         def dockerOpts="--device=/dev/kfd --device=/dev/dri --group-add video --cap-add=SYS_PTRACE --security-opt seccomp=unconfined"
         def dockerArgs = "--build-arg PREFIX=${prefixpath} "
+        def extradebugflags = ""
+        if (codecov) {
+            extradebugflags = "-fprofile-arcs -ftest-coverage"
+        }
+        def 
         def retimage
         try {
             retimage = docker.build("${image}", dockerArgs + '.')
@@ -90,9 +97,19 @@ def buildJob(Map conf, compiler){
             timeout(time: 5, unit: 'HOURS')
             {
                 if(cmd == ""){
-                    cmake_build(compiler, flags, env4make, prefixpath)
+                    cmake_build(compiler, flags, env4make, extradebugflags, prefixpath)
                 }else{
                     sh cmd
+                }
+                if (codecov) {
+                    sh '''
+                        cd build
+                        lcov --directory . --capture --output-file $(pwd)/coverage.info
+                        lcov --remove $(pwd)/coverage.info '/usr/*' --output-file $(pwd)/coverage.info
+                        lcov --list $(pwd)/coverage.info
+                        curl -s https://codecov.io/bash | bash
+                        echo "Uploaded"
+                    '''
                 }
             }
         }
@@ -211,7 +228,7 @@ pipeline {
                 stage('GCC Debug') {
                     agent{ label rocmnode("vega") }
                     steps{
-                        buildJob('g++-5', flags: '-DBUILD_DEV=On -DCMAKE_BUILD_TYPE=debug')
+                        buildJob('g++-5', flags: '-DBUILD_DEV=On -DCMAKE_BUILD_TYPE=debug', codecov: true)
                     }
                 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -73,7 +73,6 @@ def buildJob(Map conf, compiler){
         if (codecov) {
             extradebugflags = "-fprofile-arcs -ftest-coverage"
         }
-        def 
         def retimage
         try {
             retimage = docker.build("${image}", dockerArgs + '.')

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,4 @@
 ignore:
   - "addkernels/"
   - "driver/"
-  - "driver/"
   - "build/" 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,5 @@
+ignore:
+  - "addkernels/"
+  - "driver/"
+  - "driver/"
+  - "build/" 


### PR DESCRIPTION
This measures codecov using the gcc debug stage. We could try to add coverage from the hip backend as well in the future.

Right now, it only shows the coverage for this branch [here](https://codecov.io/gh/ROCmSoftwarePlatform/MIOpen/branch/codecov). Once its merged to develop then it will report back the diff coverage between develop and PRs.