### PR TITLE
Fix for huge pooling workspace (library) and for huge tensors (driver)

### DIFF
--- a/driver/tensor_driver.hpp
+++ b/driver/tensor_driver.hpp
@@ -180,8 +180,8 @@ int SetTensorNd(miopenTensorDescriptor_t t,
 
 size_t GetTensorSize(miopenTensorDescriptor_t& tensor)
 {
-    std::vector<int> len = GetTensorLengths(tensor);
-    size_t sz            = std::accumulate(len.begin(), len.end(), 1, std::multiplies<int>());
+    const auto len = GetTensorLengths(tensor);
+    size_t sz      = std::accumulate(len.begin(), len.end(), size_t{1}, std::multiplies<size_t>());
 
     return sz;
 }

--- a/src/pooling_api.cpp
+++ b/src/pooling_api.cpp
@@ -271,7 +271,7 @@ extern "C" miopenStatus_t miopenPoolingGetWorkSpaceSize(const miopenTensorDescri
     MIOPEN_LOG_FUNCTION(yDesc, workSpaceSize);
     return miopen::try_([&] {
         auto len  = miopen::deref(yDesc).GetLengths();
-        size_t sz = std::accumulate(len.begin(), len.end(), 1, std::multiplies<int>());
+        size_t sz = std::accumulate(len.begin(), len.end(), size_t{1}, std::multiplies<size_t>());
         miopen::deref(workSpaceSize) = sz * sizeof(uint8_t);
     });
 }


### PR DESCRIPTION
- Computations should be performed in `size_t` type.
- 1046ba6 resolves issue #494 (partially, at least)