### PR TITLE
Enlarge tuning range of ConvHipImplicitGemmWrwV4R4Xdlops

### DIFF
--- a/src/solver/conv_hip_implicit_gemm_wrw_v4r4_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_wrw_v4r4_xdlops.cpp
@@ -92,15 +92,15 @@ bool PerformanceImplicitGemmWrwV4R4Xdlops::SetNextValue()
             break;
         if(!NextTwoPower<1, 8>(GemmKPack))
             break;
-        if(!NextTwoPower<32, 128>(GemmNPerWave))
+        if(!NextTwoPower<4, 128>(GemmNPerWave))
             break;
-        if(!NextTwoPower<32, 128>(GemmMPerWave))
+        if(!NextTwoPower<4, 128>(GemmMPerWave))
             break;
-        if(!NextTwoPower<2, 8>(GemmKPerBlock))
+        if(!NextTwoPower<1, 8>(GemmKPerBlock))
             break;
-        if(!NextTwoPower<64, 256>(GemmNPerBlock))
+        if(!NextTwoPower<4, 256>(GemmNPerBlock))
             break;
-        if(!NextTwoPower<64, 256>(GemmMPerBlock))
+        if(!NextTwoPower<4, 256>(GemmMPerBlock))
             break;
         return false;
     } while(false);

--- a/src/solver/conv_hip_implicit_gemm_wrw_v4r4_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_wrw_v4r4_xdlops.cpp
@@ -92,12 +92,16 @@ bool PerformanceImplicitGemmWrwV4R4Xdlops::SetNextValue()
             break;
         if(!NextTwoPower<1, 8>(GemmKPack))
             break;
+        // current xdlops code only support GemmNPerWave >=16
+        //   smaller GemmNPerWave will be skipped
         if(!NextTwoPower<4, 128>(GemmNPerWave))
             break;
         if(!NextTwoPower<4, 128>(GemmMPerWave))
             break;
         if(!NextTwoPower<1, 8>(GemmKPerBlock))
             break;
+        // current xdlops code only support GemmNPerBlock >=16
+        //   smaller GemmNPerWave will be skipped
         if(!NextTwoPower<4, 256>(GemmNPerBlock))
             break;
         if(!NextTwoPower<4, 256>(GemmMPerBlock))


### PR DESCRIPTION
Enlarge tuning range of ConvHipImplicitGemmWrwV4R4Xdlops to fix failure found during Tuna tuning (Solver is applicable, but tuning range is 0-size)

This PR should not enlarge tuning range for those case where tuning range is already large because  ```PerformanceImplicitGemmWrwV4R4Xdlops::IsFastToBeUsedForTuning``` would skip slow tuning parameters

Testing this config, tuning range increase from 0 to 30
```
bin/MIOpenDriver conv -V 1 -i 1 -$ 0 --conv_stride_w 1 --fil_d 1 --group_count 1 --pad_h 0 -^ 1 --fil_h 1 -F 4 -x 1 --conv_stride_d 1 -q 0 -c 32 -m conv -H 27 --spatial_dim 2 --pad_mode default -k 256 --conv_stride_h 1 -% 0 --dilation_h 1 --in_d 1 -n 16 -W 27 --dilation_w 1 -F 4
```



testing this config, tuning range is unchanged (264).
```
MIOpenDriver convfp16 -F 1 -n 64 -g 1 -k 256 -c 1024 -H 14 -W 14 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -V 0 -w 1 -t 1 -i 1  
```