### PR TITLE
[COMGR] Added HIP PCH functionality.

### DIFF
--- a/src/comgr.cpp
+++ b/src/comgr.cpp
@@ -196,8 +196,9 @@ static void RemoveCommonOptionsUnwanted(OptionList& list)
                          [&](const auto& option) { // clang-format off
                              return miopen::StartsWith(option, "-mcpu=")
                                 || (option == "-hc")
-                                || (option == "-x hip")
+                                || (option == "-x hip") || (option == "-xhip")
                                 || (option == "--hip-link")
+                                || (option == "-lclang_rt.builtins-x86_64")
                                 || miopen::StartsWith(option, "-mllvm -amdgpu-early-inline-all")
                                 || miopen::StartsWith(option, "-mllvm -amdgpu-function-calls")
                                 || miopen::StartsWith(option, "--hip-device-lib-path="); // clang-format on
@@ -677,6 +678,10 @@ void BuildHip(const std::string& name,
             action.SetOptionList(optLink);
             const Dataset linkedBc;
             action.Do(AMD_COMGR_ACTION_LINK_BC_TO_BC, withDevLibs, linkedBc);
+
+            OptionList codegenBcToRel;
+            codegenBcToRel.push_back("-O3"); // Nothing more is required at this step.
+            action.SetOptionList(codegenBcToRel);
             const Dataset relocatable;
             action.Do(AMD_COMGR_ACTION_CODEGEN_BC_TO_RELOCATABLE, linkedBc, relocatable);
 

--- a/src/kernels/composable_kernel/include/utility/config.hpp
+++ b/src/kernels/composable_kernel/include/utility/config.hpp
@@ -1,8 +1,10 @@
 #ifndef CK_CONFIG_AMD_HPP
 #define CK_CONFIG_AMD_HPP
 
+#ifndef MIOPEN_DONT_USE_HIP_RUNTIME_HEADERS
 #include "hip/hip_runtime.h"
 #include "hip/hip_fp16.h"
+#endif
 #include "bfloat16_dev.hpp"
 
 // index type: unsigned or signed


### PR DESCRIPTION
Partially implements changes required for SWDEV-249870.

- Contains COMGR related fixes necessary for upcoming ROCm
- HIP PCH (precompiled HIP headers) related functionality implemented and tested with ROCm RC
- However functionality is enabled starting from ROCm 4.0 (in fact, currently ___disabled___)
  - In other words, this change is NFC when used with previous ROCm releases.
- ___Future___: Enable when ROCm 3.9.x implementation is available.
- ___Future___: Enable also for non-COMGR HIP build path?

## Testing results

- With enabled HIP PCH, the library shows ~1.5 better HIP compilation time.
- None performance or correctness regressions.