### PR TITLE
[Driver] Allow arbitrary solver id in `-S`. Support symbolic solver names.

### DIFF
--- a/driver/conv_driver.hpp
+++ b/driver/conv_driver.hpp
@@ -2545,6 +2545,8 @@ int ConvDriver<Tgpu, Tref>::RunBackwardDataGpuImmed()
         handle, outputTensor, weightTensor, convDesc, inputTensor, selected->solution_id, &ws_size);
     bwd_auxiliary_gwss.pause(wall_enabled);
     bwd_auxiliary.pause(wall_enabled);
+    if(rc != miopenStatusSuccess)
+        return rc;
 
 #if MIOPEN_BACKEND_OPENCL
     cl_context ctx;
@@ -2676,6 +2678,8 @@ int ConvDriver<Tgpu, Tref>::RunBackwardWrwGpuImmed()
         handle, outputTensor, inputTensor, convDesc, weightTensor, selected->solution_id, &ws_size);
     wrw_auxiliary_gwss.pause(wall_enabled);
     wrw_auxiliary.pause(wall_enabled);
+    if(rc != miopenStatusSuccess)
+        return rc;
 
 #if MIOPEN_BACKEND_OPENCL
     cl_context ctx;

--- a/driver/conv_driver.hpp
+++ b/driver/conv_driver.hpp
@@ -63,6 +63,7 @@
 #include <vector>
 #include <type_traits>
 #include <boost/range/adaptors.hpp>
+#include <boost/optional/optional_io.hpp>
 #include <../test/verify.hpp>
 #include <../test/serialize.hpp>
 #include <../test/tensor_holder.hpp>
@@ -450,8 +451,17 @@ int ConvDriver<Tgpu, Tref>::ParseCmdLineArgs(int argc, char* argv[])
     is_bwd = (inflags.GetValueInt("forw") == 0 || inflags.GetValueInt("forw") & 2);
     is_wrw = (inflags.GetValueInt("forw") == 0 || inflags.GetValueInt("forw") & 4);
 
-    const auto solution_value = inflags.GetValueInt("solution");
-
+    const auto solution_str = inflags.GetValueStr("solution");
+    auto solution_value     = static_cast<int>(miopen::solver::Id(solution_str.c_str()).Value());
+    if(solution_value == 0) // Assume number on input
+    {
+        solution_value = std::strtol(solution_str.c_str(), nullptr, 10);
+        if(errno == ERANGE)
+        {
+            errno          = 0;
+            solution_value = 0;
+        }
+    }
     if(solution_value >= 0)
         immediate_solution = solution_value;
 
@@ -628,8 +638,11 @@ int ConvDriver<Tgpu, Tref>::AddCmdLineArgs()
                          "\nAccepts integer argument N:"
                          "\n=0 Immediate mode, build and run fastest solution"
                          "\n>0 Immediate mode, build and run solution_id = N"
-                         "\n<0 Use Find() API (Default=-1)",
-                         "int");
+                         "\n<0 Use Find() API (Default=-1)"
+                         "\nAlso accepts symbolic name of solution:"
+                         "\n<valid name>   Immediate mode, build and run specified solution"
+                         "\n<invalid name> Use Find() API",
+                         "string");
 
     return 0;
 }
@@ -1804,10 +1817,13 @@ int ConvDriver<Tgpu, Tref>::RunForwardGpuImmed(const bool is_transform)
                 break;
             }
 
+    miopenConvSolution_t voluntary = {
+        -1.0, 0, *immediate_solution, static_cast<miopenConvAlgorithm_t>(-1)};
     if(selected == nullptr)
     {
-        std::cout << "Invalid solution id: " << *immediate_solution << std::endl;
-        return miopenStatusBadParm;
+        std::cout << "Warning: Solution id (" << *immediate_solution
+                  << ") is not reported by the library. Trying it anyway..." << std::endl;
+        selected = &voluntary;
     }
 
     std::size_t ws_size;
@@ -2512,10 +2528,13 @@ int ConvDriver<Tgpu, Tref>::RunBackwardDataGpuImmed()
                 break;
             }
 
+    miopenConvSolution_t voluntary = {
+        -1.0, 0, *immediate_solution, static_cast<miopenConvAlgorithm_t>(-1)};
     if(selected == nullptr)
     {
-        std::cout << "Invalid solution id: " << *immediate_solution << std::endl;
-        return miopenStatusBadParm;
+        std::cout << "Warning: Solution id (" << *immediate_solution
+                  << ") is not reported by the library. Trying it anyway..." << std::endl;
+        selected = &voluntary;
     }
 
     std::size_t ws_size;
@@ -2640,10 +2659,13 @@ int ConvDriver<Tgpu, Tref>::RunBackwardWrwGpuImmed()
                 break;
             }
 
+    miopenConvSolution_t voluntary = {
+        -1.0, 0, *immediate_solution, static_cast<miopenConvAlgorithm_t>(-1)};
     if(selected == nullptr)
     {
-        std::cout << "Invalid solution id: " << *immediate_solution << std::endl;
-        return miopenStatusBadParm;
+        std::cout << "Warning: Solution id (" << *immediate_solution
+                  << ") is not reported by the library. Trying it anyway..." << std::endl;
+        selected = &voluntary;
     }
 
     std::size_t ws_size;


### PR DESCRIPTION
Notice `-S 13` here:
```
$ ./bin/MIOpenDriver conv -S 13 -n 64 -c 256 -H 56 -W 56 -k 256 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -g 1 -F 2 -t 1 -V 0
MIOpenDriver conv -S 13 -n 64 -c 256 -H 56 -W 56 -k 256 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -g 1 -F 2 -t 1 -V 0 
Backward Data Conv solutions available: 4
- id: 55 algo: 5, time: 2.64976 ms, ws: 0, name: ConvHipImplicitGemmBwdDataV1R1
- id: 2 algo: 1, time: 2.6856 ms, ws: 0, name: ConvAsm1x1U
- id: 33 algo: 0, time: 2.80912 ms, ws: 0, name: gemm
- id: 37 algo: 3, time: 5.65664 ms, ws: 0, name: ConvBinWinogradRxSf3x2
Warning: Solution id (13) is not reported by the library. Trying it anyway...
MIOpen Backward Data Conv. Algorithm: -1, Solution: 13/ConvOclDirectFwd1x1
GPU Kernel Time Backward Data Conv. Elapsed: 4.330303 ms (average)
stats: name, n, c, ho, wo, x, y, k, flopCnt, bytesRead, bytesWritten, GFLOPs, GB/s, timeMs
stats: bwdd-conv1x1u1, 64, 256, 1, 1, 256, 56, 56,  26306674688, 17039360, 205520896, 6075, 51, 4.330303
```
And `-S ConvOclDirectFwd1x1` here:
```
$ ./bin/MIOpenDriver conv -S ConvOclDirectFwd1x1 -n 64 -c 256 -H 56 -W 56 -k 256 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -g 1 -F 2 -t 1 -V 0
MIOpenDriver conv -S ConvOclDirectFwd1x1 -n 64 -c 256 -H 56 -W 56 -k 256 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -g 1 -F 2 -t 1 -V 0
Backward Data Conv solutions available: 4
- id: 55 algo: 5, time: 2.64976 ms, ws: 0, name: ConvHipImplicitGemmBwdDataV1R1
- id: 2 algo: 1, time: 2.6856 ms, ws: 0, name: ConvAsm1x1U
- id: 33 algo: 0, time: 2.80912 ms, ws: 0, name: gemm
- id: 37 algo: 3, time: 5.65664 ms, ws: 0, name: ConvBinWinogradRxSf3x2
Warning: Solution id (13) is not reported by the library. Trying it anyway...
MIOpen Backward Data Conv. Algorithm: -1, Solution: 13/ConvOclDirectFwd1x1
GPU Kernel Time Backward Data Conv. Elapsed: 4.425041 ms (average)
stats: name, n, c, ho, wo, x, y, k, flopCnt, bytesRead, bytesWritten, GFLOPs, GB/s, timeMs
stats: bwdd-conv1x1u1, 64, 256, 1, 1, 256, 56, 56,  26306674688, 17039360, 205520896, 5945, 50, 4.425041
```