### PR TITLE
Follow up to PR#343: Fix problem description Get*Size()

### DIFF
--- a/src/include/miopen/conv/problem_description.hpp
+++ b/src/include/miopen/conv/problem_description.hpp
@@ -188,9 +188,8 @@ struct ProblemDescription
     std::size_t GetInSize() const
     {
         // clang-format off
-        return (GetInLayout() == "NCHW")
-            ? GetInBatchSize() * GetInChannels() * GetInDepth() * GetInHeight() * GetInWidth() * GetInElementSize()
-            : GetInBatchSize() * GetInBatchStride() * GetInChannelStride() * GetInStrideH() * GetInStrideW() * GetInElementSize(); // Todo: GetInStrideD() ?
+        return GetInBatchSize() * GetInChannels() * GetInDepth() * GetInHeight() * 
+            GetInWidth() * GetInElementSize();
         // clang-format on
     }
 
@@ -223,9 +222,8 @@ struct ProblemDescription
     std::size_t GetOutSize() const
     {
         // clang-format off
-        return (GetOutLayout() == "NCHW")
-            ? GetOutBatchSize() * GetOutChannels() * GetOutDepth() * GetOutHeight() * GetOutWidth() * GetOutElementSize()
-            : GetOutBatchSize() * GetOutBatchStride() * GetOutChannelStride() * GetOutStrideH() * GetOutStrideW() * GetOutElementSize(); // Todo: GetOutStrideD() ?
+        return GetOutBatchSize() * GetOutChannels() * GetOutDepth() * GetOutHeight() *
+               GetOutWidth() * GetOutElementSize();
         // clang-format on
     }
 
@@ -257,10 +255,8 @@ struct ProblemDescription
     std::size_t GetWeightsSize() const
     {
         // clang-format off
-        return GetInChannels() * GetOutChannels() * GetWeightsDepth() * GetWeightsHeight() * GetWeightsWidth() * GetWeightsElementSize();
-        // return (GetWeightsLayout() == "NCHW")
-        //    ? GetWeightsBatchSize() * GetInChannels() * GetOutChannels() * GetWeightsHeight() * GetWeightsWidth() * GetWeightsElementSize()
-        //    : GetWeightsBatchSize() * GetWeightsBatchStride() * GetWeightsChannelStride() * GetWeightsStrideH() * GetWeightsStrideW() * GetWeightsElementSize(); // Todo: GetWeightsStrideD() ?
+        return GetInChannels() * GetOutChannels() * GetWeightsDepth() * GetWeightsHeight() * 
+               GetWeightsWidth() * GetWeightsElementSize();
         // clang-format on
     }
 


### PR DESCRIPTION
Follow up from @atamazov's comments [here](https://github.com/ROCmSoftwarePlatform/MIOpen/pull/343#discussion_r456113882). The alternative condition for `Get<In/Out/Weight>Size()` are wrong, and we are not sure what it actually calculates. Fixing it in case it cause any issues in the future.

-----
Example, say we have NCHW layout, and have N: 128, C: 3 H: 5 W:5, for input size:
 - The default condition: N x C x H x W = 128 x 3 x 5 x 5
 - The alternate condition: N x CHW x HW x W = 128 x 75 x 25 x 5