### PR TITLE
Relocate compiler flag for hip version into HipBuild()

### DIFF
--- a/src/comgr.cpp
+++ b/src/comgr.cpp
@@ -700,7 +700,8 @@ void BuildHip(const std::string& name,
         {
             auto raw = options                                 //
                        + " " + GetDebugCompilerOptionsInsert() //
-                       + " " + MIOPEN_STRINGIZE(HIP_COMPILER_FLAGS);
+                       + " " + MIOPEN_STRINGIZE(HIP_COMPILER_FLAGS) +
+                       (" -DHIP_PACKAGE_VERSION_FLAT=") + std::to_string(HIP_PACKAGE_VERSION_FLAT);
             auto optCompile = miopen::SplitSpaceSeparated(raw, compiler::lc::GetOptionsNoSplit());
             compiler::lc::hip::RemoveCompilerOptionsUnwanted(optCompile);
             action.SetOptionList(optCompile);
@@ -711,7 +712,8 @@ void BuildHip(const std::string& name,
             auto raw = std::string(" -O3 ")                    // Without this, fails in lld.
                        + options                               //
                        + " " + GetDebugCompilerOptionsInsert() //
-                       + " " + MIOPEN_STRINGIZE(HIP_COMPILER_FLAGS);
+                       + " " + MIOPEN_STRINGIZE(HIP_COMPILER_FLAGS) +
+                       (" -DHIP_PACKAGE_VERSION_FLAT=") + std::to_string(HIP_PACKAGE_VERSION_FLAT);
 #if USE_HIP_PCH
             raw += " -nogpuinc -DMIOPEN_DONT_USE_HIP_RUNTIME_HEADERS=1";
 #endif

--- a/src/comgr.cpp
+++ b/src/comgr.cpp
@@ -30,6 +30,7 @@
 #include <miopen/algorithm.hpp>
 #include <miopen/env.hpp>
 #include <miopen/errors.hpp>
+#include <miopen/hip_build_utils.hpp>
 #include <miopen/kernel.hpp>
 #include <miopen/logger.hpp>
 #include <miopen/stringutils.hpp>

--- a/src/hip/hip_build_utils.cpp
+++ b/src/hip/hip_build_utils.cpp
@@ -335,4 +335,9 @@ bool external_tool_version_t::operator>=(const external_tool_version_t& rhs) con
         return false;
 }
 
+bool external_tool_version_t::operator<(const external_tool_version_t& rhs) const
+{
+    return rhs >= *this;
+}
+
 } // namespace miopen

--- a/src/hip/hip_build_utils.cpp
+++ b/src/hip/hip_build_utils.cpp
@@ -154,6 +154,10 @@ boost::filesystem::path HipBuild(boost::optional<TmpDir>& tmp_dir,
     }
 #endif
 
+    // hip version
+    params +=
+        std::string(" -DHIP_PACKAGE_VERSION_FLAT=") + std::to_string(HIP_PACKAGE_VERSION_FLAT);
+
     params += " ";
     auto bin_file = tmp_dir->path / (filename + ".o");
 

--- a/src/include/miopen/hip_build_utils.hpp
+++ b/src/include/miopen/hip_build_utils.hpp
@@ -70,6 +70,7 @@ struct external_tool_version_t
     int patch = -1;
     bool operator>(const external_tool_version_t& rhs) const;
     bool operator>=(const external_tool_version_t& rhs) const;
+    bool operator<(const external_tool_version_t& rhs) const;
 };
 
 external_tool_version_t HipCompilerVersion();

--- a/src/kernels/composable_kernel/include/utility/amd_buffer_addressing.hpp
+++ b/src/kernels/composable_kernel/include/utility/amd_buffer_addressing.hpp
@@ -139,11 +139,11 @@ __llvm_amdgcn_buffer_store_bf16x4(ushort4_t vdata,
                                   bool slc) __asm("llvm.amdgcn.buffer.store.v4bf16");
 
 #if CK_USE_AMD_BUFFER_ATOMIC_FADD
-#if CK_HIP_VERSION_FLAT >= 3010020405
+#if CK_BUFFER_FADD_RETURN_VOID
+__device__ void
+#else
 // starting ROCm-3.10, the return type becomes float
 __device__ float
-#else
-__device__ void
 #endif
 __llvm_amdgcn_buffer_atomic_add_f32(float vdata,
                                     int32x4_t rsrc,

--- a/src/kernels/composable_kernel/include/utility/amd_buffer_addressing.hpp
+++ b/src/kernels/composable_kernel/include/utility/amd_buffer_addressing.hpp
@@ -139,11 +139,11 @@ __llvm_amdgcn_buffer_store_bf16x4(ushort4_t vdata,
                                   bool slc) __asm("llvm.amdgcn.buffer.store.v4bf16");
 
 #if CK_USE_AMD_BUFFER_ATOMIC_FADD
-#if CK_BUFFER_FADD_RETURN_VOID
-__device__ void
-#else
+#if CK_HIP_VERSION_FLAT >= 3010020405
 // starting ROCm-3.10, the return type becomes float
 __device__ float
+#else
+__device__ void
 #endif
 __llvm_amdgcn_buffer_atomic_add_f32(float vdata,
                                     int32x4_t rsrc,

--- a/src/kernels/composable_kernel/include/utility/config.hpp
+++ b/src/kernels/composable_kernel/include/utility/config.hpp
@@ -7,7 +7,9 @@
 #endif
 #include "bfloat16_dev.hpp"
 
-#ifndef CK_HIP_VERSION_FLAT
+#ifdef HIP_PACKAGE_VERSION_FLAT
+#define CK_HIP_VERSION_FLAT HIP_PACKAGE_VERSION_FLAT
+#else
 #define CK_HIP_VERSION_FLAT 0
 #endif
 

--- a/src/solver/conv_hip_implicit_gemm_bwd_v1r1_xdlops_nchw_kcyx_nkhw.cpp
+++ b/src/solver/conv_hip_implicit_gemm_bwd_v1r1_xdlops_nchw_kcyx_nkhw.cpp
@@ -876,7 +876,6 @@ ConvSolution ConvHipImplicitGemmBwdDataV1R1Xdlops::GetSolution(
         std::string(" -DCK_USE_AMD_XDLOPS=") + std::to_string(IsXdlopsSupport(ctx) ? 1 : 0) +
         std::string(" -DCK_USE_AMD_XDLOPS_INLINE_ASM=") + std::to_string(miopen::IsEnabled(MIOPEN_DEBUG_IMPLICIT_GEMM_XDLOPS_INLINE_ASM{}) ? 1 : 0) +
         std::string(" -DCK_USE_AMD_XDLOPS_EMULATE=") + (miopen::IsEnabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_XDLOPS_EMULATE{}) ? '1' : '0') +
-        std::string(" -DCK_BLOCK_SYNC_LDS_WITHOUT_SYNC_VMEM=") + (miopen::IsDisabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_BLOCK_SYNC_LDS_WITHOUT_SYNC_VMEM{}) ? '0' : '1') +
         get_ck_common_compiler_flag(ctx) +
         ctx.general_compile_options;
 

--- a/src/solver/conv_hip_implicit_gemm_fwd_v4r4_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_fwd_v4r4_xdlops.cpp
@@ -940,7 +940,6 @@ ConvSolution ConvHipImplicitGemmForwardV4R4Xdlops::GetSolution(
         std::string(" -DCK_USE_AMD_XDLOPS=") + std::to_string(IsXdlopsSupport(ctx) ? 1 : 0) +
         std::string(" -DCK_USE_AMD_XDLOPS_INLINE_ASM=") + std::to_string(miopen::IsEnabled(MIOPEN_DEBUG_IMPLICIT_GEMM_XDLOPS_INLINE_ASM{}) ? 1 : 0) +
         std::string(" -DCK_USE_AMD_XDLOPS_EMULATE=") + (miopen::IsEnabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_XDLOPS_EMULATE{}) ? '1' : '0') +
-        std::string(" -DCK_BLOCK_SYNC_LDS_WITHOUT_SYNC_VMEM=") + (miopen::IsDisabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_BLOCK_SYNC_LDS_WITHOUT_SYNC_VMEM{}) ? '0' : '1') +
         get_ck_common_compiler_flag(ctx) +
         ctx.general_compile_options;
     // clang-format on

--- a/src/solver/conv_hip_implicit_gemm_fwd_v4r4_xdlops_padded_gemm.cpp
+++ b/src/solver/conv_hip_implicit_gemm_fwd_v4r4_xdlops_padded_gemm.cpp
@@ -1005,7 +1005,6 @@ ConvSolution ConvHipImplicitGemmForwardV4R4Xdlops_Padded_Gemm::GetSolution(
         std::string(" -DCK_USE_AMD_XDLOPS=") + std::to_string(IsXdlopsSupport(ctx) ? 1 : 0) +
         std::string(" -DCK_USE_AMD_XDLOPS_INLINE_ASM=") + std::to_string(miopen::IsEnabled(MIOPEN_DEBUG_IMPLICIT_GEMM_XDLOPS_INLINE_ASM{}) ? 1 : 0) +
         std::string(" -DCK_USE_AMD_XDLOPS_EMULATE=") + (miopen::IsEnabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_XDLOPS_EMULATE{}) ? '1' : '0') +
-        std::string(" -DCK_BLOCK_SYNC_LDS_WITHOUT_SYNC_VMEM=") + (miopen::IsDisabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_BLOCK_SYNC_LDS_WITHOUT_SYNC_VMEM{}) ? '0' : '1') +
         get_ck_common_compiler_flag(ctx) +
         ctx.general_compile_options;
     // clang-format on

--- a/src/solver/conv_hip_implicit_gemm_fwd_v4r5_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_fwd_v4r5_xdlops.cpp
@@ -951,7 +951,6 @@ ConvSolution ConvHipImplicitGemmForwardV4R5Xdlops::GetSolution(
         std::string(" -DCK_USE_AMD_XDLOPS=") + std::to_string(IsXdlopsSupport(ctx) ? 1 : 0) +
         std::string(" -DCK_USE_AMD_XDLOPS_INLINE_ASM=") + std::to_string(miopen::IsEnabled(MIOPEN_DEBUG_IMPLICIT_GEMM_XDLOPS_INLINE_ASM{}) ? 1 : 0) +
         std::string(" -DCK_USE_AMD_XDLOPS_EMULATE=") + (miopen::IsEnabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_XDLOPS_EMULATE{}) ? '1' : '0') +
-        std::string(" -DCK_BLOCK_SYNC_LDS_WITHOUT_SYNC_VMEM=") + (miopen::IsDisabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_BLOCK_SYNC_LDS_WITHOUT_SYNC_VMEM{}) ? '0' : '1') +
         get_ck_common_compiler_flag(ctx) +
         ctx.general_compile_options;
     // clang-format on

--- a/src/solver/conv_hip_implicit_gemm_wrw_v4r4_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_wrw_v4r4_xdlops.cpp
@@ -925,7 +925,6 @@ ConvSolution ConvHipImplicitGemmWrwV4R4Xdlops::GetSolution(
         std::string(" -DCK_USE_AMD_XDLOPS=") + std::to_string(IsXdlopsSupport(ctx) ? 1 : 0) +
         std::string(" -DCK_USE_AMD_XDLOPS_INLINE_ASM=") + std::to_string(miopen::IsEnabled(MIOPEN_DEBUG_IMPLICIT_GEMM_XDLOPS_INLINE_ASM{}) ? 1 : 0) +
         std::string(" -DCK_USE_AMD_XDLOPS_EMULATE=") + (miopen::IsEnabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_XDLOPS_EMULATE{}) ? '1' : '0') +
-        std::string(" -DCK_BLOCK_SYNC_LDS_WITHOUT_SYNC_VMEM=") + (miopen::IsDisabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_BLOCK_SYNC_LDS_WITHOUT_SYNC_VMEM{}) ? '0' : '1') +
         get_ck_common_compiler_flag(ctx) +
         ctx.general_compile_options;
     // clang-format on

--- a/src/solver/implicitgemm_util.hpp
+++ b/src/solver/implicitgemm_util.hpp
@@ -767,13 +767,20 @@ static inline auto get_ck_common_compiler_flag(const ConvolutionContext& ctx)
 {
     auto compiler_flag = std::string(" --std=c++14");
 
-    // HIP version
-    compiler_flag +=
-        std::string(" -DCK_HIP_VERSION_FLAT=") + std::to_string(HIP_PACKAGE_VERSION_FLAT);
-
     // atomic-fadd
     compiler_flag += std::string(" -DCK_USE_AMD_BUFFER_ATOMIC_FADD=") +
                      (support_amd_buffer_atomic_fadd(ctx) ? '1' : '0');
+
+    compiler_flag +=
+        std::string(" -DCK_BUFFER_FADD_RETURN_VOID=") +
+        std::to_string(miopen::HipCompilerVersion() < external_tool_version_t{3, 10, 20405});
+
+    // LDS sync
+    compiler_flag +=
+        std::string(" -DCK_BLOCK_SYNC_LDS_WITHOUT_SYNC_VMEM=") +
+        (miopen::IsDisabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_BLOCK_SYNC_LDS_WITHOUT_SYNC_VMEM{})
+             ? '0'
+             : '1');
 
     // workaround
     compiler_flag +=

--- a/src/solver/implicitgemm_util.hpp
+++ b/src/solver/implicitgemm_util.hpp
@@ -771,10 +771,6 @@ static inline auto get_ck_common_compiler_flag(const ConvolutionContext& ctx)
     compiler_flag += std::string(" -DCK_USE_AMD_BUFFER_ATOMIC_FADD=") +
                      (support_amd_buffer_atomic_fadd(ctx) ? '1' : '0');
 
-    compiler_flag +=
-        std::string(" -DCK_BUFFER_FADD_RETURN_VOID=") +
-        std::to_string(miopen::HipCompilerVersion() < external_tool_version_t{3, 10, 20405});
-
     // LDS sync
     compiler_flag +=
         std::string(" -DCK_BLOCK_SYNC_LDS_WITHOUT_SYNC_VMEM=") +


### PR DESCRIPTION
Relocate compiler flag for hip version into HipBuild(), so that it's not part of the key for kernel binary cache.

Also refactors some code.

----
This is to resolve the problem mentioned at https://github.com/ROCmSoftwarePlatform/MIOpen/pull/499#issuecomment-707391991.