### PR TITLE
Early escape for compile_only + custom err

### DIFF
--- a/include/miopen/miopen.h
+++ b/include/miopen/miopen.h
@@ -103,6 +103,7 @@ typedef enum {
     miopenStatusNotImplemented = 6, /*!< Use of unimplemented feature. */
     miopenStatusUnknownError   = 7, /*!< Unknown error occurred. */
     miopenStatusUnsupportedOp  = 8, /*!< Unsupported operator for fusion. */
+    miopenStatusNoGPU          = 9, /*!< GPU operations skipped. */
 } miopenStatus_t;
 
 /*! @brief Get character string for an error code.

--- a/include/miopen/miopen.h
+++ b/include/miopen/miopen.h
@@ -94,16 +94,16 @@ MIOPEN_DECLARE_OBJECT(miopenHandle);
  * Error codes that are returned by all MIOpen API calls.
 */
 typedef enum {
-    miopenStatusSuccess        = 0, /*!< No errors */
-    miopenStatusNotInitialized = 1, /*!< Data not initialized. */
-    miopenStatusInvalidValue   = 2, /*!< Incorrect variable value. */
-    miopenStatusBadParm        = 3, /*!< Incorrect parameter detected. */
-    miopenStatusAllocFailed    = 4, /*!< Memory allocation error. */
-    miopenStatusInternalError  = 5, /*!< MIOpen failure. */
-    miopenStatusNotImplemented = 6, /*!< Use of unimplemented feature. */
-    miopenStatusUnknownError   = 7, /*!< Unknown error occurred. */
-    miopenStatusUnsupportedOp  = 8, /*!< Unsupported operator for fusion. */
-    miopenStatusNoGPU          = 9, /*!< GPU operations skipped. */
+    miopenStatusSuccess              = 0, /*!< No errors */
+    miopenStatusNotInitialized       = 1, /*!< Data not initialized. */
+    miopenStatusInvalidValue         = 2, /*!< Incorrect variable value. */
+    miopenStatusBadParm              = 3, /*!< Incorrect parameter detected. */
+    miopenStatusAllocFailed          = 4, /*!< Memory allocation error. */
+    miopenStatusInternalError        = 5, /*!< MIOpen failure. */
+    miopenStatusNotImplemented       = 6, /*!< Use of unimplemented feature. */
+    miopenStatusUnknownError         = 7, /*!< Unknown error occurred. */
+    miopenStatusUnsupportedOp        = 8, /*!< Unsupported operator for fusion. */
+    miopenStatusGpuOperationsSkipped = 9, /*!< This is not an error. */
 } miopenStatus_t;
 
 /*! @brief Get character string for an error code.

--- a/src/handle_api.cpp
+++ b/src/handle_api.cpp
@@ -49,6 +49,8 @@ extern "C" const char* miopenGetErrorString(miopenStatus_t error)
     case miopenStatusUnknownError: return "miopenStatusUnknownError";
 
     case miopenStatusUnsupportedOp: return "miopenStatusUnsupportedOp";
+
+    case miopenStatusNoGPU: return "miopenStatusNoGPU";
     }
     return "Unknown error status";
 }

--- a/src/handle_api.cpp
+++ b/src/handle_api.cpp
@@ -50,7 +50,7 @@ extern "C" const char* miopenGetErrorString(miopenStatus_t error)
 
     case miopenStatusUnsupportedOp: return "miopenStatusUnsupportedOp";
 
-    case miopenStatusNoGPU: return "miopenStatusNoGPU";
+    case miopenStatusGpuOperationsSkipped: return "miopenStatusGpuOperationsSkipped";
     }
     return "Unknown error status";
 }

--- a/src/include/miopen/generic_search.hpp
+++ b/src/include/miopen/generic_search.hpp
@@ -481,7 +481,7 @@ auto GenericSearch(const Solver s, const Context& context, const AnyInvokeParams
     }
     else
     {
-        MIOPEN_THROW("Running kernels on GPU is disabled. Search skipped");
+        MIOPEN_THROW(miopenStatusNoGPU, "Running kernels on GPU is disabled. Search skipped");
     }
 
     MIOPEN_LOG_W("Done: " << n_runs_total << '/' << n_failed << '/' << n_runs_total << ", best #"

--- a/src/include/miopen/generic_search.hpp
+++ b/src/include/miopen/generic_search.hpp
@@ -481,7 +481,7 @@ auto GenericSearch(const Solver s, const Context& context, const AnyInvokeParams
     }
     else
     {
-        MIOPEN_THROW(miopenStatusNoGPU, "Running kernels on GPU is disabled. Search skipped");
+        MIOPEN_THROW(miopenStatusGpuOperationsSkipped, "Running kernels on GPU is disabled. Search skipped");
     }
 
     MIOPEN_LOG_W("Done: " << n_runs_total << '/' << n_failed << '/' << n_runs_total << ", best #"

--- a/src/include/miopen/generic_search.hpp
+++ b/src/include/miopen/generic_search.hpp
@@ -481,7 +481,8 @@ auto GenericSearch(const Solver s, const Context& context, const AnyInvokeParams
     }
     else
     {
-        MIOPEN_THROW(miopenStatusGpuOperationsSkipped, "Running kernels on GPU is disabled. Search skipped");
+        MIOPEN_THROW(miopenStatusGpuOperationsSkipped,
+                     "Running kernels on GPU is disabled. Search skipped");
     }
 
     MIOPEN_LOG_W("Done: " << n_runs_total << '/' << n_failed << '/' << n_runs_total << ", best #"

--- a/src/ocl/convolutionocl.cpp
+++ b/src/ocl/convolutionocl.cpp
@@ -3071,9 +3071,10 @@ void ConvolutionDescriptor::FindConvBwdWeightsAlgorithm(Handle& handle,
     }
 
     if(IsEnabled(MIOPEN_DEBUG_COMPILE_ONLY{}))
-        MIOPEN_THROW(miopenStatusGpuOperationsSkipped, "MIOPEN_DEBUG_COMPILE_ONLY is enabled, "
-                                                       "escaping backwards convolution. Search "
-                                                       "skipped.");
+        MIOPEN_THROW(miopenStatusGpuOperationsSkipped,
+                     "MIOPEN_DEBUG_COMPILE_ONLY is enabled, "
+                     "escaping backwards convolution. Search "
+                     "skipped.");
 
     if(perf_db.empty())
         MIOPEN_THROW("Backward Weights Convolution cannot be executed due to incorrect params");

--- a/src/ocl/convolutionocl.cpp
+++ b/src/ocl/convolutionocl.cpp
@@ -789,7 +789,7 @@ void ConvolutionDescriptor::FindConvFwdAlgorithm(Handle& handle,
     }
 
     if(IsEnabled(MIOPEN_DEBUG_COMPILE_ONLY{}))
-       MIOPEN_THROW(miopenStatusNoGPU,
+        MIOPEN_THROW(miopenStatusGpuOperationsSkipped,
             "MIOPEN_DEBUG_COMPILE_ONLY is enabled, escaping forward convolution. Search skipped.");
 
     if(perf_db.empty())
@@ -2299,7 +2299,7 @@ void ConvolutionDescriptor::FindConvBwdDataAlgorithm(Handle& handle,
     }
 
     if(IsEnabled(MIOPEN_DEBUG_COMPILE_ONLY{}))
-       MIOPEN_THROW(miopenStatusNoGPU,
+        MIOPEN_THROW(miopenStatusGpuOperationsSkipped,
             "MIOPEN_DEBUG_COMPILE_ONLY is enabled, escaping bwd convolution. Search skipped.");
 
     if(perf_db.empty())
@@ -3069,7 +3069,7 @@ void ConvolutionDescriptor::FindConvBwdWeightsAlgorithm(Handle& handle,
     }
 
     if(IsEnabled(MIOPEN_DEBUG_COMPILE_ONLY{}))
-       MIOPEN_THROW(miopenStatusNoGPU,
+        MIOPEN_THROW(miopenStatusGpuOperationsSkipped,
           "MIOPEN_DEBUG_COMPILE_ONLY is enabled, escaping backwards convolution. Search skipped.");
 
     if(perf_db.empty())

--- a/src/ocl/convolutionocl.cpp
+++ b/src/ocl/convolutionocl.cpp
@@ -789,7 +789,8 @@ void ConvolutionDescriptor::FindConvFwdAlgorithm(Handle& handle,
     }
 
     if(IsEnabled(MIOPEN_DEBUG_COMPILE_ONLY{}))
-        MIOPEN_THROW(miopenStatusGpuOperationsSkipped,
+        MIOPEN_THROW(
+            miopenStatusGpuOperationsSkipped,
             "MIOPEN_DEBUG_COMPILE_ONLY is enabled, escaping forward convolution. Search skipped.");
 
     if(perf_db.empty())
@@ -2299,7 +2300,8 @@ void ConvolutionDescriptor::FindConvBwdDataAlgorithm(Handle& handle,
     }
 
     if(IsEnabled(MIOPEN_DEBUG_COMPILE_ONLY{}))
-        MIOPEN_THROW(miopenStatusGpuOperationsSkipped,
+        MIOPEN_THROW(
+            miopenStatusGpuOperationsSkipped,
             "MIOPEN_DEBUG_COMPILE_ONLY is enabled, escaping bwd convolution. Search skipped.");
 
     if(perf_db.empty())
@@ -3069,8 +3071,9 @@ void ConvolutionDescriptor::FindConvBwdWeightsAlgorithm(Handle& handle,
     }
 
     if(IsEnabled(MIOPEN_DEBUG_COMPILE_ONLY{}))
-        MIOPEN_THROW(miopenStatusGpuOperationsSkipped,
-          "MIOPEN_DEBUG_COMPILE_ONLY is enabled, escaping backwards convolution. Search skipped.");
+        MIOPEN_THROW(miopenStatusGpuOperationsSkipped, "MIOPEN_DEBUG_COMPILE_ONLY is enabled, "
+                                                       "escaping backwards convolution. Search "
+                                                       "skipped.");
 
     if(perf_db.empty())
         MIOPEN_THROW("Backward Weights Convolution cannot be executed due to incorrect params");

--- a/src/ocl/convolutionocl.cpp
+++ b/src/ocl/convolutionocl.cpp
@@ -69,6 +69,7 @@ MIOPEN_DECLARE_ENV_VAR(MIOPEN_CONV_PRECISE_ROCBLAS_TIMING)
 MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEBUG_CONV_FFT)
 MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEVICE_ARCH)
 MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEBUG_CONV_IMMED_FALLBACK)
+MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEBUG_COMPILE_ONLY)
 
 #if MIOPEN_USE_GEMM
 #ifdef CPPCHECK
@@ -786,6 +787,10 @@ void ConvolutionDescriptor::FindConvFwdAlgorithm(Handle& handle,
                             use_winograd_only);
         });
     }
+
+    if(IsEnabled(MIOPEN_DEBUG_COMPILE_ONLY{}))
+       MIOPEN_THROW(miopenStatusNoGPU,
+            "MIOPEN_DEBUG_COMPILE_ONLY is enabled, escaping forward convolution. Search skipped.");
 
     if(perf_db.empty())
         MIOPEN_THROW("Forward Convolution cannot be executed due to incorrect params");
@@ -2293,6 +2298,10 @@ void ConvolutionDescriptor::FindConvBwdDataAlgorithm(Handle& handle,
         });
     }
 
+    if(IsEnabled(MIOPEN_DEBUG_COMPILE_ONLY{}))
+       MIOPEN_THROW(miopenStatusNoGPU,
+            "MIOPEN_DEBUG_COMPILE_ONLY is enabled, escaping forward convolution. Search skipped.");
+
     if(perf_db.empty())
         MIOPEN_THROW(miopenStatusUnknownError,
                      "Backward Data Convolution cannot be executed due to incorrect params");
@@ -3058,6 +3067,10 @@ void ConvolutionDescriptor::FindConvBwdWeightsAlgorithm(Handle& handle,
             }
         });
     }
+
+    if(IsEnabled(MIOPEN_DEBUG_COMPILE_ONLY{}))
+       MIOPEN_THROW(miopenStatusNoGPU,
+            "MIOPEN_DEBUG_COMPILE_ONLY is enabled, escaping forward convolution. Search skipped.");
 
     if(perf_db.empty())
         MIOPEN_THROW("Backward Weights Convolution cannot be executed due to incorrect params");

--- a/src/ocl/convolutionocl.cpp
+++ b/src/ocl/convolutionocl.cpp
@@ -2300,7 +2300,7 @@ void ConvolutionDescriptor::FindConvBwdDataAlgorithm(Handle& handle,
 
     if(IsEnabled(MIOPEN_DEBUG_COMPILE_ONLY{}))
        MIOPEN_THROW(miopenStatusNoGPU,
-            "MIOPEN_DEBUG_COMPILE_ONLY is enabled, escaping forward convolution. Search skipped.");
+            "MIOPEN_DEBUG_COMPILE_ONLY is enabled, escaping bwd convolution. Search skipped.");
 
     if(perf_db.empty())
         MIOPEN_THROW(miopenStatusUnknownError,
@@ -3070,7 +3070,7 @@ void ConvolutionDescriptor::FindConvBwdWeightsAlgorithm(Handle& handle,
 
     if(IsEnabled(MIOPEN_DEBUG_COMPILE_ONLY{}))
        MIOPEN_THROW(miopenStatusNoGPU,
-            "MIOPEN_DEBUG_COMPILE_ONLY is enabled, escaping forward convolution. Search skipped.");
+          "MIOPEN_DEBUG_COMPILE_ONLY is enabled, escaping backwards convolution. Search skipped.");
 
     if(perf_db.empty())
         MIOPEN_THROW("Backward Weights Convolution cannot be executed due to incorrect params");


### PR DESCRIPTION
During compile only perf_db is empty hence we would see "...cannot be executed due to incorrect params" err thrown, but we want to customize this err since its caused by compiling only and we want Tuna to recognize it.