### PR TITLE
[tests][WORKAROUND] Adjust min allowed speed-up for hcc DEBUG builds.

### DIFF
--- a/test/find_db.cpp
+++ b/test/find_db.cpp
@@ -32,6 +32,7 @@
 #include <miopen/find_db.hpp>
 #include <miopen/logger.hpp>
 #include <miopen/temp_file.hpp>
+#include <miopen/hip_build_utils.hpp>
 
 #include <chrono>
 #include <cstdlib>
@@ -195,7 +196,14 @@ struct FindDbTest : test_driver
         const auto find_db_speedup = time1ms / time2ms;
         MIOPEN_LOG_I("Speedup: " << find_db_speedup);
 #if !MIOPEN_DISABLE_USERDB
-        EXPECT_OP(find_db_speedup, >=, 3);
+        double limit = 3.0;
+#ifndef NDEBUG
+        // hcc debug builds are so slow at run time that the test may fail.
+        // We need to lower the threshold in this case:
+        if(miopen::IsHccCompiler())
+            limit = 1.5;
+#endif
+        EXPECT_OP(find_db_speedup, >=, limit);
 #endif
     }
 };


### PR DESCRIPTION
HCC debug builds seem so slow at run time that the `test_find_db` may fail. This PR tries to lower the threshold to avoid false failures.

[Informative] hip-clang DEBUG build output (Radeon VII):
```
atamazov@morpheus:~/github/MLOpen1/build/debug.hip-clang$ ./bin/test_find_db 2>&1 | grep -E [[]Test
MIOpen(HIP): Info [Test] Find(), 1st call (populating kcache, updating find-db): 5232.69
MIOpen(HIP): Info [Test] Find(), find-db disabled: 365.362
MIOpen(HIP): Info [Test] Find(), find-db enabled: 0.25588
MIOpen(HIP): Info [Test] Speedup: 1427.87
MIOpen(HIP): Info [TestBwdData] Starting backward find-db test.
MIOpen(HIP): Info [Test] Find(), 1st call (populating kcache, updating find-db): 6234.92
MIOpen(HIP): Info [Test] Find(), find-db disabled: 372.444
MIOpen(HIP): Info [Test] Find(), find-db enabled: 0.25586
MIOpen(HIP): Info [Test] Speedup: 1455.65
MIOpen(HIP): Info [TestWeights] Starting wrw find-db test.
MIOpen(HIP): Info [Test] Find(), 1st call (populating kcache, updating find-db): 8544.72
MIOpen(HIP): Info [Test] Find(), find-db disabled: 20.1156
MIOpen(HIP): Info [Test] Find(), find-db enabled: 0.248405
MIOpen(HIP): Info [Test] Speedup: 80.979
```