### PR TITLE
remove global_store instructions for dynamic igemm wrw pass

### DIFF
--- a/src/kernels/dynamic_igemm/igemm_v4r1_wrw_dynamic.s
+++ b/src/kernels/dynamic_igemm/igemm_v4r1_wrw_dynamic.s
@@ -1474,7 +1474,7 @@ L_debug_code_seg:
     v_sub_u32 v[v_sst_a_os], v[v_sst_a_os], v[v_tmp+1]
     v_lshrrev_b32 v[v_sst_a_os], 2, v[v_sst_a_os]
 
-    global_store_dword v[v_end:v_end+1], v[v_a], s[s_tmp+12:s_tmp+13]
+    ;global_store_dword v[v_end:v_end+1], v[v_a], s[s_tmp+12:s_tmp+13]
 
     s_waitcnt vmcnt(0)
     s_barrier
@@ -2002,7 +2002,7 @@ L_debug_code_seg_1:
     v_sub_u32 v[v_sst_a_os], v[v_sst_a_os], v[v_tmp+1]
     v_lshrrev_b32 v[v_sst_a_os], 2, v[v_sst_a_os]
 
-    global_store_dword v[v_end:v_end+1], v[v_wei_os], s[s_tmp+12:s_tmp+13]
+    ;global_store_dword v[v_end:v_end+1], v[v_wei_os], s[s_tmp+12:s_tmp+13]
 
     s_waitcnt vmcnt(0)
     s_barrier

--- a/src/kernels/dynamic_igemm/igemm_v4r1_wrw_dynamic.s
+++ b/src/kernels/dynamic_igemm/igemm_v4r1_wrw_dynamic.s
@@ -616,12 +616,6 @@ igemm_v4r1_dynamic_wrw_32x32x4_4x4_2x2x4x2x4x2_4x2x8x1_4x16:
     s_load_dwordx2  s[s_pad_w:s_pad_w+1],       s[s_ka:s_ka+1],     0+k_pad_w
     s_load_dwordx2  s[s_x:s_gemmkgroups],       s[s_ka:s_ka+1],     0+k_x
 
-    ; debug vgpr
-    v_mov_b32 v1, 0
-    v_add_lshl_u32 v[v_end], v0, v1, 2
-    ;v_lshlrev_b32 v[114], 2, v0 ; every thread write one float
-    s_load_dwordx2 s[s_tmp+16:s_tmp+17], s[s_ka:s_ka+1], k_p_out
-
     ; in e_n1_b_n2 cluster_lengths:{4,2,8,1}, sub_lengths:{1,1,1,2}, order:{0,1,3,2}
     v_and_b32 v[v_in_ib], 7, v0 ; v_in_ib=tid%8
     v_lshrrev_b32 v[v_tmp], 3, v0 ; v_tmp=tid/8
@@ -1119,12 +1113,6 @@ L_igemm_v4r1_dynamic_wrw_32x32x4_4x4_2x2x4x2x4x2_4x2x8x1_4x16_end:
     s_load_dwordx2  s[s_pad_w:s_pad_w+1],       s[s_ka:s_ka+1],     0+k_pad_w
     s_load_dwordx2  s[s_x:s_gemmkgroups],       s[s_ka:s_ka+1],     0+k_x
 
-    ; debug vgpr
-    v_mov_b32 v1, 0
-    v_add_lshl_u32 v[v_end], v0, v1, 2
-    ;v_lshlrev_b32 v[114], 2, v0 ; every thread write one float
-    s_load_dwordx2 s[s_tmp+12:s_tmp+13], s[s_ka:s_ka+1], k_p_out
-
     ; in e_n1_b_n2 cluster_lengths:{16,1,16,1}, sub_lengths:{1,2,1,4}, order:{0,1,3,2}
     v_and_b32 v[v_in_ib], 15, v0 ; in_ib=tid%16
     v_lshrrev_b32 v[v_tmp], 4, v0 ; tmp=tid/16
@@ -1327,7 +1315,6 @@ L_igemm_v4r1_dynamic_wrw_32x32x4_4x4_2x2x4x2x4x2_4x2x8x1_4x16_end:
 
     s_waitcnt vmcnt(0)
     .v_wei_sst_e_k_4_2_es512_kv2 v_gld_a, v_sst_a_os
-;s_branch L_debug_code_seg
 
     ; E = C * Y * X
     s_mul_i32 s[s_tmp], s[s_sub_c], s[s_wei_stride_k] ; s_tmp=sub_c*y*x
@@ -1346,16 +1333,12 @@ L_igemm_v4r1_dynamic_wrw_32x32x4_4x4_2x2x4x2x4x2_4x2x8x1_4x16_end:
     .v_in_load_e_n1_b_n2_1_2_1_4 v_gld_b, s_p_buf_in, v_in_os, s_in_stride_n1, s_in_stride_n2, v_flag, s_tmp
     .v_wei_load_e_k_4_2_ev4 v_gld_a, s_p_buf_wei, v_wei_os, s_wei_stride_k, s_tmp
 
-;s_branch L_debug_code_seg
-
 L_igemm_v4r1_dynamic_wrw_128x128x16_8x8_4x4x4x4x4x4_16x1x16x1_4x64_fma_body:
     ; do fma accumulate with unroll 16
     ds_read_b128 v[v_a:v_a+3], v[v_sld_a_os] 
     ds_read_b128 v[v_b:v_b+3], v[v_sld_b_os] 
     ds_read_b128 v[v_b+4:v_b+4+3], v[v_sld_b_os] offset:256
     ds_read_b128 v[v_a+4:v_a+4+3], v[v_sld_a_os] offset:256
-    
-;s_branch L_debug_code_seg
 
     .itr_k = 0
     .rept 15
@@ -1377,7 +1360,6 @@ L_igemm_v4r1_dynamic_wrw_128x128x16_8x8_4x4x4x4x4x4_16x1x16x1_4x64_fma_body:
         .itr_k = .itr_k + 1
     .endr
 
-;s_branch L_debug_code_seg
     ; last unroll
     v_xor_b32 v[v_sld_b_os], 0x4000, v[v_sld_b_os] ; switch double buffer b load
     v_xor_b32 v[v_sld_a_os], 0x4000, v[v_sld_a_os] ; switch double buffer a load
@@ -1410,7 +1392,6 @@ L_igemm_v4r1_dynamic_wrw_128x128x16_8x8_4x4x4x4x4x4_16x1x16x1_4x64_fma_body:
     s_branch L_igemm_v4r1_dynamic_wrw_128x128x16_8x8_4x4x4x4x4x4_16x1x16x1_4x64_fma_body
 L_igemm_v4r1_dynamic_wrw_128x128x16_8x8_4x4x4x4x4x4_16x1x16x1_4x64_fma_finishing:
     s_waitcnt lgkmcnt(4)
-;s_branch L_debug_code_seg
     .v_fma_4x4_s8 v_c+32,v_a+4,v_b
     .v_fma_4x4_s8 v_c+36,v_a+4,v_b+4
 L_igemm_v4r1_dynamic_wrw_128x128x16_8x8_4x4x4x4x4x4_16x1x16x1_4x64_end:
@@ -1458,28 +1439,6 @@ L_igemm_v4r1_dynamic_wrw_128x128x16_8x8_4x4x4x4x4x4_16x1x16x1_4x64_end:
     s_mov_b32 s[s_tmp+3], 0
     .v_out_write_k0_k1_n1_b_n2_2_4_2_1_4 v_c, s_p_buf_out, v_out_os, s_out_stride_k0, s_out_stride_k1, s_out_stride_n1, s_out_stride_n2, s_tmp
     
-    s_branch L_program_end
-    ; debug code to cpy vgpr to host
-L_debug_code_seg:
-    s_waitcnt lgkmcnt(0)
-    s_barrier
-    s_cmp_lg_u32 s[s_bx], 0
-    s_cbranch_scc1  L_program_end
-    ;s_cmp_lg_u32 s[s_wave_id], 0
-    ;s_cbranch_scc1  L_program_end
-    ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
-    v_mov_b32 v[v_tmp], s[s_tmp]
-
-    v_mov_b32 v[v_tmp+1], 8192
-    v_sub_u32 v[v_sst_a_os], v[v_sst_a_os], v[v_tmp+1]
-    v_lshrrev_b32 v[v_sst_a_os], 2, v[v_sst_a_os]
-
-    ;global_store_dword v[v_end:v_end+1], v[v_a], s[s_tmp+12:s_tmp+13]
-
-    s_waitcnt vmcnt(0)
-    s_barrier
-
-
 L_program_end:
     s_endpgm
 .rodata
@@ -1643,12 +1602,6 @@ L_program_end:
     s_load_dwordx4  s[s_stride_w:s_stride_w+3], s[s_ka:s_ka+1],     0+k_stride_w
     s_load_dwordx2  s[s_pad_w:s_pad_w+1],       s[s_ka:s_ka+1],     0+k_pad_w
     s_load_dwordx2  s[s_x:s_gemmkgroups],       s[s_ka:s_ka+1],     0+k_x
-
-    ; debug vgpr
-    v_mov_b32 v1, 0
-    v_add_lshl_u32 v[v_end], v0, v1, 2
-    ;v_lshlrev_b32 v[114], 2, v0 ; every thread write one float
-    s_load_dwordx2 s[s_tmp+12:s_tmp+13], s[s_ka:s_ka+1], k_p_out
 
     ; in e_n1_b_n2 cluster_lengths:{16,1,16,1}, sub_lengths:{1,2,1,4}, order:{0,1,3,2}
     v_and_b32 v[v_in_ie], 15, v0 ; in_ib=tid%16
@@ -1842,8 +1795,6 @@ L_program_end:
     v_lshlrev_b32 v[v_sst_a_os], 2, v[v_tmp]
     v_add_u32 v[v_sst_a_os], 8192, v[v_sst_a_os]
 
-;s_branch L_debug_code_seg_1
-
     s_mov_b32 s[s_p_buf_out+2], 0xffffffff
     s_mov_b32 s[s_p_buf_out+3], 0x27000
     .v_clear_nc v_c, 64
@@ -1868,12 +1819,8 @@ L_program_end:
     s_waitcnt lgkmcnt(0)
     s_barrier
 
-;s_branch L_debug_code_seg_1
-
     .v_in_load_e_n1_b_n2_1_2_1_4 v_gld_b, s_p_buf_in, v_in_os, s_in_stride_n1, s_in_stride_n2, v_flag, s_tmp
     .v_wei_load_e_k_1_8_ev1 v_gld_a, s_p_buf_wei, v_wei_os, s_wei_stride_k, s_tmp
-
-;s_branch L_debug_code_seg_1
 
 L_igemm_v4r1_dynamic_wrw_128x128x16_8x8_4x4x4x4x4x4_16x1x16x1_16x16_fma_body:
     ; do fma accumulate with unroll 16
@@ -1881,8 +1828,6 @@ L_igemm_v4r1_dynamic_wrw_128x128x16_8x8_4x4x4x4x4x4_16x1x16x1_16x16_fma_body:
     ds_read_b128 v[v_b:v_b+3], v[v_sld_b_os] 
     ds_read_b128 v[v_b+4:v_b+4+3], v[v_sld_b_os] offset:256
     ds_read_b128 v[v_a+4:v_a+4+3], v[v_sld_a_os] offset:256
-
-;s_branch L_debug_code_seg_1
     
     .itr_k = 0
     .rept 15
@@ -1903,8 +1848,6 @@ L_igemm_v4r1_dynamic_wrw_128x128x16_8x8_4x4x4x4x4x4_16x1x16x1_16x16_fma_body:
         ds_read_b128 v[v_a+4:v_a+4+3], v[v_sld_a_os] offset:0+(.itr_k+1)*512+256
         .itr_k = .itr_k + 1
     .endr
-
-;s_branch L_debug_code_seg_1
 
     ; last unroll
     v_xor_b32 v[v_sld_b_os], 0x4000, v[v_sld_b_os] ; switch double buffer b load
@@ -1938,7 +1881,6 @@ L_igemm_v4r1_dynamic_wrw_128x128x16_8x8_4x4x4x4x4x4_16x1x16x1_16x16_fma_body:
     s_branch L_igemm_v4r1_dynamic_wrw_128x128x16_8x8_4x4x4x4x4x4_16x1x16x1_16x16_fma_body
 L_igemm_v4r1_dynamic_wrw_128x128x16_8x8_4x4x4x4x4x4_16x1x16x1_16x16_fma_finishing:
     s_waitcnt lgkmcnt(4)
-;s_branch L_debug_code_seg_1
     .v_fma_4x4_s8 v_c+32,v_a+4,v_b
     .v_fma_4x4_s8 v_c+36,v_a+4,v_b+4
 L_igemm_v4r1_dynamic_wrw_128x128x16_8x8_4x4x4x4x4x4_16x1x16x1_16x16_end:
@@ -1986,28 +1928,6 @@ L_igemm_v4r1_dynamic_wrw_128x128x16_8x8_4x4x4x4x4x4_16x1x16x1_16x16_end:
     s_mov_b32 s[s_tmp+3], 0
     .v_out_write_k0_k1_n1_b_n2_2_4_2_1_4 v_c, s_p_buf_out, v_out_os, s_out_stride_k0, s_out_stride_k1, s_out_stride_n1, s_out_stride_n2, s_tmp
     
-    s_branch L_program_end_1
-    ; debug code to cpy vgpr to host
-L_debug_code_seg_1:
-    s_waitcnt lgkmcnt(0)
-    s_barrier
-    s_cmp_lg_u32 s[s_bx], 0
-    s_cbranch_scc1  L_program_end
-    ;s_cmp_lg_u32 s[s_wave_id], 0
-    ;s_cbranch_scc1  L_program_end
-    ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
-    v_mov_b32 v[v_tmp], s[s_tmp]
-
-     v_mov_b32 v[v_tmp+1], 8192
-    v_sub_u32 v[v_sst_a_os], v[v_sst_a_os], v[v_tmp+1]
-    v_lshrrev_b32 v[v_sst_a_os], 2, v[v_sst_a_os]
-
-    ;global_store_dword v[v_end:v_end+1], v[v_wei_os], s[s_tmp+12:s_tmp+13]
-
-    s_waitcnt vmcnt(0)
-    s_barrier
-
-
 L_program_end_1:
     s_endpgm
 .rodata

--- a/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_004x064.inc
+++ b/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_004x064.inc
@@ -124,9 +124,8 @@
 .set s_sub_n, 70
 .set s_group_stride, 71
 .set s_group_left, 1
-.set s_dbg, 72
-.set s_tmp, 74
-.set s_end, 80
+.set s_tmp, 72
+.set s_end, 78
 
 .set v_c, 0  ; coalescing:4, needed:2, resuable:29
 .set v_a, 2
@@ -190,11 +189,6 @@ igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt4x64x16_wt4x64_ws1x1_wr1x1_ta1x1x1x1_1x16x1x4
     ; clear vector r
     .v_clear_nc v_c+1, v_end-1
 
-    ; debug vgpr
-    v_mov_b32 v1, 0
-    v_add_lshl_u32 v[v_tmp+6], v0, v1, 2
-    ;v_lshlrev_b32 v[114], 2, v0 ; every thread write one float
-    s_load_dwordx2 s[s_dbg+0:s_dbg+1], s[s_ka:s_ka+1], k_p_wei
     ; input, thread(n0,n1b,c0,c1e): 1x1x16x1, cluster(n0,n1b,c0,c1e): 1x16x1x4
     v_mov_b32 v[v_tmp], v0
     v_and_b32 v[v_gtc_ic1e], 3, v[v_tmp]
@@ -747,29 +741,6 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt4x64x16_wt4x64_ws1x1_wr1x1_ta1x1x1x1_1x16x1
     s_mul_i32 s[s_tmp], 3, s[s_wei_stride_k]   ; i_m:3(i_m0:0,i_m1:3)
     buffer_atomic_add_f32 v[v_c+3], v[v_wei_os], s[s_p_wei:s_p_wei+3], s[s_tmp] offen offset:0
 
-    s_branch L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt4x64x16_wt4x64_ws1x1_wr1x1_ta1x1x1x1_1x16x1x4_tb1x1x16x1_1x16x1x4_gkgs_out
-    ; debug code to cpy vgpr to host
-    L_debug_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt4x64x16_wt4x64_ws1x1_wr1x1_ta1x1x1x1_1x16x1x4_tb1x1x16x1_1x16x1x4_gkgs_out_1:
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-    s_cmp_lg_u32 s[s_bx], 0
-    s_cbranch_scc1 L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt4x64x16_wt4x64_ws1x1_wr1x1_ta1x1x1x1_1x16x1x4_tb1x1x16x1_1x16x1x4_gkgs_out_1
-    ;s_cmp_lg_u32 s[s_wave_id], 0
-    ;s_cbranch_scc1  L_program_end
-    ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
-    v_mov_b32 v[v_tmp], s[s_in_offset]
-
-    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
-    s_waitcnt vmcnt(0)
-    s_barrier
-
-    L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt4x64x16_wt4x64_ws1x1_wr1x1_ta1x1x1x1_1x16x1x4_tb1x1x16x1_1x16x1x4_gkgs_out_1:
-    s_nop 2
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-
 L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt4x64x16_wt4x64_ws1x1_wr1x1_ta1x1x1x1_1x16x1x4_tb1x1x16x1_1x16x1x4_gkgs_out:
     s_endpgm
 .rodata
@@ -780,7 +751,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt4x64x16_wt4x64_ws1x1_wr1x1_ta1x1x1x1_1x16x1
     .amdhsa_system_sgpr_workgroup_id_x 1
     .amdhsa_system_vgpr_workitem_id 0
     .amdhsa_next_free_vgpr 68
-    .amdhsa_next_free_sgpr 86
+    .amdhsa_next_free_sgpr 84
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
 .end_amdhsa_kernel
@@ -884,9 +855,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt4x64x16_wt4x64_ws1x1_wr1x1_ta1x1x1x1_1x16x1
 .set s_sub_n, 70
 .set s_group_stride, 71
 .set s_group_left, 1
-.set s_dbg, 72
-.set s_tmp, 74
-.set s_end, 80
+.set s_tmp, 72
+.set s_end, 78
 
 .set v_c, 0  ; coalescing:4, needed:2, resuable:29
 .set v_a, 2
@@ -950,11 +920,6 @@ igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt4x64x16_wt4x64_ws1x1_wr1x1_ta1x1x1x1_1x16x1x4
     ; clear vector r
     .v_clear_nc v_c+1, v_end-1
 
-    ; debug vgpr
-    v_mov_b32 v1, 0
-    v_add_lshl_u32 v[v_tmp+6], v0, v1, 2
-    ;v_lshlrev_b32 v[114], 2, v0 ; every thread write one float
-    s_load_dwordx2 s[s_dbg+0:s_dbg+1], s[s_ka:s_ka+1], k_p_wei
     ; input, thread(n0,n1b,c0,c1e): 1x1x16x1, cluster(n0,n1b,c0,c1e): 1x16x1x4
     v_mov_b32 v[v_tmp], v0
     v_and_b32 v[v_gtc_ic1e], 3, v[v_tmp]
@@ -1507,29 +1472,6 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt4x64x16_wt4x64_ws1x1_wr1x1_ta1x1x1x1_1x16x1
     s_mul_i32 s[s_tmp], 3, s[s_wei_stride_k]   ; i_m:3(i_m0:0,i_m1:3)
     buffer_store_dword v[v_c+3], v[v_wei_os], s[s_p_wei:s_p_wei+3], s[s_tmp] offen offset:0
 
-    s_branch L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt4x64x16_wt4x64_ws1x1_wr1x1_ta1x1x1x1_1x16x1x4_tb1x1x16x1_1x16x1x4_out
-    ; debug code to cpy vgpr to host
-    L_debug_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt4x64x16_wt4x64_ws1x1_wr1x1_ta1x1x1x1_1x16x1x4_tb1x1x16x1_1x16x1x4_out_1:
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-    s_cmp_lg_u32 s[s_bx], 0
-    s_cbranch_scc1 L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt4x64x16_wt4x64_ws1x1_wr1x1_ta1x1x1x1_1x16x1x4_tb1x1x16x1_1x16x1x4_out_1
-    ;s_cmp_lg_u32 s[s_wave_id], 0
-    ;s_cbranch_scc1  L_program_end
-    ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
-    v_mov_b32 v[v_tmp], s[s_in_offset]
-
-    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
-    s_waitcnt vmcnt(0)
-    s_barrier
-
-    L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt4x64x16_wt4x64_ws1x1_wr1x1_ta1x1x1x1_1x16x1x4_tb1x1x16x1_1x16x1x4_out_1:
-    s_nop 2
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-
 L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt4x64x16_wt4x64_ws1x1_wr1x1_ta1x1x1x1_1x16x1x4_tb1x1x16x1_1x16x1x4_out:
     s_endpgm
 .rodata
@@ -1540,7 +1482,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt4x64x16_wt4x64_ws1x1_wr1x1_ta1x1x1x1_1x16x1
     .amdhsa_system_sgpr_workgroup_id_x 1
     .amdhsa_system_vgpr_workitem_id 0
     .amdhsa_next_free_vgpr 68
-    .amdhsa_next_free_sgpr 86
+    .amdhsa_next_free_sgpr 84
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
 .end_amdhsa_kernel

--- a/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_004x064.inc
+++ b/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_004x064.inc
@@ -760,7 +760,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt4x64x16_wt4x64_ws1x1_wr1x1_ta1x1x1x1_1x16x1
     ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
     v_mov_b32 v[v_tmp], s[s_in_offset]
 
-    global_store_dword v[v_tmp+6:v_tmp+7], v[v_in_os], s[s_dbg+0:s_dbg+1]
+    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
     s_waitcnt vmcnt(0)
     s_barrier
 
@@ -1520,7 +1520,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt4x64x16_wt4x64_ws1x1_wr1x1_ta1x1x1x1_1x16x1
     ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
     v_mov_b32 v[v_tmp], s[s_in_offset]
 
-    global_store_dword v[v_tmp+6:v_tmp+7], v[v_in_os], s[s_dbg+0:s_dbg+1]
+    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
     s_waitcnt vmcnt(0)
     s_barrier
 

--- a/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_016x032.inc
+++ b/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_016x032.inc
@@ -736,7 +736,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt16x32x16_wt8x32_ws1x1_wr1x1_ta1x1x2x1_1x16x
     ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
     v_mov_b32 v[v_tmp], s[s_in_offset]
 
-    global_store_dword v[v_tmp+6:v_tmp+7], v[v_in_os], s[s_dbg+0:s_dbg+1]
+    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
     s_waitcnt vmcnt(0)
     s_barrier
 
@@ -1472,7 +1472,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt16x32x16_wt8x32_ws1x1_wr1x1_ta1x1x2x1_1x16x
     ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
     v_mov_b32 v[v_tmp], s[s_in_offset]
 
-    global_store_dword v[v_tmp+6:v_tmp+7], v[v_in_os], s[s_dbg+0:s_dbg+1]
+    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
     s_waitcnt vmcnt(0)
     s_barrier
 
@@ -2133,7 +2133,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt16x32x8_wt8x32_ws1x1_wr1x1_ta1x1x1x1_1x8x1x
     ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
     v_mov_b32 v[v_tmp], s[s_in_offset]
 
-    global_store_dword v[v_tmp+6:v_tmp+7], v[v_in_os], s[s_dbg+0:s_dbg+1]
+    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
     s_waitcnt vmcnt(0)
     s_barrier
 
@@ -2794,7 +2794,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt16x32x8_wt8x32_ws1x1_wr1x1_ta1x1x1x1_1x8x1x
     ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
     v_mov_b32 v[v_tmp], s[s_in_offset]
 
-    global_store_dword v[v_tmp+6:v_tmp+7], v[v_in_os], s[s_dbg+0:s_dbg+1]
+    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
     s_waitcnt vmcnt(0)
     s_barrier
 

--- a/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_016x032.inc
+++ b/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_016x032.inc
@@ -124,9 +124,8 @@
 .set s_sub_n, 58
 .set s_group_stride, 59
 .set s_group_left, 1
-.set s_dbg, 60
-.set s_tmp, 62
-.set s_end, 68
+.set s_tmp, 60
+.set s_end, 66
 
 .set v_c, 0  ; coalescing:4, needed:2, resuable:18
 .set v_a, 2
@@ -190,11 +189,6 @@ igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt16x32x16_wt8x32_ws1x1_wr1x1_ta1x1x2x1_1x16x1x
     ; clear vector r
     .v_clear_nc v_c+1, v_end-1
 
-    ; debug vgpr
-    v_mov_b32 v1, 0
-    v_add_lshl_u32 v[v_tmp+6], v0, v1, 2
-    ;v_lshlrev_b32 v[114], 2, v0 ; every thread write one float
-    s_load_dwordx2 s[s_dbg+0:s_dbg+1], s[s_ka:s_ka+1], k_p_wei
     ; input, thread(n0,n1b,c0,c1e): 1x1x4x1, cluster(n0,n1b,c0,c1e): 1x16x1x8
     v_mov_b32 v[v_tmp], v0
     v_and_b32 v[v_gtc_ic1e], 7, v[v_tmp]
@@ -723,29 +717,6 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt16x32x16_wt8x32_ws1x1_wr1x1_ta1x1x2x1_1x16x
     s_mul_i32 s[s_tmp], 3, s[s_wei_stride_k]   ; i_m:3(i_m0:0,i_m1:3)
     buffer_store_dword v[v_c+3], v[v_wei_os], s[s_p_wei:s_p_wei+3], s[s_tmp] offen offset:0
 
-    s_branch L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt16x32x16_wt8x32_ws1x1_wr1x1_ta1x1x2x1_1x16x1x8_tb1x1x4x1_1x16x1x8_out
-    ; debug code to cpy vgpr to host
-    L_debug_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt16x32x16_wt8x32_ws1x1_wr1x1_ta1x1x2x1_1x16x1x8_tb1x1x4x1_1x16x1x8_out_1:
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-    s_cmp_lg_u32 s[s_bx], 0
-    s_cbranch_scc1 L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt16x32x16_wt8x32_ws1x1_wr1x1_ta1x1x2x1_1x16x1x8_tb1x1x4x1_1x16x1x8_out_1
-    ;s_cmp_lg_u32 s[s_wave_id], 0
-    ;s_cbranch_scc1  L_program_end
-    ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
-    v_mov_b32 v[v_tmp], s[s_in_offset]
-
-    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
-    s_waitcnt vmcnt(0)
-    s_barrier
-
-    L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt16x32x16_wt8x32_ws1x1_wr1x1_ta1x1x2x1_1x16x1x8_tb1x1x4x1_1x16x1x8_out_1:
-    s_nop 2
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-
 L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt16x32x16_wt8x32_ws1x1_wr1x1_ta1x1x2x1_1x16x1x8_tb1x1x4x1_1x16x1x8_out:
     s_endpgm
 .rodata
@@ -756,7 +727,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt16x32x16_wt8x32_ws1x1_wr1x1_ta1x1x2x1_1x16x
     .amdhsa_system_sgpr_workgroup_id_x 1
     .amdhsa_system_vgpr_workitem_id 0
     .amdhsa_next_free_vgpr 56
-    .amdhsa_next_free_sgpr 74
+    .amdhsa_next_free_sgpr 72
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
 .end_amdhsa_kernel
@@ -860,9 +831,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt16x32x16_wt8x32_ws1x1_wr1x1_ta1x1x2x1_1x16x
 .set s_sub_n, 58
 .set s_group_stride, 59
 .set s_group_left, 1
-.set s_dbg, 60
-.set s_tmp, 62
-.set s_end, 68
+.set s_tmp, 60
+.set s_end, 66
 
 .set v_c, 0  ; coalescing:4, needed:2, resuable:18
 .set v_a, 2
@@ -926,11 +896,6 @@ igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt16x32x16_wt8x32_ws1x1_wr1x1_ta1x1x2x1_1x16x1x
     ; clear vector r
     .v_clear_nc v_c+1, v_end-1
 
-    ; debug vgpr
-    v_mov_b32 v1, 0
-    v_add_lshl_u32 v[v_tmp+6], v0, v1, 2
-    ;v_lshlrev_b32 v[114], 2, v0 ; every thread write one float
-    s_load_dwordx2 s[s_dbg+0:s_dbg+1], s[s_ka:s_ka+1], k_p_wei
     ; input, thread(n0,n1b,c0,c1e): 1x1x4x1, cluster(n0,n1b,c0,c1e): 1x16x1x8
     v_mov_b32 v[v_tmp], v0
     v_and_b32 v[v_gtc_ic1e], 7, v[v_tmp]
@@ -1459,29 +1424,6 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt16x32x16_wt8x32_ws1x1_wr1x1_ta1x1x2x1_1x16x
     s_mul_i32 s[s_tmp], 3, s[s_wei_stride_k]   ; i_m:3(i_m0:0,i_m1:3)
     buffer_atomic_add_f32 v[v_c+3], v[v_wei_os], s[s_p_wei:s_p_wei+3], s[s_tmp] offen offset:0
 
-    s_branch L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt16x32x16_wt8x32_ws1x1_wr1x1_ta1x1x2x1_1x16x1x8_tb1x1x4x1_1x16x1x8_gkgs_out
-    ; debug code to cpy vgpr to host
-    L_debug_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt16x32x16_wt8x32_ws1x1_wr1x1_ta1x1x2x1_1x16x1x8_tb1x1x4x1_1x16x1x8_gkgs_out_1:
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-    s_cmp_lg_u32 s[s_bx], 0
-    s_cbranch_scc1 L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt16x32x16_wt8x32_ws1x1_wr1x1_ta1x1x2x1_1x16x1x8_tb1x1x4x1_1x16x1x8_gkgs_out_1
-    ;s_cmp_lg_u32 s[s_wave_id], 0
-    ;s_cbranch_scc1  L_program_end
-    ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
-    v_mov_b32 v[v_tmp], s[s_in_offset]
-
-    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
-    s_waitcnt vmcnt(0)
-    s_barrier
-
-    L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt16x32x16_wt8x32_ws1x1_wr1x1_ta1x1x2x1_1x16x1x8_tb1x1x4x1_1x16x1x8_gkgs_out_1:
-    s_nop 2
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-
 L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt16x32x16_wt8x32_ws1x1_wr1x1_ta1x1x2x1_1x16x1x8_tb1x1x4x1_1x16x1x8_gkgs_out:
     s_endpgm
 .rodata
@@ -1492,7 +1434,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt16x32x16_wt8x32_ws1x1_wr1x1_ta1x1x2x1_1x16x
     .amdhsa_system_sgpr_workgroup_id_x 1
     .amdhsa_system_vgpr_workitem_id 0
     .amdhsa_next_free_vgpr 56
-    .amdhsa_next_free_sgpr 74
+    .amdhsa_next_free_sgpr 72
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
 .end_amdhsa_kernel
@@ -1596,9 +1538,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt16x32x16_wt8x32_ws1x1_wr1x1_ta1x1x2x1_1x16x
 .set s_sub_n, 56
 .set s_group_stride, 57
 .set s_group_left, 1
-.set s_dbg, 58
-.set s_tmp, 60
-.set s_end, 66
+.set s_tmp, 58
+.set s_end, 64
 
 .set v_c, 0  ; coalescing:4, needed:2, resuable:15
 .set v_a, 2
@@ -1662,11 +1603,6 @@ igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt16x32x8_wt8x32_ws1x1_wr1x1_ta1x1x1x1_1x8x1x16
     ; clear vector r
     .v_clear_nc v_c+1, v_end-1
 
-    ; debug vgpr
-    v_mov_b32 v1, 0
-    v_add_lshl_u32 v[v_tmp+6], v0, v1, 2
-    ;v_lshlrev_b32 v[114], 2, v0 ; every thread write one float
-    s_load_dwordx2 s[s_dbg+0:s_dbg+1], s[s_ka:s_ka+1], k_p_wei
     ; input, thread(n0,n1b,c0,c1e): 1x1x2x1, cluster(n0,n1b,c0,c1e): 1x8x1x16
     v_mov_b32 v[v_tmp], v0
     v_and_b32 v[v_gtc_ic1e], 15, v[v_tmp]
@@ -2120,29 +2056,6 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt16x32x8_wt8x32_ws1x1_wr1x1_ta1x1x1x1_1x8x1x
     s_mul_i32 s[s_tmp], 3, s[s_wei_stride_k]   ; i_m:3(i_m0:0,i_m1:3)
     buffer_store_dword v[v_c+3], v[v_wei_os], s[s_p_wei:s_p_wei+3], s[s_tmp] offen offset:0
 
-    s_branch L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt16x32x8_wt8x32_ws1x1_wr1x1_ta1x1x1x1_1x8x1x16_tb1x1x2x1_1x8x1x16_out
-    ; debug code to cpy vgpr to host
-    L_debug_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt16x32x8_wt8x32_ws1x1_wr1x1_ta1x1x1x1_1x8x1x16_tb1x1x2x1_1x8x1x16_out_1:
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-    s_cmp_lg_u32 s[s_bx], 0
-    s_cbranch_scc1 L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt16x32x8_wt8x32_ws1x1_wr1x1_ta1x1x1x1_1x8x1x16_tb1x1x2x1_1x8x1x16_out_1
-    ;s_cmp_lg_u32 s[s_wave_id], 0
-    ;s_cbranch_scc1  L_program_end
-    ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
-    v_mov_b32 v[v_tmp], s[s_in_offset]
-
-    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
-    s_waitcnt vmcnt(0)
-    s_barrier
-
-    L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt16x32x8_wt8x32_ws1x1_wr1x1_ta1x1x1x1_1x8x1x16_tb1x1x2x1_1x8x1x16_out_1:
-    s_nop 2
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-
 L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt16x32x8_wt8x32_ws1x1_wr1x1_ta1x1x1x1_1x8x1x16_tb1x1x2x1_1x8x1x16_out:
     s_endpgm
 .rodata
@@ -2153,7 +2066,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt16x32x8_wt8x32_ws1x1_wr1x1_ta1x1x1x1_1x8x1x
     .amdhsa_system_sgpr_workgroup_id_x 1
     .amdhsa_system_vgpr_workitem_id 0
     .amdhsa_next_free_vgpr 54
-    .amdhsa_next_free_sgpr 72
+    .amdhsa_next_free_sgpr 70
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
 .end_amdhsa_kernel
@@ -2257,9 +2170,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt16x32x8_wt8x32_ws1x1_wr1x1_ta1x1x1x1_1x8x1x
 .set s_sub_n, 56
 .set s_group_stride, 57
 .set s_group_left, 1
-.set s_dbg, 58
-.set s_tmp, 60
-.set s_end, 66
+.set s_tmp, 58
+.set s_end, 64
 
 .set v_c, 0  ; coalescing:4, needed:2, resuable:15
 .set v_a, 2
@@ -2323,11 +2235,6 @@ igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt16x32x8_wt8x32_ws1x1_wr1x1_ta1x1x1x1_1x8x1x16
     ; clear vector r
     .v_clear_nc v_c+1, v_end-1
 
-    ; debug vgpr
-    v_mov_b32 v1, 0
-    v_add_lshl_u32 v[v_tmp+6], v0, v1, 2
-    ;v_lshlrev_b32 v[114], 2, v0 ; every thread write one float
-    s_load_dwordx2 s[s_dbg+0:s_dbg+1], s[s_ka:s_ka+1], k_p_wei
     ; input, thread(n0,n1b,c0,c1e): 1x1x2x1, cluster(n0,n1b,c0,c1e): 1x8x1x16
     v_mov_b32 v[v_tmp], v0
     v_and_b32 v[v_gtc_ic1e], 15, v[v_tmp]
@@ -2781,29 +2688,6 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt16x32x8_wt8x32_ws1x1_wr1x1_ta1x1x1x1_1x8x1x
     s_mul_i32 s[s_tmp], 3, s[s_wei_stride_k]   ; i_m:3(i_m0:0,i_m1:3)
     buffer_atomic_add_f32 v[v_c+3], v[v_wei_os], s[s_p_wei:s_p_wei+3], s[s_tmp] offen offset:0
 
-    s_branch L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt16x32x8_wt8x32_ws1x1_wr1x1_ta1x1x1x1_1x8x1x16_tb1x1x2x1_1x8x1x16_gkgs_out
-    ; debug code to cpy vgpr to host
-    L_debug_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt16x32x8_wt8x32_ws1x1_wr1x1_ta1x1x1x1_1x8x1x16_tb1x1x2x1_1x8x1x16_gkgs_out_1:
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-    s_cmp_lg_u32 s[s_bx], 0
-    s_cbranch_scc1 L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt16x32x8_wt8x32_ws1x1_wr1x1_ta1x1x1x1_1x8x1x16_tb1x1x2x1_1x8x1x16_gkgs_out_1
-    ;s_cmp_lg_u32 s[s_wave_id], 0
-    ;s_cbranch_scc1  L_program_end
-    ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
-    v_mov_b32 v[v_tmp], s[s_in_offset]
-
-    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
-    s_waitcnt vmcnt(0)
-    s_barrier
-
-    L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt16x32x8_wt8x32_ws1x1_wr1x1_ta1x1x1x1_1x8x1x16_tb1x1x2x1_1x8x1x16_gkgs_out_1:
-    s_nop 2
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-
 L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt16x32x8_wt8x32_ws1x1_wr1x1_ta1x1x1x1_1x8x1x16_tb1x1x2x1_1x8x1x16_gkgs_out:
     s_endpgm
 .rodata
@@ -2814,7 +2698,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt16x32x8_wt8x32_ws1x1_wr1x1_ta1x1x1x1_1x8x1x
     .amdhsa_system_sgpr_workgroup_id_x 1
     .amdhsa_system_vgpr_workitem_id 0
     .amdhsa_next_free_vgpr 54
-    .amdhsa_next_free_sgpr 72
+    .amdhsa_next_free_sgpr 70
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
 .end_amdhsa_kernel

--- a/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_032x032.inc
+++ b/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_032x032.inc
@@ -735,7 +735,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt32x32x16_wt16x16_ws1x1_wr1x1_ta1x1x2x1_1x16
     ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
     v_mov_b32 v[v_tmp], s[s_in_offset]
 
-    global_store_dword v[v_tmp+6:v_tmp+7], v[v_in_os], s[s_dbg+0:s_dbg+1]
+    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
     s_waitcnt vmcnt(0)
     s_barrier
 
@@ -1470,7 +1470,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt32x32x16_wt16x16_ws1x1_wr1x1_ta1x1x2x1_1x16
     ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
     v_mov_b32 v[v_tmp], s[s_in_offset]
 
-    global_store_dword v[v_tmp+6:v_tmp+7], v[v_in_os], s[s_dbg+0:s_dbg+1]
+    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
     s_waitcnt vmcnt(0)
     s_barrier
 
@@ -2130,7 +2130,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt32x32x8_wt16x16_ws1x1_wr1x1_ta1x1x1x1_1x8x1
     ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
     v_mov_b32 v[v_tmp], s[s_in_offset]
 
-    global_store_dword v[v_tmp+6:v_tmp+7], v[v_in_os], s[s_dbg+0:s_dbg+1]
+    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
     s_waitcnt vmcnt(0)
     s_barrier
 
@@ -2790,7 +2790,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt32x32x8_wt16x16_ws1x1_wr1x1_ta1x1x1x1_1x8x1
     ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
     v_mov_b32 v[v_tmp], s[s_in_offset]
 
-    global_store_dword v[v_tmp+6:v_tmp+7], v[v_in_os], s[s_dbg+0:s_dbg+1]
+    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
     s_waitcnt vmcnt(0)
     s_barrier
 

--- a/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_032x032.inc
+++ b/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_032x032.inc
@@ -124,9 +124,8 @@
 .set s_sub_n, 56
 .set s_group_stride, 57
 .set s_group_left, 1
-.set s_dbg, 58
-.set s_tmp, 60
-.set s_end, 66
+.set s_tmp, 58
+.set s_end, 64
 
 .set v_c, 0  ; coalescing:4, needed:2, resuable:16
 .set v_a, 2
@@ -190,11 +189,6 @@ igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt32x32x16_wt16x16_ws1x1_wr1x1_ta1x1x2x1_1x16x1
     ; clear vector r
     .v_clear_nc v_c+1, v_end-1
 
-    ; debug vgpr
-    v_mov_b32 v1, 0
-    v_add_lshl_u32 v[v_tmp+6], v0, v1, 2
-    ;v_lshlrev_b32 v[114], 2, v0 ; every thread write one float
-    s_load_dwordx2 s[s_dbg+0:s_dbg+1], s[s_ka:s_ka+1], k_p_wei
     ; input, thread(n0,n1b,c0,c1e): 1x1x2x1, cluster(n0,n1b,c0,c1e): 1x16x1x16
     v_mov_b32 v[v_tmp], v0
     v_and_b32 v[v_gtc_ic1e], 15, v[v_tmp]
@@ -722,29 +716,6 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt32x32x16_wt16x16_ws1x1_wr1x1_ta1x1x2x1_1x16
     s_mul_i32 s[s_tmp], 3, s[s_wei_stride_k]   ; i_m:3(i_m0:0,i_m1:3)
     buffer_atomic_add_f32 v[v_c+3], v[v_wei_os], s[s_p_wei:s_p_wei+3], s[s_tmp] offen offset:0
 
-    s_branch L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt32x32x16_wt16x16_ws1x1_wr1x1_ta1x1x2x1_1x16x1x16_tb1x1x2x1_1x16x1x16_gkgs_out
-    ; debug code to cpy vgpr to host
-    L_debug_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt32x32x16_wt16x16_ws1x1_wr1x1_ta1x1x2x1_1x16x1x16_tb1x1x2x1_1x16x1x16_gkgs_out_1:
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-    s_cmp_lg_u32 s[s_bx], 0
-    s_cbranch_scc1 L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt32x32x16_wt16x16_ws1x1_wr1x1_ta1x1x2x1_1x16x1x16_tb1x1x2x1_1x16x1x16_gkgs_out_1
-    ;s_cmp_lg_u32 s[s_wave_id], 0
-    ;s_cbranch_scc1  L_program_end
-    ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
-    v_mov_b32 v[v_tmp], s[s_in_offset]
-
-    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
-    s_waitcnt vmcnt(0)
-    s_barrier
-
-    L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt32x32x16_wt16x16_ws1x1_wr1x1_ta1x1x2x1_1x16x1x16_tb1x1x2x1_1x16x1x16_gkgs_out_1:
-    s_nop 2
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-
 L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt32x32x16_wt16x16_ws1x1_wr1x1_ta1x1x2x1_1x16x1x16_tb1x1x2x1_1x16x1x16_gkgs_out:
     s_endpgm
 .rodata
@@ -755,7 +726,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt32x32x16_wt16x16_ws1x1_wr1x1_ta1x1x2x1_1x16
     .amdhsa_system_sgpr_workgroup_id_x 1
     .amdhsa_system_vgpr_workitem_id 0
     .amdhsa_next_free_vgpr 54
-    .amdhsa_next_free_sgpr 72
+    .amdhsa_next_free_sgpr 70
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
 .end_amdhsa_kernel
@@ -859,9 +830,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt32x32x16_wt16x16_ws1x1_wr1x1_ta1x1x2x1_1x16
 .set s_sub_n, 56
 .set s_group_stride, 57
 .set s_group_left, 1
-.set s_dbg, 58
-.set s_tmp, 60
-.set s_end, 66
+.set s_tmp, 58
+.set s_end, 64
 
 .set v_c, 0  ; coalescing:4, needed:2, resuable:16
 .set v_a, 2
@@ -925,11 +895,6 @@ igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt32x32x16_wt16x16_ws1x1_wr1x1_ta1x1x2x1_1x16x1
     ; clear vector r
     .v_clear_nc v_c+1, v_end-1
 
-    ; debug vgpr
-    v_mov_b32 v1, 0
-    v_add_lshl_u32 v[v_tmp+6], v0, v1, 2
-    ;v_lshlrev_b32 v[114], 2, v0 ; every thread write one float
-    s_load_dwordx2 s[s_dbg+0:s_dbg+1], s[s_ka:s_ka+1], k_p_wei
     ; input, thread(n0,n1b,c0,c1e): 1x1x2x1, cluster(n0,n1b,c0,c1e): 1x16x1x16
     v_mov_b32 v[v_tmp], v0
     v_and_b32 v[v_gtc_ic1e], 15, v[v_tmp]
@@ -1457,29 +1422,6 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt32x32x16_wt16x16_ws1x1_wr1x1_ta1x1x2x1_1x16
     s_mul_i32 s[s_tmp], 3, s[s_wei_stride_k]   ; i_m:3(i_m0:0,i_m1:3)
     buffer_store_dword v[v_c+3], v[v_wei_os], s[s_p_wei:s_p_wei+3], s[s_tmp] offen offset:0
 
-    s_branch L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt32x32x16_wt16x16_ws1x1_wr1x1_ta1x1x2x1_1x16x1x16_tb1x1x2x1_1x16x1x16_out
-    ; debug code to cpy vgpr to host
-    L_debug_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt32x32x16_wt16x16_ws1x1_wr1x1_ta1x1x2x1_1x16x1x16_tb1x1x2x1_1x16x1x16_out_1:
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-    s_cmp_lg_u32 s[s_bx], 0
-    s_cbranch_scc1 L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt32x32x16_wt16x16_ws1x1_wr1x1_ta1x1x2x1_1x16x1x16_tb1x1x2x1_1x16x1x16_out_1
-    ;s_cmp_lg_u32 s[s_wave_id], 0
-    ;s_cbranch_scc1  L_program_end
-    ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
-    v_mov_b32 v[v_tmp], s[s_in_offset]
-
-    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
-    s_waitcnt vmcnt(0)
-    s_barrier
-
-    L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt32x32x16_wt16x16_ws1x1_wr1x1_ta1x1x2x1_1x16x1x16_tb1x1x2x1_1x16x1x16_out_1:
-    s_nop 2
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-
 L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt32x32x16_wt16x16_ws1x1_wr1x1_ta1x1x2x1_1x16x1x16_tb1x1x2x1_1x16x1x16_out:
     s_endpgm
 .rodata
@@ -1490,7 +1432,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt32x32x16_wt16x16_ws1x1_wr1x1_ta1x1x2x1_1x16
     .amdhsa_system_sgpr_workgroup_id_x 1
     .amdhsa_system_vgpr_workitem_id 0
     .amdhsa_next_free_vgpr 54
-    .amdhsa_next_free_sgpr 72
+    .amdhsa_next_free_sgpr 70
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
 .end_amdhsa_kernel
@@ -1594,9 +1536,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt32x32x16_wt16x16_ws1x1_wr1x1_ta1x1x2x1_1x16
 .set s_sub_n, 56
 .set s_group_stride, 57
 .set s_group_left, 1
-.set s_dbg, 58
-.set s_tmp, 60
-.set s_end, 66
+.set s_tmp, 58
+.set s_end, 64
 
 .set v_c, 0  ; coalescing:4, needed:2, resuable:14
 .set v_a, 2
@@ -1660,11 +1601,6 @@ igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt32x32x8_wt16x16_ws1x1_wr1x1_ta1x1x1x1_1x8x1x3
     ; clear vector r
     .v_clear_nc v_c+1, v_end-1
 
-    ; debug vgpr
-    v_mov_b32 v1, 0
-    v_add_lshl_u32 v[v_tmp+6], v0, v1, 2
-    ;v_lshlrev_b32 v[114], 2, v0 ; every thread write one float
-    s_load_dwordx2 s[s_dbg+0:s_dbg+1], s[s_ka:s_ka+1], k_p_wei
     ; input, thread(n0,n1b,c0,c1e): 1x1x1x1, cluster(n0,n1b,c0,c1e): 1x8x1x32
     v_mov_b32 v[v_tmp], v0
     v_and_b32 v[v_gtc_ic1e], 31, v[v_tmp]
@@ -2117,29 +2053,6 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt32x32x8_wt16x16_ws1x1_wr1x1_ta1x1x1x1_1x8x1
     s_mul_i32 s[s_tmp], 3, s[s_wei_stride_k]   ; i_m:3(i_m0:0,i_m1:3)
     buffer_atomic_add_f32 v[v_c+3], v[v_wei_os], s[s_p_wei:s_p_wei+3], s[s_tmp] offen offset:0
 
-    s_branch L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt32x32x8_wt16x16_ws1x1_wr1x1_ta1x1x1x1_1x8x1x32_tb1x1x1x1_1x8x1x32_gkgs_out
-    ; debug code to cpy vgpr to host
-    L_debug_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt32x32x8_wt16x16_ws1x1_wr1x1_ta1x1x1x1_1x8x1x32_tb1x1x1x1_1x8x1x32_gkgs_out_1:
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-    s_cmp_lg_u32 s[s_bx], 0
-    s_cbranch_scc1 L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt32x32x8_wt16x16_ws1x1_wr1x1_ta1x1x1x1_1x8x1x32_tb1x1x1x1_1x8x1x32_gkgs_out_1
-    ;s_cmp_lg_u32 s[s_wave_id], 0
-    ;s_cbranch_scc1  L_program_end
-    ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
-    v_mov_b32 v[v_tmp], s[s_in_offset]
-
-    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
-    s_waitcnt vmcnt(0)
-    s_barrier
-
-    L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt32x32x8_wt16x16_ws1x1_wr1x1_ta1x1x1x1_1x8x1x32_tb1x1x1x1_1x8x1x32_gkgs_out_1:
-    s_nop 2
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-
 L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt32x32x8_wt16x16_ws1x1_wr1x1_ta1x1x1x1_1x8x1x32_tb1x1x1x1_1x8x1x32_gkgs_out:
     s_endpgm
 .rodata
@@ -2150,7 +2063,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt32x32x8_wt16x16_ws1x1_wr1x1_ta1x1x1x1_1x8x1
     .amdhsa_system_sgpr_workgroup_id_x 1
     .amdhsa_system_vgpr_workitem_id 0
     .amdhsa_next_free_vgpr 52
-    .amdhsa_next_free_sgpr 72
+    .amdhsa_next_free_sgpr 70
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
 .end_amdhsa_kernel
@@ -2254,9 +2167,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt32x32x8_wt16x16_ws1x1_wr1x1_ta1x1x1x1_1x8x1
 .set s_sub_n, 56
 .set s_group_stride, 57
 .set s_group_left, 1
-.set s_dbg, 58
-.set s_tmp, 60
-.set s_end, 66
+.set s_tmp, 58
+.set s_end, 64
 
 .set v_c, 0  ; coalescing:4, needed:2, resuable:14
 .set v_a, 2
@@ -2320,11 +2232,6 @@ igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt32x32x8_wt16x16_ws1x1_wr1x1_ta1x1x1x1_1x8x1x3
     ; clear vector r
     .v_clear_nc v_c+1, v_end-1
 
-    ; debug vgpr
-    v_mov_b32 v1, 0
-    v_add_lshl_u32 v[v_tmp+6], v0, v1, 2
-    ;v_lshlrev_b32 v[114], 2, v0 ; every thread write one float
-    s_load_dwordx2 s[s_dbg+0:s_dbg+1], s[s_ka:s_ka+1], k_p_wei
     ; input, thread(n0,n1b,c0,c1e): 1x1x1x1, cluster(n0,n1b,c0,c1e): 1x8x1x32
     v_mov_b32 v[v_tmp], v0
     v_and_b32 v[v_gtc_ic1e], 31, v[v_tmp]
@@ -2777,29 +2684,6 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt32x32x8_wt16x16_ws1x1_wr1x1_ta1x1x1x1_1x8x1
     s_mul_i32 s[s_tmp], 3, s[s_wei_stride_k]   ; i_m:3(i_m0:0,i_m1:3)
     buffer_store_dword v[v_c+3], v[v_wei_os], s[s_p_wei:s_p_wei+3], s[s_tmp] offen offset:0
 
-    s_branch L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt32x32x8_wt16x16_ws1x1_wr1x1_ta1x1x1x1_1x8x1x32_tb1x1x1x1_1x8x1x32_out
-    ; debug code to cpy vgpr to host
-    L_debug_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt32x32x8_wt16x16_ws1x1_wr1x1_ta1x1x1x1_1x8x1x32_tb1x1x1x1_1x8x1x32_out_1:
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-    s_cmp_lg_u32 s[s_bx], 0
-    s_cbranch_scc1 L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt32x32x8_wt16x16_ws1x1_wr1x1_ta1x1x1x1_1x8x1x32_tb1x1x1x1_1x8x1x32_out_1
-    ;s_cmp_lg_u32 s[s_wave_id], 0
-    ;s_cbranch_scc1  L_program_end
-    ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
-    v_mov_b32 v[v_tmp], s[s_in_offset]
-
-    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
-    s_waitcnt vmcnt(0)
-    s_barrier
-
-    L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt32x32x8_wt16x16_ws1x1_wr1x1_ta1x1x1x1_1x8x1x32_tb1x1x1x1_1x8x1x32_out_1:
-    s_nop 2
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-
 L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt32x32x8_wt16x16_ws1x1_wr1x1_ta1x1x1x1_1x8x1x32_tb1x1x1x1_1x8x1x32_out:
     s_endpgm
 .rodata
@@ -2810,7 +2694,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt32x32x8_wt16x16_ws1x1_wr1x1_ta1x1x1x1_1x8x1
     .amdhsa_system_sgpr_workgroup_id_x 1
     .amdhsa_system_vgpr_workitem_id 0
     .amdhsa_next_free_vgpr 52
-    .amdhsa_next_free_sgpr 72
+    .amdhsa_next_free_sgpr 70
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
 .end_amdhsa_kernel

--- a/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_064x016.inc
+++ b/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_064x016.inc
@@ -720,7 +720,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x16x16_wt64x4_ws1x1_wr1x1_ta1x1x4x1_1x16x
     ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
     v_mov_b32 v[v_tmp], s[s_in_offset]
 
-    global_store_dword v[v_tmp+6:v_tmp+7], v[v_in_os], s[s_dbg+0:s_dbg+1]
+    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
     s_waitcnt vmcnt(0)
     s_barrier
 
@@ -1440,7 +1440,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x16x16_wt64x4_ws1x1_wr1x1_ta1x1x4x1_1x16x
     ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
     v_mov_b32 v[v_tmp], s[s_in_offset]
 
-    global_store_dword v[v_tmp+6:v_tmp+7], v[v_in_os], s[s_dbg+0:s_dbg+1]
+    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
     s_waitcnt vmcnt(0)
     s_barrier
 

--- a/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_064x016.inc
+++ b/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_064x016.inc
@@ -124,9 +124,8 @@
 .set s_sub_n, 58
 .set s_group_stride, 59
 .set s_group_left, 1
-.set s_dbg, 60
-.set s_tmp, 62
-.set s_end, 68
+.set s_tmp, 60
+.set s_end, 66
 
 .set v_c, 0  ; coalescing:4, needed:2, resuable:17
 .set v_a, 2
@@ -190,11 +189,6 @@ igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x16x16_wt64x4_ws1x1_wr1x1_ta1x1x4x1_1x16x1x
     ; clear vector r
     .v_clear_nc v_c+1, v_end-1
 
-    ; debug vgpr
-    v_mov_b32 v1, 0
-    v_add_lshl_u32 v[v_tmp+6], v0, v1, 2
-    ;v_lshlrev_b32 v[114], 2, v0 ; every thread write one float
-    s_load_dwordx2 s[s_dbg+0:s_dbg+1], s[s_ka:s_ka+1], k_p_wei
     ; input, thread(n0,n1b,c0,c1e): 1x1x1x1, cluster(n0,n1b,c0,c1e): 1x16x1x16
     v_mov_b32 v[v_tmp], v0
     v_and_b32 v[v_gtc_ic1e], 15, v[v_tmp]
@@ -707,29 +701,6 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x16x16_wt64x4_ws1x1_wr1x1_ta1x1x4x1_1x16x
     s_mul_i32 s[s_tmp], 3, s[s_wei_stride_k]   ; i_m:3(i_m0:0,i_m1:3)
     buffer_store_dword v[v_c+3], v[v_wei_os], s[s_p_wei:s_p_wei+3], s[s_tmp] offen offset:0
 
-    s_branch L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x16x16_wt64x4_ws1x1_wr1x1_ta1x1x4x1_1x16x1x16_tb1x1x1x1_1x16x1x16_out
-    ; debug code to cpy vgpr to host
-    L_debug_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x16x16_wt64x4_ws1x1_wr1x1_ta1x1x4x1_1x16x1x16_tb1x1x1x1_1x16x1x16_out_1:
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-    s_cmp_lg_u32 s[s_bx], 0
-    s_cbranch_scc1 L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x16x16_wt64x4_ws1x1_wr1x1_ta1x1x4x1_1x16x1x16_tb1x1x1x1_1x16x1x16_out_1
-    ;s_cmp_lg_u32 s[s_wave_id], 0
-    ;s_cbranch_scc1  L_program_end
-    ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
-    v_mov_b32 v[v_tmp], s[s_in_offset]
-
-    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
-    s_waitcnt vmcnt(0)
-    s_barrier
-
-    L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x16x16_wt64x4_ws1x1_wr1x1_ta1x1x4x1_1x16x1x16_tb1x1x1x1_1x16x1x16_out_1:
-    s_nop 2
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-
 L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x16x16_wt64x4_ws1x1_wr1x1_ta1x1x4x1_1x16x1x16_tb1x1x1x1_1x16x1x16_out:
     s_endpgm
 .rodata
@@ -740,7 +711,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x16x16_wt64x4_ws1x1_wr1x1_ta1x1x4x1_1x16x
     .amdhsa_system_sgpr_workgroup_id_x 1
     .amdhsa_system_vgpr_workitem_id 0
     .amdhsa_next_free_vgpr 56
-    .amdhsa_next_free_sgpr 74
+    .amdhsa_next_free_sgpr 72
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
 .end_amdhsa_kernel
@@ -844,9 +815,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x16x16_wt64x4_ws1x1_wr1x1_ta1x1x4x1_1x16x
 .set s_sub_n, 58
 .set s_group_stride, 59
 .set s_group_left, 1
-.set s_dbg, 60
-.set s_tmp, 62
-.set s_end, 68
+.set s_tmp, 60
+.set s_end, 66
 
 .set v_c, 0  ; coalescing:4, needed:2, resuable:17
 .set v_a, 2
@@ -910,11 +880,6 @@ igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x16x16_wt64x4_ws1x1_wr1x1_ta1x1x4x1_1x16x1x
     ; clear vector r
     .v_clear_nc v_c+1, v_end-1
 
-    ; debug vgpr
-    v_mov_b32 v1, 0
-    v_add_lshl_u32 v[v_tmp+6], v0, v1, 2
-    ;v_lshlrev_b32 v[114], 2, v0 ; every thread write one float
-    s_load_dwordx2 s[s_dbg+0:s_dbg+1], s[s_ka:s_ka+1], k_p_wei
     ; input, thread(n0,n1b,c0,c1e): 1x1x1x1, cluster(n0,n1b,c0,c1e): 1x16x1x16
     v_mov_b32 v[v_tmp], v0
     v_and_b32 v[v_gtc_ic1e], 15, v[v_tmp]
@@ -1427,29 +1392,6 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x16x16_wt64x4_ws1x1_wr1x1_ta1x1x4x1_1x16x
     s_mul_i32 s[s_tmp], 3, s[s_wei_stride_k]   ; i_m:3(i_m0:0,i_m1:3)
     buffer_atomic_add_f32 v[v_c+3], v[v_wei_os], s[s_p_wei:s_p_wei+3], s[s_tmp] offen offset:0
 
-    s_branch L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x16x16_wt64x4_ws1x1_wr1x1_ta1x1x4x1_1x16x1x16_tb1x1x1x1_1x16x1x16_gkgs_out
-    ; debug code to cpy vgpr to host
-    L_debug_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x16x16_wt64x4_ws1x1_wr1x1_ta1x1x4x1_1x16x1x16_tb1x1x1x1_1x16x1x16_gkgs_out_1:
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-    s_cmp_lg_u32 s[s_bx], 0
-    s_cbranch_scc1 L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x16x16_wt64x4_ws1x1_wr1x1_ta1x1x4x1_1x16x1x16_tb1x1x1x1_1x16x1x16_gkgs_out_1
-    ;s_cmp_lg_u32 s[s_wave_id], 0
-    ;s_cbranch_scc1  L_program_end
-    ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
-    v_mov_b32 v[v_tmp], s[s_in_offset]
-
-    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
-    s_waitcnt vmcnt(0)
-    s_barrier
-
-    L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x16x16_wt64x4_ws1x1_wr1x1_ta1x1x4x1_1x16x1x16_tb1x1x1x1_1x16x1x16_gkgs_out_1:
-    s_nop 2
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-
 L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x16x16_wt64x4_ws1x1_wr1x1_ta1x1x4x1_1x16x1x16_tb1x1x1x1_1x16x1x16_gkgs_out:
     s_endpgm
 .rodata
@@ -1460,7 +1402,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x16x16_wt64x4_ws1x1_wr1x1_ta1x1x4x1_1x16x
     .amdhsa_system_sgpr_workgroup_id_x 1
     .amdhsa_system_vgpr_workitem_id 0
     .amdhsa_next_free_vgpr 56
-    .amdhsa_next_free_sgpr 74
+    .amdhsa_next_free_sgpr 72
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
 .end_amdhsa_kernel

--- a/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_064x032.inc
+++ b/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_064x032.inc
@@ -124,9 +124,8 @@
 .set s_sub_n, 58
 .set s_group_stride, 59
 .set s_group_left, 1
-.set s_dbg, 60
-.set s_tmp, 62
-.set s_end, 68
+.set s_tmp, 60
+.set s_end, 66
 
 .set v_c, 0  ; coalescing:8, needed:2, resuable:20
 .set v_a, 2
@@ -190,11 +189,6 @@ igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x32x16_wt32x8_ws1x2_wr1x1_ta1x1x4x1_1x16x1x
     ; clear vector r
     .v_clear_nc v_c+1, v_end-1
 
-    ; debug vgpr
-    v_mov_b32 v1, 0
-    v_add_lshl_u32 v[v_tmp+6], v0, v1, 2
-    ;v_lshlrev_b32 v[114], 2, v0 ; every thread write one float
-    s_load_dwordx2 s[s_dbg+0:s_dbg+1], s[s_ka:s_ka+1], k_p_wei
     ; input, thread(n0,n1b,c0,c1e): 1x1x2x1, cluster(n0,n1b,c0,c1e): 1x16x1x16
     v_mov_b32 v[v_tmp], v0
     v_and_b32 v[v_gtc_ic1e], 15, v[v_tmp]
@@ -776,29 +770,6 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x32x16_wt32x8_ws1x2_wr1x1_ta1x1x4x1_1x16x
     s_mul_i32 s[s_tmp], 35, s[s_wei_stride_k]   ; i_m:35(i_m0:2,i_m1:3)
     buffer_store_dword v[v_c+7], v[v_wei_os], s[s_p_wei:s_p_wei+3], s[s_tmp] offen offset:0
 
-    s_branch L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x32x16_wt32x8_ws1x2_wr1x1_ta1x1x4x1_1x16x1x16_tb1x1x2x1_1x16x1x16_out
-    ; debug code to cpy vgpr to host
-    L_debug_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x32x16_wt32x8_ws1x2_wr1x1_ta1x1x4x1_1x16x1x16_tb1x1x2x1_1x16x1x16_out_1:
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-    s_cmp_lg_u32 s[s_bx], 0
-    s_cbranch_scc1 L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x32x16_wt32x8_ws1x2_wr1x1_ta1x1x4x1_1x16x1x16_tb1x1x2x1_1x16x1x16_out_1
-    ;s_cmp_lg_u32 s[s_wave_id], 0
-    ;s_cbranch_scc1  L_program_end
-    ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
-    v_mov_b32 v[v_tmp], s[s_in_offset]
-
-    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
-    s_waitcnt vmcnt(0)
-    s_barrier
-
-    L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x32x16_wt32x8_ws1x2_wr1x1_ta1x1x4x1_1x16x1x16_tb1x1x2x1_1x16x1x16_out_1:
-    s_nop 2
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-
 L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x32x16_wt32x8_ws1x2_wr1x1_ta1x1x4x1_1x16x1x16_tb1x1x2x1_1x16x1x16_out:
     s_endpgm
 .rodata
@@ -809,7 +780,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x32x16_wt32x8_ws1x2_wr1x1_ta1x1x4x1_1x16x
     .amdhsa_system_sgpr_workgroup_id_x 1
     .amdhsa_system_vgpr_workitem_id 0
     .amdhsa_next_free_vgpr 58
-    .amdhsa_next_free_sgpr 74
+    .amdhsa_next_free_sgpr 72
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
 .end_amdhsa_kernel
@@ -913,9 +884,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x32x16_wt32x8_ws1x2_wr1x1_ta1x1x4x1_1x16x
 .set s_sub_n, 58
 .set s_group_stride, 59
 .set s_group_left, 1
-.set s_dbg, 60
-.set s_tmp, 62
-.set s_end, 68
+.set s_tmp, 60
+.set s_end, 66
 
 .set v_c, 0  ; coalescing:8, needed:2, resuable:20
 .set v_a, 2
@@ -979,11 +949,6 @@ igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x32x16_wt32x8_ws1x2_wr1x1_ta1x1x4x1_1x16x1x
     ; clear vector r
     .v_clear_nc v_c+1, v_end-1
 
-    ; debug vgpr
-    v_mov_b32 v1, 0
-    v_add_lshl_u32 v[v_tmp+6], v0, v1, 2
-    ;v_lshlrev_b32 v[114], 2, v0 ; every thread write one float
-    s_load_dwordx2 s[s_dbg+0:s_dbg+1], s[s_ka:s_ka+1], k_p_wei
     ; input, thread(n0,n1b,c0,c1e): 1x1x2x1, cluster(n0,n1b,c0,c1e): 1x16x1x16
     v_mov_b32 v[v_tmp], v0
     v_and_b32 v[v_gtc_ic1e], 15, v[v_tmp]
@@ -1565,29 +1530,6 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x32x16_wt32x8_ws1x2_wr1x1_ta1x1x4x1_1x16x
     s_mul_i32 s[s_tmp], 35, s[s_wei_stride_k]   ; i_m:35(i_m0:2,i_m1:3)
     buffer_atomic_add_f32 v[v_c+7], v[v_wei_os], s[s_p_wei:s_p_wei+3], s[s_tmp] offen offset:0
 
-    s_branch L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x32x16_wt32x8_ws1x2_wr1x1_ta1x1x4x1_1x16x1x16_tb1x1x2x1_1x16x1x16_gkgs_out
-    ; debug code to cpy vgpr to host
-    L_debug_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x32x16_wt32x8_ws1x2_wr1x1_ta1x1x4x1_1x16x1x16_tb1x1x2x1_1x16x1x16_gkgs_out_1:
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-    s_cmp_lg_u32 s[s_bx], 0
-    s_cbranch_scc1 L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x32x16_wt32x8_ws1x2_wr1x1_ta1x1x4x1_1x16x1x16_tb1x1x2x1_1x16x1x16_gkgs_out_1
-    ;s_cmp_lg_u32 s[s_wave_id], 0
-    ;s_cbranch_scc1  L_program_end
-    ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
-    v_mov_b32 v[v_tmp], s[s_in_offset]
-
-    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
-    s_waitcnt vmcnt(0)
-    s_barrier
-
-    L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x32x16_wt32x8_ws1x2_wr1x1_ta1x1x4x1_1x16x1x16_tb1x1x2x1_1x16x1x16_gkgs_out_1:
-    s_nop 2
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-
 L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x32x16_wt32x8_ws1x2_wr1x1_ta1x1x4x1_1x16x1x16_tb1x1x2x1_1x16x1x16_gkgs_out:
     s_endpgm
 .rodata
@@ -1598,7 +1540,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x32x16_wt32x8_ws1x2_wr1x1_ta1x1x4x1_1x16x
     .amdhsa_system_sgpr_workgroup_id_x 1
     .amdhsa_system_vgpr_workitem_id 0
     .amdhsa_next_free_vgpr 58
-    .amdhsa_next_free_sgpr 74
+    .amdhsa_next_free_sgpr 72
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
 .end_amdhsa_kernel
@@ -1702,9 +1644,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x32x16_wt32x8_ws1x2_wr1x1_ta1x1x4x1_1x16x
 .set s_sub_n, 56
 .set s_group_stride, 57
 .set s_group_left, 1
-.set s_dbg, 58
-.set s_tmp, 60
-.set s_end, 66
+.set s_tmp, 58
+.set s_end, 64
 
 .set v_c, 0  ; coalescing:8, needed:2, resuable:17
 .set v_a, 2
@@ -1768,11 +1709,6 @@ igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x32x8_wt32x8_ws1x2_wr1x1_ta1x1x2x1_1x8x1x32
     ; clear vector r
     .v_clear_nc v_c+1, v_end-1
 
-    ; debug vgpr
-    v_mov_b32 v1, 0
-    v_add_lshl_u32 v[v_tmp+6], v0, v1, 2
-    ;v_lshlrev_b32 v[114], 2, v0 ; every thread write one float
-    s_load_dwordx2 s[s_dbg+0:s_dbg+1], s[s_ka:s_ka+1], k_p_wei
     ; input, thread(n0,n1b,c0,c1e): 1x1x1x1, cluster(n0,n1b,c0,c1e): 1x8x1x32
     v_mov_b32 v[v_tmp], v0
     v_and_b32 v[v_gtc_ic1e], 31, v[v_tmp]
@@ -2258,29 +2194,6 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x32x8_wt32x8_ws1x2_wr1x1_ta1x1x2x1_1x8x1x
     s_mul_i32 s[s_tmp], 35, s[s_wei_stride_k]   ; i_m:35(i_m0:1,i_m1:3)
     buffer_store_dword v[v_c+7], v[v_wei_os], s[s_p_wei:s_p_wei+3], s[s_tmp] offen offset:0
 
-    s_branch L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x32x8_wt32x8_ws1x2_wr1x1_ta1x1x2x1_1x8x1x32_tb1x1x1x1_1x8x1x32_out
-    ; debug code to cpy vgpr to host
-    L_debug_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x32x8_wt32x8_ws1x2_wr1x1_ta1x1x2x1_1x8x1x32_tb1x1x1x1_1x8x1x32_out_1:
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-    s_cmp_lg_u32 s[s_bx], 0
-    s_cbranch_scc1 L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x32x8_wt32x8_ws1x2_wr1x1_ta1x1x2x1_1x8x1x32_tb1x1x1x1_1x8x1x32_out_1
-    ;s_cmp_lg_u32 s[s_wave_id], 0
-    ;s_cbranch_scc1  L_program_end
-    ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
-    v_mov_b32 v[v_tmp], s[s_in_offset]
-
-    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
-    s_waitcnt vmcnt(0)
-    s_barrier
-
-    L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x32x8_wt32x8_ws1x2_wr1x1_ta1x1x2x1_1x8x1x32_tb1x1x1x1_1x8x1x32_out_1:
-    s_nop 2
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-
 L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x32x8_wt32x8_ws1x2_wr1x1_ta1x1x2x1_1x8x1x32_tb1x1x1x1_1x8x1x32_out:
     s_endpgm
 .rodata
@@ -2291,7 +2204,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x32x8_wt32x8_ws1x2_wr1x1_ta1x1x2x1_1x8x1x
     .amdhsa_system_sgpr_workgroup_id_x 1
     .amdhsa_system_vgpr_workitem_id 0
     .amdhsa_next_free_vgpr 56
-    .amdhsa_next_free_sgpr 72
+    .amdhsa_next_free_sgpr 70
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
 .end_amdhsa_kernel
@@ -2395,9 +2308,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x32x8_wt32x8_ws1x2_wr1x1_ta1x1x2x1_1x8x1x
 .set s_sub_n, 56
 .set s_group_stride, 57
 .set s_group_left, 1
-.set s_dbg, 58
-.set s_tmp, 60
-.set s_end, 66
+.set s_tmp, 58
+.set s_end, 64
 
 .set v_c, 0  ; coalescing:8, needed:2, resuable:17
 .set v_a, 2
@@ -2461,11 +2373,6 @@ igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x32x8_wt32x8_ws1x2_wr1x1_ta1x1x2x1_1x8x1x32
     ; clear vector r
     .v_clear_nc v_c+1, v_end-1
 
-    ; debug vgpr
-    v_mov_b32 v1, 0
-    v_add_lshl_u32 v[v_tmp+6], v0, v1, 2
-    ;v_lshlrev_b32 v[114], 2, v0 ; every thread write one float
-    s_load_dwordx2 s[s_dbg+0:s_dbg+1], s[s_ka:s_ka+1], k_p_wei
     ; input, thread(n0,n1b,c0,c1e): 1x1x1x1, cluster(n0,n1b,c0,c1e): 1x8x1x32
     v_mov_b32 v[v_tmp], v0
     v_and_b32 v[v_gtc_ic1e], 31, v[v_tmp]
@@ -2951,29 +2858,6 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x32x8_wt32x8_ws1x2_wr1x1_ta1x1x2x1_1x8x1x
     s_mul_i32 s[s_tmp], 35, s[s_wei_stride_k]   ; i_m:35(i_m0:1,i_m1:3)
     buffer_atomic_add_f32 v[v_c+7], v[v_wei_os], s[s_p_wei:s_p_wei+3], s[s_tmp] offen offset:0
 
-    s_branch L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x32x8_wt32x8_ws1x2_wr1x1_ta1x1x2x1_1x8x1x32_tb1x1x1x1_1x8x1x32_gkgs_out
-    ; debug code to cpy vgpr to host
-    L_debug_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x32x8_wt32x8_ws1x2_wr1x1_ta1x1x2x1_1x8x1x32_tb1x1x1x1_1x8x1x32_gkgs_out_1:
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-    s_cmp_lg_u32 s[s_bx], 0
-    s_cbranch_scc1 L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x32x8_wt32x8_ws1x2_wr1x1_ta1x1x2x1_1x8x1x32_tb1x1x1x1_1x8x1x32_gkgs_out_1
-    ;s_cmp_lg_u32 s[s_wave_id], 0
-    ;s_cbranch_scc1  L_program_end
-    ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
-    v_mov_b32 v[v_tmp], s[s_in_offset]
-
-    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
-    s_waitcnt vmcnt(0)
-    s_barrier
-
-    L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x32x8_wt32x8_ws1x2_wr1x1_ta1x1x2x1_1x8x1x32_tb1x1x1x1_1x8x1x32_gkgs_out_1:
-    s_nop 2
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-
 L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x32x8_wt32x8_ws1x2_wr1x1_ta1x1x2x1_1x8x1x32_tb1x1x1x1_1x8x1x32_gkgs_out:
     s_endpgm
 .rodata
@@ -2984,7 +2868,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x32x8_wt32x8_ws1x2_wr1x1_ta1x1x2x1_1x8x1x
     .amdhsa_system_sgpr_workgroup_id_x 1
     .amdhsa_system_vgpr_workitem_id 0
     .amdhsa_next_free_vgpr 56
-    .amdhsa_next_free_sgpr 72
+    .amdhsa_next_free_sgpr 70
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
 .end_amdhsa_kernel

--- a/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_064x032.inc
+++ b/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_064x032.inc
@@ -789,7 +789,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x32x16_wt32x8_ws1x2_wr1x1_ta1x1x4x1_1x16x
     ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
     v_mov_b32 v[v_tmp], s[s_in_offset]
 
-    global_store_dword v[v_tmp+6:v_tmp+7], v[v_in_os], s[s_dbg+0:s_dbg+1]
+    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
     s_waitcnt vmcnt(0)
     s_barrier
 
@@ -1578,7 +1578,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x32x16_wt32x8_ws1x2_wr1x1_ta1x1x4x1_1x16x
     ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
     v_mov_b32 v[v_tmp], s[s_in_offset]
 
-    global_store_dword v[v_tmp+6:v_tmp+7], v[v_in_os], s[s_dbg+0:s_dbg+1]
+    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
     s_waitcnt vmcnt(0)
     s_barrier
 
@@ -2271,7 +2271,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x32x8_wt32x8_ws1x2_wr1x1_ta1x1x2x1_1x8x1x
     ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
     v_mov_b32 v[v_tmp], s[s_in_offset]
 
-    global_store_dword v[v_tmp+6:v_tmp+7], v[v_in_os], s[s_dbg+0:s_dbg+1]
+    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
     s_waitcnt vmcnt(0)
     s_barrier
 
@@ -2964,7 +2964,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x32x8_wt32x8_ws1x2_wr1x1_ta1x1x2x1_1x8x1x
     ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
     v_mov_b32 v[v_tmp], s[s_in_offset]
 
-    global_store_dword v[v_tmp+6:v_tmp+7], v[v_in_os], s[s_dbg+0:s_dbg+1]
+    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
     s_waitcnt vmcnt(0)
     s_barrier
 

--- a/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_064x064.inc
+++ b/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_064x064.inc
@@ -124,9 +124,8 @@
 .set s_sub_n, 60
 .set s_group_stride, 61
 .set s_group_left, 1
-.set s_dbg, 62
-.set s_tmp, 64
-.set s_end, 70
+.set s_tmp, 62
+.set s_end, 68
 
 .set v_c, 0  ; coalescing:8, needed:2, resuable:24
 .set v_a, 2
@@ -190,11 +189,6 @@ igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x64x16_wt16x16_ws1x1_wr2x2_ta1x1x4x1_1x16x1
     ; clear vector r
     .v_clear_nc v_c+1, v_end-1
 
-    ; debug vgpr
-    v_mov_b32 v1, 0
-    v_add_lshl_u32 v[v_tmp+6], v0, v1, 2
-    ;v_lshlrev_b32 v[114], 2, v0 ; every thread write one float
-    s_load_dwordx2 s[s_dbg+0:s_dbg+1], s[s_ka:s_ka+1], k_p_wei
     ; input, thread(n0,n1b,c0,c1e): 1x1x4x1, cluster(n0,n1b,c0,c1e): 1x16x1x16
     v_mov_b32 v[v_tmp], v0
     v_and_b32 v[v_gtc_ic1e], 15, v[v_tmp]
@@ -1086,29 +1080,6 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x64x16_wt16x16_ws1x1_wr2x2_ta1x1x4x1_1x16
     s_mul_i32 s[s_tmp], 51, s[s_wei_stride_k]   ; i_m:51(i_m0:3,i_m1:3)
     buffer_store_dword v[v_c+7], v[v_wei_os], s[s_p_wei:s_p_wei+3], s[s_tmp] offen offset:0
 
-    s_branch L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x64x16_wt16x16_ws1x1_wr2x2_ta1x1x4x1_1x16x1x16_tb1x1x4x1_1x16x1x16_out
-    ; debug code to cpy vgpr to host
-    L_debug_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x64x16_wt16x16_ws1x1_wr2x2_ta1x1x4x1_1x16x1x16_tb1x1x4x1_1x16x1x16_out_1:
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-    s_cmp_lg_u32 s[s_bx], 0
-    s_cbranch_scc1 L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x64x16_wt16x16_ws1x1_wr2x2_ta1x1x4x1_1x16x1x16_tb1x1x4x1_1x16x1x16_out_1
-    ;s_cmp_lg_u32 s[s_wave_id], 0
-    ;s_cbranch_scc1  L_program_end
-    ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
-    v_mov_b32 v[v_tmp], s[s_in_offset]
-
-    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
-    s_waitcnt vmcnt(0)
-    s_barrier
-
-    L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x64x16_wt16x16_ws1x1_wr2x2_ta1x1x4x1_1x16x1x16_tb1x1x4x1_1x16x1x16_out_1:
-    s_nop 2
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-
 L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x64x16_wt16x16_ws1x1_wr2x2_ta1x1x4x1_1x16x1x16_tb1x1x4x1_1x16x1x16_out:
     s_endpgm
 .rodata
@@ -1119,7 +1090,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x64x16_wt16x16_ws1x1_wr2x2_ta1x1x4x1_1x16
     .amdhsa_system_sgpr_workgroup_id_x 1
     .amdhsa_system_vgpr_workitem_id 0
     .amdhsa_next_free_vgpr 62
-    .amdhsa_next_free_sgpr 76
+    .amdhsa_next_free_sgpr 74
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
 .end_amdhsa_kernel
@@ -1223,9 +1194,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x64x16_wt16x16_ws1x1_wr2x2_ta1x1x4x1_1x16
 .set s_sub_n, 60
 .set s_group_stride, 61
 .set s_group_left, 1
-.set s_dbg, 62
-.set s_tmp, 64
-.set s_end, 70
+.set s_tmp, 62
+.set s_end, 68
 
 .set v_c, 0  ; coalescing:8, needed:2, resuable:24
 .set v_a, 2
@@ -1289,11 +1259,6 @@ igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x64x16_wt16x16_ws1x1_wr2x2_ta1x1x4x1_1x16x1
     ; clear vector r
     .v_clear_nc v_c+1, v_end-1
 
-    ; debug vgpr
-    v_mov_b32 v1, 0
-    v_add_lshl_u32 v[v_tmp+6], v0, v1, 2
-    ;v_lshlrev_b32 v[114], 2, v0 ; every thread write one float
-    s_load_dwordx2 s[s_dbg+0:s_dbg+1], s[s_ka:s_ka+1], k_p_wei
     ; input, thread(n0,n1b,c0,c1e): 1x1x4x1, cluster(n0,n1b,c0,c1e): 1x16x1x16
     v_mov_b32 v[v_tmp], v0
     v_and_b32 v[v_gtc_ic1e], 15, v[v_tmp]
@@ -2185,29 +2150,6 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x64x16_wt16x16_ws1x1_wr2x2_ta1x1x4x1_1x16
     s_mul_i32 s[s_tmp], 51, s[s_wei_stride_k]   ; i_m:51(i_m0:3,i_m1:3)
     buffer_atomic_add_f32 v[v_c+7], v[v_wei_os], s[s_p_wei:s_p_wei+3], s[s_tmp] offen offset:0
 
-    s_branch L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x64x16_wt16x16_ws1x1_wr2x2_ta1x1x4x1_1x16x1x16_tb1x1x4x1_1x16x1x16_gkgs_out
-    ; debug code to cpy vgpr to host
-    L_debug_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x64x16_wt16x16_ws1x1_wr2x2_ta1x1x4x1_1x16x1x16_tb1x1x4x1_1x16x1x16_gkgs_out_1:
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-    s_cmp_lg_u32 s[s_bx], 0
-    s_cbranch_scc1 L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x64x16_wt16x16_ws1x1_wr2x2_ta1x1x4x1_1x16x1x16_tb1x1x4x1_1x16x1x16_gkgs_out_1
-    ;s_cmp_lg_u32 s[s_wave_id], 0
-    ;s_cbranch_scc1  L_program_end
-    ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
-    v_mov_b32 v[v_tmp], s[s_in_offset]
-
-    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
-    s_waitcnt vmcnt(0)
-    s_barrier
-
-    L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x64x16_wt16x16_ws1x1_wr2x2_ta1x1x4x1_1x16x1x16_tb1x1x4x1_1x16x1x16_gkgs_out_1:
-    s_nop 2
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-
 L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x64x16_wt16x16_ws1x1_wr2x2_ta1x1x4x1_1x16x1x16_tb1x1x4x1_1x16x1x16_gkgs_out:
     s_endpgm
 .rodata
@@ -2218,7 +2160,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x64x16_wt16x16_ws1x1_wr2x2_ta1x1x4x1_1x16
     .amdhsa_system_sgpr_workgroup_id_x 1
     .amdhsa_system_vgpr_workitem_id 0
     .amdhsa_next_free_vgpr 62
-    .amdhsa_next_free_sgpr 76
+    .amdhsa_next_free_sgpr 74
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
 .end_amdhsa_kernel
@@ -2322,9 +2264,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x64x16_wt16x16_ws1x1_wr2x2_ta1x1x4x1_1x16
 .set s_sub_n, 56
 .set s_group_stride, 57
 .set s_group_left, 1
-.set s_dbg, 58
-.set s_tmp, 60
-.set s_end, 66
+.set s_tmp, 58
+.set s_end, 64
 
 .set v_c, 0  ; coalescing:8, needed:2, resuable:20
 .set v_a, 2
@@ -2388,11 +2329,6 @@ igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x64x8_wt16x16_ws1x1_wr2x2_ta1x1x2x1_1x8x1x3
     ; clear vector r
     .v_clear_nc v_c+1, v_end-1
 
-    ; debug vgpr
-    v_mov_b32 v1, 0
-    v_add_lshl_u32 v[v_tmp+6], v0, v1, 2
-    ;v_lshlrev_b32 v[114], 2, v0 ; every thread write one float
-    s_load_dwordx2 s[s_dbg+0:s_dbg+1], s[s_ka:s_ka+1], k_p_wei
     ; input, thread(n0,n1b,c0,c1e): 1x1x2x1, cluster(n0,n1b,c0,c1e): 1x8x1x32
     v_mov_b32 v[v_tmp], v0
     v_and_b32 v[v_gtc_ic1e], 31, v[v_tmp]
@@ -3054,29 +2990,6 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x64x8_wt16x16_ws1x1_wr2x2_ta1x1x2x1_1x8x1
     s_mul_i32 s[s_tmp], 51, s[s_wei_stride_k]   ; i_m:51(i_m0:1,i_m1:19)
     buffer_store_dword v[v_c+7], v[v_wei_os], s[s_p_wei:s_p_wei+3], s[s_tmp] offen offset:0
 
-    s_branch L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x64x8_wt16x16_ws1x1_wr2x2_ta1x1x2x1_1x8x1x32_tb1x1x2x1_1x8x1x32_out
-    ; debug code to cpy vgpr to host
-    L_debug_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x64x8_wt16x16_ws1x1_wr2x2_ta1x1x2x1_1x8x1x32_tb1x1x2x1_1x8x1x32_out_1:
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-    s_cmp_lg_u32 s[s_bx], 0
-    s_cbranch_scc1 L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x64x8_wt16x16_ws1x1_wr2x2_ta1x1x2x1_1x8x1x32_tb1x1x2x1_1x8x1x32_out_1
-    ;s_cmp_lg_u32 s[s_wave_id], 0
-    ;s_cbranch_scc1  L_program_end
-    ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
-    v_mov_b32 v[v_tmp], s[s_in_offset]
-
-    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
-    s_waitcnt vmcnt(0)
-    s_barrier
-
-    L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x64x8_wt16x16_ws1x1_wr2x2_ta1x1x2x1_1x8x1x32_tb1x1x2x1_1x8x1x32_out_1:
-    s_nop 2
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-
 L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x64x8_wt16x16_ws1x1_wr2x2_ta1x1x2x1_1x8x1x32_tb1x1x2x1_1x8x1x32_out:
     s_endpgm
 .rodata
@@ -3087,7 +3000,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x64x8_wt16x16_ws1x1_wr2x2_ta1x1x2x1_1x8x1
     .amdhsa_system_sgpr_workgroup_id_x 1
     .amdhsa_system_vgpr_workitem_id 0
     .amdhsa_next_free_vgpr 58
-    .amdhsa_next_free_sgpr 72
+    .amdhsa_next_free_sgpr 70
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
 .end_amdhsa_kernel
@@ -3191,9 +3104,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x64x8_wt16x16_ws1x1_wr2x2_ta1x1x2x1_1x8x1
 .set s_sub_n, 56
 .set s_group_stride, 57
 .set s_group_left, 1
-.set s_dbg, 58
-.set s_tmp, 60
-.set s_end, 66
+.set s_tmp, 58
+.set s_end, 64
 
 .set v_c, 0  ; coalescing:8, needed:2, resuable:20
 .set v_a, 2
@@ -3257,11 +3169,6 @@ igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x64x8_wt16x16_ws1x1_wr2x2_ta1x1x2x1_1x8x1x3
     ; clear vector r
     .v_clear_nc v_c+1, v_end-1
 
-    ; debug vgpr
-    v_mov_b32 v1, 0
-    v_add_lshl_u32 v[v_tmp+6], v0, v1, 2
-    ;v_lshlrev_b32 v[114], 2, v0 ; every thread write one float
-    s_load_dwordx2 s[s_dbg+0:s_dbg+1], s[s_ka:s_ka+1], k_p_wei
     ; input, thread(n0,n1b,c0,c1e): 1x1x2x1, cluster(n0,n1b,c0,c1e): 1x8x1x32
     v_mov_b32 v[v_tmp], v0
     v_and_b32 v[v_gtc_ic1e], 31, v[v_tmp]
@@ -3923,29 +3830,6 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x64x8_wt16x16_ws1x1_wr2x2_ta1x1x2x1_1x8x1
     s_mul_i32 s[s_tmp], 51, s[s_wei_stride_k]   ; i_m:51(i_m0:1,i_m1:19)
     buffer_atomic_add_f32 v[v_c+7], v[v_wei_os], s[s_p_wei:s_p_wei+3], s[s_tmp] offen offset:0
 
-    s_branch L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x64x8_wt16x16_ws1x1_wr2x2_ta1x1x2x1_1x8x1x32_tb1x1x2x1_1x8x1x32_gkgs_out
-    ; debug code to cpy vgpr to host
-    L_debug_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x64x8_wt16x16_ws1x1_wr2x2_ta1x1x2x1_1x8x1x32_tb1x1x2x1_1x8x1x32_gkgs_out_1:
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-    s_cmp_lg_u32 s[s_bx], 0
-    s_cbranch_scc1 L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x64x8_wt16x16_ws1x1_wr2x2_ta1x1x2x1_1x8x1x32_tb1x1x2x1_1x8x1x32_gkgs_out_1
-    ;s_cmp_lg_u32 s[s_wave_id], 0
-    ;s_cbranch_scc1  L_program_end
-    ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
-    v_mov_b32 v[v_tmp], s[s_in_offset]
-
-    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
-    s_waitcnt vmcnt(0)
-    s_barrier
-
-    L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x64x8_wt16x16_ws1x1_wr2x2_ta1x1x2x1_1x8x1x32_tb1x1x2x1_1x8x1x32_gkgs_out_1:
-    s_nop 2
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-
 L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x64x8_wt16x16_ws1x1_wr2x2_ta1x1x2x1_1x8x1x32_tb1x1x2x1_1x8x1x32_gkgs_out:
     s_endpgm
 .rodata
@@ -3956,7 +3840,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x64x8_wt16x16_ws1x1_wr2x2_ta1x1x2x1_1x8x1
     .amdhsa_system_sgpr_workgroup_id_x 1
     .amdhsa_system_vgpr_workitem_id 0
     .amdhsa_next_free_vgpr 58
-    .amdhsa_next_free_sgpr 72
+    .amdhsa_next_free_sgpr 70
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
 .end_amdhsa_kernel

--- a/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_064x064.inc
+++ b/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_064x064.inc
@@ -1099,7 +1099,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x64x16_wt16x16_ws1x1_wr2x2_ta1x1x4x1_1x16
     ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
     v_mov_b32 v[v_tmp], s[s_in_offset]
 
-    global_store_dword v[v_tmp+6:v_tmp+7], v[v_in_os], s[s_dbg+0:s_dbg+1]
+    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
     s_waitcnt vmcnt(0)
     s_barrier
 
@@ -2198,7 +2198,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x64x16_wt16x16_ws1x1_wr2x2_ta1x1x4x1_1x16
     ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
     v_mov_b32 v[v_tmp], s[s_in_offset]
 
-    global_store_dword v[v_tmp+6:v_tmp+7], v[v_in_os], s[s_dbg+0:s_dbg+1]
+    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
     s_waitcnt vmcnt(0)
     s_barrier
 
@@ -3067,7 +3067,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x64x8_wt16x16_ws1x1_wr2x2_ta1x1x2x1_1x8x1
     ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
     v_mov_b32 v[v_tmp], s[s_in_offset]
 
-    global_store_dword v[v_tmp+6:v_tmp+7], v[v_in_os], s[s_dbg+0:s_dbg+1]
+    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
     s_waitcnt vmcnt(0)
     s_barrier
 
@@ -3936,7 +3936,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x64x8_wt16x16_ws1x1_wr2x2_ta1x1x2x1_1x8x1
     ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
     v_mov_b32 v[v_tmp], s[s_in_offset]
 
-    global_store_dword v[v_tmp+6:v_tmp+7], v[v_in_os], s[s_dbg+0:s_dbg+1]
+    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
     s_waitcnt vmcnt(0)
     s_barrier
 

--- a/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_064x128.inc
+++ b/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_064x128.inc
@@ -124,9 +124,8 @@
 .set s_sub_n, 64
 .set s_group_stride, 65
 .set s_group_left, 1
-.set s_dbg, 66
-.set s_tmp, 68
-.set s_end, 74
+.set s_tmp, 66
+.set s_end, 72
 
 .set v_c, 0  ; coalescing:16, needed:2, resuable:32
 .set v_a, 2
@@ -190,11 +189,6 @@ igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x128x16_wt8x32_ws2x1_wr2x2_ta1x1x4x1_1x16x1
     ; clear vector r
     .v_clear_nc v_c+1, v_end-1
 
-    ; debug vgpr
-    v_mov_b32 v1, 0
-    v_add_lshl_u32 v[v_tmp+6], v0, v1, 2
-    ;v_lshlrev_b32 v[114], 2, v0 ; every thread write one float
-    s_load_dwordx2 s[s_dbg+0:s_dbg+1], s[s_ka:s_ka+1], k_p_wei
     ; input, thread(n0,n1b,c0,c1e): 1x1x8x1, cluster(n0,n1b,c0,c1e): 1x16x1x16
     v_mov_b32 v[v_tmp], v0
     v_and_b32 v[v_gtc_ic1e], 15, v[v_tmp]
@@ -1298,29 +1292,6 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x128x16_wt8x32_ws2x1_wr2x2_ta1x1x4x1_1x16
     s_mul_i32 s[s_tmp], 59, s[s_wei_stride_k]   ; i_m:59(i_m0:3,i_m1:11)
     buffer_store_dword v[v_c+15], v[v_wei_os], s[s_p_wei:s_p_wei+3], s[s_tmp] offen offset:0
 
-    s_branch L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x128x16_wt8x32_ws2x1_wr2x2_ta1x1x4x1_1x16x1x16_tb1x1x8x1_1x16x1x16_out
-    ; debug code to cpy vgpr to host
-    L_debug_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x128x16_wt8x32_ws2x1_wr2x2_ta1x1x4x1_1x16x1x16_tb1x1x8x1_1x16x1x16_out_1:
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-    s_cmp_lg_u32 s[s_bx], 0
-    s_cbranch_scc1 L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x128x16_wt8x32_ws2x1_wr2x2_ta1x1x4x1_1x16x1x16_tb1x1x8x1_1x16x1x16_out_1
-    ;s_cmp_lg_u32 s[s_wave_id], 0
-    ;s_cbranch_scc1  L_program_end
-    ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
-    v_mov_b32 v[v_tmp], s[s_in_offset]
-
-    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
-    s_waitcnt vmcnt(0)
-    s_barrier
-
-    L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x128x16_wt8x32_ws2x1_wr2x2_ta1x1x4x1_1x16x1x16_tb1x1x8x1_1x16x1x16_out_1:
-    s_nop 2
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-
 L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x128x16_wt8x32_ws2x1_wr2x2_ta1x1x4x1_1x16x1x16_tb1x1x8x1_1x16x1x16_out:
     s_endpgm
 .rodata
@@ -1331,7 +1302,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x128x16_wt8x32_ws2x1_wr2x2_ta1x1x4x1_1x16
     .amdhsa_system_sgpr_workgroup_id_x 1
     .amdhsa_system_vgpr_workitem_id 0
     .amdhsa_next_free_vgpr 70
-    .amdhsa_next_free_sgpr 80
+    .amdhsa_next_free_sgpr 78
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
 .end_amdhsa_kernel
@@ -1435,9 +1406,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x128x16_wt8x32_ws2x1_wr2x2_ta1x1x4x1_1x16
 .set s_sub_n, 64
 .set s_group_stride, 65
 .set s_group_left, 1
-.set s_dbg, 66
-.set s_tmp, 68
-.set s_end, 74
+.set s_tmp, 66
+.set s_end, 72
 
 .set v_c, 0  ; coalescing:16, needed:2, resuable:32
 .set v_a, 2
@@ -1501,11 +1471,6 @@ igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x128x16_wt8x32_ws2x1_wr2x2_ta1x1x4x1_1x16x1
     ; clear vector r
     .v_clear_nc v_c+1, v_end-1
 
-    ; debug vgpr
-    v_mov_b32 v1, 0
-    v_add_lshl_u32 v[v_tmp+6], v0, v1, 2
-    ;v_lshlrev_b32 v[114], 2, v0 ; every thread write one float
-    s_load_dwordx2 s[s_dbg+0:s_dbg+1], s[s_ka:s_ka+1], k_p_wei
     ; input, thread(n0,n1b,c0,c1e): 1x1x8x1, cluster(n0,n1b,c0,c1e): 1x16x1x16
     v_mov_b32 v[v_tmp], v0
     v_and_b32 v[v_gtc_ic1e], 15, v[v_tmp]
@@ -2609,29 +2574,6 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x128x16_wt8x32_ws2x1_wr2x2_ta1x1x4x1_1x16
     s_mul_i32 s[s_tmp], 59, s[s_wei_stride_k]   ; i_m:59(i_m0:3,i_m1:11)
     buffer_atomic_add_f32 v[v_c+15], v[v_wei_os], s[s_p_wei:s_p_wei+3], s[s_tmp] offen offset:0
 
-    s_branch L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x128x16_wt8x32_ws2x1_wr2x2_ta1x1x4x1_1x16x1x16_tb1x1x8x1_1x16x1x16_gkgs_out
-    ; debug code to cpy vgpr to host
-    L_debug_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x128x16_wt8x32_ws2x1_wr2x2_ta1x1x4x1_1x16x1x16_tb1x1x8x1_1x16x1x16_gkgs_out_1:
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-    s_cmp_lg_u32 s[s_bx], 0
-    s_cbranch_scc1 L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x128x16_wt8x32_ws2x1_wr2x2_ta1x1x4x1_1x16x1x16_tb1x1x8x1_1x16x1x16_gkgs_out_1
-    ;s_cmp_lg_u32 s[s_wave_id], 0
-    ;s_cbranch_scc1  L_program_end
-    ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
-    v_mov_b32 v[v_tmp], s[s_in_offset]
-
-    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
-    s_waitcnt vmcnt(0)
-    s_barrier
-
-    L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x128x16_wt8x32_ws2x1_wr2x2_ta1x1x4x1_1x16x1x16_tb1x1x8x1_1x16x1x16_gkgs_out_1:
-    s_nop 2
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-
 L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x128x16_wt8x32_ws2x1_wr2x2_ta1x1x4x1_1x16x1x16_tb1x1x8x1_1x16x1x16_gkgs_out:
     s_endpgm
 .rodata
@@ -2642,7 +2584,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x128x16_wt8x32_ws2x1_wr2x2_ta1x1x4x1_1x16
     .amdhsa_system_sgpr_workgroup_id_x 1
     .amdhsa_system_vgpr_workitem_id 0
     .amdhsa_next_free_vgpr 70
-    .amdhsa_next_free_sgpr 80
+    .amdhsa_next_free_sgpr 78
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
 .end_amdhsa_kernel
@@ -2746,9 +2688,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x128x16_wt8x32_ws2x1_wr2x2_ta1x1x4x1_1x16
 .set s_sub_n, 58
 .set s_group_stride, 59
 .set s_group_left, 1
-.set s_dbg, 60
-.set s_tmp, 62
-.set s_end, 68
+.set s_tmp, 60
+.set s_end, 66
 
 .set v_c, 0  ; coalescing:8, needed:2, resuable:26
 .set v_a, 2
@@ -2812,11 +2753,6 @@ igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x128x8_wt8x32_ws2x1_wr2x2_ta1x1x2x1_1x8x1x3
     ; clear vector r
     .v_clear_nc v_c+1, v_end-1
 
-    ; debug vgpr
-    v_mov_b32 v1, 0
-    v_add_lshl_u32 v[v_tmp+6], v0, v1, 2
-    ;v_lshlrev_b32 v[114], 2, v0 ; every thread write one float
-    s_load_dwordx2 s[s_dbg+0:s_dbg+1], s[s_ka:s_ka+1], k_p_wei
     ; input, thread(n0,n1b,c0,c1e): 1x1x4x1, cluster(n0,n1b,c0,c1e): 1x8x1x32
     v_mov_b32 v[v_tmp], v0
     v_and_b32 v[v_gtc_ic1e], 31, v[v_tmp]
@@ -3625,29 +3561,6 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x128x8_wt8x32_ws2x1_wr2x2_ta1x1x2x1_1x8x1
     s_mul_i32 s[s_tmp], 59, s[s_wei_stride_k]   ; i_m:59(i_m0:1,i_m1:27)
     buffer_store_dword v[v_c+7], v[v_wei_os], s[s_p_wei:s_p_wei+3], s[s_tmp] offen offset:0
 
-    s_branch L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x128x8_wt8x32_ws2x1_wr2x2_ta1x1x2x1_1x8x1x32_tb1x1x4x1_1x8x1x32_out
-    ; debug code to cpy vgpr to host
-    L_debug_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x128x8_wt8x32_ws2x1_wr2x2_ta1x1x2x1_1x8x1x32_tb1x1x4x1_1x8x1x32_out_1:
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-    s_cmp_lg_u32 s[s_bx], 0
-    s_cbranch_scc1 L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x128x8_wt8x32_ws2x1_wr2x2_ta1x1x2x1_1x8x1x32_tb1x1x4x1_1x8x1x32_out_1
-    ;s_cmp_lg_u32 s[s_wave_id], 0
-    ;s_cbranch_scc1  L_program_end
-    ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
-    v_mov_b32 v[v_tmp], s[s_in_offset]
-
-    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
-    s_waitcnt vmcnt(0)
-    s_barrier
-
-    L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x128x8_wt8x32_ws2x1_wr2x2_ta1x1x2x1_1x8x1x32_tb1x1x4x1_1x8x1x32_out_1:
-    s_nop 2
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-
 L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x128x8_wt8x32_ws2x1_wr2x2_ta1x1x2x1_1x8x1x32_tb1x1x4x1_1x8x1x32_out:
     s_endpgm
 .rodata
@@ -3658,7 +3571,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x128x8_wt8x32_ws2x1_wr2x2_ta1x1x2x1_1x8x1
     .amdhsa_system_sgpr_workgroup_id_x 1
     .amdhsa_system_vgpr_workitem_id 0
     .amdhsa_next_free_vgpr 64
-    .amdhsa_next_free_sgpr 74
+    .amdhsa_next_free_sgpr 72
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
 .end_amdhsa_kernel
@@ -3762,9 +3675,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x128x8_wt8x32_ws2x1_wr2x2_ta1x1x2x1_1x8x1
 .set s_sub_n, 58
 .set s_group_stride, 59
 .set s_group_left, 1
-.set s_dbg, 60
-.set s_tmp, 62
-.set s_end, 68
+.set s_tmp, 60
+.set s_end, 66
 
 .set v_c, 0  ; coalescing:8, needed:2, resuable:26
 .set v_a, 2
@@ -3828,11 +3740,6 @@ igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x128x8_wt8x32_ws2x1_wr2x2_ta1x1x2x1_1x8x1x3
     ; clear vector r
     .v_clear_nc v_c+1, v_end-1
 
-    ; debug vgpr
-    v_mov_b32 v1, 0
-    v_add_lshl_u32 v[v_tmp+6], v0, v1, 2
-    ;v_lshlrev_b32 v[114], 2, v0 ; every thread write one float
-    s_load_dwordx2 s[s_dbg+0:s_dbg+1], s[s_ka:s_ka+1], k_p_wei
     ; input, thread(n0,n1b,c0,c1e): 1x1x4x1, cluster(n0,n1b,c0,c1e): 1x8x1x32
     v_mov_b32 v[v_tmp], v0
     v_and_b32 v[v_gtc_ic1e], 31, v[v_tmp]
@@ -4641,29 +4548,6 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x128x8_wt8x32_ws2x1_wr2x2_ta1x1x2x1_1x8x1
     s_mul_i32 s[s_tmp], 59, s[s_wei_stride_k]   ; i_m:59(i_m0:1,i_m1:27)
     buffer_atomic_add_f32 v[v_c+7], v[v_wei_os], s[s_p_wei:s_p_wei+3], s[s_tmp] offen offset:0
 
-    s_branch L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x128x8_wt8x32_ws2x1_wr2x2_ta1x1x2x1_1x8x1x32_tb1x1x4x1_1x8x1x32_gkgs_out
-    ; debug code to cpy vgpr to host
-    L_debug_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x128x8_wt8x32_ws2x1_wr2x2_ta1x1x2x1_1x8x1x32_tb1x1x4x1_1x8x1x32_gkgs_out_1:
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-    s_cmp_lg_u32 s[s_bx], 0
-    s_cbranch_scc1 L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x128x8_wt8x32_ws2x1_wr2x2_ta1x1x2x1_1x8x1x32_tb1x1x4x1_1x8x1x32_gkgs_out_1
-    ;s_cmp_lg_u32 s[s_wave_id], 0
-    ;s_cbranch_scc1  L_program_end
-    ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
-    v_mov_b32 v[v_tmp], s[s_in_offset]
-
-    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
-    s_waitcnt vmcnt(0)
-    s_barrier
-
-    L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x128x8_wt8x32_ws2x1_wr2x2_ta1x1x2x1_1x8x1x32_tb1x1x4x1_1x8x1x32_gkgs_out_1:
-    s_nop 2
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-
 L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x128x8_wt8x32_ws2x1_wr2x2_ta1x1x2x1_1x8x1x32_tb1x1x4x1_1x8x1x32_gkgs_out:
     s_endpgm
 .rodata
@@ -4674,7 +4558,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x128x8_wt8x32_ws2x1_wr2x2_ta1x1x2x1_1x8x1
     .amdhsa_system_sgpr_workgroup_id_x 1
     .amdhsa_system_vgpr_workitem_id 0
     .amdhsa_next_free_vgpr 64
-    .amdhsa_next_free_sgpr 74
+    .amdhsa_next_free_sgpr 72
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
 .end_amdhsa_kernel

--- a/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_064x128.inc
+++ b/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_064x128.inc
@@ -1311,7 +1311,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x128x16_wt8x32_ws2x1_wr2x2_ta1x1x4x1_1x16
     ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
     v_mov_b32 v[v_tmp], s[s_in_offset]
 
-    global_store_dword v[v_tmp+6:v_tmp+7], v[v_in_os], s[s_dbg+0:s_dbg+1]
+    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
     s_waitcnt vmcnt(0)
     s_barrier
 
@@ -2622,7 +2622,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x128x16_wt8x32_ws2x1_wr2x2_ta1x1x4x1_1x16
     ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
     v_mov_b32 v[v_tmp], s[s_in_offset]
 
-    global_store_dword v[v_tmp+6:v_tmp+7], v[v_in_os], s[s_dbg+0:s_dbg+1]
+    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
     s_waitcnt vmcnt(0)
     s_barrier
 
@@ -3638,7 +3638,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x128x8_wt8x32_ws2x1_wr2x2_ta1x1x2x1_1x8x1
     ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
     v_mov_b32 v[v_tmp], s[s_in_offset]
 
-    global_store_dword v[v_tmp+6:v_tmp+7], v[v_in_os], s[s_dbg+0:s_dbg+1]
+    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
     s_waitcnt vmcnt(0)
     s_barrier
 
@@ -4654,7 +4654,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x128x8_wt8x32_ws2x1_wr2x2_ta1x1x2x1_1x8x1
     ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
     v_mov_b32 v[v_tmp], s[s_in_offset]
 
-    global_store_dword v[v_tmp+6:v_tmp+7], v[v_in_os], s[s_dbg+0:s_dbg+1]
+    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
     s_waitcnt vmcnt(0)
     s_barrier
 

--- a/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_064x256.inc
+++ b/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_064x256.inc
@@ -1315,7 +1315,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x256x16_wt16x64_ws1x1_wr2x2_ta1x1x4x1_1x1
     ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
     v_mov_b32 v[v_tmp], s[s_in_offset]
 
-    global_store_dword v[v_tmp+6:v_tmp+7], v[v_in_os], s[s_dbg+0:s_dbg+1]
+    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
     s_waitcnt vmcnt(0)
     s_barrier
 
@@ -2630,7 +2630,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x256x16_wt16x64_ws1x1_wr2x2_ta1x1x4x1_1x1
     ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
     v_mov_b32 v[v_tmp], s[s_in_offset]
 
-    global_store_dword v[v_tmp+6:v_tmp+7], v[v_in_os], s[s_dbg+0:s_dbg+1]
+    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
     s_waitcnt vmcnt(0)
     s_barrier
 
@@ -3690,7 +3690,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x256x8_wt16x64_ws1x1_wr2x2_ta1x1x2x1_1x8x
     ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
     v_mov_b32 v[v_tmp], s[s_in_offset]
 
-    global_store_dword v[v_tmp+6:v_tmp+7], v[v_in_os], s[s_dbg+0:s_dbg+1]
+    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
     s_waitcnt vmcnt(0)
     s_barrier
 
@@ -4750,7 +4750,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x256x8_wt16x64_ws1x1_wr2x2_ta1x1x2x1_1x8x
     ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
     v_mov_b32 v[v_tmp], s[s_in_offset]
 
-    global_store_dword v[v_tmp+6:v_tmp+7], v[v_in_os], s[s_dbg+0:s_dbg+1]
+    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
     s_waitcnt vmcnt(0)
     s_barrier
 

--- a/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_064x256.inc
+++ b/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_064x256.inc
@@ -124,9 +124,8 @@
 .set s_sub_n, 72
 .set s_group_stride, 73
 .set s_group_left, 1
-.set s_dbg, 74
-.set s_tmp, 76
-.set s_end, 82
+.set s_tmp, 74
+.set s_end, 80
 
 .set v_c, 0  ; coalescing:32, needed:2, resuable:36
 .set v_a, 2
@@ -190,11 +189,6 @@ igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x256x16_wt16x64_ws1x1_wr2x2_ta1x1x4x1_1x16x
     ; clear vector r
     .v_clear_nc v_c+1, v_end-1
 
-    ; debug vgpr
-    v_mov_b32 v1, 0
-    v_add_lshl_u32 v[v_tmp+6], v0, v1, 2
-    ;v_lshlrev_b32 v[114], 2, v0 ; every thread write one float
-    s_load_dwordx2 s[s_dbg+0:s_dbg+1], s[s_ka:s_ka+1], k_p_wei
     ; input, thread(n0,n1b,c0,c1e): 1x1x16x1, cluster(n0,n1b,c0,c1e): 1x16x1x16
     v_mov_b32 v[v_tmp], v0
     v_and_b32 v[v_gtc_ic1e], 15, v[v_tmp]
@@ -1302,29 +1296,6 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x256x16_wt16x64_ws1x1_wr2x2_ta1x1x4x1_1x1
     s_mul_i32 s[s_tmp], 63, s[s_wei_stride_k]   ; i_m:63(i_m0:3,i_m1:15)
     buffer_store_dword v[v_c+31], v[v_wei_os], s[s_p_wei:s_p_wei+3], s[s_tmp] offen offset:0
 
-    s_branch L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x256x16_wt16x64_ws1x1_wr2x2_ta1x1x4x1_1x16x1x16_tb1x1x16x1_1x16x1x16_out
-    ; debug code to cpy vgpr to host
-    L_debug_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x256x16_wt16x64_ws1x1_wr2x2_ta1x1x4x1_1x16x1x16_tb1x1x16x1_1x16x1x16_out_1:
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-    s_cmp_lg_u32 s[s_bx], 0
-    s_cbranch_scc1 L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x256x16_wt16x64_ws1x1_wr2x2_ta1x1x4x1_1x16x1x16_tb1x1x16x1_1x16x1x16_out_1
-    ;s_cmp_lg_u32 s[s_wave_id], 0
-    ;s_cbranch_scc1  L_program_end
-    ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
-    v_mov_b32 v[v_tmp], s[s_in_offset]
-
-    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
-    s_waitcnt vmcnt(0)
-    s_barrier
-
-    L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x256x16_wt16x64_ws1x1_wr2x2_ta1x1x4x1_1x16x1x16_tb1x1x16x1_1x16x1x16_out_1:
-    s_nop 2
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-
 L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x256x16_wt16x64_ws1x1_wr2x2_ta1x1x4x1_1x16x1x16_tb1x1x16x1_1x16x1x16_out:
     s_endpgm
 .rodata
@@ -1335,7 +1306,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x256x16_wt16x64_ws1x1_wr2x2_ta1x1x4x1_1x1
     .amdhsa_system_sgpr_workgroup_id_x 1
     .amdhsa_system_vgpr_workitem_id 0
     .amdhsa_next_free_vgpr 74
-    .amdhsa_next_free_sgpr 88
+    .amdhsa_next_free_sgpr 86
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
 .end_amdhsa_kernel
@@ -1439,9 +1410,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x256x16_wt16x64_ws1x1_wr2x2_ta1x1x4x1_1x1
 .set s_sub_n, 72
 .set s_group_stride, 73
 .set s_group_left, 1
-.set s_dbg, 74
-.set s_tmp, 76
-.set s_end, 82
+.set s_tmp, 74
+.set s_end, 80
 
 .set v_c, 0  ; coalescing:32, needed:2, resuable:36
 .set v_a, 2
@@ -1505,11 +1475,6 @@ igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x256x16_wt16x64_ws1x1_wr2x2_ta1x1x4x1_1x16x
     ; clear vector r
     .v_clear_nc v_c+1, v_end-1
 
-    ; debug vgpr
-    v_mov_b32 v1, 0
-    v_add_lshl_u32 v[v_tmp+6], v0, v1, 2
-    ;v_lshlrev_b32 v[114], 2, v0 ; every thread write one float
-    s_load_dwordx2 s[s_dbg+0:s_dbg+1], s[s_ka:s_ka+1], k_p_wei
     ; input, thread(n0,n1b,c0,c1e): 1x1x16x1, cluster(n0,n1b,c0,c1e): 1x16x1x16
     v_mov_b32 v[v_tmp], v0
     v_and_b32 v[v_gtc_ic1e], 15, v[v_tmp]
@@ -2617,29 +2582,6 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x256x16_wt16x64_ws1x1_wr2x2_ta1x1x4x1_1x1
     s_mul_i32 s[s_tmp], 63, s[s_wei_stride_k]   ; i_m:63(i_m0:3,i_m1:15)
     buffer_atomic_add_f32 v[v_c+31], v[v_wei_os], s[s_p_wei:s_p_wei+3], s[s_tmp] offen offset:0
 
-    s_branch L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x256x16_wt16x64_ws1x1_wr2x2_ta1x1x4x1_1x16x1x16_tb1x1x16x1_1x16x1x16_gkgs_out
-    ; debug code to cpy vgpr to host
-    L_debug_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x256x16_wt16x64_ws1x1_wr2x2_ta1x1x4x1_1x16x1x16_tb1x1x16x1_1x16x1x16_gkgs_out_1:
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-    s_cmp_lg_u32 s[s_bx], 0
-    s_cbranch_scc1 L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x256x16_wt16x64_ws1x1_wr2x2_ta1x1x4x1_1x16x1x16_tb1x1x16x1_1x16x1x16_gkgs_out_1
-    ;s_cmp_lg_u32 s[s_wave_id], 0
-    ;s_cbranch_scc1  L_program_end
-    ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
-    v_mov_b32 v[v_tmp], s[s_in_offset]
-
-    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
-    s_waitcnt vmcnt(0)
-    s_barrier
-
-    L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x256x16_wt16x64_ws1x1_wr2x2_ta1x1x4x1_1x16x1x16_tb1x1x16x1_1x16x1x16_gkgs_out_1:
-    s_nop 2
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-
 L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x256x16_wt16x64_ws1x1_wr2x2_ta1x1x4x1_1x16x1x16_tb1x1x16x1_1x16x1x16_gkgs_out:
     s_endpgm
 .rodata
@@ -2650,7 +2592,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x256x16_wt16x64_ws1x1_wr2x2_ta1x1x4x1_1x1
     .amdhsa_system_sgpr_workgroup_id_x 1
     .amdhsa_system_vgpr_workitem_id 0
     .amdhsa_next_free_vgpr 74
-    .amdhsa_next_free_sgpr 88
+    .amdhsa_next_free_sgpr 86
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
 .end_amdhsa_kernel
@@ -2754,9 +2696,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x256x16_wt16x64_ws1x1_wr2x2_ta1x1x4x1_1x1
 .set s_sub_n, 62
 .set s_group_stride, 63
 .set s_group_left, 1
-.set s_dbg, 64
-.set s_tmp, 66
-.set s_end, 72
+.set s_tmp, 64
+.set s_end, 70
 
 .set v_c, 0  ; coalescing:32, needed:6, resuable:26
 .set v_a, 6
@@ -2820,11 +2761,6 @@ igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x256x8_wt16x64_ws1x1_wr2x2_ta1x1x2x1_1x8x1x
     ; clear vector r
     .v_clear_nc v_c+1, v_end-1
 
-    ; debug vgpr
-    v_mov_b32 v1, 0
-    v_add_lshl_u32 v[v_tmp+6], v0, v1, 2
-    ;v_lshlrev_b32 v[114], 2, v0 ; every thread write one float
-    s_load_dwordx2 s[s_dbg+0:s_dbg+1], s[s_ka:s_ka+1], k_p_wei
     ; input, thread(n0,n1b,c0,c1e): 1x1x8x1, cluster(n0,n1b,c0,c1e): 1x8x1x32
     v_mov_b32 v[v_tmp], v0
     v_and_b32 v[v_gtc_ic1e], 31, v[v_tmp]
@@ -3677,29 +3613,6 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x256x8_wt16x64_ws1x1_wr2x2_ta1x1x2x1_1x8x
     s_mul_i32 s[s_tmp], 63, s[s_wei_stride_k]   ; i_m:63(i_m0:1,i_m1:31)
     buffer_store_dword v[v_c+31], v[v_wei_os], s[s_p_wei:s_p_wei+3], s[s_tmp] offen offset:0
 
-    s_branch L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x256x8_wt16x64_ws1x1_wr2x2_ta1x1x2x1_1x8x1x32_tb1x1x8x1_1x8x1x32_out
-    ; debug code to cpy vgpr to host
-    L_debug_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x256x8_wt16x64_ws1x1_wr2x2_ta1x1x2x1_1x8x1x32_tb1x1x8x1_1x8x1x32_out_1:
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-    s_cmp_lg_u32 s[s_bx], 0
-    s_cbranch_scc1 L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x256x8_wt16x64_ws1x1_wr2x2_ta1x1x2x1_1x8x1x32_tb1x1x8x1_1x8x1x32_out_1
-    ;s_cmp_lg_u32 s[s_wave_id], 0
-    ;s_cbranch_scc1  L_program_end
-    ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
-    v_mov_b32 v[v_tmp], s[s_in_offset]
-
-    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
-    s_waitcnt vmcnt(0)
-    s_barrier
-
-    L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x256x8_wt16x64_ws1x1_wr2x2_ta1x1x2x1_1x8x1x32_tb1x1x8x1_1x8x1x32_out_1:
-    s_nop 2
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-
 L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x256x8_wt16x64_ws1x1_wr2x2_ta1x1x2x1_1x8x1x32_tb1x1x8x1_1x8x1x32_out:
     s_endpgm
 .rodata
@@ -3710,7 +3623,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x256x8_wt16x64_ws1x1_wr2x2_ta1x1x2x1_1x8x
     .amdhsa_system_sgpr_workgroup_id_x 1
     .amdhsa_system_vgpr_workitem_id 0
     .amdhsa_next_free_vgpr 68
-    .amdhsa_next_free_sgpr 78
+    .amdhsa_next_free_sgpr 76
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
 .end_amdhsa_kernel
@@ -3814,9 +3727,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x256x8_wt16x64_ws1x1_wr2x2_ta1x1x2x1_1x8x
 .set s_sub_n, 62
 .set s_group_stride, 63
 .set s_group_left, 1
-.set s_dbg, 64
-.set s_tmp, 66
-.set s_end, 72
+.set s_tmp, 64
+.set s_end, 70
 
 .set v_c, 0  ; coalescing:32, needed:6, resuable:26
 .set v_a, 6
@@ -3880,11 +3792,6 @@ igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x256x8_wt16x64_ws1x1_wr2x2_ta1x1x2x1_1x8x1x
     ; clear vector r
     .v_clear_nc v_c+1, v_end-1
 
-    ; debug vgpr
-    v_mov_b32 v1, 0
-    v_add_lshl_u32 v[v_tmp+6], v0, v1, 2
-    ;v_lshlrev_b32 v[114], 2, v0 ; every thread write one float
-    s_load_dwordx2 s[s_dbg+0:s_dbg+1], s[s_ka:s_ka+1], k_p_wei
     ; input, thread(n0,n1b,c0,c1e): 1x1x8x1, cluster(n0,n1b,c0,c1e): 1x8x1x32
     v_mov_b32 v[v_tmp], v0
     v_and_b32 v[v_gtc_ic1e], 31, v[v_tmp]
@@ -4737,29 +4644,6 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x256x8_wt16x64_ws1x1_wr2x2_ta1x1x2x1_1x8x
     s_mul_i32 s[s_tmp], 63, s[s_wei_stride_k]   ; i_m:63(i_m0:1,i_m1:31)
     buffer_atomic_add_f32 v[v_c+31], v[v_wei_os], s[s_p_wei:s_p_wei+3], s[s_tmp] offen offset:0
 
-    s_branch L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x256x8_wt16x64_ws1x1_wr2x2_ta1x1x2x1_1x8x1x32_tb1x1x8x1_1x8x1x32_gkgs_out
-    ; debug code to cpy vgpr to host
-    L_debug_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x256x8_wt16x64_ws1x1_wr2x2_ta1x1x2x1_1x8x1x32_tb1x1x8x1_1x8x1x32_gkgs_out_1:
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-    s_cmp_lg_u32 s[s_bx], 0
-    s_cbranch_scc1 L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x256x8_wt16x64_ws1x1_wr2x2_ta1x1x2x1_1x8x1x32_tb1x1x8x1_1x8x1x32_gkgs_out_1
-    ;s_cmp_lg_u32 s[s_wave_id], 0
-    ;s_cbranch_scc1  L_program_end
-    ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
-    v_mov_b32 v[v_tmp], s[s_in_offset]
-
-    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
-    s_waitcnt vmcnt(0)
-    s_barrier
-
-    L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x256x8_wt16x64_ws1x1_wr2x2_ta1x1x2x1_1x8x1x32_tb1x1x8x1_1x8x1x32_gkgs_out_1:
-    s_nop 2
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-
 L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x256x8_wt16x64_ws1x1_wr2x2_ta1x1x2x1_1x8x1x32_tb1x1x8x1_1x8x1x32_gkgs_out:
     s_endpgm
 .rodata
@@ -4770,7 +4654,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x256x8_wt16x64_ws1x1_wr2x2_ta1x1x2x1_1x8x
     .amdhsa_system_sgpr_workgroup_id_x 1
     .amdhsa_system_vgpr_workitem_id 0
     .amdhsa_next_free_vgpr 68
-    .amdhsa_next_free_sgpr 78
+    .amdhsa_next_free_sgpr 76
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
 .end_amdhsa_kernel

--- a/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_128x032.inc
+++ b/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_128x032.inc
@@ -1102,7 +1102,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x32x16_wt32x8_ws1x1_wr2x2_ta1x1x8x1_1x16
     ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
     v_mov_b32 v[v_tmp], s[s_in_offset]
 
-    global_store_dword v[v_tmp+6:v_tmp+7], v[v_in_os], s[s_dbg+0:s_dbg+1]
+    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
     s_waitcnt vmcnt(0)
     s_barrier
 
@@ -2204,7 +2204,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x32x16_wt32x8_ws1x1_wr2x2_ta1x1x8x1_1x16
     ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
     v_mov_b32 v[v_tmp], s[s_in_offset]
 
-    global_store_dword v[v_tmp+6:v_tmp+7], v[v_in_os], s[s_dbg+0:s_dbg+1]
+    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
     s_waitcnt vmcnt(0)
     s_barrier
 
@@ -3073,7 +3073,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x32x8_wt32x8_ws1x1_wr2x2_ta1x1x4x1_1x8x1
     ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
     v_mov_b32 v[v_tmp], s[s_in_offset]
 
-    global_store_dword v[v_tmp+6:v_tmp+7], v[v_in_os], s[s_dbg+0:s_dbg+1]
+    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
     s_waitcnt vmcnt(0)
     s_barrier
 
@@ -3942,7 +3942,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x32x8_wt32x8_ws1x1_wr2x2_ta1x1x4x1_1x8x1
     ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
     v_mov_b32 v[v_tmp], s[s_in_offset]
 
-    global_store_dword v[v_tmp+6:v_tmp+7], v[v_in_os], s[s_dbg+0:s_dbg+1]
+    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
     s_waitcnt vmcnt(0)
     s_barrier
 

--- a/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_128x032.inc
+++ b/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_128x032.inc
@@ -124,9 +124,8 @@
 .set s_sub_n, 62
 .set s_group_stride, 63
 .set s_group_left, 1
-.set s_dbg, 64
-.set s_tmp, 66
-.set s_end, 72
+.set s_tmp, 64
+.set s_end, 70
 
 .set v_c, 0  ; coalescing:16, needed:2, resuable:26
 .set v_a, 2
@@ -190,11 +189,6 @@ igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x32x16_wt32x8_ws1x1_wr2x2_ta1x1x8x1_1x16x1
     ; clear vector r
     .v_clear_nc v_c+1, v_end-1
 
-    ; debug vgpr
-    v_mov_b32 v1, 0
-    v_add_lshl_u32 v[v_tmp+6], v0, v1, 2
-    ;v_lshlrev_b32 v[114], 2, v0 ; every thread write one float
-    s_load_dwordx2 s[s_dbg+0:s_dbg+1], s[s_ka:s_ka+1], k_p_wei
     ; input, thread(n0,n1b,c0,c1e): 1x1x2x1, cluster(n0,n1b,c0,c1e): 1x16x1x16
     v_mov_b32 v[v_tmp], v0
     v_and_b32 v[v_gtc_ic1e], 15, v[v_tmp]
@@ -1089,29 +1083,6 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x32x16_wt32x8_ws1x1_wr2x2_ta1x1x8x1_1x16
     s_mul_i32 s[s_tmp], 99, s[s_wei_stride_k]   ; i_m:99(i_m0:6,i_m1:3)
     buffer_store_dword v[v_c+15], v[v_wei_os], s[s_p_wei:s_p_wei+3], s[s_tmp] offen offset:0
 
-    s_branch L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x32x16_wt32x8_ws1x1_wr2x2_ta1x1x8x1_1x16x1x16_tb1x1x2x1_1x16x1x16_out
-    ; debug code to cpy vgpr to host
-    L_debug_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x32x16_wt32x8_ws1x1_wr2x2_ta1x1x8x1_1x16x1x16_tb1x1x2x1_1x16x1x16_out_1:
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-    s_cmp_lg_u32 s[s_bx], 0
-    s_cbranch_scc1 L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x32x16_wt32x8_ws1x1_wr2x2_ta1x1x8x1_1x16x1x16_tb1x1x2x1_1x16x1x16_out_1
-    ;s_cmp_lg_u32 s[s_wave_id], 0
-    ;s_cbranch_scc1  L_program_end
-    ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
-    v_mov_b32 v[v_tmp], s[s_in_offset]
-
-    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
-    s_waitcnt vmcnt(0)
-    s_barrier
-
-    L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x32x16_wt32x8_ws1x1_wr2x2_ta1x1x8x1_1x16x1x16_tb1x1x2x1_1x16x1x16_out_1:
-    s_nop 2
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-
 L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x32x16_wt32x8_ws1x1_wr2x2_ta1x1x8x1_1x16x1x16_tb1x1x2x1_1x16x1x16_out:
     s_endpgm
 .rodata
@@ -1122,7 +1093,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x32x16_wt32x8_ws1x1_wr2x2_ta1x1x8x1_1x16
     .amdhsa_system_sgpr_workgroup_id_x 1
     .amdhsa_system_vgpr_workitem_id 0
     .amdhsa_next_free_vgpr 64
-    .amdhsa_next_free_sgpr 78
+    .amdhsa_next_free_sgpr 76
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
 .end_amdhsa_kernel
@@ -1226,9 +1197,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x32x16_wt32x8_ws1x1_wr2x2_ta1x1x8x1_1x16
 .set s_sub_n, 62
 .set s_group_stride, 63
 .set s_group_left, 1
-.set s_dbg, 64
-.set s_tmp, 66
-.set s_end, 72
+.set s_tmp, 64
+.set s_end, 70
 
 .set v_c, 0  ; coalescing:16, needed:2, resuable:26
 .set v_a, 2
@@ -1292,11 +1262,6 @@ igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x32x16_wt32x8_ws1x1_wr2x2_ta1x1x8x1_1x16x1
     ; clear vector r
     .v_clear_nc v_c+1, v_end-1
 
-    ; debug vgpr
-    v_mov_b32 v1, 0
-    v_add_lshl_u32 v[v_tmp+6], v0, v1, 2
-    ;v_lshlrev_b32 v[114], 2, v0 ; every thread write one float
-    s_load_dwordx2 s[s_dbg+0:s_dbg+1], s[s_ka:s_ka+1], k_p_wei
     ; input, thread(n0,n1b,c0,c1e): 1x1x2x1, cluster(n0,n1b,c0,c1e): 1x16x1x16
     v_mov_b32 v[v_tmp], v0
     v_and_b32 v[v_gtc_ic1e], 15, v[v_tmp]
@@ -2191,29 +2156,6 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x32x16_wt32x8_ws1x1_wr2x2_ta1x1x8x1_1x16
     s_mul_i32 s[s_tmp], 99, s[s_wei_stride_k]   ; i_m:99(i_m0:6,i_m1:3)
     buffer_atomic_add_f32 v[v_c+15], v[v_wei_os], s[s_p_wei:s_p_wei+3], s[s_tmp] offen offset:0
 
-    s_branch L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x32x16_wt32x8_ws1x1_wr2x2_ta1x1x8x1_1x16x1x16_tb1x1x2x1_1x16x1x16_gkgs_out
-    ; debug code to cpy vgpr to host
-    L_debug_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x32x16_wt32x8_ws1x1_wr2x2_ta1x1x8x1_1x16x1x16_tb1x1x2x1_1x16x1x16_gkgs_out_1:
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-    s_cmp_lg_u32 s[s_bx], 0
-    s_cbranch_scc1 L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x32x16_wt32x8_ws1x1_wr2x2_ta1x1x8x1_1x16x1x16_tb1x1x2x1_1x16x1x16_gkgs_out_1
-    ;s_cmp_lg_u32 s[s_wave_id], 0
-    ;s_cbranch_scc1  L_program_end
-    ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
-    v_mov_b32 v[v_tmp], s[s_in_offset]
-
-    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
-    s_waitcnt vmcnt(0)
-    s_barrier
-
-    L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x32x16_wt32x8_ws1x1_wr2x2_ta1x1x8x1_1x16x1x16_tb1x1x2x1_1x16x1x16_gkgs_out_1:
-    s_nop 2
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-
 L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x32x16_wt32x8_ws1x1_wr2x2_ta1x1x8x1_1x16x1x16_tb1x1x2x1_1x16x1x16_gkgs_out:
     s_endpgm
 .rodata
@@ -2224,7 +2166,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x32x16_wt32x8_ws1x1_wr2x2_ta1x1x8x1_1x16
     .amdhsa_system_sgpr_workgroup_id_x 1
     .amdhsa_system_vgpr_workitem_id 0
     .amdhsa_next_free_vgpr 64
-    .amdhsa_next_free_sgpr 78
+    .amdhsa_next_free_sgpr 76
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
 .end_amdhsa_kernel
@@ -2328,9 +2270,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x32x16_wt32x8_ws1x1_wr2x2_ta1x1x8x1_1x16
 .set s_sub_n, 58
 .set s_group_stride, 59
 .set s_group_left, 1
-.set s_dbg, 60
-.set s_tmp, 62
-.set s_end, 68
+.set s_tmp, 60
+.set s_end, 66
 
 .set v_c, 0  ; coalescing:8, needed:2, resuable:21
 .set v_a, 2
@@ -2394,11 +2335,6 @@ igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x32x8_wt32x8_ws1x1_wr2x2_ta1x1x4x1_1x8x1x3
     ; clear vector r
     .v_clear_nc v_c+1, v_end-1
 
-    ; debug vgpr
-    v_mov_b32 v1, 0
-    v_add_lshl_u32 v[v_tmp+6], v0, v1, 2
-    ;v_lshlrev_b32 v[114], 2, v0 ; every thread write one float
-    s_load_dwordx2 s[s_dbg+0:s_dbg+1], s[s_ka:s_ka+1], k_p_wei
     ; input, thread(n0,n1b,c0,c1e): 1x1x1x1, cluster(n0,n1b,c0,c1e): 1x8x1x32
     v_mov_b32 v[v_tmp], v0
     v_and_b32 v[v_gtc_ic1e], 31, v[v_tmp]
@@ -3060,29 +2996,6 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x32x8_wt32x8_ws1x1_wr2x2_ta1x1x4x1_1x8x1
     s_mul_i32 s[s_tmp], 99, s[s_wei_stride_k]   ; i_m:99(i_m0:3,i_m1:3)
     buffer_store_dword v[v_c+7], v[v_wei_os], s[s_p_wei:s_p_wei+3], s[s_tmp] offen offset:0
 
-    s_branch L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x32x8_wt32x8_ws1x1_wr2x2_ta1x1x4x1_1x8x1x32_tb1x1x1x1_1x8x1x32_out
-    ; debug code to cpy vgpr to host
-    L_debug_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x32x8_wt32x8_ws1x1_wr2x2_ta1x1x4x1_1x8x1x32_tb1x1x1x1_1x8x1x32_out_1:
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-    s_cmp_lg_u32 s[s_bx], 0
-    s_cbranch_scc1 L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x32x8_wt32x8_ws1x1_wr2x2_ta1x1x4x1_1x8x1x32_tb1x1x1x1_1x8x1x32_out_1
-    ;s_cmp_lg_u32 s[s_wave_id], 0
-    ;s_cbranch_scc1  L_program_end
-    ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
-    v_mov_b32 v[v_tmp], s[s_in_offset]
-
-    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
-    s_waitcnt vmcnt(0)
-    s_barrier
-
-    L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x32x8_wt32x8_ws1x1_wr2x2_ta1x1x4x1_1x8x1x32_tb1x1x1x1_1x8x1x32_out_1:
-    s_nop 2
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-
 L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x32x8_wt32x8_ws1x1_wr2x2_ta1x1x4x1_1x8x1x32_tb1x1x1x1_1x8x1x32_out:
     s_endpgm
 .rodata
@@ -3093,7 +3006,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x32x8_wt32x8_ws1x1_wr2x2_ta1x1x4x1_1x8x1
     .amdhsa_system_sgpr_workgroup_id_x 1
     .amdhsa_system_vgpr_workitem_id 0
     .amdhsa_next_free_vgpr 60
-    .amdhsa_next_free_sgpr 74
+    .amdhsa_next_free_sgpr 72
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
 .end_amdhsa_kernel
@@ -3197,9 +3110,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x32x8_wt32x8_ws1x1_wr2x2_ta1x1x4x1_1x8x1
 .set s_sub_n, 58
 .set s_group_stride, 59
 .set s_group_left, 1
-.set s_dbg, 60
-.set s_tmp, 62
-.set s_end, 68
+.set s_tmp, 60
+.set s_end, 66
 
 .set v_c, 0  ; coalescing:8, needed:2, resuable:21
 .set v_a, 2
@@ -3263,11 +3175,6 @@ igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x32x8_wt32x8_ws1x1_wr2x2_ta1x1x4x1_1x8x1x3
     ; clear vector r
     .v_clear_nc v_c+1, v_end-1
 
-    ; debug vgpr
-    v_mov_b32 v1, 0
-    v_add_lshl_u32 v[v_tmp+6], v0, v1, 2
-    ;v_lshlrev_b32 v[114], 2, v0 ; every thread write one float
-    s_load_dwordx2 s[s_dbg+0:s_dbg+1], s[s_ka:s_ka+1], k_p_wei
     ; input, thread(n0,n1b,c0,c1e): 1x1x1x1, cluster(n0,n1b,c0,c1e): 1x8x1x32
     v_mov_b32 v[v_tmp], v0
     v_and_b32 v[v_gtc_ic1e], 31, v[v_tmp]
@@ -3929,29 +3836,6 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x32x8_wt32x8_ws1x1_wr2x2_ta1x1x4x1_1x8x1
     s_mul_i32 s[s_tmp], 99, s[s_wei_stride_k]   ; i_m:99(i_m0:3,i_m1:3)
     buffer_atomic_add_f32 v[v_c+7], v[v_wei_os], s[s_p_wei:s_p_wei+3], s[s_tmp] offen offset:0
 
-    s_branch L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x32x8_wt32x8_ws1x1_wr2x2_ta1x1x4x1_1x8x1x32_tb1x1x1x1_1x8x1x32_gkgs_out
-    ; debug code to cpy vgpr to host
-    L_debug_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x32x8_wt32x8_ws1x1_wr2x2_ta1x1x4x1_1x8x1x32_tb1x1x1x1_1x8x1x32_gkgs_out_1:
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-    s_cmp_lg_u32 s[s_bx], 0
-    s_cbranch_scc1 L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x32x8_wt32x8_ws1x1_wr2x2_ta1x1x4x1_1x8x1x32_tb1x1x1x1_1x8x1x32_gkgs_out_1
-    ;s_cmp_lg_u32 s[s_wave_id], 0
-    ;s_cbranch_scc1  L_program_end
-    ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
-    v_mov_b32 v[v_tmp], s[s_in_offset]
-
-    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
-    s_waitcnt vmcnt(0)
-    s_barrier
-
-    L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x32x8_wt32x8_ws1x1_wr2x2_ta1x1x4x1_1x8x1x32_tb1x1x1x1_1x8x1x32_gkgs_out_1:
-    s_nop 2
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-
 L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x32x8_wt32x8_ws1x1_wr2x2_ta1x1x4x1_1x8x1x32_tb1x1x1x1_1x8x1x32_gkgs_out:
     s_endpgm
 .rodata
@@ -3962,7 +3846,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x32x8_wt32x8_ws1x1_wr2x2_ta1x1x4x1_1x8x1
     .amdhsa_system_sgpr_workgroup_id_x 1
     .amdhsa_system_vgpr_workitem_id 0
     .amdhsa_next_free_vgpr 60
-    .amdhsa_next_free_sgpr 74
+    .amdhsa_next_free_sgpr 72
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
 .end_amdhsa_kernel

--- a/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_128x064.inc
+++ b/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_128x064.inc
@@ -124,9 +124,8 @@
 .set s_sub_n, 56
 .set s_group_stride, 57
 .set s_group_left, 1
-.set s_dbg, 58
-.set s_tmp, 60
-.set s_end, 66
+.set s_tmp, 58
+.set s_end, 64
 
 .set v_c, 0  ; coalescing:16, needed:2, resuable:32
 .set v_a, 2
@@ -190,11 +189,6 @@ igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt128x64x16_wt32x8_ws1x2_wr2x2_ta1x4x2x1_1x4x1x
     ; clear vector r
     .v_clear_nc v_c+1, v_end-1
 
-    ; debug vgpr
-    v_mov_b32 v1, 0
-    v_add_lshl_u32 v[v_tmp+6], v0, v1, 2
-    ;v_lshlrev_b32 v[114], 2, v0 ; every thread write one float
-    s_load_dwordx2 s[s_dbg+0:s_dbg+1], s[s_ka:s_ka+1], k_p_wei
     ; input, thread(n0,n1b,c0,c1e): 1x4x1x1, cluster(n0,n1b,c0,c1e): 1x4x1x64
     v_mov_b32 v[v_tmp], v0
     v_and_b32 v[v_gtc_ic1e], 63, v[v_tmp]
@@ -1270,29 +1264,6 @@ L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt128x64x16_wt32x8_ws1x2_wr2x2_ta1x4x2x1_1x4x
     s_mul_i32 s[s_tmp], 115, s[s_wei_stride_k]   ; i_m:115(i_m0:1,i_m1:51)
     buffer_store_dword v[v_c+15], v[v_wei_os], s[s_p_wei:s_p_wei+3], s[s_tmp] offen offset:0
 
-    s_branch L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt128x64x16_wt32x8_ws1x2_wr2x2_ta1x4x2x1_1x4x1x64_tb1x4x1x1_1x4x1x64_out
-    ; debug code to cpy vgpr to host
-    L_debug_L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt128x64x16_wt32x8_ws1x2_wr2x2_ta1x4x2x1_1x4x1x64_tb1x4x1x1_1x4x1x64_out_1:
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-    s_cmp_lg_u32 s[s_bx], 0
-    s_cbranch_scc1 L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt128x64x16_wt32x8_ws1x2_wr2x2_ta1x4x2x1_1x4x1x64_tb1x4x1x1_1x4x1x64_out_1
-    ;s_cmp_lg_u32 s[s_wave_id], 0
-    ;s_cbranch_scc1  L_program_end
-    ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
-    v_mov_b32 v[v_tmp], s[s_in_offset]
-
-    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
-    s_waitcnt vmcnt(0)
-    s_barrier
-
-    L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt128x64x16_wt32x8_ws1x2_wr2x2_ta1x4x2x1_1x4x1x64_tb1x4x1x1_1x4x1x64_out_1:
-    s_nop 2
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-
 L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt128x64x16_wt32x8_ws1x2_wr2x2_ta1x4x2x1_1x4x1x64_tb1x4x1x1_1x4x1x64_out:
     s_endpgm
 .rodata
@@ -1303,7 +1274,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt128x64x16_wt32x8_ws1x2_wr2x2_ta1x4x2x1_1x4x
     .amdhsa_system_sgpr_workgroup_id_x 1
     .amdhsa_system_vgpr_workitem_id 0
     .amdhsa_next_free_vgpr 70
-    .amdhsa_next_free_sgpr 72
+    .amdhsa_next_free_sgpr 70
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
 .end_amdhsa_kernel
@@ -1407,9 +1378,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt128x64x16_wt32x8_ws1x2_wr2x2_ta1x4x2x1_1x4x
 .set s_sub_n, 56
 .set s_group_stride, 57
 .set s_group_left, 1
-.set s_dbg, 58
-.set s_tmp, 60
-.set s_end, 66
+.set s_tmp, 58
+.set s_end, 64
 
 .set v_c, 0  ; coalescing:16, needed:2, resuable:32
 .set v_a, 2
@@ -1473,11 +1443,6 @@ igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt128x64x16_wt32x8_ws1x2_wr2x2_ta1x4x2x1_1x4x1x
     ; clear vector r
     .v_clear_nc v_c+1, v_end-1
 
-    ; debug vgpr
-    v_mov_b32 v1, 0
-    v_add_lshl_u32 v[v_tmp+6], v0, v1, 2
-    ;v_lshlrev_b32 v[114], 2, v0 ; every thread write one float
-    s_load_dwordx2 s[s_dbg+0:s_dbg+1], s[s_ka:s_ka+1], k_p_wei
     ; input, thread(n0,n1b,c0,c1e): 1x4x1x1, cluster(n0,n1b,c0,c1e): 1x4x1x64
     v_mov_b32 v[v_tmp], v0
     v_and_b32 v[v_gtc_ic1e], 63, v[v_tmp]
@@ -2553,29 +2518,6 @@ L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt128x64x16_wt32x8_ws1x2_wr2x2_ta1x4x2x1_1x4x
     s_mul_i32 s[s_tmp], 115, s[s_wei_stride_k]   ; i_m:115(i_m0:1,i_m1:51)
     buffer_atomic_add_f32 v[v_c+15], v[v_wei_os], s[s_p_wei:s_p_wei+3], s[s_tmp] offen offset:0
 
-    s_branch L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt128x64x16_wt32x8_ws1x2_wr2x2_ta1x4x2x1_1x4x1x64_tb1x4x1x1_1x4x1x64_gkgs_out
-    ; debug code to cpy vgpr to host
-    L_debug_L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt128x64x16_wt32x8_ws1x2_wr2x2_ta1x4x2x1_1x4x1x64_tb1x4x1x1_1x4x1x64_gkgs_out_1:
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-    s_cmp_lg_u32 s[s_bx], 0
-    s_cbranch_scc1 L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt128x64x16_wt32x8_ws1x2_wr2x2_ta1x4x2x1_1x4x1x64_tb1x4x1x1_1x4x1x64_gkgs_out_1
-    ;s_cmp_lg_u32 s[s_wave_id], 0
-    ;s_cbranch_scc1  L_program_end
-    ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
-    v_mov_b32 v[v_tmp], s[s_in_offset]
-
-    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
-    s_waitcnt vmcnt(0)
-    s_barrier
-
-    L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt128x64x16_wt32x8_ws1x2_wr2x2_ta1x4x2x1_1x4x1x64_tb1x4x1x1_1x4x1x64_gkgs_out_1:
-    s_nop 2
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-
 L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt128x64x16_wt32x8_ws1x2_wr2x2_ta1x4x2x1_1x4x1x64_tb1x4x1x1_1x4x1x64_gkgs_out:
     s_endpgm
 .rodata
@@ -2586,7 +2528,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt128x64x16_wt32x8_ws1x2_wr2x2_ta1x4x2x1_1x4x
     .amdhsa_system_sgpr_workgroup_id_x 1
     .amdhsa_system_vgpr_workitem_id 0
     .amdhsa_next_free_vgpr 70
-    .amdhsa_next_free_sgpr 72
+    .amdhsa_next_free_sgpr 70
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
 .end_amdhsa_kernel
@@ -2690,9 +2632,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt128x64x16_wt32x8_ws1x2_wr2x2_ta1x4x2x1_1x4x
 .set s_sub_n, 64
 .set s_group_stride, 65
 .set s_group_left, 1
-.set s_dbg, 66
-.set s_tmp, 68
-.set s_end, 74
+.set s_tmp, 66
+.set s_end, 72
 
 .set v_c, 0  ; coalescing:16, needed:2, resuable:32
 .set v_a, 2
@@ -2756,11 +2697,6 @@ igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x64x16_wt32x8_ws1x2_wr2x2_ta1x1x8x1_1x16x1
     ; clear vector r
     .v_clear_nc v_c+1, v_end-1
 
-    ; debug vgpr
-    v_mov_b32 v1, 0
-    v_add_lshl_u32 v[v_tmp+6], v0, v1, 2
-    ;v_lshlrev_b32 v[114], 2, v0 ; every thread write one float
-    s_load_dwordx2 s[s_dbg+0:s_dbg+1], s[s_ka:s_ka+1], k_p_wei
     ; input, thread(n0,n1b,c0,c1e): 1x1x4x1, cluster(n0,n1b,c0,c1e): 1x16x1x16
     v_mov_b32 v[v_tmp], v0
     v_and_b32 v[v_gtc_ic1e], 15, v[v_tmp]
@@ -3864,29 +3800,6 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x64x16_wt32x8_ws1x2_wr2x2_ta1x1x8x1_1x16
     s_mul_i32 s[s_tmp], 115, s[s_wei_stride_k]   ; i_m:115(i_m0:7,i_m1:3)
     buffer_store_dword v[v_c+15], v[v_wei_os], s[s_p_wei:s_p_wei+3], s[s_tmp] offen offset:0
 
-    s_branch L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x64x16_wt32x8_ws1x2_wr2x2_ta1x1x8x1_1x16x1x16_tb1x1x4x1_1x16x1x16_out
-    ; debug code to cpy vgpr to host
-    L_debug_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x64x16_wt32x8_ws1x2_wr2x2_ta1x1x8x1_1x16x1x16_tb1x1x4x1_1x16x1x16_out_1:
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-    s_cmp_lg_u32 s[s_bx], 0
-    s_cbranch_scc1 L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x64x16_wt32x8_ws1x2_wr2x2_ta1x1x8x1_1x16x1x16_tb1x1x4x1_1x16x1x16_out_1
-    ;s_cmp_lg_u32 s[s_wave_id], 0
-    ;s_cbranch_scc1  L_program_end
-    ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
-    v_mov_b32 v[v_tmp], s[s_in_offset]
-
-    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
-    s_waitcnt vmcnt(0)
-    s_barrier
-
-    L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x64x16_wt32x8_ws1x2_wr2x2_ta1x1x8x1_1x16x1x16_tb1x1x4x1_1x16x1x16_out_1:
-    s_nop 2
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-
 L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x64x16_wt32x8_ws1x2_wr2x2_ta1x1x8x1_1x16x1x16_tb1x1x4x1_1x16x1x16_out:
     s_endpgm
 .rodata
@@ -3897,7 +3810,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x64x16_wt32x8_ws1x2_wr2x2_ta1x1x8x1_1x16
     .amdhsa_system_sgpr_workgroup_id_x 1
     .amdhsa_system_vgpr_workitem_id 0
     .amdhsa_next_free_vgpr 70
-    .amdhsa_next_free_sgpr 80
+    .amdhsa_next_free_sgpr 78
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
 .end_amdhsa_kernel
@@ -4001,9 +3914,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x64x16_wt32x8_ws1x2_wr2x2_ta1x1x8x1_1x16
 .set s_sub_n, 64
 .set s_group_stride, 65
 .set s_group_left, 1
-.set s_dbg, 66
-.set s_tmp, 68
-.set s_end, 74
+.set s_tmp, 66
+.set s_end, 72
 
 .set v_c, 0  ; coalescing:16, needed:2, resuable:32
 .set v_a, 2
@@ -4067,11 +3979,6 @@ igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x64x16_wt32x8_ws1x2_wr2x2_ta1x1x8x1_1x16x1
     ; clear vector r
     .v_clear_nc v_c+1, v_end-1
 
-    ; debug vgpr
-    v_mov_b32 v1, 0
-    v_add_lshl_u32 v[v_tmp+6], v0, v1, 2
-    ;v_lshlrev_b32 v[114], 2, v0 ; every thread write one float
-    s_load_dwordx2 s[s_dbg+0:s_dbg+1], s[s_ka:s_ka+1], k_p_wei
     ; input, thread(n0,n1b,c0,c1e): 1x1x4x1, cluster(n0,n1b,c0,c1e): 1x16x1x16
     v_mov_b32 v[v_tmp], v0
     v_and_b32 v[v_gtc_ic1e], 15, v[v_tmp]
@@ -5175,29 +5082,6 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x64x16_wt32x8_ws1x2_wr2x2_ta1x1x8x1_1x16
     s_mul_i32 s[s_tmp], 115, s[s_wei_stride_k]   ; i_m:115(i_m0:7,i_m1:3)
     buffer_atomic_add_f32 v[v_c+15], v[v_wei_os], s[s_p_wei:s_p_wei+3], s[s_tmp] offen offset:0
 
-    s_branch L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x64x16_wt32x8_ws1x2_wr2x2_ta1x1x8x1_1x16x1x16_tb1x1x4x1_1x16x1x16_gkgs_out
-    ; debug code to cpy vgpr to host
-    L_debug_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x64x16_wt32x8_ws1x2_wr2x2_ta1x1x8x1_1x16x1x16_tb1x1x4x1_1x16x1x16_gkgs_out_1:
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-    s_cmp_lg_u32 s[s_bx], 0
-    s_cbranch_scc1 L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x64x16_wt32x8_ws1x2_wr2x2_ta1x1x8x1_1x16x1x16_tb1x1x4x1_1x16x1x16_gkgs_out_1
-    ;s_cmp_lg_u32 s[s_wave_id], 0
-    ;s_cbranch_scc1  L_program_end
-    ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
-    v_mov_b32 v[v_tmp], s[s_in_offset]
-
-    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
-    s_waitcnt vmcnt(0)
-    s_barrier
-
-    L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x64x16_wt32x8_ws1x2_wr2x2_ta1x1x8x1_1x16x1x16_tb1x1x4x1_1x16x1x16_gkgs_out_1:
-    s_nop 2
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-
 L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x64x16_wt32x8_ws1x2_wr2x2_ta1x1x8x1_1x16x1x16_tb1x1x4x1_1x16x1x16_gkgs_out:
     s_endpgm
 .rodata
@@ -5208,7 +5092,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x64x16_wt32x8_ws1x2_wr2x2_ta1x1x8x1_1x16
     .amdhsa_system_sgpr_workgroup_id_x 1
     .amdhsa_system_vgpr_workitem_id 0
     .amdhsa_next_free_vgpr 70
-    .amdhsa_next_free_sgpr 80
+    .amdhsa_next_free_sgpr 78
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
 .end_amdhsa_kernel
@@ -5312,9 +5196,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x64x16_wt32x8_ws1x2_wr2x2_ta1x1x8x1_1x16
 .set s_sub_n, 58
 .set s_group_stride, 59
 .set s_group_left, 1
-.set s_dbg, 60
-.set s_tmp, 62
-.set s_end, 68
+.set s_tmp, 60
+.set s_end, 66
 
 .set v_c, 0  ; coalescing:16, needed:2, resuable:26
 .set v_a, 2
@@ -5378,11 +5261,6 @@ igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x64x8_wt32x8_ws1x2_wr2x2_ta1x1x4x1_1x8x1x3
     ; clear vector r
     .v_clear_nc v_c+1, v_end-1
 
-    ; debug vgpr
-    v_mov_b32 v1, 0
-    v_add_lshl_u32 v[v_tmp+6], v0, v1, 2
-    ;v_lshlrev_b32 v[114], 2, v0 ; every thread write one float
-    s_load_dwordx2 s[s_dbg+0:s_dbg+1], s[s_ka:s_ka+1], k_p_wei
     ; input, thread(n0,n1b,c0,c1e): 1x1x2x1, cluster(n0,n1b,c0,c1e): 1x8x1x32
     v_mov_b32 v[v_tmp], v0
     v_and_b32 v[v_gtc_ic1e], 31, v[v_tmp]
@@ -6179,29 +6057,6 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x64x8_wt32x8_ws1x2_wr2x2_ta1x1x4x1_1x8x1
     s_mul_i32 s[s_tmp], 115, s[s_wei_stride_k]   ; i_m:115(i_m0:3,i_m1:19)
     buffer_store_dword v[v_c+15], v[v_wei_os], s[s_p_wei:s_p_wei+3], s[s_tmp] offen offset:0
 
-    s_branch L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x64x8_wt32x8_ws1x2_wr2x2_ta1x1x4x1_1x8x1x32_tb1x1x2x1_1x8x1x32_out
-    ; debug code to cpy vgpr to host
-    L_debug_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x64x8_wt32x8_ws1x2_wr2x2_ta1x1x4x1_1x8x1x32_tb1x1x2x1_1x8x1x32_out_1:
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-    s_cmp_lg_u32 s[s_bx], 0
-    s_cbranch_scc1 L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x64x8_wt32x8_ws1x2_wr2x2_ta1x1x4x1_1x8x1x32_tb1x1x2x1_1x8x1x32_out_1
-    ;s_cmp_lg_u32 s[s_wave_id], 0
-    ;s_cbranch_scc1  L_program_end
-    ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
-    v_mov_b32 v[v_tmp], s[s_in_offset]
-
-    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
-    s_waitcnt vmcnt(0)
-    s_barrier
-
-    L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x64x8_wt32x8_ws1x2_wr2x2_ta1x1x4x1_1x8x1x32_tb1x1x2x1_1x8x1x32_out_1:
-    s_nop 2
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-
 L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x64x8_wt32x8_ws1x2_wr2x2_ta1x1x4x1_1x8x1x32_tb1x1x2x1_1x8x1x32_out:
     s_endpgm
 .rodata
@@ -6212,7 +6067,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x64x8_wt32x8_ws1x2_wr2x2_ta1x1x4x1_1x8x1
     .amdhsa_system_sgpr_workgroup_id_x 1
     .amdhsa_system_vgpr_workitem_id 0
     .amdhsa_next_free_vgpr 64
-    .amdhsa_next_free_sgpr 74
+    .amdhsa_next_free_sgpr 72
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
 .end_amdhsa_kernel
@@ -6316,9 +6171,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x64x8_wt32x8_ws1x2_wr2x2_ta1x1x4x1_1x8x1
 .set s_sub_n, 58
 .set s_group_stride, 59
 .set s_group_left, 1
-.set s_dbg, 60
-.set s_tmp, 62
-.set s_end, 68
+.set s_tmp, 60
+.set s_end, 66
 
 .set v_c, 0  ; coalescing:16, needed:2, resuable:26
 .set v_a, 2
@@ -6382,11 +6236,6 @@ igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x64x8_wt32x8_ws1x2_wr2x2_ta1x1x4x1_1x8x1x3
     ; clear vector r
     .v_clear_nc v_c+1, v_end-1
 
-    ; debug vgpr
-    v_mov_b32 v1, 0
-    v_add_lshl_u32 v[v_tmp+6], v0, v1, 2
-    ;v_lshlrev_b32 v[114], 2, v0 ; every thread write one float
-    s_load_dwordx2 s[s_dbg+0:s_dbg+1], s[s_ka:s_ka+1], k_p_wei
     ; input, thread(n0,n1b,c0,c1e): 1x1x2x1, cluster(n0,n1b,c0,c1e): 1x8x1x32
     v_mov_b32 v[v_tmp], v0
     v_and_b32 v[v_gtc_ic1e], 31, v[v_tmp]
@@ -7183,29 +7032,6 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x64x8_wt32x8_ws1x2_wr2x2_ta1x1x4x1_1x8x1
     s_mul_i32 s[s_tmp], 115, s[s_wei_stride_k]   ; i_m:115(i_m0:3,i_m1:19)
     buffer_atomic_add_f32 v[v_c+15], v[v_wei_os], s[s_p_wei:s_p_wei+3], s[s_tmp] offen offset:0
 
-    s_branch L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x64x8_wt32x8_ws1x2_wr2x2_ta1x1x4x1_1x8x1x32_tb1x1x2x1_1x8x1x32_gkgs_out
-    ; debug code to cpy vgpr to host
-    L_debug_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x64x8_wt32x8_ws1x2_wr2x2_ta1x1x4x1_1x8x1x32_tb1x1x2x1_1x8x1x32_gkgs_out_1:
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-    s_cmp_lg_u32 s[s_bx], 0
-    s_cbranch_scc1 L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x64x8_wt32x8_ws1x2_wr2x2_ta1x1x4x1_1x8x1x32_tb1x1x2x1_1x8x1x32_gkgs_out_1
-    ;s_cmp_lg_u32 s[s_wave_id], 0
-    ;s_cbranch_scc1  L_program_end
-    ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
-    v_mov_b32 v[v_tmp], s[s_in_offset]
-
-    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
-    s_waitcnt vmcnt(0)
-    s_barrier
-
-    L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x64x8_wt32x8_ws1x2_wr2x2_ta1x1x4x1_1x8x1x32_tb1x1x2x1_1x8x1x32_gkgs_out_1:
-    s_nop 2
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-
 L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x64x8_wt32x8_ws1x2_wr2x2_ta1x1x4x1_1x8x1x32_tb1x1x2x1_1x8x1x32_gkgs_out:
     s_endpgm
 .rodata
@@ -7216,7 +7042,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x64x8_wt32x8_ws1x2_wr2x2_ta1x1x4x1_1x8x1
     .amdhsa_system_sgpr_workgroup_id_x 1
     .amdhsa_system_vgpr_workitem_id 0
     .amdhsa_next_free_vgpr 64
-    .amdhsa_next_free_sgpr 74
+    .amdhsa_next_free_sgpr 72
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
 .end_amdhsa_kernel

--- a/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_128x064.inc
+++ b/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_128x064.inc
@@ -1283,7 +1283,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt128x64x16_wt32x8_ws1x2_wr2x2_ta1x4x2x1_1x4x
     ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
     v_mov_b32 v[v_tmp], s[s_in_offset]
 
-    global_store_dword v[v_tmp+6:v_tmp+7], v[v_in_os], s[s_dbg+0:s_dbg+1]
+    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
     s_waitcnt vmcnt(0)
     s_barrier
 
@@ -2566,7 +2566,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt128x64x16_wt32x8_ws1x2_wr2x2_ta1x4x2x1_1x4x
     ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
     v_mov_b32 v[v_tmp], s[s_in_offset]
 
-    global_store_dword v[v_tmp+6:v_tmp+7], v[v_in_os], s[s_dbg+0:s_dbg+1]
+    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
     s_waitcnt vmcnt(0)
     s_barrier
 
@@ -3877,7 +3877,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x64x16_wt32x8_ws1x2_wr2x2_ta1x1x8x1_1x16
     ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
     v_mov_b32 v[v_tmp], s[s_in_offset]
 
-    global_store_dword v[v_tmp+6:v_tmp+7], v[v_in_os], s[s_dbg+0:s_dbg+1]
+    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
     s_waitcnt vmcnt(0)
     s_barrier
 
@@ -5188,7 +5188,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x64x16_wt32x8_ws1x2_wr2x2_ta1x1x8x1_1x16
     ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
     v_mov_b32 v[v_tmp], s[s_in_offset]
 
-    global_store_dword v[v_tmp+6:v_tmp+7], v[v_in_os], s[s_dbg+0:s_dbg+1]
+    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
     s_waitcnt vmcnt(0)
     s_barrier
 
@@ -6192,7 +6192,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x64x8_wt32x8_ws1x2_wr2x2_ta1x1x4x1_1x8x1
     ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
     v_mov_b32 v[v_tmp], s[s_in_offset]
 
-    global_store_dword v[v_tmp+6:v_tmp+7], v[v_in_os], s[s_dbg+0:s_dbg+1]
+    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
     s_waitcnt vmcnt(0)
     s_barrier
 
@@ -7196,7 +7196,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x64x8_wt32x8_ws1x2_wr2x2_ta1x1x4x1_1x8x1
     ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
     v_mov_b32 v[v_tmp], s[s_in_offset]
 
-    global_store_dword v[v_tmp+6:v_tmp+7], v[v_in_os], s[s_dbg+0:s_dbg+1]
+    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
     s_waitcnt vmcnt(0)
     s_barrier
 

--- a/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_128x128.inc
+++ b/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_128x128.inc
@@ -1284,7 +1284,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt128x128x16_wt32x32_ws1x1_wr2x2_ta1x4x2x1_1x
     ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
     v_mov_b32 v[v_tmp], s[s_in_offset]
 
-    global_store_dword v[v_tmp+6:v_tmp+7], v[v_in_os], s[s_dbg+0:s_dbg+1]
+    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
     s_waitcnt vmcnt(0)
     s_barrier
 
@@ -2568,7 +2568,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt128x128x16_wt32x32_ws1x1_wr2x2_ta1x4x2x1_1x
     ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
     v_mov_b32 v[v_tmp], s[s_in_offset]
 
-    global_store_dword v[v_tmp+6:v_tmp+7], v[v_in_os], s[s_dbg+0:s_dbg+1]
+    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
     s_waitcnt vmcnt(0)
     s_barrier
 
@@ -3885,7 +3885,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x128x16_wt32x32_ws1x1_wr2x2_ta1x1x8x1_1x
     ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
     v_mov_b32 v[v_tmp], s[s_in_offset]
 
-    global_store_dword v[v_tmp+6:v_tmp+7], v[v_in_os], s[s_dbg+0:s_dbg+1]
+    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
     s_waitcnt vmcnt(0)
     s_barrier
 
@@ -5202,7 +5202,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x128x16_wt32x32_ws1x1_wr2x2_ta1x1x8x1_1x
     ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
     v_mov_b32 v[v_tmp], s[s_in_offset]
 
-    global_store_dword v[v_tmp+6:v_tmp+7], v[v_in_os], s[s_dbg+0:s_dbg+1]
+    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
     s_waitcnt vmcnt(0)
     s_barrier
 
@@ -6271,7 +6271,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x128x8_wt32x32_ws1x1_wr2x2_ta1x1x4x1_1x8
     ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
     v_mov_b32 v[v_tmp], s[s_in_offset]
 
-    global_store_dword v[v_tmp+6:v_tmp+7], v[v_in_os], s[s_dbg+0:s_dbg+1]
+    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
     s_waitcnt vmcnt(0)
     s_barrier
 
@@ -7340,7 +7340,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x128x8_wt32x32_ws1x1_wr2x2_ta1x1x4x1_1x8
     ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
     v_mov_b32 v[v_tmp], s[s_in_offset]
 
-    global_store_dword v[v_tmp+6:v_tmp+7], v[v_in_os], s[s_dbg+0:s_dbg+1]
+    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
     s_waitcnt vmcnt(0)
     s_barrier
 

--- a/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_128x128.inc
+++ b/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_128x128.inc
@@ -124,9 +124,8 @@
 .set s_sub_n, 56
 .set s_group_stride, 57
 .set s_group_left, 1
-.set s_dbg, 58
-.set s_tmp, 60
-.set s_end, 66
+.set s_tmp, 58
+.set s_end, 64
 
 .set v_c, 0  ; coalescing:16, needed:2, resuable:32
 .set v_a, 2
@@ -190,11 +189,6 @@ igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt128x128x16_wt32x32_ws1x1_wr2x2_ta1x4x2x1_1x4x
     ; clear vector r
     .v_clear_nc v_c+1, v_end-1
 
-    ; debug vgpr
-    v_mov_b32 v1, 0
-    v_add_lshl_u32 v[v_tmp+6], v0, v1, 2
-    ;v_lshlrev_b32 v[114], 2, v0 ; every thread write one float
-    s_load_dwordx2 s[s_dbg+0:s_dbg+1], s[s_ka:s_ka+1], k_p_wei
     ; input, thread(n0,n1b,c0,c1e): 1x4x2x1, cluster(n0,n1b,c0,c1e): 1x4x1x64
     v_mov_b32 v[v_tmp], v0
     v_and_b32 v[v_gtc_ic1e], 63, v[v_tmp]
@@ -1271,29 +1265,6 @@ L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt128x128x16_wt32x32_ws1x1_wr2x2_ta1x4x2x1_1x
     s_mul_i32 s[s_tmp], 123, s[s_wei_stride_k]   ; i_m:123(i_m0:1,i_m1:59)
     buffer_store_dword v[v_c+15], v[v_wei_os], s[s_p_wei:s_p_wei+3], s[s_tmp] offen offset:0
 
-    s_branch L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt128x128x16_wt32x32_ws1x1_wr2x2_ta1x4x2x1_1x4x1x64_tb1x4x2x1_1x4x1x64_out
-    ; debug code to cpy vgpr to host
-    L_debug_L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt128x128x16_wt32x32_ws1x1_wr2x2_ta1x4x2x1_1x4x1x64_tb1x4x2x1_1x4x1x64_out_1:
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-    s_cmp_lg_u32 s[s_bx], 0
-    s_cbranch_scc1 L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt128x128x16_wt32x32_ws1x1_wr2x2_ta1x4x2x1_1x4x1x64_tb1x4x2x1_1x4x1x64_out_1
-    ;s_cmp_lg_u32 s[s_wave_id], 0
-    ;s_cbranch_scc1  L_program_end
-    ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
-    v_mov_b32 v[v_tmp], s[s_in_offset]
-
-    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
-    s_waitcnt vmcnt(0)
-    s_barrier
-
-    L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt128x128x16_wt32x32_ws1x1_wr2x2_ta1x4x2x1_1x4x1x64_tb1x4x2x1_1x4x1x64_out_1:
-    s_nop 2
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-
 L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt128x128x16_wt32x32_ws1x1_wr2x2_ta1x4x2x1_1x4x1x64_tb1x4x2x1_1x4x1x64_out:
     s_endpgm
 .rodata
@@ -1304,7 +1275,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt128x128x16_wt32x32_ws1x1_wr2x2_ta1x4x2x1_1x
     .amdhsa_system_sgpr_workgroup_id_x 1
     .amdhsa_system_vgpr_workitem_id 0
     .amdhsa_next_free_vgpr 70
-    .amdhsa_next_free_sgpr 72
+    .amdhsa_next_free_sgpr 70
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
 .end_amdhsa_kernel
@@ -1408,9 +1379,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt128x128x16_wt32x32_ws1x1_wr2x2_ta1x4x2x1_1x
 .set s_sub_n, 56
 .set s_group_stride, 57
 .set s_group_left, 1
-.set s_dbg, 58
-.set s_tmp, 60
-.set s_end, 66
+.set s_tmp, 58
+.set s_end, 64
 
 .set v_c, 0  ; coalescing:16, needed:2, resuable:32
 .set v_a, 2
@@ -1474,11 +1444,6 @@ igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt128x128x16_wt32x32_ws1x1_wr2x2_ta1x4x2x1_1x4x
     ; clear vector r
     .v_clear_nc v_c+1, v_end-1
 
-    ; debug vgpr
-    v_mov_b32 v1, 0
-    v_add_lshl_u32 v[v_tmp+6], v0, v1, 2
-    ;v_lshlrev_b32 v[114], 2, v0 ; every thread write one float
-    s_load_dwordx2 s[s_dbg+0:s_dbg+1], s[s_ka:s_ka+1], k_p_wei
     ; input, thread(n0,n1b,c0,c1e): 1x4x2x1, cluster(n0,n1b,c0,c1e): 1x4x1x64
     v_mov_b32 v[v_tmp], v0
     v_and_b32 v[v_gtc_ic1e], 63, v[v_tmp]
@@ -2555,29 +2520,6 @@ L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt128x128x16_wt32x32_ws1x1_wr2x2_ta1x4x2x1_1x
     s_mul_i32 s[s_tmp], 123, s[s_wei_stride_k]   ; i_m:123(i_m0:1,i_m1:59)
     buffer_atomic_add_f32 v[v_c+15], v[v_wei_os], s[s_p_wei:s_p_wei+3], s[s_tmp] offen offset:0
 
-    s_branch L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt128x128x16_wt32x32_ws1x1_wr2x2_ta1x4x2x1_1x4x1x64_tb1x4x2x1_1x4x1x64_gkgs_out
-    ; debug code to cpy vgpr to host
-    L_debug_L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt128x128x16_wt32x32_ws1x1_wr2x2_ta1x4x2x1_1x4x1x64_tb1x4x2x1_1x4x1x64_gkgs_out_1:
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-    s_cmp_lg_u32 s[s_bx], 0
-    s_cbranch_scc1 L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt128x128x16_wt32x32_ws1x1_wr2x2_ta1x4x2x1_1x4x1x64_tb1x4x2x1_1x4x1x64_gkgs_out_1
-    ;s_cmp_lg_u32 s[s_wave_id], 0
-    ;s_cbranch_scc1  L_program_end
-    ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
-    v_mov_b32 v[v_tmp], s[s_in_offset]
-
-    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
-    s_waitcnt vmcnt(0)
-    s_barrier
-
-    L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt128x128x16_wt32x32_ws1x1_wr2x2_ta1x4x2x1_1x4x1x64_tb1x4x2x1_1x4x1x64_gkgs_out_1:
-    s_nop 2
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-
 L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt128x128x16_wt32x32_ws1x1_wr2x2_ta1x4x2x1_1x4x1x64_tb1x4x2x1_1x4x1x64_gkgs_out:
     s_endpgm
 .rodata
@@ -2588,7 +2530,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt128x128x16_wt32x32_ws1x1_wr2x2_ta1x4x2x1_1x
     .amdhsa_system_sgpr_workgroup_id_x 1
     .amdhsa_system_vgpr_workitem_id 0
     .amdhsa_next_free_vgpr 70
-    .amdhsa_next_free_sgpr 72
+    .amdhsa_next_free_sgpr 70
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
 .end_amdhsa_kernel
@@ -2692,9 +2634,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt128x128x16_wt32x32_ws1x1_wr2x2_ta1x4x2x1_1x
 .set s_sub_n, 68
 .set s_group_stride, 69
 .set s_group_left, 1
-.set s_dbg, 70
-.set s_tmp, 72
-.set s_end, 78
+.set s_tmp, 70
+.set s_end, 76
 
 .set v_c, 0  ; coalescing:16, needed:2, resuable:32
 .set v_a, 2
@@ -2758,11 +2699,6 @@ igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x128x16_wt32x32_ws1x1_wr2x2_ta1x1x8x1_1x16
     ; clear vector r
     .v_clear_nc v_c+1, v_end-1
 
-    ; debug vgpr
-    v_mov_b32 v1, 0
-    v_add_lshl_u32 v[v_tmp+6], v0, v1, 2
-    ;v_lshlrev_b32 v[114], 2, v0 ; every thread write one float
-    s_load_dwordx2 s[s_dbg+0:s_dbg+1], s[s_ka:s_ka+1], k_p_wei
     ; input, thread(n0,n1b,c0,c1e): 1x1x8x1, cluster(n0,n1b,c0,c1e): 1x16x1x16
     v_mov_b32 v[v_tmp], v0
     v_and_b32 v[v_gtc_ic1e], 15, v[v_tmp]
@@ -3872,29 +3808,6 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x128x16_wt32x32_ws1x1_wr2x2_ta1x1x8x1_1x
     s_mul_i32 s[s_tmp], 123, s[s_wei_stride_k]   ; i_m:123(i_m0:7,i_m1:11)
     buffer_atomic_add_f32 v[v_c+15], v[v_wei_os], s[s_p_wei:s_p_wei+3], s[s_tmp] offen offset:0
 
-    s_branch L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x128x16_wt32x32_ws1x1_wr2x2_ta1x1x8x1_1x16x1x16_tb1x1x8x1_1x16x1x16_gkgs_out
-    ; debug code to cpy vgpr to host
-    L_debug_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x128x16_wt32x32_ws1x1_wr2x2_ta1x1x8x1_1x16x1x16_tb1x1x8x1_1x16x1x16_gkgs_out_1:
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-    s_cmp_lg_u32 s[s_bx], 0
-    s_cbranch_scc1 L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x128x16_wt32x32_ws1x1_wr2x2_ta1x1x8x1_1x16x1x16_tb1x1x8x1_1x16x1x16_gkgs_out_1
-    ;s_cmp_lg_u32 s[s_wave_id], 0
-    ;s_cbranch_scc1  L_program_end
-    ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
-    v_mov_b32 v[v_tmp], s[s_in_offset]
-
-    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
-    s_waitcnt vmcnt(0)
-    s_barrier
-
-    L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x128x16_wt32x32_ws1x1_wr2x2_ta1x1x8x1_1x16x1x16_tb1x1x8x1_1x16x1x16_gkgs_out_1:
-    s_nop 2
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-
 L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x128x16_wt32x32_ws1x1_wr2x2_ta1x1x8x1_1x16x1x16_tb1x1x8x1_1x16x1x16_gkgs_out:
     s_endpgm
 .rodata
@@ -3905,7 +3818,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x128x16_wt32x32_ws1x1_wr2x2_ta1x1x8x1_1x
     .amdhsa_system_sgpr_workgroup_id_x 1
     .amdhsa_system_vgpr_workitem_id 0
     .amdhsa_next_free_vgpr 70
-    .amdhsa_next_free_sgpr 84
+    .amdhsa_next_free_sgpr 82
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
 .end_amdhsa_kernel
@@ -4009,9 +3922,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x128x16_wt32x32_ws1x1_wr2x2_ta1x1x8x1_1x
 .set s_sub_n, 68
 .set s_group_stride, 69
 .set s_group_left, 1
-.set s_dbg, 70
-.set s_tmp, 72
-.set s_end, 78
+.set s_tmp, 70
+.set s_end, 76
 
 .set v_c, 0  ; coalescing:16, needed:2, resuable:32
 .set v_a, 2
@@ -4075,11 +3987,6 @@ igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x128x16_wt32x32_ws1x1_wr2x2_ta1x1x8x1_1x16
     ; clear vector r
     .v_clear_nc v_c+1, v_end-1
 
-    ; debug vgpr
-    v_mov_b32 v1, 0
-    v_add_lshl_u32 v[v_tmp+6], v0, v1, 2
-    ;v_lshlrev_b32 v[114], 2, v0 ; every thread write one float
-    s_load_dwordx2 s[s_dbg+0:s_dbg+1], s[s_ka:s_ka+1], k_p_wei
     ; input, thread(n0,n1b,c0,c1e): 1x1x8x1, cluster(n0,n1b,c0,c1e): 1x16x1x16
     v_mov_b32 v[v_tmp], v0
     v_and_b32 v[v_gtc_ic1e], 15, v[v_tmp]
@@ -5189,29 +5096,6 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x128x16_wt32x32_ws1x1_wr2x2_ta1x1x8x1_1x
     s_mul_i32 s[s_tmp], 123, s[s_wei_stride_k]   ; i_m:123(i_m0:7,i_m1:11)
     buffer_store_dword v[v_c+15], v[v_wei_os], s[s_p_wei:s_p_wei+3], s[s_tmp] offen offset:0
 
-    s_branch L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x128x16_wt32x32_ws1x1_wr2x2_ta1x1x8x1_1x16x1x16_tb1x1x8x1_1x16x1x16_out
-    ; debug code to cpy vgpr to host
-    L_debug_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x128x16_wt32x32_ws1x1_wr2x2_ta1x1x8x1_1x16x1x16_tb1x1x8x1_1x16x1x16_out_1:
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-    s_cmp_lg_u32 s[s_bx], 0
-    s_cbranch_scc1 L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x128x16_wt32x32_ws1x1_wr2x2_ta1x1x8x1_1x16x1x16_tb1x1x8x1_1x16x1x16_out_1
-    ;s_cmp_lg_u32 s[s_wave_id], 0
-    ;s_cbranch_scc1  L_program_end
-    ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
-    v_mov_b32 v[v_tmp], s[s_in_offset]
-
-    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
-    s_waitcnt vmcnt(0)
-    s_barrier
-
-    L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x128x16_wt32x32_ws1x1_wr2x2_ta1x1x8x1_1x16x1x16_tb1x1x8x1_1x16x1x16_out_1:
-    s_nop 2
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-
 L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x128x16_wt32x32_ws1x1_wr2x2_ta1x1x8x1_1x16x1x16_tb1x1x8x1_1x16x1x16_out:
     s_endpgm
 .rodata
@@ -5222,7 +5106,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x128x16_wt32x32_ws1x1_wr2x2_ta1x1x8x1_1x
     .amdhsa_system_sgpr_workgroup_id_x 1
     .amdhsa_system_vgpr_workitem_id 0
     .amdhsa_next_free_vgpr 70
-    .amdhsa_next_free_sgpr 84
+    .amdhsa_next_free_sgpr 82
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
 .end_amdhsa_kernel
@@ -5326,9 +5210,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x128x16_wt32x32_ws1x1_wr2x2_ta1x1x8x1_1x
 .set s_sub_n, 60
 .set s_group_stride, 61
 .set s_group_left, 1
-.set s_dbg, 62
-.set s_tmp, 64
-.set s_end, 70
+.set s_tmp, 62
+.set s_end, 68
 
 .set v_c, 0  ; coalescing:16, needed:2, resuable:24
 .set v_a, 2
@@ -5392,11 +5275,6 @@ igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x128x8_wt32x32_ws1x1_wr2x2_ta1x1x4x1_1x8x1
     ; clear vector r
     .v_clear_nc v_c+1, v_end-1
 
-    ; debug vgpr
-    v_mov_b32 v1, 0
-    v_add_lshl_u32 v[v_tmp+6], v0, v1, 2
-    ;v_lshlrev_b32 v[114], 2, v0 ; every thread write one float
-    s_load_dwordx2 s[s_dbg+0:s_dbg+1], s[s_ka:s_ka+1], k_p_wei
     ; input, thread(n0,n1b,c0,c1e): 1x1x4x1, cluster(n0,n1b,c0,c1e): 1x8x1x32
     v_mov_b32 v[v_tmp], v0
     v_and_b32 v[v_gtc_ic1e], 31, v[v_tmp]
@@ -6258,29 +6136,6 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x128x8_wt32x32_ws1x1_wr2x2_ta1x1x4x1_1x8
     s_mul_i32 s[s_tmp], 123, s[s_wei_stride_k]   ; i_m:123(i_m0:3,i_m1:27)
     buffer_store_dword v[v_c+15], v[v_wei_os], s[s_p_wei:s_p_wei+3], s[s_tmp] offen offset:0
 
-    s_branch L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x128x8_wt32x32_ws1x1_wr2x2_ta1x1x4x1_1x8x1x32_tb1x1x4x1_1x8x1x32_out
-    ; debug code to cpy vgpr to host
-    L_debug_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x128x8_wt32x32_ws1x1_wr2x2_ta1x1x4x1_1x8x1x32_tb1x1x4x1_1x8x1x32_out_1:
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-    s_cmp_lg_u32 s[s_bx], 0
-    s_cbranch_scc1 L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x128x8_wt32x32_ws1x1_wr2x2_ta1x1x4x1_1x8x1x32_tb1x1x4x1_1x8x1x32_out_1
-    ;s_cmp_lg_u32 s[s_wave_id], 0
-    ;s_cbranch_scc1  L_program_end
-    ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
-    v_mov_b32 v[v_tmp], s[s_in_offset]
-
-    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
-    s_waitcnt vmcnt(0)
-    s_barrier
-
-    L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x128x8_wt32x32_ws1x1_wr2x2_ta1x1x4x1_1x8x1x32_tb1x1x4x1_1x8x1x32_out_1:
-    s_nop 2
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-
 L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x128x8_wt32x32_ws1x1_wr2x2_ta1x1x4x1_1x8x1x32_tb1x1x4x1_1x8x1x32_out:
     s_endpgm
 .rodata
@@ -6291,7 +6146,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x128x8_wt32x32_ws1x1_wr2x2_ta1x1x4x1_1x8
     .amdhsa_system_sgpr_workgroup_id_x 1
     .amdhsa_system_vgpr_workitem_id 0
     .amdhsa_next_free_vgpr 64
-    .amdhsa_next_free_sgpr 76
+    .amdhsa_next_free_sgpr 74
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
 .end_amdhsa_kernel
@@ -6395,9 +6250,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x128x8_wt32x32_ws1x1_wr2x2_ta1x1x4x1_1x8
 .set s_sub_n, 60
 .set s_group_stride, 61
 .set s_group_left, 1
-.set s_dbg, 62
-.set s_tmp, 64
-.set s_end, 70
+.set s_tmp, 62
+.set s_end, 68
 
 .set v_c, 0  ; coalescing:16, needed:2, resuable:24
 .set v_a, 2
@@ -6461,11 +6315,6 @@ igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x128x8_wt32x32_ws1x1_wr2x2_ta1x1x4x1_1x8x1
     ; clear vector r
     .v_clear_nc v_c+1, v_end-1
 
-    ; debug vgpr
-    v_mov_b32 v1, 0
-    v_add_lshl_u32 v[v_tmp+6], v0, v1, 2
-    ;v_lshlrev_b32 v[114], 2, v0 ; every thread write one float
-    s_load_dwordx2 s[s_dbg+0:s_dbg+1], s[s_ka:s_ka+1], k_p_wei
     ; input, thread(n0,n1b,c0,c1e): 1x1x4x1, cluster(n0,n1b,c0,c1e): 1x8x1x32
     v_mov_b32 v[v_tmp], v0
     v_and_b32 v[v_gtc_ic1e], 31, v[v_tmp]
@@ -7327,29 +7176,6 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x128x8_wt32x32_ws1x1_wr2x2_ta1x1x4x1_1x8
     s_mul_i32 s[s_tmp], 123, s[s_wei_stride_k]   ; i_m:123(i_m0:3,i_m1:27)
     buffer_atomic_add_f32 v[v_c+15], v[v_wei_os], s[s_p_wei:s_p_wei+3], s[s_tmp] offen offset:0
 
-    s_branch L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x128x8_wt32x32_ws1x1_wr2x2_ta1x1x4x1_1x8x1x32_tb1x1x4x1_1x8x1x32_gkgs_out
-    ; debug code to cpy vgpr to host
-    L_debug_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x128x8_wt32x32_ws1x1_wr2x2_ta1x1x4x1_1x8x1x32_tb1x1x4x1_1x8x1x32_gkgs_out_1:
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-    s_cmp_lg_u32 s[s_bx], 0
-    s_cbranch_scc1 L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x128x8_wt32x32_ws1x1_wr2x2_ta1x1x4x1_1x8x1x32_tb1x1x4x1_1x8x1x32_gkgs_out_1
-    ;s_cmp_lg_u32 s[s_wave_id], 0
-    ;s_cbranch_scc1  L_program_end
-    ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
-    v_mov_b32 v[v_tmp], s[s_in_offset]
-
-    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
-    s_waitcnt vmcnt(0)
-    s_barrier
-
-    L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x128x8_wt32x32_ws1x1_wr2x2_ta1x1x4x1_1x8x1x32_tb1x1x4x1_1x8x1x32_gkgs_out_1:
-    s_nop 2
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-
 L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x128x8_wt32x32_ws1x1_wr2x2_ta1x1x4x1_1x8x1x32_tb1x1x4x1_1x8x1x32_gkgs_out:
     s_endpgm
 .rodata
@@ -7360,7 +7186,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x128x8_wt32x32_ws1x1_wr2x2_ta1x1x4x1_1x8
     .amdhsa_system_sgpr_workgroup_id_x 1
     .amdhsa_system_vgpr_workitem_id 0
     .amdhsa_next_free_vgpr 64
-    .amdhsa_next_free_sgpr 76
+    .amdhsa_next_free_sgpr 74
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
 .end_amdhsa_kernel

--- a/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_256x032.inc
+++ b/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_256x032.inc
@@ -1320,7 +1320,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x32x16_wt64x4_ws1x2_wr2x2_ta1x1x16x1_1x1
     ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
     v_mov_b32 v[v_tmp], s[s_in_offset]
 
-    global_store_dword v[v_tmp+6:v_tmp+7], v[v_in_os], s[s_dbg+0:s_dbg+1]
+    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
     s_waitcnt vmcnt(0)
     s_barrier
 
@@ -2640,7 +2640,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x32x16_wt64x4_ws1x2_wr2x2_ta1x1x16x1_1x1
     ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
     v_mov_b32 v[v_tmp], s[s_in_offset]
 
-    global_store_dword v[v_tmp+6:v_tmp+7], v[v_in_os], s[s_dbg+0:s_dbg+1]
+    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
     s_waitcnt vmcnt(0)
     s_barrier
 
@@ -3645,7 +3645,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x32x8_wt64x4_ws1x2_wr2x2_ta1x1x8x1_1x8x1
     ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
     v_mov_b32 v[v_tmp], s[s_in_offset]
 
-    global_store_dword v[v_tmp+6:v_tmp+7], v[v_in_os], s[s_dbg+0:s_dbg+1]
+    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
     s_waitcnt vmcnt(0)
     s_barrier
 
@@ -4650,7 +4650,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x32x8_wt64x4_ws1x2_wr2x2_ta1x1x8x1_1x8x1
     ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
     v_mov_b32 v[v_tmp], s[s_in_offset]
 
-    global_store_dword v[v_tmp+6:v_tmp+7], v[v_in_os], s[s_dbg+0:s_dbg+1]
+    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
     s_waitcnt vmcnt(0)
     s_barrier
 

--- a/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_256x032.inc
+++ b/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_256x032.inc
@@ -124,9 +124,8 @@
 .set s_sub_n, 70
 .set s_group_stride, 71
 .set s_group_left, 1
-.set s_dbg, 72
-.set s_tmp, 74
-.set s_end, 80
+.set s_tmp, 72
+.set s_end, 78
 
 .set v_c, 0  ; coalescing:32, needed:2, resuable:38
 .set v_a, 2
@@ -190,11 +189,6 @@ igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x32x16_wt64x4_ws1x2_wr2x2_ta1x1x16x1_1x16x
     ; clear vector r
     .v_clear_nc v_c+1, v_end-1
 
-    ; debug vgpr
-    v_mov_b32 v1, 0
-    v_add_lshl_u32 v[v_tmp+6], v0, v1, 2
-    ;v_lshlrev_b32 v[114], 2, v0 ; every thread write one float
-    s_load_dwordx2 s[s_dbg+0:s_dbg+1], s[s_ka:s_ka+1], k_p_wei
     ; input, thread(n0,n1b,c0,c1e): 1x1x2x1, cluster(n0,n1b,c0,c1e): 1x16x1x16
     v_mov_b32 v[v_tmp], v0
     v_and_b32 v[v_gtc_ic1e], 15, v[v_tmp]
@@ -1307,29 +1301,6 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x32x16_wt64x4_ws1x2_wr2x2_ta1x1x16x1_1x1
     s_mul_i32 s[s_tmp], 227, s[s_wei_stride_k]   ; i_m:227(i_m0:14,i_m1:3)
     buffer_store_dword v[v_c+31], v[v_wei_os], s[s_p_wei:s_p_wei+3], s[s_tmp] offen offset:0
 
-    s_branch L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x32x16_wt64x4_ws1x2_wr2x2_ta1x1x16x1_1x16x1x16_tb1x1x2x1_1x16x1x16_out
-    ; debug code to cpy vgpr to host
-    L_debug_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x32x16_wt64x4_ws1x2_wr2x2_ta1x1x16x1_1x16x1x16_tb1x1x2x1_1x16x1x16_out_1:
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-    s_cmp_lg_u32 s[s_bx], 0
-    s_cbranch_scc1 L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x32x16_wt64x4_ws1x2_wr2x2_ta1x1x16x1_1x16x1x16_tb1x1x2x1_1x16x1x16_out_1
-    ;s_cmp_lg_u32 s[s_wave_id], 0
-    ;s_cbranch_scc1  L_program_end
-    ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
-    v_mov_b32 v[v_tmp], s[s_in_offset]
-
-    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
-    s_waitcnt vmcnt(0)
-    s_barrier
-
-    L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x32x16_wt64x4_ws1x2_wr2x2_ta1x1x16x1_1x16x1x16_tb1x1x2x1_1x16x1x16_out_1:
-    s_nop 2
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-
 L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x32x16_wt64x4_ws1x2_wr2x2_ta1x1x16x1_1x16x1x16_tb1x1x2x1_1x16x1x16_out:
     s_endpgm
 .rodata
@@ -1340,7 +1311,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x32x16_wt64x4_ws1x2_wr2x2_ta1x1x16x1_1x1
     .amdhsa_system_sgpr_workgroup_id_x 1
     .amdhsa_system_vgpr_workitem_id 0
     .amdhsa_next_free_vgpr 76
-    .amdhsa_next_free_sgpr 86
+    .amdhsa_next_free_sgpr 84
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
 .end_amdhsa_kernel
@@ -1444,9 +1415,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x32x16_wt64x4_ws1x2_wr2x2_ta1x1x16x1_1x1
 .set s_sub_n, 70
 .set s_group_stride, 71
 .set s_group_left, 1
-.set s_dbg, 72
-.set s_tmp, 74
-.set s_end, 80
+.set s_tmp, 72
+.set s_end, 78
 
 .set v_c, 0  ; coalescing:32, needed:2, resuable:38
 .set v_a, 2
@@ -1510,11 +1480,6 @@ igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x32x16_wt64x4_ws1x2_wr2x2_ta1x1x16x1_1x16x
     ; clear vector r
     .v_clear_nc v_c+1, v_end-1
 
-    ; debug vgpr
-    v_mov_b32 v1, 0
-    v_add_lshl_u32 v[v_tmp+6], v0, v1, 2
-    ;v_lshlrev_b32 v[114], 2, v0 ; every thread write one float
-    s_load_dwordx2 s[s_dbg+0:s_dbg+1], s[s_ka:s_ka+1], k_p_wei
     ; input, thread(n0,n1b,c0,c1e): 1x1x2x1, cluster(n0,n1b,c0,c1e): 1x16x1x16
     v_mov_b32 v[v_tmp], v0
     v_and_b32 v[v_gtc_ic1e], 15, v[v_tmp]
@@ -2627,29 +2592,6 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x32x16_wt64x4_ws1x2_wr2x2_ta1x1x16x1_1x1
     s_mul_i32 s[s_tmp], 227, s[s_wei_stride_k]   ; i_m:227(i_m0:14,i_m1:3)
     buffer_atomic_add_f32 v[v_c+31], v[v_wei_os], s[s_p_wei:s_p_wei+3], s[s_tmp] offen offset:0
 
-    s_branch L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x32x16_wt64x4_ws1x2_wr2x2_ta1x1x16x1_1x16x1x16_tb1x1x2x1_1x16x1x16_gkgs_out
-    ; debug code to cpy vgpr to host
-    L_debug_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x32x16_wt64x4_ws1x2_wr2x2_ta1x1x16x1_1x16x1x16_tb1x1x2x1_1x16x1x16_gkgs_out_1:
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-    s_cmp_lg_u32 s[s_bx], 0
-    s_cbranch_scc1 L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x32x16_wt64x4_ws1x2_wr2x2_ta1x1x16x1_1x16x1x16_tb1x1x2x1_1x16x1x16_gkgs_out_1
-    ;s_cmp_lg_u32 s[s_wave_id], 0
-    ;s_cbranch_scc1  L_program_end
-    ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
-    v_mov_b32 v[v_tmp], s[s_in_offset]
-
-    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
-    s_waitcnt vmcnt(0)
-    s_barrier
-
-    L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x32x16_wt64x4_ws1x2_wr2x2_ta1x1x16x1_1x16x1x16_tb1x1x2x1_1x16x1x16_gkgs_out_1:
-    s_nop 2
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-
 L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x32x16_wt64x4_ws1x2_wr2x2_ta1x1x16x1_1x16x1x16_tb1x1x2x1_1x16x1x16_gkgs_out:
     s_endpgm
 .rodata
@@ -2660,7 +2602,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x32x16_wt64x4_ws1x2_wr2x2_ta1x1x16x1_1x1
     .amdhsa_system_sgpr_workgroup_id_x 1
     .amdhsa_system_vgpr_workitem_id 0
     .amdhsa_next_free_vgpr 76
-    .amdhsa_next_free_sgpr 86
+    .amdhsa_next_free_sgpr 84
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
 .end_amdhsa_kernel
@@ -2764,9 +2706,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x32x16_wt64x4_ws1x2_wr2x2_ta1x1x16x1_1x1
 .set s_sub_n, 62
 .set s_group_stride, 63
 .set s_group_left, 1
-.set s_dbg, 64
-.set s_tmp, 66
-.set s_end, 72
+.set s_tmp, 64
+.set s_end, 70
 
 .set v_c, 0  ; coalescing:16, needed:2, resuable:29
 .set v_a, 2
@@ -2830,11 +2771,6 @@ igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x32x8_wt64x4_ws1x2_wr2x2_ta1x1x8x1_1x8x1x3
     ; clear vector r
     .v_clear_nc v_c+1, v_end-1
 
-    ; debug vgpr
-    v_mov_b32 v1, 0
-    v_add_lshl_u32 v[v_tmp+6], v0, v1, 2
-    ;v_lshlrev_b32 v[114], 2, v0 ; every thread write one float
-    s_load_dwordx2 s[s_dbg+0:s_dbg+1], s[s_ka:s_ka+1], k_p_wei
     ; input, thread(n0,n1b,c0,c1e): 1x1x1x1, cluster(n0,n1b,c0,c1e): 1x8x1x32
     v_mov_b32 v[v_tmp], v0
     v_and_b32 v[v_gtc_ic1e], 31, v[v_tmp]
@@ -3632,29 +3568,6 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x32x8_wt64x4_ws1x2_wr2x2_ta1x1x8x1_1x8x1
     s_mul_i32 s[s_tmp], 227, s[s_wei_stride_k]   ; i_m:227(i_m0:7,i_m1:3)
     buffer_store_dword v[v_c+15], v[v_wei_os], s[s_p_wei:s_p_wei+3], s[s_tmp] offen offset:0
 
-    s_branch L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x32x8_wt64x4_ws1x2_wr2x2_ta1x1x8x1_1x8x1x32_tb1x1x1x1_1x8x1x32_out
-    ; debug code to cpy vgpr to host
-    L_debug_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x32x8_wt64x4_ws1x2_wr2x2_ta1x1x8x1_1x8x1x32_tb1x1x1x1_1x8x1x32_out_1:
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-    s_cmp_lg_u32 s[s_bx], 0
-    s_cbranch_scc1 L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x32x8_wt64x4_ws1x2_wr2x2_ta1x1x8x1_1x8x1x32_tb1x1x1x1_1x8x1x32_out_1
-    ;s_cmp_lg_u32 s[s_wave_id], 0
-    ;s_cbranch_scc1  L_program_end
-    ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
-    v_mov_b32 v[v_tmp], s[s_in_offset]
-
-    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
-    s_waitcnt vmcnt(0)
-    s_barrier
-
-    L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x32x8_wt64x4_ws1x2_wr2x2_ta1x1x8x1_1x8x1x32_tb1x1x1x1_1x8x1x32_out_1:
-    s_nop 2
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-
 L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x32x8_wt64x4_ws1x2_wr2x2_ta1x1x8x1_1x8x1x32_tb1x1x1x1_1x8x1x32_out:
     s_endpgm
 .rodata
@@ -3665,7 +3578,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x32x8_wt64x4_ws1x2_wr2x2_ta1x1x8x1_1x8x1
     .amdhsa_system_sgpr_workgroup_id_x 1
     .amdhsa_system_vgpr_workitem_id 0
     .amdhsa_next_free_vgpr 68
-    .amdhsa_next_free_sgpr 78
+    .amdhsa_next_free_sgpr 76
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
 .end_amdhsa_kernel
@@ -3769,9 +3682,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x32x8_wt64x4_ws1x2_wr2x2_ta1x1x8x1_1x8x1
 .set s_sub_n, 62
 .set s_group_stride, 63
 .set s_group_left, 1
-.set s_dbg, 64
-.set s_tmp, 66
-.set s_end, 72
+.set s_tmp, 64
+.set s_end, 70
 
 .set v_c, 0  ; coalescing:16, needed:2, resuable:29
 .set v_a, 2
@@ -3835,11 +3747,6 @@ igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x32x8_wt64x4_ws1x2_wr2x2_ta1x1x8x1_1x8x1x3
     ; clear vector r
     .v_clear_nc v_c+1, v_end-1
 
-    ; debug vgpr
-    v_mov_b32 v1, 0
-    v_add_lshl_u32 v[v_tmp+6], v0, v1, 2
-    ;v_lshlrev_b32 v[114], 2, v0 ; every thread write one float
-    s_load_dwordx2 s[s_dbg+0:s_dbg+1], s[s_ka:s_ka+1], k_p_wei
     ; input, thread(n0,n1b,c0,c1e): 1x1x1x1, cluster(n0,n1b,c0,c1e): 1x8x1x32
     v_mov_b32 v[v_tmp], v0
     v_and_b32 v[v_gtc_ic1e], 31, v[v_tmp]
@@ -4637,29 +4544,6 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x32x8_wt64x4_ws1x2_wr2x2_ta1x1x8x1_1x8x1
     s_mul_i32 s[s_tmp], 227, s[s_wei_stride_k]   ; i_m:227(i_m0:7,i_m1:3)
     buffer_atomic_add_f32 v[v_c+15], v[v_wei_os], s[s_p_wei:s_p_wei+3], s[s_tmp] offen offset:0
 
-    s_branch L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x32x8_wt64x4_ws1x2_wr2x2_ta1x1x8x1_1x8x1x32_tb1x1x1x1_1x8x1x32_gkgs_out
-    ; debug code to cpy vgpr to host
-    L_debug_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x32x8_wt64x4_ws1x2_wr2x2_ta1x1x8x1_1x8x1x32_tb1x1x1x1_1x8x1x32_gkgs_out_1:
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-    s_cmp_lg_u32 s[s_bx], 0
-    s_cbranch_scc1 L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x32x8_wt64x4_ws1x2_wr2x2_ta1x1x8x1_1x8x1x32_tb1x1x1x1_1x8x1x32_gkgs_out_1
-    ;s_cmp_lg_u32 s[s_wave_id], 0
-    ;s_cbranch_scc1  L_program_end
-    ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
-    v_mov_b32 v[v_tmp], s[s_in_offset]
-
-    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
-    s_waitcnt vmcnt(0)
-    s_barrier
-
-    L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x32x8_wt64x4_ws1x2_wr2x2_ta1x1x8x1_1x8x1x32_tb1x1x1x1_1x8x1x32_gkgs_out_1:
-    s_nop 2
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-
 L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x32x8_wt64x4_ws1x2_wr2x2_ta1x1x8x1_1x8x1x32_tb1x1x1x1_1x8x1x32_gkgs_out:
     s_endpgm
 .rodata
@@ -4670,7 +4554,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x32x8_wt64x4_ws1x2_wr2x2_ta1x1x8x1_1x8x1
     .amdhsa_system_sgpr_workgroup_id_x 1
     .amdhsa_system_vgpr_workitem_id 0
     .amdhsa_next_free_vgpr 68
-    .amdhsa_next_free_sgpr 78
+    .amdhsa_next_free_sgpr 76
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
 .end_amdhsa_kernel

--- a/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_256x064.inc
+++ b/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_256x064.inc
@@ -1271,7 +1271,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt256x64x16_wt64x16_ws1x1_wr2x2_ta1x4x4x1_1x4
     ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
     v_mov_b32 v[v_tmp], s[s_in_offset]
 
-    global_store_dword v[v_tmp+6:v_tmp+7], v[v_in_os], s[s_dbg+0:s_dbg+1]
+    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
     s_waitcnt vmcnt(0)
     s_barrier
 
@@ -2542,7 +2542,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt256x64x16_wt64x16_ws1x1_wr2x2_ta1x4x4x1_1x4
     ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
     v_mov_b32 v[v_tmp], s[s_in_offset]
 
-    global_store_dword v[v_tmp+6:v_tmp+7], v[v_in_os], s[s_dbg+0:s_dbg+1]
+    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
     s_waitcnt vmcnt(0)
     s_barrier
 
@@ -3860,7 +3860,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x64x16_wt64x16_ws1x1_wr2x2_ta1x1x16x1_1x
     ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
     v_mov_b32 v[v_tmp], s[s_in_offset]
 
-    global_store_dword v[v_tmp+6:v_tmp+7], v[v_in_os], s[s_dbg+0:s_dbg+1]
+    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
     s_waitcnt vmcnt(0)
     s_barrier
 
@@ -5178,7 +5178,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x64x16_wt64x16_ws1x1_wr2x2_ta1x1x16x1_1x
     ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
     v_mov_b32 v[v_tmp], s[s_in_offset]
 
-    global_store_dword v[v_tmp+6:v_tmp+7], v[v_in_os], s[s_dbg+0:s_dbg+1]
+    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
     s_waitcnt vmcnt(0)
     s_barrier
 
@@ -6253,7 +6253,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x64x8_wt64x16_ws1x1_wr2x2_ta1x1x8x1_1x8x
     ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
     v_mov_b32 v[v_tmp], s[s_in_offset]
 
-    global_store_dword v[v_tmp+6:v_tmp+7], v[v_in_os], s[s_dbg+0:s_dbg+1]
+    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
     s_waitcnt vmcnt(0)
     s_barrier
 
@@ -7328,7 +7328,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x64x8_wt64x16_ws1x1_wr2x2_ta1x1x8x1_1x8x
     ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
     v_mov_b32 v[v_tmp], s[s_in_offset]
 
-    global_store_dword v[v_tmp+6:v_tmp+7], v[v_in_os], s[s_dbg+0:s_dbg+1]
+    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
     s_waitcnt vmcnt(0)
     s_barrier
 
@@ -8296,7 +8296,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x64x4_wt64x16_ws1x1_wr2x2_ta1x1x4x1_1x4x
     ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
     v_mov_b32 v[v_tmp], s[s_in_offset]
 
-    global_store_dword v[v_tmp+6:v_tmp+7], v[v_in_os], s[s_dbg+0:s_dbg+1]
+    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
     s_waitcnt vmcnt(0)
     s_barrier
 
@@ -9264,7 +9264,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x64x4_wt64x16_ws1x1_wr2x2_ta1x1x4x1_1x4x
     ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
     v_mov_b32 v[v_tmp], s[s_in_offset]
 
-    global_store_dword v[v_tmp+6:v_tmp+7], v[v_in_os], s[s_dbg+0:s_dbg+1]
+    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
     s_waitcnt vmcnt(0)
     s_barrier
 

--- a/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_256x064.inc
+++ b/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_256x064.inc
@@ -124,9 +124,8 @@
 .set s_sub_n, 58
 .set s_group_stride, 59
 .set s_group_left, 1
-.set s_dbg, 60
-.set s_tmp, 62
-.set s_end, 68
+.set s_tmp, 60
+.set s_end, 66
 
 .set v_c, 0  ; coalescing:32, needed:2, resuable:36
 .set v_a, 2
@@ -190,11 +189,6 @@ igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt256x64x16_wt64x16_ws1x1_wr2x2_ta1x4x4x1_1x4x1
     ; clear vector r
     .v_clear_nc v_c+1, v_end-1
 
-    ; debug vgpr
-    v_mov_b32 v1, 0
-    v_add_lshl_u32 v[v_tmp+6], v0, v1, 2
-    ;v_lshlrev_b32 v[114], 2, v0 ; every thread write one float
-    s_load_dwordx2 s[s_dbg+0:s_dbg+1], s[s_ka:s_ka+1], k_p_wei
     ; input, thread(n0,n1b,c0,c1e): 1x4x1x1, cluster(n0,n1b,c0,c1e): 1x4x1x64
     v_mov_b32 v[v_tmp], v0
     v_and_b32 v[v_gtc_ic1e], 63, v[v_tmp]
@@ -1258,29 +1252,6 @@ L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt256x64x16_wt64x16_ws1x1_wr2x2_ta1x4x4x1_1x4
     s_mul_i32 s[s_tmp], 243, s[s_wei_stride_k]   ; i_m:243(i_m0:3,i_m1:51)
     buffer_store_dword v[v_c+31], v[v_wei_os], s[s_p_wei:s_p_wei+3], s[s_tmp] offen offset:0
 
-    s_branch L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt256x64x16_wt64x16_ws1x1_wr2x2_ta1x4x4x1_1x4x1x64_tb1x4x1x1_1x4x1x64_out
-    ; debug code to cpy vgpr to host
-    L_debug_L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt256x64x16_wt64x16_ws1x1_wr2x2_ta1x4x4x1_1x4x1x64_tb1x4x1x1_1x4x1x64_out_1:
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-    s_cmp_lg_u32 s[s_bx], 0
-    s_cbranch_scc1 L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt256x64x16_wt64x16_ws1x1_wr2x2_ta1x4x4x1_1x4x1x64_tb1x4x1x1_1x4x1x64_out_1
-    ;s_cmp_lg_u32 s[s_wave_id], 0
-    ;s_cbranch_scc1  L_program_end
-    ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
-    v_mov_b32 v[v_tmp], s[s_in_offset]
-
-    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
-    s_waitcnt vmcnt(0)
-    s_barrier
-
-    L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt256x64x16_wt64x16_ws1x1_wr2x2_ta1x4x4x1_1x4x1x64_tb1x4x1x1_1x4x1x64_out_1:
-    s_nop 2
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-
 L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt256x64x16_wt64x16_ws1x1_wr2x2_ta1x4x4x1_1x4x1x64_tb1x4x1x1_1x4x1x64_out:
     s_endpgm
 .rodata
@@ -1291,7 +1262,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt256x64x16_wt64x16_ws1x1_wr2x2_ta1x4x4x1_1x4
     .amdhsa_system_sgpr_workgroup_id_x 1
     .amdhsa_system_vgpr_workitem_id 0
     .amdhsa_next_free_vgpr 74
-    .amdhsa_next_free_sgpr 74
+    .amdhsa_next_free_sgpr 72
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
 .end_amdhsa_kernel
@@ -1395,9 +1366,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt256x64x16_wt64x16_ws1x1_wr2x2_ta1x4x4x1_1x4
 .set s_sub_n, 58
 .set s_group_stride, 59
 .set s_group_left, 1
-.set s_dbg, 60
-.set s_tmp, 62
-.set s_end, 68
+.set s_tmp, 60
+.set s_end, 66
 
 .set v_c, 0  ; coalescing:32, needed:2, resuable:36
 .set v_a, 2
@@ -1461,11 +1431,6 @@ igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt256x64x16_wt64x16_ws1x1_wr2x2_ta1x4x4x1_1x4x1
     ; clear vector r
     .v_clear_nc v_c+1, v_end-1
 
-    ; debug vgpr
-    v_mov_b32 v1, 0
-    v_add_lshl_u32 v[v_tmp+6], v0, v1, 2
-    ;v_lshlrev_b32 v[114], 2, v0 ; every thread write one float
-    s_load_dwordx2 s[s_dbg+0:s_dbg+1], s[s_ka:s_ka+1], k_p_wei
     ; input, thread(n0,n1b,c0,c1e): 1x4x1x1, cluster(n0,n1b,c0,c1e): 1x4x1x64
     v_mov_b32 v[v_tmp], v0
     v_and_b32 v[v_gtc_ic1e], 63, v[v_tmp]
@@ -2529,29 +2494,6 @@ L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt256x64x16_wt64x16_ws1x1_wr2x2_ta1x4x4x1_1x4
     s_mul_i32 s[s_tmp], 243, s[s_wei_stride_k]   ; i_m:243(i_m0:3,i_m1:51)
     buffer_atomic_add_f32 v[v_c+31], v[v_wei_os], s[s_p_wei:s_p_wei+3], s[s_tmp] offen offset:0
 
-    s_branch L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt256x64x16_wt64x16_ws1x1_wr2x2_ta1x4x4x1_1x4x1x64_tb1x4x1x1_1x4x1x64_gkgs_out
-    ; debug code to cpy vgpr to host
-    L_debug_L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt256x64x16_wt64x16_ws1x1_wr2x2_ta1x4x4x1_1x4x1x64_tb1x4x1x1_1x4x1x64_gkgs_out_1:
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-    s_cmp_lg_u32 s[s_bx], 0
-    s_cbranch_scc1 L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt256x64x16_wt64x16_ws1x1_wr2x2_ta1x4x4x1_1x4x1x64_tb1x4x1x1_1x4x1x64_gkgs_out_1
-    ;s_cmp_lg_u32 s[s_wave_id], 0
-    ;s_cbranch_scc1  L_program_end
-    ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
-    v_mov_b32 v[v_tmp], s[s_in_offset]
-
-    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
-    s_waitcnt vmcnt(0)
-    s_barrier
-
-    L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt256x64x16_wt64x16_ws1x1_wr2x2_ta1x4x4x1_1x4x1x64_tb1x4x1x1_1x4x1x64_gkgs_out_1:
-    s_nop 2
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-
 L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt256x64x16_wt64x16_ws1x1_wr2x2_ta1x4x4x1_1x4x1x64_tb1x4x1x1_1x4x1x64_gkgs_out:
     s_endpgm
 .rodata
@@ -2562,7 +2504,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt256x64x16_wt64x16_ws1x1_wr2x2_ta1x4x4x1_1x4
     .amdhsa_system_sgpr_workgroup_id_x 1
     .amdhsa_system_vgpr_workitem_id 0
     .amdhsa_next_free_vgpr 74
-    .amdhsa_next_free_sgpr 74
+    .amdhsa_next_free_sgpr 72
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
 .end_amdhsa_kernel
@@ -2666,9 +2608,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt256x64x16_wt64x16_ws1x1_wr2x2_ta1x4x4x1_1x4
 .set s_sub_n, 72
 .set s_group_stride, 73
 .set s_group_left, 1
-.set s_dbg, 74
-.set s_tmp, 76
-.set s_end, 82
+.set s_tmp, 74
+.set s_end, 80
 
 .set v_c, 0  ; coalescing:32, needed:2, resuable:36
 .set v_a, 2
@@ -2732,11 +2673,6 @@ igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x64x16_wt64x16_ws1x1_wr2x2_ta1x1x16x1_1x16
     ; clear vector r
     .v_clear_nc v_c+1, v_end-1
 
-    ; debug vgpr
-    v_mov_b32 v1, 0
-    v_add_lshl_u32 v[v_tmp+6], v0, v1, 2
-    ;v_lshlrev_b32 v[114], 2, v0 ; every thread write one float
-    s_load_dwordx2 s[s_dbg+0:s_dbg+1], s[s_ka:s_ka+1], k_p_wei
     ; input, thread(n0,n1b,c0,c1e): 1x1x4x1, cluster(n0,n1b,c0,c1e): 1x16x1x16
     v_mov_b32 v[v_tmp], v0
     v_and_b32 v[v_gtc_ic1e], 15, v[v_tmp]
@@ -3847,29 +3783,6 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x64x16_wt64x16_ws1x1_wr2x2_ta1x1x16x1_1x
     s_mul_i32 s[s_tmp], 243, s[s_wei_stride_k]   ; i_m:243(i_m0:15,i_m1:3)
     buffer_store_dword v[v_c+31], v[v_wei_os], s[s_p_wei:s_p_wei+3], s[s_tmp] offen offset:0
 
-    s_branch L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x64x16_wt64x16_ws1x1_wr2x2_ta1x1x16x1_1x16x1x16_tb1x1x4x1_1x16x1x16_out
-    ; debug code to cpy vgpr to host
-    L_debug_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x64x16_wt64x16_ws1x1_wr2x2_ta1x1x16x1_1x16x1x16_tb1x1x4x1_1x16x1x16_out_1:
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-    s_cmp_lg_u32 s[s_bx], 0
-    s_cbranch_scc1 L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x64x16_wt64x16_ws1x1_wr2x2_ta1x1x16x1_1x16x1x16_tb1x1x4x1_1x16x1x16_out_1
-    ;s_cmp_lg_u32 s[s_wave_id], 0
-    ;s_cbranch_scc1  L_program_end
-    ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
-    v_mov_b32 v[v_tmp], s[s_in_offset]
-
-    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
-    s_waitcnt vmcnt(0)
-    s_barrier
-
-    L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x64x16_wt64x16_ws1x1_wr2x2_ta1x1x16x1_1x16x1x16_tb1x1x4x1_1x16x1x16_out_1:
-    s_nop 2
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-
 L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x64x16_wt64x16_ws1x1_wr2x2_ta1x1x16x1_1x16x1x16_tb1x1x4x1_1x16x1x16_out:
     s_endpgm
 .rodata
@@ -3880,7 +3793,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x64x16_wt64x16_ws1x1_wr2x2_ta1x1x16x1_1x
     .amdhsa_system_sgpr_workgroup_id_x 1
     .amdhsa_system_vgpr_workitem_id 0
     .amdhsa_next_free_vgpr 74
-    .amdhsa_next_free_sgpr 88
+    .amdhsa_next_free_sgpr 86
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
 .end_amdhsa_kernel
@@ -3984,9 +3897,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x64x16_wt64x16_ws1x1_wr2x2_ta1x1x16x1_1x
 .set s_sub_n, 72
 .set s_group_stride, 73
 .set s_group_left, 1
-.set s_dbg, 74
-.set s_tmp, 76
-.set s_end, 82
+.set s_tmp, 74
+.set s_end, 80
 
 .set v_c, 0  ; coalescing:32, needed:2, resuable:36
 .set v_a, 2
@@ -4050,11 +3962,6 @@ igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x64x16_wt64x16_ws1x1_wr2x2_ta1x1x16x1_1x16
     ; clear vector r
     .v_clear_nc v_c+1, v_end-1
 
-    ; debug vgpr
-    v_mov_b32 v1, 0
-    v_add_lshl_u32 v[v_tmp+6], v0, v1, 2
-    ;v_lshlrev_b32 v[114], 2, v0 ; every thread write one float
-    s_load_dwordx2 s[s_dbg+0:s_dbg+1], s[s_ka:s_ka+1], k_p_wei
     ; input, thread(n0,n1b,c0,c1e): 1x1x4x1, cluster(n0,n1b,c0,c1e): 1x16x1x16
     v_mov_b32 v[v_tmp], v0
     v_and_b32 v[v_gtc_ic1e], 15, v[v_tmp]
@@ -5165,29 +5072,6 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x64x16_wt64x16_ws1x1_wr2x2_ta1x1x16x1_1x
     s_mul_i32 s[s_tmp], 243, s[s_wei_stride_k]   ; i_m:243(i_m0:15,i_m1:3)
     buffer_atomic_add_f32 v[v_c+31], v[v_wei_os], s[s_p_wei:s_p_wei+3], s[s_tmp] offen offset:0
 
-    s_branch L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x64x16_wt64x16_ws1x1_wr2x2_ta1x1x16x1_1x16x1x16_tb1x1x4x1_1x16x1x16_gkgs_out
-    ; debug code to cpy vgpr to host
-    L_debug_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x64x16_wt64x16_ws1x1_wr2x2_ta1x1x16x1_1x16x1x16_tb1x1x4x1_1x16x1x16_gkgs_out_1:
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-    s_cmp_lg_u32 s[s_bx], 0
-    s_cbranch_scc1 L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x64x16_wt64x16_ws1x1_wr2x2_ta1x1x16x1_1x16x1x16_tb1x1x4x1_1x16x1x16_gkgs_out_1
-    ;s_cmp_lg_u32 s[s_wave_id], 0
-    ;s_cbranch_scc1  L_program_end
-    ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
-    v_mov_b32 v[v_tmp], s[s_in_offset]
-
-    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
-    s_waitcnt vmcnt(0)
-    s_barrier
-
-    L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x64x16_wt64x16_ws1x1_wr2x2_ta1x1x16x1_1x16x1x16_tb1x1x4x1_1x16x1x16_gkgs_out_1:
-    s_nop 2
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-
 L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x64x16_wt64x16_ws1x1_wr2x2_ta1x1x16x1_1x16x1x16_tb1x1x4x1_1x16x1x16_gkgs_out:
     s_endpgm
 .rodata
@@ -5198,7 +5082,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x64x16_wt64x16_ws1x1_wr2x2_ta1x1x16x1_1x
     .amdhsa_system_sgpr_workgroup_id_x 1
     .amdhsa_system_vgpr_workitem_id 0
     .amdhsa_next_free_vgpr 74
-    .amdhsa_next_free_sgpr 88
+    .amdhsa_next_free_sgpr 86
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
 .end_amdhsa_kernel
@@ -5302,9 +5186,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x64x16_wt64x16_ws1x1_wr2x2_ta1x1x16x1_1x
 .set s_sub_n, 62
 .set s_group_stride, 63
 .set s_group_left, 1
-.set s_dbg, 64
-.set s_tmp, 66
-.set s_end, 72
+.set s_tmp, 64
+.set s_end, 70
 
 .set v_c, 0  ; coalescing:16, needed:2, resuable:26
 .set v_a, 2
@@ -5368,11 +5251,6 @@ igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x64x8_wt64x16_ws1x1_wr2x2_ta1x1x8x1_1x8x1x
     ; clear vector r
     .v_clear_nc v_c+1, v_end-1
 
-    ; debug vgpr
-    v_mov_b32 v1, 0
-    v_add_lshl_u32 v[v_tmp+6], v0, v1, 2
-    ;v_lshlrev_b32 v[114], 2, v0 ; every thread write one float
-    s_load_dwordx2 s[s_dbg+0:s_dbg+1], s[s_ka:s_ka+1], k_p_wei
     ; input, thread(n0,n1b,c0,c1e): 1x1x2x1, cluster(n0,n1b,c0,c1e): 1x8x1x32
     v_mov_b32 v[v_tmp], v0
     v_and_b32 v[v_gtc_ic1e], 31, v[v_tmp]
@@ -6240,29 +6118,6 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x64x8_wt64x16_ws1x1_wr2x2_ta1x1x8x1_1x8x
     s_mul_i32 s[s_tmp], 243, s[s_wei_stride_k]   ; i_m:243(i_m0:7,i_m1:19)
     buffer_store_dword v[v_c+15], v[v_wei_os], s[s_p_wei:s_p_wei+3], s[s_tmp] offen offset:0
 
-    s_branch L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x64x8_wt64x16_ws1x1_wr2x2_ta1x1x8x1_1x8x1x32_tb1x1x2x1_1x8x1x32_out
-    ; debug code to cpy vgpr to host
-    L_debug_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x64x8_wt64x16_ws1x1_wr2x2_ta1x1x8x1_1x8x1x32_tb1x1x2x1_1x8x1x32_out_1:
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-    s_cmp_lg_u32 s[s_bx], 0
-    s_cbranch_scc1 L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x64x8_wt64x16_ws1x1_wr2x2_ta1x1x8x1_1x8x1x32_tb1x1x2x1_1x8x1x32_out_1
-    ;s_cmp_lg_u32 s[s_wave_id], 0
-    ;s_cbranch_scc1  L_program_end
-    ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
-    v_mov_b32 v[v_tmp], s[s_in_offset]
-
-    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
-    s_waitcnt vmcnt(0)
-    s_barrier
-
-    L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x64x8_wt64x16_ws1x1_wr2x2_ta1x1x8x1_1x8x1x32_tb1x1x2x1_1x8x1x32_out_1:
-    s_nop 2
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-
 L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x64x8_wt64x16_ws1x1_wr2x2_ta1x1x8x1_1x8x1x32_tb1x1x2x1_1x8x1x32_out:
     s_endpgm
 .rodata
@@ -6273,7 +6128,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x64x8_wt64x16_ws1x1_wr2x2_ta1x1x8x1_1x8x
     .amdhsa_system_sgpr_workgroup_id_x 1
     .amdhsa_system_vgpr_workitem_id 0
     .amdhsa_next_free_vgpr 64
-    .amdhsa_next_free_sgpr 78
+    .amdhsa_next_free_sgpr 76
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
 .end_amdhsa_kernel
@@ -6377,9 +6232,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x64x8_wt64x16_ws1x1_wr2x2_ta1x1x8x1_1x8x
 .set s_sub_n, 62
 .set s_group_stride, 63
 .set s_group_left, 1
-.set s_dbg, 64
-.set s_tmp, 66
-.set s_end, 72
+.set s_tmp, 64
+.set s_end, 70
 
 .set v_c, 0  ; coalescing:16, needed:2, resuable:26
 .set v_a, 2
@@ -6443,11 +6297,6 @@ igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x64x8_wt64x16_ws1x1_wr2x2_ta1x1x8x1_1x8x1x
     ; clear vector r
     .v_clear_nc v_c+1, v_end-1
 
-    ; debug vgpr
-    v_mov_b32 v1, 0
-    v_add_lshl_u32 v[v_tmp+6], v0, v1, 2
-    ;v_lshlrev_b32 v[114], 2, v0 ; every thread write one float
-    s_load_dwordx2 s[s_dbg+0:s_dbg+1], s[s_ka:s_ka+1], k_p_wei
     ; input, thread(n0,n1b,c0,c1e): 1x1x2x1, cluster(n0,n1b,c0,c1e): 1x8x1x32
     v_mov_b32 v[v_tmp], v0
     v_and_b32 v[v_gtc_ic1e], 31, v[v_tmp]
@@ -7315,29 +7164,6 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x64x8_wt64x16_ws1x1_wr2x2_ta1x1x8x1_1x8x
     s_mul_i32 s[s_tmp], 243, s[s_wei_stride_k]   ; i_m:243(i_m0:7,i_m1:19)
     buffer_atomic_add_f32 v[v_c+15], v[v_wei_os], s[s_p_wei:s_p_wei+3], s[s_tmp] offen offset:0
 
-    s_branch L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x64x8_wt64x16_ws1x1_wr2x2_ta1x1x8x1_1x8x1x32_tb1x1x2x1_1x8x1x32_gkgs_out
-    ; debug code to cpy vgpr to host
-    L_debug_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x64x8_wt64x16_ws1x1_wr2x2_ta1x1x8x1_1x8x1x32_tb1x1x2x1_1x8x1x32_gkgs_out_1:
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-    s_cmp_lg_u32 s[s_bx], 0
-    s_cbranch_scc1 L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x64x8_wt64x16_ws1x1_wr2x2_ta1x1x8x1_1x8x1x32_tb1x1x2x1_1x8x1x32_gkgs_out_1
-    ;s_cmp_lg_u32 s[s_wave_id], 0
-    ;s_cbranch_scc1  L_program_end
-    ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
-    v_mov_b32 v[v_tmp], s[s_in_offset]
-
-    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
-    s_waitcnt vmcnt(0)
-    s_barrier
-
-    L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x64x8_wt64x16_ws1x1_wr2x2_ta1x1x8x1_1x8x1x32_tb1x1x2x1_1x8x1x32_gkgs_out_1:
-    s_nop 2
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-
 L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x64x8_wt64x16_ws1x1_wr2x2_ta1x1x8x1_1x8x1x32_tb1x1x2x1_1x8x1x32_gkgs_out:
     s_endpgm
 .rodata
@@ -7348,7 +7174,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x64x8_wt64x16_ws1x1_wr2x2_ta1x1x8x1_1x8x
     .amdhsa_system_sgpr_workgroup_id_x 1
     .amdhsa_system_vgpr_workitem_id 0
     .amdhsa_next_free_vgpr 64
-    .amdhsa_next_free_sgpr 78
+    .amdhsa_next_free_sgpr 76
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
 .end_amdhsa_kernel
@@ -7452,9 +7278,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x64x8_wt64x16_ws1x1_wr2x2_ta1x1x8x1_1x8x
 .set s_sub_n, 58
 .set s_group_stride, 59
 .set s_group_left, 1
-.set s_dbg, 60
-.set s_tmp, 62
-.set s_end, 68
+.set s_tmp, 60
+.set s_end, 66
 
 .set v_c, 0  ; coalescing:8, needed:2, resuable:21
 .set v_a, 2
@@ -7518,11 +7343,6 @@ igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x64x4_wt64x16_ws1x1_wr2x2_ta1x1x4x1_1x4x1x
     ; clear vector r
     .v_clear_nc v_c+1, v_end-1
 
-    ; debug vgpr
-    v_mov_b32 v1, 0
-    v_add_lshl_u32 v[v_tmp+6], v0, v1, 2
-    ;v_lshlrev_b32 v[114], 2, v0 ; every thread write one float
-    s_load_dwordx2 s[s_dbg+0:s_dbg+1], s[s_ka:s_ka+1], k_p_wei
     ; input, thread(n0,n1b,c0,c1e): 1x1x1x1, cluster(n0,n1b,c0,c1e): 1x4x1x64
     v_mov_b32 v[v_tmp], v0
     v_and_b32 v[v_gtc_ic1e], 63, v[v_tmp]
@@ -8283,29 +8103,6 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x64x4_wt64x16_ws1x1_wr2x2_ta1x1x4x1_1x4x
     s_mul_i32 s[s_tmp], 243, s[s_wei_stride_k]   ; i_m:243(i_m0:3,i_m1:51)
     buffer_store_dword v[v_c+7], v[v_wei_os], s[s_p_wei:s_p_wei+3], s[s_tmp] offen offset:0
 
-    s_branch L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x64x4_wt64x16_ws1x1_wr2x2_ta1x1x4x1_1x4x1x64_tb1x1x1x1_1x4x1x64_out
-    ; debug code to cpy vgpr to host
-    L_debug_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x64x4_wt64x16_ws1x1_wr2x2_ta1x1x4x1_1x4x1x64_tb1x1x1x1_1x4x1x64_out_1:
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-    s_cmp_lg_u32 s[s_bx], 0
-    s_cbranch_scc1 L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x64x4_wt64x16_ws1x1_wr2x2_ta1x1x4x1_1x4x1x64_tb1x1x1x1_1x4x1x64_out_1
-    ;s_cmp_lg_u32 s[s_wave_id], 0
-    ;s_cbranch_scc1  L_program_end
-    ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
-    v_mov_b32 v[v_tmp], s[s_in_offset]
-
-    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
-    s_waitcnt vmcnt(0)
-    s_barrier
-
-    L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x64x4_wt64x16_ws1x1_wr2x2_ta1x1x4x1_1x4x1x64_tb1x1x1x1_1x4x1x64_out_1:
-    s_nop 2
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-
 L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x64x4_wt64x16_ws1x1_wr2x2_ta1x1x4x1_1x4x1x64_tb1x1x1x1_1x4x1x64_out:
     s_endpgm
 .rodata
@@ -8316,7 +8113,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x64x4_wt64x16_ws1x1_wr2x2_ta1x1x4x1_1x4x
     .amdhsa_system_sgpr_workgroup_id_x 1
     .amdhsa_system_vgpr_workitem_id 0
     .amdhsa_next_free_vgpr 64
-    .amdhsa_next_free_sgpr 74
+    .amdhsa_next_free_sgpr 72
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
 .end_amdhsa_kernel
@@ -8420,9 +8217,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x64x4_wt64x16_ws1x1_wr2x2_ta1x1x4x1_1x4x
 .set s_sub_n, 58
 .set s_group_stride, 59
 .set s_group_left, 1
-.set s_dbg, 60
-.set s_tmp, 62
-.set s_end, 68
+.set s_tmp, 60
+.set s_end, 66
 
 .set v_c, 0  ; coalescing:8, needed:2, resuable:21
 .set v_a, 2
@@ -8486,11 +8282,6 @@ igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x64x4_wt64x16_ws1x1_wr2x2_ta1x1x4x1_1x4x1x
     ; clear vector r
     .v_clear_nc v_c+1, v_end-1
 
-    ; debug vgpr
-    v_mov_b32 v1, 0
-    v_add_lshl_u32 v[v_tmp+6], v0, v1, 2
-    ;v_lshlrev_b32 v[114], 2, v0 ; every thread write one float
-    s_load_dwordx2 s[s_dbg+0:s_dbg+1], s[s_ka:s_ka+1], k_p_wei
     ; input, thread(n0,n1b,c0,c1e): 1x1x1x1, cluster(n0,n1b,c0,c1e): 1x4x1x64
     v_mov_b32 v[v_tmp], v0
     v_and_b32 v[v_gtc_ic1e], 63, v[v_tmp]
@@ -9251,29 +9042,6 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x64x4_wt64x16_ws1x1_wr2x2_ta1x1x4x1_1x4x
     s_mul_i32 s[s_tmp], 243, s[s_wei_stride_k]   ; i_m:243(i_m0:3,i_m1:51)
     buffer_atomic_add_f32 v[v_c+7], v[v_wei_os], s[s_p_wei:s_p_wei+3], s[s_tmp] offen offset:0
 
-    s_branch L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x64x4_wt64x16_ws1x1_wr2x2_ta1x1x4x1_1x4x1x64_tb1x1x1x1_1x4x1x64_gkgs_out
-    ; debug code to cpy vgpr to host
-    L_debug_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x64x4_wt64x16_ws1x1_wr2x2_ta1x1x4x1_1x4x1x64_tb1x1x1x1_1x4x1x64_gkgs_out_1:
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-    s_cmp_lg_u32 s[s_bx], 0
-    s_cbranch_scc1 L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x64x4_wt64x16_ws1x1_wr2x2_ta1x1x4x1_1x4x1x64_tb1x1x1x1_1x4x1x64_gkgs_out_1
-    ;s_cmp_lg_u32 s[s_wave_id], 0
-    ;s_cbranch_scc1  L_program_end
-    ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
-    v_mov_b32 v[v_tmp], s[s_in_offset]
-
-    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
-    s_waitcnt vmcnt(0)
-    s_barrier
-
-    L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x64x4_wt64x16_ws1x1_wr2x2_ta1x1x4x1_1x4x1x64_tb1x1x1x1_1x4x1x64_gkgs_out_1:
-    s_nop 2
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-
 L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x64x4_wt64x16_ws1x1_wr2x2_ta1x1x4x1_1x4x1x64_tb1x1x1x1_1x4x1x64_gkgs_out:
     s_endpgm
 .rodata
@@ -9284,7 +9052,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x64x4_wt64x16_ws1x1_wr2x2_ta1x1x4x1_1x4x
     .amdhsa_system_sgpr_workgroup_id_x 1
     .amdhsa_system_vgpr_workitem_id 0
     .amdhsa_next_free_vgpr 64
-    .amdhsa_next_free_sgpr 74
+    .amdhsa_next_free_sgpr 72
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
 .end_amdhsa_kernel

--- a/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_256x128.inc
+++ b/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_256x128.inc
@@ -124,9 +124,8 @@
 .set s_sub_n, 58
 .set s_group_stride, 59
 .set s_group_left, 1
-.set s_dbg, 60
-.set s_tmp, 62
-.set s_end, 68
+.set s_tmp, 60
+.set s_end, 66
 
 .set v_c, 0  ; coalescing:32, needed:2, resuable:40
 .set v_a, 2
@@ -190,11 +189,6 @@ igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt256x128x16_wt64x32_ws1x1_wr2x2_ta1x4x4x1_1x4x
     ; clear vector r
     .v_clear_nc v_c+1, v_end-1
 
-    ; debug vgpr
-    v_mov_b32 v1, 0
-    v_add_lshl_u32 v[v_tmp+6], v0, v1, 2
-    ;v_lshlrev_b32 v[114], 2, v0 ; every thread write one float
-    s_load_dwordx2 s[s_dbg+0:s_dbg+1], s[s_ka:s_ka+1], k_p_wei
     ; input, thread(n0,n1b,c0,c1e): 1x4x2x1, cluster(n0,n1b,c0,c1e): 1x4x1x64
     v_mov_b32 v[v_tmp], v0
     v_and_b32 v[v_gtc_ic1e], 63, v[v_tmp]
@@ -1522,29 +1516,6 @@ L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt256x128x16_wt64x32_ws1x1_wr2x2_ta1x4x4x1_1x
     s_mul_i32 s[s_tmp], 251, s[s_wei_stride_k]   ; i_m:251(i_m0:3,i_m1:59)
     buffer_store_dword v[v_c+31], v[v_wei_os], s[s_p_wei:s_p_wei+3], s[s_tmp] offen offset:0
 
-    s_branch L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt256x128x16_wt64x32_ws1x1_wr2x2_ta1x4x4x1_1x4x1x64_tb1x4x2x1_1x4x1x64_out
-    ; debug code to cpy vgpr to host
-    L_debug_L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt256x128x16_wt64x32_ws1x1_wr2x2_ta1x4x4x1_1x4x1x64_tb1x4x2x1_1x4x1x64_out_1:
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-    s_cmp_lg_u32 s[s_bx], 0
-    s_cbranch_scc1 L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt256x128x16_wt64x32_ws1x1_wr2x2_ta1x4x4x1_1x4x1x64_tb1x4x2x1_1x4x1x64_out_1
-    ;s_cmp_lg_u32 s[s_wave_id], 0
-    ;s_cbranch_scc1  L_program_end
-    ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
-    v_mov_b32 v[v_tmp], s[s_in_offset]
-
-    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
-    s_waitcnt vmcnt(0)
-    s_barrier
-
-    L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt256x128x16_wt64x32_ws1x1_wr2x2_ta1x4x4x1_1x4x1x64_tb1x4x2x1_1x4x1x64_out_1:
-    s_nop 2
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-
 L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt256x128x16_wt64x32_ws1x1_wr2x2_ta1x4x4x1_1x4x1x64_tb1x4x2x1_1x4x1x64_out:
     s_endpgm
 .rodata
@@ -1555,7 +1526,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt256x128x16_wt64x32_ws1x1_wr2x2_ta1x4x4x1_1x
     .amdhsa_system_sgpr_workgroup_id_x 1
     .amdhsa_system_vgpr_workitem_id 0
     .amdhsa_next_free_vgpr 128
-    .amdhsa_next_free_sgpr 74
+    .amdhsa_next_free_sgpr 72
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
 .end_amdhsa_kernel
@@ -1659,9 +1630,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt256x128x16_wt64x32_ws1x1_wr2x2_ta1x4x4x1_1x
 .set s_sub_n, 58
 .set s_group_stride, 59
 .set s_group_left, 1
-.set s_dbg, 60
-.set s_tmp, 62
-.set s_end, 68
+.set s_tmp, 60
+.set s_end, 66
 
 .set v_c, 0  ; coalescing:32, needed:2, resuable:40
 .set v_a, 2
@@ -1725,11 +1695,6 @@ igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt256x128x16_wt64x32_ws1x1_wr2x2_ta1x4x4x1_1x4x
     ; clear vector r
     .v_clear_nc v_c+1, v_end-1
 
-    ; debug vgpr
-    v_mov_b32 v1, 0
-    v_add_lshl_u32 v[v_tmp+6], v0, v1, 2
-    ;v_lshlrev_b32 v[114], 2, v0 ; every thread write one float
-    s_load_dwordx2 s[s_dbg+0:s_dbg+1], s[s_ka:s_ka+1], k_p_wei
     ; input, thread(n0,n1b,c0,c1e): 1x4x2x1, cluster(n0,n1b,c0,c1e): 1x4x1x64
     v_mov_b32 v[v_tmp], v0
     v_and_b32 v[v_gtc_ic1e], 63, v[v_tmp]
@@ -3057,29 +3022,6 @@ L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt256x128x16_wt64x32_ws1x1_wr2x2_ta1x4x4x1_1x
     s_mul_i32 s[s_tmp], 251, s[s_wei_stride_k]   ; i_m:251(i_m0:3,i_m1:59)
     buffer_atomic_add_f32 v[v_c+31], v[v_wei_os], s[s_p_wei:s_p_wei+3], s[s_tmp] offen offset:0
 
-    s_branch L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt256x128x16_wt64x32_ws1x1_wr2x2_ta1x4x4x1_1x4x1x64_tb1x4x2x1_1x4x1x64_gkgs_out
-    ; debug code to cpy vgpr to host
-    L_debug_L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt256x128x16_wt64x32_ws1x1_wr2x2_ta1x4x4x1_1x4x1x64_tb1x4x2x1_1x4x1x64_gkgs_out_1:
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-    s_cmp_lg_u32 s[s_bx], 0
-    s_cbranch_scc1 L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt256x128x16_wt64x32_ws1x1_wr2x2_ta1x4x4x1_1x4x1x64_tb1x4x2x1_1x4x1x64_gkgs_out_1
-    ;s_cmp_lg_u32 s[s_wave_id], 0
-    ;s_cbranch_scc1  L_program_end
-    ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
-    v_mov_b32 v[v_tmp], s[s_in_offset]
-
-    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
-    s_waitcnt vmcnt(0)
-    s_barrier
-
-    L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt256x128x16_wt64x32_ws1x1_wr2x2_ta1x4x4x1_1x4x1x64_tb1x4x2x1_1x4x1x64_gkgs_out_1:
-    s_nop 2
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-
 L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt256x128x16_wt64x32_ws1x1_wr2x2_ta1x4x4x1_1x4x1x64_tb1x4x2x1_1x4x1x64_gkgs_out:
     s_endpgm
 .rodata
@@ -3090,7 +3032,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt256x128x16_wt64x32_ws1x1_wr2x2_ta1x4x4x1_1x
     .amdhsa_system_sgpr_workgroup_id_x 1
     .amdhsa_system_vgpr_workitem_id 0
     .amdhsa_next_free_vgpr 128
-    .amdhsa_next_free_sgpr 74
+    .amdhsa_next_free_sgpr 72
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
 .end_amdhsa_kernel
@@ -3194,9 +3136,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt256x128x16_wt64x32_ws1x1_wr2x2_ta1x4x4x1_1x
 .set s_sub_n, 56
 .set s_group_stride, 57
 .set s_group_left, 1
-.set s_dbg, 58
-.set s_tmp, 60
-.set s_end, 66
+.set s_tmp, 58
+.set s_end, 64
 
 .set v_c, 0  ; coalescing:16, needed:2, resuable:28
 .set v_a, 2
@@ -3260,11 +3201,6 @@ igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt256x128x8_wt64x32_ws1x1_wr2x2_ta1x4x2x1_1x2x1
     ; clear vector r
     .v_clear_nc v_c+1, v_end-1
 
-    ; debug vgpr
-    v_mov_b32 v1, 0
-    v_add_lshl_u32 v[v_tmp+6], v0, v1, 2
-    ;v_lshlrev_b32 v[114], 2, v0 ; every thread write one float
-    s_load_dwordx2 s[s_dbg+0:s_dbg+1], s[s_ka:s_ka+1], k_p_wei
     ; input, thread(n0,n1b,c0,c1e): 1x4x1x1, cluster(n0,n1b,c0,c1e): 1x2x1x128
     v_mov_b32 v[v_tmp], v0
     v_and_b32 v[v_gtc_ic1e], 127, v[v_tmp]
@@ -4376,29 +4312,6 @@ L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt256x128x8_wt64x32_ws1x1_wr2x2_ta1x4x2x1_1x2
     s_mul_i32 s[s_tmp], 251, s[s_wei_stride_k]   ; i_m:251(i_m0:1,i_m1:123)
     buffer_store_dword v[v_c+15], v[v_wei_os], s[s_p_wei:s_p_wei+3], s[s_tmp] offen offset:0
 
-    s_branch L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt256x128x8_wt64x32_ws1x1_wr2x2_ta1x4x2x1_1x2x1x128_tb1x4x1x1_1x2x1x128_out
-    ; debug code to cpy vgpr to host
-    L_debug_L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt256x128x8_wt64x32_ws1x1_wr2x2_ta1x4x2x1_1x2x1x128_tb1x4x1x1_1x2x1x128_out_1:
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-    s_cmp_lg_u32 s[s_bx], 0
-    s_cbranch_scc1 L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt256x128x8_wt64x32_ws1x1_wr2x2_ta1x4x2x1_1x2x1x128_tb1x4x1x1_1x2x1x128_out_1
-    ;s_cmp_lg_u32 s[s_wave_id], 0
-    ;s_cbranch_scc1  L_program_end
-    ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
-    v_mov_b32 v[v_tmp], s[s_in_offset]
-
-    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
-    s_waitcnt vmcnt(0)
-    s_barrier
-
-    L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt256x128x8_wt64x32_ws1x1_wr2x2_ta1x4x2x1_1x2x1x128_tb1x4x1x1_1x2x1x128_out_1:
-    s_nop 2
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-
 L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt256x128x8_wt64x32_ws1x1_wr2x2_ta1x4x2x1_1x2x1x128_tb1x4x1x1_1x2x1x128_out:
     s_endpgm
 .rodata
@@ -4409,7 +4322,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt256x128x8_wt64x32_ws1x1_wr2x2_ta1x4x2x1_1x2
     .amdhsa_system_sgpr_workgroup_id_x 1
     .amdhsa_system_vgpr_workitem_id 0
     .amdhsa_next_free_vgpr 128
-    .amdhsa_next_free_sgpr 72
+    .amdhsa_next_free_sgpr 70
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
 .end_amdhsa_kernel
@@ -4513,9 +4426,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt256x128x8_wt64x32_ws1x1_wr2x2_ta1x4x2x1_1x2
 .set s_sub_n, 56
 .set s_group_stride, 57
 .set s_group_left, 1
-.set s_dbg, 58
-.set s_tmp, 60
-.set s_end, 66
+.set s_tmp, 58
+.set s_end, 64
 
 .set v_c, 0  ; coalescing:16, needed:2, resuable:28
 .set v_a, 2
@@ -4579,11 +4491,6 @@ igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt256x128x8_wt64x32_ws1x1_wr2x2_ta1x4x2x1_1x2x1
     ; clear vector r
     .v_clear_nc v_c+1, v_end-1
 
-    ; debug vgpr
-    v_mov_b32 v1, 0
-    v_add_lshl_u32 v[v_tmp+6], v0, v1, 2
-    ;v_lshlrev_b32 v[114], 2, v0 ; every thread write one float
-    s_load_dwordx2 s[s_dbg+0:s_dbg+1], s[s_ka:s_ka+1], k_p_wei
     ; input, thread(n0,n1b,c0,c1e): 1x4x1x1, cluster(n0,n1b,c0,c1e): 1x2x1x128
     v_mov_b32 v[v_tmp], v0
     v_and_b32 v[v_gtc_ic1e], 127, v[v_tmp]
@@ -5695,29 +5602,6 @@ L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt256x128x8_wt64x32_ws1x1_wr2x2_ta1x4x2x1_1x2
     s_mul_i32 s[s_tmp], 251, s[s_wei_stride_k]   ; i_m:251(i_m0:1,i_m1:123)
     buffer_atomic_add_f32 v[v_c+15], v[v_wei_os], s[s_p_wei:s_p_wei+3], s[s_tmp] offen offset:0
 
-    s_branch L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt256x128x8_wt64x32_ws1x1_wr2x2_ta1x4x2x1_1x2x1x128_tb1x4x1x1_1x2x1x128_gkgs_out
-    ; debug code to cpy vgpr to host
-    L_debug_L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt256x128x8_wt64x32_ws1x1_wr2x2_ta1x4x2x1_1x2x1x128_tb1x4x1x1_1x2x1x128_gkgs_out_1:
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-    s_cmp_lg_u32 s[s_bx], 0
-    s_cbranch_scc1 L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt256x128x8_wt64x32_ws1x1_wr2x2_ta1x4x2x1_1x2x1x128_tb1x4x1x1_1x2x1x128_gkgs_out_1
-    ;s_cmp_lg_u32 s[s_wave_id], 0
-    ;s_cbranch_scc1  L_program_end
-    ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
-    v_mov_b32 v[v_tmp], s[s_in_offset]
-
-    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
-    s_waitcnt vmcnt(0)
-    s_barrier
-
-    L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt256x128x8_wt64x32_ws1x1_wr2x2_ta1x4x2x1_1x2x1x128_tb1x4x1x1_1x2x1x128_gkgs_out_1:
-    s_nop 2
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-
 L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt256x128x8_wt64x32_ws1x1_wr2x2_ta1x4x2x1_1x2x1x128_tb1x4x1x1_1x2x1x128_gkgs_out:
     s_endpgm
 .rodata
@@ -5728,7 +5612,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt256x128x8_wt64x32_ws1x1_wr2x2_ta1x4x2x1_1x2
     .amdhsa_system_sgpr_workgroup_id_x 1
     .amdhsa_system_vgpr_workitem_id 0
     .amdhsa_next_free_vgpr 128
-    .amdhsa_next_free_sgpr 72
+    .amdhsa_next_free_sgpr 70
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
 .end_amdhsa_kernel
@@ -5832,9 +5716,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt256x128x8_wt64x32_ws1x1_wr2x2_ta1x4x2x1_1x2
 .set s_sub_n, 76
 .set s_group_stride, 77
 .set s_group_left, 1
-.set s_dbg, 78
-.set s_tmp, 80
-.set s_end, 86
+.set s_tmp, 78
+.set s_end, 84
 
 .set v_c, 0  ; coalescing:32, needed:2, resuable:40
 .set v_a, 2
@@ -5898,11 +5781,6 @@ igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x128x16_wt64x32_ws1x1_wr2x2_ta1x1x16x1_1x1
     ; clear vector r
     .v_clear_nc v_c+1, v_end-1
 
-    ; debug vgpr
-    v_mov_b32 v1, 0
-    v_add_lshl_u32 v[v_tmp+6], v0, v1, 2
-    ;v_lshlrev_b32 v[114], 2, v0 ; every thread write one float
-    s_load_dwordx2 s[s_dbg+0:s_dbg+1], s[s_ka:s_ka+1], k_p_wei
     ; input, thread(n0,n1b,c0,c1e): 1x1x8x1, cluster(n0,n1b,c0,c1e): 1x16x1x16
     v_mov_b32 v[v_tmp], v0
     v_and_b32 v[v_gtc_ic1e], 15, v[v_tmp]
@@ -7282,29 +7160,6 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x128x16_wt64x32_ws1x1_wr2x2_ta1x1x16x1_1
     s_mul_i32 s[s_tmp], 251, s[s_wei_stride_k]   ; i_m:251(i_m0:15,i_m1:11)
     buffer_store_dword v[v_c+31], v[v_wei_os], s[s_p_wei:s_p_wei+3], s[s_tmp] offen offset:0
 
-    s_branch L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x128x16_wt64x32_ws1x1_wr2x2_ta1x1x16x1_1x16x1x16_tb1x1x8x1_1x16x1x16_out
-    ; debug code to cpy vgpr to host
-    L_debug_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x128x16_wt64x32_ws1x1_wr2x2_ta1x1x16x1_1x16x1x16_tb1x1x8x1_1x16x1x16_out_1:
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-    s_cmp_lg_u32 s[s_bx], 0
-    s_cbranch_scc1 L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x128x16_wt64x32_ws1x1_wr2x2_ta1x1x16x1_1x16x1x16_tb1x1x8x1_1x16x1x16_out_1
-    ;s_cmp_lg_u32 s[s_wave_id], 0
-    ;s_cbranch_scc1  L_program_end
-    ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
-    v_mov_b32 v[v_tmp], s[s_in_offset]
-
-    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
-    s_waitcnt vmcnt(0)
-    s_barrier
-
-    L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x128x16_wt64x32_ws1x1_wr2x2_ta1x1x16x1_1x16x1x16_tb1x1x8x1_1x16x1x16_out_1:
-    s_nop 2
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-
 L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x128x16_wt64x32_ws1x1_wr2x2_ta1x1x16x1_1x16x1x16_tb1x1x8x1_1x16x1x16_out:
     s_endpgm
 .rodata
@@ -7315,7 +7170,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x128x16_wt64x32_ws1x1_wr2x2_ta1x1x16x1_1
     .amdhsa_system_sgpr_workgroup_id_x 1
     .amdhsa_system_vgpr_workitem_id 0
     .amdhsa_next_free_vgpr 128
-    .amdhsa_next_free_sgpr 92
+    .amdhsa_next_free_sgpr 90
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
 .end_amdhsa_kernel
@@ -7419,9 +7274,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x128x16_wt64x32_ws1x1_wr2x2_ta1x1x16x1_1
 .set s_sub_n, 76
 .set s_group_stride, 77
 .set s_group_left, 1
-.set s_dbg, 78
-.set s_tmp, 80
-.set s_end, 86
+.set s_tmp, 78
+.set s_end, 84
 
 .set v_c, 0  ; coalescing:32, needed:2, resuable:40
 .set v_a, 2
@@ -7485,11 +7339,6 @@ igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x128x16_wt64x32_ws1x1_wr2x2_ta1x1x16x1_1x1
     ; clear vector r
     .v_clear_nc v_c+1, v_end-1
 
-    ; debug vgpr
-    v_mov_b32 v1, 0
-    v_add_lshl_u32 v[v_tmp+6], v0, v1, 2
-    ;v_lshlrev_b32 v[114], 2, v0 ; every thread write one float
-    s_load_dwordx2 s[s_dbg+0:s_dbg+1], s[s_ka:s_ka+1], k_p_wei
     ; input, thread(n0,n1b,c0,c1e): 1x1x8x1, cluster(n0,n1b,c0,c1e): 1x16x1x16
     v_mov_b32 v[v_tmp], v0
     v_and_b32 v[v_gtc_ic1e], 15, v[v_tmp]
@@ -8869,29 +8718,6 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x128x16_wt64x32_ws1x1_wr2x2_ta1x1x16x1_1
     s_mul_i32 s[s_tmp], 251, s[s_wei_stride_k]   ; i_m:251(i_m0:15,i_m1:11)
     buffer_atomic_add_f32 v[v_c+31], v[v_wei_os], s[s_p_wei:s_p_wei+3], s[s_tmp] offen offset:0
 
-    s_branch L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x128x16_wt64x32_ws1x1_wr2x2_ta1x1x16x1_1x16x1x16_tb1x1x8x1_1x16x1x16_gkgs_out
-    ; debug code to cpy vgpr to host
-    L_debug_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x128x16_wt64x32_ws1x1_wr2x2_ta1x1x16x1_1x16x1x16_tb1x1x8x1_1x16x1x16_gkgs_out_1:
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-    s_cmp_lg_u32 s[s_bx], 0
-    s_cbranch_scc1 L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x128x16_wt64x32_ws1x1_wr2x2_ta1x1x16x1_1x16x1x16_tb1x1x8x1_1x16x1x16_gkgs_out_1
-    ;s_cmp_lg_u32 s[s_wave_id], 0
-    ;s_cbranch_scc1  L_program_end
-    ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
-    v_mov_b32 v[v_tmp], s[s_in_offset]
-
-    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
-    s_waitcnt vmcnt(0)
-    s_barrier
-
-    L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x128x16_wt64x32_ws1x1_wr2x2_ta1x1x16x1_1x16x1x16_tb1x1x8x1_1x16x1x16_gkgs_out_1:
-    s_nop 2
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-
 L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x128x16_wt64x32_ws1x1_wr2x2_ta1x1x16x1_1x16x1x16_tb1x1x8x1_1x16x1x16_gkgs_out:
     s_endpgm
 .rodata
@@ -8902,7 +8728,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x128x16_wt64x32_ws1x1_wr2x2_ta1x1x16x1_1
     .amdhsa_system_sgpr_workgroup_id_x 1
     .amdhsa_system_vgpr_workitem_id 0
     .amdhsa_next_free_vgpr 128
-    .amdhsa_next_free_sgpr 92
+    .amdhsa_next_free_sgpr 90
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
 .end_amdhsa_kernel
@@ -9006,9 +8832,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x128x16_wt64x32_ws1x1_wr2x2_ta1x1x16x1_1
 .set s_sub_n, 64
 .set s_group_stride, 65
 .set s_group_left, 1
-.set s_dbg, 66
-.set s_tmp, 68
-.set s_end, 74
+.set s_tmp, 66
+.set s_end, 72
 
 .set v_c, 0  ; coalescing:16, needed:2, resuable:28
 .set v_a, 2
@@ -9072,11 +8897,6 @@ igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x128x8_wt64x32_ws1x1_wr2x2_ta1x1x8x1_1x8x1
     ; clear vector r
     .v_clear_nc v_c+1, v_end-1
 
-    ; debug vgpr
-    v_mov_b32 v1, 0
-    v_add_lshl_u32 v[v_tmp+6], v0, v1, 2
-    ;v_lshlrev_b32 v[114], 2, v0 ; every thread write one float
-    s_load_dwordx2 s[s_dbg+0:s_dbg+1], s[s_ka:s_ka+1], k_p_wei
     ; input, thread(n0,n1b,c0,c1e): 1x1x4x1, cluster(n0,n1b,c0,c1e): 1x8x1x32
     v_mov_b32 v[v_tmp], v0
     v_and_b32 v[v_gtc_ic1e], 31, v[v_tmp]
@@ -10216,29 +10036,6 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x128x8_wt64x32_ws1x1_wr2x2_ta1x1x8x1_1x8
     s_mul_i32 s[s_tmp], 251, s[s_wei_stride_k]   ; i_m:251(i_m0:7,i_m1:27)
     buffer_store_dword v[v_c+15], v[v_wei_os], s[s_p_wei:s_p_wei+3], s[s_tmp] offen offset:0
 
-    s_branch L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x128x8_wt64x32_ws1x1_wr2x2_ta1x1x8x1_1x8x1x32_tb1x1x4x1_1x8x1x32_out
-    ; debug code to cpy vgpr to host
-    L_debug_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x128x8_wt64x32_ws1x1_wr2x2_ta1x1x8x1_1x8x1x32_tb1x1x4x1_1x8x1x32_out_1:
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-    s_cmp_lg_u32 s[s_bx], 0
-    s_cbranch_scc1 L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x128x8_wt64x32_ws1x1_wr2x2_ta1x1x8x1_1x8x1x32_tb1x1x4x1_1x8x1x32_out_1
-    ;s_cmp_lg_u32 s[s_wave_id], 0
-    ;s_cbranch_scc1  L_program_end
-    ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
-    v_mov_b32 v[v_tmp], s[s_in_offset]
-
-    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
-    s_waitcnt vmcnt(0)
-    s_barrier
-
-    L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x128x8_wt64x32_ws1x1_wr2x2_ta1x1x8x1_1x8x1x32_tb1x1x4x1_1x8x1x32_out_1:
-    s_nop 2
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-
 L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x128x8_wt64x32_ws1x1_wr2x2_ta1x1x8x1_1x8x1x32_tb1x1x4x1_1x8x1x32_out:
     s_endpgm
 .rodata
@@ -10249,7 +10046,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x128x8_wt64x32_ws1x1_wr2x2_ta1x1x8x1_1x8
     .amdhsa_system_sgpr_workgroup_id_x 1
     .amdhsa_system_vgpr_workitem_id 0
     .amdhsa_next_free_vgpr 128
-    .amdhsa_next_free_sgpr 80
+    .amdhsa_next_free_sgpr 78
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
 .end_amdhsa_kernel
@@ -10353,9 +10150,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x128x8_wt64x32_ws1x1_wr2x2_ta1x1x8x1_1x8
 .set s_sub_n, 64
 .set s_group_stride, 65
 .set s_group_left, 1
-.set s_dbg, 66
-.set s_tmp, 68
-.set s_end, 74
+.set s_tmp, 66
+.set s_end, 72
 
 .set v_c, 0  ; coalescing:16, needed:2, resuable:28
 .set v_a, 2
@@ -10419,11 +10215,6 @@ igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x128x8_wt64x32_ws1x1_wr2x2_ta1x1x8x1_1x8x1
     ; clear vector r
     .v_clear_nc v_c+1, v_end-1
 
-    ; debug vgpr
-    v_mov_b32 v1, 0
-    v_add_lshl_u32 v[v_tmp+6], v0, v1, 2
-    ;v_lshlrev_b32 v[114], 2, v0 ; every thread write one float
-    s_load_dwordx2 s[s_dbg+0:s_dbg+1], s[s_ka:s_ka+1], k_p_wei
     ; input, thread(n0,n1b,c0,c1e): 1x1x4x1, cluster(n0,n1b,c0,c1e): 1x8x1x32
     v_mov_b32 v[v_tmp], v0
     v_and_b32 v[v_gtc_ic1e], 31, v[v_tmp]
@@ -11563,29 +11354,6 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x128x8_wt64x32_ws1x1_wr2x2_ta1x1x8x1_1x8
     s_mul_i32 s[s_tmp], 251, s[s_wei_stride_k]   ; i_m:251(i_m0:7,i_m1:27)
     buffer_atomic_add_f32 v[v_c+15], v[v_wei_os], s[s_p_wei:s_p_wei+3], s[s_tmp] offen offset:0
 
-    s_branch L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x128x8_wt64x32_ws1x1_wr2x2_ta1x1x8x1_1x8x1x32_tb1x1x4x1_1x8x1x32_gkgs_out
-    ; debug code to cpy vgpr to host
-    L_debug_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x128x8_wt64x32_ws1x1_wr2x2_ta1x1x8x1_1x8x1x32_tb1x1x4x1_1x8x1x32_gkgs_out_1:
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-    s_cmp_lg_u32 s[s_bx], 0
-    s_cbranch_scc1 L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x128x8_wt64x32_ws1x1_wr2x2_ta1x1x8x1_1x8x1x32_tb1x1x4x1_1x8x1x32_gkgs_out_1
-    ;s_cmp_lg_u32 s[s_wave_id], 0
-    ;s_cbranch_scc1  L_program_end
-    ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
-    v_mov_b32 v[v_tmp], s[s_in_offset]
-
-    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
-    s_waitcnt vmcnt(0)
-    s_barrier
-
-    L_program_end_L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x128x8_wt64x32_ws1x1_wr2x2_ta1x1x8x1_1x8x1x32_tb1x1x4x1_1x8x1x32_gkgs_out_1:
-    s_nop 2
-    s_waitcnt lgkmcnt(0)
-    s_waitcnt vmcnt(0)
-    s_barrier
-
 L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x128x8_wt64x32_ws1x1_wr2x2_ta1x1x8x1_1x8x1x32_tb1x1x4x1_1x8x1x32_gkgs_out:
     s_endpgm
 .rodata
@@ -11596,7 +11364,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x128x8_wt64x32_ws1x1_wr2x2_ta1x1x8x1_1x8
     .amdhsa_system_sgpr_workgroup_id_x 1
     .amdhsa_system_vgpr_workitem_id 0
     .amdhsa_next_free_vgpr 128
-    .amdhsa_next_free_sgpr 80
+    .amdhsa_next_free_sgpr 78
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
 .end_amdhsa_kernel

--- a/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_256x128.inc
+++ b/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_256x128.inc
@@ -1535,7 +1535,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt256x128x16_wt64x32_ws1x1_wr2x2_ta1x4x4x1_1x
     ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
     v_mov_b32 v[v_tmp], s[s_in_offset]
 
-    global_store_dword v[v_tmp+6:v_tmp+7], v[v_in_os], s[s_dbg+0:s_dbg+1]
+    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
     s_waitcnt vmcnt(0)
     s_barrier
 
@@ -3070,7 +3070,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt256x128x16_wt64x32_ws1x1_wr2x2_ta1x4x4x1_1x
     ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
     v_mov_b32 v[v_tmp], s[s_in_offset]
 
-    global_store_dword v[v_tmp+6:v_tmp+7], v[v_in_os], s[s_dbg+0:s_dbg+1]
+    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
     s_waitcnt vmcnt(0)
     s_barrier
 
@@ -4389,7 +4389,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt256x128x8_wt64x32_ws1x1_wr2x2_ta1x4x2x1_1x2
     ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
     v_mov_b32 v[v_tmp], s[s_in_offset]
 
-    global_store_dword v[v_tmp+6:v_tmp+7], v[v_in_os], s[s_dbg+0:s_dbg+1]
+    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
     s_waitcnt vmcnt(0)
     s_barrier
 
@@ -5708,7 +5708,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt256x128x8_wt64x32_ws1x1_wr2x2_ta1x4x2x1_1x2
     ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
     v_mov_b32 v[v_tmp], s[s_in_offset]
 
-    global_store_dword v[v_tmp+6:v_tmp+7], v[v_in_os], s[s_dbg+0:s_dbg+1]
+    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
     s_waitcnt vmcnt(0)
     s_barrier
 
@@ -7295,7 +7295,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x128x16_wt64x32_ws1x1_wr2x2_ta1x1x16x1_1
     ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
     v_mov_b32 v[v_tmp], s[s_in_offset]
 
-    global_store_dword v[v_tmp+6:v_tmp+7], v[v_in_os], s[s_dbg+0:s_dbg+1]
+    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
     s_waitcnt vmcnt(0)
     s_barrier
 
@@ -8882,7 +8882,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x128x16_wt64x32_ws1x1_wr2x2_ta1x1x16x1_1
     ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
     v_mov_b32 v[v_tmp], s[s_in_offset]
 
-    global_store_dword v[v_tmp+6:v_tmp+7], v[v_in_os], s[s_dbg+0:s_dbg+1]
+    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
     s_waitcnt vmcnt(0)
     s_barrier
 
@@ -10229,7 +10229,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x128x8_wt64x32_ws1x1_wr2x2_ta1x1x8x1_1x8
     ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
     v_mov_b32 v[v_tmp], s[s_in_offset]
 
-    global_store_dword v[v_tmp+6:v_tmp+7], v[v_in_os], s[s_dbg+0:s_dbg+1]
+    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
     s_waitcnt vmcnt(0)
     s_barrier
 
@@ -11576,7 +11576,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x128x8_wt64x32_ws1x1_wr2x2_ta1x1x8x1_1x8
     ;v_add_co_u32 v34, vcc, 0, v[v_a0+2]
     v_mov_b32 v[v_tmp], s[s_in_offset]
 
-    global_store_dword v[v_tmp+6:v_tmp+7], v[v_in_os], s[s_dbg+0:s_dbg+1]
+    buffer_store_dword v[v_in_os], v[v_tmp+6], s[s_p_wei+0:s_p_wei+3], s[s_tmp] offen
     s_waitcnt vmcnt(0)
     s_barrier
 


### PR DESCRIPTION
Remove globla_store_dword instruction in dynamic igemm wrw pass, because the instruction does not use 64 bits vaddr any more.