### PR TITLE
Passing HIP compiler version to composable kernel

### DIFF
--- a/src/include/miopen/hip_build_utils.hpp
+++ b/src/include/miopen/hip_build_utils.hpp
@@ -26,6 +26,7 @@
 #ifndef MIOPEN_GUARD_MLOPEN_HIP_BUILD_UTILS_HPP
 #define MIOPEN_GUARD_MLOPEN_HIP_BUILD_UTILS_HPP
 
+#include <miopen/config.h>
 #include <miopen/kernel.hpp>
 #include <miopen/tmp_dir.hpp>
 #include <miopen/write_file.hpp>
@@ -42,13 +43,14 @@
 #define HIP_PACKAGE_VERSION_PATCH 0
 #endif
 
-// 3 decimal digits for major and minor, 5 digits for patch number.
+// 3 decimal digits for major and minor, 6 digits for patch number.
+// Max number is 999,999,999999 == 0xE8,D4A5,0FFF that fits into 64-bit math.
 #if HIP_PACKAGE_VERSION_MAJOR > 999 || HIP_PACKAGE_VERSION_MAJOR > 999 || \
-    HIP_PACKAGE_VERSION_PATCH > 99999
+    HIP_PACKAGE_VERSION_PATCH > 999999
 #error "Too big HIP version number(s)"
 #endif
-#define HIP_PACKAGE_VERSION_FLAT                                               \
-    ((HIP_PACKAGE_VERSION_MAJOR * 1000 + HIP_PACKAGE_VERSION_MINOR) * 100000 + \
+#define HIP_PACKAGE_VERSION_FLAT                                                   \
+    ((HIP_PACKAGE_VERSION_MAJOR * 1000ULL + HIP_PACKAGE_VERSION_MINOR) * 1000000 + \
      HIP_PACKAGE_VERSION_PATCH)
 
 namespace miopen {

--- a/src/include/miopen/hip_build_utils.hpp
+++ b/src/include/miopen/hip_build_utils.hpp
@@ -32,6 +32,25 @@
 #include <boost/optional.hpp>
 #include <string>
 
+#ifndef HIP_PACKAGE_VERSION_MAJOR
+#define HIP_PACKAGE_VERSION_MAJOR 0
+#endif
+#ifndef HIP_PACKAGE_VERSION_MINOR
+#define HIP_PACKAGE_VERSION_MINOR 0
+#endif
+#ifndef HIP_PACKAGE_VERSION_PATCH
+#define HIP_PACKAGE_VERSION_PATCH 0
+#endif
+
+// 3 decimal digits for major and minor, 5 digits for patch number.
+#if HIP_PACKAGE_VERSION_MAJOR > 999 || HIP_PACKAGE_VERSION_MAJOR > 999 || \
+    HIP_PACKAGE_VERSION_PATCH > 99999
+#error "Too big HIP version number(s)"
+#endif
+#define HIP_PACKAGE_VERSION_FLAT                                               \
+    ((HIP_PACKAGE_VERSION_MAJOR * 1000 + HIP_PACKAGE_VERSION_MINOR) * 100000 + \
+     HIP_PACKAGE_VERSION_PATCH)
+
 namespace miopen {
 
 boost::filesystem::path HipBuild(boost::optional<miopen::TmpDir>& tmp_dir,

--- a/src/kernels/composable_kernel/include/utility/amd_buffer_addressing.hpp
+++ b/src/kernels/composable_kernel/include/utility/amd_buffer_addressing.hpp
@@ -139,7 +139,7 @@ __llvm_amdgcn_buffer_store_bf16x4(ushort4_t vdata,
                                   bool slc) __asm("llvm.amdgcn.buffer.store.v4bf16");
 
 #if CK_USE_AMD_BUFFER_ATOMIC_FADD
-#if CK_HIP_VERSION >= 31020405
+#if CK_HIP_VERSION_FLAT >= 301020405
 // starting ROCm-3.10, the return type becomes float
 __device__ float
 #else

--- a/src/kernels/composable_kernel/include/utility/amd_buffer_addressing.hpp
+++ b/src/kernels/composable_kernel/include/utility/amd_buffer_addressing.hpp
@@ -139,7 +139,7 @@ __llvm_amdgcn_buffer_store_bf16x4(ushort4_t vdata,
                                   bool slc) __asm("llvm.amdgcn.buffer.store.v4bf16");
 
 #if CK_USE_AMD_BUFFER_ATOMIC_FADD
-#if CK_HIP_VERSION_FLAT >= 301020405
+#if CK_HIP_VERSION_FLAT >= 3010020405
 // starting ROCm-3.10, the return type becomes float
 __device__ float
 #else

--- a/src/kernels/composable_kernel/include/utility/amd_buffer_addressing.hpp
+++ b/src/kernels/composable_kernel/include/utility/amd_buffer_addressing.hpp
@@ -139,7 +139,12 @@ __llvm_amdgcn_buffer_store_bf16x4(ushort4_t vdata,
                                   bool slc) __asm("llvm.amdgcn.buffer.store.v4bf16");
 
 #if CK_USE_AMD_BUFFER_ATOMIC_ADD
+#if CK_HIP_COMPILER_VERSION >= 309020354
+// starting ROCm-3.10, the return type becomes float
+__device__ float
+#else
 __device__ void
+#endif
 __llvm_amdgcn_buffer_atomic_add_f32(float vdata,
                                     int32x4_t rsrc,
                                     index_t vindex,

--- a/src/kernels/composable_kernel/include/utility/amd_buffer_addressing.hpp
+++ b/src/kernels/composable_kernel/include/utility/amd_buffer_addressing.hpp
@@ -138,8 +138,8 @@ __llvm_amdgcn_buffer_store_bf16x4(ushort4_t vdata,
                                   bool glc,
                                   bool slc) __asm("llvm.amdgcn.buffer.store.v4bf16");
 
-#if CK_USE_AMD_BUFFER_ATOMIC_ADD
-#if CK_HIP_COMPILER_VERSION >= 309020354
+#if CK_USE_AMD_BUFFER_ATOMIC_FADD
+#if CK_HIP_VERSION >= 31020405
 // starting ROCm-3.10, the return type becomes float
 __device__ float
 #else
@@ -170,7 +170,7 @@ __device__ void amd_buffer_store(const T* p_src,
                                  index_t dst_thread_data_offset,
                                  index_t dst_const_data_offset);
 
-#if CK_USE_AMD_BUFFER_ATOMIC_ADD
+#if CK_USE_AMD_BUFFER_ATOMIC_FADD
 template <typename T, index_t VectorSize>
 __device__ void amd_buffer_atomic_add(const T* p_src,
                                       T* p_dst_block,
@@ -743,7 +743,7 @@ __device__ void amd_buffer_store<ushort, 4>(const ushort* p_src,
 #endif
 }
 
-#if CK_USE_AMD_BUFFER_ATOMIC_ADD
+#if CK_USE_AMD_BUFFER_ATOMIC_FADD
 template <>
 __device__ void amd_buffer_atomic_add<float, 1>(const float* p_src,
                                                 float* p_dst_block,
@@ -791,7 +791,7 @@ __device__ void amd_buffer_atomic_add<float, 4>(const float* p_src,
             &p_src[i], p_dst_block, dst_thread_data_offset, dst_const_data_offset + i);
     }
 }
-#endif // CK_USE_AMD_BUFFER_ATOMIC_ADD
+#endif // CK_USE_AMD_BUFFER_ATOMIC_FADD
 
 } // namespace ck
 #endif

--- a/src/kernels/composable_kernel/include/utility/config.hpp
+++ b/src/kernels/composable_kernel/include/utility/config.hpp
@@ -7,8 +7,8 @@
 #endif
 #include "bfloat16_dev.hpp"
 
-#ifndef CK_HIP_VERSION
-#define CK_HIP_VERSION 0
+#ifndef CK_HIP_VERSION_FLAT
+#define CK_HIP_VERSION_FLAT 0
 #endif
 
 // index type: unsigned or signed

--- a/src/kernels/composable_kernel/include/utility/config.hpp
+++ b/src/kernels/composable_kernel/include/utility/config.hpp
@@ -7,6 +7,10 @@
 #endif
 #include "bfloat16_dev.hpp"
 
+#ifndef CK_HIP_COMPILER_VERSION
+#define CK_HIP_COMPILER_VERSION 0
+#endif
+
 // index type: unsigned or signed
 #define CK_UNSIGNED_INDEX_TYPE 0
 

--- a/src/kernels/composable_kernel/include/utility/config.hpp
+++ b/src/kernels/composable_kernel/include/utility/config.hpp
@@ -7,8 +7,8 @@
 #endif
 #include "bfloat16_dev.hpp"
 
-#ifndef CK_HIP_COMPILER_VERSION
-#define CK_HIP_COMPILER_VERSION 0
+#ifndef CK_HIP_VERSION
+#define CK_HIP_VERSION 0
 #endif
 
 // index type: unsigned or signed
@@ -32,8 +32,8 @@
 #endif
 
 // only gfx908 support native floating point atomic add
-#ifndef CK_USE_AMD_BUFFER_ATOMIC_ADD
-#define CK_USE_AMD_BUFFER_ATOMIC_ADD 0
+#ifndef CK_USE_AMD_BUFFER_ATOMIC_FADD
+#define CK_USE_AMD_BUFFER_ATOMIC_FADD 0
 #endif
 
 // AMD XDLOPS

--- a/src/kernels/composable_kernel/include/utility/in_memory_operation.hpp
+++ b/src/kernels/composable_kernel/include/utility/in_memory_operation.hpp
@@ -111,7 +111,7 @@ struct AtomicAddData
                         *reinterpret_cast<const vector_t*>(&p_src[src_offset]));
     }
 
-#if CK_USE_AMD_BUFFER_ADDRESSING && CK_USE_AMD_BUFFER_ATOMIC_ADD
+#if CK_USE_AMD_BUFFER_ADDRESSING && CK_USE_AMD_BUFFER_ATOMIC_FADD
     // buffer_atomic_add requires:
     //   1) p_src must be in vgpr space, d_dst must be global memory
     //   2) p_dst to be a block-invariant pointer.

--- a/src/solver/conv_hip_implicit_gemm_bwd_data_v1r1.cpp
+++ b/src/solver/conv_hip_implicit_gemm_bwd_data_v1r1.cpp
@@ -775,7 +775,6 @@ ConvSolution ConvHipImplicitGemmBwdDataV1R1::GetSolution(
 
     // clang-format off
     construction_parameters.comp_options =
-        std::string(" -std=c++14 ") +
         std::string(" -DCK_PARAM_PROBLEM_N=") + std::to_string(ConvolutionContextInterpreter::GetBatchN(ctx)) +
         std::string(" -DCK_PARAM_PROBLEM_K=") + std::to_string(ConvolutionContextInterpreter::GetOutputChannelK(ctx)) +
         std::string(" -DCK_PARAM_PROBLEM_C=") + std::to_string(ConvolutionContextInterpreter::GetInputChannelC(ctx)) +
@@ -813,7 +812,7 @@ ConvSolution ConvHipImplicitGemmBwdDataV1R1::GetSolution(
         std::string(" -DCK_PARAM_DEPENDENT_GRID_SIZE=") + std::to_string(grid_size) +
         std::string(" -DCK_THREADWISE_GEMM_USE_AMD_INLINE_ASM=") + (use_amd_inline_asm(ctx) ? '1' : '0') +
         std::string(" -DCK_USE_AMD_INLINE_ASM=") + (use_amd_inline_asm(ctx) ? '1' : '0') +
-        std::string(" -DCK_USE_AMD_BUFFER_ATOMIC_ADD=") + (support_amd_buffer_atomic_add(ctx) ? '1' : '0') +
+        get_ck_common_compiler_flag(ctx) +
         ctx.general_compile_options;
     // clang-format on
     if(ctx.Is3d())

--- a/src/solver/conv_hip_implicit_gemm_bwd_data_v4r1.cpp
+++ b/src/solver/conv_hip_implicit_gemm_bwd_data_v4r1.cpp
@@ -880,7 +880,6 @@ ConvSolution ConvHipImplicitGemmBwdDataV4R1::GetSolution(
 
             // clang-format off
             construction_parameters.comp_options =
-                std::string(" -std=c++14 ") +
                 std::string(" -DCK_PARAM_PROBLEM_N=") + std::to_string(ConvolutionContextInterpreter::GetBatchN(ctx)) +
                 std::string(" -DCK_PARAM_PROBLEM_K=") + std::to_string(ConvolutionContextInterpreter::GetOutputChannelK(ctx)) +
                 std::string(" -DCK_PARAM_PROBLEM_C=") + std::to_string(ConvolutionContextInterpreter::GetInputChannelC(ctx)) +
@@ -921,6 +920,7 @@ ConvSolution ConvHipImplicitGemmBwdDataV4R1::GetSolution(
                 std::string(" -DCK_THREADWISE_GEMM_USE_AMD_INLINE_ASM=") + (use_amd_inline_asm(ctx) ? '1' : '0') +
                 std::string(" -DCK_USE_AMD_INLINE_ASM=") + (use_amd_inline_asm(ctx) ? '1' : '0') +
                 std::string(" -DCK_PARAM_GEMM_ID=") + std::to_string(gemm_id) +
+                get_ck_common_compiler_flag(ctx) +
                 ctx.general_compile_options;
             // clang-format on
 

--- a/src/solver/conv_hip_implicit_gemm_bwd_data_v4r1_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_bwd_data_v4r1_xdlops.cpp
@@ -921,7 +921,6 @@ ConvSolution ConvHipImplicitGemmBwdDataV4R1Xdlops::GetSolution(
 
             // clang-format off
             construction_parameters.comp_options =
-                std::string(" -std=c++14 ") +
                 std::string(" -DCK_PARAM_PROBLEM_N=") + std::to_string(ConvolutionContextInterpreter::GetBatchN(ctx)) +
                 std::string(" -DCK_PARAM_PROBLEM_K=") + std::to_string(ConvolutionContextInterpreter::GetOutputChannelK(ctx)) +
                 std::string(" -DCK_PARAM_PROBLEM_C=") + std::to_string(ConvolutionContextInterpreter::GetInputChannelC(ctx)) +
@@ -957,11 +956,11 @@ ConvSolution ConvHipImplicitGemmBwdDataV4R1Xdlops::GetSolution(
 
                 std::string(" -DCK_PARAM_TUNABLE_GEMM_B_BLOCK_COPY_SRC_DATA_PER_READ_GEMM_N=") + std::to_string(GemmBBlockCopySrcDataPerRead_GemmN) +
                 std::string(" -DCK_PARAM_DEPENDENT_GRID_SIZE=") + std::to_string(grid_size) +
-                std::string(" -DCK_USE_AMD_BUFFER_ATOMIC_ADD=") + (support_amd_buffer_atomic_add(ctx) ? '1' : '0') +
                 std::string(" -DCK_USE_AMD_XDLOPS=") + std::to_string(IsXdlopsSupport(ctx) ? 1 : 0) +
                 std::string(" -DCK_USE_AMD_XDLOPS_INLINE_ASM=") + std::to_string(miopen::IsEnabled(MIOPEN_DEBUG_IMPLICIT_GEMM_XDLOPS_INLINE_ASM{}) ? 1 : 0) +
                 std::string(" -DCK_USE_AMD_XDLOPS_EMULATE=") + (miopen::IsEnabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_XDLOPS_EMULATE{}) ? '1' : '0') +
                 std::string(" -DCK_PARAM_GEMM_ID=") + std::to_string(gemm_id) +
+                get_ck_common_compiler_flag(ctx) +
                 ctx.general_compile_options;
 
                 construction_parameters.comp_options +=

--- a/src/solver/conv_hip_implicit_gemm_bwd_v1r1_xdlops_nchw_kcyx_nkhw.cpp
+++ b/src/solver/conv_hip_implicit_gemm_bwd_v1r1_xdlops_nchw_kcyx_nkhw.cpp
@@ -534,13 +534,6 @@ bool PerformanceImplicitGemmBwdV1R1Xdlops::IsFastToBeUsedForTuning(
             return false;
     }
 
-#if WORKAROUND_SWDEV_240356
-    {
-        if(ctx.IsBfp16() && GemmMPerWave * GemmNPerWave > 64 * 64)
-            return false;
-    }
-#endif
-
     // don't need too many blocks
     {
         int gemm_m = 0;
@@ -554,11 +547,7 @@ bool PerformanceImplicitGemmBwdV1R1Xdlops::IsFastToBeUsedForTuning(
 
         // this the the biggest blockwise-GEMM you can do
         int max_blockwise_gemm_size =
-#if WORKAROUND_SWDEV_240356
-            gcd(128, gemm_m) * gcd(128, gemm_n);
-#else
             std::max(gcd(256, gemm_m) * gcd(128, gemm_n), gcd(128, gemm_m) * gcd(256, gemm_n));
-#endif
 
         // this is the grid size using the biggest blockwise-GEMM
         auto grid_size_max_blockwise_gemm =

--- a/src/solver/conv_hip_implicit_gemm_bwd_v1r1_xdlops_nchw_kcyx_nkhw.cpp
+++ b/src/solver/conv_hip_implicit_gemm_bwd_v1r1_xdlops_nchw_kcyx_nkhw.cpp
@@ -848,7 +848,6 @@ ConvSolution ConvHipImplicitGemmBwdDataV1R1Xdlops::GetSolution(
 
     // clang-format off
     construction_parameters.comp_options =
-        std::string(" -std=c++14 ") +
         std::string(" -DCK_PARAM_PROBLEM_G=") + std::to_string(ConvolutionContextInterpreter::GetGroupCountG(ctx)) +
         std::string(" -DCK_PARAM_PROBLEM_N=") + std::to_string(ConvolutionContextInterpreter::GetBatchN(ctx)) +
         std::string(" -DCK_PARAM_PROBLEM_K=") + std::to_string(ConvolutionContextInterpreter::GetOutputChannelK(ctx)) +
@@ -887,11 +886,9 @@ ConvSolution ConvHipImplicitGemmBwdDataV1R1Xdlops::GetSolution(
         std::string(" -DCK_PARAM_DEPENDENT_GEMM_B_BLOCK_COPY_DST_DATA_PER_WRITE_GEMM_KPACK=") + std::to_string(GemmBBlockCopyDstDataPerWrite_GemmKPack) +
         std::string(" -DCK_USE_AMD_XDLOPS=") + std::to_string(IsXdlopsSupport(ctx) ? 1 : 0) +
         std::string(" -DCK_USE_AMD_XDLOPS_INLINE_ASM=") + std::to_string(miopen::IsEnabled(MIOPEN_DEBUG_IMPLICIT_GEMM_XDLOPS_INLINE_ASM{}) ? 1 : 0) +
-        std::string(" -DCK_USE_AMD_BUFFER_ATOMIC_ADD=") + (support_amd_buffer_atomic_add(ctx) ? '1' : '0') +
         std::string(" -DCK_USE_AMD_XDLOPS_EMULATE=") + (miopen::IsEnabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_XDLOPS_EMULATE{}) ? '1' : '0') +
         std::string(" -DCK_BLOCK_SYNC_LDS_WITHOUT_SYNC_VMEM=") + (miopen::IsDisabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_BLOCK_SYNC_LDS_WITHOUT_SYNC_VMEM{}) ? '0' : '1') +
-        std::string(" -DCK_WORKAROUND_SWDEV_229564=") + std::to_string(WORKAROUND_SWDEV_229564) +
-        std::string(" -DCK_WORKAROUND_SWDEV_231101=") + std::to_string(WORKAROUND_SWDEV_231101) +
+        get_ck_common_compiler_flag(ctx) +
         ctx.general_compile_options;
 
     result.invoker_factory = conv::MakeImplGemmDataInvokerFactory(ctx);

--- a/src/solver/conv_hip_implicit_gemm_fwd_v4r4_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_fwd_v4r4_xdlops.cpp
@@ -633,13 +633,6 @@ bool PerformanceImplicitGemmForwardV4R4Xdlops::IsFastToBeUsedForTuning(
             return false;
     }
 
-#if WORKAROUND_SWDEV_240356
-    {
-        if(ctx.IsBfp16() && GemmMPerWave * GemmNPerWave > 64 * 64)
-            return false;
-    }
-#endif
-
     // don't need too many blocks
     {
         int gemm_m = 0;
@@ -653,11 +646,7 @@ bool PerformanceImplicitGemmForwardV4R4Xdlops::IsFastToBeUsedForTuning(
 
         // this the the biggest blockwise-GEMM you can do
         int max_blockwise_gemm_size =
-#if WORKAROUND_SWDEV_240356
-            gcd(128, gemm_m) * gcd(128, gemm_n);
-#else
             std::max(gcd(256, gemm_m) * gcd(128, gemm_n), gcd(128, gemm_m) * gcd(256, gemm_n));
-#endif
 
         // this is the grid size using the biggest blockwise-GEMM
         auto grid_size_max_blockwise_gemm =

--- a/src/solver/conv_hip_implicit_gemm_fwd_v4r4_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_fwd_v4r4_xdlops.cpp
@@ -912,7 +912,6 @@ ConvSolution ConvHipImplicitGemmForwardV4R4Xdlops::GetSolution(
 
     // clang-format off
     construction_parameters.comp_options =
-        std::string(" -std=c++14 ") +
         std::string(" -DCK_PARAM_PROBLEM_G=") + std::to_string(ConvolutionContextInterpreter::GetGroupCountG(ctx)) +
         std::string(" -DCK_PARAM_PROBLEM_N=") + std::to_string(ConvolutionContextInterpreter::GetBatchN(ctx)) +
         std::string(" -DCK_PARAM_PROBLEM_K=") + std::to_string(ConvolutionContextInterpreter::GetOutputChannelK(ctx)) +
@@ -953,8 +952,7 @@ ConvSolution ConvHipImplicitGemmForwardV4R4Xdlops::GetSolution(
         std::string(" -DCK_USE_AMD_XDLOPS_INLINE_ASM=") + std::to_string(miopen::IsEnabled(MIOPEN_DEBUG_IMPLICIT_GEMM_XDLOPS_INLINE_ASM{}) ? 1 : 0) +
         std::string(" -DCK_USE_AMD_XDLOPS_EMULATE=") + (miopen::IsEnabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_XDLOPS_EMULATE{}) ? '1' : '0') +
         std::string(" -DCK_BLOCK_SYNC_LDS_WITHOUT_SYNC_VMEM=") + (miopen::IsDisabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_BLOCK_SYNC_LDS_WITHOUT_SYNC_VMEM{}) ? '0' : '1') +
-        std::string(" -DCK_WORKAROUND_SWDEV_229564=") + std::to_string(WORKAROUND_SWDEV_229564) +
-        std::string(" -DCK_WORKAROUND_SWDEV_231101=") + std::to_string(WORKAROUND_SWDEV_231101) +
+        get_ck_common_compiler_flag(ctx) +
         ctx.general_compile_options;
     // clang-format on
 

--- a/src/solver/conv_hip_implicit_gemm_fwd_v4r4_xdlops_padded_gemm.cpp
+++ b/src/solver/conv_hip_implicit_gemm_fwd_v4r4_xdlops_padded_gemm.cpp
@@ -665,13 +665,6 @@ bool PerformanceImplicitGemmForwardV4R4Xdlops_Padded_Gemm::IsFastToBeUsedForTuni
             return false;
     }
 
-#if WORKAROUND_SWDEV_240356
-    {
-        if(ctx.IsBfp16() && GemmMPerWave * GemmNPerWave > 64 * 64)
-            return false;
-    }
-#endif
-
     // don't need too many blocks
     {
         int gemm_m = 0;
@@ -686,11 +679,7 @@ bool PerformanceImplicitGemmForwardV4R4Xdlops_Padded_Gemm::IsFastToBeUsedForTuni
 
         // this the the biggest blockwise-GEMM you can do
         int max_blockwise_gemm_size =
-#if WORKAROUND_SWDEV_240356
-            gcd(128, gemm_m) * gcd(128, gemm_n);
-#else
             std::max(gcd(256, gemm_m) * gcd(128, gemm_n), gcd(128, gemm_m) * gcd(256, gemm_n));
-#endif
 
         // this is the grid size using the biggest blockwise-GEMM
         auto grid_size_max_blockwise_gemm =

--- a/src/solver/conv_hip_implicit_gemm_fwd_v4r4_xdlops_padded_gemm.cpp
+++ b/src/solver/conv_hip_implicit_gemm_fwd_v4r4_xdlops_padded_gemm.cpp
@@ -974,7 +974,6 @@ ConvSolution ConvHipImplicitGemmForwardV4R4Xdlops_Padded_Gemm::GetSolution(
 
     // clang-format off
     construction_parameters.comp_options =
-        std::string(" -std=c++14 ") +
         std::string(" -DCK_PARAM_PROBLEM_G=") + std::to_string(ConvolutionContextInterpreter::GetGroupCountG(ctx)) +
         std::string(" -DCK_PARAM_PROBLEM_N=") + std::to_string(ConvolutionContextInterpreter::GetBatchN(ctx)) +
         std::string(" -DCK_PARAM_PROBLEM_K=") + std::to_string(ConvolutionContextInterpreter::GetOutputChannelK(ctx)) +
@@ -1018,8 +1017,7 @@ ConvSolution ConvHipImplicitGemmForwardV4R4Xdlops_Padded_Gemm::GetSolution(
         std::string(" -DCK_USE_AMD_XDLOPS_INLINE_ASM=") + std::to_string(miopen::IsEnabled(MIOPEN_DEBUG_IMPLICIT_GEMM_XDLOPS_INLINE_ASM{}) ? 1 : 0) +
         std::string(" -DCK_USE_AMD_XDLOPS_EMULATE=") + (miopen::IsEnabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_XDLOPS_EMULATE{}) ? '1' : '0') +
         std::string(" -DCK_BLOCK_SYNC_LDS_WITHOUT_SYNC_VMEM=") + (miopen::IsDisabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_BLOCK_SYNC_LDS_WITHOUT_SYNC_VMEM{}) ? '0' : '1') +
-        std::string(" -DCK_WORKAROUND_SWDEV_229564=") + std::to_string(WORKAROUND_SWDEV_229564) +
-        std::string(" -DCK_WORKAROUND_SWDEV_231101=") + std::to_string(WORKAROUND_SWDEV_231101) +
+        get_ck_common_compiler_flag(ctx) +
         ctx.general_compile_options;
     // clang-format on
 

--- a/src/solver/conv_hip_implicit_gemm_fwd_v4r5_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_fwd_v4r5_xdlops.cpp
@@ -911,7 +911,6 @@ ConvSolution ConvHipImplicitGemmForwardV4R5Xdlops::GetSolution(
 
     // clang-format off
     construction_parameters.comp_options =
-        std::string(" -std=c++14 ") +
         std::string(" -DCK_PARAM_PROBLEM_G=") + std::to_string(ConvolutionContextInterpreter::GetGroupCountG(ctx)) +
         std::string(" -DCK_PARAM_PROBLEM_N=") + std::to_string(ConvolutionContextInterpreter::GetBatchN(ctx)) +
         std::string(" -DCK_PARAM_PROBLEM_K=") + std::to_string(ConvolutionContextInterpreter::GetOutputChannelK(ctx)) +
@@ -953,8 +952,7 @@ ConvSolution ConvHipImplicitGemmForwardV4R5Xdlops::GetSolution(
         std::string(" -DCK_USE_AMD_XDLOPS_INLINE_ASM=") + std::to_string(miopen::IsEnabled(MIOPEN_DEBUG_IMPLICIT_GEMM_XDLOPS_INLINE_ASM{}) ? 1 : 0) +
         std::string(" -DCK_USE_AMD_XDLOPS_EMULATE=") + (miopen::IsEnabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_XDLOPS_EMULATE{}) ? '1' : '0') +
         std::string(" -DCK_BLOCK_SYNC_LDS_WITHOUT_SYNC_VMEM=") + (miopen::IsDisabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_BLOCK_SYNC_LDS_WITHOUT_SYNC_VMEM{}) ? '0' : '1') +
-        std::string(" -DCK_WORKAROUND_SWDEV_229564=") + std::to_string(WORKAROUND_SWDEV_229564) +
-        std::string(" -DCK_WORKAROUND_SWDEV_231101=") + std::to_string(WORKAROUND_SWDEV_231101) +
+        get_ck_common_compiler_flag(ctx) +
         ctx.general_compile_options;
     // clang-format on
 

--- a/src/solver/conv_hip_implicit_gemm_v4r1.cpp
+++ b/src/solver/conv_hip_implicit_gemm_v4r1.cpp
@@ -275,7 +275,6 @@ ConvSolution ConvHipImplicitGemmV4R1Fwd::GetSolution(const ConvolutionContext& c
 
     // clang-format off
     construction_parameters.comp_options =
-        std::string(" -std=c++14 ") +
         std::string(" -DCK_PARAM_PROBLEM_N=") + std::to_string(n) +
         std::string(" -DCK_PARAM_PROBLEM_K=") + std::to_string(k) +
         std::string(" -DCK_PARAM_PROBLEM_C=") + std::to_string(c) +
@@ -320,6 +319,7 @@ ConvSolution ConvHipImplicitGemmV4R1Fwd::GetSolution(const ConvolutionContext& c
         std::string(" -DCK_PARAM_EPACK_LENGTH=") + std::to_string(GetEPackLength(ctx, false)) +
         std::string(" -DCK_THREADWISE_GEMM_USE_AMD_INLINE_ASM=") + (use_amd_inline_asm(ctx) ? '1' : '0') +
         std::string(" -DCK_USE_AMD_INLINE_ASM=") + (use_amd_inline_asm(ctx) ? '1' : '0') +
+        get_ck_common_compiler_flag(ctx) +
         ctx.general_compile_options;
     // clang-format on
 
@@ -476,7 +476,6 @@ ConvSolution ConvHipImplicitGemmV4R1WrW::GetSolution(const ConvolutionContext& c
 
     // clang-format off
     construction_parameters.comp_options =
-        std::string(" -std=c++14 ") +
         std::string(" -DCK_PARAM_PROBLEM_N=") + std::to_string(n) +
         std::string(" -DCK_PARAM_PROBLEM_K=") + std::to_string(k) +
         std::string(" -DCK_PARAM_PROBLEM_C=") + std::to_string(c) +
@@ -521,6 +520,7 @@ ConvSolution ConvHipImplicitGemmV4R1WrW::GetSolution(const ConvolutionContext& c
         std::string(" -DCK_PARAM_EPACK_LENGTH=") + std::to_string(GetEPackLength(ctx, false)) +
         std::string(" -DCK_THREADWISE_GEMM_USE_AMD_INLINE_ASM=") + (use_amd_inline_asm(ctx)? '1' : '0') +
         std::string(" -DCK_USE_AMD_INLINE_ASM=") + (use_amd_inline_asm(ctx) ? '1' : '0') +
+        get_ck_common_compiler_flag(ctx) +
         ctx.general_compile_options;
     // clang-format on
 

--- a/src/solver/conv_hip_implicit_gemm_v4r4.cpp
+++ b/src/solver/conv_hip_implicit_gemm_v4r4.cpp
@@ -700,7 +700,6 @@ ConvSolution ConvHipImplicitGemmV4R4Fwd::GetSolution(const ConvolutionContext& c
 
     // clang-format off
     construction_parameters.comp_options =
-        std::string(" -std=c++14 ") +
         std::string(" -DCK_PARAM_PROBLEM_N=") + std::to_string(ConvolutionContextInterpreter::GetBatchN(ctx)) +
         std::string(" -DCK_PARAM_PROBLEM_K=") + std::to_string(ConvolutionContextInterpreter::GetOutputChannelK(ctx)) +
         std::string(" -DCK_PARAM_PROBLEM_C=") + std::to_string(ConvolutionContextInterpreter::GetInputChannelC(ctx)) +
@@ -743,6 +742,7 @@ ConvSolution ConvHipImplicitGemmV4R4Fwd::GetSolution(const ConvolutionContext& c
         std::string(" -DCK_PARAM_DEPENDENT_GRID_SIZE=") + std::to_string(grid_size) +
         std::string(" -DCK_THREADWISE_GEMM_USE_AMD_INLINE_ASM=") + (use_amd_inline_asm(ctx) ? '1' : '0') +
         std::string(" -DCK_USE_AMD_INLINE_ASM=") + (use_amd_inline_asm(ctx) ? '1' : '0') +
+        get_ck_common_compiler_flag(ctx) +
         ctx.general_compile_options;
 
         if (ctx.Is3d()){

--- a/src/solver/conv_hip_implicit_gemm_wrw_v4r4_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_wrw_v4r4_xdlops.cpp
@@ -826,11 +826,7 @@ ConvHipImplicitGemmWrwV4R4Xdlops::GetPerformanceConfig(const ConvolutionContext&
     MIOPEN_LOG_I(config.ToString());
     return config;
 }
-static inline bool is_support_amd_buffer_atomic_add(const ConvolutionContext& ctx)
-{
-    const auto device_name = ctx.GetStream().GetDeviceName();
-    return StartsWith(device_name, "gfx908");
-}
+
 ConvSolution ConvHipImplicitGemmWrwV4R4Xdlops::GetSolution(
     const ConvolutionContext& ctx, const PerformanceImplicitGemmWrwV4R4Xdlops& config, bool) const
 {
@@ -889,7 +885,6 @@ ConvSolution ConvHipImplicitGemmWrwV4R4Xdlops::GetSolution(
 
     // clang-format off
     construction_parameters.comp_options =
-        std::string(" -std=c++14 ") +
         std::string(" -DCK_PARAM_PROBLEM_G=") + std::to_string(ConvolutionContextInterpreter::GetGroupCountG(ctx)) +
         std::string(" -DCK_PARAM_PROBLEM_N=") + std::to_string(ConvolutionContextInterpreter::GetBatchN(ctx)) +
         std::string(" -DCK_PARAM_PROBLEM_K=") + std::to_string(ConvolutionContextInterpreter::GetOutputChannelK(ctx)) +
@@ -931,8 +926,7 @@ ConvSolution ConvHipImplicitGemmWrwV4R4Xdlops::GetSolution(
         std::string(" -DCK_USE_AMD_XDLOPS_INLINE_ASM=") + std::to_string(miopen::IsEnabled(MIOPEN_DEBUG_IMPLICIT_GEMM_XDLOPS_INLINE_ASM{}) ? 1 : 0) +
         std::string(" -DCK_USE_AMD_XDLOPS_EMULATE=") + (miopen::IsEnabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_XDLOPS_EMULATE{}) ? '1' : '0') +
         std::string(" -DCK_BLOCK_SYNC_LDS_WITHOUT_SYNC_VMEM=") + (miopen::IsDisabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_BLOCK_SYNC_LDS_WITHOUT_SYNC_VMEM{}) ? '0' : '1') +
-        std::string(" -DCK_WORKAROUND_SWDEV_231101=") + std::to_string(WORKAROUND_SWDEV_231101) +
-        std::string(" -DCK_USE_AMD_BUFFER_ATOMIC_ADD=") + (is_support_amd_buffer_atomic_add(ctx) ? '1' : '0') +
+        get_ck_common_compiler_flag(ctx) +
         ctx.general_compile_options;
     // clang-format on
 

--- a/src/solver/conv_hip_implicit_gemm_wrw_weights_v4r4.cpp
+++ b/src/solver/conv_hip_implicit_gemm_wrw_weights_v4r4.cpp
@@ -703,7 +703,6 @@ ConvSolution ConvHipImplicitGemmV4R4WrW::GetSolution(const ConvolutionContext& c
 
     // clang-format off
     construction_parameters.comp_options =
-        std::string(" -std=c++14 ") +
         std::string(" -DCK_PARAM_PROBLEM_N=") + std::to_string(ConvolutionContextInterpreter::GetBatchN(ctx)) +
         std::string(" -DCK_PARAM_PROBLEM_C=") + std::to_string(ConvolutionContextInterpreter::GetInputChannelC(ctx)) +
         std::string(" -DCK_PARAM_PROBLEM_K=") + std::to_string(ConvolutionContextInterpreter::GetOutputChannelK(ctx)) +
@@ -746,6 +745,7 @@ ConvSolution ConvHipImplicitGemmV4R4WrW::GetSolution(const ConvolutionContext& c
         std::string(" -DCK_PARAM_DEPENDENT_GRID_SIZE=") + std::to_string(grid_size) +
         std::string(" -DCK_THREADWISE_GEMM_USE_AMD_INLINE_ASM=") + (use_amd_inline_asm(ctx) ? '1' : '0') +
         std::string(" -DCK_USE_AMD_INLINE_ASM=") + (use_amd_inline_asm(ctx) ? '1' : '0') +
+        get_ck_common_compiler_flag(ctx) +
         ctx.general_compile_options;
 
         if (ctx.Is3d()){

--- a/src/solver/implicitgemm_util.hpp
+++ b/src/solver/implicitgemm_util.hpp
@@ -686,7 +686,7 @@ static inline bool use_amd_inline_asm(const ConvolutionContext& ctx)
 static inline bool support_amd_buffer_atomic_fadd(const ConvolutionContext& ctx)
 {
     const auto device_name = ctx.GetStream().GetDeviceName();
-    return StartsWith(device_name, "gfx908") && ctx.IsFp32();
+    return StartsWith(device_name, "gfx908");
 }
 
 template <typename T>

--- a/src/solver/implicitgemm_util.hpp
+++ b/src/solver/implicitgemm_util.hpp
@@ -18,14 +18,9 @@ MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_BLOCK_SYNC_LDS_WITHOUT_SY
 #define WORKAROUND_SWDEV_229564 1
 // workaround for buffer load/store fp16/bfp16 intrinsic bug
 #define WORKAROUND_SWDEV_231101 1
-// LLVM xdlops instrinsic will do unnecessey VGRP <--> AGPR movement, and result in
-// register spill, for bfloat16 datatype, when doing wave-wise GEMM larger than 64x64
-#define WORKAROUND_SWDEV_240356 1
 // due to compiler bug, iGEMM xdlops kernels fail verification in some cases, if using "-O3" flag,
 // (but will pass verification with "-O1" flag)
 #define WORKAROUND_SWDEV_251757 1
-// workaround failure of ConvHipImplicitGemmV4R4GenWrWXdlops with vector load
-#define WORKAROUND_ISSUE_2532 1
 
 namespace miopen {
 
@@ -773,19 +768,8 @@ static inline auto get_ck_common_compiler_flag(const ConvolutionContext& ctx)
     auto compiler_flag = std::string(" --std=c++14");
 
     // HIP version
-    {
-        const auto hip_version = HipCompilerVersion();
-
-        auto hip_version_major = std::to_string(hip_version.major);
-        auto hip_version_minor = std::to_string(hip_version.minor);
-        auto hip_version_patch = std::to_string(hip_version.patch);
-
-        hip_version_minor = std::string(2 - hip_version_minor.length(), '0') + hip_version_minor;
-        hip_version_patch = std::string(5 - hip_version_patch.length(), '0') + hip_version_patch;
-
-        compiler_flag += std::string(" -DCK_HIP_VERSION=") + hip_version_major + hip_version_minor +
-                         hip_version_patch;
-    }
+    compiler_flag +=
+        std::string(" -DCK_HIP_VERSION_FLAT=") + std::to_string(HIP_PACKAGE_VERSION_FLAT);
 
     // atomic-fadd
     compiler_flag += std::string(" -DCK_USE_AMD_BUFFER_ATOMIC_FADD=") +

--- a/src/solver/implicitgemm_util.hpp
+++ b/src/solver/implicitgemm_util.hpp
@@ -768,6 +768,35 @@ int amd_lds_write_max_length()
 
 constexpr std::size_t get_lds_max_number_of_byte() { return 65536; }
 
+static inline auto get_ck_common_compiler_flag(const ConvolutionContext& ctx)
+{
+    auto compiler_flag = std::string(" --std=c++14");
+
+    // HIP compiler version
+    const auto hip_compiler_version = HipCompilerVersion();
+
+    auto version_major = std::to_string(hip_compiler_version.major);
+    auto version_minor = std::to_string(hip_compiler_version.minor);
+    auto version_patch = std::to_string(hip_compiler_version.patch);
+
+    version_minor = std::string(2 - version_minor.length(), '0') + version_minor;
+    version_patch = std::string(6 - version_patch.length(), '0') + version_patch;
+
+    compiler_flag +=
+        std::string(" -DCK_HIP_COMPILER_VERSION=") + version_major + version_minor + version_patch;
+
+    // atomic-add
+    compiler_flag += std::string(" -DCK_USE_AMD_BUFFER_ATOMIC_ADD=") +
+                     (support_amd_buffer_atomic_add(ctx) ? '1' : '0');
+
+    // workaround
+    compiler_flag +=
+        std::string(" -DCK_WORKAROUND_SWDEV_229564=") + std::to_string(WORKAROUND_SWDEV_229564) +
+        std::string(" -DCK_WORKAROUND_SWDEV_231101=") + std::to_string(WORKAROUND_SWDEV_231101);
+
+    return compiler_flag;
+}
+
 } // namespace solver
 } // namespace miopen
 


### PR DESCRIPTION
Passing HIP compiler version number to composable kernel, to fix this issue due to change intrinsic function:
http://ontrack-internal.amd.com/browse/SWDEV-255582

The hip-clang version that will have the change in intrinsic is 3.10.20405