### PR TITLE
revise int8 conv test validation check based on latest conv host

### DIFF
--- a/test/conv_common.hpp
+++ b/test/conv_common.hpp
@@ -111,20 +111,16 @@ static inline bool is_gemm_workspace_valid(miopen::Handle& handle,
                                            const miopen::TensorDescriptor& wDesc,
                                            const miopen::TensorDescriptor& yDesc)
 {
-    bool is_gemmtrans = (convDesc.GetSpatialDimension() == 2 && std::all_of(wDesc.GetLengths().begin() + 2,
-                                                                 wDesc.GetLengths().end(),
-                                                                 [](auto v) {
-        return v == 1; }) &&
-              miopen::all_of(convDesc.GetConvPads(), [](auto v) {
-        return v == 0; }) &&
-              miopen::all_of(convDesc.GetConvStrides(), [](auto v) {
-        return v == 2; });
-auto fwd_get_wksp = convDesc.ForwardGetWorkSpaceSize(handle, wDesc, xDesc, yDesc);
-	      return !((is_gemmtrans && fwd_get_wksp <
-                  convDesc.ForwardGetWorkSpaceSizeGEMMTranspose(xDesc, yDesc)) ||
-             (!is_gemmtrans &&
-              fwd_get_wksp <
-                  convDesc.ForwardGetWorkSpaceSizeGEMM(wDesc, yDesc)));
+    bool is_gemmtrans = convDesc.GetSpatialDimension() == 2 &&
+                        std::all_of(wDesc.GetLengths().begin() + 2,
+                                    wDesc.GetLengths().end(),
+                                    [](auto v) { return v == 1; }) &&
+                        miopen::all_of(convDesc.GetConvPads(), [](auto v) { return v == 0; }) &&
+                        miopen::all_of(convDesc.GetConvStrides(), [](auto v) { return v == 2; });
+    auto fwd_get_wksp = convDesc.ForwardGetWorkSpaceSize(handle, wDesc, xDesc, yDesc);
+    return !((is_gemmtrans &&
+              fwd_get_wksp < convDesc.ForwardGetWorkSpaceSizeGEMMTranspose(xDesc, yDesc)) ||
+             (!is_gemmtrans && fwd_get_wksp < convDesc.ForwardGetWorkSpaceSizeGEMM(wDesc, yDesc)));
 }
 
 struct scalar_gen_random_float

--- a/test/conv_common.hpp
+++ b/test/conv_common.hpp
@@ -112,19 +112,20 @@ static inline bool is_gemm_workspace_valid(miopen::Handle& handle,
                                            const miopen::TensorDescriptor& yDesc)
 {
 
-    return !(((std::all_of(wDesc.GetLengths().begin() + 2,
-                           wDesc.GetLengths().end(),
-                           [](auto v) { return v == 1; }) &&
-               miopen::all_of(convDesc.GetConvPads(), [](auto v) { return v == 0; })) &&
-              ((std::all_of(xDesc.GetLengths().begin() + 2,
-                            xDesc.GetLengths().end(),
-                            [](auto v) { return v <= 14; }) &&
-                miopen::all_of(convDesc.GetConvStrides(), [](auto v) { return v == 1; })) ||
-               (miopen::all_of(convDesc.GetConvStrides(), [](auto v) { return v == 2; }))) &&
-              (convDesc.ForwardGetWorkSpaceSize(handle, wDesc, xDesc, yDesc) <
-               convDesc.ForwardGetWorkSpaceSizeGEMMTranspose(xDesc, yDesc))) ||
-             (convDesc.ForwardGetWorkSpaceSize(handle, wDesc, xDesc, yDesc) <
-              convDesc.ForwardGetWorkSpaceSizeGEMM(wDesc, yDesc)));
+    return !((convDesc.GetSpatialDimension() == 2 && std::all_of(wDesc.GetLengths().begin() + 2,
+                                                                 wDesc.GetLengths().end(),
+                                                                 [](auto v) { return v == 1; }) &&
+              miopen::all_of(convDesc.GetConvPads(), [](auto v) { return v == 0; }) &&
+              miopen::all_of(convDesc.GetConvStrides(), [](auto v) { return v == 2; }) &&
+              convDesc.ForwardGetWorkSpaceSize(handle, wDesc, xDesc, yDesc) <
+                  convDesc.ForwardGetWorkSpaceSizeGEMMTranspose(xDesc, yDesc)) ||
+             (!(convDesc.GetSpatialDimension() == 2 && std::all_of(wDesc.GetLengths().begin() + 2,
+                                                                   wDesc.GetLengths().end(),
+                                                                   [](auto v) { return v == 1; }) &&
+                miopen::all_of(convDesc.GetConvPads(), [](auto v) { return v == 0; }) &&
+                miopen::all_of(convDesc.GetConvStrides(), [](auto v) { return v == 2; })) &&
+              convDesc.ForwardGetWorkSpaceSize(handle, wDesc, xDesc, yDesc) <
+                  convDesc.ForwardGetWorkSpaceSizeGEMM(wDesc, yDesc)));
 }
 
 struct scalar_gen_random_float

--- a/test/conv_common.hpp
+++ b/test/conv_common.hpp
@@ -111,20 +111,19 @@ static inline bool is_gemm_workspace_valid(miopen::Handle& handle,
                                            const miopen::TensorDescriptor& wDesc,
                                            const miopen::TensorDescriptor& yDesc)
 {
-
-    return !((convDesc.GetSpatialDimension() == 2 && std::all_of(wDesc.GetLengths().begin() + 2,
+    bool is_gemmtrans = (convDesc.GetSpatialDimension() == 2 && std::all_of(wDesc.GetLengths().begin() + 2,
                                                                  wDesc.GetLengths().end(),
-                                                                 [](auto v) { return v == 1; }) &&
-              miopen::all_of(convDesc.GetConvPads(), [](auto v) { return v == 0; }) &&
-              miopen::all_of(convDesc.GetConvStrides(), [](auto v) { return v == 2; }) &&
-              convDesc.ForwardGetWorkSpaceSize(handle, wDesc, xDesc, yDesc) <
+                                                                 [](auto v) {
+        return v == 1; }) &&
+              miopen::all_of(convDesc.GetConvPads(), [](auto v) {
+        return v == 0; }) &&
+              miopen::all_of(convDesc.GetConvStrides(), [](auto v) {
+        return v == 2; });
+auto fwd_get_wksp = convDesc.ForwardGetWorkSpaceSize(handle, wDesc, xDesc, yDesc);
+	      return !((is_gemmtrans && fwd_get_wksp <
                   convDesc.ForwardGetWorkSpaceSizeGEMMTranspose(xDesc, yDesc)) ||
-             (!(convDesc.GetSpatialDimension() == 2 && std::all_of(wDesc.GetLengths().begin() + 2,
-                                                                   wDesc.GetLengths().end(),
-                                                                   [](auto v) { return v == 1; }) &&
-                miopen::all_of(convDesc.GetConvPads(), [](auto v) { return v == 0; }) &&
-                miopen::all_of(convDesc.GetConvStrides(), [](auto v) { return v == 2; })) &&
-              convDesc.ForwardGetWorkSpaceSize(handle, wDesc, xDesc, yDesc) <
+             (!is_gemmtrans &&
+              fwd_get_wksp <
                   convDesc.ForwardGetWorkSpaceSizeGEMM(wDesc, yDesc)));
 }
 


### PR DESCRIPTION
The rule in convolutionocl has been change for GEMM validation check.
https://github.com/ROCmSoftwarePlatform/MIOpen/blob/88bd3f7cfe95ddd2c4e953f47320166bd25d96b0/src/ocl/convolutionocl.cpp#L365-L368

Adjust ctest according to new rules for int8 test.