### PR TITLE
[BN] Update kernel to stabilize variance calculation.

### DIFF
--- a/src/kernels/MIOpenBatchNormFwdTrainPerAct.cl
+++ b/src/kernels/MIOpenBatchNormFwdTrainPerAct.cl
@@ -90,11 +90,20 @@ __kernel void MIOpenBatchNormFwdTrainPerActivation(
                 index           = in_nstride * n + adjIndex;
                 _FLOAT_PREC xin = (_FLOAT_PREC)(*(in + index));
                 mean += xin;
-                variance = mad(xin, xin, variance);
             } // end for(n)
             mean *= (_FLOAT_PREC)invN;
+            variance = 0.;
+
+#pragma unroll
+            for(unsigned int n = 0; n < MIO_BN_N; n++)
+            {
+                index           = in_nstride * n + adjIndex;
+                _FLOAT_PREC xin = (_FLOAT_PREC)(*(in + index));
+                variance += (xin - mean) * (xin - mean);
+            } // end for(n)
+
+            variance = sqrt(variance);
             variance *= (_FLOAT_PREC)invN;
-            variance    = mad(-mean, mean, variance);
             invVariance = rsqrt(variance + epsilon);
             pvt_scale   = *(scale + adjIndex);
             pvt_bias    = *(bias + adjIndex);

--- a/src/kernels/MIOpenBatchNormFwdTrainPerAct.cl
+++ b/src/kernels/MIOpenBatchNormFwdTrainPerAct.cl
@@ -69,63 +69,51 @@ __kernel void MIOpenBatchNormFwdTrainPerActivation(
     unsigned int xgid    = get_global_id(0);
     unsigned int ygid    = get_global_id(1);
     unsigned int yglb_sz = get_global_size(1);
-    unsigned int Cidx    = MIO_BN_HW * xgid;
-    unsigned int adjIndex, inImgIndex, index;
+    int cidx             = MIO_BN_HW * xgid;
+    int adjIndex, index;
 
     _FLOAT_PREC invN = 1.0 / (_FLOAT_PREC)MIO_BN_N;
 
     // move across the sections of the image mini_batch stack
-    for(unsigned int img_offset = 0; img_offset < in_cstride; img_offset += yglb_sz)
+    for(int idx = ygid; idx < in_cstride; idx += yglb_sz)
     {
-        inImgIndex = img_offset + ygid;
-        if(inImgIndex < in_cstride)
+        mean     = (_FLOAT_PREC)0.;
+        adjIndex = cidx + idx; // gamma and beta tensor index
+        for(int n = 0; n < MIO_BN_N; n++)
         {
-            mean     = (_FLOAT_PREC)0.;
-            variance = (_FLOAT_PREC)0.;
-            adjIndex = Cidx + inImgIndex; // gamma and beta tensor index
+            index = in_nstride * n + adjIndex;
+            mean += (_FLOAT_PREC)in[index];
+        } // end for(n)
+        mean *= invN;
+        variance = 0.;
 
-#pragma unroll
-            for(unsigned int n = 0; n < MIO_BN_N; n++)
-            {
-                index           = in_nstride * n + adjIndex;
-                _FLOAT_PREC xin = (_FLOAT_PREC)(*(in + index));
-                mean += xin;
-            } // end for(n)
-            mean *= (_FLOAT_PREC)invN;
-            variance = 0.;
-
-#pragma unroll
-            for(unsigned int n = 0; n < MIO_BN_N; n++)
-            {
-                index           = in_nstride * n + adjIndex;
-                _FLOAT_PREC xin = (_FLOAT_PREC)(*(in + index));
-                variance += (xin - mean) * (xin - mean);
-            } // end for(n)
-
-            variance = sqrt(variance);
-            variance *= (_FLOAT_PREC)invN;
-            invVariance = rsqrt(variance + epsilon);
-            pvt_scale   = *(scale + adjIndex);
-            pvt_bias    = *(bias + adjIndex);
+        for(int n = 0; n < MIO_BN_N; n++)
+        {
+            index             = in_nstride * n + adjIndex;
+            _FLOAT_PREC xdiff = (_FLOAT_PREC)(in[index] - mean);
+            variance += (xdiff * xdiff);
+        } // end for(n)
+        variance *= (_FLOAT_PREC)invN;
+        invVariance = rsqrt(variance + epsilon);
+        pvt_scale   = *(scale + adjIndex);
+        pvt_bias    = *(bias + adjIndex);
 
 #if(MIO_RUNNING_RESULT == 1)
-            running_stash_pa(
-                resultRunningMean, resultRunningVariance, expAvgFactor, mean, variance, adjIndex);
+        running_stash_pa(
+            resultRunningMean, resultRunningVariance, expAvgFactor, mean, variance, adjIndex);
 #endif
 
 #if(MIO_SAVE_MEAN_VARIANCE == 1)
-            saved_stash(resultSaveMean, resultSaveInvVariance, mean, invVariance, adjIndex);
+        saved_stash(resultSaveMean, resultSaveInvVariance, mean, invVariance, adjIndex);
 #endif
 
-#pragma unroll
-            for(unsigned int n = 0; n < MIO_BN_N; n++)
-            { // per (x-dims) channel load a block of data unsigned into LDS
-                index      = in_nstride * n + adjIndex;
-                inhat      = ((_FLOAT_PREC)(*(in + index)) - mean) * invVariance;
-                out[index] = (_FLOAT)(mad(pvt_scale, inhat, pvt_bias));
-            } // end for(n)
-        }     // end if(inImgIndex)
-    }         // end for(img_offset) //image mini_batch is processed
+        for(int n = 0; n < MIO_BN_N; n++)
+        { // per (x-dims) channel load a block of data unsigned into LDS
+            index      = in_nstride * n + adjIndex;
+            inhat      = ((_FLOAT_PREC)in[index] - mean) * invVariance;
+            out[index] = (_FLOAT)(mad(pvt_scale, inhat, pvt_bias));
+        } // end for(n)
+    }     // end for(img_offset) //image mini_batch is processed
 }
 
 // Restore warnings

--- a/src/ocl/batchnormocl.cpp
+++ b/src/ocl/batchnormocl.cpp
@@ -461,7 +461,7 @@ void BatchNormForwardTraining(Handle& handle,
     {
         xlocalsize            = 1;
         ylocalsize            = 256;
-        size_t segment        = std::ceil(double(in_cstride) / double(ylocalsize));
+        std::size_t segment   = (in_cstride + ylocalsize - 1) / ylocalsize;
         xgridsize             = c;
         ygridsize             = segment * ylocalsize;
         std::string algo_name = "miopenBatchNormForwardTrainingPerActivation";

--- a/test/bn_peract_test.cpp
+++ b/test/bn_peract_test.cpp
@@ -1019,7 +1019,8 @@ struct batch_norm_per_activation_driver : test_driver
         // backprop recalc
         unsigned long max_value = miopen_type<T>{} == miopenHalf ? 5 : 17;
 
-        auto dy_input = tensor<T>{n, c, h, w}.generate(
+        this->tolerance = 8000 * input.desc.GetElementSize();
+        auto dy_input   = tensor<T>{n, c, h, w}.generate(
             tensor_elem_gen_integer{max_value}); //= std::get<0>(outpair.first);//
         verify(verify_backward_bn_per_activation_recalc<T, PREC_TYPE>{input, dy_input, scale});
 


### PR DESCRIPTION
~~This comes from this issue. Should stabilize the calculation:
http://ontrack-internal.amd.com/browse/SWDEV-253606~~

Turns out not to be the issue. Still though calculations are not stable in our tests.

