### PR TITLE
Added missing checks for new iGemm solvers so they obey the ASM & HIP kernel on/off controls.

### DIFF
--- a/src/solver/conv_asm_implicit_gemm_bwd_v4r1_dynamic.cpp
+++ b/src/solver/conv_asm_implicit_gemm_bwd_v4r1_dynamic.cpp
@@ -132,6 +132,9 @@ bool ConvAsmImplicitGemmV4R1DynamicBwd::IsApplicable(const ConvolutionContext& c
     if(!(StartsWith(device_name, "gfx900") || StartsWith(device_name, "gfx906")))
         return false;
 
+    if(!ctx.use_asm_kernels)
+        return false;
+
     if(!ctx.direction.IsBackwardData())
         return false;
 

--- a/src/solver/conv_asm_implicit_gemm_gtc_bwd.cpp
+++ b/src/solver/conv_asm_implicit_gemm_gtc_bwd.cpp
@@ -258,6 +258,9 @@ bool ConvAsmImplicitGemmGTCDynamicBwdXdlops::IsApplicable(const ConvolutionConte
     if(!(StartsWith(device_name, "gfx908")))
         return false;
 
+    if(!ctx.use_asm_kernels)
+        return false;
+
     if(!ctx.direction.IsBackwardData())
         return false;
 

--- a/src/solver/conv_asm_implicit_gemm_gtc_fwd.cpp
+++ b/src/solver/conv_asm_implicit_gemm_gtc_fwd.cpp
@@ -502,6 +502,9 @@ bool ConvAsmImplicitGemmGTCDynamicFwdXdlops::IsApplicable(const ConvolutionConte
     if(!(StartsWith(device_name, "gfx908")))
         return false;
 
+    if(!ctx.use_asm_kernels)
+        return false;
+
     if(!ctx.direction.IsForward())
         return false;
 

--- a/src/solver/conv_asm_implicit_gemm_v4r1_dynamic.cpp
+++ b/src/solver/conv_asm_implicit_gemm_v4r1_dynamic.cpp
@@ -276,6 +276,9 @@ bool ConvAsmImplicitGemmV4R1DynamicFwd::IsApplicable(const ConvolutionContext& c
     if(!(StartsWith(device_name, "gfx900") || StartsWith(device_name, "gfx906")))
         return false;
 
+    if(!ctx.use_asm_kernels)
+        return false;
+
     if(!ctx.direction.IsForward())
         return false;
 
@@ -300,6 +303,9 @@ bool ConvAsmImplicitGemmV4R1DynamicFwd_1x1::IsApplicable(const ConvolutionContex
 {
     const auto device_name = ctx.GetStream().GetDeviceName();
     if(!(StartsWith(device_name, "gfx900") || StartsWith(device_name, "gfx906")))
+        return false;
+
+    if(!ctx.use_asm_kernels)
         return false;
 
     if(!ctx.direction.IsForward())

--- a/src/solver/conv_asm_implicit_gemm_wrw_gtc_dynamic_xdlops.cpp
+++ b/src/solver/conv_asm_implicit_gemm_wrw_gtc_dynamic_xdlops.cpp
@@ -485,6 +485,9 @@ bool ConvAsmImplicitGemmGTCDynamicWrwXdlops::IsApplicable(const ConvolutionConte
     if(!(StartsWith(device_name, "gfx908")))
         return false;
 
+    if(!ctx.use_asm_kernels)
+        return false;
+
     if(!IsApplicableXdlops(ctx))
         return false;
 

--- a/src/solver/conv_asm_implicit_gemm_wrw_v4r1_dynamic.cpp
+++ b/src/solver/conv_asm_implicit_gemm_wrw_v4r1_dynamic.cpp
@@ -298,6 +298,9 @@ bool ConvAsmImplicitGemmV4R1DynamicWrw::IsApplicable(const ConvolutionContext& c
     if(!(StartsWith(device_name, "gfx900") || StartsWith(device_name, "gfx906")))
         return false;
 
+    if(!ctx.use_asm_kernels)
+        return false;
+
     if(GetGemmkGroups(ctx) > 0) // GetSolution() adds HIP kernels in this case.
         if(!ctx.use_hip_kernels)
             return false;

--- a/src/solver/conv_asm_implicit_gemm_wrw_v4r1_dynamic.cpp
+++ b/src/solver/conv_asm_implicit_gemm_wrw_v4r1_dynamic.cpp
@@ -277,11 +277,30 @@ size_t ConvAsmImplicitGemmV4R1DynamicWrw::GetWorkspaceSize(const ConvolutionCont
     return k * c * y * x * ele_size * extra_groups;
 }
 
+static int GetGemmkGroups(const ConvolutionContext& ctx)
+{
+    const auto& k    = ctx.n_inputs;
+    const auto& c    = ctx.n_outputs;
+    const auto& y    = ctx.kernel_size_h;
+    const auto& x    = ctx.kernel_size_w;
+    const auto GemmN = c * y * x;
+
+    int GemmKPerBlock = 4;
+    if((k % 128 == 0) && (GemmN % 128 == 0))
+        GemmKPerBlock = 16;
+
+    return GetImplicitGemmWrwV4R1DynamicGemmkGroups(ctx.conv_problem, GemmKPerBlock);
+}
+
 bool ConvAsmImplicitGemmV4R1DynamicWrw::IsApplicable(const ConvolutionContext& ctx) const
 {
     const auto device_name = ctx.GetStream().GetDeviceName();
     if(!(StartsWith(device_name, "gfx900") || StartsWith(device_name, "gfx906")))
         return false;
+
+    if(GetGemmkGroups(ctx) > 0) // GetSolution() adds HIP kernels in this case.
+        if(!ctx.use_hip_kernels)
+            return false;
 
     if(!ctx.direction.IsBackwardWrW())
         return false;
@@ -320,19 +339,6 @@ ConvSolution ConvAsmImplicitGemmV4R1DynamicWrw::GetSolution(const ConvolutionCon
     if(!ret)
         MIOPEN_THROW("this kernel should not run with igemm dynamic!");
 
-    int k = ctx.n_inputs;
-    int c = ctx.n_outputs;
-    int y = ctx.kernel_size_h;
-    int x = ctx.kernel_size_w;
-    int GemmKPerBlock;
-    int GemmN = c * y * x;
-
-    if((k % 128 == 0) && (GemmN % 128 == 0))
-        GemmKPerBlock = 16;
-    else
-        GemmKPerBlock = 4;
-    int gemmk_groups  = GetImplicitGemmWrwV4R1DynamicGemmkGroups(ctx.conv_problem, GemmKPerBlock);
-
     result.workspce_sz = GetWorkspaceSize(ctx);
 
     kernel.kernel_file = "igemm_v4r1_wrw_dynamic.s";
@@ -358,7 +364,7 @@ ConvSolution ConvAsmImplicitGemmV4R1DynamicWrw::GetSolution(const ConvolutionCon
 
     result.construction_params.push_back(kernel);
 
-    if(gemmk_groups > 0)
+    if(GetGemmkGroups(ctx) > 0)
     {
         KernelInfo kernel_reduction;
         int reduction_per_thread     = 4;

--- a/src/solver/conv_hip_implicit_gemm_bwd_v1r1_xdlops_nchw_kcyx_nkhw.cpp
+++ b/src/solver/conv_hip_implicit_gemm_bwd_v1r1_xdlops_nchw_kcyx_nkhw.cpp
@@ -749,6 +749,9 @@ bool ConvHipImplicitGemmBwdDataV1R1Xdlops::IsApplicable(const ConvolutionContext
     if(ctx.skip_solutions_that_take_long_time_to_build_and_have_narrow_coverage)
         return false;
 
+    if(!ctx.use_hip_kernels)
+        return false;
+
     if(!IsXdlopsSupport(ctx))
         return false;
 

--- a/src/solver/conv_hip_implicit_gemm_fwd_v4r4_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_fwd_v4r4_xdlops.cpp
@@ -954,6 +954,9 @@ bool ConvHipImplicitGemmForwardV4R4Xdlops::IsApplicable(const ConvolutionContext
     if(ctx.skip_solutions_that_take_long_time_to_build_and_have_narrow_coverage)
         return false;
 
+    if(!ctx.use_hip_kernels)
+        return false;
+
     if(!IsXdlopsSupport(ctx))
         return false;
 

--- a/src/solver/conv_hip_implicit_gemm_fwd_v4r4_xdlops_padded_gemm.cpp
+++ b/src/solver/conv_hip_implicit_gemm_fwd_v4r4_xdlops_padded_gemm.cpp
@@ -1020,6 +1020,9 @@ bool ConvHipImplicitGemmForwardV4R4Xdlops_Padded_Gemm::IsApplicable(
     if(ctx.skip_solutions_that_take_long_time_to_build_and_have_narrow_coverage)
         return false;
 
+    if(!ctx.use_hip_kernels)
+        return false;
+
     if(!IsXdlopsSupport(ctx))
         return false;
 

--- a/src/solver/conv_hip_implicit_gemm_fwd_v4r5_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_fwd_v4r5_xdlops.cpp
@@ -100,7 +100,7 @@ operator==(const PerformanceImplicitGemmForwardV4R5Xdlops& other) const
         && GemmKPerBlock == other.GemmKPerBlock
         && GemmMPerWave == other.GemmMPerWave
         && GemmNPerWave == other.GemmNPerWave
-        && GemmKPack == other.GemmKPack 
+        && GemmKPack == other.GemmKPack
         && GemmAThreadCopyMoreGemmK  == other.GemmAThreadCopyMoreGemmK
         && GemmBThreadCopyMoreGemmKPack  == other.GemmBThreadCopyMoreGemmKPack
         && GemmBThreadDataPerRead_GemmN  == other.GemmBThreadDataPerRead_GemmN;
@@ -963,6 +963,9 @@ ConvSolution ConvHipImplicitGemmForwardV4R5Xdlops::GetSolution(
 bool ConvHipImplicitGemmForwardV4R5Xdlops::IsApplicable(const ConvolutionContext& ctx) const
 {
     if(ctx.skip_solutions_that_take_long_time_to_build_and_have_narrow_coverage)
+        return false;
+
+    if(!ctx.use_hip_kernels)
         return false;
 
     if(!IsXdlopsSupport(ctx))

--- a/src/solver/conv_hip_implicit_gemm_wrw_v4r4_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_wrw_v4r4_xdlops.cpp
@@ -74,7 +74,7 @@ operator==(const PerformanceImplicitGemmWrwV4R4Xdlops& other) const
         && GemmKPerBlock == other.GemmKPerBlock
         && GemmMPerWave == other.GemmMPerWave
         && GemmNPerWave == other.GemmNPerWave
-        && GemmKPack == other.GemmKPack 
+        && GemmKPack == other.GemmKPack
         && GemmAThreadCopyMoreGemmK  == other.GemmAThreadCopyMoreGemmK
         && GemmBThreadCopyMoreGemmK  == other.GemmBThreadCopyMoreGemmK;
     // clang-format on
@@ -992,10 +992,13 @@ ConvSolution ConvHipImplicitGemmWrwV4R4Xdlops::GetSolution(
 
 bool ConvHipImplicitGemmWrwV4R4Xdlops::IsApplicable(const ConvolutionContext& ctx) const
 {
-    if(!IsXdlopsSupport(ctx))
+    if(ctx.skip_solutions_that_take_long_time_to_build_and_have_narrow_coverage)
         return false;
 
-    if(ctx.skip_solutions_that_take_long_time_to_build_and_have_narrow_coverage)
+    if(!ctx.use_hip_kernels)
+        return false;
+
+    if(!IsXdlopsSupport(ctx))
         return false;
 
     if(!(ctx.IsFp32() || ctx.IsFp16() || ctx.IsBfp16()))


### PR DESCRIPTION
This is #537 for `develop` + more fixes due to more new solvers. We must keep debugging controls in good shape.

/cc @daniellowell 