### PR TITLE
refactor lstm cpu verification to const function

### DIFF
--- a/test/lstm_common.hpp
+++ b/test/lstm_common.hpp
@@ -51,42 +51,399 @@
 #define MIO_LSTM_TEST_DEBUG 0
 #define MIO_RNN_TIME_EVERYTHING 0
 
+//****************************************************
+// FORWARD BASE
+//****************************************************
+template <class T>
+struct verify_forward_lstm
+{
+    std::vector<T> input{};
+    std::vector<T> initHidden{};
+    std::vector<T> initCell{};
+    std::vector<T> weights{};
+    std::vector<int> batch_seq{};
+    int hiddenSize{};
+    int seqLength{};
+    int nLayers{};
+    int biasMode{};
+    int dirMode{};
+    int inputMode{};
+    int batch_n{};
+    int inputVecLen{};
+    miopenRNNDescriptor_t rnnDesc{};
+    size_t realHiddenSize{};
+    bool nohx{};
+    bool nocx{};
+    bool nohy{};
+    bool nocy{};
+
+    void LSTMFwdCPUVerify(miopen::Handle& handle,
+                          const bool use_dropout,
+                          const miopen::DropoutDescriptor& dropoutDesc,
+                          const std::vector<T>& in,
+                          const std::vector<T>& wei,
+                          std::vector<T>& hy_host,
+                          const std::vector<T>& hx,
+                          std::vector<T>& cy_host,
+                          const std::vector<T>& cx,
+                          std::vector<T>& out_host,
+                          const std::vector<int>& in_n,
+                          int in_h,
+                          const int seqLength,
+                          const int bidirection,
+                          const int biased,
+                          const int hy_d,
+                          const int hy_n,
+                          const int hy_h,
+                          const int out_h,
+                          const int inputMode,
+                          std::vector<T>& rsvspace,
+                          const bool hx_is_null = false,
+                          const bool cx_is_null = false) const;
+};
+
+//****************************************************
+// BACKWARDS DATA
+//****************************************************
+template <class T>
+struct verify_backward_data_lstm
+{
+    std::vector<T> yin;        // Y
+    std::vector<T> dy;         // dY
+    std::vector<T> dhy;        // dHY
+    std::vector<T> dcy;        // dHY
+    std::vector<T> initHidden; // HX
+    std::vector<T> initCell;   // CX
+    std::vector<T> weights;
+    std::vector<int> batch_seq;
+    int hiddenSize;
+    int seqLength;
+    int nLayers;
+    int biasMode;
+    int dirMode;
+    int inputMode;
+    int batch_n;
+    int inputVecLen;
+    miopenRNNDescriptor_t rnnDesc;
+    size_t realHiddenSize;
+    bool nohx;
+    bool nocx;
+    bool nodhy;
+    bool nodcy;
+    bool nodhx;
+    bool nodcx;
+    bool use_dropout;
+    typename std::vector<T>::iterator RSVgpu;
+    typename std::vector<T>::iterator RSVcpu;
+
+    verify_backward_data_lstm(miopenRNNDescriptor_t pRD,
+                              const std::vector<T>& py,
+                              const std::vector<T>& pdy,
+                              const std::vector<T>& pdhy,
+                              const std::vector<T>& phx,
+                              const std::vector<T>& pdcy,
+                              const std::vector<T>& pcx,
+                              const std::vector<T>& pW,
+                              std::vector<T>& pRSVgpu,
+                              std::vector<T>& pRSVcpu,
+                              const std::vector<int>& pBS,
+                              const int pHS,
+                              const int pBN,
+                              const int pS,
+                              const int pNL,
+                              const int pBM,
+                              const int pDM,
+                              const int pIM,
+                              const int pVL,
+                              const size_t pHXZ,
+                              const bool pnohx        = false,
+                              const bool pnocx        = false,
+                              const bool pnodhy       = false,
+                              const bool pnodcy       = false,
+                              const bool pnodhx       = false,
+                              const bool pnodcx       = false,
+                              const bool puse_dropout = false)
+        : yin(py),
+          dy(pdy),
+          dhy(pdhy),
+          dcy(pdcy),
+          initHidden(phx),
+          initCell(pcx),
+          weights(pW),
+          batch_seq(pBS),
+          hiddenSize(pHS),
+          seqLength(pS),
+          nLayers(pNL),
+          biasMode(pBM),
+          dirMode(pDM),
+          inputMode(pIM),
+          batch_n(pBN),
+          inputVecLen(pVL),
+          rnnDesc(pRD),
+          realHiddenSize(pHXZ),
+          nohx(pnohx),
+          nocx(pnocx),
+          nodhy(pnodhy),
+          nodcy(pnodcy),
+          nodhx(pnodhx),
+          nodcx(pnodcx),
+          use_dropout(puse_dropout),
+          RSVgpu(pRSVgpu.begin()),
+          RSVcpu(pRSVcpu.begin())
+    {
+        if(!nohx)
+            initHidden = phx; // this may be intentionally a nullptr
+        else
+            initHidden.resize(realHiddenSize);
+
+        if(!nocx)
+            initCell = pcx; // this may be intentionally a nullptr
+        else
+            initCell.resize(realHiddenSize);
+
+        if(!nodhy)
+            dhy = pdhy; // this may be intentionally a nullptr
+        else
+            dhy.resize(realHiddenSize);
+
+        if(!nodcy)
+            dcy = pdcy; // this may be intentionally a nullptr
+        else
+            dcy.resize(realHiddenSize);
+    }
+
+    void LSTMBwdDataCPUVerify(const bool use_dropout,
+                              const miopen::DropoutDescriptor& dropoutDesc,
+                              std::vector<T>& din_host,
+                              const std::vector<T>& wei,
+                              const std::vector<T>& dhy,
+                              std::vector<T>& dhx_host,
+                              const std::vector<T>& hx,
+                              const std::vector<T>& dcy,
+                              std::vector<T>& dcx_host,
+                              const std::vector<T>& cx,
+                              const std::vector<T>& out,
+                              const std::vector<T>& dout,
+                              const std::vector<int>& in_n,
+                              int in_h,
+                              const int seqLength,
+                              const int bidirection,
+                              const int,
+                              const int hy_d,
+                              const int hy_n,
+                              const int hy_h,
+                              const int out_h,
+                              const int inputMode,
+                              std::vector<T>& rsvspace,
+                              std::vector<T>& wkspace,
+                              const bool cx_is_null  = false,
+                              const bool dhy_is_null = false,
+                              const bool dcy_is_null = false) const;
+
+    std::tuple<std::vector<T>, std::vector<T>, std::vector<T>, std::vector<T>> cpu() const;
+    std::tuple<std::vector<T>, std::vector<T>, std::vector<T>, std::vector<T>> gpu() const;
+
+    void fail(int badtensor) const
+    {
+
+        std::cout << "./bin/MIOpenDriver rnn -n ";
+        for(int i = 0; i < seqLength; i++)
+        {
+            if(i < seqLength - 1)
+            {
+                std::cout << batch_seq.at(i) << ",";
+            }
+            else
+            {
+                std::cout << batch_seq.at(i);
+            }
+        }
+        std::cout << " -m lstm "
+                  << " -k " << seqLength << " -H " << hiddenSize << " -W " << inputVecLen << " -l "
+                  << nLayers << " -F 0 "
+                  << " -r " << dirMode << " -b " << biasMode << " -p " << inputMode << std::endl;
+
+        std::cout << "inputMode: " << inputMode << " biasMode: " << biasMode
+                  << " dirMode: " << dirMode << std::endl;
+        std::cout << "hz: " << hiddenSize << " batch_n: " << batch_n << " seqLength: " << seqLength
+                  << " inputLen: " << inputVecLen << " numLayers: " << nLayers
+                  << " useDropout: " << int(use_dropout) << std::endl;
+        std::cout << "Backward Data LSTM: " << std::endl;
+
+        switch(badtensor)
+        {
+        case(0): std::cout << "Output dx failed verification." << std::endl; break;
+        case(1): std::cout << "Hidden state dhx tensor failed verification." << std::endl; break;
+        case(2): std::cout << "Hidden cell dcx tensor failed verification." << std::endl; break;
+        case(3): std::cout << "Workspace space tensor failed verification." << std::endl; break;
+        default: break;
+        }
+    }
+};
+//~~~~~~~~~~~~ END BACKWARD DATA ~~~~~~~~~~~~~~~~~~~~~~~~
+
+//****************************************************
+// BACKWARDS WEIGHTS
+//****************************************************
+template <class T>
+struct verify_backward_weights_lstm
+{
+    std::vector<T> input;      // Y
+    std::vector<T> dy;         // dY
+    std::vector<T> initHidden; // HX
+    std::vector<T> workSpace;
+    std::vector<int> batch_seq;
+    int weightSize;
+    int hiddenSize;
+    int seqLength;
+    int nLayers;
+    int biasMode;
+    int dirMode;
+    int inputMode;
+    int batch_n;
+    int inputVecLen;
+    miopenRNNDescriptor_t rnnDesc;
+    size_t realHiddenSize;
+    bool nohx;
+    bool use_dropout;
+    typename std::vector<T> reserveSpace_gpu;
+    typename std::vector<T> reserveSpace_cpu;
+
+    verify_backward_weights_lstm(miopenRNNDescriptor_t pRD,
+                                 const std::vector<T>& px,
+                                 const std::vector<T>& pdy,
+                                 const std::vector<T>& phx,
+                                 const std::vector<T>& pRSVgpu,
+                                 const std::vector<T>& pRSVcpu,
+                                 const std::vector<T>& pWS,
+                                 const std::vector<int>& pBS,
+                                 const int pHS,
+                                 const int pW,
+                                 const int pBN,
+                                 const int pS,
+                                 const int pNL,
+                                 const int pBM,
+                                 const int pDM,
+                                 const int pIM,
+                                 const int pVL,
+                                 const size_t pHXZ,
+                                 const bool pnohx        = false,
+                                 const bool puse_dropout = false)
+        : input(px),
+          dy(pdy),
+          initHidden(phx),
+          workSpace(pWS),
+          batch_seq(pBS),
+          weightSize(pW),
+          hiddenSize(pHS),
+          seqLength(pS),
+          nLayers(pNL),
+          biasMode(pBM),
+          dirMode(pDM),
+          inputMode(pIM),
+          batch_n(pBN),
+          inputVecLen(pVL),
+          rnnDesc(pRD),
+          realHiddenSize(pHXZ),
+          nohx(pnohx),
+          use_dropout(puse_dropout),
+          reserveSpace_gpu(pRSVgpu),
+          reserveSpace_cpu(pRSVcpu)
+    {
+        if(!nohx)
+            initHidden = phx; // this may be intentionally a nullptr
+        else
+            initHidden.resize(realHiddenSize);
+    }
+
+    void LSTMBwdWeightCPUVerify(const bool use_dropout,
+                                const std::vector<T>& in,
+                                std::vector<T>& dwei_host,
+                                const std::vector<T>& hx,
+                                const std::vector<T>& dout,
+                                const std::vector<int>& in_n,
+                                int in_h,
+                                const int seqLength,
+                                const int bidirection,
+                                const int biased,
+                                const int hy_d,
+                                const int hy_n,
+                                const int hy_h,
+                                const int out_h,
+                                const int inputMode,
+                                const std::vector<T>& rsvspace,
+                                const std::vector<T>& wkspace,
+                                const bool hx_is_null = false) const;
+
+    std::vector<T> cpu() const;
+    std::vector<T> gpu() const;
+
+    void fail(int) const
+    {
+        std::cout << "./bin/MIOpenDriver rnn -n ";
+        for(int i = 0; i < seqLength; i++)
+        {
+            if(i < seqLength - 1)
+            {
+                std::cout << batch_seq.at(i) << ",";
+            }
+            else
+            {
+                std::cout << batch_seq.at(i);
+            }
+        }
+        std::cout << " -m lstm "
+                  << " -k " << seqLength << " -H " << hiddenSize << " -W " << inputVecLen << " -l "
+                  << nLayers << " -F 0 "
+                  << " -r " << dirMode << " -b " << biasMode << " -p " << inputMode << std::endl;
+
+        std::cout << "inputMode: " << inputMode << " biasMode: " << biasMode
+                  << " dirMode: " << dirMode << std::endl;
+        std::cout << "hz: " << hiddenSize << " batch_n: " << batch_n << " seqLength: " << seqLength
+                  << " inputLen: " << inputVecLen << " numLayers: " << nLayers
+                  << " useDropout: " << int(use_dropout) << std::endl;
+        std::cout << "Backward Weights LSTM: " << std::endl;
+    }
+};
+//~~~~~~~~~~~~ END BACKWARD WEIGHTS ~~~~~~~~~~~~~~~~~~~~~~~~
+
 /**********************************************
  * CPU verification functions
  *
  **********************************************/
 
-template <typename T>
-void LSTMFwdCPUVerify(miopen::Handle& handle,
-                      bool use_dropout,
-                      miopen::DropoutDescriptor& dropoutDesc,
-                      std::vector<T>& in,
-                      std::vector<T>& wei,     // [ input_state_weight_trans
-                                               // hidden_state_weight0_trans input1_trans
-                                               // hidden1_trans ... output_weight;
-                                               // bidirectional reversed weights ]
-                      std::vector<T>& hy_host, // current/final hidden state
-                      std::vector<T>& hx,      // initial hidden state
-                      std::vector<T>& cy_host, // current/final cell state
-                      std::vector<T>& cx,      // initial cell state
-                      std::vector<T>& out_host,
-                      std::vector<int>& in_n, // input batch size
-                      int in_h,               // input data length
-                      int seqLength,          // Number of iterations to unroll over
-                      int bidirection,        // whether using bidirectional net
-                      int biased,             // whether using bias
-                      int hy_d,  // 1 by numlayer (number of stacks of hidden layers) for
-                                 // unidirection, 2 by numlayer for bidirection
-                      int hy_n,  // equal to input batch size in_n[0]
-                      int hy_h,  // hidden state number
-                      int out_h, // 1 by hy_h related function for unidirection, 2 by hy_h
-                                 // related function for bidirection
-                      int inputMode,
-                      std::vector<T>& rsvspace,
-                      bool hx_is_null = false,
-                      bool cx_is_null = false)
+template <class T>
+void verify_forward_lstm<T>::LSTMFwdCPUVerify(
+    miopen::Handle& handle,
+    const bool use_dropout,
+    const miopen::DropoutDescriptor& dropoutDesc,
+    const std::vector<T>& in,
+    const std::vector<T>& wei, // [ input_state_weight_trans
+                               // hidden_state_weight0_trans input1_trans
+                               // hidden1_trans ... output_weight;
+                               // bidirectional reversed weights ]
+    std::vector<T>& hy_host,   // current/final hidden state
+    const std::vector<T>& hx,  // initial hidden state
+    std::vector<T>& cy_host,   // current/final cell state
+    const std::vector<T>& cx,  // initial cell state
+    std::vector<T>& out_host,
+    const std::vector<int>& in_n, // input batch size
+    int in_h,                     // input data length
+    const int seqLength_cpu,      // Number of iterations to unroll over
+    const int bidirection,        // whether using bidirectional net
+    const int biased,             // whether using bias
+    const int hy_d,               // 1 by numlayer (number of stacks of hidden layers) for
+                                  // unidirection, 2 by numlayer for bidirection
+    const int hy_n,               // equal to input batch size in_n[0]
+    const int hy_h,               // hidden state number
+    const int out_h,              // 1 by hy_h related function for unidirection, 2 by hy_h
+                                  // related function for bidirection
+    const int inputMode_cpu,
+    std::vector<T>& rsvspace,
+    const bool hx_is_null,
+    const bool cx_is_null) const
 {
-    int batch_n = sumvc(in_n);
+    int batch_n_cpu = sumvc(in_n);
 
     int numlayer = bidirection ? hy_d / 2 : hy_d;
     int bi       = bidirection ? 2 : 1;
@@ -99,7 +456,7 @@ void LSTMFwdCPUVerify(miopen::Handle& handle,
     int uni_stride = hy_h;
     int bi_stride  = hy_h * bi;
 
-    if(inputMode == 1)
+    if(inputMode_cpu == 1)
     {
         if(in_h != hy_h)
         {
@@ -124,7 +481,7 @@ void LSTMFwdCPUVerify(miopen::Handle& handle,
         dropout_states_host = std::vector<prngStates>(states_size);
         InitKernelStateEmulator(dropout_states_host, dropoutDesc);
 
-        std::array<int, 2> drop_in_len  = {{batch_n, hy_h * bi}};
+        std::array<int, 2> drop_in_len  = {{batch_n_cpu, hy_h * bi}};
         std::array<int, 2> drop_in_str  = {{hy_stride, 1}};
         std::array<int, 2> drop_out_str = {{hy_h * bi, 1}};
         miopenCreateTensorDescriptor(&dropout_inputTensor);
@@ -140,21 +497,22 @@ void LSTMFwdCPUVerify(miopen::Handle& handle,
         dropout_reservespace_host = std::vector<unsigned char>(reserve_size * (numlayer - 1),
                                                                static_cast<unsigned char>(1));
 
-        dropout_hid_state = std::vector<T>((numlayer - 1) * batch_n * hy_h * bi, static_cast<T>(0));
+        dropout_hid_state =
+            std::vector<T>((numlayer - 1) * batch_n_cpu * hy_h * bi, static_cast<T>(0));
     }
 
     // forward emulator
     for(int li = 0; li < numlayer; li++)
     {
-        int hid_shift = li * batch_n * hy_stride;
+        int hid_shift = li * batch_n_cpu * hy_stride;
         int hx_shift  = li * in_n.at(0) * h_stride;
 
         // from input
         if(li == 0)
         {
-            if(inputMode == 1)
+            if(inputMode_cpu == 1)
             {
-                for(int bs = 0; bs < batch_n; bs++)
+                for(int bs = 0; bs < batch_n_cpu; bs++)
                 {
                     for(int h = 0; h < hy_h; h++)
                     {
@@ -174,7 +532,7 @@ void LSTMFwdCPUVerify(miopen::Handle& handle,
                 // from bias
                 if(biased)
                 {
-                    for(int bs = 0; bs < batch_n; bs++)
+                    for(int bs = 0; bs < batch_n_cpu; bs++)
                     {
                         for(int h = 0; h < wei_stride; h++)
                         {
@@ -188,7 +546,7 @@ void LSTMFwdCPUVerify(miopen::Handle& handle,
             {
                 RNN_mm_cpu<T>(in.data(),
                               in_h,
-                              batch_n,
+                              batch_n_cpu,
                               in_stride,
                               0,
                               wei.data(),
@@ -198,7 +556,7 @@ void LSTMFwdCPUVerify(miopen::Handle& handle,
                               RNN_MM_TRANSPOSE,
                               &rsvspace[hid_shift],
                               hy_h * bi * 4,
-                              batch_n,
+                              batch_n_cpu,
                               hy_stride,
                               0,
                               1,
@@ -207,7 +565,7 @@ void LSTMFwdCPUVerify(miopen::Handle& handle,
                 // from bias
                 if(biased)
                 {
-                    for(int bs = 0; bs < batch_n; bs++)
+                    for(int bs = 0; bs < batch_n_cpu; bs++)
                     {
                         for(int h = 0; h < wei_stride; h++)
                         {
@@ -221,11 +579,11 @@ void LSTMFwdCPUVerify(miopen::Handle& handle,
         else
         {
             int wei_shift = (in_h + hy_h) * wei_stride + (li - 1) * (bi * hy_h + hy_h) * wei_stride;
-            int prelayer_shift = (li - 1) * batch_n * hy_stride + bi * 5 * hy_h;
+            int prelayer_shift = (li - 1) * batch_n_cpu * hy_stride + bi * 5 * hy_h;
             if(use_dropout)
             {
                 auto dropout_states_tmp = dropout_states_host;
-                size_t drop_out_offset  = (li - 1) * batch_n * hy_h * bi;
+                size_t drop_out_offset  = (li - 1) * batch_n_cpu * hy_h * bi;
 
                 DropoutForwardVerify<T>(handle,
                                         dropoutDesc,
@@ -245,7 +603,7 @@ void LSTMFwdCPUVerify(miopen::Handle& handle,
             RNN_mm_cpu<T>(use_dropout ? &dropout_hid_state[prelayer_shift]
                                       : &rsvspace[prelayer_shift],
                           hy_h * bi,
-                          batch_n,
+                          batch_n_cpu,
                           use_dropout ? hy_h * bi : hy_stride,
                           0,
                           &wei[wei_shift],
@@ -255,7 +613,7 @@ void LSTMFwdCPUVerify(miopen::Handle& handle,
                           RNN_MM_TRANSPOSE,
                           &rsvspace[hid_shift],
                           hy_h * bi * 4,
-                          batch_n,
+                          batch_n_cpu,
                           hy_stride,
                           0,
                           1,
@@ -266,7 +624,7 @@ void LSTMFwdCPUVerify(miopen::Handle& handle,
             {
                 int wei_shift_bias_temp = wei_shift_bias + li * 2 * wei_stride;
 
-                for(int bs = 0; bs < batch_n; bs++)
+                for(int bs = 0; bs < batch_n_cpu; bs++)
                 {
                     for(int h = 0; h < wei_stride; h++)
                     {
@@ -279,10 +637,10 @@ void LSTMFwdCPUVerify(miopen::Handle& handle,
 
         // from hidden state
         int bacc   = 0;
-        int baccbi = batch_n;
-        for(int ti = 0; ti < seqLength; ti++)
+        int baccbi = batch_n_cpu;
+        for(int ti = 0; ti < seqLength_cpu; ti++)
         {
-            baccbi -= in_n.at(seqLength - 1 - ti);
+            baccbi -= in_n.at(seqLength_cpu - 1 - ti);
             int wei_shift = in_h * wei_stride + li * (bi * hy_h + hy_h) * wei_stride;
 
             if(ti == 0)
@@ -326,7 +684,7 @@ void LSTMFwdCPUVerify(miopen::Handle& handle,
                     {
                         RNN_mm_cpu<T>(&hx[hx_shift + hy_n * hy_h],
                                       hy_h,
-                                      in_n.at(seqLength - 1 - ti),
+                                      in_n.at(seqLength_cpu - 1 - ti),
                                       uni_stride,
                                       0,
                                       &wei[wei_shift + 4 * hy_h * uni_stride],
@@ -336,7 +694,7 @@ void LSTMFwdCPUVerify(miopen::Handle& handle,
                                       RNN_MM_TRANSPOSE,
                                       &rsvspace[hid_shift + baccbi * hy_stride + 4 * hy_h],
                                       hy_h * 4,
-                                      in_n.at(seqLength - 1 - ti),
+                                      in_n.at(seqLength_cpu - 1 - ti),
                                       hy_stride,
                                       0,
                                       1,
@@ -347,7 +705,7 @@ void LSTMFwdCPUVerify(miopen::Handle& handle,
                         {
                             int wei_shift_bias_temp = wei_shift_bias + (li * 2 + 1) * wei_stride;
 
-                            for(int bs = 0; bs < in_n.at(seqLength - 1 - ti); bs++)
+                            for(int bs = 0; bs < in_n.at(seqLength_cpu - 1 - ti); bs++)
                             {
                                 for(int h = 0; h < 4 * hy_h; h++)
                                 {
@@ -398,12 +756,12 @@ void LSTMFwdCPUVerify(miopen::Handle& handle,
                 if(bidirection)
                 {
 
-                    if(!hx_is_null && in_n.at(seqLength - 1 - ti) > in_n.at(seqLength - ti))
+                    if(!hx_is_null && in_n.at(seqLength_cpu - 1 - ti) > in_n.at(seqLength_cpu - ti))
                     {
                         RNN_mm_cpu<T>(
-                            &hx[hx_shift + hy_n * hy_h + in_n.at(seqLength - ti) * hy_h],
+                            &hx[hx_shift + hy_n * hy_h + in_n.at(seqLength_cpu - ti) * hy_h],
                             hy_h,
-                            (in_n.at(seqLength - 1 - ti) - in_n.at(seqLength - ti)),
+                            (in_n.at(seqLength_cpu - 1 - ti) - in_n.at(seqLength_cpu - ti)),
                             uni_stride,
                             0,
                             &wei[wei_shift + 4 * hy_h * uni_stride],
@@ -411,10 +769,11 @@ void LSTMFwdCPUVerify(miopen::Handle& handle,
                             hy_h * 4,
                             uni_stride,
                             RNN_MM_TRANSPOSE,
-                            &rsvspace[hid_shift + (baccbi + in_n.at(seqLength - ti)) * hy_stride +
+                            &rsvspace[hid_shift +
+                                      (baccbi + in_n.at(seqLength_cpu - ti)) * hy_stride +
                                       4 * hy_h],
                             hy_h * 4,
-                            (in_n.at(seqLength - 1 - ti) - in_n.at(seqLength - ti)),
+                            (in_n.at(seqLength_cpu - 1 - ti) - in_n.at(seqLength_cpu - ti)),
                             hy_stride,
                             0,
                             1,
@@ -425,7 +784,8 @@ void LSTMFwdCPUVerify(miopen::Handle& handle,
                         {
                             int wei_shift_bias_temp = wei_shift_bias + (li * 2 + 1) * wei_stride;
 
-                            for(int bs = in_n.at(seqLength - ti); bs < in_n.at(seqLength - 1 - ti);
+                            for(int bs = in_n.at(seqLength_cpu - ti);
+                                bs < in_n.at(seqLength_cpu - 1 - ti);
                                 bs++)
                             {
                                 for(int h = 0; h < 4 * hy_h; h++)
@@ -440,7 +800,7 @@ void LSTMFwdCPUVerify(miopen::Handle& handle,
 
                     RNN_mm_cpu<T>(&hy_host[hx_shift + hy_n * hy_h],
                                   hy_h,
-                                  in_n.at(seqLength - ti),
+                                  in_n.at(seqLength_cpu - ti),
                                   uni_stride,
                                   0,
                                   &wei[wei_shift + 4 * hy_h * uni_stride],
@@ -450,7 +810,7 @@ void LSTMFwdCPUVerify(miopen::Handle& handle,
                                   RNN_MM_TRANSPOSE,
                                   &rsvspace[hid_shift + baccbi * hy_stride + 4 * hy_h],
                                   hy_h * 4,
-                                  in_n.at(seqLength - ti),
+                                  in_n.at(seqLength_cpu - ti),
                                   hy_stride,
                                   0,
                                   1,
@@ -461,7 +821,7 @@ void LSTMFwdCPUVerify(miopen::Handle& handle,
                     {
                         int wei_shift_bias_temp = wei_shift_bias + (li * 2 + 1) * wei_stride;
 
-                        for(int bs = 0; bs < in_n.at(seqLength - ti); bs++)
+                        for(int bs = 0; bs < in_n.at(seqLength_cpu - ti); bs++)
                         {
                             for(int h = 0; h < 4 * hy_h; h++)
                             {
@@ -495,7 +855,7 @@ void LSTMFwdCPUVerify(miopen::Handle& handle,
                     }
                     else
                     {
-                        int prec_shift = li * batch_n * hy_stride +
+                        int prec_shift = li * batch_n_cpu * hy_stride +
                                          (bacc - in_n.at(ti - 1)) * hy_stride + bi * 4 * hy_h;
 
                         rsvspace.at(hid_shift + (bacc + bs) * hy_stride + bi * 4 * hy_h + h) +=
@@ -512,21 +872,21 @@ void LSTMFwdCPUVerify(miopen::Handle& handle,
                             1);
 
                     rsvspace.at(hid_shift + (bacc + bs) * hy_stride + h +
-                                numlayer * batch_n * hy_stride) =
+                                numlayer * batch_n_cpu * hy_stride) =
                         activfunc(rsvspace.at(hid_shift + (bacc + bs) * hy_stride + h), 2);
                     rsvspace.at(hid_shift + (bacc + bs) * hy_stride + hy_h + h +
-                                numlayer * batch_n * hy_stride) =
+                                numlayer * batch_n_cpu * hy_stride) =
                         activfunc(rsvspace.at(hid_shift + (bacc + bs) * hy_stride + hy_h + h), 2);
                     rsvspace.at(hid_shift + (bacc + bs) * hy_stride + 2 * hy_h + h +
-                                numlayer * batch_n * hy_stride) =
+                                numlayer * batch_n_cpu * hy_stride) =
                         activfunc(rsvspace.at(hid_shift + (bacc + bs) * hy_stride + 2 * hy_h + h),
                                   2);
                     rsvspace.at(hid_shift + (bacc + bs) * hy_stride + 3 * hy_h + h +
-                                numlayer * batch_n * hy_stride) =
+                                numlayer * batch_n_cpu * hy_stride) =
                         activfunc(rsvspace.at(hid_shift + (bacc + bs) * hy_stride + 3 * hy_h + h),
                                   1);
                     rsvspace.at(hid_shift + (bacc + bs) * hy_stride + bi * 4 * hy_h + h +
-                                numlayer * batch_n * hy_stride) =
+                                numlayer * batch_n_cpu * hy_stride) =
                         activfunc(
                             rsvspace.at(hid_shift + (bacc + bs) * hy_stride + bi * 4 * hy_h + h),
                             1);
@@ -540,7 +900,7 @@ void LSTMFwdCPUVerify(miopen::Handle& handle,
 
             if(bidirection)
             {
-                for(int bs = 0; bs < in_n.at(seqLength - 1 - ti); bs++)
+                for(int bs = 0; bs < in_n.at(seqLength_cpu - 1 - ti); bs++)
                 {
                     for(int h = 0; h < hy_h; h++)
                     {
@@ -567,9 +927,10 @@ void LSTMFwdCPUVerify(miopen::Handle& handle,
                         else
                         {
 
-                            if(!cx_is_null && in_n.at(seqLength - 1 - ti) > in_n.at(seqLength - ti))
+                            if(!cx_is_null &&
+                               in_n.at(seqLength_cpu - 1 - ti) > in_n.at(seqLength_cpu - ti))
                             {
-                                if(bs >= in_n.at(seqLength - ti))
+                                if(bs >= in_n.at(seqLength_cpu - ti))
                                 {
                                     rsvspace.at(hid_shift + (baccbi + bs) * hy_stride +
                                                 bi * 4 * hy_h + hy_h + h) +=
@@ -581,11 +942,11 @@ void LSTMFwdCPUVerify(miopen::Handle& handle,
                                 }
                             }
 
-                            if(bs < in_n.at(seqLength - ti))
+                            if(bs < in_n.at(seqLength_cpu - ti))
                             {
                                 int prec_shift =
-                                    li * batch_n * hy_stride +
-                                    (baccbi + in_n.at(seqLength - 1 - ti)) * hy_stride +
+                                    li * batch_n_cpu * hy_stride +
+                                    (baccbi + in_n.at(seqLength_cpu - 1 - ti)) * hy_stride +
                                     bi * 4 * hy_h + hy_h;
 
                                 rsvspace.at(hid_shift + (baccbi + bs) * hy_stride + bi * 4 * hy_h +
@@ -607,27 +968,27 @@ void LSTMFwdCPUVerify(miopen::Handle& handle,
                                       1);
 
                         rsvspace.at(hid_shift + (baccbi + bs) * hy_stride + 4 * hy_h + h +
-                                    numlayer * batch_n * hy_stride) =
+                                    numlayer * batch_n_cpu * hy_stride) =
                             activfunc(
                                 rsvspace.at(hid_shift + (baccbi + bs) * hy_stride + 4 * hy_h + h),
                                 2);
                         rsvspace.at(hid_shift + (baccbi + bs) * hy_stride + 5 * hy_h + h +
-                                    numlayer * batch_n * hy_stride) =
+                                    numlayer * batch_n_cpu * hy_stride) =
                             activfunc(
                                 rsvspace.at(hid_shift + (baccbi + bs) * hy_stride + 5 * hy_h + h),
                                 2);
                         rsvspace.at(hid_shift + (baccbi + bs) * hy_stride + 6 * hy_h + h +
-                                    numlayer * batch_n * hy_stride) =
+                                    numlayer * batch_n_cpu * hy_stride) =
                             activfunc(
                                 rsvspace.at(hid_shift + (baccbi + bs) * hy_stride + 6 * hy_h + h),
                                 2);
                         rsvspace.at(hid_shift + (baccbi + bs) * hy_stride + 7 * hy_h + h +
-                                    numlayer * batch_n * hy_stride) =
+                                    numlayer * batch_n_cpu * hy_stride) =
                             activfunc(
                                 rsvspace.at(hid_shift + (baccbi + bs) * hy_stride + 7 * hy_h + h),
                                 1);
                         rsvspace.at(hid_shift + (baccbi + bs) * hy_stride + bi * 4 * hy_h + hy_h +
-                                    h + numlayer * batch_n * hy_stride) =
+                                    h + numlayer * batch_n_cpu * hy_stride) =
                             activfunc(rsvspace.at(hid_shift + (baccbi + bs) * hy_stride +
                                                   bi * 4 * hy_h + hy_h + h),
                                       1);
@@ -645,9 +1006,9 @@ void LSTMFwdCPUVerify(miopen::Handle& handle,
     }
 
     // output
-    int prelayer_shift = (numlayer - 1) * batch_n * hy_stride + bi * 5 * hy_h;
+    int prelayer_shift = (numlayer - 1) * batch_n_cpu * hy_stride + bi * 5 * hy_h;
 
-    for(int bs = 0; bs < batch_n; bs++)
+    for(int bs = 0; bs < batch_n_cpu; bs++)
     {
         for(int h = 0; h < out_h; h++)
         {
@@ -657,54 +1018,55 @@ void LSTMFwdCPUVerify(miopen::Handle& handle,
 
     if(use_dropout)
     {
-        for(int i = 0; i < (numlayer - 1) * batch_n * hy_h * bi; i++)
+        for(int i = 0; i < (numlayer - 1) * batch_n_cpu * hy_h * bi; i++)
         {
-            rsvspace.at(numlayer * batch_n * hy_stride * 2 + i) = dropout_hid_state.at(i);
+            rsvspace.at(numlayer * batch_n_cpu * hy_stride * 2 + i) = dropout_hid_state.at(i);
         }
         auto p_drop_rsv = reinterpret_cast<unsigned char*>(&rsvspace.at(
-            numlayer * batch_n * hy_stride * 2 + (numlayer - 1) * batch_n * hy_h * bi));
-        for(int i = 0; i < (numlayer - 1) * batch_n * hy_h * bi; i++)
+            numlayer * batch_n_cpu * hy_stride * 2 + (numlayer - 1) * batch_n_cpu * hy_h * bi));
+        for(int i = 0; i < (numlayer - 1) * batch_n_cpu * hy_h * bi; i++)
         {
             *(p_drop_rsv + i) = dropout_reservespace_host.at(i);
         }
     }
 }
 
-template <typename T>
-void LSTMBwdDataCPUVerify(bool use_dropout,
-                          miopen::DropoutDescriptor& dropoutDesc,
-                          std::vector<T>& din_host,
-                          std::vector<T>& wei, // [ input_state_weight_trans
-                                               // hidden_state_weight0_trans input1_trans
-                                               // hidden1_trans ... output_weight;
-                                               // bidirectional reversed weights ]
-                          std::vector<T>& dhy, // current/final hidden state
-                          std::vector<T>& dhx_host,
-                          std::vector<T>& hx,  // initial hidden state
-                          std::vector<T>& dcy, // current/final cell state
-                          std::vector<T>& dcx_host,
-                          std::vector<T>& cx,
-                          std::vector<T>& out,
-                          std::vector<T>& dout,
-                          std::vector<int>& in_n, // input batch size
-                          int in_h,               // input data length
-                          int seqLength,          // Number of iterations to unroll over
-                          int bidirection,        // whether using bidirectional net
-                          int,                    // whether using bias
-                          int hy_d,  // 1 by numlayer (number of stacks of hidden layers)
-                                     // for unidirection, 2 by numlayer for bidirection
-                          int hy_n,  // equal to input batch size in_n[0]
-                          int hy_h,  // hidden state number
-                          int out_h, // 1 by hy_h related function for unidirection, 2 by
-                                     // hy_h related function for bidirection
-                          int inputMode,
-                          std::vector<T>& rsvspace,
-                          std::vector<T>& wkspace,
-                          bool cx_is_null  = false,
-                          bool dhy_is_null = false,
-                          bool dcy_is_null = false)
+template <class T>
+void verify_backward_data_lstm<T>::LSTMBwdDataCPUVerify(
+    const bool use_dropout_cpu,
+    const miopen::DropoutDescriptor& dropoutDesc,
+    std::vector<T>& din_host,
+    const std::vector<T>& wei,     // [ input_state_weight_trans
+                                   // hidden_state_weight0_trans input1_trans
+                                   // hidden1_trans ... output_weight;
+                                   // bidirectional reversed weights ]
+    const std::vector<T>& dhy_cpu, // current/final hidden state
+    std::vector<T>& dhx_host,
+    const std::vector<T>& hx,      // initial hidden state
+    const std::vector<T>& dcy_cpu, // current/final cell state
+    std::vector<T>& dcx_host,
+    const std::vector<T>& cx,
+    const std::vector<T>& out,
+    const std::vector<T>& dout,
+    const std::vector<int>& in_n, // input batch size
+    int in_h,                     // input data length
+    const int seqLength_cpu,      // Number of iterations to unroll over
+    const int bidirection,        // whether using bidirectional net
+    const int,                    // whether using bias
+    const int hy_d,               // 1 by numlayer (number of stacks of hidden layers)
+                                  // for unidirection, 2 by numlayer for bidirection
+    const int hy_n,               // equal to input batch size in_n[0]
+    const int hy_h,               // hidden state number
+    const int out_h,              // 1 by hy_h related function for unidirection, 2 by
+                                  // hy_h related function for bidirection
+    const int inputMode_cpu,
+    std::vector<T>& rsvspace,
+    std::vector<T>& wkspace,
+    const bool cx_is_null,
+    const bool dhy_is_null,
+    const bool dcy_is_null) const
 {
-    int batch_n = sumvc(in_n);
+    int batch_n_cpu = sumvc(in_n);
     (void)out;
     (void)hx;
 
@@ -719,7 +1081,7 @@ void LSTMBwdDataCPUVerify(bool use_dropout,
     int uni_stride = hy_h;
     int bi_stride  = hy_h * bi;
 
-    if(inputMode == 1)
+    if(inputMode_cpu == 1)
     {
         if(in_h != hy_h)
         {
@@ -734,9 +1096,9 @@ void LSTMBwdDataCPUVerify(bool use_dropout,
     // initial dropoput
     miopenTensorDescriptor_t dropout_inputTensor{};
     std::vector<unsigned char> dropout_reservespace_host;
-    if(use_dropout)
+    if(use_dropout_cpu)
     {
-        std::array<int, 2> drop_in_len = {{batch_n, hy_h * bi}};
+        std::array<int, 2> drop_in_len = {{batch_n_cpu, hy_h * bi}};
         std::array<int, 2> drop_in_str = {{hy_stride, 1}};
         miopenCreateTensorDescriptor(&dropout_inputTensor);
         miopenSetTensorDescriptor(
@@ -749,8 +1111,8 @@ void LSTMBwdDataCPUVerify(bool use_dropout,
                                                                static_cast<unsigned char>(0));
 
         auto p_drop_rsv = reinterpret_cast<unsigned char*>(&rsvspace.at(
-            numlayer * batch_n * hy_stride * 2 + (numlayer - 1) * batch_n * hy_h * bi));
-        for(int i = 0; i < (numlayer - 1) * batch_n * hy_h * bi; i++)
+            numlayer * batch_n_cpu * hy_stride * 2 + (numlayer - 1) * batch_n_cpu * hy_h * bi));
+        for(int i = 0; i < (numlayer - 1) * batch_n_cpu * hy_h * bi; i++)
         {
             dropout_reservespace_host.at(i) = *(p_drop_rsv + i);
         }
@@ -760,12 +1122,12 @@ void LSTMBwdDataCPUVerify(bool use_dropout,
     for(int li = numlayer - 1; li >= 0; li--)
     {
         int wei_shift = (in_h + hy_h) * wei_stride + li * (bi * hy_h + hy_h) * wei_stride;
-        int hid_shift = li * batch_n * hy_stride;
+        int hid_shift = li * batch_n_cpu * hy_stride;
         int hx_shift  = li * in_n.at(0) * h_stride;
 
         if(li == numlayer - 1)
         {
-            for(int bs = 0; bs < batch_n; bs++)
+            for(int bs = 0; bs < batch_n_cpu; bs++)
             {
                 for(int h = 0; h < out_h; h++)
                 {
@@ -776,11 +1138,11 @@ void LSTMBwdDataCPUVerify(bool use_dropout,
         }
         else
         {
-            int prelayer_shift = (li + 1) * batch_n * hy_stride;
+            int prelayer_shift = (li + 1) * batch_n_cpu * hy_stride;
 
             RNN_mm_cpu<T>(&wkspace[prelayer_shift],
                           hy_h * bi * 4,
-                          batch_n,
+                          batch_n_cpu,
                           hy_stride,
                           0,
                           &wei[wei_shift],
@@ -790,13 +1152,13 @@ void LSTMBwdDataCPUVerify(bool use_dropout,
                           0,
                           &wkspace[hid_shift + bi * 5 * hy_h],
                           hy_h * bi,
-                          batch_n,
+                          batch_n_cpu,
                           hy_stride,
                           0,
                           1,
                           1);
 
-            if(use_dropout)
+            if(use_dropout_cpu)
             {
                 DropoutBackwardVerify<T>(dropoutDesc,
                                          miopen::deref(dropout_inputTensor),
@@ -806,18 +1168,18 @@ void LSTMBwdDataCPUVerify(bool use_dropout,
                                          dropout_reservespace_host,
                                          hid_shift + bi * 5 * hy_h,
                                          hid_shift + bi * 5 * hy_h,
-                                         li * batch_n * hy_h * bi);
+                                         li * batch_n_cpu * hy_h * bi);
             }
         }
 
         // from hidden state
-        int bacc   = batch_n;
+        int bacc   = batch_n_cpu;
         int baccbi = 0;
-        for(int ti = seqLength - 1; ti >= 0; ti--)
+        for(int ti = seqLength_cpu - 1; ti >= 0; ti--)
         {
             bacc -= in_n.at(ti);
 
-            if(ti == seqLength - 1)
+            if(ti == seqLength_cpu - 1)
             {
                 for(int bs = 0; bs < in_n.at(ti); bs++)
                 {
@@ -826,19 +1188,19 @@ void LSTMBwdDataCPUVerify(bool use_dropout,
                         if(!dhy_is_null)
                         {
                             wkspace.at(hid_shift + (bacc + bs) * hy_stride + bi * 5 * hy_h + h) +=
-                                dhy.at(hx_shift + bs * uni_stride + h);
+                                dhy_cpu.at(hx_shift + bs * uni_stride + h);
                         }
                         if(!dcy_is_null)
                         {
                             wkspace.at(hid_shift + (bacc + bs) * hy_stride + bi * 4 * hy_h + h) +=
-                                dcy.at(hx_shift + bs * uni_stride + h);
+                                dcy_cpu.at(hx_shift + bs * uni_stride + h);
                         }
                     }
                 }
 
                 if(bidirection)
                 {
-                    for(int bs = 0; bs < in_n.at(seqLength - 1 - ti); bs++)
+                    for(int bs = 0; bs < in_n.at(seqLength_cpu - 1 - ti); bs++)
                     {
                         for(int h = 0; h < hy_h; h++)
                         {
@@ -846,13 +1208,13 @@ void LSTMBwdDataCPUVerify(bool use_dropout,
                             {
                                 wkspace.at(hid_shift + (baccbi + bs) * hy_stride + bi * 5 * hy_h +
                                            hy_h + h) +=
-                                    dhy.at(hx_shift + bs * uni_stride + hy_n * hy_h + h);
+                                    dhy_cpu.at(hx_shift + bs * uni_stride + hy_n * hy_h + h);
                             }
                             if(!dcy_is_null)
                             {
                                 wkspace.at(hid_shift + (baccbi + bs) * hy_stride + bi * 4 * hy_h +
                                            hy_h + h) +=
-                                    dcy.at(hx_shift + bs * uni_stride + hy_n * hy_h + h);
+                                    dcy_cpu.at(hx_shift + bs * uni_stride + hy_n * hy_h + h);
                             }
                         }
                     }
@@ -867,7 +1229,7 @@ void LSTMBwdDataCPUVerify(bool use_dropout,
                         for(int h = 0; h < hy_h; h++)
                         {
                             wkspace.at(hid_shift + (bacc + bs) * hy_stride + bi * 5 * hy_h + h) +=
-                                dhy.at(hx_shift + bs * uni_stride + h);
+                                dhy_cpu.at(hx_shift + bs * uni_stride + h);
                         }
                     }
                 }
@@ -879,12 +1241,12 @@ void LSTMBwdDataCPUVerify(bool use_dropout,
                         for(int h = 0; h < hy_h; h++)
                         {
                             wkspace.at(hid_shift + (bacc + bs) * hy_stride + bi * 4 * hy_h + h) +=
-                                dcy.at(hx_shift + bs * uni_stride + h);
+                                dcy_cpu.at(hx_shift + bs * uni_stride + h);
                         }
                     }
                 }
 
-                int pretime_shift = li * batch_n * hy_stride + (bacc + in_n.at(ti)) * hy_stride;
+                int pretime_shift = li * batch_n_cpu * hy_stride + (bacc + in_n.at(ti)) * hy_stride;
                 int weitime_shift = in_h * wei_stride + li * (bi * hy_h + hy_h) * wei_stride;
 
                 RNN_mm_cpu<T>(&wkspace[pretime_shift],
@@ -907,14 +1269,15 @@ void LSTMBwdDataCPUVerify(bool use_dropout,
 
                 if(bidirection)
                 {
-                    pretime_shift = li * batch_n * hy_stride +
-                                    (baccbi - in_n.at(seqLength - 2 - ti)) * hy_stride + hy_h * 4;
+                    pretime_shift = li * batch_n_cpu * hy_stride +
+                                    (baccbi - in_n.at(seqLength_cpu - 2 - ti)) * hy_stride +
+                                    hy_h * 4;
                     weitime_shift = in_h * wei_stride + li * (bi * hy_h + hy_h) * wei_stride +
                                     hy_h * 4 * uni_stride;
 
                     RNN_mm_cpu<T>(&wkspace[pretime_shift],
                                   hy_h * 4,
-                                  in_n.at(seqLength - 1 - ti),
+                                  in_n.at(seqLength_cpu - 1 - ti),
                                   hy_stride,
                                   0,
                                   &wei[weitime_shift],
@@ -924,7 +1287,7 @@ void LSTMBwdDataCPUVerify(bool use_dropout,
                                   0,
                                   &wkspace[hid_shift + baccbi * hy_stride + bi * 5 * hy_h + hy_h],
                                   hy_h,
-                                  in_n.at(seqLength - 1 - ti),
+                                  in_n.at(seqLength_cpu - 1 - ti),
                                   hy_stride,
                                   0,
                                   1,
@@ -936,12 +1299,12 @@ void LSTMBwdDataCPUVerify(bool use_dropout,
             {
                 for(int h = 0; h < hy_h; h++)
                 {
-                    if(ti < seqLength - 1)
+                    if(ti < seqLength_cpu - 1)
                     {
                         if(bs < in_n.at(ti + 1))
                         {
                             int pretime_shift =
-                                li * batch_n * hy_stride + (bacc + in_n.at(ti)) * hy_stride;
+                                li * batch_n_cpu * hy_stride + (bacc + in_n.at(ti)) * hy_stride;
 
                             wkspace.at(hid_shift + (bacc + bs) * hy_stride + bi * 4 * hy_h + h) +=
                                 wkspace.at(pretime_shift + bs * hy_stride + bi * 4 * hy_h + h) *
@@ -972,7 +1335,7 @@ void LSTMBwdDataCPUVerify(bool use_dropout,
                     else
                     {
                         int pretime_shift =
-                            li * batch_n * hy_stride + (bacc - in_n.at(ti - 1)) * hy_stride;
+                            li * batch_n_cpu * hy_stride + (bacc - in_n.at(ti - 1)) * hy_stride;
 
                         wkspace.at(hid_shift + (bacc + bs) * hy_stride + hy_h + h) +=
                             wkspace.at(hid_shift + (bacc + bs) * hy_stride + bi * 4 * hy_h + h) *
@@ -1002,14 +1365,15 @@ void LSTMBwdDataCPUVerify(bool use_dropout,
 
             if(bidirection)
             {
-                for(int bs = 0; bs < in_n.at(seqLength - 1 - ti); bs++)
+                for(int bs = 0; bs < in_n.at(seqLength_cpu - 1 - ti); bs++)
                 {
                     for(int h = 0; h < hy_h; h++)
                     {
-                        if(ti < seqLength - 1)
+                        if(ti < seqLength_cpu - 1)
                         {
-                            int pretime_shift = li * batch_n * hy_stride +
-                                                (baccbi - in_n.at(seqLength - 2 - ti)) * hy_stride;
+                            int pretime_shift =
+                                li * batch_n_cpu * hy_stride +
+                                (baccbi - in_n.at(seqLength_cpu - 2 - ti)) * hy_stride;
 
                             wkspace.at(hid_shift + (baccbi + bs) * hy_stride + bi * 4 * hy_h +
                                        hy_h + h) +=
@@ -1046,8 +1410,8 @@ void LSTMBwdDataCPUVerify(bool use_dropout,
                         else
                         {
                             if(!cx_is_null &&
-                               in_n.at(seqLength - 1 - ti) > in_n.at(seqLength - ti) &&
-                               bs >= in_n.at(seqLength - ti))
+                               in_n.at(seqLength_cpu - 1 - ti) > in_n.at(seqLength_cpu - ti) &&
+                               bs >= in_n.at(seqLength_cpu - ti))
                             {
                                 wkspace.at(hid_shift + (baccbi + bs) * hy_stride + 5 * hy_h + h) +=
                                     wkspace.at(hid_shift + (baccbi + bs) * hy_stride +
@@ -1059,11 +1423,11 @@ void LSTMBwdDataCPUVerify(bool use_dropout,
                                                   2);
                             }
 
-                            if(bs < in_n.at(seqLength - ti))
+                            if(bs < in_n.at(seqLength_cpu - ti))
                             {
                                 int pretime_shift =
-                                    li * batch_n * hy_stride +
-                                    (baccbi + in_n.at(seqLength - 1 - ti)) * hy_stride;
+                                    li * batch_n_cpu * hy_stride +
+                                    (baccbi + in_n.at(seqLength_cpu - 1 - ti)) * hy_stride;
 
                                 wkspace.at(hid_shift + (baccbi + bs) * hy_stride + 5 * hy_h + h) +=
                                     wkspace.at(hid_shift + (baccbi + bs) * hy_stride +
@@ -1107,11 +1471,11 @@ void LSTMBwdDataCPUVerify(bool use_dropout,
                 }
             }
 
-            baccbi += in_n.at(seqLength - 1 - ti);
+            baccbi += in_n.at(seqLength_cpu - 1 - ti);
         }
 
         // dcx, dhx
-        int pretime_shift = li * batch_n * hy_stride;
+        int pretime_shift = li * batch_n_cpu * hy_stride;
         int weitime_shift = in_h * wei_stride + li * (bi * hy_h + hy_h) * wei_stride;
 
         RNN_mm_cpu<T>(&wkspace[pretime_shift],
@@ -1144,14 +1508,14 @@ void LSTMBwdDataCPUVerify(bool use_dropout,
 
         if(bidirection)
         {
-            int ti = seqLength - 1, cur_bat = 0, pre_bat = batch_n;
+            int ti = seqLength_cpu - 1, cur_bat = 0, pre_bat = batch_n_cpu;
 
             while(ti >= 0)
             {
                 pre_bat -= in_n.at(ti);
                 if(in_n.at(ti) > cur_bat)
                 {
-                    pretime_shift = li * batch_n * hy_stride + (pre_bat + cur_bat) * hy_stride;
+                    pretime_shift = li * batch_n_cpu * hy_stride + (pre_bat + cur_bat) * hy_stride;
 
                     RNN_mm_cpu<T>(&wkspace[pretime_shift + 4 * hy_h],
                                   hy_h * 4,
@@ -1190,9 +1554,9 @@ void LSTMBwdDataCPUVerify(bool use_dropout,
     }
 
     // dinput
-    if(inputMode == 1)
+    if(inputMode_cpu == 1)
     {
-        for(int bs = 0; bs < batch_n; bs++)
+        for(int bs = 0; bs < batch_n_cpu; bs++)
         {
             for(int h = 0; h < hy_h; h++)
             {
@@ -1212,7 +1576,7 @@ void LSTMBwdDataCPUVerify(bool use_dropout,
     {
         RNN_mm_cpu<T>(wkspace.data(),
                       hy_h * bi * 4,
-                      batch_n,
+                      batch_n_cpu,
                       hy_stride,
                       0,
                       wei.data(),
@@ -1222,7 +1586,7 @@ void LSTMBwdDataCPUVerify(bool use_dropout,
                       0,
                       din_host.data(),
                       in_h,
-                      batch_n,
+                      batch_n_cpu,
                       in_stride,
                       0,
                       1,
@@ -1230,36 +1594,37 @@ void LSTMBwdDataCPUVerify(bool use_dropout,
     }
 }
 
-template <typename T>
-void LSTMBwdWeightCPUVerify(bool use_dropout,
-                            std::vector<T>& in,
-                            std::vector<T>& dwei_host, // [ input_state_weight_trans
-                                                       // hidden_state_weight0_trans
-                                                       // input1_trans hidden1_trans ...
-                                                       // output_weight; bidirectional
-                                                       // reversed weights ]
-                            std::vector<T>& hx,        // initial hidden state
-                            std::vector<T>& dout,
-                            std::vector<int>& in_n, // input batch size
-                            int in_h,               // input data length
-                            int seqLength,          // Number of iterations to unroll over
-                            int bidirection,        // whether using bidirectional net
-                            int biased,             // whether using bias
-                            int hy_d,               // 1 by numlayer (number of stacks of hidden
-                                                    // layers) for unidirection, 2 by numlayer for
-                                                    // bidirection
-                            int hy_n,               // equal to input batch size in_n[0]
-                            int hy_h,               // hidden state number
-                            int out_h, // 1 by hy_h related function for unidirection, 2
-                                       // by hy_h related function for bidirection
-                            int inputMode,
-                            std::vector<T>& rsvspace,
-                            std::vector<T>& wkspace,
-                            bool hx_is_null = false)
+template <class T>
+void verify_backward_weights_lstm<T>::LSTMBwdWeightCPUVerify(
+    const bool use_dropout_cpu,
+    const std::vector<T>& in,
+    std::vector<T>& dwei_host, // [ input_state_weight_trans
+                               // hidden_state_weight0_trans
+                               // input1_trans hidden1_trans ...
+                               // output_weight; bidirectional
+                               // reversed weights ]
+    const std::vector<T>& hx,  // initial hidden state
+    const std::vector<T>& dout,
+    const std::vector<int>& in_n, // input batch size
+    int in_h,                     // input data length
+    const int seqLength_cpu,      // Number of iterations to unroll over
+    const int bidirection,        // whether using bidirectional net
+    const int biased,             // whether using bias
+    const int hy_d,               // 1 by numlayer (number of stacks of hidden
+                                  // layers) for unidirection, 2 by numlayer for
+                                  // bidirection
+    const int hy_n,               // equal to input batch size in_n[0]
+    const int hy_h,               // hidden state number
+    const int out_h,              // 1 by hy_h related function for unidirection, 2
+                                  // by hy_h related function for bidirection
+    const int inputMode_cpu,
+    const std::vector<T>& rsvspace,
+    const std::vector<T>& wkspace,
+    const bool hx_is_null) const
 {
-    int batch_n  = sumvc(in_n);
-    int numlayer = bidirection ? hy_d / 2 : hy_d;
-    int bi       = bidirection ? 2 : 1;
+    int batch_n_cpu = sumvc(in_n);
+    int numlayer    = bidirection ? hy_d / 2 : hy_d;
+    int bi          = bidirection ? 2 : 1;
 
     int in_stride  = in_h;
     int wei_stride = bi * 4 * hy_h;
@@ -1270,7 +1635,7 @@ void LSTMBwdWeightCPUVerify(bool use_dropout,
     (void)dout;
     (void)out_h;
 
-    if(inputMode == 1)
+    if(inputMode_cpu == 1)
     {
         if(in_h != hy_h)
         {
@@ -1290,16 +1655,16 @@ void LSTMBwdWeightCPUVerify(bool use_dropout,
         // between layers
         if(li == 0)
         {
-            if(inputMode != 1)
+            if(inputMode_cpu != 1)
             {
                 RNN_mm_cpu<T>(wkspace.data(),
                               hy_h * bi * 4,
-                              batch_n,
+                              batch_n_cpu,
                               hy_stride,
                               RNN_MM_TRANSPOSE,
                               in.data(),
                               in_h,
-                              batch_n,
+                              batch_n_cpu,
                               in_stride,
                               0,
                               dwei_host.data(),
@@ -1315,7 +1680,7 @@ void LSTMBwdWeightCPUVerify(bool use_dropout,
             {
                 for(int h = 0; h < wei_stride; h++)
                 {
-                    for(int w = 0; w < batch_n; w++)
+                    for(int w = 0; w < batch_n_cpu; w++)
                     {
                         dwei_host.at(wei_shift_bias + h) += wkspace.at(w * hy_stride + h);
                     }
@@ -1325,20 +1690,21 @@ void LSTMBwdWeightCPUVerify(bool use_dropout,
         else
         {
             int prelayer_shift =
-                use_dropout ? 2 * numlayer * batch_n * hy_stride + (li - 1) * batch_n * hy_h * bi
-                            : (li - 1) * batch_n * hy_stride + bi * hy_h * 5;
-            int hid_shift = li * batch_n * hy_stride;
+                use_dropout_cpu
+                    ? 2 * numlayer * batch_n_cpu * hy_stride + (li - 1) * batch_n_cpu * hy_h * bi
+                    : (li - 1) * batch_n_cpu * hy_stride + bi * hy_h * 5;
+            int hid_shift = li * batch_n_cpu * hy_stride;
             int wei_shift = (in_h + hy_h) * wei_stride + (li - 1) * (bi * hy_h + hy_h) * wei_stride;
 
             RNN_mm_cpu<T>(&wkspace[hid_shift],
                           hy_h * bi * 4,
-                          batch_n,
+                          batch_n_cpu,
                           hy_stride,
                           RNN_MM_TRANSPOSE,
                           &rsvspace[prelayer_shift],
                           hy_h * bi,
-                          batch_n,
-                          use_dropout ? hy_h * bi : hy_stride,
+                          batch_n_cpu,
+                          use_dropout_cpu ? hy_h * bi : hy_stride,
                           0,
                           &dwei_host[wei_shift],
                           hy_h * bi,
@@ -1354,7 +1720,7 @@ void LSTMBwdWeightCPUVerify(bool use_dropout,
 
                 for(int h = 0; h < wei_stride; h++)
                 {
-                    for(int w = 0; w < batch_n; w++)
+                    for(int w = 0; w < batch_n_cpu; w++)
                     {
                         dwei_host.at(wei_shift + h) += wkspace.at(hid_shift + w * hy_stride + h);
                     }
@@ -1364,9 +1730,9 @@ void LSTMBwdWeightCPUVerify(bool use_dropout,
 
         // between time
         int bacc = 0;
-        for(int ti = 0; ti < seqLength; ti++)
+        for(int ti = 0; ti < seqLength_cpu; ti++)
         {
-            int hid_shift = li * batch_n * hy_stride + bacc * hy_stride;
+            int hid_shift = li * batch_n_cpu * hy_stride + bacc * hy_stride;
             int hx_shift  = li * in_n.at(0) * h_stride;
             int wei_shift = in_h * wei_stride + li * (bi * hy_h + hy_h) * wei_stride;
             int pretime_shift;
@@ -1411,8 +1777,8 @@ void LSTMBwdWeightCPUVerify(bool use_dropout,
             }
             else
             {
-                pretime_shift =
-                    li * batch_n * hy_stride + (bacc - in_n.at(ti - 1)) * hy_stride + bi * 5 * hy_h;
+                pretime_shift = li * batch_n_cpu * hy_stride +
+                                (bacc - in_n.at(ti - 1)) * hy_stride + bi * 5 * hy_h;
 
                 RNN_mm_cpu<T>(&wkspace[hid_shift],
                               hy_h * 4,
@@ -1449,7 +1815,7 @@ void LSTMBwdWeightCPUVerify(bool use_dropout,
 
             if(bidirection)
             {
-                if(ti == seqLength - 1)
+                if(ti == seqLength_cpu - 1)
                 {
                     if(!hx_is_null)
                     {
@@ -1523,8 +1889,8 @@ void LSTMBwdWeightCPUVerify(bool use_dropout,
                         }
                     }
 
-                    pretime_shift =
-                        li * batch_n * hy_stride + (bacc + in_n.at(ti)) * hy_stride + bi * 5 * hy_h;
+                    pretime_shift = li * batch_n_cpu * hy_stride +
+                                    (bacc + in_n.at(ti)) * hy_stride + bi * 5 * hy_h;
 
                     RNN_mm_cpu<T>(&wkspace[hid_shift + 4 * hy_h],
                                   hy_h * 4,
@@ -1570,27 +1936,27 @@ void LSTMBwdWeightCPUVerify(bool use_dropout,
 // FORWARD INFERENCE
 //****************************************************
 template <class T>
-struct verify_forward_infer_lstm
+struct verify_forward_infer_lstm : verify_forward_lstm<T>
 {
-    std::vector<T> input;
-    std::vector<T> initHidden;
-    std::vector<T> initCell;
-    std::vector<T> weights;
-    std::vector<int> batch_seq;
-    int hiddenSize;
-    int seqLength;
-    int nLayers;
-    int biasMode;
-    int dirMode;
-    int inputMode;
-    int batch_n;
-    int inputVecLen;
-    miopenRNNDescriptor_t rnnDesc;
-    size_t realHiddenSize;
-    bool nohx;
-    bool nocx;
-    bool nohy;
-    bool nocy;
+    using verify_forward_lstm<T>::input;
+    using verify_forward_lstm<T>::initHidden;
+    using verify_forward_lstm<T>::initCell;
+    using verify_forward_lstm<T>::weights;
+    using verify_forward_lstm<T>::batch_seq;
+    using verify_forward_lstm<T>::hiddenSize;
+    using verify_forward_lstm<T>::seqLength;
+    using verify_forward_lstm<T>::nLayers;
+    using verify_forward_lstm<T>::biasMode;
+    using verify_forward_lstm<T>::dirMode;
+    using verify_forward_lstm<T>::inputMode;
+    using verify_forward_lstm<T>::batch_n;
+    using verify_forward_lstm<T>::inputVecLen;
+    using verify_forward_lstm<T>::rnnDesc;
+    using verify_forward_lstm<T>::realHiddenSize;
+    using verify_forward_lstm<T>::nohx;
+    using verify_forward_lstm<T>::nocx;
+    using verify_forward_lstm<T>::nohy;
+    using verify_forward_lstm<T>::nocy;
 
     verify_forward_infer_lstm(miopenRNNDescriptor_t pRD,
                               const std::vector<T>& px,
@@ -1611,26 +1977,27 @@ struct verify_forward_infer_lstm
                               const bool pnocx = false,
                               const bool pnohy = false,
                               const bool pnocy = false)
-        : input(px),
-          initHidden(phx),
-          initCell(pcx),
-          weights(pW),
-          batch_seq(pBS),
-          hiddenSize(pHS),
-          seqLength(pS),
-          nLayers(pNL),
-          biasMode(pBM),
-          dirMode(pDM),
-          inputMode(pIM),
-          batch_n(pBN),
-          inputVecLen(pVL),
-          rnnDesc(pRD),
-          realHiddenSize(pHXZ),
-          nohx(pnohx),
-          nocx(pnocx),
-          nohy(pnohy),
-          nocy(pnocy)
     {
+        input          = px;
+        initHidden     = phx;
+        initCell       = pcx;
+        weights        = pW;
+        batch_seq      = pBS;
+        hiddenSize     = pHS;
+        seqLength      = pS;
+        nLayers        = pNL;
+        biasMode       = pBM;
+        dirMode        = pDM;
+        inputMode      = pIM;
+        batch_n        = pBN;
+        inputVecLen    = pVL;
+        rnnDesc        = pRD;
+        realHiddenSize = pHXZ;
+        nohx           = pnohx;
+        nocx           = pnocx;
+        nohy           = pnohy;
+        nocy           = pnocy;
+
         if(!nohx)
             initHidden = phx; // this may be intentionally a nullptr
         else
@@ -1642,7 +2009,7 @@ struct verify_forward_infer_lstm
             initCell.resize(realHiddenSize);
     }
 
-    std::vector<T> cpu()
+    std::vector<T> cpu() const
     {
 
 #if(MIO_RNN_TIME_EVERYTHING == 1)
@@ -1687,34 +2054,35 @@ struct verify_forward_infer_lstm
         std::vector<T> hiddenState(initHidden.size());
         std::vector<T> cellState(initCell.size());
 
-        LSTMFwdCPUVerify(handle,
-                         false,
-                         miopen::deref(miopen::deref(rnnDesc).dropoutDesc),
-                         input,
-                         weights,     // [ input_state_weight_trans
-                                      // hidden_state_weight0_trans input1_trans
-                                      // hidden1_trans ... output_weight;
-                                      // bidirectional reversed weights ]
-                         hiddenState, // current/final hidden state
-                         initHidden,  // initial hidden state
-                         cellState,   // current/final cell state
-                         initCell,    // initial cell state
-                         output,
-                         batch_seq,       // input batch size
-                         inputVecLen,     // input data length
-                         seqLength,       // Number of iterations to unroll over
-                         dirMode,         // whether using bidirectional net
-                         biasMode,        // whether using bias
-                         bi * nLayers,    // 1 by numlayer (number of stacks of hidden layers) for
-                                          // unidirection, 2 by numlayer for bidirection
-                         batch_seq.at(0), // equal to input batch size in_n[0]
-                         hiddenSize,      // hidden state number
-                         bi_stride,       // 1 by hy_h related function for unidirection, 2 by hy_h
+        this->LSTMFwdCPUVerify(handle,
+                               false,
+                               miopen::deref(miopen::deref(rnnDesc).dropoutDesc),
+                               input,
+                               weights,     // [ input_state_weight_trans
+                                            // hidden_state_weight0_trans input1_trans
+                                            // hidden1_trans ... output_weight;
+                                            // bidirectional reversed weights ]
+                               hiddenState, // current/final hidden state
+                               initHidden,  // initial hidden state
+                               cellState,   // current/final cell state
+                               initCell,    // initial cell state
+                               output,
+                               batch_seq,   // input batch size
+                               inputVecLen, // input data length
+                               seqLength,   // Number of iterations to unroll over
+                               dirMode,     // whether using bidirectional net
+                               biasMode,    // whether using bias
+                               bi *
+                                   nLayers, // 1 by numlayer (number of stacks of hidden layers) for
+                                            // unidirection, 2 by numlayer for bidirection
+                               batch_seq.at(0), // equal to input batch size in_n[0]
+                               hiddenSize,      // hidden state number
+                               bi_stride, // 1 by hy_h related function for unidirection, 2 by hy_h
                                           // related function for bidirection
-                         inputMode,
-                         reserveSpace,
-                         nohx,
-                         nocx);
+                               inputMode,
+                               reserveSpace,
+                               nohx,
+                               nocx);
 
 #if(MIO_LSTM_TEST_DEBUG == 2)
         for(int i = 0; i < output.size(); i++)
@@ -1737,7 +2105,7 @@ struct verify_forward_infer_lstm
         return output;
     }
 
-    std::vector<T> gpu()
+    std::vector<T> gpu() const
     {
 
 #if(MIO_RNN_TIME_EVERYTHING == 1)
@@ -1863,27 +2231,28 @@ struct verify_forward_infer_lstm
 // FORWARD TRAIN
 //****************************************************
 template <class T>
-struct verify_forward_train_lstm
+struct verify_forward_train_lstm : verify_forward_lstm<T>
 {
-    std::vector<T> input;
-    std::vector<T> initHidden;
-    std::vector<T> initCell;
-    std::vector<T> weights;
-    std::vector<int> batch_seq;
-    int hiddenSize;
-    int seqLength;
-    int nLayers;
-    int biasMode;
-    int dirMode;
-    int inputMode;
-    int batch_n;
-    int inputVecLen;
-    miopenRNNDescriptor_t rnnDesc;
-    size_t realHiddenSize;
-    bool nohx;
-    bool nocx;
-    bool nohy;
-    bool nocy;
+    using verify_forward_lstm<T>::input;
+    using verify_forward_lstm<T>::initHidden;
+    using verify_forward_lstm<T>::initCell;
+    using verify_forward_lstm<T>::weights;
+    using verify_forward_lstm<T>::batch_seq;
+    using verify_forward_lstm<T>::hiddenSize;
+    using verify_forward_lstm<T>::seqLength;
+    using verify_forward_lstm<T>::nLayers;
+    using verify_forward_lstm<T>::biasMode;
+    using verify_forward_lstm<T>::dirMode;
+    using verify_forward_lstm<T>::inputMode;
+    using verify_forward_lstm<T>::batch_n;
+    using verify_forward_lstm<T>::inputVecLen;
+    using verify_forward_lstm<T>::rnnDesc;
+    using verify_forward_lstm<T>::realHiddenSize;
+    using verify_forward_lstm<T>::nohx;
+    using verify_forward_lstm<T>::nocx;
+    using verify_forward_lstm<T>::nohy;
+    using verify_forward_lstm<T>::nocy;
+
     bool use_dropout;
     typename std::vector<T>::iterator RSVgpu;
     typename std::vector<T>::iterator RSVcpu;
@@ -1910,29 +2279,30 @@ struct verify_forward_train_lstm
                               const bool pnohy        = false,
                               const bool pnocy        = false,
                               const bool puse_dropout = false)
-        : input(px),
-          initHidden(phx),
-          initCell(pcx),
-          weights(pW),
-          batch_seq(pBS),
-          hiddenSize(pHS),
-          seqLength(pS),
-          nLayers(pNL),
-          biasMode(pBM),
-          dirMode(pDM),
-          inputMode(pIM),
-          batch_n(pBN),
-          inputVecLen(pVL),
-          rnnDesc(pRD),
-          realHiddenSize(pHXZ),
-          nohx(pnohx),
-          nocx(pnocx),
-          nohy(pnohy),
-          nocy(pnocy),
-          use_dropout(puse_dropout),
-          RSVgpu(pRSVgpu.begin()),
-          RSVcpu(pRSVcpu.begin())
     {
+        input          = px;
+        initHidden     = phx;
+        initCell       = pcx;
+        weights        = pW;
+        batch_seq      = pBS;
+        hiddenSize     = pHS;
+        seqLength      = pS;
+        nLayers        = pNL;
+        biasMode       = pBM;
+        dirMode        = pDM;
+        inputMode      = pIM;
+        batch_n        = pBN;
+        inputVecLen    = pVL;
+        rnnDesc        = pRD;
+        realHiddenSize = pHXZ;
+        nohx           = pnohx;
+        nocx           = pnocx;
+        nohy           = pnohy;
+        nocy           = pnocy;
+        use_dropout    = puse_dropout;
+        RSVgpu         = pRSVgpu.begin();
+        RSVcpu         = pRSVcpu.begin();
+
         if(!nohx)
             initHidden = phx; // this may be intentionally a nullptr
         else
@@ -1944,7 +2314,7 @@ struct verify_forward_train_lstm
             initCell.resize(realHiddenSize);
     }
 
-    std::tuple<std::vector<T>, std::vector<T>, std::vector<T>> cpu()
+    std::tuple<std::vector<T>, std::vector<T>, std::vector<T>> cpu() const
     {
 
 #if(MIO_RNN_TIME_EVERYTHING == 1)
@@ -1993,34 +2363,35 @@ struct verify_forward_train_lstm
         std::vector<T> hiddenState(initHidden.size());
         std::vector<T> cellState(initCell.size());
 
-        LSTMFwdCPUVerify(handle,
-                         use_dropout,
-                         miopen::deref(miopen::deref(rnnDesc).dropoutDesc),
-                         input,
-                         weights,     // [ input_state_weight_trans
-                                      // hidden_state_weight0_trans input1_trans
-                                      // hidden1_trans ... output_weight;
-                                      // bidirectional reversed weights ]
-                         hiddenState, // current/final hidden state
-                         initHidden,  // initial hidden state
-                         cellState,   // current/final cell state
-                         initCell,    // initial cell state
-                         output,
-                         batch_seq,       // input batch size
-                         inputVecLen,     // input data length
-                         seqLength,       // Number of iterations to unroll over
-                         dirMode,         // whether using bidirectional net
-                         biasMode,        // whether using bias
-                         bi * nLayers,    // 1 by numlayer (number of stacks of hidden layers) for
-                                          // unidirection, 2 by numlayer for bidirection
-                         batch_seq.at(0), // equal to input batch size in_n[0]
-                         hiddenSize,      // hidden state number
-                         bi_stride,       // 1 by hy_h related function for unidirection, 2 by hy_h
+        this->LSTMFwdCPUVerify(handle,
+                               use_dropout,
+                               miopen::deref(miopen::deref(rnnDesc).dropoutDesc),
+                               input,
+                               weights,     // [ input_state_weight_trans
+                                            // hidden_state_weight0_trans input1_trans
+                                            // hidden1_trans ... output_weight;
+                                            // bidirectional reversed weights ]
+                               hiddenState, // current/final hidden state
+                               initHidden,  // initial hidden state
+                               cellState,   // current/final cell state
+                               initCell,    // initial cell state
+                               output,
+                               batch_seq,   // input batch size
+                               inputVecLen, // input data length
+                               seqLength,   // Number of iterations to unroll over
+                               dirMode,     // whether using bidirectional net
+                               biasMode,    // whether using bias
+                               bi *
+                                   nLayers, // 1 by numlayer (number of stacks of hidden layers) for
+                                            // unidirection, 2 by numlayer for bidirection
+                               batch_seq.at(0), // equal to input batch size in_n[0]
+                               hiddenSize,      // hidden state number
+                               bi_stride, // 1 by hy_h related function for unidirection, 2 by hy_h
                                           // related function for bidirection
-                         inputMode,
-                         reserveSpace,
-                         nohx,
-                         nocx);
+                               inputMode,
+                               reserveSpace,
+                               nohx,
+                               nocx);
 
 #if(MIO_LSTM_TEST_DEBUG == 2)
         for(int i = 0; i < output.size(); i++)
@@ -2047,7 +2418,7 @@ struct verify_forward_train_lstm
         return retSet;
     }
 
-    std::tuple<std::vector<T>, std::vector<T>, std::vector<T>> gpu()
+    std::tuple<std::vector<T>, std::vector<T>, std::vector<T>> gpu() const
     {
 
 #if(MIO_RNN_TIME_EVERYTHING == 1)
@@ -2195,578 +2566,335 @@ struct verify_forward_train_lstm
 //~~~~~~~~~~~~ END FWD TRAIN ~~~~~~~~~~~~~~~~~~~~~~~~
 
 //****************************************************
-// BACKWARDS DATA
+// BACKWARDS DATA CPU & GPU
 //****************************************************
 template <class T>
-struct verify_backward_data_lstm
+std::tuple<std::vector<T>, std::vector<T>, std::vector<T>, std::vector<T>>
+verify_backward_data_lstm<T>::cpu() const
 {
-    std::vector<T> yin;        // Y
-    std::vector<T> dy;         // dY
-    std::vector<T> dhy;        // dHY
-    std::vector<T> dcy;        // dHY
-    std::vector<T> initHidden; // HX
-    std::vector<T> initCell;   // CX
-    std::vector<T> weights;
-    std::vector<int> batch_seq;
-    int hiddenSize;
-    int seqLength;
-    int nLayers;
-    int biasMode;
-    int dirMode;
-    int inputMode;
-    int batch_n;
-    int inputVecLen;
-    miopenRNNDescriptor_t rnnDesc;
-    size_t realHiddenSize;
-    bool nohx;
-    bool nocx;
-    bool nodhy;
-    bool nodcy;
-    bool nodhx;
-    bool nodcx;
-    bool use_dropout;
-    typename std::vector<T>::iterator RSVgpu;
-    typename std::vector<T>::iterator RSVcpu;
-
-    verify_backward_data_lstm(miopenRNNDescriptor_t pRD,
-                              const std::vector<T>& py,
-                              const std::vector<T>& pdy,
-                              const std::vector<T>& pdhy,
-                              const std::vector<T>& phx,
-                              const std::vector<T>& pdcy,
-                              const std::vector<T>& pcx,
-                              const std::vector<T>& pW,
-                              std::vector<T>& pRSVgpu,
-                              std::vector<T>& pRSVcpu,
-                              const std::vector<int>& pBS,
-                              const int pHS,
-                              const int pBN,
-                              const int pS,
-                              const int pNL,
-                              const int pBM,
-                              const int pDM,
-                              const int pIM,
-                              const int pVL,
-                              const size_t pHXZ,
-                              const bool pnohx        = false,
-                              const bool pnocx        = false,
-                              const bool pnodhy       = false,
-                              const bool pnodcy       = false,
-                              const bool pnodhx       = false,
-                              const bool pnodcx       = false,
-                              const bool puse_dropout = false)
-        : yin(py),
-          dy(pdy),
-          dhy(pdhy),
-          dcy(pdcy),
-          initHidden(phx),
-          initCell(pcx),
-          weights(pW),
-          batch_seq(pBS),
-          hiddenSize(pHS),
-          seqLength(pS),
-          nLayers(pNL),
-          biasMode(pBM),
-          dirMode(pDM),
-          inputMode(pIM),
-          batch_n(pBN),
-          inputVecLen(pVL),
-          rnnDesc(pRD),
-          realHiddenSize(pHXZ),
-          nohx(pnohx),
-          nocx(pnocx),
-          nodhy(pnodhy),
-          nodcy(pnodcy),
-          nodhx(pnodhx),
-          nodcx(pnodcx),
-          use_dropout(puse_dropout),
-          RSVgpu(pRSVgpu.begin()),
-          RSVcpu(pRSVcpu.begin())
-    {
-        if(!nohx)
-            initHidden = phx; // this may be intentionally a nullptr
-        else
-            initHidden.resize(realHiddenSize);
-
-        if(!nocx)
-            initCell = pcx; // this may be intentionally a nullptr
-        else
-            initCell.resize(realHiddenSize);
-
-        if(!nodhy)
-            dhy = pdhy; // this may be intentionally a nullptr
-        else
-            dhy.resize(realHiddenSize);
-
-        if(!nodcy)
-            dcy = pdcy; // this may be intentionally a nullptr
-        else
-            dcy.resize(realHiddenSize);
-    }
-
-    std::tuple<std::vector<T>, std::vector<T>, std::vector<T>, std::vector<T>> cpu()
-    {
 
 #if(MIO_RNN_TIME_EVERYTHING == 1)
-        auto t_start = std::chrono::high_resolution_clock::now();
+    auto t_start = std::chrono::high_resolution_clock::now();
 #endif
 
-        auto&& handle = get_handle();
+    auto&& handle = get_handle();
 
-        int bi        = dirMode != 0 ? 2 : 1;
-        int hy_h      = hiddenSize;
-        int bi_stride = bi * hy_h;
-        size_t workSpaceSize;
+    int bi        = dirMode != 0 ? 2 : 1;
+    int hy_h      = hiddenSize;
+    int bi_stride = bi * hy_h;
+    size_t workSpaceSize;
 
-        std::vector<miopen::TensorDescriptor> inputCPPDescs;
-        std::vector<miopenTensorDescriptor_t> inputDescs;
-        createTensorDescArray(
-            inputCPPDescs, inputDescs, batch_seq, inputVecLen, miopen::deref(rnnDesc).dataType);
+    std::vector<miopen::TensorDescriptor> inputCPPDescs;
+    std::vector<miopenTensorDescriptor_t> inputDescs;
+    createTensorDescArray(
+        inputCPPDescs, inputDescs, batch_seq, inputVecLen, miopen::deref(rnnDesc).dataType);
 
-        // Outputs ----------
-        size_t in_sz = 0;
-        miopenGetRNNInputTensorSize(&handle, rnnDesc, seqLength, inputDescs.data(), &in_sz);
-        miopenGetRNNWorkspaceSize(&handle, rnnDesc, seqLength, inputDescs.data(), &workSpaceSize);
-        std::vector<T> workSpace(workSpaceSize / sizeof(T));
-        std::vector<T> dx(in_sz / sizeof(T));
-        std::vector<T> dhx(initHidden.size());
-        std::vector<T> dcx(initHidden.size());
+    // Outputs ----------
+    size_t in_sz = 0;
+    miopenGetRNNInputTensorSize(&handle, rnnDesc, seqLength, inputDescs.data(), &in_sz);
+    miopenGetRNNWorkspaceSize(&handle, rnnDesc, seqLength, inputDescs.data(), &workSpaceSize);
+    std::vector<T> workSpace(workSpaceSize / sizeof(T));
+    std::vector<T> dx(in_sz / sizeof(T));
+    std::vector<T> dhx(initHidden.size());
+    std::vector<T> dcx(initHidden.size());
 
-        size_t inputBatchLenSum =
-            std::accumulate(batch_seq.begin(), batch_seq.begin() + seqLength, 0);
-        size_t reserveSpaceSize;
-        reserveSpaceSize = 2 * 6 * miopen::deref(rnnDesc).nLayers * inputBatchLenSum * hiddenSize *
-                           ((dirMode != 0) ? 2 : 1);
-        if(use_dropout)
-        {
-            reserveSpaceSize += (miopen::deref(rnnDesc).nLayers - 1) * inputBatchLenSum *
-                                hiddenSize * ((dirMode != 0) ? 2 : 1);
-            reserveSpaceSize *= sizeof(T);
-            reserveSpaceSize += (miopen::deref(rnnDesc).nLayers - 1) * inputBatchLenSum *
-                                hiddenSize * ((dirMode != 0) ? 2 : 1);
-            reserveSpaceSize = (reserveSpaceSize + sizeof(T) - 1) / sizeof(T);
-        }
-
-        std::vector<T> reserveSpace(reserveSpaceSize);
-        std::copy(RSVcpu, RSVcpu + reserveSpaceSize, reserveSpace.begin());
-
-        LSTMBwdDataCPUVerify(use_dropout,
-                             miopen::deref(miopen::deref(rnnDesc).dropoutDesc),
-                             dx,              // DX (output)
-                             weights,         // [ input_state_weight_trans
-                                              //   hidden_state_weight0_trans input1_trans
-                                              //   hidden1_trans ... output_weight;
-                                              //   bidirectional reversed weights ]
-                             dhy,             // current/final hidden state
-                             dhx,             // DHX (output)
-                             initHidden,      // HX initial hidden state
-                             dcy,             // DCY current/final cell state
-                             dcx,             // DCX (output)
-                             initCell,        // CX
-                             yin,             // Y
-                             dy,              // DY
-                             batch_seq,       // input batch size
-                             inputVecLen,     // input data length
-                             seqLength,       // Number of iterations to unroll over
-                             dirMode,         // whether using bidirectional net
-                             biasMode,        // whether using bias
-                             bi * nLayers,    // 1 by numlayer (number of stacks of hidden layers)
-                                              // for unidirection, 2 by numlayer for bidirection
-                             batch_seq.at(0), // equal to input batch size in_n[0]
-                             hiddenSize,      // hidden state number
-                             bi_stride,       // 1 by hy_h related function for unidirection, 2 by
-                             // hy_h related function for bidirection
-                             inputMode,
-                             reserveSpace,
-                             workSpace,
-                             nocx,
-                             nodhy,
-                             nodcy);
-
-#if(MIO_RNN_TIME_EVERYTHING == 1)
-        auto t_end = std::chrono::high_resolution_clock::now();
-
-        std::cout << "Wall clock: CPU backward data LSTM pass time: "
-                  << std::chrono::duration<double>(t_end - t_start).count() << " seconds."
-                  << std::endl;
-#endif
-        std::copy(reserveSpace.begin(), reserveSpace.end(), RSVcpu);
-        auto retSet =
-            std::make_tuple(dx, (nodhx ? initHidden : dhx), (nodcx ? initCell : dcx), workSpace);
-
-#if(MIO_LSTM_TEST_DEBUG > 0)
-        std::cout << "Done with LSTM backward data CPU" << std::endl;
-        std::cout << "---------------------------------\n" << std::endl;
-#endif
-        return retSet;
+    size_t inputBatchLenSum = std::accumulate(batch_seq.begin(), batch_seq.begin() + seqLength, 0);
+    size_t reserveSpaceSize;
+    reserveSpaceSize = 2 * 6 * miopen::deref(rnnDesc).nLayers * inputBatchLenSum * hiddenSize *
+                       ((dirMode != 0) ? 2 : 1);
+    if(use_dropout)
+    {
+        reserveSpaceSize += (miopen::deref(rnnDesc).nLayers - 1) * inputBatchLenSum * hiddenSize *
+                            ((dirMode != 0) ? 2 : 1);
+        reserveSpaceSize *= sizeof(T);
+        reserveSpaceSize += (miopen::deref(rnnDesc).nLayers - 1) * inputBatchLenSum * hiddenSize *
+                            ((dirMode != 0) ? 2 : 1);
+        reserveSpaceSize = (reserveSpaceSize + sizeof(T) - 1) / sizeof(T);
     }
 
-    std::tuple<std::vector<T>, std::vector<T>, std::vector<T>, std::vector<T>> gpu()
-    {
+    std::vector<T> reserveSpace(reserveSpaceSize);
+    std::copy(RSVcpu, RSVcpu + reserveSpaceSize, reserveSpace.begin());
 
-#if(MIO_RNN_TIME_EVERYTHING == 1)
-        auto t_start = std::chrono::high_resolution_clock::now();
-#endif
-
-        auto&& handle = get_handle();
-
-        size_t workSpaceSize = 0;
-
-        std::vector<miopen::TensorDescriptor> inputCPPDescs;
-        std::vector<miopenTensorDescriptor_t> inputDescs;
-        createTensorDescArray(
-            inputCPPDescs, inputDescs, batch_seq, inputVecLen, miopen::deref(rnnDesc).dataType);
-
-        std::vector<miopen::TensorDescriptor> outputCPPDescs;
-        std::vector<miopenTensorDescriptor_t> outputDescs;
-        createTensorDescArray(outputCPPDescs,
-                              outputDescs,
-                              batch_seq,
-                              hiddenSize * ((dirMode != 0) ? 2 : 1),
-                              miopen::deref(rnnDesc).dataType);
-
-        miopenGetRNNWorkspaceSize(&handle, rnnDesc, seqLength, inputDescs.data(), &workSpaceSize);
-        std::vector<T> workSpace(workSpaceSize / sizeof(T));
-        auto workSpace_dev = handle.Write(workSpace);
-
-        size_t reserveSpaceSize;
-        miopenGetRNNTrainingReserveSize(
-            &handle, rnnDesc, seqLength, inputDescs.data(), &reserveSpaceSize);
-        std::vector<T> reserveSpace((reserveSpaceSize + sizeof(T) - 1) / sizeof(T));
-        std::copy(RSVgpu, RSVgpu + reserveSpace.size(), reserveSpace.begin());
-
-        auto yin_dev          = handle.Write(yin);
-        auto dyin_dev         = handle.Write(dy);
-        auto reserveSpace_dev = handle.Write(reserveSpace);
-        auto weights_dev      = handle.Write(weights);
-
-        std::vector<int> hlens(3, 0);
-        hlens[0] = nLayers * (dirMode != 0 ? 2 : 1);
-        hlens[1] = batch_seq[0];
-        hlens[2] = hiddenSize;
-        miopen::TensorDescriptor hiddenDesc(miopen::deref(rnnDesc).dataType, hlens.data(), 3);
-
-        std::vector<int> wlen(1, 0);
-        wlen[0] = weights.size();
-        miopen::TensorDescriptor weightDesc(miopen::deref(rnnDesc).dataType, wlen.data(), 1);
-
-        size_t in_sz = 0;
-        miopenGetRNNInputTensorSize(&handle, rnnDesc, seqLength, inputDescs.data(), &in_sz);
-        std::vector<T> dx(in_sz / sizeof(T));
-        auto dx_dev = handle.Write(dx);
-
-        std::vector<T> dhx(initHidden.size());
-        auto dhx_dev = handle.Write(dhx);
-
-        std::vector<T> dcx(initHidden.size());
-        auto dcx_dev = handle.Write(dcx);
-
-        miopenRNNBackwardData(&handle,
-                              rnnDesc,
-                              seqLength,
-                              outputDescs.data(),
-                              yin_dev.get(),
-                              outputDescs.data(),
-                              dyin_dev.get(),
-                              &hiddenDesc,
-                              ((nodhy) ? nullptr : handle.Write(dhy).get()),
-                              &hiddenDesc,
-                              ((nodcy) ? nullptr : handle.Write(dcy).get()),
-                              &weightDesc,
-                              weights_dev.get(),
-                              &hiddenDesc,
-                              ((nohx) ? nullptr : handle.Write(initHidden).get()),
-                              &hiddenDesc,
-                              ((nocx) ? nullptr : handle.Write(initCell).get()),
-                              inputDescs.data(),
-                              dx_dev.get(),
-                              &hiddenDesc,
-                              ((nodhx) ? nullptr : dhx_dev.get()),
-                              &hiddenDesc,
-                              ((nodcx) ? nullptr : dcx_dev.get()),
-                              workSpace_dev.get(),
-                              workSpaceSize,
-                              reserveSpace_dev.get(),
-                              reserveSpace.size() * sizeof(T));
-
-        reserveSpace = handle.Read<T>(reserveSpace_dev, reserveSpace.size());
-        std::copy(reserveSpace.begin(), reserveSpace.end(), RSVgpu);
-        auto retSet = std::make_tuple(handle.Read<T>(dx_dev, dx.size()),
-                                      (nodhx ? initHidden : handle.Read<T>(dhx_dev, dhx.size())),
-                                      (nodcx ? initCell : handle.Read<T>(dcx_dev, dcx.size())),
-                                      handle.Read<T>(workSpace_dev, workSpace.size()));
-
-#if(MIO_RNN_TIME_EVERYTHING == 1)
-        auto t_end = std::chrono::high_resolution_clock::now();
-
-        std::cout << "Wall clock: GPU backward data LSTM pass time: "
-                  << std::chrono::duration<double>(t_end - t_start).count() << " seconds."
-                  << std::endl;
-#endif
-#if(MIO_LSTM_TEST_DEBUG > 0)
-        std::cout << "Done with LSTM backward data GPU" << std::endl;
-#endif
-        return retSet;
-    }
-
-    void fail(int badtensor) const
-    {
-
-        std::cout << "./bin/MIOpenDriver rnn -n ";
-        for(int i = 0; i < seqLength; i++)
-        {
-            if(i < seqLength - 1)
-            {
-                std::cout << batch_seq.at(i) << ",";
-            }
-            else
-            {
-                std::cout << batch_seq.at(i);
-            }
-        }
-        std::cout << " -m lstm "
-                  << " -k " << seqLength << " -H " << hiddenSize << " -W " << inputVecLen << " -l "
-                  << nLayers << " -F 0 "
-                  << " -r " << dirMode << " -b " << biasMode << " -p " << inputMode << std::endl;
-
-        std::cout << "inputMode: " << inputMode << " biasMode: " << biasMode
-                  << " dirMode: " << dirMode << std::endl;
-        std::cout << "hz: " << hiddenSize << " batch_n: " << batch_n << " seqLength: " << seqLength
-                  << " inputLen: " << inputVecLen << " numLayers: " << nLayers
-                  << " useDropout: " << int(use_dropout) << std::endl;
-        std::cout << "Backward Data LSTM: " << std::endl;
-
-        switch(badtensor)
-        {
-        case(0): std::cout << "Output dx failed verification." << std::endl; break;
-        case(1): std::cout << "Hidden state dhx tensor failed verification." << std::endl; break;
-        case(2): std::cout << "Hidden cell dcx tensor failed verification." << std::endl; break;
-        case(3): std::cout << "Workspace space tensor failed verification." << std::endl; break;
-        default: break;
-        }
-    }
-};
-//~~~~~~~~~~~~ END BACKWARD DATA ~~~~~~~~~~~~~~~~~~~~~~~~
-
-//****************************************************
-// BACKWARDS WEIGHTS
-//****************************************************
-template <class T>
-struct verify_backward_weights_lstm
-{
-    std::vector<T> input;      // Y
-    std::vector<T> dy;         // dY
-    std::vector<T> initHidden; // HX
-    std::vector<T> workSpace;
-    std::vector<int> batch_seq;
-    int weightSize;
-    int hiddenSize;
-    int seqLength;
-    int nLayers;
-    int biasMode;
-    int dirMode;
-    int inputMode;
-    int batch_n;
-    int inputVecLen;
-    miopenRNNDescriptor_t rnnDesc;
-    size_t realHiddenSize;
-    bool nohx;
-    bool use_dropout;
-    typename std::vector<T> reserveSpace_gpu;
-    typename std::vector<T> reserveSpace_cpu;
-
-    verify_backward_weights_lstm(miopenRNNDescriptor_t pRD,
-                                 const std::vector<T>& px,
-                                 const std::vector<T>& pdy,
-                                 const std::vector<T>& phx,
-                                 const std::vector<T>& pRSVgpu,
-                                 const std::vector<T>& pRSVcpu,
-                                 const std::vector<T>& pWS,
-                                 const std::vector<int>& pBS,
-                                 const int pHS,
-                                 const int pW,
-                                 const int pBN,
-                                 const int pS,
-                                 const int pNL,
-                                 const int pBM,
-                                 const int pDM,
-                                 const int pIM,
-                                 const int pVL,
-                                 const size_t pHXZ,
-                                 const bool pnohx        = false,
-                                 const bool puse_dropout = false)
-        : input(px),
-          dy(pdy),
-          initHidden(phx),
-          workSpace(pWS),
-          batch_seq(pBS),
-          weightSize(pW),
-          hiddenSize(pHS),
-          seqLength(pS),
-          nLayers(pNL),
-          biasMode(pBM),
-          dirMode(pDM),
-          inputMode(pIM),
-          batch_n(pBN),
-          inputVecLen(pVL),
-          rnnDesc(pRD),
-          realHiddenSize(pHXZ),
-          nohx(pnohx),
-          use_dropout(puse_dropout),
-          reserveSpace_gpu(pRSVgpu),
-          reserveSpace_cpu(pRSVcpu)
-    {
-        if(!nohx)
-            initHidden = phx; // this may be intentionally a nullptr
-        else
-            initHidden.resize(realHiddenSize);
-    }
-
-    std::vector<T> cpu()
-    {
-
-#if(MIO_RNN_TIME_EVERYTHING == 1)
-        auto t_start = std::chrono::high_resolution_clock::now();
-#endif
-        int bi        = dirMode != 0 ? 2 : 1;
-        int hy_h      = hiddenSize;
-        int bi_stride = bi * hy_h;
-        std::vector<T> dweights(weightSize);
-
-        LSTMBwdWeightCPUVerify(use_dropout,
-                               input,
-                               dweights,   // (output) [ input_state_weight_trans
-                                           // hidden_state_weight0_trans
-                                           // input1_trans hidden1_trans ...
-                                           // output_weight; bidirectional
-                                           // reversed weights ]
-                               initHidden, // initial hidden state
-                               dy,
+    this->LSTMBwdDataCPUVerify(use_dropout,
+                               miopen::deref(miopen::deref(rnnDesc).dropoutDesc),
+                               dx,              // DX (output)
+                               weights,         // [ input_state_weight_trans
+                                                //   hidden_state_weight0_trans input1_trans
+                                                //   hidden1_trans ... output_weight;
+                                                //   bidirectional reversed weights ]
+                               dhy,             // current/final hidden state
+                               dhx,             // DHX (output)
+                               initHidden,      // HX initial hidden state
+                               dcy,             // DCY current/final cell state
+                               dcx,             // DCX (output)
+                               initCell,        // CX
+                               yin,             // Y
+                               dy,              // DY
                                batch_seq,       // input batch size
                                inputVecLen,     // input data length
                                seqLength,       // Number of iterations to unroll over
                                dirMode,         // whether using bidirectional net
                                biasMode,        // whether using bias
-                               bi * nLayers,    // 1 by numlayer (number of stacks of hidden
-                                                // layers) for unidirection, 2 by numlayer for
-                                                // bidirection
+                               bi * nLayers,    // 1 by numlayer (number of stacks of hidden layers)
+                                                // for unidirection, 2 by numlayer for bidirection
                                batch_seq.at(0), // equal to input batch size in_n[0]
                                hiddenSize,      // hidden state number
-                               bi_stride,       // 1 by hy_h related function for unidirection, 2
-                                                // by hy_h related function for bidirection
+                               bi_stride,       // 1 by hy_h related function for unidirection, 2 by
+                               // hy_h related function for bidirection
                                inputMode,
-                               reserveSpace_cpu,
+                               reserveSpace,
                                workSpace,
-                               nohx);
+                               nocx,
+                               nodhy,
+                               nodcy);
 
 #if(MIO_RNN_TIME_EVERYTHING == 1)
-        auto t_end = std::chrono::high_resolution_clock::now();
+    auto t_end = std::chrono::high_resolution_clock::now();
 
-        std::cout << "Wall clock: CPU backward_weights LSTM pass time: "
-                  << std::chrono::duration<double>(t_end - t_start).count() << " seconds."
-                  << std::endl;
+    std::cout << "Wall clock: CPU backward data LSTM pass time: "
+              << std::chrono::duration<double>(t_end - t_start).count() << " seconds." << std::endl;
+#endif
+    std::copy(reserveSpace.begin(), reserveSpace.end(), RSVcpu);
+    auto retSet =
+        std::make_tuple(dx, (nodhx ? initHidden : dhx), (nodcx ? initCell : dcx), workSpace);
+
+#if(MIO_LSTM_TEST_DEBUG > 0)
+    std::cout << "Done with LSTM backward data CPU" << std::endl;
+    std::cout << "---------------------------------\n" << std::endl;
+#endif
+    return retSet;
+}
+
+template <class T>
+std::tuple<std::vector<T>, std::vector<T>, std::vector<T>, std::vector<T>>
+verify_backward_data_lstm<T>::gpu() const
+{
+
+#if(MIO_RNN_TIME_EVERYTHING == 1)
+    auto t_start = std::chrono::high_resolution_clock::now();
+#endif
+
+    auto&& handle = get_handle();
+
+    size_t workSpaceSize = 0;
+
+    std::vector<miopen::TensorDescriptor> inputCPPDescs;
+    std::vector<miopenTensorDescriptor_t> inputDescs;
+    createTensorDescArray(
+        inputCPPDescs, inputDescs, batch_seq, inputVecLen, miopen::deref(rnnDesc).dataType);
+
+    std::vector<miopen::TensorDescriptor> outputCPPDescs;
+    std::vector<miopenTensorDescriptor_t> outputDescs;
+    createTensorDescArray(outputCPPDescs,
+                          outputDescs,
+                          batch_seq,
+                          hiddenSize * ((dirMode != 0) ? 2 : 1),
+                          miopen::deref(rnnDesc).dataType);
+
+    miopenGetRNNWorkspaceSize(&handle, rnnDesc, seqLength, inputDescs.data(), &workSpaceSize);
+    std::vector<T> workSpace(workSpaceSize / sizeof(T));
+    auto workSpace_dev = handle.Write(workSpace);
+
+    size_t reserveSpaceSize;
+    miopenGetRNNTrainingReserveSize(
+        &handle, rnnDesc, seqLength, inputDescs.data(), &reserveSpaceSize);
+    std::vector<T> reserveSpace((reserveSpaceSize + sizeof(T) - 1) / sizeof(T));
+    std::copy(RSVgpu, RSVgpu + reserveSpace.size(), reserveSpace.begin());
+
+    auto yin_dev          = handle.Write(yin);
+    auto dyin_dev         = handle.Write(dy);
+    auto reserveSpace_dev = handle.Write(reserveSpace);
+    auto weights_dev      = handle.Write(weights);
+
+    std::vector<int> hlens(3, 0);
+    hlens[0] = nLayers * (dirMode != 0 ? 2 : 1);
+    hlens[1] = batch_seq[0];
+    hlens[2] = hiddenSize;
+    miopen::TensorDescriptor hiddenDesc(miopen::deref(rnnDesc).dataType, hlens.data(), 3);
+
+    std::vector<int> wlen(1, 0);
+    wlen[0] = weights.size();
+    miopen::TensorDescriptor weightDesc(miopen::deref(rnnDesc).dataType, wlen.data(), 1);
+
+    size_t in_sz = 0;
+    miopenGetRNNInputTensorSize(&handle, rnnDesc, seqLength, inputDescs.data(), &in_sz);
+    std::vector<T> dx(in_sz / sizeof(T));
+    auto dx_dev = handle.Write(dx);
+
+    std::vector<T> dhx(initHidden.size());
+    auto dhx_dev = handle.Write(dhx);
+
+    std::vector<T> dcx(initHidden.size());
+    auto dcx_dev = handle.Write(dcx);
+
+    miopenRNNBackwardData(&handle,
+                          rnnDesc,
+                          seqLength,
+                          outputDescs.data(),
+                          yin_dev.get(),
+                          outputDescs.data(),
+                          dyin_dev.get(),
+                          &hiddenDesc,
+                          ((nodhy) ? nullptr : handle.Write(dhy).get()),
+                          &hiddenDesc,
+                          ((nodcy) ? nullptr : handle.Write(dcy).get()),
+                          &weightDesc,
+                          weights_dev.get(),
+                          &hiddenDesc,
+                          ((nohx) ? nullptr : handle.Write(initHidden).get()),
+                          &hiddenDesc,
+                          ((nocx) ? nullptr : handle.Write(initCell).get()),
+                          inputDescs.data(),
+                          dx_dev.get(),
+                          &hiddenDesc,
+                          ((nodhx) ? nullptr : dhx_dev.get()),
+                          &hiddenDesc,
+                          ((nodcx) ? nullptr : dcx_dev.get()),
+                          workSpace_dev.get(),
+                          workSpaceSize,
+                          reserveSpace_dev.get(),
+                          reserveSpace.size() * sizeof(T));
+
+    reserveSpace = handle.Read<T>(reserveSpace_dev, reserveSpace.size());
+    std::copy(reserveSpace.begin(), reserveSpace.end(), RSVgpu);
+    auto retSet = std::make_tuple(handle.Read<T>(dx_dev, dx.size()),
+                                  (nodhx ? initHidden : handle.Read<T>(dhx_dev, dhx.size())),
+                                  (nodcx ? initCell : handle.Read<T>(dcx_dev, dcx.size())),
+                                  handle.Read<T>(workSpace_dev, workSpace.size()));
+
+#if(MIO_RNN_TIME_EVERYTHING == 1)
+    auto t_end = std::chrono::high_resolution_clock::now();
+
+    std::cout << "Wall clock: GPU backward data LSTM pass time: "
+              << std::chrono::duration<double>(t_end - t_start).count() << " seconds." << std::endl;
 #endif
 #if(MIO_LSTM_TEST_DEBUG > 0)
-        std::cout << "Done with LSTM backward weights CPU" << std::endl;
-        std::cout << "---------------------------------\n" << std::endl;
+    std::cout << "Done with LSTM backward data GPU" << std::endl;
 #endif
-        return dweights;
-    }
+    return retSet;
+}
+//~~~~~~~~~~~~ END BACKWARD DATA CPU & GPU ~~~~~~~~~~~~~~~~~~~~~~~~
 
-    std::vector<T> gpu()
-    {
+//****************************************************
+// BACKWARDS WEIGHTS CPU & GPU
+//****************************************************
+template <class T>
+std::vector<T> verify_backward_weights_lstm<T>::cpu() const
+{
 
 #if(MIO_RNN_TIME_EVERYTHING == 1)
-        auto t_start = std::chrono::high_resolution_clock::now();
+    auto t_start = std::chrono::high_resolution_clock::now();
 #endif
+    int bi        = dirMode != 0 ? 2 : 1;
+    int hy_h      = hiddenSize;
+    int bi_stride = bi * hy_h;
+    std::vector<T> dweights(weightSize);
 
-        auto&& handle = get_handle();
-
-        std::vector<miopen::TensorDescriptor> inputCPPDescs;
-        std::vector<miopenTensorDescriptor_t> inputDescs;
-        createTensorDescArray(
-            inputCPPDescs, inputDescs, batch_seq, inputVecLen, miopen::deref(rnnDesc).dataType);
-
-        std::vector<miopen::TensorDescriptor> outputCPPDescs;
-        std::vector<miopenTensorDescriptor_t> outputDescs;
-        createTensorDescArray(outputCPPDescs,
-                              outputDescs,
-                              batch_seq,
-                              hiddenSize * ((dirMode != 0) ? 2 : 1),
-                              miopen::deref(rnnDesc).dataType);
-
-        auto workSpace_dev    = handle.Write(workSpace);
-        auto reserveSpace_dev = handle.Write(reserveSpace_gpu);
-        std::vector<T> dweights(weightSize);
-        auto dweights_dev = handle.Write(dweights);
-        miopen::TensorDescriptor weightDesc(miopen::deref(rnnDesc).dataType, &weightSize, 1);
-
-        std::vector<int> hlens(3, 0);
-        hlens[0] = nLayers * (dirMode != 0 ? 2 : 1);
-        hlens[1] = batch_seq[0];
-        hlens[2] = hiddenSize;
-        miopen::TensorDescriptor hiddenDesc(miopen::deref(rnnDesc).dataType, hlens.data(), 3);
-        auto dy_dev    = handle.Write(dy);
-        auto input_dev = handle.Write(input);
-
-        miopenRNNBackwardWeights(&handle,
-                                 rnnDesc,
-                                 seqLength,
-                                 inputDescs.data(),
-                                 input_dev.get(),
-                                 &hiddenDesc,
-                                 ((nohx) ? nullptr : handle.Write(initHidden).get()),
-                                 outputDescs.data(),
-                                 dy_dev.get(),
-                                 &weightDesc,
-                                 dweights_dev.get(),
-                                 workSpace_dev.get(),
-                                 workSpace.size() * sizeof(T),
-                                 reserveSpace_dev.get(),
-                                 reserveSpace_gpu.size() * sizeof(T));
+    this->LSTMBwdWeightCPUVerify(use_dropout,
+                                 input,
+                                 dweights,   // (output) [ input_state_weight_trans
+                                             // hidden_state_weight0_trans
+                                             // input1_trans hidden1_trans ...
+                                             // output_weight; bidirectional
+                                             // reversed weights ]
+                                 initHidden, // initial hidden state
+                                 dy,
+                                 batch_seq,       // input batch size
+                                 inputVecLen,     // input data length
+                                 seqLength,       // Number of iterations to unroll over
+                                 dirMode,         // whether using bidirectional net
+                                 biasMode,        // whether using bias
+                                 bi * nLayers,    // 1 by numlayer (number of stacks of hidden
+                                                  // layers) for unidirection, 2 by numlayer for
+                                                  // bidirection
+                                 batch_seq.at(0), // equal to input batch size in_n[0]
+                                 hiddenSize,      // hidden state number
+                                 bi_stride,       // 1 by hy_h related function for unidirection, 2
+                                                  // by hy_h related function for bidirection
+                                 inputMode,
+                                 reserveSpace_cpu,
+                                 workSpace,
+                                 nohx);
 
 #if(MIO_RNN_TIME_EVERYTHING == 1)
-        auto t_end = std::chrono::high_resolution_clock::now();
+    auto t_end = std::chrono::high_resolution_clock::now();
 
-        std::cout << "Wall clock: GPU backwards_weights LSTM pass time: "
-                  << std::chrono::duration<double>(t_end - t_start).count() << " seconds."
-                  << std::endl;
+    std::cout << "Wall clock: CPU backward_weights LSTM pass time: "
+              << std::chrono::duration<double>(t_end - t_start).count() << " seconds." << std::endl;
 #endif
 #if(MIO_LSTM_TEST_DEBUG > 0)
-        std::cout << "Done with LSTM backward weights GPU" << std::endl;
+    std::cout << "Done with LSTM backward weights CPU" << std::endl;
+    std::cout << "---------------------------------\n" << std::endl;
 #endif
-        auto retvec = handle.Read<T>(dweights_dev, dweights.size());
-        return retvec;
-    }
+    return dweights;
+}
 
-    void fail(int) const
-    {
-        std::cout << "./bin/MIOpenDriver rnn -n ";
-        for(int i = 0; i < seqLength; i++)
-        {
-            if(i < seqLength - 1)
-            {
-                std::cout << batch_seq.at(i) << ",";
-            }
-            else
-            {
-                std::cout << batch_seq.at(i);
-            }
-        }
-        std::cout << " -m lstm "
-                  << " -k " << seqLength << " -H " << hiddenSize << " -W " << inputVecLen << " -l "
-                  << nLayers << " -F 0 "
-                  << " -r " << dirMode << " -b " << biasMode << " -p " << inputMode << std::endl;
+template <class T>
+std::vector<T> verify_backward_weights_lstm<T>::gpu() const
+{
 
-        std::cout << "inputMode: " << inputMode << " biasMode: " << biasMode
-                  << " dirMode: " << dirMode << std::endl;
-        std::cout << "hz: " << hiddenSize << " batch_n: " << batch_n << " seqLength: " << seqLength
-                  << " inputLen: " << inputVecLen << " numLayers: " << nLayers
-                  << " useDropout: " << int(use_dropout) << std::endl;
-        std::cout << "Backward Weights LSTM: " << std::endl;
-    }
-};
-//~~~~~~~~~~~~ END BACKWARD WEIGHTS ~~~~~~~~~~~~~~~~~~~~~~~~
+#if(MIO_RNN_TIME_EVERYTHING == 1)
+    auto t_start = std::chrono::high_resolution_clock::now();
+#endif
+
+    auto&& handle = get_handle();
+
+    std::vector<miopen::TensorDescriptor> inputCPPDescs;
+    std::vector<miopenTensorDescriptor_t> inputDescs;
+    createTensorDescArray(
+        inputCPPDescs, inputDescs, batch_seq, inputVecLen, miopen::deref(rnnDesc).dataType);
+
+    std::vector<miopen::TensorDescriptor> outputCPPDescs;
+    std::vector<miopenTensorDescriptor_t> outputDescs;
+    createTensorDescArray(outputCPPDescs,
+                          outputDescs,
+                          batch_seq,
+                          hiddenSize * ((dirMode != 0) ? 2 : 1),
+                          miopen::deref(rnnDesc).dataType);
+
+    auto workSpace_dev    = handle.Write(workSpace);
+    auto reserveSpace_dev = handle.Write(reserveSpace_gpu);
+    std::vector<T> dweights(weightSize);
+    auto dweights_dev = handle.Write(dweights);
+    miopen::TensorDescriptor weightDesc(miopen::deref(rnnDesc).dataType, &weightSize, 1);
+
+    std::vector<int> hlens(3, 0);
+    hlens[0] = nLayers * (dirMode != 0 ? 2 : 1);
+    hlens[1] = batch_seq[0];
+    hlens[2] = hiddenSize;
+    miopen::TensorDescriptor hiddenDesc(miopen::deref(rnnDesc).dataType, hlens.data(), 3);
+    auto dy_dev    = handle.Write(dy);
+    auto input_dev = handle.Write(input);
+
+    miopenRNNBackwardWeights(&handle,
+                             rnnDesc,
+                             seqLength,
+                             inputDescs.data(),
+                             input_dev.get(),
+                             &hiddenDesc,
+                             ((nohx) ? nullptr : handle.Write(initHidden).get()),
+                             outputDescs.data(),
+                             dy_dev.get(),
+                             &weightDesc,
+                             dweights_dev.get(),
+                             workSpace_dev.get(),
+                             workSpace.size() * sizeof(T),
+                             reserveSpace_dev.get(),
+                             reserveSpace_gpu.size() * sizeof(T));
+
+#if(MIO_RNN_TIME_EVERYTHING == 1)
+    auto t_end = std::chrono::high_resolution_clock::now();
+
+    std::cout << "Wall clock: GPU backwards_weights LSTM pass time: "
+              << std::chrono::duration<double>(t_end - t_start).count() << " seconds." << std::endl;
+#endif
+#if(MIO_LSTM_TEST_DEBUG > 0)
+    std::cout << "Done with LSTM backward weights GPU" << std::endl;
+#endif
+    auto retvec = handle.Read<T>(dweights_dev, dweights.size());
+    return retvec;
+}
+//~~~~~~~~~~~~ END BACKWARD WEIGHTS CPU & GPU ~~~~~~~~~~~~~~~~~~~~~~~~
 
 //====================== DRIVER ============================
 template <class T>

--- a/test/lstm_common.hpp
+++ b/test/lstm_common.hpp
@@ -78,7 +78,7 @@ struct verify_forward_lstm
     bool nocy{};
 
     void LSTMFwdCPUVerify(miopen::Handle& handle,
-                          const bool use_dropout,
+                          bool use_dropout,
                           const miopen::DropoutDescriptor& dropoutDesc,
                           const std::vector<T>& in,
                           const std::vector<T>& wei,
@@ -89,17 +89,17 @@ struct verify_forward_lstm
                           std::vector<T>& out_host,
                           const std::vector<int>& in_n,
                           int in_h,
-                          const int seqLength,
-                          const int bidirection,
-                          const int biased,
-                          const int hy_d,
-                          const int hy_n,
-                          const int hy_h,
-                          const int out_h,
-                          const int inputMode,
+                          int seqLength_cpu,
+                          int bidirection,
+                          int biased,
+                          int hy_d,
+                          int hy_n,
+                          int hy_h,
+                          int out_h,
+                          int inputMode_cpu,
                           std::vector<T>& rsvspace,
-                          const bool hx_is_null = false,
-                          const bool cx_is_null = false) const;
+                          bool hx_is_null = false,
+                          bool cx_is_null = false) const;
 };
 
 //****************************************************
@@ -212,7 +212,7 @@ struct verify_backward_data_lstm
             dcy.resize(realHiddenSize);
     }
 
-    void LSTMBwdDataCPUVerify(const bool use_dropout,
+    void LSTMBwdDataCPUVerify(bool use_dropout_cpu,
                               const miopen::DropoutDescriptor& dropoutDesc,
                               std::vector<T>& din_host,
                               const std::vector<T>& wei,
@@ -226,19 +226,19 @@ struct verify_backward_data_lstm
                               const std::vector<T>& dout,
                               const std::vector<int>& in_n,
                               int in_h,
-                              const int seqLength,
-                              const int bidirection,
-                              const int,
-                              const int hy_d,
-                              const int hy_n,
-                              const int hy_h,
-                              const int out_h,
-                              const int inputMode,
+                              int seqLength_cpu,
+                              int bidirection,
+                              int,
+                              int hy_d,
+                              int hy_n,
+                              int hy_h,
+                              int out_h,
+                              int inputMode_cpu,
                               std::vector<T>& rsvspace,
                               std::vector<T>& wkspace,
-                              const bool cx_is_null  = false,
-                              const bool dhy_is_null = false,
-                              const bool dcy_is_null = false) const;
+                              bool cx_is_null  = false,
+                              bool dhy_is_null = false,
+                              bool dcy_is_null = false) const;
 
     std::tuple<std::vector<T>, std::vector<T>, std::vector<T>, std::vector<T>> cpu() const;
     std::tuple<std::vector<T>, std::vector<T>, std::vector<T>, std::vector<T>> gpu() const;
@@ -356,24 +356,24 @@ struct verify_backward_weights_lstm
             initHidden.resize(realHiddenSize);
     }
 
-    void LSTMBwdWeightCPUVerify(const bool use_dropout,
+    void LSTMBwdWeightCPUVerify(bool use_dropout_cpu,
                                 const std::vector<T>& in,
                                 std::vector<T>& dwei_host,
                                 const std::vector<T>& hx,
                                 const std::vector<T>& dout,
                                 const std::vector<int>& in_n,
                                 int in_h,
-                                const int seqLength,
-                                const int bidirection,
-                                const int biased,
-                                const int hy_d,
-                                const int hy_n,
-                                const int hy_h,
-                                const int out_h,
-                                const int inputMode,
+                                int seqLength_cpu,
+                                int bidirection,
+                                int biased,
+                                int hy_d,
+                                int hy_n,
+                                int hy_h,
+                                int out_h,
+                                int inputMode_cpu,
                                 const std::vector<T>& rsvspace,
                                 const std::vector<T>& wkspace,
-                                const bool hx_is_null = false) const;
+                                bool hx_is_null = false) const;
 
     std::vector<T> cpu() const;
     std::vector<T> gpu() const;
@@ -415,7 +415,7 @@ struct verify_backward_weights_lstm
 template <class T>
 void verify_forward_lstm<T>::LSTMFwdCPUVerify(
     miopen::Handle& handle,
-    const bool use_dropout,
+    bool use_dropout,
     const miopen::DropoutDescriptor& dropoutDesc,
     const std::vector<T>& in,
     const std::vector<T>& wei, // [ input_state_weight_trans
@@ -429,24 +429,24 @@ void verify_forward_lstm<T>::LSTMFwdCPUVerify(
     std::vector<T>& out_host,
     const std::vector<int>& in_n, // input batch size
     int in_h,                     // input data length
-    const int seqLength_cpu,      // Number of iterations to unroll over
-    const int bidirection,        // whether using bidirectional net
-    const int biased,             // whether using bias
-    const int hy_d,               // 1 by numlayer (number of stacks of hidden layers) for
+    int seqLength_cpu,            // Number of iterations to unroll over
+    int bidirection,              // whether using bidirectional net
+    int biased,                   // whether using bias
+    int hy_d,                     // 1 by numlayer (number of stacks of hidden layers) for
                                   // unidirection, 2 by numlayer for bidirection
-    const int hy_n,               // equal to input batch size in_n[0]
-    const int hy_h,               // hidden state number
-    const int out_h,              // 1 by hy_h related function for unidirection, 2 by hy_h
+    int hy_n,                     // equal to input batch size in_n[0]
+    int hy_h,                     // hidden state number
+    int out_h,                    // 1 by hy_h related function for unidirection, 2 by hy_h
                                   // related function for bidirection
-    const int inputMode_cpu,
+    int inputMode_cpu,
     std::vector<T>& rsvspace,
-    const bool hx_is_null,
-    const bool cx_is_null) const
+    bool hx_is_null,
+    bool cx_is_null) const
 {
     int batch_n_cpu = sumvc(in_n);
 
-    int numlayer = bidirection ? hy_d / 2 : hy_d;
-    int bi       = bidirection ? 2 : 1;
+    int numlayer = bidirection == 1 ? hy_d / 2 : hy_d;
+    int bi       = bidirection == 1 ? 2 : 1;
 
     int in_stride  = in_h;
     int out_stride = out_h;
@@ -520,7 +520,7 @@ void verify_forward_lstm<T>::LSTMFwdCPUVerify(
                         {
                             rsvspace.at(hid_shift + bs * hy_stride + gi * hy_h + h) +=
                                 in.at(bs * in_stride + h);
-                            if(bidirection)
+                            if(bidirection == 1)
                             {
                                 rsvspace.at(hid_shift + bs * hy_stride + (gi + 4) * hy_h + h) +=
                                     in.at(bs * in_stride + h);
@@ -530,7 +530,7 @@ void verify_forward_lstm<T>::LSTMFwdCPUVerify(
                 }
 
                 // from bias
-                if(biased)
+                if(biased == 1)
                 {
                     for(int bs = 0; bs < batch_n_cpu; bs++)
                     {
@@ -563,7 +563,7 @@ void verify_forward_lstm<T>::LSTMFwdCPUVerify(
                               1);
 
                 // from bias
-                if(biased)
+                if(biased == 1)
                 {
                     for(int bs = 0; bs < batch_n_cpu; bs++)
                     {
@@ -620,7 +620,7 @@ void verify_forward_lstm<T>::LSTMFwdCPUVerify(
                           1);
 
             // from bias
-            if(biased)
+            if(biased == 1)
             {
                 int wei_shift_bias_temp = wei_shift_bias + li * 2 * wei_stride;
 
@@ -666,7 +666,7 @@ void verify_forward_lstm<T>::LSTMFwdCPUVerify(
                                   1);
 
                     // from bias
-                    if(biased)
+                    if(biased == 1)
                     {
                         int wei_shift_bias_temp = wei_shift_bias + (li * 2 + 1) * wei_stride;
 
@@ -680,7 +680,7 @@ void verify_forward_lstm<T>::LSTMFwdCPUVerify(
                         }
                     }
 
-                    if(bidirection)
+                    if(bidirection == 1)
                     {
                         RNN_mm_cpu<T>(&hx[hx_shift + hy_n * hy_h],
                                       hy_h,
@@ -701,7 +701,7 @@ void verify_forward_lstm<T>::LSTMFwdCPUVerify(
                                       1);
 
                         // from bias
-                        if(biased)
+                        if(biased == 1)
                         {
                             int wei_shift_bias_temp = wei_shift_bias + (li * 2 + 1) * wei_stride;
 
@@ -739,7 +739,7 @@ void verify_forward_lstm<T>::LSTMFwdCPUVerify(
                               1);
 
                 // from bias
-                if(biased)
+                if(biased == 1)
                 {
                     int wei_shift_bias_temp = wei_shift_bias + (li * 2 + 1) * wei_stride;
 
@@ -753,7 +753,7 @@ void verify_forward_lstm<T>::LSTMFwdCPUVerify(
                     }
                 }
 
-                if(bidirection)
+                if(bidirection == 1)
                 {
 
                     if(!hx_is_null && in_n.at(seqLength_cpu - 1 - ti) > in_n.at(seqLength_cpu - ti))
@@ -780,7 +780,7 @@ void verify_forward_lstm<T>::LSTMFwdCPUVerify(
                             1);
 
                         // from bias
-                        if(biased)
+                        if(biased == 1)
                         {
                             int wei_shift_bias_temp = wei_shift_bias + (li * 2 + 1) * wei_stride;
 
@@ -817,7 +817,7 @@ void verify_forward_lstm<T>::LSTMFwdCPUVerify(
                                   1);
 
                     // from bias
-                    if(biased)
+                    if(biased == 1)
                     {
                         int wei_shift_bias_temp = wei_shift_bias + (li * 2 + 1) * wei_stride;
 
@@ -898,7 +898,7 @@ void verify_forward_lstm<T>::LSTMFwdCPUVerify(
                 }
             }
 
-            if(bidirection)
+            if(bidirection == 1)
             {
                 for(int bs = 0; bs < in_n.at(seqLength_cpu - 1 - ti); bs++)
                 {
@@ -1033,7 +1033,7 @@ void verify_forward_lstm<T>::LSTMFwdCPUVerify(
 
 template <class T>
 void verify_backward_data_lstm<T>::LSTMBwdDataCPUVerify(
-    const bool use_dropout_cpu,
+    bool use_dropout_cpu,
     const miopen::DropoutDescriptor& dropoutDesc,
     std::vector<T>& din_host,
     const std::vector<T>& wei,     // [ input_state_weight_trans
@@ -1050,28 +1050,28 @@ void verify_backward_data_lstm<T>::LSTMBwdDataCPUVerify(
     const std::vector<T>& dout,
     const std::vector<int>& in_n, // input batch size
     int in_h,                     // input data length
-    const int seqLength_cpu,      // Number of iterations to unroll over
-    const int bidirection,        // whether using bidirectional net
-    const int,                    // whether using bias
-    const int hy_d,               // 1 by numlayer (number of stacks of hidden layers)
+    int seqLength_cpu,            // Number of iterations to unroll over
+    int bidirection,              // whether using bidirectional net
+    int,                          // whether using bias
+    int hy_d,                     // 1 by numlayer (number of stacks of hidden layers)
                                   // for unidirection, 2 by numlayer for bidirection
-    const int hy_n,               // equal to input batch size in_n[0]
-    const int hy_h,               // hidden state number
-    const int out_h,              // 1 by hy_h related function for unidirection, 2 by
+    int hy_n,                     // equal to input batch size in_n[0]
+    int hy_h,                     // hidden state number
+    int out_h,                    // 1 by hy_h related function for unidirection, 2 by
                                   // hy_h related function for bidirection
-    const int inputMode_cpu,
+    int inputMode_cpu,
     std::vector<T>& rsvspace,
     std::vector<T>& wkspace,
-    const bool cx_is_null,
-    const bool dhy_is_null,
-    const bool dcy_is_null) const
+    bool cx_is_null,
+    bool dhy_is_null,
+    bool dcy_is_null) const
 {
     int batch_n_cpu = sumvc(in_n);
     (void)out;
     (void)hx;
 
-    int numlayer = bidirection ? hy_d / 2 : hy_d;
-    int bi       = bidirection ? 2 : 1;
+    int numlayer = bidirection == 1 ? hy_d / 2 : hy_d;
+    int bi       = bidirection == 1 ? 2 : 1;
 
     int in_stride  = in_h;
     int out_stride = out_h;
@@ -1198,7 +1198,7 @@ void verify_backward_data_lstm<T>::LSTMBwdDataCPUVerify(
                     }
                 }
 
-                if(bidirection)
+                if(bidirection == 1)
                 {
                     for(int bs = 0; bs < in_n.at(seqLength_cpu - 1 - ti); bs++)
                     {
@@ -1267,7 +1267,7 @@ void verify_backward_data_lstm<T>::LSTMBwdDataCPUVerify(
                               1,
                               1);
 
-                if(bidirection)
+                if(bidirection == 1)
                 {
                     pretime_shift = li * batch_n_cpu * hy_stride +
                                     (baccbi - in_n.at(seqLength_cpu - 2 - ti)) * hy_stride +
@@ -1363,7 +1363,7 @@ void verify_backward_data_lstm<T>::LSTMBwdDataCPUVerify(
                 }
             }
 
-            if(bidirection)
+            if(bidirection == 1)
             {
                 for(int bs = 0; bs < in_n.at(seqLength_cpu - 1 - ti); bs++)
                 {
@@ -1506,7 +1506,7 @@ void verify_backward_data_lstm<T>::LSTMBwdDataCPUVerify(
             }
         }
 
-        if(bidirection)
+        if(bidirection == 1)
         {
             int ti = seqLength_cpu - 1, cur_bat = 0, pre_bat = batch_n_cpu;
 
@@ -1563,7 +1563,7 @@ void verify_backward_data_lstm<T>::LSTMBwdDataCPUVerify(
                 for(int gi = 0; gi < 4; gi++)
                 {
                     din_host.at(bs * in_stride + h) += wkspace.at(bs * hy_stride + gi * hy_h + h);
-                    if(bidirection)
+                    if(bidirection == 1)
                     {
                         din_host.at(bs * in_stride + h) +=
                             wkspace.at(bs * hy_stride + (gi + 4) * hy_h + h);
@@ -1596,7 +1596,7 @@ void verify_backward_data_lstm<T>::LSTMBwdDataCPUVerify(
 
 template <class T>
 void verify_backward_weights_lstm<T>::LSTMBwdWeightCPUVerify(
-    const bool use_dropout_cpu,
+    bool use_dropout_cpu,
     const std::vector<T>& in,
     std::vector<T>& dwei_host, // [ input_state_weight_trans
                                // hidden_state_weight0_trans
@@ -1607,24 +1607,24 @@ void verify_backward_weights_lstm<T>::LSTMBwdWeightCPUVerify(
     const std::vector<T>& dout,
     const std::vector<int>& in_n, // input batch size
     int in_h,                     // input data length
-    const int seqLength_cpu,      // Number of iterations to unroll over
-    const int bidirection,        // whether using bidirectional net
-    const int biased,             // whether using bias
-    const int hy_d,               // 1 by numlayer (number of stacks of hidden
+    int seqLength_cpu,            // Number of iterations to unroll over
+    int bidirection,              // whether using bidirectional net
+    int biased,                   // whether using bias
+    int hy_d,                     // 1 by numlayer (number of stacks of hidden
                                   // layers) for unidirection, 2 by numlayer for
                                   // bidirection
-    const int hy_n,               // equal to input batch size in_n[0]
-    const int hy_h,               // hidden state number
-    const int out_h,              // 1 by hy_h related function for unidirection, 2
+    int hy_n,                     // equal to input batch size in_n[0]
+    int hy_h,                     // hidden state number
+    int out_h,                    // 1 by hy_h related function for unidirection, 2
                                   // by hy_h related function for bidirection
-    const int inputMode_cpu,
+    int inputMode_cpu,
     const std::vector<T>& rsvspace,
     const std::vector<T>& wkspace,
-    const bool hx_is_null) const
+    bool hx_is_null) const
 {
     int batch_n_cpu = sumvc(in_n);
-    int numlayer    = bidirection ? hy_d / 2 : hy_d;
-    int bi          = bidirection ? 2 : 1;
+    int numlayer    = bidirection == 1 ? hy_d / 2 : hy_d;
+    int bi          = bidirection == 1 ? 2 : 1;
 
     int in_stride  = in_h;
     int wei_stride = bi * 4 * hy_h;
@@ -1676,7 +1676,7 @@ void verify_backward_weights_lstm<T>::LSTMBwdWeightCPUVerify(
                               1);
             }
 
-            if(biased)
+            if(biased == 1)
             {
                 for(int h = 0; h < wei_stride; h++)
                 {
@@ -1714,7 +1714,7 @@ void verify_backward_weights_lstm<T>::LSTMBwdWeightCPUVerify(
                           1,
                           1);
 
-            if(biased)
+            if(biased == 1)
             {
                 wei_shift = wei_shift_bias + li * 2 * wei_stride;
 
@@ -1760,7 +1760,7 @@ void verify_backward_weights_lstm<T>::LSTMBwdWeightCPUVerify(
                                   1,
                                   1);
 
-                    if(biased)
+                    if(biased == 1)
                     {
                         int bias_shift = wei_shift_bias + li * 2 * wei_stride + wei_stride;
 
@@ -1798,7 +1798,7 @@ void verify_backward_weights_lstm<T>::LSTMBwdWeightCPUVerify(
                               1,
                               1);
 
-                if(biased)
+                if(biased == 1)
                 {
                     int bias_shift = wei_shift_bias + li * 2 * wei_stride + wei_stride;
 
@@ -1813,7 +1813,7 @@ void verify_backward_weights_lstm<T>::LSTMBwdWeightCPUVerify(
                 }
             }
 
-            if(bidirection)
+            if(bidirection == 1)
             {
                 if(ti == seqLength_cpu - 1)
                 {
@@ -1837,7 +1837,7 @@ void verify_backward_weights_lstm<T>::LSTMBwdWeightCPUVerify(
                                       1,
                                       1);
 
-                        if(biased)
+                        if(biased == 1)
                         {
                             int bias_shift = wei_shift_bias + li * 2 * wei_stride + wei_stride;
 
@@ -1874,7 +1874,7 @@ void verify_backward_weights_lstm<T>::LSTMBwdWeightCPUVerify(
                                       1,
                                       1);
 
-                        if(biased)
+                        if(biased == 1)
                         {
                             int bias_shift = wei_shift_bias + li * 2 * wei_stride + wei_stride;
 
@@ -1910,7 +1910,7 @@ void verify_backward_weights_lstm<T>::LSTMBwdWeightCPUVerify(
                                   1,
                                   1);
 
-                    if(biased)
+                    if(biased == 1)
                     {
                         int bias_shift = wei_shift_bias + li * 2 * wei_stride + wei_stride;
 

--- a/test/lstm_common.hpp
+++ b/test/lstm_common.hpp
@@ -2279,6 +2279,7 @@ struct verify_forward_train_lstm : verify_forward_lstm<T>
                               const bool pnohy        = false,
                               const bool pnocy        = false,
                               const bool puse_dropout = false)
+        : RSVgpu(pRSVgpu.begin()), RSVcpu(pRSVcpu.begin())
     {
         input          = px;
         initHidden     = phx;
@@ -2300,8 +2301,6 @@ struct verify_forward_train_lstm : verify_forward_lstm<T>
         nohy           = pnohy;
         nocy           = pnocy;
         use_dropout    = puse_dropout;
-        RSVgpu         = pRSVgpu.begin();
-        RSVcpu         = pRSVcpu.begin();
 
         if(!nohx)
             initHidden = phx; // this may be intentionally a nullptr


### PR DESCRIPTION
The purpose of this PR is to convert non-const lstm cpu verification function to const type in order to help reduce the test time and the robustness of the verification.

Related work: #448 