### PR TITLE
Fix for distinct compile/evaluate 

### DIFF
--- a/src/include/miopen/generic_search.hpp
+++ b/src/include/miopen/generic_search.hpp
@@ -353,6 +353,7 @@ auto GenericSearch(const Solver s, const Context& context, const AnyInvokeParams
         compile_and_run = c_and_r;
     }
 
+    std::vector<KernelInfo> kernels;
     for(const auto& current_config : all_configs)
     {
         float elapsed_time = 0.0f;
@@ -369,7 +370,6 @@ auto GenericSearch(const Solver s, const Context& context, const AnyInvokeParams
 
             if(compile_and_run == "0")
             {
-                std::vector<KernelInfo> kernels;
                 for(auto&& kernel : current_solution.construction_params)
                 {
                     if(profile_h.HasProgram(kernel.kernel_file, kernel.comp_options))
@@ -377,7 +377,6 @@ auto GenericSearch(const Solver s, const Context& context, const AnyInvokeParams
                     kernels.push_back(kernel);
                 }
 
-                std::vector<Program> programs = PrecompileKernels(profile_h, kernels);
                 continue;
             }
 
@@ -475,6 +474,11 @@ auto GenericSearch(const Solver s, const Context& context, const AnyInvokeParams
         heartbeat.Monitor(
             ret != 0, elapsed_time, n_current, best_time, n_failed, n_runs_total, current_config);
         ++n_current;
+    }
+
+    if(compile_and_run == "0")
+    {
+        std::vector<Program> programs = PrecompileKernels(profile_h, kernels);
     }
 
     MIOPEN_LOG_W("Done: " << n_runs_total << '/' << n_failed << '/' << n_runs_total << ", best #"

--- a/src/include/miopen/generic_search.hpp
+++ b/src/include/miopen/generic_search.hpp
@@ -366,7 +366,6 @@ auto GenericSearch(const Solver s, const Context& context, const AnyInvokeParams
     }
     std::vector<Program> programs = PrecompileKernels(profile_h, kernels);
 
-
     if(compile_and_run != "0")
     {
         for(const auto& current_config : all_configs)
@@ -386,14 +385,14 @@ auto GenericSearch(const Solver s, const Context& context, const AnyInvokeParams
                 {
                     ret = -2;
                     MIOPEN_LOG_E('#' << n_current << " (" << n_runs_total << ") "
-                                 << "Workspace size should not depend on PerformanceConfig: "
-                                 << default_solution.workspce_sz
-                                 << " != "
-                                 << current_solution.workspce_sz);
+                                     << "Workspace size should not depend on PerformanceConfig: "
+                                     << default_solution.workspce_sz
+                                     << " != "
+                                     << current_solution.workspce_sz);
                 }
 
                 invoker = profile_h.PrepareInvoker(*current_solution.invoker_factory,
-                                             current_solution.construction_params);
+                                                   current_solution.construction_params);
                 invoker(profile_h, invoke_ctx);
                 elapsed_time = profile_h.GetKernelTime();
             }
@@ -424,8 +423,9 @@ auto GenericSearch(const Solver s, const Context& context, const AnyInvokeParams
                 // and decide using average of all 5 attempts vs. the best.
                 if(elapsed_time / best_time < 1.05f)
                 {
-                    MIOPEN_LOG_I2("Finding average for: " << elapsed_time << " / " << best_time << " = "
-                                                      << (elapsed_time / best_time));
+                    MIOPEN_LOG_I2("Finding average for: " << elapsed_time << " / " << best_time
+                                                          << " = "
+                                                          << (elapsed_time / best_time));
 
                     try
                     {
@@ -447,12 +447,12 @@ auto GenericSearch(const Solver s, const Context& context, const AnyInvokeParams
                         if(elapsed_time < best_time)
                         {
                             MIOPEN_LOG_I('#' << n_current << '/' << n_failed << '/' << n_runs_total
-                                            << ' '
-                                            << elapsed_time
-                                            << " < "
-                                            << best_time
-                                            << ' '
-                                            << current_config);
+                                             << ' '
+                                             << elapsed_time
+                                             << " < "
+                                             << best_time
+                                             << ' '
+                                             << current_config);
                             best_config = current_config;
                             best_time   = elapsed_time;
                             n_best      = n_current;
@@ -473,8 +473,13 @@ auto GenericSearch(const Solver s, const Context& context, const AnyInvokeParams
                                  << ret);
                 ++n_failed;
             }
-            heartbeat.Monitor(
-                ret != 0, elapsed_time, n_current, best_time, n_failed, n_runs_total, current_config);
+            heartbeat.Monitor(ret != 0,
+                              elapsed_time,
+                              n_current,
+                              best_time,
+                              n_failed,
+                              n_runs_total,
+                              current_config);
             ++n_current;
         }
     }

--- a/src/include/miopen/generic_search.hpp
+++ b/src/include/miopen/generic_search.hpp
@@ -338,13 +338,14 @@ auto GenericSearch(const Solver s, const Context& context, const AnyInvokeParams
                                << (useSpare ? " (spare)" : "")
                                << "...");
 
-    bool is_passed   = false; // left false only if all iterations failed.
-    float best_time  = std::numeric_limits<float>::max();
-    size_t n_failed  = 0;
-    size_t n_best    = 0;
+    bool is_passed  = false; // left false only if all iterations failed.
+    float best_time = std::numeric_limits<float>::max();
+    size_t n_failed = 0;
+    size_t n_best   = 0;
     HeartBeat<PerformanceConfig> heartbeat;
     heartbeat.Start();
 
+//PrecompileKernels call saves to binary_cache, this needs to be escaped if KERN_CACHE is not on.
 #if MIOPEN_ENABLE_SQLITE_KERN_CACHE
     std::vector<KernelInfo> kernels;
     for(const auto& current_config : all_configs)

--- a/src/include/miopen/generic_search.hpp
+++ b/src/include/miopen/generic_search.hpp
@@ -345,7 +345,7 @@ auto GenericSearch(const Solver s, const Context& context, const AnyInvokeParams
     HeartBeat<PerformanceConfig> heartbeat;
     heartbeat.Start();
 
-//PrecompileKernels call saves to binary_cache, this needs to be escaped if KERN_CACHE is not on.
+// PrecompileKernels call saves to binary_cache, this needs to be escaped if KERN_CACHE is not on.
 #if MIOPEN_ENABLE_SQLITE_KERN_CACHE
     std::vector<KernelInfo> kernels;
     for(const auto& current_config : all_configs)


### PR DESCRIPTION
Compiling all kernels at once with Precompile kernels. This enables us to compile in parallel for Tuna.

Ran local tests to get speed for compiling/evaluating separately on MI100.
./build/bin/MIOpenDriver conv -F 2 -n 128 -g 1 -k 1024 -c 1024 -H 35 -W 35 -y 3 -x 3 -p 0 -q 0 -u 2 -v 2 -l 1 -j 1 -V 0 -w 1 -t 1 -i 1
common env vars:
export MIOPEN_FIND_ENFORCE=4
export MIOPEN_LOG_LEVEL=6
export MIOPEN_DEBUG_CONV_GEMM=0
export MIOPEN_DEBUG_CONV_FFT=0 
export MIOPEN_DEBUG_CONV_DIRECT=0
export MIOPEN_DEBUG_CONV_WINOGRAD=0 
export MIOPEN_DEBUG_CONV_IMPLICIT_GEMM=1



Regular compile+evaluate at the same time for igemm: 
 -- 5 iteration: **avg 282 sec** 
 -- 10 iteration: **avg 145 sec**

Separate compile, evaluate using extra env vars for compile:
export MIOPEN_COMPILE_AND_RUN=0
export MIOPEN_CUSTOM_CACHE_DIR=/root/test

First run with  MIOPEN_COMPILE_PARALLEL_LEVEL=20
 -- compile  avg: 12 sec
 -- run avg:  8 sec
 -- total avg: **20 sec**

Second run with MIOPEN_COMPILE_PARALLEL_LEVEL=10
 -- compile  avg: 19 sec
 -- run avg:  8 sec
 -- total avg: **27 sec**


**UPDATE: parallel compile for kernels has been added as default behavior to generic_search. We can now compile in parallel and execute in the same run. No env vars needed other than set the compile level with: MIOPEN_COMPILE_PARALLEL_LEVEL=20.

We can still compile/execute separately using: 
export MIOPEN_COMPILE_AND_RUN=0**


