### PR TITLE
[rocm-3.10.x-staging] Important cherry-picks

### DIFF
--- a/src/comgr.cpp
+++ b/src/comgr.cpp
@@ -140,6 +140,14 @@ static auto GetOptionsNoSplit()
     return rv;
 }
 
+static bool IsEnabledFeatureSramEcc(const std::string& device)
+{
+    /// \todo Read actual feature status from runtime.
+    static const auto rv = (device == "gfx906" || device == "gfx908") &&
+                           !miopen::IsEnabled(MIOPEN_DEBUG_SRAM_EDC_DISABLED{});
+    return rv;
+}
+
 namespace gcnasm {
 
 static void RemoveOptionsUnwanted(OptionList& list)
@@ -164,7 +172,7 @@ namespace ocl {
 #error "Wrong OCL_STANDARD"
 #endif
 
-static void AddCompilerOptions(OptionList& list)
+static void AddCompilerOptions(OptionList& list, const std::string& device)
 {
     list.push_back("-cl-kernel-arg-info");
 #if 0 // For experimients.
@@ -185,7 +193,7 @@ static void AddCompilerOptions(OptionList& list)
 
     // It seems like these options are used only in codegen.
     // However it seems ok to pass these to compiler.
-    if(!miopen::IsEnabled(MIOPEN_DEBUG_SRAM_EDC_DISABLED{}))
+    if(IsEnabledFeatureSramEcc(device))
         list.push_back("-msram-ecc");
     else
         list.push_back("-mno-sram-ecc");
@@ -261,10 +269,7 @@ static void RemoveLinkOptionsUnwanted(OptionList& list)
 /// \todo Get list of supported isa names from comgr and select.
 static std::string GetIsaName(const std::string& device)
 {
-    const char* const ecc_suffix = (!miopen::IsEnabled(MIOPEN_DEBUG_SRAM_EDC_DISABLED{}) &&
-                                    (device == "gfx906" || device == "gfx908"))
-                                       ? "+sram-ecc"
-                                       : "";
+    const char* const ecc_suffix = IsEnabledFeatureSramEcc(device) ? "+sram-ecc" : "";
     return {"amdgcn-amd-amdhsa--" + device + ecc_suffix};
 }
 
@@ -786,7 +791,7 @@ void BuildOcl(const std::string& name,
 
         auto optCompile = miopen::SplitSpaceSeparated(options);
         compiler::lc::ocl::RemoveOptionsUnwanted(optCompile);
-        compiler::lc::ocl::AddCompilerOptions(optCompile);
+        compiler::lc::ocl::AddCompilerOptions(optCompile, device);
         action.SetOptionList(optCompile);
 
         const Dataset addedPch;

--- a/src/include/miopen/gcn_asm_utils.hpp
+++ b/src/include/miopen/gcn_asm_utils.hpp
@@ -27,17 +27,14 @@
 #define GCN_ASM_UTILS_H
 
 #include <string>
-#include <vector>
 #include <sstream>
 
 /// Since 3.8.20403, ".amdhsa_reserve_xnack_mask 0" is not working without
 /// explicit "-mno-xnack" option.
 #define WORKAROUND_SWDEV_255735 1
 
-std::string GetGcnAssemblerPath();
 bool ValidateGcnAssembler();
 std::string AmdgcnAssemble(const std::string& source, const std::string& params);
-bool GcnAssemblerHasBug34765();
 
 template <typename TValue>
 void GenerateClangDefsym(std::ostream& stream, const std::string& name, TValue value)
@@ -49,12 +46,5 @@ template <>
 void GenerateClangDefsym<const std::string&>(std::ostream& stream,
                                              const std::string& name,
                                              const std::string& value);
-
-/// @param dir 1: fwd, 0: bwd wrt data. Use 0 for WrW.
-/// Encodes key with default strides (u1v1)
-std::string MakeLutKey(int w, int h, int c, int n, int k, int dir, int CUs = -1);
-/// Allows for any strides.
-std::string MakeLutKey(
-    int w, int h, int c, int n, int k, int conv_stride_h, int conv_stride_w, int dir, int CUs = -1);
 
 #endif // GCN_ASM_UTILS_H

--- a/src/include/miopen/gcn_asm_utils.hpp
+++ b/src/include/miopen/gcn_asm_utils.hpp
@@ -28,13 +28,16 @@
 
 #include <string>
 #include <sstream>
+#include <miopen/config.h>
 
 /// Since 3.8.20403, ".amdhsa_reserve_xnack_mask 0" is not working without
 /// explicit "-mno-xnack" option.
 #define WORKAROUND_SWDEV_255735 1
 
 bool ValidateGcnAssembler();
+#if !MIOPEN_USE_COMGR
 std::string AmdgcnAssemble(const std::string& source, const std::string& params);
+#endif
 
 template <typename TValue>
 void GenerateClangDefsym(std::ostream& stream, const std::string& name, TValue value)

--- a/src/ocl/gcn_asm_utils.cpp
+++ b/src/ocl/gcn_asm_utils.cpp
@@ -62,6 +62,7 @@ MIOPEN_DECLARE_ENV_VAR(MIOPEN_EXPERIMENTAL_GCN_ASM_PATH)
 
 static const char option_no_co_v3[] = "-mno-code-object-v3";
 
+static bool GcnAssemblerHasBug34765();
 static bool GcnAssemblerSupportsNoCOv3();
 static std::string CleanupPath(const char* p);
 
@@ -280,7 +281,7 @@ static bool GcnAssemblerHasBug34765Impl()
     }
 }
 
-bool GcnAssemblerHasBug34765()
+static bool GcnAssemblerHasBug34765()
 {
     const static bool b = GcnAssemblerHasBug34765Impl();
     return b;
@@ -316,18 +317,4 @@ void GenerateClangDefsym<const std::string&>(std::ostream& stream,
                                              const std::string& value)
 {
     stream << " -Wa,-defsym," << name << "=" << value;
-}
-
-std::string MakeLutKey(
-    int w, int h, int c, int n, int k, int conv_stride_h, int conv_stride_w, int dir, int CUs)
-{
-    std::ostringstream ss;
-    ss << w << ";" << h << ";" << c << ";" << n << ";" << k << ";" << conv_stride_h << ";"
-       << conv_stride_w << ";" << dir << ";" << CUs;
-    return ss.str();
-}
-
-std::string MakeLutKey(int w, int h, int c, int n, int k, int dir, int CUs)
-{
-    return MakeLutKey(w, h, c, n, k, 1, 1, dir, CUs);
 }

--- a/src/ocl/gcn_asm_utils.cpp
+++ b/src/ocl/gcn_asm_utils.cpp
@@ -24,12 +24,18 @@
  *
  *******************************************************************************/
 #include <miopen/gcn_asm_utils.hpp>
+#include <miopen/config.h>
+
+#if MIOPEN_USE_COMGR
+
+bool ValidateGcnAssembler() { return true; }
+
+#else // !MIOPEN_USE_COMGR
 
 #include <cctype>
 #include <cstdio>
 #include <cstdlib>
 #include <fstream>
-#include <miopen/config.h>
 #include <miopen/env.hpp>
 #include <miopen/errors.hpp>
 #include <miopen/manage_ptr.hpp>
@@ -310,6 +316,8 @@ static bool GcnAssemblerSupportsNoCOv3()
     const static bool b = GcnAssemblerSupportsOption(option_no_co_v3);
     return b;
 }
+
+#endif // !MIOPEN_USE_COMGR
 
 template <>
 void GenerateClangDefsym<const std::string&>(std::ostream& stream,

--- a/src/solver/conv_asm_implicit_gemm_bwd_v4r1_dynamic.cpp
+++ b/src/solver/conv_asm_implicit_gemm_bwd_v4r1_dynamic.cpp
@@ -132,6 +132,9 @@ bool ConvAsmImplicitGemmV4R1DynamicBwd::IsApplicable(const ConvolutionContext& c
     if(!(StartsWith(device_name, "gfx900") || StartsWith(device_name, "gfx906")))
         return false;
 
+    if(!ctx.use_asm_kernels)
+        return false;
+
     if(!ctx.direction.IsBackwardData())
         return false;
 

--- a/src/solver/conv_asm_implicit_gemm_gtc_bwd.cpp
+++ b/src/solver/conv_asm_implicit_gemm_gtc_bwd.cpp
@@ -258,6 +258,9 @@ bool ConvAsmImplicitGemmGTCDynamicBwdXdlops::IsApplicable(const ConvolutionConte
     if(!(StartsWith(device_name, "gfx908")))
         return false;
 
+    if(!ctx.use_asm_kernels)
+        return false;
+
     if(!ctx.direction.IsBackwardData())
         return false;
 

--- a/src/solver/conv_asm_implicit_gemm_gtc_fwd.cpp
+++ b/src/solver/conv_asm_implicit_gemm_gtc_fwd.cpp
@@ -502,6 +502,9 @@ bool ConvAsmImplicitGemmGTCDynamicFwdXdlops::IsApplicable(const ConvolutionConte
     if(!(StartsWith(device_name, "gfx908")))
         return false;
 
+    if(!ctx.use_asm_kernels)
+        return false;
+
     if(!ctx.direction.IsForward())
         return false;
 

--- a/src/solver/conv_asm_implicit_gemm_v4r1_dynamic.cpp
+++ b/src/solver/conv_asm_implicit_gemm_v4r1_dynamic.cpp
@@ -276,6 +276,9 @@ bool ConvAsmImplicitGemmV4R1DynamicFwd::IsApplicable(const ConvolutionContext& c
     if(!(StartsWith(device_name, "gfx900") || StartsWith(device_name, "gfx906")))
         return false;
 
+    if(!ctx.use_asm_kernels)
+        return false;
+
     if(!ctx.direction.IsForward())
         return false;
 
@@ -300,6 +303,9 @@ bool ConvAsmImplicitGemmV4R1DynamicFwd_1x1::IsApplicable(const ConvolutionContex
 {
     const auto device_name = ctx.GetStream().GetDeviceName();
     if(!(StartsWith(device_name, "gfx900") || StartsWith(device_name, "gfx906")))
+        return false;
+
+    if(!ctx.use_asm_kernels)
         return false;
 
     if(!ctx.direction.IsForward())

--- a/src/solver/conv_asm_implicit_gemm_wrw_gtc_dynamic_xdlops.cpp
+++ b/src/solver/conv_asm_implicit_gemm_wrw_gtc_dynamic_xdlops.cpp
@@ -485,6 +485,9 @@ bool ConvAsmImplicitGemmGTCDynamicWrwXdlops::IsApplicable(const ConvolutionConte
     if(!(StartsWith(device_name, "gfx908")))
         return false;
 
+    if(!ctx.use_asm_kernels)
+        return false;
+
     if(!IsApplicableXdlops(ctx))
         return false;
 

--- a/src/solver/conv_asm_implicit_gemm_wrw_v4r1_dynamic.cpp
+++ b/src/solver/conv_asm_implicit_gemm_wrw_v4r1_dynamic.cpp
@@ -298,6 +298,9 @@ bool ConvAsmImplicitGemmV4R1DynamicWrw::IsApplicable(const ConvolutionContext& c
     if(!(StartsWith(device_name, "gfx900") || StartsWith(device_name, "gfx906")))
         return false;
 
+    if(!ctx.use_asm_kernels)
+        return false;
+
     if(GetGemmkGroups(ctx) > 0) // GetSolution() adds HIP kernels in this case.
         if(!ctx.use_hip_kernels)
             return false;

--- a/src/solver/conv_asm_implicit_gemm_wrw_v4r1_dynamic.cpp
+++ b/src/solver/conv_asm_implicit_gemm_wrw_v4r1_dynamic.cpp
@@ -277,11 +277,30 @@ size_t ConvAsmImplicitGemmV4R1DynamicWrw::GetWorkspaceSize(const ConvolutionCont
     return k * c * y * x * ele_size * extra_groups;
 }
 
+static int GetGemmkGroups(const ConvolutionContext& ctx)
+{
+    const auto& k    = ctx.n_inputs;
+    const auto& c    = ctx.n_outputs;
+    const auto& y    = ctx.kernel_size_h;
+    const auto& x    = ctx.kernel_size_w;
+    const auto GemmN = c * y * x;
+
+    int GemmKPerBlock = 4;
+    if((k % 128 == 0) && (GemmN % 128 == 0))
+        GemmKPerBlock = 16;
+
+    return GetImplicitGemmWrwV4R1DynamicGemmkGroups(ctx.conv_problem, GemmKPerBlock);
+}
+
 bool ConvAsmImplicitGemmV4R1DynamicWrw::IsApplicable(const ConvolutionContext& ctx) const
 {
     const auto device_name = ctx.GetStream().GetDeviceName();
     if(!(StartsWith(device_name, "gfx900") || StartsWith(device_name, "gfx906")))
         return false;
+
+    if(GetGemmkGroups(ctx) > 0) // GetSolution() adds HIP kernels in this case.
+        if(!ctx.use_hip_kernels)
+            return false;
 
     if(!ctx.direction.IsBackwardWrW())
         return false;
@@ -320,19 +339,6 @@ ConvSolution ConvAsmImplicitGemmV4R1DynamicWrw::GetSolution(const ConvolutionCon
     if(!ret)
         MIOPEN_THROW("this kernel should not run with igemm dynamic!");
 
-    int k = ctx.n_inputs;
-    int c = ctx.n_outputs;
-    int y = ctx.kernel_size_h;
-    int x = ctx.kernel_size_w;
-    int GemmKPerBlock;
-    int GemmN = c * y * x;
-
-    if((k % 128 == 0) && (GemmN % 128 == 0))
-        GemmKPerBlock = 16;
-    else
-        GemmKPerBlock = 4;
-    int gemmk_groups  = GetImplicitGemmWrwV4R1DynamicGemmkGroups(ctx.conv_problem, GemmKPerBlock);
-
     result.workspce_sz = GetWorkspaceSize(ctx);
 
     kernel.kernel_file = "igemm_v4r1_wrw_dynamic.s";
@@ -358,7 +364,7 @@ ConvSolution ConvAsmImplicitGemmV4R1DynamicWrw::GetSolution(const ConvolutionCon
 
     result.construction_params.push_back(kernel);
 
-    if(gemmk_groups > 0)
+    if(GetGemmkGroups(ctx) > 0)
     {
         KernelInfo kernel_reduction;
         int reduction_per_thread     = 4;

--- a/src/solver/conv_hip_implicit_gemm_bwd_v1r1_xdlops_nchw_kcyx_nkhw.cpp
+++ b/src/solver/conv_hip_implicit_gemm_bwd_v1r1_xdlops_nchw_kcyx_nkhw.cpp
@@ -749,6 +749,9 @@ bool ConvHipImplicitGemmBwdDataV1R1Xdlops::IsApplicable(const ConvolutionContext
     if(ctx.skip_solutions_that_take_long_time_to_build_and_have_narrow_coverage)
         return false;
 
+    if(!ctx.use_hip_kernels)
+        return false;
+
     if(!IsXdlopsSupport(ctx))
         return false;
 

--- a/src/solver/conv_hip_implicit_gemm_fwd_v4r4_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_fwd_v4r4_xdlops.cpp
@@ -955,6 +955,9 @@ bool ConvHipImplicitGemmForwardV4R4Xdlops::IsApplicable(const ConvolutionContext
     if(ctx.skip_solutions_that_take_long_time_to_build_and_have_narrow_coverage)
         return false;
 
+    if(!ctx.use_hip_kernels)
+        return false;
+
     if(!IsXdlopsSupport(ctx))
         return false;
 

--- a/src/solver/conv_hip_implicit_gemm_fwd_v4r4_xdlops_padded_gemm.cpp
+++ b/src/solver/conv_hip_implicit_gemm_fwd_v4r4_xdlops_padded_gemm.cpp
@@ -1021,6 +1021,9 @@ bool ConvHipImplicitGemmForwardV4R4Xdlops_Padded_Gemm::IsApplicable(
     if(ctx.skip_solutions_that_take_long_time_to_build_and_have_narrow_coverage)
         return false;
 
+    if(!ctx.use_hip_kernels)
+        return false;
+
     if(!IsXdlopsSupport(ctx))
         return false;
 

--- a/src/solver/conv_hip_implicit_gemm_fwd_v4r5_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_fwd_v4r5_xdlops.cpp
@@ -100,7 +100,7 @@ operator==(const PerformanceImplicitGemmForwardV4R5Xdlops& other) const
         && GemmKPerBlock == other.GemmKPerBlock
         && GemmMPerWave == other.GemmMPerWave
         && GemmNPerWave == other.GemmNPerWave
-        && GemmKPack == other.GemmKPack 
+        && GemmKPack == other.GemmKPack
         && GemmAThreadCopyMoreGemmK  == other.GemmAThreadCopyMoreGemmK
         && GemmBThreadCopyMoreGemmKPack  == other.GemmBThreadCopyMoreGemmKPack
         && GemmBThreadDataPerRead_GemmN  == other.GemmBThreadDataPerRead_GemmN;
@@ -964,6 +964,9 @@ ConvSolution ConvHipImplicitGemmForwardV4R5Xdlops::GetSolution(
 bool ConvHipImplicitGemmForwardV4R5Xdlops::IsApplicable(const ConvolutionContext& ctx) const
 {
     if(ctx.skip_solutions_that_take_long_time_to_build_and_have_narrow_coverage)
+        return false;
+
+    if(!ctx.use_hip_kernels)
         return false;
 
     if(!IsXdlopsSupport(ctx))

--- a/src/solver/conv_hip_implicit_gemm_wrw_v4r4_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_wrw_v4r4_xdlops.cpp
@@ -74,7 +74,7 @@ operator==(const PerformanceImplicitGemmWrwV4R4Xdlops& other) const
         && GemmKPerBlock == other.GemmKPerBlock
         && GemmMPerWave == other.GemmMPerWave
         && GemmNPerWave == other.GemmNPerWave
-        && GemmKPack == other.GemmKPack 
+        && GemmKPack == other.GemmKPack
         && GemmAThreadCopyMoreGemmK  == other.GemmAThreadCopyMoreGemmK
         && GemmBThreadCopyMoreGemmKPack  == other.GemmBThreadCopyMoreGemmKPack;
     // clang-format on
@@ -993,10 +993,13 @@ ConvSolution ConvHipImplicitGemmWrwV4R4Xdlops::GetSolution(
 
 bool ConvHipImplicitGemmWrwV4R4Xdlops::IsApplicable(const ConvolutionContext& ctx) const
 {
-    if(!IsXdlopsSupport(ctx))
+    if(ctx.skip_solutions_that_take_long_time_to_build_and_have_narrow_coverage)
         return false;
 
-    if(ctx.skip_solutions_that_take_long_time_to_build_and_have_narrow_coverage)
+    if(!ctx.use_hip_kernels)
+        return false;
+
+    if(!IsXdlopsSupport(ctx))
         return false;
 
     if(!(ctx.IsFp32() || ctx.IsFp16() || ctx.IsBfp16()))


### PR DESCRIPTION
Cherry-picks for `rocm-3.10.x-staging` from:
- #529 [COMGR] OCL builds: fix for sram-ecc feature for gfx900
- #536 [COMGR] Disable unnecesssary assembler detection.
- #538 Added missing checks for new iGemm solvers so they obey the ASM & HIP kernel on/off controls.

These are necessary for embedded builds.

## :cyclone: Local performance & correctness testing

- Radeon VII, ROCm 3.5.
- 93 known FP32 convolution configs
- Baseline vs this PR
  - Normal Find mode + Immediate mode, HIP backend
  - Normal Find mode, COMgr path

No regressions.