### PR TITLE
Fixed offload_arch cflags with targetID HIP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -181,8 +181,17 @@ endif()
 find_package(hip REQUIRED PATHS /opt/rocm)
 message(STATUS "Build with HIP ${hip_VERSION}")
 target_flags(HIP_COMPILER_FLAGS hip::device)
+
+if(HIP_COMPILER_FLAGS MATCHES "offload-arch")
+	add_definitions("-DMIOPEN_ARCH_FLAG=\"offload-arch\"")
+else()
+	add_definitions("-DMIOPEN_ARCH_FLAG=\"cuda-gpu-arch\"")
+endif()
+
+
 # Remove cuda arch flags
 string(REGEX REPLACE --cuda-gpu-arch=[a-z0-9]+ "" HIP_COMPILER_FLAGS "${HIP_COMPILER_FLAGS}")
+string(REGEX REPLACE --offload-arch=[a-z0-9]+ "" HIP_COMPILER_FLAGS "${HIP_COMPILER_FLAGS}")
 
 message(STATUS "Hip compiler flags: ${HIP_COMPILER_FLAGS}")
 

--- a/src/hip/hip_build_utils.cpp
+++ b/src/hip/hip_build_utils.cpp
@@ -118,7 +118,6 @@ boost::filesystem::path HipBuild(boost::optional<TmpDir>& tmp_dir,
         params += " -O3 ";
     }
 
-    //std::cerr << ">>>>>>>>>>>> HIP_COMPILER_FLAGS: " << MIOPEN_STRINGIZE(HIP_COMPILER_FLAGS) << std::endl;
     params += " -Wno-unused-command-line-argument -I. ";
     params += MIOPEN_STRINGIZE(HIP_COMPILER_FLAGS);
     params += " --" + std::string(MIOPEN_ARCH_FLAG) + "=" + dev_name;
@@ -161,7 +160,6 @@ boost::filesystem::path HipBuild(boost::optional<TmpDir>& tmp_dir,
         std::string(" -DHIP_PACKAGE_VERSION_FLAT=") + std::to_string(HIP_PACKAGE_VERSION_FLAT);
 
     params += " ";
-    std::cerr << ">>>>>>>>>>>> params = " << params << std::endl;
     auto bin_file = tmp_dir->path / (filename + ".o");
 
     // compile

--- a/src/hip/hip_build_utils.cpp
+++ b/src/hip/hip_build_utils.cpp
@@ -118,8 +118,10 @@ boost::filesystem::path HipBuild(boost::optional<TmpDir>& tmp_dir,
         params += " -O3 ";
     }
 
+    //std::cerr << ">>>>>>>>>>>> HIP_COMPILER_FLAGS: " << MIOPEN_STRINGIZE(HIP_COMPILER_FLAGS) << std::endl;
     params += " -Wno-unused-command-line-argument -I. ";
     params += MIOPEN_STRINGIZE(HIP_COMPILER_FLAGS);
+    params += " --" + std::string(MIOPEN_ARCH_FLAG) + "=" + dev_name;
     if(IsHccCompiler())
     {
         env += std::string("KMOPTLLC=\"-mattr=+enable-ds128 ");
@@ -159,6 +161,7 @@ boost::filesystem::path HipBuild(boost::optional<TmpDir>& tmp_dir,
         std::string(" -DHIP_PACKAGE_VERSION_FLAT=") + std::to_string(HIP_PACKAGE_VERSION_FLAT);
 
     params += " ";
+    std::cerr << ">>>>>>>>>>>> params = " << params << std::endl;
     auto bin_file = tmp_dir->path / (filename + ".o");
 
     // compile

--- a/src/hip/hip_build_utils.cpp
+++ b/src/hip/hip_build_utils.cpp
@@ -113,6 +113,7 @@ boost::filesystem::path HipBuild(boost::optional<TmpDir>& tmp_dir,
         if(params.find("-std=") == std::string::npos)
             params += " --std=c++11";
         params += " --cuda-gpu-arch=" + dev_name;
+        params += " --" + std::string(MIOPEN_ARCH_FLAG) + "=" + dev_name;
         params += " --cuda-device-only";
         params += " -c";
         params += " -O3 ";
@@ -120,7 +121,6 @@ boost::filesystem::path HipBuild(boost::optional<TmpDir>& tmp_dir,
 
     params += " -Wno-unused-command-line-argument -I. ";
     params += MIOPEN_STRINGIZE(HIP_COMPILER_FLAGS);
-    params += " --" + std::string(MIOPEN_ARCH_FLAG) + "=" + dev_name;
     if(IsHccCompiler())
     {
         env += std::string("KMOPTLLC=\"-mattr=+enable-ds128 ");


### PR DESCRIPTION
- To fix the issue: SWDEV-259381 that introduces new offload_arch flags for all supported devices, which causes the following error
`fatal error: error in backend: Cannot select: intrinsic %llvm.amdgcn.mfma.f32.32x32x4f16`
- Remove all offload_arch flags in HIP_COMPILER_FLAGS, and then add offload_arch flag back with the target device.