### PR TITLE
Fix ConvHipImplicitGemmWrwV4R4Xdlops_Padded_Gemm performance parameter calculation issue

### DIFF
--- a/src/conv/invokers/impl_gemm.cpp
+++ b/src/conv/invokers/impl_gemm.cpp
@@ -49,19 +49,19 @@ InvokerFactory MakeImplGemmDataInvokerFactory(const ConvolutionContext& ctx)
                     kernel.GetName() == "gridwise_convolution_backward_data_implicit_gemm_v1r1_ncdhw_kczyx_nkdhw"))
                 // clang-format on
                 {
-                    bool need_atomic_add = false;
+                    bool need_atomic_add        = false;
                     bool every_pixel_is_written = true;
 
                     for(int i = 0; i < conv.GetSpatialDimension(); ++i)
                     {
-                        const auto conv_stride = conv.GetConvStrides()[i];
+                        const auto conv_stride   = conv.GetConvStrides()[i];
                         const auto conv_dilation = conv.GetConvDilations()[i];
-                        const auto filter_size = tensors.wDesc.GetLengths()[2+i];
+                        const auto filter_size   = tensors.wDesc.GetLengths()[2 + i];
 
                         if(conv_stride < conv_dilation * (filter_size - 1) + 1)
                             need_atomic_add = true;
 
-                        //todo: can be relaxed
+                        // todo: can be relaxed
                         if(!(conv_dilation == 1 && conv_stride <= filter_size))
                             every_pixel_is_written = false;
                     }
@@ -169,11 +169,11 @@ InvokerFactory MakeImplGemmDataInvokerFactory(const ConvolutionContext& ctx)
 
                     for(int i = 0; i < conv.GetSpatialDimension(); ++i)
                     {
-                        const auto conv_stride = conv.GetConvStrides()[i];
+                        const auto conv_stride   = conv.GetConvStrides()[i];
                         const auto conv_dilation = conv.GetConvDilations()[i];
-                        const auto filter_size = tensors.wDesc.GetLengths()[2+i];
+                        const auto filter_size   = tensors.wDesc.GetLengths()[2 + i];
 
-                        //todo: can be relaxed
+                        // todo: can be relaxed
                         if(!(conv_dilation == 1 && conv_stride <= filter_size))
                             every_pixel_is_written = false;
                     }

--- a/src/include/miopen/solver.hpp
+++ b/src/include/miopen/solver.hpp
@@ -1962,7 +1962,7 @@ struct PerformanceImplicitGemmWrwV4R4Xdlops_Padded_Gemm
     int GemmKPack;
     int GemmMFactor;
     int GemmNFactor;
-    int GemmKFactor;
+    int GemmKTotalFactor;
     bool GemmAThreadCopyMoreGemmK;
     bool GemmBThreadCopyMoreGemmK;
 
@@ -1985,7 +1985,7 @@ struct PerformanceImplicitGemmWrwV4R4Xdlops_Padded_Gemm
         f(self.GemmKPack, "GemmKPack");
         f(self.GemmMFactor, "GemmMFactor");
         f(self.GemmNFactor, "GemmNFactor");
-        f(self.GemmKFactor, "GemmKFactor");
+        f(self.GemmKTotalFactor, "GemmKTotalFactor");
         f(self.GemmAThreadCopyMoreGemmK, "GemmAThreadCopyMoreGemmK");
         f(self.GemmBThreadCopyMoreGemmK, "GemmBThreadCopyMoreGemmK");
     }
@@ -2001,6 +2001,8 @@ struct PerformanceImplicitGemmWrwV4R4Xdlops_Padded_Gemm
     bool IsFastToBeUsedForTuning(const ConvolutionContext& ctx) const;
     int CalculateGemmKBlocks(const ConvolutionContext& ctx) const;
 
+    std::tuple<int, int, int, int, int, int, int, int, bool>
+    CalculateGemmSizeAndGemmKBlock(const ConvolutionContext& ctx) const;
     std::tuple<int, bool> CalculateBlockSize() const;
     std::tuple<int, bool> CalculateGridSize(const ConvolutionContext& ctx) const;
     std::tuple<int, int, int, int, int, bool>
@@ -2011,8 +2013,6 @@ struct PerformanceImplicitGemmWrwV4R4Xdlops_Padded_Gemm
 };
 struct ConvHipImplicitGemmWrwV4R4Xdlops_Padded_Gemm : SolverBase<ConvolutionContext>
 {
-    static std::tuple<int, int, int, int, int, int, int> CalculateGemmSize(
-        const ConvolutionContext& ctx, int GemmMFactor, int GemmNFactor, int GemmKFactor);
     PerformanceImplicitGemmWrwV4R4Xdlops_Padded_Gemm
     GetPerformanceConfig(const ConvolutionContext& ctx) const;
     size_t GetWorkspaceSize(const ConvolutionContext& ctx) const;

--- a/src/include/miopen/solver.hpp
+++ b/src/include/miopen/solver.hpp
@@ -1924,8 +1924,9 @@ struct PerformanceImplicitGemmWrwV4R4Xdlops : Serializable<PerformanceImplicitGe
     bool IsValid(const ConvolutionContext& ctx) const;
     bool IsReallyValid(const ConvolutionContext& ctx) const;
     bool IsFastToBeUsedForTuning(const ConvolutionContext& ctx) const;
-    int CalculateGemmKBlocks(const ConvolutionContext& ctx) const;
 
+    std::tuple<int, int, int, int, int, bool>
+    CalculateGemmSizeAndGemmKBlock(const ConvolutionContext& ctx) const;
     std::tuple<int, bool> CalculateBlockSize() const;
     std::tuple<int, bool> CalculateGridSize(const ConvolutionContext& ctx) const;
     std::tuple<int, int, int, int, int, bool>
@@ -1934,9 +1935,9 @@ struct PerformanceImplicitGemmWrwV4R4Xdlops : Serializable<PerformanceImplicitGe
     CalculateGemmBBlockCopyPerformanceParameters(const ConvolutionContext& ctx) const;
     std::tuple<std::size_t, bool> CalculateLdsNumberOfByte(const ConvolutionContext& ctx) const;
 };
+
 struct ConvHipImplicitGemmWrwV4R4Xdlops : SolverBase<ConvolutionContext>
 {
-    static std::tuple<int, int, int, int> CalculateGemmSize(const ConvolutionContext& ctx);
     PerformanceImplicitGemmWrwV4R4Xdlops GetPerformanceConfig(const ConvolutionContext& ctx) const;
     size_t GetWorkspaceSize(const ConvolutionContext& ctx) const;
     bool IsValidPerformanceConfig(const ConvolutionContext& ctx,

--- a/src/kernels/composable_kernel/include/kernel_algorithm/gridwise_convolution_backward_weights_implicit_gemm_v4r4_xdlops_nchw_kcyx_nkhw.hpp
+++ b/src/kernels/composable_kernel/include/kernel_algorithm/gridwise_convolution_backward_weights_implicit_gemm_v4r4_xdlops_nchw_kcyx_nkhw.hpp
@@ -89,15 +89,9 @@ struct GridwiseConvolutionBackwardWeightsImplicitGemm_v4r4_xdlops_nchw_kcyx_nkhw
 
         constexpr index_t GemmK = GemmKTotal / GemmKPack;
 
-#if 0
         static_assert(GemmM % GemmMPerBlock == 0 && GemmN % GemmNPerBlock == 0 &&
                           GemmK % GemmKPerBlock == 0,
                       "wrong! cannot divide work evenly among block");
-#else
-        static_assert(GemmM % GemmMPerBlock == 0, "wrong! cannot divide work evenly among block");
-        static_assert(GemmN % GemmNPerBlock == 0, "wrong! cannot divide work evenly among block");
-        static_assert(GemmK % GemmKPerBlock == 0, "wrong! cannot divide work evenly among block");
-#endif
 
         // construct tensor descriptor for group convolution
         constexpr auto in_g_n_cpergroup_hi_wi_global_desc = make_native_tensor_descriptor(

--- a/src/kernels/composable_kernel/include/kernel_algorithm/gridwise_convolution_backward_weights_implicit_gemm_v4r4_xdlops_nchw_kcyx_nkhw_padded_gemm.hpp
+++ b/src/kernels/composable_kernel/include/kernel_algorithm/gridwise_convolution_backward_weights_implicit_gemm_v4r4_xdlops_nchw_kcyx_nkhw_padded_gemm.hpp
@@ -92,9 +92,15 @@ struct GridwiseConvolutionBackwardWeightsImplicitGemm_v4r4_xdlops_nchw_kcyx_nkhw
 
         constexpr index_t GemmK = GemmKTotal / GemmKPack;
 
+#if 0
         static_assert(GemmM % GemmMPerBlock == 0 && GemmN % GemmNPerBlock == 0 &&
                           GemmK % GemmKPerBlock == 0,
                       "wrong! cannot divide work evenly among block");
+#else
+        static_assert(GemmM % GemmMPerBlock == 0, "wrong! cannot divide work evenly among block");
+        static_assert(GemmN % GemmNPerBlock == 0, "wrong! cannot divide work evenly among block");
+        static_assert(GemmK % GemmKPerBlock == 0, "wrong! cannot divide work evenly among block");
+#endif
 
         // construct tensor descriptor for group convolution
         constexpr auto in_g_n_cpergroup_hi_wi_global_desc = make_native_tensor_descriptor(

--- a/src/kernels/composable_kernel/include/kernel_algorithm/gridwise_convolution_backward_weights_implicit_gemm_v4r4_xdlops_nchw_kcyx_nkhw_padded_gemm.hpp
+++ b/src/kernels/composable_kernel/include/kernel_algorithm/gridwise_convolution_backward_weights_implicit_gemm_v4r4_xdlops_nchw_kcyx_nkhw_padded_gemm.hpp
@@ -44,9 +44,9 @@ template <index_t GridSize,
           index_t GemmBBlockCopyDstDataPerWrite_GemmKPack,
           index_t GemmMPad,
           index_t GemmNPad,
-          index_t GemmKPad,
+          index_t GemmKTotalPad,
           WorkgroupScheduleOrder WorkgroupSchdOrder,
-          index_t GemmKBlocks>
+          index_t GemmKBlock>
 struct GridwiseConvolutionBackwardWeightsImplicitGemm_v4r4_xdlops_nchw_kcyx_nkhw_padded_gemm
 {
     __device__ void Run(const ABFloat* const __restrict__ p_in_global,
@@ -79,37 +79,31 @@ struct GridwiseConvolutionBackwardWeightsImplicitGemm_v4r4_xdlops_nchw_kcyx_nkhw
         constexpr index_t ConvDilationH = ConvDilations{}[0];
         constexpr index_t ConvDilationW = ConvDilations{}[1];
 
-        static_assert(N % GemmKBlocks == 0, "wrong! N should be multiple of GemmKBlocks");
-        constexpr index_t NSub = N / GemmKBlocks;
+        static_assert(N % GemmKBlock == 0, "wrong! N should be multiple of GemmKBlock");
+        constexpr index_t NSub = N / GemmKBlock;
 
-        constexpr index_t GemmG      = G * GemmKBlocks;
+        constexpr index_t GemmG      = G * GemmKBlock;
         constexpr index_t GemmM      = KPerGroup + GemmMPad;
         constexpr index_t GemmN      = CPerGroup * Y * X + GemmNPad;
-        constexpr index_t GemmKTotal = NSub * Ho * Wo + GemmKPad;
+        constexpr index_t GemmKTotal = NSub * Ho * Wo + GemmKTotalPad;
 
         static_assert(GemmKTotal % GemmKPack == 0,
                       "wrong! GemmKTotal should be multiple of GemmKPack");
 
         constexpr index_t GemmK = GemmKTotal / GemmKPack;
 
-#if 0
         static_assert(GemmM % GemmMPerBlock == 0 && GemmN % GemmNPerBlock == 0 &&
                           GemmK % GemmKPerBlock == 0,
                       "wrong! cannot divide work evenly among block");
-#else
-        static_assert(GemmM % GemmMPerBlock == 0, "wrong! cannot divide work evenly among block");
-        static_assert(GemmN % GemmNPerBlock == 0, "wrong! cannot divide work evenly among block");
-        static_assert(GemmK % GemmKPerBlock == 0, "wrong! cannot divide work evenly among block");
-#endif
 
         // construct tensor descriptor for group convolution
         constexpr auto in_g_n_cpergroup_hi_wi_global_desc = make_native_tensor_descriptor(
             Sequence<G, N, CPerGroup, Hi, Wi>{},
             Sequence<CPerGroup * Hi * Wi, C * Hi * Wi, Hi * Wi, Wi, 1>{});
 
-        constexpr auto wei_gemmkblocks_g_kpergroup_cpergroup_y_x_global_desc =
+        constexpr auto wei_gemmkblock_g_kpergroup_cpergroup_y_x_global_desc =
             make_native_tensor_descriptor(
-                Sequence<GemmKBlocks, G, KPerGroup, CPerGroup, Y, X>{},
+                Sequence<GemmKBlock, G, KPerGroup, CPerGroup, Y, X>{},
                 Sequence<0, KPerGroup * CPerGroup * Y * X, CPerGroup * Y * X, Y * X, X, 1>{});
 
         constexpr auto out_g_n_kpergroup_ho_wo_global_desc = make_native_tensor_descriptor(
@@ -117,21 +111,20 @@ struct GridwiseConvolutionBackwardWeightsImplicitGemm_v4r4_xdlops_nchw_kcyx_nkhw
             Sequence<KPerGroup * Ho * Wo, K * Ho * Wo, Ho * Wo, Wo, 1>{});
 
         // output tensor  A matrix
-        constexpr auto I3 = Number<3>{};
-        constexpr auto I4 = Number<4>{};
-        constexpr auto out_g_gemmkblocks_nsub_kpergroup_hw_global_desc =
-            transform_tensor_descriptor(
-                unfold_tensor_descriptor(out_g_n_kpergroup_ho_wo_global_desc, I3, I4),
-                make_tuple(PassThrough<G>{},
-                           UnMerge<Sequence<GemmKBlocks, NSub>>{},
-                           PassThrough<KPerGroup>{},
-                           PassThrough<Ho * Wo>{}),
-                make_tuple(Sequence<0>{}, Sequence<1>{}, Sequence<2>{}, Sequence<3>{}),
-                make_tuple(Sequence<0>{}, Sequence<1, 2>{}, Sequence<3>{}, Sequence<4>{}));
+        constexpr auto I3                                             = Number<3>{};
+        constexpr auto I4                                             = Number<4>{};
+        constexpr auto out_g_gemmkblock_nsub_kpergroup_hw_global_desc = transform_tensor_descriptor(
+            unfold_tensor_descriptor(out_g_n_kpergroup_ho_wo_global_desc, I3, I4),
+            make_tuple(PassThrough<G>{},
+                       UnMerge<Sequence<GemmKBlock, NSub>>{},
+                       PassThrough<KPerGroup>{},
+                       PassThrough<Ho * Wo>{}),
+            make_tuple(Sequence<0>{}, Sequence<1>{}, Sequence<2>{}, Sequence<3>{}),
+            make_tuple(Sequence<0>{}, Sequence<1, 2>{}, Sequence<3>{}, Sequence<4>{}));
 
         constexpr auto out_gemmg_gemmktotal_gemmm_global_desc = transform_tensor_descriptor(
-            out_g_gemmkblocks_nsub_kpergroup_hw_global_desc,
-            make_tuple(Merge<Sequence<G, GemmKBlocks>>{},
+            out_g_gemmkblock_nsub_kpergroup_hw_global_desc,
+            make_tuple(Merge<Sequence<G, GemmKBlock>>{},
                        PassThrough<KPerGroup>{},
                        Merge<Sequence<NSub, Ho * Wo>>{}),
             make_tuple(Sequence<0, 1>{}, Sequence<3>{}, Sequence<2, 4>{}),
@@ -141,7 +134,9 @@ struct GridwiseConvolutionBackwardWeightsImplicitGemm_v4r4_xdlops_nchw_kcyx_nkhw
             transform_tensor_descriptor(
                 out_gemmg_gemmktotal_gemmm_global_desc,
                 make_tuple(PassThrough<GemmG>{},
-                           Pad<Sequence<GemmKTotal - GemmKPad>, Sequence<0>, Sequence<GemmKPad>>{},
+                           Pad<Sequence<GemmKTotal - GemmKTotalPad>,
+                               Sequence<0>,
+                               Sequence<GemmKTotalPad>>{},
                            Pad<Sequence<GemmM - GemmMPad>, Sequence<0>, Sequence<GemmMPad>>{}),
                 make_tuple(Sequence<0>{}, Sequence<1>{}, Sequence<2>{}),
                 make_tuple(Sequence<0>{}, Sequence<1>{}, Sequence<2>{}));
@@ -159,11 +154,11 @@ struct GridwiseConvolutionBackwardWeightsImplicitGemm_v4r4_xdlops_nchw_kcyx_nkhw
         static_assert(a_gemmk == GemmK && a_gemmm == GemmM && a_gemmkpack == GemmKPack,
                       "error A matrix");
         // input tensor matrix B
-        constexpr auto in_g_gemmkblocks_nsub_cpergroup_hi_wi_global_desc =
+        constexpr auto in_g_gemmkblock_nsub_cpergroup_hi_wi_global_desc =
             transform_tensor_descriptor(
                 in_g_n_cpergroup_hi_wi_global_desc,
                 make_tuple(PassThrough<G>{},
-                           UnMerge<Sequence<GemmKBlocks, NSub>>{},
+                           UnMerge<Sequence<GemmKBlock, NSub>>{},
                            PassThrough<CPerGroup>{},
                            PassThrough<Hi>{},
                            PassThrough<Wi>{}),
@@ -173,8 +168,8 @@ struct GridwiseConvolutionBackwardWeightsImplicitGemm_v4r4_xdlops_nchw_kcyx_nkhw
                     Sequence<0>{}, Sequence<1, 2>{}, Sequence<3>{}, Sequence<4>{}, Sequence<5>{}));
 
         constexpr auto in_gemmg_nsub_cpergroup_hip_wip_global_desc = transform_tensor_descriptor(
-            in_g_gemmkblocks_nsub_cpergroup_hi_wi_global_desc,
-            make_tuple(Merge<Sequence<G, GemmKBlocks>>{},
+            in_g_gemmkblock_nsub_cpergroup_hi_wi_global_desc,
+            make_tuple(Merge<Sequence<G, GemmKBlock>>{},
                        PassThrough<NSub>{},
                        PassThrough<CPerGroup>{},
                        Pad<Sequence<Hi, Wi>, InLeftPads, InRightPads>{}),
@@ -205,9 +200,10 @@ struct GridwiseConvolutionBackwardWeightsImplicitGemm_v4r4_xdlops_nchw_kcyx_nkhw
 
         constexpr auto in_gemmg_gemmkpadd_gemmn_gemmkpack_global_desc = transform_tensor_descriptor(
             in_gemmg_gemmktotal_gemmn_global_desc,
-            make_tuple(PassThrough<GemmG>{},
-                       Pad<Sequence<GemmKTotal - GemmKPad>, Sequence<0>, Sequence<GemmKPad>>{},
-                       PassThrough<GemmN - GemmNPad>{}),
+            make_tuple(
+                PassThrough<GemmG>{},
+                Pad<Sequence<GemmKTotal - GemmKTotalPad>, Sequence<0>, Sequence<GemmKTotalPad>>{},
+                PassThrough<GemmN - GemmNPad>{}),
             make_tuple(Sequence<0>{}, Sequence<1>{}, Sequence<2>{}),
             make_tuple(Sequence<0>{}, Sequence<1>{}, Sequence<2>{}));
 
@@ -227,8 +223,8 @@ struct GridwiseConvolutionBackwardWeightsImplicitGemm_v4r4_xdlops_nchw_kcyx_nkhw
         // weight tensor  C matrix
         constexpr auto wei_gemmg_gemmm_gemmn_padding_global_desc = transform_tensor_descriptor(
             unfold_tensor_descriptor(
-                wei_gemmkblocks_g_kpergroup_cpergroup_y_x_global_desc, Number<3>{}, Number<5>{}),
-            make_tuple(Merge<Sequence<G, GemmKBlocks>>{},
+                wei_gemmkblock_g_kpergroup_cpergroup_y_x_global_desc, Number<3>{}, Number<5>{}),
+            make_tuple(Merge<Sequence<G, GemmKBlock>>{},
                        PassThrough<GemmM - GemmMPad>{},
                        Pad<Sequence<GemmN - GemmNPad>, Sequence<0>, Sequence<GemmNPad>>{}),
             make_tuple(Sequence<1, 0>{}, Sequence<2>{}, Sequence<3>{}),
@@ -236,7 +232,7 @@ struct GridwiseConvolutionBackwardWeightsImplicitGemm_v4r4_xdlops_nchw_kcyx_nkhw
 
         constexpr auto wei_gemmg_gemmm_gemmn_global_desc = transform_tensor_descriptor(
             wei_gemmg_gemmm_gemmn_padding_global_desc,
-            make_tuple(PassThrough<GemmG * GemmKBlocks>{},
+            make_tuple(PassThrough<GemmG * GemmKBlock>{},
                        Pad<Sequence<GemmM - GemmMPad>, Sequence<0>, Sequence<GemmMPad>>{},
                        PassThrough<GemmN>{}),
             make_tuple(Sequence<0>{}, Sequence<1>{}, Sequence<2>{}),
@@ -247,7 +243,7 @@ struct GridwiseConvolutionBackwardWeightsImplicitGemm_v4r4_xdlops_nchw_kcyx_nkhw
         static_assert(c_gemmn == GemmN && c_gemmm == GemmM, "error C matrix");
 
         constexpr InMemoryDataOperation CGlobalMemoryDataOperation =
-            GemmKBlocks > 1 ? InMemoryDataOperation::AtomicAdd : InMemoryDataOperation::Set;
+            GemmKBlock > 1 ? InMemoryDataOperation::AtomicAdd : InMemoryDataOperation::Set;
         // gridwise batch-GEMM
         constexpr auto gridwise_gemm = GridwiseBatchGemmXdlops_gkmkpack_gknkpack_gmn_v2<
             GridSize,

--- a/src/kernels/composable_kernel/src/kernel_wrapper/gridwise_convolution_backward_weights_implicit_gemm_v4r4_xdlops_nchw_kcyx_nkhw.cpp
+++ b/src/kernels/composable_kernel/src/kernel_wrapper/gridwise_convolution_backward_weights_implicit_gemm_v4r4_xdlops_nchw_kcyx_nkhw.cpp
@@ -58,9 +58,9 @@ extern "C" __global__
     constexpr index_t GemmKPack     = CK_PARAM_TUNABLE_GEMM_KPACK;
 
     // read params: dependent parameters
-    constexpr index_t BlockSize   = CK_PARAM_DEPENDENT_BLOCK_SIZE;
-    constexpr index_t GridSize    = CK_PARAM_DEPENDENT_GRID_SIZE;
-    constexpr index_t GemmKBlocks = CK_PARAM_GEMM_K_BLOCKS;
+    constexpr index_t BlockSize  = CK_PARAM_DEPENDENT_BLOCK_SIZE;
+    constexpr index_t GridSize   = CK_PARAM_DEPENDENT_GRID_SIZE;
+    constexpr index_t GemmKBlock = CK_PARAM_GEMM_K_BLOCK;
 
     // A matrix copy
     constexpr index_t GemmABlockCopyClusterLengths_GemmK =
@@ -175,6 +175,6 @@ extern "C" __global__
             GemmBBlockCopySrcDataPerRead_GemmKPack,
             GemmBBlockCopyDstDataPerWrite_GemmKPack,
             wkgrp_schd_order,
-            GemmKBlocks>{};
+            GemmKBlock>{};
     gridwise_conv.Run(p_in_global, p_out_global, p_wei_global);
 }

--- a/src/kernels/composable_kernel/src/kernel_wrapper/gridwise_convolution_backward_weights_implicit_gemm_v4r4_xdlops_nchw_kcyx_nkhw_padded_gemm.cpp
+++ b/src/kernels/composable_kernel/src/kernel_wrapper/gridwise_convolution_backward_weights_implicit_gemm_v4r4_xdlops_nchw_kcyx_nkhw_padded_gemm.cpp
@@ -58,9 +58,9 @@ extern "C" __global__
     constexpr index_t GemmKPack     = CK_PARAM_TUNABLE_GEMM_KPACK;
 
     // read params: dependent parameters
-    constexpr index_t BlockSize   = CK_PARAM_DEPENDENT_BLOCK_SIZE;
-    constexpr index_t GridSize    = CK_PARAM_DEPENDENT_GRID_SIZE;
-    constexpr index_t GemmKBlocks = CK_PARAM_GEMM_K_BLOCKS;
+    constexpr index_t BlockSize  = CK_PARAM_DEPENDENT_BLOCK_SIZE;
+    constexpr index_t GridSize   = CK_PARAM_DEPENDENT_GRID_SIZE;
+    constexpr index_t GemmKBlock = CK_PARAM_GEMM_K_BLOCK;
 
     // A matrix copy
     constexpr index_t GemmABlockCopyClusterLengths_GemmK =
@@ -140,7 +140,7 @@ extern "C" __global__
     constexpr auto wkgrp_schd_order = NBlock1MBlock0;
     constexpr auto GemmMPad         = CK_GEMM_M_PAD;
     constexpr auto GemmNPad         = CK_GEMM_N_PAD;
-    constexpr auto GemmKPad         = CK_GEMM_K_PAD;
+    constexpr auto GemmKTotalPad    = CK_GEMM_K_TOTAL_PAD;
 
     constexpr auto gridwise_conv =
         GridwiseConvolutionBackwardWeightsImplicitGemm_v4r4_xdlops_nchw_kcyx_nkhw_padded_gemm<
@@ -179,8 +179,8 @@ extern "C" __global__
             GemmBBlockCopyDstDataPerWrite_GemmKPack,
             GemmMPad,
             GemmNPad,
-            GemmKPad,
+            GemmKTotalPad,
             wkgrp_schd_order,
-            GemmKBlocks>{};
+            GemmKBlock>{};
     gridwise_conv.Run(p_in_global, p_out_global, p_wei_global);
 }

--- a/src/solver/conv_hip_implicit_gemm_bwd_data_v4r1_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_bwd_data_v4r1_xdlops.cpp
@@ -690,8 +690,7 @@ void PerformanceImplicitGemmBwdDataV4R1Xdlops::EuristicInit(const ConvolutionCon
     // final check
     if(!tmp.IsReallyValid(ctx))
     {
-        MIOPEN_LOG_E("All attempts failed");
-        assert(false);
+        MIOPEN_LOG_I("All attempts failed");
     }
     *this = tmp;
     MIOPEN_LOG_I(ToString());
@@ -840,7 +839,11 @@ ConvSolution ConvHipImplicitGemmBwdDataV4R1Xdlops::GetSolution(
 {
     ConvSolution result;
 
-    assert(config.IsValid(ctx));
+    if(!config.IsReallyValid(ctx))
+    {
+        MIOPEN_LOG_E("invalid performance parameter");
+        assert(false);
+    }
 
     // a series of kernels
     for(std::size_t gemm_id = 0; gemm_id < CalculateNumberOfGemm(ctx); ++gemm_id)

--- a/src/solver/conv_hip_implicit_gemm_bwd_v1r1_xdlops_nchw_kcyx_nkhw.cpp
+++ b/src/solver/conv_hip_implicit_gemm_bwd_v1r1_xdlops_nchw_kcyx_nkhw.cpp
@@ -224,8 +224,7 @@ void PerformanceImplicitGemmBwdV1R1Xdlops::EuristicInit(const ConvolutionContext
     // final check
     if(!tmp.IsReallyValid(ctx))
     {
-        MIOPEN_LOG_E("All attempts failed");
-        assert(false);
+        MIOPEN_LOG_I("All attempts failed");
     }
     *this = tmp;
     MIOPEN_LOG_I(ToString());
@@ -789,6 +788,13 @@ ConvSolution ConvHipImplicitGemmBwdDataV1R1Xdlops::GetSolution(
     const ConvolutionContext& ctx, const PerformanceImplicitGemmBwdV1R1Xdlops& config, bool) const
 {
     ConvSolution result;
+
+    if(!config.IsReallyValid(ctx))
+    {
+        MIOPEN_LOG_E("invalid performance parameter");
+        assert(false);
+    }
+
     KernelInfo construction_parameters;
 
     construction_parameters.kernel_file =

--- a/src/solver/conv_hip_implicit_gemm_fwd_v4r4_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_fwd_v4r4_xdlops.cpp
@@ -245,8 +245,7 @@ void PerformanceImplicitGemmForwardV4R4Xdlops::EuristicInit(const ConvolutionCon
     // final check
     if(!tmp.IsReallyValid(ctx))
     {
-        MIOPEN_LOG_E("All attempts failed");
-        assert(false);
+        MIOPEN_LOG_I("All attempts failed");
     }
     *this = tmp;
     MIOPEN_LOG_I(ToString());
@@ -854,9 +853,14 @@ ConvSolution ConvHipImplicitGemmForwardV4R4Xdlops::GetSolution(
     bool) const
 {
     ConvSolution result;
-    KernelInfo construction_parameters;
 
-    assert(config.IsReallyValid(ctx));
+    if(!config.IsReallyValid(ctx))
+    {
+        MIOPEN_LOG_E("invalid performance parameter");
+        assert(false);
+    }
+
+    KernelInfo construction_parameters;
 
     construction_parameters.kernel_file =
         "gridwise_convolution_forward_implicit_gemm_v4r4_xdlops_nchw_kcyx_nkhw.cpp";

--- a/src/solver/conv_hip_implicit_gemm_fwd_v4r4_xdlops_padded_gemm.cpp
+++ b/src/solver/conv_hip_implicit_gemm_fwd_v4r4_xdlops_padded_gemm.cpp
@@ -257,8 +257,7 @@ void PerformanceImplicitGemmForwardV4R4Xdlops_Padded_Gemm::EuristicInit(
     // final check
     if(!tmp.IsReallyValid(ctx))
     {
-        MIOPEN_LOG_E("All attempts failed");
-        assert(false);
+        MIOPEN_LOG_I("All attempts failed");
     }
     *this = tmp;
     MIOPEN_LOG_I(ToString());
@@ -898,9 +897,14 @@ ConvSolution ConvHipImplicitGemmForwardV4R4Xdlops_Padded_Gemm::GetSolution(
     bool) const
 {
     ConvSolution result;
-    KernelInfo construction_parameters;
 
-    assert(config.IsReallyValid(ctx));
+    if(!config.IsReallyValid(ctx))
+    {
+        MIOPEN_LOG_E("invalid performance parameter");
+        assert(false);
+    }
+
+    KernelInfo construction_parameters;
 
     construction_parameters.kernel_file =
         "gridwise_convolution_forward_implicit_gemm_v4r4_xdlops_nchw_kcyx_nkhw_padded_gemm.cpp";

--- a/src/solver/conv_hip_implicit_gemm_fwd_v4r5_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_fwd_v4r5_xdlops.cpp
@@ -277,8 +277,7 @@ void PerformanceImplicitGemmForwardV4R5Xdlops::EuristicInit(const ConvolutionCon
     // final check
     if(!tmp.IsReallyValid(ctx))
     {
-        MIOPEN_LOG_E("All attempts failed");
-        assert(false);
+        MIOPEN_LOG_I("All attempts failed");
     }
     *this = tmp;
     MIOPEN_LOG_I(ToString());
@@ -877,9 +876,14 @@ ConvSolution ConvHipImplicitGemmForwardV4R5Xdlops::GetSolution(
     bool) const
 {
     ConvSolution result;
-    KernelInfo construction_parameters;
 
-    assert(config.IsReallyValid(ctx));
+    if(!config.IsReallyValid(ctx))
+    {
+        MIOPEN_LOG_E("invalid performance parameter");
+        assert(false);
+    }
+
+    KernelInfo construction_parameters;
 
     construction_parameters.kernel_file =
         "gridwise_convolution_forward_implicit_gemm_v4r5_xdlops_nchw_kcyx_nkhw.cpp";

--- a/src/solver/conv_hip_implicit_gemm_wrw_v4r4_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_wrw_v4r4_xdlops.cpp
@@ -334,7 +334,7 @@ PerformanceImplicitGemmWrwV4R4Xdlops::CalculateGemmSizeAndGemmKBlock(
 
         int grid_size_without_split_gemmk = g * (gemm_m / GemmMPerBlock) * (gemm_n / GemmNPerBlock);
 
-        const int max_grid_size = 20 * ctx.GetStream().GetMaxComputeUnits();
+        const int max_grid_size = 20 * static_cast<int>(ctx.GetStream().GetMaxComputeUnits());
 
         gemm_k_block = std::max(max_grid_size / grid_size_without_split_gemmk, 1);
         gemm_k_block = std::min(gemm_k_block, n);

--- a/src/solver/conv_hip_implicit_gemm_wrw_v4r4_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_wrw_v4r4_xdlops.cpp
@@ -41,7 +41,7 @@ namespace solver {
 
 PerformanceImplicitGemmWrwV4R4Xdlops::PerformanceImplicitGemmWrwV4R4Xdlops()
     : PerformanceImplicitGemmWrwV4R4Xdlops::PerformanceImplicitGemmWrwV4R4Xdlops(
-          64, 64, 2, 32, 32, 4, false, false)
+          4, 4, 1, 4, 4, 1, false, false)
 {
 }
 
@@ -274,12 +274,17 @@ PerformanceImplicitGemmWrwV4R4Xdlops::CalculateGridSize(const ConvolutionContext
 
     try
     {
+        bool valid = false;
+
         int gemm_g = -1;
         int gemm_m = -1;
         int gemm_n = -1;
 
-        std::tie(gemm_g, gemm_m, gemm_n, std::ignore, std::ignore, std::ignore) =
+        std::tie(gemm_g, gemm_m, gemm_n, std::ignore, std::ignore, valid) =
             CalculateGemmSizeAndGemmKBlock(ctx);
+
+        if(!valid)
+            MIOPEN_THROW("invalid performance parameter");
 
         if(!(gemm_m % GemmMPerBlock == 0 && gemm_n % GemmNPerBlock == 0))
             MIOPEN_THROW("invalid performance parameter");

--- a/src/solver/conv_hip_implicit_gemm_wrw_v4r4_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_wrw_v4r4_xdlops.cpp
@@ -233,8 +233,7 @@ void PerformanceImplicitGemmWrwV4R4Xdlops::EuristicInit(const ConvolutionContext
     // final check
     if(!tmp.IsReallyValid(ctx))
     {
-        MIOPEN_LOG_E("All attempts failed");
-        assert(false);
+        MIOPEN_LOG_I("All attempts failed");
     }
     *this = tmp;
     MIOPEN_LOG_I(ToString());
@@ -852,9 +851,14 @@ ConvSolution ConvHipImplicitGemmWrwV4R4Xdlops::GetSolution(
     const ConvolutionContext& ctx, const PerformanceImplicitGemmWrwV4R4Xdlops& config, bool) const
 {
     ConvSolution result;
-    KernelInfo construction_parameters;
 
-    assert(config.IsReallyValid(ctx));
+    if(!config.IsReallyValid(ctx))
+    {
+        MIOPEN_LOG_E("invalid performance parameter");
+        assert(false);
+    }
+
+    KernelInfo construction_parameters;
 
     construction_parameters.kernel_file =
         "gridwise_convolution_backward_weights_implicit_gemm_v4r4_xdlops_nchw_kcyx_nkhw.cpp";

--- a/src/solver/conv_hip_implicit_gemm_wrw_v4r4_xdlops_padded_gemm.cpp
+++ b/src/solver/conv_hip_implicit_gemm_wrw_v4r4_xdlops_padded_gemm.cpp
@@ -847,7 +847,7 @@ PerformanceImplicitGemmWrwV4R4Xdlops_Padded_Gemm::CalculateGemmSizeAndGemmKBlock
 
         int grid_size_without_split_gemmk = g * (gemm_m / GemmMPerBlock) * (gemm_n / GemmNPerBlock);
 
-        const int max_grid_size = 20 * ctx.GetStream().GetMaxComputeUnits();
+        const int max_grid_size = 20 * static_cast<int>(ctx.GetStream().GetMaxComputeUnits());
 
         // calculate gemm_k_block
         gemm_k_block = std::max(max_grid_size / grid_size_without_split_gemmk, 1);
@@ -864,7 +864,6 @@ PerformanceImplicitGemmWrwV4R4Xdlops_Padded_Gemm::CalculateGemmSizeAndGemmKBlock
 
             // pad gemm_k_total
             gemm_k_total = ((gemm_k_total_no_pad - 1) / GemmKTotalFactor + 1) * GemmKTotalFactor;
-            gemm_k_total_pad = gemm_k_total - gemm_k_total_no_pad;
 
             if(!(gemm_k_total % (GemmKPerBlock * GemmKPack) == 0))
                 continue;
@@ -879,7 +878,9 @@ PerformanceImplicitGemmWrwV4R4Xdlops_Padded_Gemm::CalculateGemmSizeAndGemmKBlock
 
         const auto gemm_k_total_no_pad = n_sub * ho * wo;
 
-        gemm_k_total     = ((gemm_k_total_no_pad - 1) / GemmKTotalFactor + 1) * GemmKTotalFactor;
+        gemm_k_total = ((gemm_k_total_no_pad - 1) / GemmKTotalFactor + 1) * GemmKTotalFactor;
+
+        // gemm_k_total_pad
         gemm_k_total_pad = gemm_k_total - gemm_k_total_no_pad;
 
         // gemm_g

--- a/src/solver/conv_hip_implicit_gemm_wrw_v4r4_xdlops_padded_gemm.cpp
+++ b/src/solver/conv_hip_implicit_gemm_wrw_v4r4_xdlops_padded_gemm.cpp
@@ -238,8 +238,7 @@ void PerformanceImplicitGemmWrwV4R4Xdlops_Padded_Gemm::EuristicInit(const Convol
     // final check
     if(!tmp.IsReallyValid(ctx))
     {
-        MIOPEN_LOG_E("All attempts failed");
-        assert(false);
+        MIOPEN_LOG_I("All attempts failed");
     }
     *this = tmp;
     MIOPEN_LOG_I(ToString());
@@ -918,9 +917,14 @@ ConvSolution ConvHipImplicitGemmWrwV4R4Xdlops_Padded_Gemm::GetSolution(
     bool) const
 {
     ConvSolution result;
-    KernelInfo construction_parameters;
 
-    assert(config.IsReallyValid(ctx));
+    if(!config.IsReallyValid(ctx))
+    {
+        MIOPEN_LOG_E("invalid performance parameter");
+        assert(false);
+    }
+
+    KernelInfo construction_parameters;
 
     construction_parameters.kernel_file = "gridwise_convolution_backward_weights_implicit_gemm_"
                                           "v4r4_xdlops_nchw_kcyx_nkhw_padded_gemm.cpp";


### PR DESCRIPTION
1. Refactor some of functions for ```ConvHipImplicitGemmWrwV4R4Xdlops``` and ```ConvHipImplicitGemmWrwV4R4Xdlops_Padded_Gemm``` performance parameter calculation
2. Fix performance parameter calculation issues in ```ConvHipImplicitGemmWrwV4R4Xdlops_Padded_Gemm``` that cause several compilation failures in 
http://ontrack-internal.amd.com/browse/SWDEV-258416
http://ontrack-internal.amd.com/browse/SWDEV-257202
```
MIOpenDriver conv -F 4 -n 120 -g 1 -k 340 -c 256 -H  1 -W  1 -y 3 -x 3 -p 1 -q 1 -u 1 -v 1 -l 1 -j 1 -V 1 -w 1 -t 1 -i 1 
MIOpenDriver conv -F 4 -n 120 -c 510 -H 5 -W 5 -k 250 -y 3 -x 3 -p 1 -q 1 -u 1 -v 1 -l 1 -j 1 -g 1 -t 1
```
3. Fixed bwd-data-v4r1 issue: need to call SetZero for some cases.