### PR TITLE
[tests] Reduce of workload for "test_sqlite_perfdb --all"

### DIFF
--- a/test/sqlite_perfdb.cpp
+++ b/test/sqlite_perfdb.cpp
@@ -1236,9 +1236,9 @@ struct PerfDbDriver : test_driver
         if(full_set)
         {
             tests::full_set()                         = true;
-            DBMultiThreadedTestWork::threads_count    = 32;
-            DBMultiThreadedTestWork::common_part_size = 128;
-            DBMultiThreadedTestWork::unique_part_size = 128;
+            DBMultiThreadedTestWork::threads_count    = 16;
+            DBMultiThreadedTestWork::common_part_size = 32;
+            DBMultiThreadedTestWork::unique_part_size = 32;
         }
         if(mt_child_id >= 0)
         {


### PR DESCRIPTION
Currently the test has imperfections that can lead to timeouts under heavy loads. This should reduce the probability of timeouts, especially on systems with slow HDD.

On my system (fast SSD storage):

test | \<blank\> | --all
-- | -- | --
test_perfdb | 1.6 sec | 13 sec 
test_sqlite_perfdb (baseline) | 29 sec | __480 sec__
test_sqlite_perfdb (this PR) | 29 sec | ___114 sec___
