### PR TITLE
Fix "Workaround for SWDEV-255735" (PR 505)

### DIFF
--- a/src/comgr.cpp
+++ b/src/comgr.cpp
@@ -30,6 +30,8 @@
 #include <miopen/algorithm.hpp>
 #include <miopen/env.hpp>
 #include <miopen/errors.hpp>
+#include <miopen/hip_build_utils.hpp>
+#include <miopen/gcn_asm_utils.hpp>
 #include <miopen/kernel.hpp>
 #include <miopen/logger.hpp>
 #include <miopen/stringutils.hpp>
@@ -858,6 +860,10 @@ void BuildAsm(const std::string& name,
         SetIsaName(action, device);
         action.SetLogging(true);
         auto optAsm = miopen::SplitSpaceSeparated(options);
+#if WORKAROUND_SWDEV_255735
+        if(miopen::HipCompilerVersion() >= miopen::external_tool_version_t{3, 8, 20403})
+            optAsm.push_back("-mno-xnack");
+#endif
         compiler::lc::gcnasm::RemoveOptionsUnwanted(optAsm);
         action.SetOptionList(optAsm);
 

--- a/src/include/miopen/gcn_asm_utils.hpp
+++ b/src/include/miopen/gcn_asm_utils.hpp
@@ -30,6 +30,10 @@
 #include <vector>
 #include <sstream>
 
+/// Since 3.8.20403, ".amdhsa_reserve_xnack_mask 0" is not working without
+/// explicit "-mno-xnack" option.
+#define WORKAROUND_SWDEV_255735 1
+
 std::string GetGcnAssemblerPath();
 bool ValidateGcnAssembler();
 std::string AmdgcnAssemble(const std::string& source, const std::string& params);

--- a/src/kernels/inst_wrappers.inc
+++ b/src/kernels/inst_wrappers.inc
@@ -62,7 +62,7 @@
 
 // ADD_CO (gfx8 add)
 .macro _v_add_co_u32 dst, co, src0, src1, dpp=
-    .if ((.option.machine_version_major == 8) || ((.option.machine_version_major == 9) && (WORKAROUND_BUG_34765 == 1)))
+    .if (.option.machine_version_major == 8)
         v_add_u32 \dst, \co, \src0, \src1 \dpp
     .else
         v_add_co_u32 \dst, \co, \src0, \src1 \dpp
@@ -71,7 +71,7 @@
 
 // ADD_CO_CI (gfx8 addc)
 .macro _v_add_co_ci_u32 dst, co, src0, src1, ci, dpp=
-    .if ((.option.machine_version_major == 8) || ((.option.machine_version_major == 9) && (WORKAROUND_BUG_34765 == 1)))
+    .if (.option.machine_version_major == 8)
 		v_addc_u32 \dst, \co, \src0, \src1, \ci \dpp
     .else
 		v_addc_co_u32 \dst, \co, \src0, \src1, \ci \dpp
@@ -80,7 +80,7 @@
 
 // SUB_CO (gfx8 sub)
 .macro _v_sub_co_u32 dst, co, src0, src1, dpp=
-    .if ((.option.machine_version_major == 8) || ((.option.machine_version_major == 9) && (WORKAROUND_BUG_34765 == 1)))
+    .if (.option.machine_version_major == 8)
         v_sub_u32 \dst, \co, \src0, \src1 \dpp
     .else
         v_sub_co_u32 \dst, \co, \src0, \src1 \dpp
@@ -89,7 +89,7 @@
 
 // SUBREV_CO (gfx8 subrev)
 .macro _v_subrev_co_u32 dst, co, src0, src1, dpp=
-    .if ((.option.machine_version_major == 8) || ((.option.machine_version_major == 9) && (WORKAROUND_BUG_34765 == 1)))
+    .if (.option.machine_version_major == 8)
         v_subrev_u32 \dst, \co, \src0, \src1 \dpp
     .else
         v_subrev_co_u32 \dst, \co, \src0, \src1 \dpp

--- a/src/kernels/inst_wrappers.inc
+++ b/src/kernels/inst_wrappers.inc
@@ -62,7 +62,7 @@
 
 // ADD_CO (gfx8 add)
 .macro _v_add_co_u32 dst, co, src0, src1, dpp=
-    .if (.option.machine_version_major == 8)
+    .if ((.option.machine_version_major == 8) || ((.option.machine_version_major == 9) && (WORKAROUND_BUG_34765 == 1)))
         v_add_u32 \dst, \co, \src0, \src1 \dpp
     .else
         v_add_co_u32 \dst, \co, \src0, \src1 \dpp
@@ -71,7 +71,7 @@
 
 // ADD_CO_CI (gfx8 addc)
 .macro _v_add_co_ci_u32 dst, co, src0, src1, ci, dpp=
-    .if (.option.machine_version_major == 8)
+    .if ((.option.machine_version_major == 8) || ((.option.machine_version_major == 9) && (WORKAROUND_BUG_34765 == 1)))
 		v_addc_u32 \dst, \co, \src0, \src1, \ci \dpp
     .else
 		v_addc_co_u32 \dst, \co, \src0, \src1, \ci \dpp
@@ -80,7 +80,7 @@
 
 // SUB_CO (gfx8 sub)
 .macro _v_sub_co_u32 dst, co, src0, src1, dpp=
-    .if (.option.machine_version_major == 8)
+    .if ((.option.machine_version_major == 8) || ((.option.machine_version_major == 9) && (WORKAROUND_BUG_34765 == 1)))
         v_sub_u32 \dst, \co, \src0, \src1 \dpp
     .else
         v_sub_co_u32 \dst, \co, \src0, \src1 \dpp
@@ -89,7 +89,7 @@
 
 // SUBREV_CO (gfx8 subrev)
 .macro _v_subrev_co_u32 dst, co, src0, src1, dpp=
-    .if (.option.machine_version_major == 8)
+    .if ((.option.machine_version_major == 8) || ((.option.machine_version_major == 9) && (WORKAROUND_BUG_34765 == 1)))
         v_subrev_u32 \dst, \co, \src0, \src1 \dpp
     .else
         v_subrev_co_u32 \dst, \co, \src0, \src1 \dpp


### PR DESCRIPTION
Fix "Workaround for SWDEV-255735" #505.
- Removed useless xnack option from AmdgcnAssembleQuiet(), that was implemented with bugs.
- Added missing xnack option to comgr.

<details><summary><b><i>Original description</i></b></summary><hr>

- Fixed the macro of v_add/sub_co_u32 that allows v_add_u32 with vcc on gfx9
- Used v_add_u32 with 4 operands on gfx9, but gfx9 should only support 3 operands (
https://llvm.org/docs/AMDGPU/AMDGPUAsmGFX9.html#id19). For some reason, the old assembler (rocm 3.7/3.8) accept it. But it failed with rocm 3.10.
<hr></details>