### PR TITLE
Navi21 supported fmac

### DIFF
--- a/src/kernels/composable_kernel/include/utility/amd_inline_asm.hpp
+++ b/src/kernels/composable_kernel/include/utility/amd_inline_asm.hpp
@@ -9,18 +9,37 @@ namespace ck {
 // outer-product: c[i,j] += inner_product(a[i], b[j])
 __device__ void amd_assembly_outer_product_1x2(float a, float b0, float b1, float& c0, float& c1)
 {
+#if CK_USE_AMD_V_FMAC_F32
+    asm volatile("\n \
+            v_fmac_f32 %0, %2, %3 \n \
+            v_fmac_f32 %1, %2, %4 \n \
+            "
+                 : "=v"(c0), "=v"(c1)
+                 : "v"(a), "v"(b0), "v"(b1), "0"(c0), "1"(c1));
+#else
     asm volatile("\n \
             v_mac_f32 %0, %2, %3 \n \
             v_mac_f32 %1, %2, %4 \n \
             "
                  : "=v"(c0), "=v"(c1)
                  : "v"(a), "v"(b0), "v"(b1), "0"(c0), "1"(c1));
+#endif
 }
 
 // outer-product: c[i,j] += inner_product(a[i], b[j])
 __device__ void amd_assembly_outer_product_1x4(
     float a, float b0, float b1, float b2, float b3, float& c0, float& c1, float& c2, float& c3)
 {
+#if CK_USE_AMD_V_FMAC_F32
+    asm volatile("\n \
+            v_fmac_f32 %0, %4, %5 \n \
+            v_fmac_f32 %1, %4, %6 \n \
+            v_fmac_f32 %2, %4, %7 \n \
+            v_fmac_f32 %3, %4, %8 \n \
+            "
+                 : "=v"(c0), "=v"(c1), "=v"(c2), "=v"(c3)
+                 : "v"(a), "v"(b0), "v"(b1), "v"(b2), "v"(b3), "0"(c0), "1"(c1), "2"(c2), "3"(c3));
+#else
     asm volatile("\n \
             v_mac_f32 %0, %4, %5 \n \
             v_mac_f32 %1, %4, %6 \n \
@@ -29,6 +48,7 @@ __device__ void amd_assembly_outer_product_1x4(
             "
                  : "=v"(c0), "=v"(c1), "=v"(c2), "=v"(c3)
                  : "v"(a), "v"(b0), "v"(b1), "v"(b2), "v"(b3), "0"(c0), "1"(c1), "2"(c2), "3"(c3));
+#endif
 }
 #endif
 

--- a/src/kernels/composable_kernel/include/utility/config.hpp
+++ b/src/kernels/composable_kernel/include/utility/config.hpp
@@ -38,6 +38,11 @@
 #define CK_USE_AMD_BUFFER_ATOMIC_FADD 0
 #endif
 
+// gfx1030 not suport v_mac_f32
+#ifndef CK_USE_AMD_V_FMAC_F32
+#define CK_USE_AMD_V_FMAC_F32 0
+#endif
+
 // AMD XDLOPS
 #ifndef CK_USE_AMD_XDLOPS
 #define CK_USE_AMD_XDLOPS 0

--- a/src/solver/implicitgemm_util.hpp
+++ b/src/solver/implicitgemm_util.hpp
@@ -707,6 +707,22 @@ static inline bool support_amd_buffer_atomic_fadd(const ConvolutionContext& ctx)
     return StartsWith(device_name, "gfx908");
 }
 
+static inline bool device_name_is_gfx10XX(const ConvolutionContext& ctx)
+{
+    const auto device_name = ctx.GetStream().GetDeviceName();
+    return StartsWith(device_name, "gfx1030");
+}
+
+static inline bool support_amd_buffer_load_store(const ConvolutionContext& ctx)
+{
+    return !device_name_is_gfx10XX(ctx);
+}
+
+static inline bool is_using_v_fmac_f32(const ConvolutionContext& ctx)
+{
+    return device_name_is_gfx10XX(ctx);
+}
+
 template <typename T>
 int amd_buffer_load_max_length()
 {
@@ -800,6 +816,14 @@ static inline auto get_ck_common_compiler_flag(const ConvolutionContext& ctx)
     compiler_flag +=
         std::string(" -DCK_WORKAROUND_SWDEV_229564=") + std::to_string(WORKAROUND_SWDEV_229564) +
         std::string(" -DCK_WORKAROUND_SWDEV_231101=") + std::to_string(WORKAROUND_SWDEV_231101);
+
+    // fgx10XX
+    compiler_flag += std::string(" -DCK_USE_AMD_BUFFER_ADDRESSING=") +
+                     (support_amd_buffer_load_store(ctx) ? '1' : '0');
+
+    // using v_fmac_f32
+    compiler_flag +=
+        std::string(" -DCK_USE_AMD_V_FMAC_F32=") + (is_using_v_fmac_f32(ctx) ? '1' : '0');
 
     return compiler_flag;
 }


### PR DESCRIPTION
Solve the issue[#484](https://github.com/ROCmSoftwarePlatform/MIOpen/issues/484), test  on gfx1030 and gfx906
change 2 items:
1. Replace v_mac_f32 as v_fmac_f32, if flag CK_USE_AMD_V_FMAC_F32 is true
2. Disable  buffer_load/store when device name is gfx1030