### PR TITLE
[COMGR] Disable unnecesssary assembler detection

### DIFF
--- a/src/include/miopen/gcn_asm_utils.hpp
+++ b/src/include/miopen/gcn_asm_utils.hpp
@@ -27,17 +27,14 @@
 #define GCN_ASM_UTILS_H
 
 #include <string>
-#include <vector>
 #include <sstream>
 
 /// Since 3.8.20403, ".amdhsa_reserve_xnack_mask 0" is not working without
 /// explicit "-mno-xnack" option.
 #define WORKAROUND_SWDEV_255735 1
 
-std::string GetGcnAssemblerPath();
 bool ValidateGcnAssembler();
 std::string AmdgcnAssemble(const std::string& source, const std::string& params);
-bool GcnAssemblerHasBug34765();
 
 template <typename TValue>
 void GenerateClangDefsym(std::ostream& stream, const std::string& name, TValue value)
@@ -49,12 +46,5 @@ template <>
 void GenerateClangDefsym<const std::string&>(std::ostream& stream,
                                              const std::string& name,
                                              const std::string& value);
-
-/// @param dir 1: fwd, 0: bwd wrt data. Use 0 for WrW.
-/// Encodes key with default strides (u1v1)
-std::string MakeLutKey(int w, int h, int c, int n, int k, int dir, int CUs = -1);
-/// Allows for any strides.
-std::string MakeLutKey(
-    int w, int h, int c, int n, int k, int conv_stride_h, int conv_stride_w, int dir, int CUs = -1);
 
 #endif // GCN_ASM_UTILS_H

--- a/src/include/miopen/gcn_asm_utils.hpp
+++ b/src/include/miopen/gcn_asm_utils.hpp
@@ -28,13 +28,16 @@
 
 #include <string>
 #include <sstream>
+#include <miopen/config.h>
 
 /// Since 3.8.20403, ".amdhsa_reserve_xnack_mask 0" is not working without
 /// explicit "-mno-xnack" option.
 #define WORKAROUND_SWDEV_255735 1
 
 bool ValidateGcnAssembler();
+#if !MIOPEN_USE_COMGR
 std::string AmdgcnAssemble(const std::string& source, const std::string& params);
+#endif
 
 template <typename TValue>
 void GenerateClangDefsym(std::ostream& stream, const std::string& name, TValue value)

--- a/src/ocl/gcn_asm_utils.cpp
+++ b/src/ocl/gcn_asm_utils.cpp
@@ -62,6 +62,7 @@ MIOPEN_DECLARE_ENV_VAR(MIOPEN_EXPERIMENTAL_GCN_ASM_PATH)
 
 static const char option_no_co_v3[] = "-mno-code-object-v3";
 
+static bool GcnAssemblerHasBug34765();
 static bool GcnAssemblerSupportsNoCOv3();
 static std::string CleanupPath(const char* p);
 
@@ -280,7 +281,7 @@ static bool GcnAssemblerHasBug34765Impl()
     }
 }
 
-bool GcnAssemblerHasBug34765()
+static bool GcnAssemblerHasBug34765()
 {
     const static bool b = GcnAssemblerHasBug34765Impl();
     return b;
@@ -316,18 +317,4 @@ void GenerateClangDefsym<const std::string&>(std::ostream& stream,
                                              const std::string& value)
 {
     stream << " -Wa,-defsym," << name << "=" << value;
-}
-
-std::string MakeLutKey(
-    int w, int h, int c, int n, int k, int conv_stride_h, int conv_stride_w, int dir, int CUs)
-{
-    std::ostringstream ss;
-    ss << w << ";" << h << ";" << c << ";" << n << ";" << k << ";" << conv_stride_h << ";"
-       << conv_stride_w << ";" << dir << ";" << CUs;
-    return ss.str();
-}
-
-std::string MakeLutKey(int w, int h, int c, int n, int k, int dir, int CUs)
-{
-    return MakeLutKey(w, h, c, n, k, 1, 1, dir, CUs);
 }

--- a/src/ocl/gcn_asm_utils.cpp
+++ b/src/ocl/gcn_asm_utils.cpp
@@ -24,12 +24,18 @@
  *
  *******************************************************************************/
 #include <miopen/gcn_asm_utils.hpp>
+#include <miopen/config.h>
+
+#if MIOPEN_USE_COMGR
+
+bool ValidateGcnAssembler() { return true; }
+
+#else // !MIOPEN_USE_COMGR
 
 #include <cctype>
 #include <cstdio>
 #include <cstdlib>
 #include <fstream>
-#include <miopen/config.h>
 #include <miopen/env.hpp>
 #include <miopen/errors.hpp>
 #include <miopen/manage_ptr.hpp>
@@ -310,6 +316,8 @@ static bool GcnAssemblerSupportsNoCOv3()
     const static bool b = GcnAssemblerSupportsOption(option_no_co_v3);
     return b;
 }
+
+#endif // !MIOPEN_USE_COMGR
 
 template <>
 void GenerateClangDefsym<const std::string&>(std::ostream& stream,


### PR DESCRIPTION
Offline assembler detection fails in embedded environment (and unnecessary for COMGR assembly path). The detection happens at run time. Symptom:
```
MIOpen(HIP): Error [ValidateGcnAssemblerImpl] Wrong path to assembler: '/opt/rocm/llvm/bin/clang'. Expect performance degradation.
```
As a result, all solvers that use ASM kernels will be disabled.

This PR fixes this issue.