### PR TITLE
Workaround for SWDEV-255735

### DIFF
--- a/src/include/miopen/gcn_asm_utils.hpp
+++ b/src/include/miopen/gcn_asm_utils.hpp
@@ -46,6 +46,8 @@ void GenerateClangDefsym<const std::string&>(std::ostream& stream,
                                              const std::string& name,
                                              const std::string& value);
 
+std::string GenerateClangBuildOptSetXnack(const bool isEnabled);
+
 /// @param dir 1: fwd, 0: bwd wrt data. Use 0 for WrW.
 /// Encodes key with default strides (u1v1)
 std::string MakeLutKey(int w, int h, int c, int n, int k, int dir, int CUs = -1);

--- a/src/include/miopen/gcn_asm_utils.hpp
+++ b/src/include/miopen/gcn_asm_utils.hpp
@@ -46,8 +46,6 @@ void GenerateClangDefsym<const std::string&>(std::ostream& stream,
                                              const std::string& name,
                                              const std::string& value);
 
-std::string GenerateClangBuildOptSetXnack(bool isEnabled);
-
 /// @param dir 1: fwd, 0: bwd wrt data. Use 0 for WrW.
 /// Encodes key with default strides (u1v1)
 std::string MakeLutKey(int w, int h, int c, int n, int k, int dir, int CUs = -1);

--- a/src/include/miopen/gcn_asm_utils.hpp
+++ b/src/include/miopen/gcn_asm_utils.hpp
@@ -46,7 +46,7 @@ void GenerateClangDefsym<const std::string&>(std::ostream& stream,
                                              const std::string& name,
                                              const std::string& value);
 
-std::string GenerateClangBuildOptSetXnack(const bool isEnabled);
+std::string GenerateClangBuildOptSetXnack(bool isEnabled);
 
 /// @param dir 1: fwd, 0: bwd wrt data. Use 0 for WrW.
 /// Encodes key with default strides (u1v1)

--- a/src/kernels/Conv_Winograd_v13_3_12_epilogue.inc
+++ b/src/kernels/Conv_Winograd_v13_3_12_epilogue.inc
@@ -32,6 +32,11 @@ workgroup_size_x = 512
 .amdgcn.next_free_sgpr = 101
 .amdgcn.next_free_vgpr = 128
 
+//xnack disabled by default for asm kernels
+__sgpr_reserve_vcc_default = 1
+__sgpr_reserve_xnack_default = 0
+__sgpr_reserve_flatscr_default = 0
+
 .rodata
 .p2align 6
 .amdhsa_kernel miopenSp3AsmConvRxSU
@@ -45,9 +50,9 @@ workgroup_size_x = 512
     .amdhsa_system_vgpr_workitem_id 0
     .amdhsa_next_free_vgpr .amdgcn.next_free_vgpr
     .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
-    .amdhsa_reserve_vcc 1
-    .amdhsa_reserve_xnack_mask 1
-    .amdhsa_reserve_flat_scratch 0
+    .amdhsa_reserve_vcc __sgpr_reserve_vcc_default
+    .amdhsa_reserve_xnack_mask __sgpr_reserve_xnack_default
+    .amdhsa_reserve_flat_scratch __sgpr_reserve_flatscr_default
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
 .end_amdhsa_kernel

--- a/src/kernels/Conv_Winograd_v16_5_0_epilogue.inc
+++ b/src/kernels/Conv_Winograd_v16_5_0_epilogue.inc
@@ -32,6 +32,11 @@ workgroup_size_x = 512
 .amdgcn.next_free_sgpr = 101
 .amdgcn.next_free_vgpr = 128
 
+//xnack disabled by default for asm kernels
+__sgpr_reserve_vcc_default = 1
+__sgpr_reserve_xnack_default = 0
+__sgpr_reserve_flatscr_default = 0
+
 .rodata
 .p2align 6
 .amdhsa_kernel  miopenSp3AsmConvRxSf3x2
@@ -45,9 +50,9 @@ workgroup_size_x = 512
     .amdhsa_system_vgpr_workitem_id 0
     .amdhsa_next_free_vgpr .amdgcn.next_free_vgpr
     .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
-    .amdhsa_reserve_vcc 1
-    .amdhsa_reserve_xnack_mask 1
-    .amdhsa_reserve_flat_scratch 0
+    .amdhsa_reserve_vcc __sgpr_reserve_vcc_default
+    .amdhsa_reserve_xnack_mask __sgpr_reserve_xnack_default
+    .amdhsa_reserve_flat_scratch __sgpr_reserve_flatscr_default
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
 .end_amdhsa_kernel

--- a/src/kernels/Conv_Winograd_v21_1_0_metadata.inc
+++ b/src/kernels/Conv_Winograd_v21_1_0_metadata.inc
@@ -116,6 +116,11 @@ workgroup_size_x = 512
 .amdgcn.next_free_sgpr = 101
 .amdgcn.next_free_vgpr = 128
 
+//xnack disabled by default for asm kernels
+__sgpr_reserve_vcc_default = 1
+__sgpr_reserve_xnack_default = 0
+__sgpr_reserve_flatscr_default = 0
+
 .rodata
 .p2align 6
 .amdhsa_kernel \kernel_name
@@ -129,9 +134,9 @@ workgroup_size_x = 512
     .amdhsa_system_vgpr_workitem_id 0
     .amdhsa_next_free_vgpr .amdgcn.next_free_vgpr
     .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
-    .amdhsa_reserve_vcc 1
-    .amdhsa_reserve_xnack_mask 1
-    .amdhsa_reserve_flat_scratch 0
+    .amdhsa_reserve_vcc __sgpr_reserve_vcc_default
+    .amdhsa_reserve_xnack_mask __sgpr_reserve_xnack_default
+    .amdhsa_reserve_flat_scratch __sgpr_reserve_flatscr_default
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
 .end_amdhsa_kernel

--- a/src/kernels/conv1x1u.s
+++ b/src/kernels/conv1x1u.s
@@ -280,7 +280,8 @@ raw_filter_dword_k_cnt = 1
     .SGPR_ALLOC_ONCE loop_cnt
     .SGPR_ALLOC_ONCE stmp_offset
     .SGPR_ALLOC_ONCE stmp
-    .SGPR_RESERVE_XNACK
+    //xnack disabled by default
+    //.SGPR_RESERVE_XNACK
     .SGPR_RESERVE_VCC
 
     .VGPR_ALLOC_FROM 0

--- a/src/kernels/conv1x1u_bias_activ.s
+++ b/src/kernels/conv1x1u_bias_activ.s
@@ -353,7 +353,8 @@ bias_buffer_size = (output_channels + elements_in_dword - 1) / elements_in_dword
         .SGPR_ALLOC_ONCE beta
         .SGPR_ALLOC_ONCE gamma
     .endif
-    .SGPR_RESERVE_XNACK
+    //xnack disabled by default
+    //.SGPR_RESERVE_XNACK
     .SGPR_RESERVE_VCC
 
     .VGPR_ALLOC_FROM 0

--- a/src/kernels/conv1x1u_stride2.s
+++ b/src/kernels/conv1x1u_stride2.s
@@ -215,7 +215,8 @@ static_assert (output_n_stride * (batch_size + n_per_wave) < maxU31)
     .SGPR_ALLOC loop_cnt
     .SGPR_ALLOC stmp_offset
     .SGPR_ALLOC stmp
-    .SGPR_RESERVE_XNACK
+    //xnack disabled by default
+    //.SGPR_RESERVE_XNACK
     .SGPR_RESERVE_VCC
 
     .VGPR_ALLOC_FROM 0

--- a/src/kernels/conv1x1wrw.s
+++ b/src/kernels/conv1x1wrw.s
@@ -306,7 +306,8 @@ part2_offset = part1_chunks * input_w_stride * active_lanes_in_part1_chunks
 .SGPR_ALLOC loop_begin_ptr, 2
 .SGPR_ALLOC wave_id // wave_id in group
 
-.SGPR_RESERVE_XNACK
+//xnack disabled by default
+//.SGPR_RESERVE_XNACK
 .SGPR_RESERVE_VCC
 
 .VGPR_ALLOC_FROM 0

--- a/src/kernels/conv3x3.s
+++ b/src/kernels/conv3x3.s
@@ -220,7 +220,8 @@ output_buffer_window = 4 * img_height * img_width
 .if limit_wave_cnt
   .SET_MAX_WAVES_LIMIT limit_wave_cnt
 .endif
-.SGPR_RESERVE_XNACK
+//xnack disabled by default
+//.SGPR_RESERVE_XNACK
 
 // allocate filters
 filter_part_size = weights_per_filter & 0x3

--- a/src/kernels/conv3x3wrw.s
+++ b/src/kernels/conv3x3wrw.s
@@ -212,7 +212,8 @@ max_hw_lcnt = 15
 .SGPR_ALLOC loop_n_cnt
 .SGPR_ALLOC loop_h_cnt
 .SGPR_ALLOC wave_id // wave_id in group
-.SGPR_RESERVE_XNACK
+//xnack disabled by default
+//.SGPR_RESERVE_XNACK
 .SGPR_RESERVE_VCC
 
 

--- a/src/kernels/conv5x10u2v2b1.s
+++ b/src/kernels/conv5x10u2v2b1.s
@@ -846,10 +846,10 @@ skip_write:
 .rodata
 .p2align 6
 
-__sgpr_reserve_vcc = 1
-__sgpr_reserve_xnack = 0
-__sgpr_reserve_flatscr = 0
-__amdhsa_next_free_sgpr = SGPR_COUNT - (2 * (__sgpr_reserve_flatscr + __sgpr_reserve_xnack + __sgpr_reserve_vcc))
+__sgpr_reserve_vcc_default = 1
+__sgpr_reserve_xnack_default = 0
+__sgpr_reserve_flatscr_default = 0
+__amdhsa_next_free_sgpr = SGPR_COUNT - (2 * (__sgpr_reserve_flatscr_default + __sgpr_reserve_xnack_default + __sgpr_reserve_vcc_default))
 
 .amdhsa_kernel miopenConv5x10u2v2b1
         .amdhsa_dx10_clamp 0
@@ -858,9 +858,9 @@ __amdhsa_next_free_sgpr = SGPR_COUNT - (2 * (__sgpr_reserve_flatscr + __sgpr_res
         .amdhsa_float_round_mode_16_64 0
         .amdhsa_float_denorm_mode_32 0
         .amdhsa_float_denorm_mode_16_64 0
-        .amdhsa_reserve_flat_scratch __sgpr_reserve_flatscr
-        .amdhsa_reserve_xnack_mask __sgpr_reserve_xnack
-        .amdhsa_reserve_vcc __sgpr_reserve_vcc
+        .amdhsa_reserve_flat_scratch __sgpr_reserve_flatscr_default
+        .amdhsa_reserve_xnack_mask __sgpr_reserve_xnack_default
+        .amdhsa_reserve_vcc __sgpr_reserve_vcc_default
         .amdhsa_system_sgpr_workgroup_id_x 1
         .amdhsa_system_sgpr_workgroup_id_y 1
         .amdhsa_system_sgpr_workgroup_id_z 1

--- a/src/kernels/conv5x10u2v2f1.s
+++ b/src/kernels/conv5x10u2v2f1.s
@@ -1215,10 +1215,10 @@ skip_write:
 .rodata
 .p2align 6
 
-__sgpr_reserve_vcc = 1
-__sgpr_reserve_xnack = 0
-__sgpr_reserve_flatscr = 0
-__amdhsa_next_free_sgpr = SGPR_COUNT - (2 * (__sgpr_reserve_flatscr + __sgpr_reserve_xnack + __sgpr_reserve_vcc))
+__sgpr_reserve_vcc_default = 1
+__sgpr_reserve_xnack_default = 0
+__sgpr_reserve_flatscr_default = 0
+__amdhsa_next_free_sgpr = SGPR_COUNT - (2 * (__sgpr_reserve_flatscr_default + __sgpr_reserve_xnack_default + __sgpr_reserve_vcc_default))
 
 .amdhsa_kernel miopenConv5x10u2v2f1
         .amdhsa_dx10_clamp 0
@@ -1227,9 +1227,9 @@ __amdhsa_next_free_sgpr = SGPR_COUNT - (2 * (__sgpr_reserve_flatscr + __sgpr_res
         .amdhsa_float_round_mode_16_64 0
         .amdhsa_float_denorm_mode_32 0
         .amdhsa_float_denorm_mode_16_64 3
-        .amdhsa_reserve_flat_scratch __sgpr_reserve_flatscr
-        .amdhsa_reserve_xnack_mask __sgpr_reserve_xnack
-        .amdhsa_reserve_vcc __sgpr_reserve_vcc
+        .amdhsa_reserve_flat_scratch __sgpr_reserve_flatscr_default
+        .amdhsa_reserve_xnack_mask __sgpr_reserve_xnack_default
+        .amdhsa_reserve_vcc __sgpr_reserve_vcc_default
         .amdhsa_system_sgpr_workgroup_id_x 1
         .amdhsa_system_sgpr_workgroup_id_y 1
         .amdhsa_system_sgpr_workgroup_id_z 1

--- a/src/kernels/conv7x7c3h224w224k64u2v2p3q3f1.s
+++ b/src/kernels/conv7x7c3h224w224k64u2v2p3q3f1.s
@@ -771,10 +771,10 @@ loop_channel:
 .rodata
 .p2align 6
 
-__sgpr_reserve_vcc = 1
-__sgpr_reserve_xnack = 0
-__sgpr_reserve_flatscr = 0
-__amdhsa_next_free_sgpr = SGPR_COUNT - (2 * (__sgpr_reserve_flatscr + __sgpr_reserve_xnack + __sgpr_reserve_vcc))
+__sgpr_reserve_vcc_default = 1
+__sgpr_reserve_xnack_default = 0
+__sgpr_reserve_flatscr_default = 0
+__amdhsa_next_free_sgpr = SGPR_COUNT - (2 * (__sgpr_reserve_flatscr_default + __sgpr_reserve_xnack_default + __sgpr_reserve_vcc_default))
 
 .amdhsa_kernel miopenGcnAsmConv7x7c3h224w224k64u2v2p3q3f1
         .amdhsa_dx10_clamp 0
@@ -783,9 +783,9 @@ __amdhsa_next_free_sgpr = SGPR_COUNT - (2 * (__sgpr_reserve_flatscr + __sgpr_res
         .amdhsa_float_round_mode_16_64 0
         .amdhsa_float_denorm_mode_32 0
         .amdhsa_float_denorm_mode_16_64 0
-        .amdhsa_reserve_flat_scratch __sgpr_reserve_flatscr
-        .amdhsa_reserve_xnack_mask __sgpr_reserve_xnack
-        .amdhsa_reserve_vcc __sgpr_reserve_vcc
+        .amdhsa_reserve_flat_scratch __sgpr_reserve_flatscr_default
+        .amdhsa_reserve_xnack_mask __sgpr_reserve_xnack_default
+        .amdhsa_reserve_vcc __sgpr_reserve_vcc_default
         .amdhsa_system_sgpr_workgroup_id_x 1
         .amdhsa_system_sgpr_workgroup_id_y 1
         .amdhsa_system_sgpr_workgroup_id_z 1

--- a/src/kernels/conv_3x3_wheel_alpha_v3_0b_epilogue.inc
+++ b/src/kernels/conv_3x3_wheel_alpha_v3_0b_epilogue.inc
@@ -32,6 +32,11 @@ workgroup_size_x=512
 .amdgcn.next_free_sgpr = 92
 .amdgcn.next_free_vgpr = 128
 
+//xnack disabled by default for asm kernels
+__sgpr_reserve_vcc_default = 1
+__sgpr_reserve_xnack_default = 0
+__sgpr_reserve_flatscr_default = 0
+
 .rodata
 .p2align 6
 .amdhsa_kernel miopenSp3AsmConv3x3F
@@ -45,9 +50,9 @@ workgroup_size_x=512
     .amdhsa_system_vgpr_workitem_id 0
     .amdhsa_next_free_vgpr .amdgcn.next_free_vgpr
     .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
-    .amdhsa_reserve_vcc 1
-    .amdhsa_reserve_xnack_mask 1
-    .amdhsa_reserve_flat_scratch 0
+    .amdhsa_reserve_vcc __sgpr_reserve_vcc_default
+    .amdhsa_reserve_xnack_mask __sgpr_reserve_xnack_default
+    .amdhsa_reserve_flat_scratch __sgpr_reserve_flatscr_default
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
 .end_amdhsa_kernel

--- a/src/kernels/conv_3x3_wheel_alpha_v7_0_3b_epilogue.inc
+++ b/src/kernels/conv_3x3_wheel_alpha_v7_0_3b_epilogue.inc
@@ -32,6 +32,11 @@ workgroup_size_x = 512
 .amdgcn.next_free_sgpr = 87
 .amdgcn.next_free_vgpr = 128
 
+//xnack disabled by default for asm kernels
+__sgpr_reserve_vcc_default = 1
+__sgpr_reserve_xnack_default = 0
+__sgpr_reserve_flatscr_default = 0
+
 .rodata
 .p2align 6
 .amdhsa_kernel miopenSp3AsmConv3x3F
@@ -45,9 +50,9 @@ workgroup_size_x = 512
     .amdhsa_system_vgpr_workitem_id 0
     .amdhsa_next_free_vgpr .amdgcn.next_free_vgpr
     .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
-    .amdhsa_reserve_vcc 1
-    .amdhsa_reserve_xnack_mask 1
-    .amdhsa_reserve_flat_scratch 0
+    .amdhsa_reserve_vcc __sgpr_reserve_vcc_default
+    .amdhsa_reserve_xnack_mask __sgpr_reserve_xnack_default
+    .amdhsa_reserve_flat_scratch __sgpr_reserve_flatscr_default
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
 .end_amdhsa_kernel

--- a/src/kernels/conv_3x3_wheel_alpha_v9_0_15_epilogue.inc
+++ b/src/kernels/conv_3x3_wheel_alpha_v9_0_15_epilogue.inc
@@ -32,6 +32,11 @@ workgroup_size_x = 512
 .amdgcn.next_free_sgpr = 97
 .amdgcn.next_free_vgpr = 128
 
+//xnack disabled by default for asm kernels
+__sgpr_reserve_vcc_default = 1
+__sgpr_reserve_xnack_default = 0
+__sgpr_reserve_flatscr_default = 0
+
 .rodata
 .p2align 6
 .amdhsa_kernel miopenSp3AsmConvRxSU
@@ -45,9 +50,9 @@ workgroup_size_x = 512
     .amdhsa_system_vgpr_workitem_id 0
     .amdhsa_next_free_vgpr .amdgcn.next_free_vgpr
     .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
-    .amdhsa_reserve_vcc 1
-    .amdhsa_reserve_xnack_mask 1
-    .amdhsa_reserve_flat_scratch 0
+    .amdhsa_reserve_vcc __sgpr_reserve_vcc_default
+    .amdhsa_reserve_xnack_mask __sgpr_reserve_xnack_default
+    .amdhsa_reserve_flat_scratch __sgpr_reserve_flatscr_default
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
 .end_amdhsa_kernel

--- a/src/kernels/conv_3x3_wheel_alpha_v9_2_7_epilogue.inc
+++ b/src/kernels/conv_3x3_wheel_alpha_v9_2_7_epilogue.inc
@@ -32,6 +32,11 @@ workgroup_size_x = 512
 .amdgcn.next_free_sgpr = 101
 .amdgcn.next_free_vgpr = 128
 
+//xnack disabled by default for asm kernels
+__sgpr_reserve_vcc_default = 1
+__sgpr_reserve_xnack_default = 0
+__sgpr_reserve_flatscr_default = 0
+
 .rodata
 .p2align 6
 .amdhsa_kernel  miopenSp3AsmConvRxSU_CBA
@@ -45,9 +50,9 @@ workgroup_size_x = 512
     .amdhsa_system_vgpr_workitem_id 0
     .amdhsa_next_free_vgpr .amdgcn.next_free_vgpr
     .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
-    .amdhsa_reserve_vcc 1
-    .amdhsa_reserve_xnack_mask 1
-    .amdhsa_reserve_flat_scratch 0
+    .amdhsa_reserve_vcc __sgpr_reserve_vcc_default
+    .amdhsa_reserve_xnack_mask __sgpr_reserve_xnack_default
+    .amdhsa_reserve_flat_scratch __sgpr_reserve_flatscr_default
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
 .end_amdhsa_kernel

--- a/src/kernels/dynamic_igemm/igemm_bwd_gtc_dynamic.s
+++ b/src/kernels/dynamic_igemm/igemm_bwd_gtc_dynamic.s
@@ -1227,6 +1227,8 @@ L_igemm_v4r1_bwd_dynamic_end:
     .amdhsa_next_free_sgpr 72
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 ;----------------------------------------------------------
 ; starting of kernel igemm_bwd_gtc_bt128x128x16_tt8x8_gm2x4x4_gn2x4x4_ta1x1x1x2x4_16x1x1x16x1_tb1x1x1x2x4x1x1_16x1x1x16x1x1x1
@@ -1762,6 +1764,8 @@ L_igemm_bwd_gtc_bt128x128x16_tt8x8_gm2x4x4_gn2x4x4_ta1x1x1x2x4_16x1x1x16x1_tb1x1
     .amdhsa_next_free_sgpr 78
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -2294,6 +2298,8 @@ L_igemm_bwd_gtc_bt64x64x8_tt8x8_gm2x4x2_gn2x4x2_ta1x2x1x1x4_4x1x1x16x1_tb1x2x1x1
     .amdhsa_next_free_sgpr 78
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -2828,6 +2834,8 @@ L_igemm_bwd_gtc_bt128x128x16_tt8x8_gm2x4x4_gn2x4x4_ta1x2x1x1x4_8x1x1x32x1_tb1x2x
     .amdhsa_next_free_sgpr 78
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -3360,6 +3368,8 @@ L_igemm_bwd_gtc_bt128x128x8_tt8x8_gm2x4x4_gn2x4x4_ta1x1x1x1x4_8x1x1x32x1_tb1x1x1
     .amdhsa_next_free_sgpr 78
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -3892,6 +3902,8 @@ L_igemm_bwd_gtc_bt64x128x8_tt4x8_gm2x4x4_gn2x4x4_ta1x1x1x1x2_8x1x1x32x1_tb1x1x1x
     .amdhsa_next_free_sgpr 78
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -4421,6 +4433,8 @@ L_igemm_bwd_gtc_bt64x128x8_tt4x8_gm2x4x4_gn2x4x4_ta1x1x1x1x2_8x1x1x32x1_tb1x1x1x
     .amdhsa_next_free_sgpr 78
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 .amdgpu_metadata

--- a/src/kernels/dynamic_igemm/igemm_gtc_bwd/igemm_bwd_gtc_gfx908_004x064.inc
+++ b/src/kernels/dynamic_igemm/igemm_gtc_bwd/igemm_bwd_gtc_gfx908_004x064.inc
@@ -795,6 +795,8 @@ L_igemm_bwd_gtcx_nchw_fp32_bx1_ex1_bt4x64x16_wt4x64_ws1x1_wr1x1_ta1x1x1x1_1x16x1
     .amdhsa_next_free_sgpr 88
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -1391,5 +1393,7 @@ L_igemm_bwd_gtcx_nchw_fp32_bx1_ex0_bt4x64x16_wt4x64_ws1x1_wr1x1_ta1x1x1x1_1x16x1
     .amdhsa_next_free_sgpr 66
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 

--- a/src/kernels/dynamic_igemm/igemm_gtc_bwd/igemm_bwd_gtc_gfx908_008x064.inc
+++ b/src/kernels/dynamic_igemm/igemm_gtc_bwd/igemm_bwd_gtc_gfx908_008x064.inc
@@ -771,6 +771,8 @@ L_igemm_bwd_gtcx_nchw_fp32_bx1_ex1_bt8x64x16_wt4x64_ws1x1_wr1x1_ta1x1x1x1_1x16x1
     .amdhsa_next_free_sgpr 80
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -1343,5 +1345,7 @@ L_igemm_bwd_gtcx_nchw_fp32_bx1_ex0_bt8x64x16_wt4x64_ws1x1_wr1x1_ta1x1x1x1_1x16x1
     .amdhsa_next_free_sgpr 58
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 

--- a/src/kernels/dynamic_igemm/igemm_gtc_bwd/igemm_bwd_gtc_gfx908_016x032.inc
+++ b/src/kernels/dynamic_igemm/igemm_gtc_bwd/igemm_bwd_gtc_gfx908_016x032.inc
@@ -770,6 +770,8 @@ L_igemm_bwd_gtcx_nchw_fp32_bx1_ex1_bt16x32x16_wt8x32_ws1x1_wr1x1_ta1x1x2x1_1x16x
     .amdhsa_next_free_sgpr 76
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -1342,6 +1344,8 @@ L_igemm_bwd_gtcx_nchw_fp32_bx1_ex0_bt16x32x16_wt8x32_ws1x1_wr1x1_ta1x1x2x1_1x16x
     .amdhsa_next_free_sgpr 54
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -2006,6 +2010,8 @@ L_igemm_bwd_gtcx_nchw_fp32_bx1_ex1_bt16x32x4_wt8x32_ws2x1_wr1x1_ta1x1x1x1_1x4x1x
     .amdhsa_next_free_sgpr 74
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -2670,6 +2676,8 @@ L_igemm_bwd_gtcx_nchw_fp32_bx4_ex1_bt16x32x4_wt8x32_ws2x1_wr1x1_ta1x1x1x1_1x4x1x
     .amdhsa_next_free_sgpr 74
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -3334,6 +3342,8 @@ L_igemm_bwd_gtcx_nchw_fp32_bx8_ex1_bt16x32x4_wt8x32_ws2x1_wr1x1_ta1x1x1x1_1x4x1x
     .amdhsa_next_free_sgpr 74
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -3998,5 +4008,7 @@ L_igemm_bwd_gtcx_nchw_fp32_bx16_ex1_bt16x32x4_wt8x32_ws2x1_wr1x1_ta1x1x1x1_1x4x1
     .amdhsa_next_free_sgpr 74
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 

--- a/src/kernels/dynamic_igemm/igemm_gtc_bwd/igemm_bwd_gtc_gfx908_016x064.inc
+++ b/src/kernels/dynamic_igemm/igemm_gtc_bwd/igemm_bwd_gtc_gfx908_016x064.inc
@@ -755,6 +755,8 @@ L_igemm_bwd_gtcx_nchw_fp32_bx1_ex1_bt16x64x16_wt4x64_ws1x1_wr1x1_ta1x1x1x1_1x16x
     .amdhsa_next_free_sgpr 76
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -1311,5 +1313,7 @@ L_igemm_bwd_gtcx_nchw_fp32_bx1_ex0_bt16x64x16_wt4x64_ws1x1_wr1x1_ta1x1x1x1_1x16x
     .amdhsa_next_free_sgpr 54
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 

--- a/src/kernels/dynamic_igemm/igemm_gtc_bwd/igemm_bwd_gtc_gfx908_016x128.inc
+++ b/src/kernels/dynamic_igemm/igemm_gtc_bwd/igemm_bwd_gtc_gfx908_016x128.inc
@@ -749,6 +749,8 @@ L_igemm_bwd_gtcx_nchw_fp32_bx1_ex1_bt16x128x8_wt16x64_ws1x1_wr1x1_ta1x1x1x1_1x8x
     .amdhsa_next_free_sgpr 80
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -1299,5 +1301,7 @@ L_igemm_bwd_gtcx_nchw_fp32_bx1_ex0_bt16x128x8_wt16x64_ws1x1_wr1x1_ta1x1x1x1_1x8x
     .amdhsa_next_free_sgpr 58
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 

--- a/src/kernels/dynamic_igemm/igemm_gtc_bwd/igemm_bwd_gtc_gfx908_016x256.inc
+++ b/src/kernels/dynamic_igemm/igemm_gtc_bwd/igemm_bwd_gtc_gfx908_016x256.inc
@@ -1153,6 +1153,8 @@ L_igemm_bwd_gtcx_nchw_fp32_bx1_ex1_bt16x256x16_wt4x64_ws1x1_wr2x2_ta1x1x1x1_1x16
     .amdhsa_next_free_sgpr 88
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -2107,5 +2109,7 @@ L_igemm_bwd_gtcx_nchw_fp32_bx1_ex0_bt16x256x16_wt4x64_ws1x1_wr2x2_ta1x1x1x1_1x16
     .amdhsa_next_free_sgpr 66
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 

--- a/src/kernels/dynamic_igemm/igemm_gtc_bwd/igemm_bwd_gtc_gfx908_032x016.inc
+++ b/src/kernels/dynamic_igemm/igemm_gtc_bwd/igemm_bwd_gtc_gfx908_032x016.inc
@@ -767,6 +767,8 @@ L_igemm_bwd_gtcx_nchw_fp32_bx1_ex1_bt32x16x16_wt32x8_ws1x1_wr1x1_ta1x1x4x1_1x16x
     .amdhsa_next_free_sgpr 76
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -1336,6 +1338,8 @@ L_igemm_bwd_gtcx_nchw_fp32_bx1_ex0_bt32x16x16_wt32x8_ws1x1_wr1x1_ta1x1x4x1_1x16x
     .amdhsa_next_free_sgpr 54
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -1988,6 +1992,8 @@ L_igemm_bwd_gtcx_nchw_fp32_bx1_ex1_bt32x16x4_wt32x8_ws1x2_wr1x1_ta1x1x2x1_1x4x1x
     .amdhsa_next_free_sgpr 74
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -2640,6 +2646,8 @@ L_igemm_bwd_gtcx_nchw_fp32_bx4_ex1_bt32x16x4_wt32x8_ws1x2_wr1x1_ta1x1x2x1_1x4x1x
     .amdhsa_next_free_sgpr 74
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -3292,6 +3300,8 @@ L_igemm_bwd_gtcx_nchw_fp32_bx8_ex1_bt32x16x4_wt32x8_ws1x2_wr1x1_ta1x1x2x1_1x4x1x
     .amdhsa_next_free_sgpr 74
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -3944,5 +3954,7 @@ L_igemm_bwd_gtcx_nchw_fp32_bx16_ex1_bt32x16x4_wt32x8_ws1x2_wr1x1_ta1x1x2x1_1x4x1
     .amdhsa_next_free_sgpr 74
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 

--- a/src/kernels/dynamic_igemm/igemm_gtc_bwd/igemm_bwd_gtc_gfx908_032x032.inc
+++ b/src/kernels/dynamic_igemm/igemm_gtc_bwd/igemm_bwd_gtc_gfx908_032x032.inc
@@ -695,6 +695,8 @@ L_igemm_bwd_gtcx_nchw_fp32_bx1_ex1_bt32x32x8_wt16x16_ws1x1_wr1x1_ta1x1x1x1_1x8x1
     .amdhsa_next_free_sgpr 74
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -1191,5 +1193,7 @@ L_igemm_bwd_gtcx_nchw_fp32_bx1_ex0_bt32x32x8_wt16x16_ws1x1_wr1x1_ta1x1x1x1_1x8x1
     .amdhsa_next_free_sgpr 52
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 

--- a/src/kernels/dynamic_igemm/igemm_gtc_bwd/igemm_bwd_gtc_gfx908_032x064.inc
+++ b/src/kernels/dynamic_igemm/igemm_gtc_bwd/igemm_bwd_gtc_gfx908_032x064.inc
@@ -829,6 +829,8 @@ L_igemm_bwd_gtcx_nchw_fp32_bx1_ex1_bt32x64x16_wt8x32_ws2x1_wr1x1_ta2x1x1x1_1x8x1
     .amdhsa_next_free_sgpr 76
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -1548,6 +1550,8 @@ L_igemm_bwd_gtcx_nchw_fp32_bx1_ex1_bt32x64x8_wt8x32_ws2x1_wr1x1_ta1x1x1x1_1x8x1x
     .amdhsa_next_free_sgpr 74
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -2089,5 +2093,7 @@ L_igemm_bwd_gtcx_nchw_fp32_bx1_ex0_bt32x64x8_wt8x32_ws2x1_wr1x1_ta1x1x1x1_1x8x1x
     .amdhsa_next_free_sgpr 52
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 

--- a/src/kernels/dynamic_igemm/igemm_gtc_bwd/igemm_bwd_gtc_gfx908_032x128.inc
+++ b/src/kernels/dynamic_igemm/igemm_gtc_bwd/igemm_bwd_gtc_gfx908_032x128.inc
@@ -981,6 +981,8 @@ L_igemm_bwd_gtcx_nchw_fp32_bx1_ex0_bt32x128x16_wt8x32_ws1x1_wr2x2_ta2x1x1x1_1x8x
     .amdhsa_next_free_sgpr 58
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -2099,5 +2101,7 @@ L_igemm_bwd_gtcx_nchw_fp32_bx1_ex1_bt32x128x16_wt8x32_ws1x1_wr2x2_ta2x1x1x1_1x8x
     .amdhsa_next_free_sgpr 80
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 

--- a/src/kernels/dynamic_igemm/igemm_gtc_bwd/igemm_bwd_gtc_gfx908_032x256.inc
+++ b/src/kernels/dynamic_igemm/igemm_gtc_bwd/igemm_bwd_gtc_gfx908_032x256.inc
@@ -1197,6 +1197,8 @@ L_igemm_bwd_gtcx_nchw_fp32_bx1_ex0_bt32x256x16_wt4x64_ws2x1_wr2x2_ta2x1x1x1_1x8x
     .amdhsa_next_free_sgpr 66
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -2531,6 +2533,8 @@ L_igemm_bwd_gtcx_nchw_fp32_bx1_ex1_bt32x256x16_wt4x64_ws2x1_wr2x2_ta2x1x1x1_1x8x
     .amdhsa_next_free_sgpr 88
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -3547,5 +3551,7 @@ L_igemm_bwd_gtcx_nchw_fp32_bx1_ex1_bt32x256x8_wt4x64_ws2x1_wr2x2_ta1x1x1x1_1x8x1
     .amdhsa_next_free_sgpr 80
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 

--- a/src/kernels/dynamic_igemm/igemm_gtc_bwd/igemm_bwd_gtc_gfx908_064x004.inc
+++ b/src/kernels/dynamic_igemm/igemm_gtc_bwd/igemm_bwd_gtc_gfx908_064x004.inc
@@ -796,6 +796,8 @@ L_igemm_bwd_gtcx_nchw_fp32_bx1_ex1_bt64x4x16_wt64x4_ws1x1_wr1x1_ta1x1x16x1_1x16x
     .amdhsa_next_free_sgpr 88
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -1569,6 +1571,8 @@ L_igemm_bwd_gtcx_nchw_fp32_bx4_ex1_bt64x4x16_wt64x4_ws1x1_wr1x1_ta1x1x16x1_1x16x
     .amdhsa_next_free_sgpr 88
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -2167,6 +2171,8 @@ L_igemm_bwd_gtcx_nchw_fp32_bx1_ex0_bt64x4x16_wt64x4_ws1x1_wr1x1_ta1x1x16x1_1x16x
     .amdhsa_next_free_sgpr 66
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -2724,5 +2730,7 @@ L_igemm_bwd_gtcx_nchw_fp32_bx4_ex0_bt64x4x16_wt64x4_ws1x1_wr1x1_ta1x1x4x4_1x16x1
     .amdhsa_next_free_sgpr 54
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 

--- a/src/kernels/dynamic_igemm/igemm_gtc_bwd/igemm_bwd_gtc_gfx908_064x008.inc
+++ b/src/kernels/dynamic_igemm/igemm_gtc_bwd/igemm_bwd_gtc_gfx908_064x008.inc
@@ -770,6 +770,8 @@ L_igemm_bwd_gtcx_nchw_fp32_bx1_ex1_bt64x8x16_wt64x4_ws1x1_wr1x1_ta1x1x8x1_1x16x1
     .amdhsa_next_free_sgpr 80
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -1342,5 +1344,7 @@ L_igemm_bwd_gtcx_nchw_fp32_bx1_ex0_bt64x8x16_wt64x4_ws1x1_wr1x1_ta1x1x8x1_1x16x1
     .amdhsa_next_free_sgpr 58
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 

--- a/src/kernels/dynamic_igemm/igemm_gtc_bwd/igemm_bwd_gtc_gfx908_064x016.inc
+++ b/src/kernels/dynamic_igemm/igemm_gtc_bwd/igemm_bwd_gtc_gfx908_064x016.inc
@@ -754,6 +754,8 @@ L_igemm_bwd_gtcx_nchw_fp32_bx1_ex1_bt64x16x16_wt64x4_ws1x1_wr1x1_ta1x1x4x1_1x16x
     .amdhsa_next_free_sgpr 76
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -1310,5 +1312,7 @@ L_igemm_bwd_gtcx_nchw_fp32_bx1_ex0_bt64x16x16_wt64x4_ws1x1_wr1x1_ta1x1x4x1_1x16x
     .amdhsa_next_free_sgpr 54
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 

--- a/src/kernels/dynamic_igemm/igemm_gtc_bwd/igemm_bwd_gtc_gfx908_064x032.inc
+++ b/src/kernels/dynamic_igemm/igemm_gtc_bwd/igemm_bwd_gtc_gfx908_064x032.inc
@@ -823,6 +823,8 @@ L_igemm_bwd_gtcx_nchw_fp32_bx1_ex1_bt64x32x16_wt32x8_ws1x2_wr1x1_ta2x1x2x1_1x8x1
     .amdhsa_next_free_sgpr 76
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -1463,6 +1465,8 @@ L_igemm_bwd_gtcx_nchw_fp32_bx1_ex0_bt64x32x16_wt32x8_ws1x2_wr1x1_ta2x1x2x1_1x8x1
     .amdhsa_next_free_sgpr 54
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -2167,5 +2171,7 @@ L_igemm_bwd_gtcx_nchw_fp32_bx1_ex1_bt64x32x8_wt32x8_ws1x2_wr1x1_ta1x1x2x1_1x8x1x
     .amdhsa_next_free_sgpr 74
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 

--- a/src/kernels/dynamic_igemm/igemm_gtc_bwd/igemm_bwd_gtc_gfx908_064x064.inc
+++ b/src/kernels/dynamic_igemm/igemm_gtc_bwd/igemm_bwd_gtc_gfx908_064x064.inc
@@ -979,6 +979,8 @@ L_igemm_bwd_gtcx_nchw_fp32_bx1_ex0_bt64x64x16_wt16x16_ws1x1_wr2x2_ta2x1x2x1_1x8x
     .amdhsa_next_free_sgpr 54
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -2097,6 +2099,8 @@ L_igemm_bwd_gtcx_nchw_fp32_bx1_ex1_bt64x64x16_wt16x16_ws1x1_wr2x2_ta2x1x2x1_1x8x
     .amdhsa_next_free_sgpr 76
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -2979,5 +2983,7 @@ L_igemm_bwd_gtcx_nchw_fp32_bx1_ex1_bt64x64x8_wt16x16_ws1x1_wr2x2_ta1x1x2x1_1x8x1
     .amdhsa_next_free_sgpr 74
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 

--- a/src/kernels/dynamic_igemm/igemm_gtc_bwd/igemm_bwd_gtc_gfx908_064x128.inc
+++ b/src/kernels/dynamic_igemm/igemm_gtc_bwd/igemm_bwd_gtc_gfx908_064x128.inc
@@ -1193,6 +1193,8 @@ L_igemm_bwd_gtcx_nchw_fp32_bx1_ex0_bt64x128x16_wt8x32_ws2x1_wr2x2_ta2x1x2x1_1x8x
     .amdhsa_next_free_sgpr 58
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -2525,6 +2527,8 @@ L_igemm_bwd_gtcx_nchw_fp32_bx1_ex1_bt64x128x16_wt8x32_ws2x1_wr2x2_ta2x1x2x1_1x8x
     .amdhsa_next_free_sgpr 80
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -3558,5 +3562,7 @@ L_igemm_bwd_gtcx_nchw_fp32_bx1_ex1_bt64x128x8_wt8x32_ws2x1_wr2x2_ta1x1x2x1_1x8x1
     .amdhsa_next_free_sgpr 76
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 

--- a/src/kernels/dynamic_igemm/igemm_gtc_bwd/igemm_bwd_gtc_gfx908_064x256.inc
+++ b/src/kernels/dynamic_igemm/igemm_gtc_bwd/igemm_bwd_gtc_gfx908_064x256.inc
@@ -1201,6 +1201,8 @@ L_igemm_bwd_gtcx_nchw_fp32_bx1_ex0_bt64x256x16_wt16x64_ws1x1_wr2x2_ta2x1x2x1_1x8
     .amdhsa_next_free_sgpr 66
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -2541,6 +2543,8 @@ L_igemm_bwd_gtcx_nchw_fp32_bx1_ex1_bt64x256x16_wt16x64_ws1x1_wr2x2_ta2x1x2x1_1x8
     .amdhsa_next_free_sgpr 88
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -3614,5 +3618,7 @@ L_igemm_bwd_gtcx_nchw_fp32_bx1_ex1_bt64x256x8_wt16x64_ws1x1_wr2x2_ta1x1x2x1_1x8x
     .amdhsa_next_free_sgpr 80
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 

--- a/src/kernels/dynamic_igemm/igemm_gtc_bwd/igemm_bwd_gtc_gfx908_128x016.inc
+++ b/src/kernels/dynamic_igemm/igemm_gtc_bwd/igemm_bwd_gtc_gfx908_128x016.inc
@@ -751,6 +751,8 @@ L_igemm_bwd_gtcx_nchw_fp32_bx1_ex1_bt128x16x8_wt64x16_ws1x1_wr1x1_ta1x1x8x1_1x8x
     .amdhsa_next_free_sgpr 80
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -1304,5 +1306,7 @@ L_igemm_bwd_gtcx_nchw_fp32_bx1_ex0_bt128x16x8_wt64x16_ws1x1_wr1x1_ta1x1x8x1_1x8x
     .amdhsa_next_free_sgpr 58
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 

--- a/src/kernels/dynamic_igemm/igemm_gtc_bwd/igemm_bwd_gtc_gfx908_128x032.inc
+++ b/src/kernels/dynamic_igemm/igemm_gtc_bwd/igemm_bwd_gtc_gfx908_128x032.inc
@@ -978,6 +978,8 @@ L_igemm_bwd_gtcx_nchw_fp32_bx1_ex0_bt128x32x16_wt32x8_ws1x1_wr2x2_ta2x1x4x1_1x8x
     .amdhsa_next_free_sgpr 58
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -2093,6 +2095,8 @@ L_igemm_bwd_gtcx_nchw_fp32_bx1_ex1_bt128x32x16_wt32x8_ws1x1_wr2x2_ta2x1x4x1_1x8x
     .amdhsa_next_free_sgpr 80
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -2975,5 +2979,7 @@ L_igemm_bwd_gtcx_nchw_fp32_bx1_ex1_bt128x32x8_wt32x8_ws1x1_wr2x2_ta1x1x4x1_1x8x1
     .amdhsa_next_free_sgpr 76
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 

--- a/src/kernels/dynamic_igemm/igemm_gtc_bwd/igemm_bwd_gtc_gfx908_128x064.inc
+++ b/src/kernels/dynamic_igemm/igemm_gtc_bwd/igemm_bwd_gtc_gfx908_128x064.inc
@@ -1193,6 +1193,8 @@ L_igemm_bwd_gtcx_nchw_fp32_bx1_ex0_bt128x64x16_wt32x8_ws1x2_wr2x2_ta2x1x4x1_1x8x
     .amdhsa_next_free_sgpr 58
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -2525,6 +2527,8 @@ L_igemm_bwd_gtcx_nchw_fp32_bx1_ex1_bt128x64x16_wt32x8_ws1x2_wr2x2_ta2x1x4x1_1x8x
     .amdhsa_next_free_sgpr 80
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -3542,5 +3546,7 @@ L_igemm_bwd_gtcx_nchw_fp32_bx1_ex1_bt128x64x8_wt32x8_ws1x2_wr2x2_ta1x1x4x1_1x8x1
     .amdhsa_next_free_sgpr 76
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 

--- a/src/kernels/dynamic_igemm/igemm_gtc_bwd/igemm_bwd_gtc_gfx908_128x128.inc
+++ b/src/kernels/dynamic_igemm/igemm_gtc_bwd/igemm_bwd_gtc_gfx908_128x128.inc
@@ -1148,6 +1148,8 @@ L_igemm_bwd_gtcx_nchw_fp32_bx16_ex0_bt128x128x16_wt32x32_ws1x1_wr2x2_ta2x1x1x4_1
     .amdhsa_next_free_sgpr 52
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -2273,6 +2275,8 @@ L_igemm_bwd_gtcx_nchw_fp32_bx4_ex0_bt128x128x16_wt32x32_ws1x1_wr2x2_ta2x1x1x4_1x
     .amdhsa_next_free_sgpr 52
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -3426,6 +3430,8 @@ L_igemm_bwd_gtcx_nchw_fp32_bx1_ex0_bt128x128x16_wt32x32_ws1x1_wr2x2_ta2x1x1x4_1x
     .amdhsa_next_free_sgpr 58
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -4308,6 +4314,8 @@ L_igemm_bwd_gtcx_nchw_fp32_bx16_ex0_bt128x128x8_wt32x32_ws1x1_wr2x2_ta1x1x1x4_1x
     .amdhsa_next_free_sgpr 52
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -5190,6 +5198,8 @@ L_igemm_bwd_gtcx_nchw_fp32_bx4_ex0_bt128x128x8_wt32x32_ws1x1_wr2x2_ta1x1x1x4_1x8
     .amdhsa_next_free_sgpr 52
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -6085,6 +6095,8 @@ L_igemm_bwd_gtcx_nchw_fp32_bx1_ex0_bt128x128x8_wt32x32_ws1x1_wr2x2_ta1x1x1x4_1x8
     .amdhsa_next_free_sgpr 54
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -7429,6 +7441,8 @@ L_igemm_bwd_gtcx_nchw_fp32_bx16_ex1_bt128x128x16_wt32x32_ws1x1_wr2x2_ta2x1x4x1_1
     .amdhsa_next_free_sgpr 84
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -8773,6 +8787,8 @@ L_igemm_bwd_gtcx_nchw_fp32_bx4_ex1_bt128x128x16_wt32x32_ws1x1_wr2x2_ta2x1x4x1_1x
     .amdhsa_next_free_sgpr 84
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -10117,6 +10133,8 @@ L_igemm_bwd_gtcx_nchw_fp32_bx1_ex1_bt128x128x16_wt32x32_ws1x1_wr2x2_ta2x1x4x1_1x
     .amdhsa_next_free_sgpr 84
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -11203,5 +11221,7 @@ L_igemm_bwd_gtcx_nchw_fp32_bx1_ex1_bt128x128x8_wt32x32_ws1x1_wr2x2_ta1x1x4x1_1x8
     .amdhsa_next_free_sgpr 78
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 

--- a/src/kernels/dynamic_igemm/igemm_gtc_bwd/igemm_bwd_gtc_gfx908_128x256.inc
+++ b/src/kernels/dynamic_igemm/igemm_gtc_bwd/igemm_bwd_gtc_gfx908_128x256.inc
@@ -1382,6 +1382,8 @@ L_igemm_bwd_gtcx_nchw_fp32_bx16_ex0_bt128x256x16_wt32x64_ws1x1_wr2x2_ta1x1x2x4_1
     .amdhsa_next_free_sgpr 54
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -2741,6 +2743,8 @@ L_igemm_bwd_gtcx_nchw_fp32_bx4_ex0_bt128x256x16_wt32x64_ws1x1_wr2x2_ta1x1x2x4_1x
     .amdhsa_next_free_sgpr 54
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -4165,6 +4169,8 @@ L_igemm_bwd_gtcx_nchw_fp32_bx1_ex0_bt128x256x16_wt32x64_ws1x1_wr2x2_ta2x1x1x4_1x
     .amdhsa_next_free_sgpr 66
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -5315,6 +5321,8 @@ L_igemm_bwd_gtcx_nchw_fp32_bx16_ex0_bt128x256x8_wt32x64_ws1x1_wr2x2_ta1x1x1x4_1x
     .amdhsa_next_free_sgpr 52
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -6465,6 +6473,8 @@ L_igemm_bwd_gtcx_nchw_fp32_bx4_ex0_bt128x256x8_wt32x64_ws1x1_wr2x2_ta1x1x1x4_1x8
     .amdhsa_next_free_sgpr 52
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -7635,6 +7645,8 @@ L_igemm_bwd_gtcx_nchw_fp32_bx1_ex0_bt128x256x8_wt32x64_ws1x1_wr2x2_ta1x1x1x4_1x8
     .amdhsa_next_free_sgpr 58
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -9250,6 +9262,8 @@ L_igemm_bwd_gtcx_nchw_fp32_bx1_ex1_bt128x256x16_wt32x64_ws1x1_wr2x2_ta2x1x4x1_1x
     .amdhsa_next_free_sgpr 92
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -10865,6 +10879,8 @@ L_igemm_bwd_gtcx_nchw_fp32_bx4_ex1_bt128x256x16_wt32x64_ws1x1_wr2x2_ta2x1x4x1_1x
     .amdhsa_next_free_sgpr 92
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -12480,6 +12496,8 @@ L_igemm_bwd_gtcx_nchw_fp32_bx16_ex1_bt128x256x16_wt32x64_ws1x1_wr2x2_ta2x1x4x1_1
     .amdhsa_next_free_sgpr 92
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -13849,5 +13867,7 @@ L_igemm_bwd_gtcx_nchw_fp32_bx1_ex1_bt128x256x8_wt32x64_ws1x1_wr2x2_ta1x1x4x1_1x8
     .amdhsa_next_free_sgpr 82
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 

--- a/src/kernels/dynamic_igemm/igemm_gtc_bwd/igemm_bwd_gtc_gfx908_256x016.inc
+++ b/src/kernels/dynamic_igemm/igemm_gtc_bwd/igemm_bwd_gtc_gfx908_256x016.inc
@@ -980,6 +980,8 @@ L_igemm_bwd_gtcx_nchw_fp32_bx1_ex0_bt256x16x16_wt64x4_ws1x1_wr2x2_ta1x1x16x1_1x1
     .amdhsa_next_free_sgpr 66
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -2112,5 +2114,7 @@ L_igemm_bwd_gtcx_nchw_fp32_bx1_ex1_bt256x16x16_wt64x4_ws1x1_wr2x2_ta1x1x16x1_1x1
     .amdhsa_next_free_sgpr 88
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 

--- a/src/kernels/dynamic_igemm/igemm_gtc_bwd/igemm_bwd_gtc_gfx908_256x032.inc
+++ b/src/kernels/dynamic_igemm/igemm_gtc_bwd/igemm_bwd_gtc_gfx908_256x032.inc
@@ -1354,6 +1354,8 @@ L_igemm_bwd_gtcx_nchw_fp32_bx1_ex1_bt256x32x16_wt64x4_ws1x2_wr2x2_ta1x1x16x1_1x1
     .amdhsa_next_free_sgpr 88
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -2510,6 +2512,8 @@ L_igemm_bwd_gtcx_nchw_fp32_bx1_ex0_bt256x32x16_wt64x4_ws1x2_wr2x2_ta1x1x16x1_1x1
     .amdhsa_next_free_sgpr 66
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -3528,5 +3532,7 @@ L_igemm_bwd_gtcx_nchw_fp32_bx1_ex1_bt256x32x8_wt64x4_ws1x2_wr2x2_ta1x1x8x1_1x8x1
     .amdhsa_next_free_sgpr 80
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 

--- a/src/kernels/dynamic_igemm/igemm_gtc_bwd/igemm_bwd_gtc_gfx908_256x064.inc
+++ b/src/kernels/dynamic_igemm/igemm_gtc_bwd/igemm_bwd_gtc_gfx908_256x064.inc
@@ -1204,6 +1204,8 @@ L_igemm_bwd_gtcx_nchw_fp32_bx1_ex0_bt256x64x16_wt64x16_ws1x1_wr2x2_ta2x1x8x1_1x8
     .amdhsa_next_free_sgpr 66
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -2547,6 +2549,8 @@ L_igemm_bwd_gtcx_nchw_fp32_bx1_ex1_bt256x64x16_wt64x16_ws1x1_wr2x2_ta2x1x8x1_1x8
     .amdhsa_next_free_sgpr 88
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -3540,5 +3544,7 @@ L_igemm_bwd_gtcx_nchw_fp32_bx1_ex1_bt256x64x4_wt64x16_ws1x1_wr2x2_ta1x1x4x1_1x4x
     .amdhsa_next_free_sgpr 76
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 

--- a/src/kernels/dynamic_igemm/igemm_gtc_bwd/igemm_bwd_gtc_gfx908_256x128.inc
+++ b/src/kernels/dynamic_igemm/igemm_gtc_bwd/igemm_bwd_gtc_gfx908_256x128.inc
@@ -1385,6 +1385,8 @@ L_igemm_bwd_gtcx_nchw_fp32_bx4_ex0_bt256x128x16_wt64x32_ws1x1_wr2x2_ta1x1x4x4_1x
     .amdhsa_next_free_sgpr 54
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -2747,6 +2749,8 @@ L_igemm_bwd_gtcx_nchw_fp32_bx16_ex0_bt256x128x16_wt64x32_ws1x1_wr2x2_ta1x1x4x4_1
     .amdhsa_next_free_sgpr 54
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -4129,6 +4133,8 @@ L_igemm_bwd_gtcx_nchw_fp32_bx1_ex0_bt256x128x16_wt64x32_ws1x1_wr2x2_ta1x1x4x4_1x
     .amdhsa_next_free_sgpr 60
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -5279,6 +5285,8 @@ L_igemm_bwd_gtcx_nchw_fp32_bx4_ex0_bt256x128x8_wt64x32_ws1x1_wr2x2_ta1x1x2x4_1x8
     .amdhsa_next_free_sgpr 52
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -6429,6 +6437,8 @@ L_igemm_bwd_gtcx_nchw_fp32_bx16_ex0_bt256x128x8_wt64x32_ws1x1_wr2x2_ta1x1x2x4_1x
     .amdhsa_next_free_sgpr 52
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -7592,6 +7602,8 @@ L_igemm_bwd_gtcx_nchw_fp32_bx1_ex0_bt256x128x8_wt64x32_ws1x1_wr2x2_ta1x1x2x4_1x8
     .amdhsa_next_free_sgpr 54
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -9210,6 +9222,8 @@ L_igemm_bwd_gtcx_nchw_fp32_bx4_ex1_bt256x128x16_wt64x32_ws1x1_wr2x2_ta2x1x8x1_1x
     .amdhsa_next_free_sgpr 92
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -10828,6 +10842,8 @@ L_igemm_bwd_gtcx_nchw_fp32_bx16_ex1_bt256x128x16_wt64x32_ws1x1_wr2x2_ta2x1x8x1_1
     .amdhsa_next_free_sgpr 92
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -12446,6 +12462,8 @@ L_igemm_bwd_gtcx_nchw_fp32_bx1_ex1_bt256x128x16_wt64x32_ws1x1_wr2x2_ta2x1x8x1_1x
     .amdhsa_next_free_sgpr 92
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -13818,5 +13836,7 @@ L_igemm_bwd_gtcx_nchw_fp32_bx1_ex1_bt256x128x8_wt64x32_ws1x1_wr2x2_ta1x1x8x1_1x8
     .amdhsa_next_free_sgpr 82
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 

--- a/src/kernels/dynamic_igemm/igemm_gtc_fwd/igemm_fwd_gtc_gfx908_004x064.inc
+++ b/src/kernels/dynamic_igemm/igemm_gtc_fwd/igemm_fwd_gtc_gfx908_004x064.inc
@@ -590,6 +590,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx64_ex0_bt4x64x16_wt4x64_ws1x1_wr1x1_ta1x1x1x1_1x16x
     .amdhsa_next_free_sgpr 60
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -1178,6 +1180,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx32_ex0_bt4x64x16_wt4x64_ws1x1_wr1x1_ta1x1x1x1_1x16x
     .amdhsa_next_free_sgpr 60
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -1754,6 +1758,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt4x64x16_wt4x64_ws1x1_wr1x1_ta1x1x1x1_1x16x1
     .amdhsa_next_free_sgpr 60
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -2435,6 +2441,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt4x64x16_wt4x64_ws1x1_wr1x1_ta1x1x1x1_1x16x1
     .amdhsa_next_free_sgpr 74
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -3011,6 +3019,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt4x64x16_wt4x64_ws1x1_wr1x1_ta1x1x1x1_1x16x1
     .amdhsa_next_free_sgpr 60
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -3692,6 +3702,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt4x64x16_wt4x64_ws1x1_wr1x1_ta1x1x1x1_1x16x1
     .amdhsa_next_free_sgpr 74
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -4265,6 +4277,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt4x64x16_wt4x64_ws1x1_wr1x1_ta1x1x1x1_1x16x1
     .amdhsa_next_free_sgpr 60
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -4942,6 +4956,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt4x64x16_wt4x64_ws1x1_wr1x1_ta1x1x1x1_1x16x1
     .amdhsa_next_free_sgpr 74
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -5515,6 +5531,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt4x64x16_wt4x64_ws1x1_wr1x1_ta1x1x1x1_1x16x1
     .amdhsa_next_free_sgpr 60
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -6192,5 +6210,7 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt4x64x16_wt4x64_ws1x1_wr1x1_ta1x1x1x1_1x16x1
     .amdhsa_next_free_sgpr 74
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 

--- a/src/kernels/dynamic_igemm/igemm_gtc_fwd/igemm_fwd_gtc_gfx908_008x064.inc
+++ b/src/kernels/dynamic_igemm/igemm_gtc_fwd/igemm_fwd_gtc_gfx908_008x064.inc
@@ -575,6 +575,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt8x64x16_wt4x64_ws1x1_wr1x1_ta1x1x1x1_1x16x1
     .amdhsa_next_free_sgpr 52
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -1232,6 +1234,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt8x64x16_wt4x64_ws1x1_wr1x1_ta1x1x1x1_1x16x1
     .amdhsa_next_free_sgpr 66
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -1784,6 +1788,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt8x64x16_wt4x64_ws1x1_wr1x1_ta1x1x1x1_1x16x1
     .amdhsa_next_free_sgpr 52
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -2441,6 +2447,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt8x64x16_wt4x64_ws1x1_wr1x1_ta1x1x1x1_1x16x1
     .amdhsa_next_free_sgpr 66
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -2990,6 +2998,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt8x64x16_wt4x64_ws1x1_wr1x1_ta1x1x1x1_1x16x1
     .amdhsa_next_free_sgpr 52
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -3643,6 +3653,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt8x64x16_wt4x64_ws1x1_wr1x1_ta1x1x1x1_1x16x1
     .amdhsa_next_free_sgpr 66
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -4192,6 +4204,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt8x64x16_wt4x64_ws1x1_wr1x1_ta1x1x1x1_1x16x1
     .amdhsa_next_free_sgpr 52
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -4845,5 +4859,7 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt8x64x16_wt4x64_ws1x1_wr1x1_ta1x1x1x1_1x16x1
     .amdhsa_next_free_sgpr 66
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 

--- a/src/kernels/dynamic_igemm/igemm_gtc_fwd/igemm_fwd_gtc_gfx908_016x016.inc
+++ b/src/kernels/dynamic_igemm/igemm_gtc_fwd/igemm_fwd_gtc_gfx908_016x016.inc
@@ -448,5 +448,7 @@ L_igemm_fwd_gtcx_nchw_fp32_bx16_ex0_bt16x16x4_wt16x16_ws1x1_wr1x1_ta1x1x1x1_1x4x
     .amdhsa_next_free_sgpr 46
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 

--- a/src/kernels/dynamic_igemm/igemm_gtc_fwd/igemm_fwd_gtc_gfx908_016x032.inc
+++ b/src/kernels/dynamic_igemm/igemm_gtc_fwd/igemm_fwd_gtc_gfx908_016x032.inc
@@ -569,6 +569,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt16x32x16_wt8x32_ws1x1_wr1x1_ta1x1x2x1_1x16x
     .amdhsa_next_free_sgpr 48
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -1220,6 +1222,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt16x32x16_wt8x32_ws1x1_wr1x1_ta1x1x2x1_1x16x
     .amdhsa_next_free_sgpr 62
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -1766,6 +1770,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt16x32x16_wt8x32_ws1x1_wr1x1_ta1x1x2x1_1x16x
     .amdhsa_next_free_sgpr 48
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -2417,6 +2423,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt16x32x16_wt8x32_ws1x1_wr1x1_ta1x1x2x1_1x16x
     .amdhsa_next_free_sgpr 62
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -2967,6 +2975,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt16x32x16_wt8x32_ws1x1_wr1x1_ta1x1x2x1_1x16x
     .amdhsa_next_free_sgpr 50
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -3621,6 +3631,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt16x32x16_wt8x32_ws1x1_wr1x1_ta1x1x2x1_1x16x
     .amdhsa_next_free_sgpr 64
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -4171,6 +4183,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt16x32x16_wt8x32_ws1x1_wr1x1_ta1x1x2x1_1x16x
     .amdhsa_next_free_sgpr 50
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -4825,6 +4839,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt16x32x16_wt8x32_ws1x1_wr1x1_ta1x1x2x1_1x16x
     .amdhsa_next_free_sgpr 64
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -5436,6 +5452,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt16x32x16_wt8x32_ws2x1_wr1x1_ta1x2x2x1_1x8x1
     .amdhsa_next_free_sgpr 52
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -6152,6 +6170,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt16x32x16_wt8x32_ws2x1_wr1x1_ta1x2x2x1_1x8x1
     .amdhsa_next_free_sgpr 66
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -6763,6 +6783,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt16x32x16_wt8x32_ws2x1_wr1x1_ta1x2x2x1_1x8x1
     .amdhsa_next_free_sgpr 52
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -7479,6 +7501,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt16x32x16_wt8x32_ws2x1_wr1x1_ta1x2x2x1_1x8x1
     .amdhsa_next_free_sgpr 66
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -8087,6 +8111,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt16x32x16_wt8x32_ws2x1_wr1x1_ta1x2x2x1_1x8x1
     .amdhsa_next_free_sgpr 54
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -8799,6 +8825,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt16x32x16_wt8x32_ws2x1_wr1x1_ta1x2x2x1_1x8x1
     .amdhsa_next_free_sgpr 68
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -9407,6 +9435,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt16x32x16_wt8x32_ws2x1_wr1x1_ta1x2x2x1_1x8x1
     .amdhsa_next_free_sgpr 54
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -10119,6 +10149,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt16x32x16_wt8x32_ws2x1_wr1x1_ta1x2x2x1_1x8x1
     .amdhsa_next_free_sgpr 68
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -10624,6 +10656,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt16x32x8_wt8x32_ws2x1_wr1x1_ta1x1x2x1_1x8x1x
     .amdhsa_next_free_sgpr 48
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -11234,6 +11268,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt16x32x8_wt8x32_ws2x1_wr1x1_ta1x1x2x1_1x8x1x
     .amdhsa_next_free_sgpr 62
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -11739,6 +11775,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt16x32x8_wt8x32_ws2x1_wr1x1_ta1x1x2x1_1x8x1x
     .amdhsa_next_free_sgpr 48
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -12349,6 +12387,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt16x32x8_wt8x32_ws2x1_wr1x1_ta1x1x2x1_1x8x1x
     .amdhsa_next_free_sgpr 62
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -12858,6 +12898,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt16x32x8_wt8x32_ws2x1_wr1x1_ta1x1x2x1_1x8x1x
     .amdhsa_next_free_sgpr 50
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -13471,6 +13513,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt16x32x8_wt8x32_ws2x1_wr1x1_ta1x1x2x1_1x8x1x
     .amdhsa_next_free_sgpr 64
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -13980,6 +14024,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt16x32x8_wt8x32_ws2x1_wr1x1_ta1x1x2x1_1x8x1x
     .amdhsa_next_free_sgpr 50
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -14593,5 +14639,7 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt16x32x8_wt8x32_ws2x1_wr1x1_ta1x1x2x1_1x8x1x
     .amdhsa_next_free_sgpr 64
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 

--- a/src/kernels/dynamic_igemm/igemm_gtc_fwd/igemm_fwd_gtc_gfx908_016x064.inc
+++ b/src/kernels/dynamic_igemm/igemm_gtc_fwd/igemm_fwd_gtc_gfx908_016x064.inc
@@ -552,6 +552,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt16x64x16_wt4x64_ws1x1_wr1x1_ta1x1x1x1_1x16x
     .amdhsa_next_free_sgpr 48
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -1186,6 +1188,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt16x64x16_wt4x64_ws1x1_wr1x1_ta1x1x1x1_1x16x
     .amdhsa_next_free_sgpr 62
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -1715,6 +1719,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt16x64x16_wt4x64_ws1x1_wr1x1_ta1x1x1x1_1x16x
     .amdhsa_next_free_sgpr 48
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -2349,6 +2355,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt16x64x16_wt4x64_ws1x1_wr1x1_ta1x1x1x1_1x16x
     .amdhsa_next_free_sgpr 62
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -2882,6 +2890,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt16x64x16_wt4x64_ws1x1_wr1x1_ta1x1x1x1_1x16x
     .amdhsa_next_free_sgpr 48
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -3519,6 +3529,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt16x64x16_wt4x64_ws1x1_wr1x1_ta1x1x1x1_1x16x
     .amdhsa_next_free_sgpr 62
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -4052,6 +4064,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt16x64x16_wt4x64_ws1x1_wr1x1_ta1x1x1x1_1x16x
     .amdhsa_next_free_sgpr 48
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -4689,6 +4703,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt16x64x16_wt4x64_ws1x1_wr1x1_ta1x1x1x1_1x16x
     .amdhsa_next_free_sgpr 62
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -5290,6 +5306,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt16x64x16_wt4x64_ws2x1_wr1x1_ta1x2x1x1_1x8x1
     .amdhsa_next_free_sgpr 52
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -5996,6 +6014,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt16x64x16_wt4x64_ws2x1_wr1x1_ta1x2x1x1_1x8x1
     .amdhsa_next_free_sgpr 66
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -6597,6 +6617,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt16x64x16_wt4x64_ws2x1_wr1x1_ta1x2x1x1_1x8x1
     .amdhsa_next_free_sgpr 52
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -7303,6 +7325,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt16x64x16_wt4x64_ws2x1_wr1x1_ta1x2x1x1_1x8x1
     .amdhsa_next_free_sgpr 66
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -7901,6 +7925,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt16x64x16_wt4x64_ws2x1_wr1x1_ta1x2x1x1_1x8x1
     .amdhsa_next_free_sgpr 52
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -8603,6 +8629,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt16x64x16_wt4x64_ws2x1_wr1x1_ta1x2x1x1_1x8x1
     .amdhsa_next_free_sgpr 66
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -9201,6 +9229,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt16x64x16_wt4x64_ws2x1_wr1x1_ta1x2x1x1_1x8x1
     .amdhsa_next_free_sgpr 52
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -9903,6 +9933,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt16x64x16_wt4x64_ws2x1_wr1x1_ta1x2x1x1_1x8x1
     .amdhsa_next_free_sgpr 66
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -10400,6 +10432,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt16x64x8_wt4x64_ws2x1_wr1x1_ta1x1x1x1_1x8x1x
     .amdhsa_next_free_sgpr 48
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -11002,6 +11036,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt16x64x8_wt4x64_ws2x1_wr1x1_ta1x1x1x1_1x8x1x
     .amdhsa_next_free_sgpr 62
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -11499,6 +11535,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt16x64x8_wt4x64_ws2x1_wr1x1_ta1x1x1x1_1x8x1x
     .amdhsa_next_free_sgpr 48
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -12101,6 +12139,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt16x64x8_wt4x64_ws2x1_wr1x1_ta1x1x1x1_1x8x1x
     .amdhsa_next_free_sgpr 62
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -12602,6 +12642,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt16x64x8_wt4x64_ws2x1_wr1x1_ta1x1x1x1_1x8x1x
     .amdhsa_next_free_sgpr 48
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -13207,6 +13249,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt16x64x8_wt4x64_ws2x1_wr1x1_ta1x1x1x1_1x8x1x
     .amdhsa_next_free_sgpr 62
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -13708,6 +13752,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt16x64x8_wt4x64_ws2x1_wr1x1_ta1x1x1x1_1x8x1x
     .amdhsa_next_free_sgpr 48
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -14313,5 +14359,7 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt16x64x8_wt4x64_ws2x1_wr1x1_ta1x1x1x1_1x8x1x
     .amdhsa_next_free_sgpr 62
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 

--- a/src/kernels/dynamic_igemm/igemm_gtc_fwd/igemm_fwd_gtc_gfx908_032x016.inc
+++ b/src/kernels/dynamic_igemm/igemm_gtc_fwd/igemm_fwd_gtc_gfx908_032x016.inc
@@ -562,6 +562,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt32x16x16_wt32x8_ws1x1_wr1x1_ta1x2x2x1_1x8x1
     .amdhsa_next_free_sgpr 46
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -1206,6 +1208,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt32x16x16_wt32x8_ws1x1_wr1x1_ta1x2x2x1_1x8x1
     .amdhsa_next_free_sgpr 60
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -1745,6 +1749,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt32x16x16_wt32x8_ws1x1_wr1x1_ta1x2x2x1_1x8x1
     .amdhsa_next_free_sgpr 46
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -2389,6 +2395,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt32x16x16_wt32x8_ws1x1_wr1x1_ta1x2x2x1_1x8x1
     .amdhsa_next_free_sgpr 60
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -2932,6 +2940,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt32x16x16_wt32x8_ws1x1_wr1x1_ta1x2x2x1_1x8x1
     .amdhsa_next_free_sgpr 48
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -3579,6 +3589,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt32x16x16_wt32x8_ws1x1_wr1x1_ta1x2x2x1_1x8x1
     .amdhsa_next_free_sgpr 62
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -4122,6 +4134,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt32x16x16_wt32x8_ws1x1_wr1x1_ta1x2x2x1_1x8x1
     .amdhsa_next_free_sgpr 48
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -4769,6 +4783,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt32x16x16_wt32x8_ws1x1_wr1x1_ta1x2x2x1_1x8x1
     .amdhsa_next_free_sgpr 62
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -5361,6 +5377,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt32x16x16_wt32x8_ws1x2_wr1x1_ta1x4x2x1_1x4x1
     .amdhsa_next_free_sgpr 48
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -6058,6 +6076,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt32x16x16_wt32x8_ws1x2_wr1x1_ta1x4x2x1_1x4x1
     .amdhsa_next_free_sgpr 62
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -6650,6 +6670,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt32x16x16_wt32x8_ws1x2_wr1x1_ta1x4x2x1_1x4x1
     .amdhsa_next_free_sgpr 48
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -7347,6 +7369,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt32x16x16_wt32x8_ws1x2_wr1x1_ta1x4x2x1_1x4x1
     .amdhsa_next_free_sgpr 62
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -7943,6 +7967,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt32x16x16_wt32x8_ws1x2_wr1x1_ta1x4x2x1_1x4x1
     .amdhsa_next_free_sgpr 50
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -8643,6 +8669,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt32x16x16_wt32x8_ws1x2_wr1x1_ta1x4x2x1_1x4x1
     .amdhsa_next_free_sgpr 64
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -9239,6 +9267,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt32x16x16_wt32x8_ws1x2_wr1x1_ta1x4x2x1_1x4x1
     .amdhsa_next_free_sgpr 50
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -9939,6 +9969,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt32x16x16_wt32x8_ws1x2_wr1x1_ta1x4x2x1_1x4x1
     .amdhsa_next_free_sgpr 64
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -10440,6 +10472,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt32x16x8_wt32x8_ws1x2_wr1x1_ta1x2x2x1_1x4x1x
     .amdhsa_next_free_sgpr 46
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -11046,6 +11080,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt32x16x8_wt32x8_ws1x2_wr1x1_ta1x2x2x1_1x4x1x
     .amdhsa_next_free_sgpr 60
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -11547,6 +11583,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt32x16x8_wt32x8_ws1x2_wr1x1_ta1x2x2x1_1x4x1x
     .amdhsa_next_free_sgpr 46
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -12153,6 +12191,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt32x16x8_wt32x8_ws1x2_wr1x1_ta1x2x2x1_1x4x1x
     .amdhsa_next_free_sgpr 60
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -12658,6 +12698,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt32x16x8_wt32x8_ws1x2_wr1x1_ta1x2x2x1_1x4x1x
     .amdhsa_next_free_sgpr 48
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -13267,6 +13309,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt32x16x8_wt32x8_ws1x2_wr1x1_ta1x2x2x1_1x4x1x
     .amdhsa_next_free_sgpr 62
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -13772,6 +13816,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt32x16x8_wt32x8_ws1x2_wr1x1_ta1x2x2x1_1x4x1x
     .amdhsa_next_free_sgpr 48
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -14381,5 +14427,7 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt32x16x8_wt32x8_ws1x2_wr1x1_ta1x2x2x1_1x4x1x
     .amdhsa_next_free_sgpr 62
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 

--- a/src/kernels/dynamic_igemm/igemm_gtc_fwd/igemm_fwd_gtc_gfx908_032x032.inc
+++ b/src/kernels/dynamic_igemm/igemm_gtc_fwd/igemm_fwd_gtc_gfx908_032x032.inc
@@ -564,6 +564,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt32x32x16_wt16x16_ws1x1_wr1x1_ta1x2x1x1_1x8x
     .amdhsa_next_free_sgpr 46
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -1210,6 +1212,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt32x32x16_wt16x16_ws1x1_wr1x1_ta1x2x1x1_1x8x
     .amdhsa_next_free_sgpr 60
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -1751,6 +1755,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt32x32x16_wt16x16_ws1x1_wr1x1_ta1x2x1x1_1x8x
     .amdhsa_next_free_sgpr 46
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -2397,6 +2403,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt32x32x16_wt16x16_ws1x1_wr1x1_ta1x2x1x1_1x8x
     .amdhsa_next_free_sgpr 60
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -2942,6 +2950,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt32x32x16_wt16x16_ws1x1_wr1x1_ta1x2x1x1_1x8x
     .amdhsa_next_free_sgpr 46
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -3591,6 +3601,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt32x32x16_wt16x16_ws1x1_wr1x1_ta1x2x1x1_1x8x
     .amdhsa_next_free_sgpr 60
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -4136,6 +4148,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt32x32x16_wt16x16_ws1x1_wr1x1_ta1x2x1x1_1x8x
     .amdhsa_next_free_sgpr 46
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -4785,5 +4799,7 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt32x32x16_wt16x16_ws1x1_wr1x1_ta1x2x1x1_1x8x
     .amdhsa_next_free_sgpr 60
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 

--- a/src/kernels/dynamic_igemm/igemm_gtc_fwd/igemm_fwd_gtc_gfx908_032x064.inc
+++ b/src/kernels/dynamic_igemm/igemm_gtc_fwd/igemm_fwd_gtc_gfx908_032x064.inc
@@ -621,6 +621,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt32x64x16_wt8x32_ws2x1_wr1x1_ta1x2x1x1_1x8x1
     .amdhsa_next_free_sgpr 48
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -1324,6 +1326,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt32x64x16_wt8x32_ws2x1_wr1x1_ta1x2x1x1_1x8x1
     .amdhsa_next_free_sgpr 62
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -1922,6 +1926,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt32x64x16_wt8x32_ws2x1_wr1x1_ta1x2x1x1_1x8x1
     .amdhsa_next_free_sgpr 48
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -2625,6 +2631,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt32x64x16_wt8x32_ws2x1_wr1x1_ta1x2x1x1_1x8x1
     .amdhsa_next_free_sgpr 62
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -3227,6 +3235,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt32x64x16_wt8x32_ws2x1_wr1x1_ta1x2x1x1_1x8x1
     .amdhsa_next_free_sgpr 48
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -3933,6 +3943,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt32x64x16_wt8x32_ws2x1_wr1x1_ta1x2x1x1_1x8x1
     .amdhsa_next_free_sgpr 62
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -4535,6 +4547,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt32x64x16_wt8x32_ws2x1_wr1x1_ta1x2x1x1_1x8x1
     .amdhsa_next_free_sgpr 48
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -5241,6 +5255,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt32x64x16_wt8x32_ws2x1_wr1x1_ta1x2x1x1_1x8x1
     .amdhsa_next_free_sgpr 62
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -5755,6 +5771,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt32x64x8_wt8x32_ws2x1_wr1x1_ta1x1x1x1_1x8x1x
     .amdhsa_next_free_sgpr 46
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -6374,6 +6392,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt32x64x8_wt8x32_ws2x1_wr1x1_ta1x1x1x1_1x8x1x
     .amdhsa_next_free_sgpr 60
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -6888,6 +6908,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt32x64x8_wt8x32_ws2x1_wr1x1_ta1x1x1x1_1x8x1x
     .amdhsa_next_free_sgpr 46
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -7507,6 +7529,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt32x64x8_wt8x32_ws2x1_wr1x1_ta1x1x1x1_1x8x1x
     .amdhsa_next_free_sgpr 60
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -8025,6 +8049,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt32x64x8_wt8x32_ws2x1_wr1x1_ta1x1x1x1_1x8x1x
     .amdhsa_next_free_sgpr 46
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -8647,6 +8673,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt32x64x8_wt8x32_ws2x1_wr1x1_ta1x1x1x1_1x8x1x
     .amdhsa_next_free_sgpr 60
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -9165,6 +9193,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt32x64x8_wt8x32_ws2x1_wr1x1_ta1x1x1x1_1x8x1x
     .amdhsa_next_free_sgpr 46
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -9787,5 +9817,7 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt32x64x8_wt8x32_ws2x1_wr1x1_ta1x1x1x1_1x8x1x
     .amdhsa_next_free_sgpr 60
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 

--- a/src/kernels/dynamic_igemm/igemm_gtc_fwd/igemm_fwd_gtc_gfx908_032x128.inc
+++ b/src/kernels/dynamic_igemm/igemm_gtc_fwd/igemm_fwd_gtc_gfx908_032x128.inc
@@ -1397,6 +1397,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt32x128x32_wt8x32_ws1x1_wr2x2_ta1x4x1x1_1x8x
     .amdhsa_next_free_sgpr 60
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -2312,6 +2314,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt32x128x16_wt8x32_ws1x1_wr2x2_ta1x2x1x1_1x8x
     .amdhsa_next_free_sgpr 52
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -3332,6 +3336,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt32x128x16_wt8x32_ws1x1_wr2x2_ta1x2x1x1_1x8x
     .amdhsa_next_free_sgpr 66
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -4247,6 +4253,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt32x128x16_wt8x32_ws1x1_wr2x2_ta1x2x1x1_1x8x
     .amdhsa_next_free_sgpr 52
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -5267,6 +5275,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt32x128x16_wt8x32_ws1x1_wr2x2_ta1x2x1x1_1x8x
     .amdhsa_next_free_sgpr 66
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -6179,6 +6189,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt32x128x16_wt8x32_ws1x1_wr2x2_ta1x2x1x1_1x8x
     .amdhsa_next_free_sgpr 52
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -7195,6 +7207,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt32x128x16_wt8x32_ws1x1_wr2x2_ta1x2x1x1_1x8x
     .amdhsa_next_free_sgpr 66
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -8107,6 +8121,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt32x128x16_wt8x32_ws1x1_wr2x2_ta1x2x1x1_1x8x
     .amdhsa_next_free_sgpr 52
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -9123,6 +9139,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt32x128x16_wt8x32_ws1x1_wr2x2_ta1x2x1x1_1x8x
     .amdhsa_next_free_sgpr 66
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -9804,6 +9822,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt32x128x8_wt8x32_ws1x1_wr2x2_ta1x1x1x1_1x8x1
     .amdhsa_next_free_sgpr 48
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -10590,6 +10610,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt32x128x8_wt8x32_ws1x1_wr2x2_ta1x1x1x1_1x8x1
     .amdhsa_next_free_sgpr 62
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -11271,6 +11293,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt32x128x8_wt8x32_ws1x1_wr2x2_ta1x1x1x1_1x8x1
     .amdhsa_next_free_sgpr 48
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -12057,6 +12081,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt32x128x8_wt8x32_ws1x1_wr2x2_ta1x1x1x1_1x8x1
     .amdhsa_next_free_sgpr 62
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -12742,6 +12768,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt32x128x8_wt8x32_ws1x1_wr2x2_ta1x1x1x1_1x8x1
     .amdhsa_next_free_sgpr 48
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -13531,6 +13559,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt32x128x8_wt8x32_ws1x1_wr2x2_ta1x1x1x1_1x8x1
     .amdhsa_next_free_sgpr 62
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -14216,6 +14246,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt32x128x8_wt8x32_ws1x1_wr2x2_ta1x1x1x1_1x8x1
     .amdhsa_next_free_sgpr 48
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -15005,5 +15037,7 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt32x128x8_wt8x32_ws1x1_wr2x2_ta1x1x1x1_1x8x1
     .amdhsa_next_free_sgpr 62
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 

--- a/src/kernels/dynamic_igemm/igemm_gtc_fwd/igemm_fwd_gtc_gfx908_032x256.inc
+++ b/src/kernels/dynamic_igemm/igemm_gtc_fwd/igemm_fwd_gtc_gfx908_032x256.inc
@@ -1150,6 +1150,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt32x256x16_wt4x64_ws2x1_wr2x2_ta1x2x1x1_1x8x
     .amdhsa_next_free_sgpr 60
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -2382,6 +2384,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt32x256x16_wt4x64_ws2x1_wr2x2_ta1x2x1x1_1x8x
     .amdhsa_next_free_sgpr 74
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -3509,6 +3513,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt32x256x16_wt4x64_ws2x1_wr2x2_ta1x2x1x1_1x8x
     .amdhsa_next_free_sgpr 60
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -4741,6 +4747,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt32x256x16_wt4x64_ws2x1_wr2x2_ta1x2x1x1_1x8x
     .amdhsa_next_free_sgpr 74
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -5865,6 +5873,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt32x256x16_wt4x64_ws2x1_wr2x2_ta1x2x1x1_1x8x
     .amdhsa_next_free_sgpr 60
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -7093,6 +7103,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt32x256x16_wt4x64_ws2x1_wr2x2_ta1x2x1x1_1x8x
     .amdhsa_next_free_sgpr 74
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -8217,6 +8229,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt32x256x16_wt4x64_ws2x1_wr2x2_ta1x2x1x1_1x8x
     .amdhsa_next_free_sgpr 60
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -9445,6 +9459,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt32x256x16_wt4x64_ws2x1_wr2x2_ta1x2x1x1_1x8x
     .amdhsa_next_free_sgpr 74
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -10263,6 +10279,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt32x256x8_wt4x64_ws2x1_wr2x2_ta1x1x1x1_1x8x1
     .amdhsa_next_free_sgpr 52
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -11186,6 +11204,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt32x256x8_wt4x64_ws2x1_wr2x2_ta1x1x1x1_1x8x1
     .amdhsa_next_free_sgpr 66
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -12004,6 +12024,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt32x256x8_wt4x64_ws2x1_wr2x2_ta1x1x1x1_1x8x1
     .amdhsa_next_free_sgpr 52
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -12927,6 +12949,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt32x256x8_wt4x64_ws2x1_wr2x2_ta1x1x1x1_1x8x1
     .amdhsa_next_free_sgpr 66
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -13742,6 +13766,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt32x256x8_wt4x64_ws2x1_wr2x2_ta1x1x1x1_1x8x1
     .amdhsa_next_free_sgpr 52
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -14661,6 +14687,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt32x256x8_wt4x64_ws2x1_wr2x2_ta1x1x1x1_1x8x1
     .amdhsa_next_free_sgpr 66
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -15476,6 +15504,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt32x256x8_wt4x64_ws2x1_wr2x2_ta1x1x1x1_1x8x1
     .amdhsa_next_free_sgpr 52
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -16395,5 +16425,7 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt32x256x8_wt4x64_ws2x1_wr2x2_ta1x1x1x1_1x8x1
     .amdhsa_next_free_sgpr 66
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 

--- a/src/kernels/dynamic_igemm/igemm_gtc_fwd/igemm_fwd_gtc_gfx908_064x004.inc
+++ b/src/kernels/dynamic_igemm/igemm_gtc_fwd/igemm_fwd_gtc_gfx908_064x004.inc
@@ -598,6 +598,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt64x4x16_wt64x4_ws1x1_wr1x1_ta1x1x16x1_1x16x
     .amdhsa_next_free_sgpr 60
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -1277,6 +1279,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt64x4x16_wt64x4_ws1x1_wr1x1_ta1x1x16x1_1x16x
     .amdhsa_next_free_sgpr 74
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -1852,6 +1856,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt64x4x16_wt64x4_ws1x1_wr1x1_ta1x1x16x1_1x16x
     .amdhsa_next_free_sgpr 60
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -2531,5 +2537,7 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt64x4x16_wt64x4_ws1x1_wr1x1_ta1x1x16x1_1x16x
     .amdhsa_next_free_sgpr 74
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 

--- a/src/kernels/dynamic_igemm/igemm_gtc_fwd/igemm_fwd_gtc_gfx908_064x008.inc
+++ b/src/kernels/dynamic_igemm/igemm_gtc_fwd/igemm_fwd_gtc_gfx908_064x008.inc
@@ -572,6 +572,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt64x8x16_wt64x4_ws1x1_wr1x1_ta1x1x8x1_1x16x1
     .amdhsa_next_free_sgpr 52
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -1225,6 +1227,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt64x8x16_wt64x4_ws1x1_wr1x1_ta1x1x8x1_1x16x1
     .amdhsa_next_free_sgpr 66
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -1774,6 +1778,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt64x8x16_wt64x4_ws1x1_wr1x1_ta1x1x8x1_1x16x1
     .amdhsa_next_free_sgpr 52
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -2427,5 +2433,7 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt64x8x16_wt64x4_ws1x1_wr1x1_ta1x1x8x1_1x16x1
     .amdhsa_next_free_sgpr 66
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 

--- a/src/kernels/dynamic_igemm/igemm_gtc_fwd/igemm_fwd_gtc_gfx908_064x016.inc
+++ b/src/kernels/dynamic_igemm/igemm_gtc_fwd/igemm_fwd_gtc_gfx908_064x016.inc
@@ -547,6 +547,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt64x16x16_wt64x4_ws1x1_wr1x1_ta1x4x1x1_1x4x1
     .amdhsa_next_free_sgpr 46
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -1175,6 +1177,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt64x16x16_wt64x4_ws1x1_wr1x1_ta1x4x1x1_1x4x1
     .amdhsa_next_free_sgpr 60
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -1699,6 +1703,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt64x16x16_wt64x4_ws1x1_wr1x1_ta1x4x1x1_1x4x1
     .amdhsa_next_free_sgpr 46
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -2327,6 +2333,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt64x16x16_wt64x4_ws1x1_wr1x1_ta1x4x1x1_1x4x1
     .amdhsa_next_free_sgpr 60
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -2912,6 +2920,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt64x16x16_wt64x4_ws1x2_wr1x1_ta1x4x2x1_1x4x1
     .amdhsa_next_free_sgpr 46
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -3602,6 +3612,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt64x16x16_wt64x4_ws1x2_wr1x1_ta1x4x2x1_1x4x1
     .amdhsa_next_free_sgpr 60
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -4187,6 +4199,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt64x16x16_wt64x4_ws1x2_wr1x1_ta1x4x2x1_1x4x1
     .amdhsa_next_free_sgpr 46
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -4877,6 +4891,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt64x16x16_wt64x4_ws1x2_wr1x1_ta1x4x2x1_1x4x1
     .amdhsa_next_free_sgpr 60
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -5466,6 +5482,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt64x16x16_wt64x4_ws1x2_wr1x1_ta1x4x2x1_1x4x1
     .amdhsa_next_free_sgpr 48
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -6159,6 +6177,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt64x16x16_wt64x4_ws1x2_wr1x1_ta1x4x2x1_1x4x1
     .amdhsa_next_free_sgpr 62
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -6748,6 +6768,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt64x16x16_wt64x4_ws1x2_wr1x1_ta1x4x2x1_1x4x1
     .amdhsa_next_free_sgpr 48
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -7441,6 +7463,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt64x16x16_wt64x4_ws1x2_wr1x1_ta1x4x2x1_1x4x1
     .amdhsa_next_free_sgpr 62
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -7933,6 +7957,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt64x16x8_wt64x4_ws1x2_wr1x1_ta1x4x1x1_1x2x1x
     .amdhsa_next_free_sgpr 46
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -8529,6 +8555,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt64x16x8_wt64x4_ws1x2_wr1x1_ta1x4x1x1_1x2x1x
     .amdhsa_next_free_sgpr 60
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -9021,6 +9049,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt64x16x8_wt64x4_ws1x2_wr1x1_ta1x4x1x1_1x2x1x
     .amdhsa_next_free_sgpr 46
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -9617,5 +9647,7 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt64x16x8_wt64x4_ws1x2_wr1x1_ta1x4x1x1_1x2x1x
     .amdhsa_next_free_sgpr 60
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 

--- a/src/kernels/dynamic_igemm/igemm_gtc_fwd/igemm_fwd_gtc_gfx908_064x032.inc
+++ b/src/kernels/dynamic_igemm/igemm_gtc_fwd/igemm_fwd_gtc_gfx908_064x032.inc
@@ -613,6 +613,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt64x32x16_wt32x8_ws1x2_wr1x1_ta1x4x1x1_1x4x1
     .amdhsa_next_free_sgpr 46
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -1308,6 +1310,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt64x32x16_wt32x8_ws1x2_wr1x1_ta1x4x1x1_1x4x1
     .amdhsa_next_free_sgpr 60
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -1898,6 +1902,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt64x32x16_wt32x8_ws1x2_wr1x1_ta1x4x1x1_1x4x1
     .amdhsa_next_free_sgpr 46
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -2593,6 +2599,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt64x32x16_wt32x8_ws1x2_wr1x1_ta1x4x1x1_1x4x1
     .amdhsa_next_free_sgpr 60
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -3187,6 +3195,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt64x32x16_wt32x8_ws1x2_wr1x1_ta1x4x1x1_1x4x1
     .amdhsa_next_free_sgpr 46
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -3885,6 +3895,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt64x32x16_wt32x8_ws1x2_wr1x1_ta1x4x1x1_1x4x1
     .amdhsa_next_free_sgpr 60
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -4479,6 +4491,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt64x32x16_wt32x8_ws1x2_wr1x1_ta1x4x1x1_1x4x1
     .amdhsa_next_free_sgpr 46
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -5177,6 +5191,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt64x32x16_wt32x8_ws1x2_wr1x1_ta1x4x1x1_1x4x1
     .amdhsa_next_free_sgpr 60
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -5679,6 +5695,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt64x32x8_wt32x8_ws1x2_wr1x1_ta1x2x1x1_1x4x1x
     .amdhsa_next_free_sgpr 46
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -6285,6 +6303,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt64x32x8_wt32x8_ws1x2_wr1x1_ta1x2x1x1_1x4x1x
     .amdhsa_next_free_sgpr 60
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -6787,6 +6807,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt64x32x8_wt32x8_ws1x2_wr1x1_ta1x2x1x1_1x4x1x
     .amdhsa_next_free_sgpr 46
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -7393,5 +7415,7 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt64x32x8_wt32x8_ws1x2_wr1x1_ta1x2x1x1_1x4x1x
     .amdhsa_next_free_sgpr 60
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 

--- a/src/kernels/dynamic_igemm/igemm_gtc_fwd/igemm_fwd_gtc_gfx908_064x064.inc
+++ b/src/kernels/dynamic_igemm/igemm_gtc_fwd/igemm_fwd_gtc_gfx908_064x064.inc
@@ -2308,6 +2308,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt64x64x64_wt16x16_ws1x1_wr2x2_ta1x4x1x4_1x16
     .amdhsa_next_free_sgpr 62
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -3208,6 +3210,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt64x64x16_wt16x16_ws1x1_wr2x2_ta1x4x1x1_1x4x
     .amdhsa_next_free_sgpr 48
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -4213,6 +4217,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt64x64x16_wt16x16_ws1x1_wr2x2_ta1x4x1x1_1x4x
     .amdhsa_next_free_sgpr 62
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -5113,6 +5119,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt64x64x16_wt16x16_ws1x1_wr2x2_ta1x4x1x1_1x4x
     .amdhsa_next_free_sgpr 48
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -6118,6 +6126,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt64x64x16_wt16x16_ws1x1_wr2x2_ta1x4x1x1_1x4x
     .amdhsa_next_free_sgpr 62
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -7022,6 +7032,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt64x64x16_wt16x16_ws1x1_wr2x2_ta1x4x1x1_1x4x
     .amdhsa_next_free_sgpr 48
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -8030,6 +8042,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt64x64x16_wt16x16_ws1x1_wr2x2_ta1x4x1x1_1x4x
     .amdhsa_next_free_sgpr 62
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -8934,6 +8948,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt64x64x16_wt16x16_ws1x1_wr2x2_ta1x4x1x1_1x4x
     .amdhsa_next_free_sgpr 48
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -9942,6 +9958,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt64x64x16_wt16x16_ws1x1_wr2x2_ta1x4x1x1_1x4x
     .amdhsa_next_free_sgpr 62
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -10617,6 +10635,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt64x64x8_wt16x16_ws1x1_wr2x2_ta1x2x1x1_1x4x1
     .amdhsa_next_free_sgpr 46
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -11397,6 +11417,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt64x64x8_wt16x16_ws1x1_wr2x2_ta1x2x1x1_1x4x1
     .amdhsa_next_free_sgpr 60
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -12072,6 +12094,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt64x64x8_wt16x16_ws1x1_wr2x2_ta1x2x1x1_1x4x1
     .amdhsa_next_free_sgpr 46
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -12852,6 +12876,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt64x64x8_wt16x16_ws1x1_wr2x2_ta1x2x1x1_1x4x1
     .amdhsa_next_free_sgpr 60
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -13531,6 +13557,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt64x64x8_wt16x16_ws1x1_wr2x2_ta1x2x1x1_1x4x1
     .amdhsa_next_free_sgpr 46
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -14314,6 +14342,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt64x64x8_wt16x16_ws1x1_wr2x2_ta1x2x1x1_1x4x1
     .amdhsa_next_free_sgpr 60
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -14993,6 +15023,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt64x64x8_wt16x16_ws1x1_wr2x2_ta1x2x1x1_1x4x1
     .amdhsa_next_free_sgpr 46
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -15776,5 +15808,7 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt64x64x8_wt16x16_ws1x1_wr2x2_ta1x2x1x1_1x4x1
     .amdhsa_next_free_sgpr 60
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 

--- a/src/kernels/dynamic_igemm/igemm_gtc_fwd/igemm_fwd_gtc_gfx908_064x128.inc
+++ b/src/kernels/dynamic_igemm/igemm_gtc_fwd/igemm_fwd_gtc_gfx908_064x128.inc
@@ -1753,6 +1753,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt64x128x32_wt8x32_ws2x1_wr2x2_ta1x4x1x2_1x8x
     .amdhsa_next_free_sgpr 60
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -2872,6 +2874,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt64x128x16_wt8x32_ws2x1_wr2x2_ta1x4x1x1_1x4x
     .amdhsa_next_free_sgpr 52
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -4096,6 +4100,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt64x128x16_wt8x32_ws2x1_wr2x2_ta1x4x1x1_1x4x
     .amdhsa_next_free_sgpr 66
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -5215,6 +5221,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt64x128x16_wt8x32_ws2x1_wr2x2_ta1x4x1x1_1x4x
     .amdhsa_next_free_sgpr 52
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -6439,6 +6447,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt64x128x16_wt8x32_ws2x1_wr2x2_ta1x4x1x1_1x4x
     .amdhsa_next_free_sgpr 66
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -7555,6 +7565,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt64x128x16_wt8x32_ws2x1_wr2x2_ta1x4x1x1_1x4x
     .amdhsa_next_free_sgpr 52
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -8775,6 +8787,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt64x128x16_wt8x32_ws2x1_wr2x2_ta1x4x1x1_1x4x
     .amdhsa_next_free_sgpr 66
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -9891,6 +9905,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt64x128x16_wt8x32_ws2x1_wr2x2_ta1x4x1x1_1x4x
     .amdhsa_next_free_sgpr 52
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -11111,6 +11127,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt64x128x16_wt8x32_ws2x1_wr2x2_ta1x4x1x1_1x4x
     .amdhsa_next_free_sgpr 66
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -11933,6 +11951,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt64x128x8_wt8x32_ws2x1_wr2x2_ta1x2x1x1_1x4x1
     .amdhsa_next_free_sgpr 48
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -12860,6 +12880,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt64x128x8_wt8x32_ws2x1_wr2x2_ta1x2x1x1_1x4x1
     .amdhsa_next_free_sgpr 62
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -13682,6 +13704,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt64x128x8_wt8x32_ws2x1_wr2x2_ta1x2x1x1_1x4x1
     .amdhsa_next_free_sgpr 48
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -14609,6 +14633,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt64x128x8_wt8x32_ws2x1_wr2x2_ta1x2x1x1_1x4x1
     .amdhsa_next_free_sgpr 62
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -15435,6 +15461,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt64x128x8_wt8x32_ws2x1_wr2x2_ta1x2x1x1_1x4x1
     .amdhsa_next_free_sgpr 48
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -16365,6 +16393,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt64x128x8_wt8x32_ws2x1_wr2x2_ta1x2x1x1_1x4x1
     .amdhsa_next_free_sgpr 62
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -17191,6 +17221,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt64x128x8_wt8x32_ws2x1_wr2x2_ta1x2x1x1_1x4x1
     .amdhsa_next_free_sgpr 48
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -18121,6 +18153,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt64x128x8_wt8x32_ws2x1_wr2x2_ta1x2x1x1_1x4x1
     .amdhsa_next_free_sgpr 62
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -18793,6 +18827,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt64x128x4_wt8x32_ws2x1_wr2x2_ta1x1x1x1_1x4x1
     .amdhsa_next_free_sgpr 46
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -19570,6 +19606,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt64x128x4_wt8x32_ws2x1_wr2x2_ta1x1x1x1_1x4x1
     .amdhsa_next_free_sgpr 60
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -20242,6 +20280,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt64x128x4_wt8x32_ws2x1_wr2x2_ta1x1x1x1_1x4x1
     .amdhsa_next_free_sgpr 46
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -21019,6 +21059,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt64x128x4_wt8x32_ws2x1_wr2x2_ta1x1x1x1_1x4x1
     .amdhsa_next_free_sgpr 60
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -21695,6 +21737,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt64x128x4_wt8x32_ws2x1_wr2x2_ta1x1x1x1_1x4x1
     .amdhsa_next_free_sgpr 46
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -22475,6 +22519,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt64x128x4_wt8x32_ws2x1_wr2x2_ta1x1x1x1_1x4x1
     .amdhsa_next_free_sgpr 60
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -23151,6 +23197,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt64x128x4_wt8x32_ws2x1_wr2x2_ta1x1x1x1_1x4x1
     .amdhsa_next_free_sgpr 46
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -23931,5 +23979,7 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt64x128x4_wt8x32_ws2x1_wr2x2_ta1x1x1x1_1x4x1
     .amdhsa_next_free_sgpr 60
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 

--- a/src/kernels/dynamic_igemm/igemm_gtc_fwd/igemm_fwd_gtc_gfx908_064x256.inc
+++ b/src/kernels/dynamic_igemm/igemm_gtc_fwd/igemm_fwd_gtc_gfx908_064x256.inc
@@ -1146,6 +1146,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt64x256x16_wt16x64_ws1x1_wr2x2_ta1x4x1x1_1x4
     .amdhsa_next_free_sgpr 60
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -2374,6 +2376,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt64x256x16_wt16x64_ws1x1_wr2x2_ta1x4x1x1_1x4
     .amdhsa_next_free_sgpr 74
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -3497,6 +3501,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt64x256x16_wt16x64_ws1x1_wr2x2_ta1x4x1x1_1x4
     .amdhsa_next_free_sgpr 60
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -4725,6 +4731,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt64x256x16_wt16x64_ws1x1_wr2x2_ta1x4x1x1_1x4
     .amdhsa_next_free_sgpr 74
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -5845,6 +5853,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt64x256x16_wt16x64_ws1x1_wr2x2_ta1x4x1x1_1x4
     .amdhsa_next_free_sgpr 60
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -7069,6 +7079,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt64x256x16_wt16x64_ws1x1_wr2x2_ta1x4x1x1_1x4
     .amdhsa_next_free_sgpr 74
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -8189,6 +8201,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt64x256x16_wt16x64_ws1x1_wr2x2_ta1x4x1x1_1x4
     .amdhsa_next_free_sgpr 60
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -9413,6 +9427,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt64x256x16_wt16x64_ws1x1_wr2x2_ta1x4x1x1_1x4
     .amdhsa_next_free_sgpr 74
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -10286,6 +10302,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt64x256x8_wt16x64_ws1x1_wr2x2_ta1x2x1x1_1x4x
     .amdhsa_next_free_sgpr 52
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -11264,6 +11282,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt64x256x8_wt16x64_ws1x1_wr2x2_ta1x2x1x1_1x4x
     .amdhsa_next_free_sgpr 66
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -12137,6 +12157,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt64x256x8_wt16x64_ws1x1_wr2x2_ta1x2x1x1_1x4x
     .amdhsa_next_free_sgpr 52
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -13115,6 +13137,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt64x256x8_wt16x64_ws1x1_wr2x2_ta1x2x1x1_1x4x
     .amdhsa_next_free_sgpr 66
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -13985,6 +14009,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt64x256x8_wt16x64_ws1x1_wr2x2_ta1x2x1x1_1x4x
     .amdhsa_next_free_sgpr 52
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -14959,6 +14985,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt64x256x8_wt16x64_ws1x1_wr2x2_ta1x2x1x1_1x4x
     .amdhsa_next_free_sgpr 66
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -15829,6 +15857,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt64x256x8_wt16x64_ws1x1_wr2x2_ta1x2x1x1_1x4x
     .amdhsa_next_free_sgpr 52
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -16803,6 +16833,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt64x256x8_wt16x64_ws1x1_wr2x2_ta1x2x1x1_1x4x
     .amdhsa_next_free_sgpr 66
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -17542,6 +17574,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt64x256x4_wt16x64_ws1x1_wr2x2_ta1x1x1x1_1x4x
     .amdhsa_next_free_sgpr 48
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -18386,6 +18420,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt64x256x4_wt16x64_ws1x1_wr2x2_ta1x1x1x1_1x4x
     .amdhsa_next_free_sgpr 62
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -19125,6 +19161,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt64x256x4_wt16x64_ws1x1_wr2x2_ta1x1x1x1_1x4x
     .amdhsa_next_free_sgpr 48
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -19969,6 +20007,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt64x256x4_wt16x64_ws1x1_wr2x2_ta1x1x1x1_1x4x
     .amdhsa_next_free_sgpr 62
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -20714,6 +20754,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt64x256x4_wt16x64_ws1x1_wr2x2_ta1x1x1x1_1x4x
     .amdhsa_next_free_sgpr 48
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -21563,6 +21605,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt64x256x4_wt16x64_ws1x1_wr2x2_ta1x1x1x1_1x4x
     .amdhsa_next_free_sgpr 62
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -22308,6 +22352,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt64x256x4_wt16x64_ws1x1_wr2x2_ta1x1x1x1_1x4x
     .amdhsa_next_free_sgpr 48
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -23157,5 +23203,7 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt64x256x4_wt16x64_ws1x1_wr2x2_ta1x1x1x1_1x4x
     .amdhsa_next_free_sgpr 62
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 

--- a/src/kernels/dynamic_igemm/igemm_gtc_fwd/igemm_fwd_gtc_gfx908_128x032.inc
+++ b/src/kernels/dynamic_igemm/igemm_gtc_fwd/igemm_fwd_gtc_gfx908_128x032.inc
@@ -919,6 +919,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt128x32x16_wt32x8_ws1x1_wr2x2_ta1x4x2x1_1x4x
     .amdhsa_next_free_sgpr 46
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -1920,6 +1922,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt128x32x16_wt32x8_ws1x1_wr2x2_ta1x4x2x1_1x4x
     .amdhsa_next_free_sgpr 60
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -2816,6 +2820,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt128x32x16_wt32x8_ws1x1_wr2x2_ta1x4x2x1_1x4x
     .amdhsa_next_free_sgpr 46
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -3817,6 +3823,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt128x32x16_wt32x8_ws1x1_wr2x2_ta1x4x2x1_1x4x
     .amdhsa_next_free_sgpr 60
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -4717,6 +4725,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt128x32x16_wt32x8_ws1x1_wr2x2_ta1x4x2x1_1x4x
     .amdhsa_next_free_sgpr 48
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -5721,6 +5731,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt128x32x16_wt32x8_ws1x1_wr2x2_ta1x4x2x1_1x4x
     .amdhsa_next_free_sgpr 62
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -6621,6 +6633,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt128x32x16_wt32x8_ws1x1_wr2x2_ta1x4x2x1_1x4x
     .amdhsa_next_free_sgpr 48
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -7625,6 +7639,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt128x32x16_wt32x8_ws1x1_wr2x2_ta1x4x2x1_1x4x
     .amdhsa_next_free_sgpr 62
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -8298,6 +8314,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt128x32x8_wt32x8_ws1x1_wr2x2_ta1x4x1x1_1x2x1
     .amdhsa_next_free_sgpr 46
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -9075,6 +9093,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt128x32x8_wt32x8_ws1x1_wr2x2_ta1x4x1x1_1x2x1
     .amdhsa_next_free_sgpr 60
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -9748,6 +9768,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt128x32x8_wt32x8_ws1x1_wr2x2_ta1x4x1x1_1x2x1
     .amdhsa_next_free_sgpr 46
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -10525,5 +10547,7 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt128x32x8_wt32x8_ws1x1_wr2x2_ta1x4x1x1_1x2x1
     .amdhsa_next_free_sgpr 60
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 

--- a/src/kernels/dynamic_igemm/igemm_gtc_fwd/igemm_fwd_gtc_gfx908_128x064.inc
+++ b/src/kernels/dynamic_igemm/igemm_gtc_fwd/igemm_fwd_gtc_gfx908_128x064.inc
@@ -1744,6 +1744,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt128x64x32_wt32x8_ws1x2_wr2x2_ta1x4x1x4_1x8x
     .amdhsa_next_free_sgpr 54
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -3570,6 +3572,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt128x64x32_wt32x8_ws1x2_wr2x2_ta1x4x1x4_1x8x
     .amdhsa_next_free_sgpr 68
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -4675,6 +4679,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt128x64x16_wt32x8_ws1x2_wr2x2_ta1x4x2x1_1x4x
     .amdhsa_next_free_sgpr 48
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -5885,6 +5891,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt128x64x16_wt32x8_ws1x2_wr2x2_ta1x4x2x1_1x4x
     .amdhsa_next_free_sgpr 62
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -6990,6 +6998,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt128x64x16_wt32x8_ws1x2_wr2x2_ta1x4x2x1_1x4x
     .amdhsa_next_free_sgpr 48
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -8200,6 +8210,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt128x64x16_wt32x8_ws1x2_wr2x2_ta1x4x2x1_1x4x
     .amdhsa_next_free_sgpr 62
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -9309,6 +9321,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt128x64x16_wt32x8_ws1x2_wr2x2_ta1x4x2x1_1x4x
     .amdhsa_next_free_sgpr 50
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -10522,6 +10536,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt128x64x16_wt32x8_ws1x2_wr2x2_ta1x4x2x1_1x4x
     .amdhsa_next_free_sgpr 64
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -11631,6 +11647,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt128x64x16_wt32x8_ws1x2_wr2x2_ta1x4x2x1_1x4x
     .amdhsa_next_free_sgpr 50
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -12844,6 +12862,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt128x64x16_wt32x8_ws1x2_wr2x2_ta1x4x2x1_1x4x
     .amdhsa_next_free_sgpr 64
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -13649,6 +13669,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt128x64x8_wt32x8_ws1x2_wr2x2_ta1x4x1x1_1x2x1
     .amdhsa_next_free_sgpr 46
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -14559,6 +14581,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt128x64x8_wt32x8_ws1x2_wr2x2_ta1x4x1x1_1x2x1
     .amdhsa_next_free_sgpr 60
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -15364,6 +15388,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt128x64x8_wt32x8_ws1x2_wr2x2_ta1x4x1x1_1x2x1
     .amdhsa_next_free_sgpr 46
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -16274,6 +16300,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt128x64x8_wt32x8_ws1x2_wr2x2_ta1x4x1x1_1x2x1
     .amdhsa_next_free_sgpr 60
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -17083,6 +17111,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt128x64x8_wt32x8_ws1x2_wr2x2_ta1x4x1x1_1x2x1
     .amdhsa_next_free_sgpr 46
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -17996,6 +18026,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt128x64x8_wt32x8_ws1x2_wr2x2_ta1x4x1x1_1x2x1
     .amdhsa_next_free_sgpr 60
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -18805,6 +18837,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt128x64x8_wt32x8_ws1x2_wr2x2_ta1x4x1x1_1x2x1
     .amdhsa_next_free_sgpr 46
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -19718,6 +19752,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt128x64x8_wt32x8_ws1x2_wr2x2_ta1x4x1x1_1x2x1
     .amdhsa_next_free_sgpr 60
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -20375,6 +20411,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt128x64x4_wt32x8_ws1x2_wr2x2_ta1x2x1x1_1x2x1
     .amdhsa_next_free_sgpr 46
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -21136,6 +21174,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt128x64x4_wt32x8_ws1x2_wr2x2_ta1x2x1x1_1x2x1
     .amdhsa_next_free_sgpr 60
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -21793,6 +21833,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt128x64x4_wt32x8_ws1x2_wr2x2_ta1x2x1x1_1x2x1
     .amdhsa_next_free_sgpr 46
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -22554,5 +22596,7 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt128x64x4_wt32x8_ws1x2_wr2x2_ta1x2x1x1_1x2x1
     .amdhsa_next_free_sgpr 60
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 

--- a/src/kernels/dynamic_igemm/igemm_gtc_fwd/igemm_fwd_gtc_gfx908_128x128.inc
+++ b/src/kernels/dynamic_igemm/igemm_gtc_fwd/igemm_fwd_gtc_gfx908_128x128.inc
@@ -1141,6 +1141,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt128x128x16_wt32x32_ws1x1_wr2x2_ta1x4x2x1_1x
     .amdhsa_next_free_sgpr 52
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -2364,6 +2366,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt128x128x16_wt32x32_ws1x1_wr2x2_ta1x4x2x1_1x
     .amdhsa_next_free_sgpr 66
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -3482,6 +3486,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt128x128x16_wt32x32_ws1x1_wr2x2_ta1x4x2x1_1x
     .amdhsa_next_free_sgpr 52
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -4705,6 +4711,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt128x128x16_wt32x32_ws1x1_wr2x2_ta1x4x2x1_1x
     .amdhsa_next_free_sgpr 66
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -5820,6 +5828,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt128x128x16_wt32x32_ws1x1_wr2x2_ta1x4x2x1_1x
     .amdhsa_next_free_sgpr 54
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -7039,6 +7049,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt128x128x16_wt32x32_ws1x1_wr2x2_ta1x4x2x1_1x
     .amdhsa_next_free_sgpr 68
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -8154,6 +8166,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt128x128x16_wt32x32_ws1x1_wr2x2_ta1x4x2x1_1x
     .amdhsa_next_free_sgpr 54
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -9373,6 +9387,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt128x128x16_wt32x32_ws1x1_wr2x2_ta1x4x2x1_1x
     .amdhsa_next_free_sgpr 68
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -10243,6 +10259,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt128x128x8_wt32x32_ws1x1_wr2x2_ta1x4x1x1_1x2
     .amdhsa_next_free_sgpr 48
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -11218,6 +11236,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt128x128x8_wt32x32_ws1x1_wr2x2_ta1x4x1x1_1x2
     .amdhsa_next_free_sgpr 62
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -12088,6 +12108,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt128x128x8_wt32x32_ws1x1_wr2x2_ta1x4x1x1_1x2
     .amdhsa_next_free_sgpr 48
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -13063,6 +13085,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt128x128x8_wt32x32_ws1x1_wr2x2_ta1x4x1x1_1x2
     .amdhsa_next_free_sgpr 62
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -13937,6 +13961,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt128x128x8_wt32x32_ws1x1_wr2x2_ta1x4x1x1_1x2
     .amdhsa_next_free_sgpr 48
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -14915,6 +14941,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt128x128x8_wt32x32_ws1x1_wr2x2_ta1x4x1x1_1x2
     .amdhsa_next_free_sgpr 62
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -15789,6 +15817,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt128x128x8_wt32x32_ws1x1_wr2x2_ta1x4x1x1_1x2
     .amdhsa_next_free_sgpr 48
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -16767,5 +16797,7 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt128x128x8_wt32x32_ws1x1_wr2x2_ta1x4x1x1_1x2
     .amdhsa_next_free_sgpr 62
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 

--- a/src/kernels/dynamic_igemm/igemm_gtc_fwd/igemm_fwd_gtc_gfx908_128x256.inc
+++ b/src/kernels/dynamic_igemm/igemm_gtc_fwd/igemm_fwd_gtc_gfx908_128x256.inc
@@ -1408,6 +1408,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt128x256x16_wt32x64_ws1x1_wr2x2_ta1x4x2x1_1x
     .amdhsa_next_free_sgpr 60
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -2898,6 +2900,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt128x256x16_wt32x64_ws1x1_wr2x2_ta1x4x2x1_1x
     .amdhsa_next_free_sgpr 74
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -4283,6 +4287,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt128x256x16_wt32x64_ws1x1_wr2x2_ta1x4x2x1_1x
     .amdhsa_next_free_sgpr 60
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -5773,6 +5779,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt128x256x16_wt32x64_ws1x1_wr2x2_ta1x4x2x1_1x
     .amdhsa_next_free_sgpr 74
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -7155,6 +7163,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt128x256x16_wt32x64_ws1x1_wr2x2_ta1x4x2x1_1x
     .amdhsa_next_free_sgpr 62
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -8641,6 +8651,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt128x256x16_wt32x64_ws1x1_wr2x2_ta1x4x2x1_1x
     .amdhsa_next_free_sgpr 76
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -10023,6 +10035,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt128x256x16_wt32x64_ws1x1_wr2x2_ta1x4x2x1_1x
     .amdhsa_next_free_sgpr 62
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -11509,6 +11523,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt128x256x16_wt32x64_ws1x1_wr2x2_ta1x4x2x1_1x
     .amdhsa_next_free_sgpr 76
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -12661,6 +12677,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt128x256x8_wt32x64_ws1x1_wr2x2_ta1x4x1x1_1x2
     .amdhsa_next_free_sgpr 52
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -13918,6 +13936,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt128x256x8_wt32x64_ws1x1_wr2x2_ta1x4x1x1_1x2
     .amdhsa_next_free_sgpr 66
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -15070,6 +15090,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt128x256x8_wt32x64_ws1x1_wr2x2_ta1x4x1x1_1x2
     .amdhsa_next_free_sgpr 52
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -16327,6 +16349,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt128x256x8_wt32x64_ws1x1_wr2x2_ta1x4x1x1_1x2
     .amdhsa_next_free_sgpr 66
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -17476,6 +17500,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt128x256x8_wt32x64_ws1x1_wr2x2_ta1x4x1x1_1x2
     .amdhsa_next_free_sgpr 52
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -18729,6 +18755,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt128x256x8_wt32x64_ws1x1_wr2x2_ta1x4x1x1_1x2
     .amdhsa_next_free_sgpr 66
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -19878,6 +19906,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt128x256x8_wt32x64_ws1x1_wr2x2_ta1x4x1x1_1x2
     .amdhsa_next_free_sgpr 52
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -21131,5 +21161,7 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt128x256x8_wt32x64_ws1x1_wr2x2_ta1x4x1x1_1x2
     .amdhsa_next_free_sgpr 66
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 

--- a/src/kernels/dynamic_igemm/igemm_gtc_fwd/igemm_fwd_gtc_gfx908_256x032.inc
+++ b/src/kernels/dynamic_igemm/igemm_gtc_fwd/igemm_fwd_gtc_gfx908_256x032.inc
@@ -1120,6 +1120,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt256x32x16_wt64x4_ws1x2_wr2x2_ta1x4x4x1_1x4x
     .amdhsa_next_free_sgpr 48
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -2322,6 +2324,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt256x32x16_wt64x4_ws1x2_wr2x2_ta1x4x4x1_1x4x
     .amdhsa_next_free_sgpr 62
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -3419,6 +3423,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt256x32x16_wt64x4_ws1x2_wr2x2_ta1x4x4x1_1x4x
     .amdhsa_next_free_sgpr 48
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -4621,6 +4627,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt256x32x16_wt64x4_ws1x2_wr2x2_ta1x4x4x1_1x4x
     .amdhsa_next_free_sgpr 62
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -5722,6 +5730,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt256x32x16_wt64x4_ws1x2_wr2x2_ta1x4x4x1_1x4x
     .amdhsa_next_free_sgpr 50
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -6927,6 +6937,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt256x32x16_wt64x4_ws1x2_wr2x2_ta1x4x4x1_1x4x
     .amdhsa_next_free_sgpr 64
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -8028,6 +8040,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt256x32x16_wt64x4_ws1x2_wr2x2_ta1x4x4x1_1x4x
     .amdhsa_next_free_sgpr 50
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -9233,6 +9247,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt256x32x16_wt64x4_ws1x2_wr2x2_ta1x4x4x1_1x4x
     .amdhsa_next_free_sgpr 64
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -10035,6 +10051,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt256x32x8_wt64x4_ws1x2_wr2x2_ta1x4x2x1_1x2x1
     .amdhsa_next_free_sgpr 46
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -10941,6 +10959,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt256x32x8_wt64x4_ws1x2_wr2x2_ta1x4x2x1_1x2x1
     .amdhsa_next_free_sgpr 60
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -11743,6 +11763,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt256x32x8_wt64x4_ws1x2_wr2x2_ta1x4x2x1_1x2x1
     .amdhsa_next_free_sgpr 46
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -12649,5 +12671,7 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt256x32x8_wt64x4_ws1x2_wr2x2_ta1x4x2x1_1x2x1
     .amdhsa_next_free_sgpr 60
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 

--- a/src/kernels/dynamic_igemm/igemm_gtc_fwd/igemm_fwd_gtc_gfx908_256x064.inc
+++ b/src/kernels/dynamic_igemm/igemm_gtc_fwd/igemm_fwd_gtc_gfx908_256x064.inc
@@ -1118,6 +1118,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt256x64x16_wt64x16_ws1x1_wr2x2_ta1x4x4x1_1x4
     .amdhsa_next_free_sgpr 50
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -2318,6 +2320,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt256x64x16_wt64x16_ws1x1_wr2x2_ta1x4x4x1_1x4
     .amdhsa_next_free_sgpr 64
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -3413,6 +3417,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt256x64x16_wt64x16_ws1x1_wr2x2_ta1x4x4x1_1x4
     .amdhsa_next_free_sgpr 50
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -4613,6 +4619,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt256x64x16_wt64x16_ws1x1_wr2x2_ta1x4x4x1_1x4
     .amdhsa_next_free_sgpr 64
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -5712,6 +5720,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt256x64x16_wt64x16_ws1x1_wr2x2_ta1x4x4x1_1x4
     .amdhsa_next_free_sgpr 52
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -6915,6 +6925,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt256x64x16_wt64x16_ws1x1_wr2x2_ta1x4x4x1_1x4
     .amdhsa_next_free_sgpr 66
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -8014,6 +8026,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt256x64x16_wt64x16_ws1x1_wr2x2_ta1x4x4x1_1x4
     .amdhsa_next_free_sgpr 52
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -9217,6 +9231,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt256x64x16_wt64x16_ws1x1_wr2x2_ta1x4x4x1_1x4
     .amdhsa_next_free_sgpr 66
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -10086,6 +10102,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt256x64x8_wt64x16_ws1x1_wr2x2_ta1x4x2x1_1x2x
     .amdhsa_next_free_sgpr 46
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -11060,6 +11078,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt256x64x8_wt64x16_ws1x1_wr2x2_ta1x4x2x1_1x2x
     .amdhsa_next_free_sgpr 60
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -11929,6 +11949,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt256x64x8_wt64x16_ws1x1_wr2x2_ta1x4x2x1_1x2x
     .amdhsa_next_free_sgpr 46
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -12903,6 +12925,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt256x64x8_wt64x16_ws1x1_wr2x2_ta1x4x2x1_1x2x
     .amdhsa_next_free_sgpr 60
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -13776,6 +13800,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt256x64x8_wt64x16_ws1x1_wr2x2_ta1x4x2x1_1x2x
     .amdhsa_next_free_sgpr 48
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -14753,6 +14779,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt256x64x8_wt64x16_ws1x1_wr2x2_ta1x4x2x1_1x2x
     .amdhsa_next_free_sgpr 62
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -15626,6 +15654,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt256x64x8_wt64x16_ws1x1_wr2x2_ta1x4x2x1_1x2x
     .amdhsa_next_free_sgpr 48
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -16603,6 +16633,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt256x64x8_wt64x16_ws1x1_wr2x2_ta1x4x2x1_1x2x
     .amdhsa_next_free_sgpr 62
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -17380,6 +17412,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt256x64x4_wt64x16_ws1x1_wr2x2_ta1x2x2x1_1x2x
     .amdhsa_next_free_sgpr 46
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -18261,6 +18295,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt256x64x4_wt64x16_ws1x1_wr2x2_ta1x2x2x1_1x2x
     .amdhsa_next_free_sgpr 60
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -19038,6 +19074,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt256x64x4_wt64x16_ws1x1_wr2x2_ta1x2x2x1_1x2x
     .amdhsa_next_free_sgpr 46
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -19919,5 +19957,7 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt256x64x4_wt64x16_ws1x1_wr2x2_ta1x2x2x1_1x2x
     .amdhsa_next_free_sgpr 60
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 

--- a/src/kernels/dynamic_igemm/igemm_gtc_fwd/igemm_fwd_gtc_gfx908_256x128.inc
+++ b/src/kernels/dynamic_igemm/igemm_gtc_fwd/igemm_fwd_gtc_gfx908_256x128.inc
@@ -1394,6 +1394,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt256x128x16_wt64x32_ws1x1_wr2x2_ta1x4x4x1_1x
     .amdhsa_next_free_sgpr 54
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -2870,6 +2872,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt256x128x16_wt64x32_ws1x1_wr2x2_ta1x4x4x1_1x
     .amdhsa_next_free_sgpr 68
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -4241,6 +4245,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt256x128x16_wt64x32_ws1x1_wr2x2_ta1x4x4x1_1x
     .amdhsa_next_free_sgpr 54
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -5717,6 +5723,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt256x128x16_wt64x32_ws1x1_wr2x2_ta1x4x4x1_1x
     .amdhsa_next_free_sgpr 68
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -7085,6 +7093,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt256x128x16_wt64x32_ws1x1_wr2x2_ta1x4x4x1_1x
     .amdhsa_next_free_sgpr 56
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -8557,6 +8567,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt256x128x16_wt64x32_ws1x1_wr2x2_ta1x4x4x1_1x
     .amdhsa_next_free_sgpr 70
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -9925,6 +9937,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt256x128x16_wt64x32_ws1x1_wr2x2_ta1x4x4x1_1x
     .amdhsa_next_free_sgpr 56
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -11397,6 +11411,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt256x128x16_wt64x32_ws1x1_wr2x2_ta1x4x4x1_1x
     .amdhsa_next_free_sgpr 70
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -12538,6 +12554,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt256x128x8_wt64x32_ws1x1_wr2x2_ta1x4x2x1_1x2
     .amdhsa_next_free_sgpr 48
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -13784,6 +13802,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt256x128x8_wt64x32_ws1x1_wr2x2_ta1x4x2x1_1x2
     .amdhsa_next_free_sgpr 62
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -14925,6 +14945,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt256x128x8_wt64x32_ws1x1_wr2x2_ta1x4x2x1_1x2
     .amdhsa_next_free_sgpr 48
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -16171,6 +16193,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt256x128x8_wt64x32_ws1x1_wr2x2_ta1x4x2x1_1x2
     .amdhsa_next_free_sgpr 62
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -17316,6 +17340,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex0_bt256x128x8_wt64x32_ws1x1_wr2x2_ta1x4x2x1_1x2
     .amdhsa_next_free_sgpr 50
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -18565,6 +18591,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx4_ex1_bt256x128x8_wt64x32_ws1x1_wr2x2_ta1x4x2x1_1x2
     .amdhsa_next_free_sgpr 64
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -19710,6 +19738,8 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex0_bt256x128x8_wt64x32_ws1x1_wr2x2_ta1x4x2x1_1x2
     .amdhsa_next_free_sgpr 50
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -20959,5 +20989,7 @@ L_igemm_fwd_gtcx_nchw_fp32_bx1_ex1_bt256x128x8_wt64x32_ws1x1_wr2x2_ta1x4x2x1_1x2
     .amdhsa_next_free_sgpr 64
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 

--- a/src/kernels/dynamic_igemm/igemm_v4r1_dynamic.s
+++ b/src/kernels/dynamic_igemm/igemm_v4r1_dynamic.s
@@ -935,6 +935,8 @@ L_igemm_v4r1_dynamic_128x128x16_8x8_4x4x4x4x4x4_16x1x16x1_4x64_end:
     .amdhsa_next_free_sgpr 54
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -1408,6 +1410,8 @@ L_igemm_v4r1_dynamic_128x128x8_8x8_4x4x4x4x4x4_8x2x16x1_2x128_end:
     .amdhsa_next_free_sgpr 54
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -1883,6 +1887,8 @@ L_igemm_v4r1_dynamic_128x64x8_8x8_4x4x4x4x4x2_8x1x8x2_2x64_end:
     .amdhsa_next_free_sgpr 54
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -2355,6 +2361,8 @@ L_igemm_v4r1_dynamic_64x64x8_8x8_4x4x2x4x2x4_8x1x8x1_4x16_end:
     .amdhsa_next_free_sgpr 54
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -2826,6 +2834,8 @@ L_igemm_v4r1_dynamic_32x128x4_8x8_4x1x4x4x4x4_4x1x16x1_4x16_end:
     .amdhsa_next_free_sgpr 54
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -3296,6 +3306,8 @@ L_igemm_v4r1_dynamic_16x64x4_4x4_2x2x2x2x4x4_4x1x16x1_4x16_end:
     .amdhsa_next_free_sgpr 54
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -3769,6 +3781,8 @@ L_igemm_v4r1_dynamic_32x32x4_4x4_2x2x4x2x4x2_4x2x8x1_4x16_end:
     .amdhsa_next_free_sgpr 54
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -4194,6 +4208,8 @@ L_igemm_v4r1_1x1_dynamic_128x128x16_8x8_4x4x4x4x4x4_16x1x16x1_4x64_end:
     .amdhsa_next_free_sgpr 54
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -4620,6 +4636,8 @@ L_igemm_v4r1_1x1_dynamic_128x128x8_8x8_4x4x4x4x4x4_8x2x16x1_2x128_end:
     .amdhsa_next_free_sgpr 54
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -5048,6 +5066,8 @@ L_igemm_v4r1_1x1_dynamic_128x64x8_8x8_4x4x4x4x4x2_8x1x8x2_2x64_end:
     .amdhsa_next_free_sgpr 54
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -5473,6 +5493,8 @@ L_igemm_v4r1_1x1_dynamic_64x64x8_8x8_4x4x2x4x2x4_8x1x8x1_4x16_end:
     .amdhsa_next_free_sgpr 54
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -5897,6 +5919,8 @@ L_igemm_v4r1_1x1_dynamic_32x128x4_8x8_4x1x4x4x4x4_4x1x16x1_4x16_end:
     .amdhsa_next_free_sgpr 54
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -6320,6 +6344,8 @@ L_igemm_v4r1_1x1_dynamic_16x64x4_4x4_2x2x2x2x4x4_4x1x16x1_4x16_end:
     .amdhsa_next_free_sgpr 54
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -6746,6 +6772,8 @@ L_igemm_v4r1_1x1_dynamic_32x32x4_4x4_2x2x4x2x4x2_4x2x8x1_4x16_end:
     .amdhsa_next_free_sgpr 54
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 .amdgpu_metadata

--- a/src/kernels/dynamic_igemm/igemm_v4r1_wrw_dynamic.s
+++ b/src/kernels/dynamic_igemm/igemm_v4r1_wrw_dynamic.s
@@ -968,6 +968,8 @@ L_igemm_v4r1_dynamic_wrw_32x32x4_4x4_2x2x4x2x4x2_4x2x8x1_4x16_end:
     .amdhsa_next_free_sgpr 58
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -1493,6 +1495,8 @@ L_program_end:
     .amdhsa_next_free_sgpr 58
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -2021,6 +2025,8 @@ L_program_end_1:
     .amdhsa_next_free_sgpr 58
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 .amdgpu_metadata

--- a/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_004x064.inc
+++ b/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_004x064.inc
@@ -783,6 +783,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt4x64x16_wt4x64_ws1x1_wr1x1_ta1x1x1x1_1x16x1
     .amdhsa_next_free_sgpr 86
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -1543,5 +1545,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt4x64x16_wt4x64_ws1x1_wr1x1_ta1x1x1x1_1x16x1
     .amdhsa_next_free_sgpr 86
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 

--- a/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_016x032.inc
+++ b/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_016x032.inc
@@ -759,6 +759,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt16x32x16_wt8x32_ws1x1_wr1x1_ta1x1x2x1_1x16x
     .amdhsa_next_free_sgpr 74
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -1495,6 +1497,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt16x32x16_wt8x32_ws1x1_wr1x1_ta1x1x2x1_1x16x
     .amdhsa_next_free_sgpr 74
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -2156,6 +2160,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt16x32x8_wt8x32_ws1x1_wr1x1_ta1x1x1x1_1x8x1x
     .amdhsa_next_free_sgpr 72
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -2817,5 +2823,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt16x32x8_wt8x32_ws1x1_wr1x1_ta1x1x1x1_1x8x1x
     .amdhsa_next_free_sgpr 72
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 

--- a/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_032x032.inc
+++ b/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_032x032.inc
@@ -758,6 +758,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt32x32x16_wt16x16_ws1x1_wr1x1_ta1x1x2x1_1x16
     .amdhsa_next_free_sgpr 72
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -1493,6 +1495,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt32x32x16_wt16x16_ws1x1_wr1x1_ta1x1x2x1_1x16
     .amdhsa_next_free_sgpr 72
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -2153,6 +2157,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt32x32x8_wt16x16_ws1x1_wr1x1_ta1x1x1x1_1x8x1
     .amdhsa_next_free_sgpr 72
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -2813,5 +2819,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt32x32x8_wt16x16_ws1x1_wr1x1_ta1x1x1x1_1x8x1
     .amdhsa_next_free_sgpr 72
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 

--- a/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_064x016.inc
+++ b/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_064x016.inc
@@ -743,6 +743,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x16x16_wt64x4_ws1x1_wr1x1_ta1x1x4x1_1x16x
     .amdhsa_next_free_sgpr 74
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -1463,5 +1465,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x16x16_wt64x4_ws1x1_wr1x1_ta1x1x4x1_1x16x
     .amdhsa_next_free_sgpr 74
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 

--- a/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_064x032.inc
+++ b/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_064x032.inc
@@ -812,6 +812,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x32x16_wt32x8_ws1x2_wr1x1_ta1x1x4x1_1x16x
     .amdhsa_next_free_sgpr 74
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -1601,6 +1603,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x32x16_wt32x8_ws1x2_wr1x1_ta1x1x4x1_1x16x
     .amdhsa_next_free_sgpr 74
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -2294,6 +2298,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x32x8_wt32x8_ws1x2_wr1x1_ta1x1x2x1_1x8x1x
     .amdhsa_next_free_sgpr 72
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -2987,5 +2993,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x32x8_wt32x8_ws1x2_wr1x1_ta1x1x2x1_1x8x1x
     .amdhsa_next_free_sgpr 72
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 

--- a/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_064x064.inc
+++ b/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_064x064.inc
@@ -1122,6 +1122,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x64x16_wt16x16_ws1x1_wr2x2_ta1x1x4x1_1x16
     .amdhsa_next_free_sgpr 76
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -2221,6 +2223,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x64x16_wt16x16_ws1x1_wr2x2_ta1x1x4x1_1x16
     .amdhsa_next_free_sgpr 76
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -3090,6 +3094,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x64x8_wt16x16_ws1x1_wr2x2_ta1x1x2x1_1x8x1
     .amdhsa_next_free_sgpr 72
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -3959,5 +3965,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x64x8_wt16x16_ws1x1_wr2x2_ta1x1x2x1_1x8x1
     .amdhsa_next_free_sgpr 72
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 

--- a/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_064x128.inc
+++ b/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_064x128.inc
@@ -1334,6 +1334,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x128x16_wt8x32_ws2x1_wr2x2_ta1x1x4x1_1x16
     .amdhsa_next_free_sgpr 80
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -2645,6 +2647,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x128x16_wt8x32_ws2x1_wr2x2_ta1x1x4x1_1x16
     .amdhsa_next_free_sgpr 80
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -3661,6 +3665,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x128x8_wt8x32_ws2x1_wr2x2_ta1x1x2x1_1x8x1
     .amdhsa_next_free_sgpr 74
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -4677,5 +4683,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x128x8_wt8x32_ws2x1_wr2x2_ta1x1x2x1_1x8x1
     .amdhsa_next_free_sgpr 74
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 

--- a/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_064x256.inc
+++ b/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_064x256.inc
@@ -1338,6 +1338,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x256x16_wt16x64_ws1x1_wr2x2_ta1x1x4x1_1x1
     .amdhsa_next_free_sgpr 88
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -2653,6 +2655,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x256x16_wt16x64_ws1x1_wr2x2_ta1x1x4x1_1x1
     .amdhsa_next_free_sgpr 88
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -3713,6 +3717,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x256x8_wt16x64_ws1x1_wr2x2_ta1x1x2x1_1x8x
     .amdhsa_next_free_sgpr 78
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -4773,5 +4779,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt64x256x8_wt16x64_ws1x1_wr2x2_ta1x1x2x1_1x8x
     .amdhsa_next_free_sgpr 78
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 

--- a/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_128x032.inc
+++ b/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_128x032.inc
@@ -1125,6 +1125,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x32x16_wt32x8_ws1x1_wr2x2_ta1x1x8x1_1x16
     .amdhsa_next_free_sgpr 78
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -2227,6 +2229,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x32x16_wt32x8_ws1x1_wr2x2_ta1x1x8x1_1x16
     .amdhsa_next_free_sgpr 78
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -3096,6 +3100,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x32x8_wt32x8_ws1x1_wr2x2_ta1x1x4x1_1x8x1
     .amdhsa_next_free_sgpr 74
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -3965,5 +3971,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x32x8_wt32x8_ws1x1_wr2x2_ta1x1x4x1_1x8x1
     .amdhsa_next_free_sgpr 74
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 

--- a/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_128x064.inc
+++ b/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_128x064.inc
@@ -1306,6 +1306,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt128x64x16_wt32x8_ws1x2_wr2x2_ta1x4x2x1_1x4x
     .amdhsa_next_free_sgpr 72
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -2589,6 +2591,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt128x64x16_wt32x8_ws1x2_wr2x2_ta1x4x2x1_1x4x
     .amdhsa_next_free_sgpr 72
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -3900,6 +3904,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x64x16_wt32x8_ws1x2_wr2x2_ta1x1x8x1_1x16
     .amdhsa_next_free_sgpr 80
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -5211,6 +5217,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x64x16_wt32x8_ws1x2_wr2x2_ta1x1x8x1_1x16
     .amdhsa_next_free_sgpr 80
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -6215,6 +6223,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x64x8_wt32x8_ws1x2_wr2x2_ta1x1x4x1_1x8x1
     .amdhsa_next_free_sgpr 74
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -7219,5 +7229,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x64x8_wt32x8_ws1x2_wr2x2_ta1x1x4x1_1x8x1
     .amdhsa_next_free_sgpr 74
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 

--- a/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_128x128.inc
+++ b/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_128x128.inc
@@ -1307,6 +1307,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt128x128x16_wt32x32_ws1x1_wr2x2_ta1x4x2x1_1x
     .amdhsa_next_free_sgpr 72
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -2591,6 +2593,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt128x128x16_wt32x32_ws1x1_wr2x2_ta1x4x2x1_1x
     .amdhsa_next_free_sgpr 72
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -3908,6 +3912,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x128x16_wt32x32_ws1x1_wr2x2_ta1x1x8x1_1x
     .amdhsa_next_free_sgpr 84
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -5225,6 +5231,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x128x16_wt32x32_ws1x1_wr2x2_ta1x1x8x1_1x
     .amdhsa_next_free_sgpr 84
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -6294,6 +6302,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x128x8_wt32x32_ws1x1_wr2x2_ta1x1x4x1_1x8
     .amdhsa_next_free_sgpr 76
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -7363,5 +7373,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt128x128x8_wt32x32_ws1x1_wr2x2_ta1x1x4x1_1x8
     .amdhsa_next_free_sgpr 76
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 

--- a/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_256x032.inc
+++ b/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_256x032.inc
@@ -1343,6 +1343,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x32x16_wt64x4_ws1x2_wr2x2_ta1x1x16x1_1x1
     .amdhsa_next_free_sgpr 86
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -2663,6 +2665,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x32x16_wt64x4_ws1x2_wr2x2_ta1x1x16x1_1x1
     .amdhsa_next_free_sgpr 86
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -3668,6 +3672,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x32x8_wt64x4_ws1x2_wr2x2_ta1x1x8x1_1x8x1
     .amdhsa_next_free_sgpr 78
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -4673,5 +4679,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x32x8_wt64x4_ws1x2_wr2x2_ta1x1x8x1_1x8x1
     .amdhsa_next_free_sgpr 78
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 

--- a/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_256x064.inc
+++ b/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_256x064.inc
@@ -1294,6 +1294,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt256x64x16_wt64x16_ws1x1_wr2x2_ta1x4x4x1_1x4
     .amdhsa_next_free_sgpr 74
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -2565,6 +2567,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt256x64x16_wt64x16_ws1x1_wr2x2_ta1x4x4x1_1x4
     .amdhsa_next_free_sgpr 74
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -3883,6 +3887,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x64x16_wt64x16_ws1x1_wr2x2_ta1x1x16x1_1x
     .amdhsa_next_free_sgpr 88
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -5201,6 +5207,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x64x16_wt64x16_ws1x1_wr2x2_ta1x1x16x1_1x
     .amdhsa_next_free_sgpr 88
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -6276,6 +6284,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x64x8_wt64x16_ws1x1_wr2x2_ta1x1x8x1_1x8x
     .amdhsa_next_free_sgpr 78
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -7351,6 +7361,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x64x8_wt64x16_ws1x1_wr2x2_ta1x1x8x1_1x8x
     .amdhsa_next_free_sgpr 78
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -8319,6 +8331,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x64x4_wt64x16_ws1x1_wr2x2_ta1x1x4x1_1x4x
     .amdhsa_next_free_sgpr 74
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -9287,5 +9301,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x64x4_wt64x16_ws1x1_wr2x2_ta1x1x4x1_1x4x
     .amdhsa_next_free_sgpr 74
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 

--- a/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_256x128.inc
+++ b/src/kernels/dynamic_igemm/igemm_wrw_gtc_gfx908/igemm_wrw_gtc_gfx908_256x128.inc
@@ -1558,6 +1558,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt256x128x16_wt64x32_ws1x1_wr2x2_ta1x4x4x1_1x
     .amdhsa_next_free_sgpr 74
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -3093,6 +3095,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt256x128x16_wt64x32_ws1x1_wr2x2_ta1x4x4x1_1x
     .amdhsa_next_free_sgpr 74
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -4412,6 +4416,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt256x128x8_wt64x32_ws1x1_wr2x2_ta1x4x2x1_1x2
     .amdhsa_next_free_sgpr 72
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -5731,6 +5737,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx4_ex0_bt256x128x8_wt64x32_ws1x1_wr2x2_ta1x4x2x1_1x2
     .amdhsa_next_free_sgpr 72
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -7318,6 +7326,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x128x16_wt64x32_ws1x1_wr2x2_ta1x1x16x1_1
     .amdhsa_next_free_sgpr 92
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -8905,6 +8915,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x128x16_wt64x32_ws1x1_wr2x2_ta1x1x16x1_1
     .amdhsa_next_free_sgpr 92
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -10252,6 +10264,8 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x128x8_wt64x32_ws1x1_wr2x2_ta1x1x8x1_1x8
     .amdhsa_next_free_sgpr 80
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 
 ;----------------------------------------------------------
@@ -11599,5 +11613,7 @@ L_igemm_wrw_gtcx_nchw_fp32_bx1_ex1_bt256x128x8_wt64x32_ws1x1_wr2x2_ta1x1x8x1_1x8
     .amdhsa_next_free_sgpr 80
     .amdhsa_ieee_mode 0
     .amdhsa_dx10_clamp 0
+    //xnack disabled by default for asm kernels
+    .amdhsa_reserve_xnack_mask 0
 .end_amdhsa_kernel
 

--- a/src/kernels/gcnAsmBNBwdTrainSpatial.s
+++ b/src/kernels/gcnAsmBNBwdTrainSpatial.s
@@ -82,7 +82,8 @@ fmamix_instructions_available = 0
     .SGPR_ALLOC stmp8 //19
     .SGPR_ALLOC stmp9 //20
     .SGPR_ALLOC stmp10 //21
-    .SGPR_RESERVE_XNACK
+    //xnack disabled by default
+    //.SGPR_RESERVE_XNACK
     .SGPR_RESERVE_VCC
 
     .VGPR_ALLOC_FROM 0

--- a/src/kernels/xform_bidirect_winograd_code.inc
+++ b/src/kernels/xform_bidirect_winograd_code.inc
@@ -297,6 +297,7 @@ gid_x = 2
 .SGPR_ALLOC x_TW_stride
 .SGPR_ALLOC x_TH_stride
 .SGPR_ALLOC addr_step
+.SGPR_RESERVE_VCC
 
 .VGPR_ALLOC_FROM 0
 .VGPR_ALLOC tid

--- a/src/ocl/gcn_asm_utils.cpp
+++ b/src/ocl/gcn_asm_utils.cpp
@@ -245,9 +245,9 @@ static void AmdgcnAssembleQuiet(const std::string& source, const std::string& pa
     std::stringstream clang_stdout_unused;
     const auto clang_path = GetGcnAssemblerPath();
     const auto args       = " -x assembler -target amdgcn--amdhsa " +
-        // \todo detect is xnack enabled or disabled
-        // by default disabled
-        GenerateClangBuildOptSetXnack(false) + params + " " + source +
+                      // \todo detect is xnack enabled or disabled
+                      // by default disabled
+                      GenerateClangBuildOptSetXnack(false) + params + " " + source +
                       " -o /dev/null" + // We do not need output file
                       " 2>&1";          // Keep console clean from error messages.
     MIOPEN_LOG_NQI2(clang_path << " " << args);

--- a/src/ocl/gcn_asm_utils.cpp
+++ b/src/ocl/gcn_asm_utils.cpp
@@ -175,11 +175,6 @@ std::string AmdgcnAssemble(const std::string& source, const std::string& params)
 
     std::ostringstream options;
     options << " -x assembler -target amdgcn--amdhsa";
-
-    // \todo detect is xnack enabled or disabled
-    // by default disabled
-    options << GenerateClangBuildOptSetXnack(false);
-
     /// \todo Hacky way to find out which CO version we need to assemble for.
     if(params.find("ROCM_METADATA_VERSION=5", 0) == std::string::npos) // Assume that !COv3 == COv2.
         if(GcnAssemblerSupportsNoCOv3()) // If assembling for COv2, then disable COv3.
@@ -244,10 +239,7 @@ static void AmdgcnAssembleQuiet(const std::string& source, const std::string& pa
 #ifdef __linux__
     std::stringstream clang_stdout_unused;
     const auto clang_path = GetGcnAssemblerPath();
-    const auto args       = " -x assembler -target amdgcn--amdhsa " +
-                      // \todo detect is xnack enabled or disabled
-                      // by default disabled
-                      GenerateClangBuildOptSetXnack(false) + params + " " + source +
+    const auto args       = " -x assembler -target amdgcn--amdhsa " + params + " " + source +
                       " -o /dev/null" + // We do not need output file
                       " 2>&1";          // Keep console clean from error messages.
     MIOPEN_LOG_NQI2(clang_path << " " << args);
@@ -314,13 +306,6 @@ void GenerateClangDefsym<const std::string&>(std::ostream& stream,
                                              const std::string& value)
 {
     stream << " -Wa,-defsym," << name << "=" << value;
-}
-std::string GenerateClangBuildOptSetXnack(const bool isEnabled)
-{
-    if(isEnabled)
-        return " -mxnack ";
-    else
-        return " -mno-xnack ";
 }
 
 std::string MakeLutKey(


### PR DESCRIPTION
Now the assembler does a stronger check than before. Therefore, AMDHSA kernel xnack directive update are required.

`.amdhsa_reserve_xnack_mask` directive value (`1` or `0`) must match passed compiler argument (`-mxnack` or`-mno-xnack`) and curent GPU xnack mode (enabled or disabled). If the value does not match, the solver must be disabled.

Decided to disable xnack by default for asm kernels, since in most devices exclude APUs xnack disabled by default.

Full support for xnack requires the ability to detect the current GPU mode. This possibly can be done by using `Code Object Target Identification` which include xnack and ecc  mode ``amdgcn-amd-amdhsa--gfx906:sramecc-:xnack-``.

igemm kernels were updated using ``find ./ -type f -exec sed -i 's/.end_amdhsa_kernel/    \/\/xnack disabled by default for asm kernels\n    .amdhsa_reserve_xnack_mask 0\n.end_amdhsa_kernel/g' {} \;``