### PR TITLE
Workaround for SWDEV-262823

### DIFF
--- a/src/hip/handlehip.cpp
+++ b/src/hip/handlehip.cpp
@@ -520,7 +520,7 @@ std::size_t Handle::GetMaxMemoryAllocSize()
     return m_MaxMemoryAllocSizeCached;
 }
 
-std::string Handle::GetDeviceName() const
+static std::string GetDeviceNameImpl(const std::unique_ptr<HandleImpl>& handle_impl)
 {
     const char* const arch = miopen::GetStringEnv(MIOPEN_DEVICE_ARCH{});
     if(arch != nullptr && strlen(arch) > 0)
@@ -528,9 +528,15 @@ std::string Handle::GetDeviceName() const
         return arch;
     }
     hipDeviceProp_t props{};
-    hipGetDeviceProperties(&props, this->impl->device);
+    hipGetDeviceProperties(&props, handle_impl->device);
     std::string n("gfx" + std::to_string(props.gcnArch));
     return GetDeviceNameFromMap(n);
+}
+
+std::string Handle::GetDeviceName() const
+{
+    static const auto rv = GetDeviceNameImpl(this->impl);
+    return rv;
 }
 
 std::ostream& Handle::Print(std::ostream& os) const

--- a/src/include/miopen/device_name.hpp
+++ b/src/include/miopen/device_name.hpp
@@ -59,9 +59,9 @@ std::string inline GetDeviceNameFromMap(const std::string& name)
     if(p_asciz != nullptr && strlen(p_asciz) > 0)
         return {p_asciz};
 
-    auto device_name_iterator = device_name_map.find(name);
-    if(device_name_iterator != device_name_map.end())
-        return device_name_iterator->second;
+    auto match = device_name_map.find(name);
+    if(match != device_name_map.end())
+        return match->second;
     return name;
 }
 

--- a/src/include/miopen/device_name.hpp
+++ b/src/include/miopen/device_name.hpp
@@ -26,6 +26,8 @@
 #ifndef GUARD_MIOPEN_DEVICE_NAME_HPP
 #define GUARD_MIOPEN_DEVICE_NAME_HPP
 
+#define WORKAROUND_SWDEV_262823 1
+
 #include <map>
 #include <string>
 #include <miopen/env.hpp>
@@ -36,7 +38,7 @@ MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEVICE_CU)
 
 namespace miopen {
 
-std::string inline GetDeviceNameFromMap(const std::string& name)
+std::string inline GetDeviceNameFromMap(const std::string& in)
 {
 
     static std::map<std::string, std::string> device_name_map = {
@@ -58,6 +60,12 @@ std::string inline GetDeviceNameFromMap(const std::string& name)
     const char* const p_asciz = miopen::GetStringEnv(MIOPEN_DEBUG_ENFORCE_DEVICE{});
     if(p_asciz != nullptr && strlen(p_asciz) > 0)
         return {p_asciz};
+
+#if WORKAROUND_SWDEV_262823
+    const auto name = in.substr(0, in.find(':')); // str.substr(0, npos) returns str.
+#else
+    const auto name(in);
+#endif
 
     auto match = device_name_map.find(name);
     if(match != device_name_map.end())

--- a/src/include/miopen/device_name.hpp
+++ b/src/include/miopen/device_name.hpp
@@ -49,13 +49,9 @@ std::string inline GetDeviceNameFromMap(const std::string& name)
         {"Fiji", "gfx803"},
         {"gfx800", "gfx803"},
         {"gfx802", "gfx803"},
-        {"gfx803", "gfx803"},
         {"gfx804", "gfx803"},
         {"Vega10", "gfx900"},
-        {"gfx900", "gfx900"},
         {"gfx901", "gfx900"},
-        {"gfx906", "gfx906"},
-        {"gfx908", "gfx908"},
         {"10.3.0 Sienna_Cichlid 18", "gfx1030"},
     };
 

--- a/src/include/miopen/device_name.hpp
+++ b/src/include/miopen/device_name.hpp
@@ -55,22 +55,14 @@ std::string inline GetDeviceNameFromMap(const std::string& name)
         {"10.3.0 Sienna_Cichlid 18", "gfx1030"},
     };
 
-    std::string n(name);
     const char* const p_asciz = miopen::GetStringEnv(MIOPEN_DEBUG_ENFORCE_DEVICE{});
     if(p_asciz != nullptr && strlen(p_asciz) > 0)
-    {
-        n = p_asciz;
-    }
+        return {p_asciz};
 
-    auto device_name_iterator = device_name_map.find(n);
+    auto device_name_iterator = device_name_map.find(name);
     if(device_name_iterator != device_name_map.end())
-    {
         return device_name_iterator->second;
-    }
-    else
-    {
-        return n;
-    }
+    return name;
 }
 
 } // namespace miopen

--- a/src/ocl/handleocl.cpp
+++ b/src/ocl/handleocl.cpp
@@ -635,7 +635,7 @@ std::size_t Handle::GetGlobalMemorySize() const
     return miopen::GetDeviceInfo<CL_DEVICE_GLOBAL_MEM_SIZE>(miopen::GetDevice(this->GetStream()));
 }
 
-static std::string GetDeviceNameImpl(miopenAcceleratorQueue_t& stream) const
+static std::string GetDeviceNameImpl(miopenAcceleratorQueue_t stream)
 {
     const char* const arch = miopen::GetStringEnv(MIOPEN_DEVICE_ARCH{});
     if(arch != nullptr && strlen(arch) > 0)

--- a/src/ocl/handleocl.cpp
+++ b/src/ocl/handleocl.cpp
@@ -635,16 +635,22 @@ std::size_t Handle::GetGlobalMemorySize() const
     return miopen::GetDeviceInfo<CL_DEVICE_GLOBAL_MEM_SIZE>(miopen::GetDevice(this->GetStream()));
 }
 
-std::string Handle::GetDeviceName() const
+static std::string GetDeviceNameImpl(miopenAcceleratorQueue_t& stream) const
 {
     const char* const arch = miopen::GetStringEnv(MIOPEN_DEVICE_ARCH{});
     if(arch != nullptr && strlen(arch) > 0)
     {
         return arch;
     }
-    std::string name = miopen::GetDeviceInfo<CL_DEVICE_NAME>(miopen::GetDevice(this->GetStream()));
+    std::string name = miopen::GetDeviceInfo<CL_DEVICE_NAME>(miopen::GetDevice(stream));
     ParseDevName(name);
     return GetDeviceNameFromMap(name);
+}
+
+std::string Handle::GetDeviceName() const
+{
+    static const auto rv = GetDeviceNameImpl(this->GetStream());
+    return rv;
 }
 
 std::ostream& Handle::Print(std::ostream& os) const


### PR DESCRIPTION
- Trim target features from the device name, e.g. `gfx908:sramecc+:xnack-` -> `gfx908`.
  - [Note] This PR is NFC if target features are not reported by runtime.
- Optimize for speed to compensate for additional calculations in `GetDeviceName()`.
