### PR TITLE
Igemm v4r5 fast tuning fix

### DIFF
--- a/src/solver/conv_hip_implicit_gemm_fwd_v4r5_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_fwd_v4r5_xdlops.cpp
@@ -715,7 +715,7 @@ bool PerformanceImplicitGemmForwardV4R5Xdlops::IsFastToBeUsedForTuning(
     {
         const int wave_per_block = (GemmMPerBlock / GemmMPerWave) * (GemmNPerBlock / GemmNPerWave);
 
-        if(!(wave_per_block > 1 && wave_per_block <= 4))
+        if(!(wave_per_block >= 1 && wave_per_block <= 4))
         {
             return false;
         }


### PR DESCRIPTION
- Enlarge the search space that allows the number of waves per block = 1.

This PR is in reference to the divide-by-zero hazard:
Potential divide by zero hazard was triggered [here](http://micimaster.amd.com/blue/organizations/jenkins/MLLibs%2FMIOpen/detail/reshuffleAndReduceTestCases/117/pipeline)

```
./multi_index_transform.hpp:210:45: error: division by zero is undefined [-Werror,-Wdivision-by-zero] 
 idx_low(idim) = itmp / stride; 
 ^ ~~~~~~
```

Found with PR #147
