### PR TITLE
Add spare in the tuning of V4R5

### DIFF
--- a/src/include/miopen/solver.hpp
+++ b/src/include/miopen/solver.hpp
@@ -945,9 +945,17 @@ struct PerformanceImplicitGemmForwardV4R5Xdlops
     bool GemmBThreadCopyMoreGemmKPack;
     int GemmBThreadDataPerRead_GemmN;
 
-    PerformanceImplicitGemmForwardV4R5Xdlops(int, int, int, int, int, int, bool, bool, int);
+    bool use_spare_set;
+
+    PerformanceImplicitGemmForwardV4R5Xdlops(int, int, int, int, int, int, bool, bool, int, bool);
     PerformanceImplicitGemmForwardV4R5Xdlops();
-    PerformanceImplicitGemmForwardV4R5Xdlops(bool) : PerformanceImplicitGemmForwardV4R5Xdlops() {}
+    PerformanceImplicitGemmForwardV4R5Xdlops(bool spare);
+
+    PerformanceImplicitGemmForwardV4R5Xdlops(
+        int a, int b, int c, int d, int e, int f, bool g, bool h, int i)
+        : PerformanceImplicitGemmForwardV4R5Xdlops(a, b, c, d, e, f, g, h, i, false)
+    {
+    }
 
     template <class Self, class F>
     static void Visit(Self&& self, F f)

--- a/src/solver/conv_hip_implicit_gemm_fwd_v4r5_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_fwd_v4r5_xdlops.cpp
@@ -65,7 +65,13 @@ static std::tuple<int, int, int, int> CalculateGemmSize(const ConvolutionContext
 
 PerformanceImplicitGemmForwardV4R5Xdlops::PerformanceImplicitGemmForwardV4R5Xdlops()
     : PerformanceImplicitGemmForwardV4R5Xdlops::PerformanceImplicitGemmForwardV4R5Xdlops(
-          4, 4, 1, 4, 4, 1, false, false, 1)
+          4, 4, 1, 4, 4, 1, false, false, 1, false)
+{
+}
+
+PerformanceImplicitGemmForwardV4R5Xdlops::PerformanceImplicitGemmForwardV4R5Xdlops(bool spare)
+    : PerformanceImplicitGemmForwardV4R5Xdlops::PerformanceImplicitGemmForwardV4R5Xdlops(
+          4, 4, 1, 4, 4, 1, false, false, 1, spare)
 {
 }
 
@@ -78,7 +84,8 @@ PerformanceImplicitGemmForwardV4R5Xdlops::PerformanceImplicitGemmForwardV4R5Xdlo
     int GemmKPack_,
     bool GemmAThreadCopyMoreGemmK_,
     bool GemmBThreadCopyMoreGemmKPack_,
-    int GemmBThreadDataPerRead_GemmN_)
+    int GemmBThreadDataPerRead_GemmN_,
+    bool use_spare_set_)
     : GemmMPerBlock(GemmMPerBlock_),
       GemmNPerBlock(GemmNPerBlock_),
       GemmKPerBlock(GemmKPerBlock_),
@@ -87,7 +94,8 @@ PerformanceImplicitGemmForwardV4R5Xdlops::PerformanceImplicitGemmForwardV4R5Xdlo
       GemmKPack(GemmKPack_),
       GemmAThreadCopyMoreGemmK(GemmAThreadCopyMoreGemmK_),
       GemmBThreadCopyMoreGemmKPack(GemmBThreadCopyMoreGemmKPack_),
-      GemmBThreadDataPerRead_GemmN(GemmBThreadDataPerRead_GemmN_)
+      GemmBThreadDataPerRead_GemmN(GemmBThreadDataPerRead_GemmN_),
+      use_spare_set(use_spare_set_)
 {
 }
 
@@ -103,7 +111,8 @@ operator==(const PerformanceImplicitGemmForwardV4R5Xdlops& other) const
         && GemmKPack == other.GemmKPack 
         && GemmAThreadCopyMoreGemmK  == other.GemmAThreadCopyMoreGemmK
         && GemmBThreadCopyMoreGemmKPack  == other.GemmBThreadCopyMoreGemmKPack
-        && GemmBThreadDataPerRead_GemmN  == other.GemmBThreadDataPerRead_GemmN;
+        && GemmBThreadDataPerRead_GemmN  == other.GemmBThreadDataPerRead_GemmN
+        && use_spare_set == other.use_spare_set;
     // clang-format on
 }
 
@@ -657,6 +666,9 @@ bool PerformanceImplicitGemmForwardV4R5Xdlops::IsReallyValid(const ConvolutionCo
 bool PerformanceImplicitGemmForwardV4R5Xdlops::IsFastToBeUsedForTuning(
     const ConvolutionContext& ctx) const
 {
+    if(!use_spare_set)
+        return true;
+
     // somehow, 128x128 wave-wise GEMM tend to spill register
     // TODO revisit this when 128x128 wave-wise GEMM become efficient
     {

--- a/src/solver/conv_hip_implicit_gemm_fwd_v4r5_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_fwd_v4r5_xdlops.cpp
@@ -666,7 +666,7 @@ bool PerformanceImplicitGemmForwardV4R5Xdlops::IsReallyValid(const ConvolutionCo
 bool PerformanceImplicitGemmForwardV4R5Xdlops::IsFastToBeUsedForTuning(
     const ConvolutionContext& ctx) const
 {
-    if(!use_spare_set)
+    if(use_spare_set)
         return true;
 
     // somehow, 128x128 wave-wise GEMM tend to spill register


### PR DESCRIPTION
-  To fix the failure [here](http://micimaster.amd.com/blue/organizations/jenkins/MLLibs%2FMIOpen/detail/reshuffleAndReduceTestCases/117/pipeline/), which is due to narrowed search space for fast tuning.
- Failed config: ./bin/MIOpenDriver convfp16 -n 1 -c 16 -k 16 -H 28 -W 28 -u 2 -v 2 -l 1 -j 1 -p 3 -q 3 -x 3 -y 3 -F 1
- Add spare, 1) first-round use fast tuning, 2) second-round do full search
- Based on PR #528