### PR TITLE
Immediate Mode Fallback: Implement & use GetWti for Winograd v21_1_1 and GEMM

### DIFF
--- a/src/include/miopen/convolution.hpp
+++ b/src/include/miopen/convolution.hpp
@@ -445,6 +445,10 @@ struct ConvolutionDescriptor : miopenConvolutionDescriptor
                             const TensorDescriptor& xDesc,
                             const TensorDescriptor& yDesc) const;
 
+    float ComputeGemmWtiBwd(const TensorDescriptor& dyDesc,
+                            const TensorDescriptor& wDesc,
+                            const TensorDescriptor& dxDesc) const;
+
     float ComputeGemmWtiWrw(const TensorDescriptor& dyDesc,
                             const TensorDescriptor& xDesc,
                             const TensorDescriptor& dwDesc) const;

--- a/src/include/miopen/convolution.hpp
+++ b/src/include/miopen/convolution.hpp
@@ -441,6 +441,10 @@ struct ConvolutionDescriptor : miopenConvolutionDescriptor
                              const TensorDescriptor& xDesc,
                              const TensorDescriptor& dwDesc) const;
 
+    float ComputeGemmWtiFwd(const TensorDescriptor& wDesc,
+                            const TensorDescriptor& xDesc,
+                            const TensorDescriptor& yDesc) const;
+
     std::size_t GetSolutionCountFallback(Handle& handle, const ProblemDescription& problem) const;
 };
 

--- a/src/include/miopen/convolution.hpp
+++ b/src/include/miopen/convolution.hpp
@@ -445,6 +445,10 @@ struct ConvolutionDescriptor : miopenConvolutionDescriptor
                             const TensorDescriptor& xDesc,
                             const TensorDescriptor& yDesc) const;
 
+    float ComputeGemmWtiWrw(const TensorDescriptor& dyDesc,
+                            const TensorDescriptor& xDesc,
+                            const TensorDescriptor& dwDesc) const;
+
     std::size_t GetSolutionCountFallback(Handle& handle, const ProblemDescription& problem) const;
 };
 

--- a/src/include/miopen/solver.hpp
+++ b/src/include/miopen/solver.hpp
@@ -1373,7 +1373,6 @@ struct ConvBinWinograd3x3U : SolverBase<ConvolutionContext>
 {
     bool IsApplicable(const ConvolutionContext& params) const;
     bool IsDynamic() const { return true; }
-    float GetWti(const ConvolutionContext& params) const;
     ConvSolution GetSolution(const ConvolutionContext& params) const;
 };
 

--- a/src/include/miopen/solver.hpp
+++ b/src/include/miopen/solver.hpp
@@ -1438,6 +1438,7 @@ struct ConvBinWinogradRxSf2x3g1 : SolverBase<ConvolutionContext>
 {
     bool IsApplicable(const ConvolutionContext& params) const;
     bool IsDynamic() const { return true; }
+    float GetWti(const ConvolutionContext& params) const;
     ConvSolution GetSolution(const ConvolutionContext& params) const;
 };
 

--- a/src/include/miopen/solver.hpp
+++ b/src/include/miopen/solver.hpp
@@ -1424,6 +1424,7 @@ struct ConvBinWinogradRxSf2x3 : SolverBase<ConvolutionContext>
 
     bool IsApplicable(const ConvolutionContext& params) const;
     bool IsDynamic() const { return true; }
+    float GetWti(const ConvolutionContext& params) const;
     ConvSolution GetSolution(const ConvolutionContext& params,
                              const PerformanceConfigConvBinWinogradRxSf2x3& config,
                              bool disableConfigOverrideFromEnv = false) const;

--- a/src/ocl/convolutionocl.cpp
+++ b/src/ocl/convolutionocl.cpp
@@ -1493,6 +1493,94 @@ struct SolutionSortWrapper : miopenConvSolution_t
     }
 };
 
+float ConvolutionDescriptor::ComputeGemmWtiFwd(const TensorDescriptor& wDesc,
+                                               const TensorDescriptor& xDesc,
+                                               const TensorDescriptor& yDesc) const
+
+{
+    int n_transpose_NCHW2CNHW    = 0;
+    int n_transpose_CNHW2NCHW    = 0;
+    int n_gemm_strided_batched   = 1; // not strided-batched by default
+    int n_gemm_runs              = 1;
+    int n_transpose_packed_MN2NM = 0;
+    int n_CastTensor             = 0;
+    int n_Im2ColGPU              = 0;
+
+    std::size_t in_n, in_c;
+    std::tie(in_n, in_c) = tie_pick<0, 1>()(xDesc.GetLengths());
+    std::size_t spatial_dim = GetSpatialDimension();
+    auto wei_spatial        = boost::adaptors::slice(wDesc.GetLengths(), 2, 2 + spatial_dim);
+
+    // Use transpose path 1x1, stride=2
+    if(GetSpatialDimension() == 2 && miopen::all_of(wei_spatial, [](auto v) { return v == 1; }) &&
+       miopen::all_of(GetConvPads(), [](auto v) { return v == 0; }) &&
+       miopen::all_of(GetConvStrides(), [](auto v) { return v == 2; }))
+    {
+        n_transpose_NCHW2CNHW = 1;
+        if(wDesc.GetType() == miopenInt8)
+            n_transpose_packed_MN2NM = 1;
+        n_gemm_strided_batched       = group_count;
+        n_transpose_CNHW2NCHW        = 1;
+        if((wDesc.GetType() == miopenInt8 || wDesc.GetType() == miopenInt8x4) &&
+           yDesc.GetType() != miopenInt32)
+            n_CastTensor = 1;
+    }
+    // 1x1_stride=1 with GEMM and zero workspace
+    else if(miopen::all_of(wei_spatial, [](auto v) { return v == 1; }) &&
+            miopen::all_of(GetConvPads(), [](auto v) { return v == 0; }) &&
+            miopen::all_of(GetConvStrides(), [](auto v) { return v == 1; }))
+    {
+
+        if(wDesc.GetType() == miopenInt8)
+        {
+            n_transpose_packed_MN2NM = in_n;
+            n_gemm_runs              = in_n;
+        }
+        else
+        {
+            n_gemm_strided_batched = group_count;
+            n_gemm_runs            = in_n;
+        }
+        if((wDesc.GetType() == miopenInt8 || wDesc.GetType() == miopenInt8x4) &&
+           yDesc.GetType() != miopenInt32)
+            n_CastTensor = 1;
+    }
+    else // not 1x1
+    {
+        n_Im2ColGPU = in_n;
+        if(wDesc.GetType() == miopenInt8)
+            n_transpose_packed_MN2NM = in_n;
+        n_gemm_strided_batched       = group_count;
+        n_gemm_runs                  = in_n;
+        if((wDesc.GetType() == miopenInt8 || wDesc.GetType() == miopenInt8x4) &&
+           yDesc.GetType() != miopenInt32)
+            n_CastTensor = 1;
+    }
+
+    auto slowdownFactor =
+        [](int n_oper, const double oper_factor, const double multiple_oper_factor) {
+            if(n_oper > 0)
+            {
+                auto rv = oper_factor;
+                if(n_oper > 1)
+                    rv *= multiple_oper_factor;
+                return rv;
+            }
+            else
+                return 1.0;
+        };
+
+    auto wti = 1.0;
+    wti *= slowdownFactor(n_transpose_NCHW2CNHW, 0.7, 0.9);
+    wti *= slowdownFactor(n_transpose_CNHW2NCHW, 0.7, 0.9);
+    wti *= slowdownFactor(n_gemm_runs, 0.9, 0.9);
+    wti *= slowdownFactor(n_gemm_strided_batched, 1.0, 0.95);
+    wti *= slowdownFactor(n_transpose_packed_MN2NM, 0.7, 0.9);
+    wti *= slowdownFactor(n_CastTensor, 0.95, 0.9);
+    wti *= slowdownFactor(n_Im2ColGPU, 0.4, 0.8);
+    return wti;
+}
+
 void ConvolutionDescriptor::GetSolutionsFallback(Handle& handle,
                                                  const ProblemDescription& problem,
                                                  const size_t maxSolutionCount,
@@ -1524,6 +1612,13 @@ void ConvolutionDescriptor::GetSolutionsFallback(Handle& handle,
     ctx.SetStream(&handle);
     ctx.DetectRocm();
 
+    const auto wti2time = [](const float& wti) {
+        assert(wti != 0.0f);
+        if(wti <= 0.0f) // Return negative values as is, avoid DIV/0.
+            return wti;
+        return 10.0f / wti; // Assume WTI == 1.0 (100%) is 10 ms.
+    };
+
     const auto& map = miopen::solver::GetMapValueToAnySolver();
     for(const auto& item : map)
     {
@@ -1545,11 +1640,10 @@ void ConvolutionDescriptor::GetSolutionsFallback(Handle& handle,
 
         const auto wti = s.GetWti(ctx);
         MIOPEN_LOG_I2(solver_id.ToString() << " Estimated WTI = " << wti);
-        if(wti <= 0.0f) // Skip unknown WTIs and avoid DIV/0.
+        if(wti < 0.0f) // Skip unknown WTIs.
             continue;
-        const auto time = 10.0f / wti; // Assume WTI == 1.0 (100%) is 10 ms.
 
-        interim.emplace_back(time, s.GetWorkspaceSize(ctx), solver_id.Value(), algo);
+        interim.emplace_back(wti2time(wti), s.GetWorkspaceSize(ctx), solver_id.Value(), algo);
     }
 
     /// Separate path for GEMM algo, intermediate implementation.
@@ -1559,7 +1653,7 @@ void ConvolutionDescriptor::GetSolutionsFallback(Handle& handle,
         if(IsGemmApplicableFwd(weightsDesc, inDesc, outDesc))
         {
             interim.emplace_back(
-                -1.0,
+                wti2time(ComputeGemmWtiFwd(weightsDesc, inDesc, outDesc)),
                 ForwardGetValidWorkSpaceSizeGemm(handle, weightsDesc, inDesc, outDesc),
                 solver::Id::gemm().Value(),
                 miopenConvolutionAlgoGEMM);

--- a/src/ocl/convolutionocl.cpp
+++ b/src/ocl/convolutionocl.cpp
@@ -1582,6 +1582,59 @@ float ConvolutionDescriptor::ComputeGemmWtiFwd(const TensorDescriptor& wDesc,
     return wti;
 }
 
+float ConvolutionDescriptor::ComputeGemmWtiBwd(const TensorDescriptor& dyDesc,
+                                               const TensorDescriptor& wDesc,
+                                               const TensorDescriptor& dxDesc) const
+{
+    std::ignore = dyDesc;
+
+    int n_SetTensor            = 0;
+    int n_transpose_NCHW2CNHW  = 0;
+    int n_transpose_CNHW2NCHW  = 0;
+    int n_gemm_strided_batched = 1; // not strided-batched by default
+    int n_gemm_runs            = 1;
+    int n_Col2ImGPU            = 0;
+
+    std::size_t in_n, in_c;
+    std::tie(in_n, in_c) = tie_pick<0, 1>()(dxDesc.GetLengths());
+    std::size_t spatial_dim = GetSpatialDimension();
+    auto wei_spatial        = boost::adaptors::slice(wDesc.GetLengths(), 2, 2 + spatial_dim);
+
+    // 1x1 does not require col2im
+    if(GetSpatialDimension() == 2 && miopen::all_of(wei_spatial, [](auto v) { return v == 1; }) &&
+       miopen::all_of(GetConvPads(), [](auto v) { return v == 0; }) &&
+       miopen::all_of(GetConvStrides(), [](auto v) { return v == 2; }))
+    {
+        n_SetTensor            = 1;
+        n_transpose_NCHW2CNHW  = 1;
+        n_gemm_strided_batched = group_count;
+        n_transpose_CNHW2NCHW  = 1;
+    }
+    // 1x1_stride=1 convolutions use GEMM and zero workspace
+    else if(miopen::all_of(wei_spatial, [](auto v) { return v == 1; }) &&
+            miopen::all_of(GetConvPads(), [](auto v) { return v == 0; }) &&
+            miopen::all_of(GetConvStrides(), [](auto v) { return v == 1; }))
+    {
+        n_gemm_strided_batched = in_n;
+    }
+    // if not 1x1
+    else
+    {
+        n_gemm_strided_batched = group_count;
+        n_gemm_runs            = in_n;
+        n_Col2ImGPU            = in_n;
+    }
+
+    auto wti = 1.0;
+    wti *= SlowdownFactor(n_SetTensor, 0.95, 0.99);
+    wti *= SlowdownFactor(n_transpose_NCHW2CNHW, 0.7, 0.9);
+    wti *= SlowdownFactor(n_transpose_CNHW2NCHW, 0.7, 0.9);
+    wti *= SlowdownFactor(n_gemm_runs, 0.9, 0.9);
+    wti *= SlowdownFactor(n_gemm_strided_batched, 1.0, 0.95);
+    wti *= SlowdownFactor(n_Col2ImGPU, 0.4, 0.8);
+    return wti;
+}
+
 float ConvolutionDescriptor::ComputeGemmWtiWrw(const TensorDescriptor& dyDesc,
                                                const TensorDescriptor& xDesc,
                                                const TensorDescriptor& dwDesc) const
@@ -1705,7 +1758,7 @@ void ConvolutionDescriptor::GetSolutionsFallback(Handle& handle,
     {
         if(IsGemmApplicableBwd(outDesc, weightsDesc, inDesc))
         {
-            interim.emplace_back(-1.0,
+            interim.emplace_back(wti2time(ComputeGemmWtiBwd(outDesc, weightsDesc, inDesc)),
                                  BackwardGetValidWorkSpaceSizeGemm(outDesc, weightsDesc, inDesc),
                                  solver::Id::gemm().Value(),
                                  miopenConvolutionAlgoGEMM);

--- a/src/ocl/convolutionocl.cpp
+++ b/src/ocl/convolutionocl.cpp
@@ -1414,8 +1414,10 @@ static const char immFallbackFailed[] =
 std::size_t ConvolutionDescriptor::GetSolutionCountFallback(Handle& handle,
                                                             const ProblemDescription& problem) const
 {
-    size_t n = 0;
-    GetSolutionsFallback(handle, problem, 1, &n, nullptr);
+    size_t n                    = 0;
+    const auto maxSolutionCount = miopen::solver::GetMapValueToAnySolver()
+                                      .size(); // Simple and guarantees to provide enough space.
+    GetSolutionsFallback(handle, problem, maxSolutionCount, &n, nullptr);
     if(n > 0)
         return n;
     MIOPEN_LOG_I(immFallbackFailed);
@@ -1475,7 +1477,20 @@ struct SolutionSortWrapper : miopenConvSolution_t
         : miopenConvSolution_t{t, ws, id, algo}
     {
     }
-    bool operator<(const SolutionSortWrapper& other) const { return (time < other.time); }
+    bool operator<(const SolutionSortWrapper& other) const
+    {
+        // Negative values are very coarse estimations.
+        // The more modulus, the "worse" (slower) is solution.
+        if(time < 0 && other.time < 0)
+            return !(time < other.time);
+        // Positive values are always "better" than negative (coarse) estimations.
+        if(time > 0 && other.time < 0)
+            return true;
+        if(time < 0 && other.time > 0)
+            return false;
+        // Both values are positive. The less is the better.
+        return (time < other.time);
+    }
 };
 
 void ConvolutionDescriptor::GetSolutionsFallback(Handle& handle,
@@ -1520,10 +1535,7 @@ void ConvolutionDescriptor::GetSolutionsFallback(Handle& handle,
             continue;
         const auto& s = item.second;
         if(!s.IsDynamic()) // Let's allow non-dynamic later, if necessary.
-        {
-            MIOPEN_LOG_I2(solver_id.ToString() << " Not dynamic, skipped");
             continue;
-        }
         if(!s.IsApplicable(ctx))
             continue;
 
@@ -1540,79 +1552,37 @@ void ConvolutionDescriptor::GetSolutionsFallback(Handle& handle,
         interim.emplace_back(time, s.GetWorkspaceSize(ctx), solver_id.Value(), algo);
     }
 
-    // Dual purpose variable:
-    // * Used as index for writing into output array (solutions).
-    // * Counts the number of entries written, yielding value for solutionsCount.
-    auto i = std::size_t{0};
-
-    if(!interim.empty())
-    {
-        std::sort(begin(interim), end(interim));
-        for(const auto& entry : interim)
-        {
-            if(i >= maxSolutionCount)
-                break;
-            if(solutions != nullptr)
-                solutions[i] = entry;
-            ++i;
-        }
-        *solutionCount = i;
-        /// Right now we do not have GetWti() for GEMM.
-        /// And only those solutions that are faster than GEMM return WTI.
-        /// Therefore it is Ok for now to not use GEMM if some other solution is found.
-        /// \todo Rework this when we have GetWti() for GEMM.
-        return;
-    }
-
     /// Separate path for GEMM algo, intermediate implementation.
     /// \todo Remove when GEMM Solver(s) ready.
-    if(i >= maxSolutionCount)
+    if(problem.direction.IsForward())
     {
-        // Do nothing.
-    }
-    else if(problem.direction.IsForward())
-    {
-        if(IsGemmApplicableFwd(weightsDesc, inDesc, outDesc) && (i < maxSolutionCount))
+        if(IsGemmApplicableFwd(weightsDesc, inDesc, outDesc))
         {
-            if(solutions != nullptr)
-            {
-                solutions[i].algorithm = miopenConvolutionAlgoGEMM;
-                solutions[i].time      = -1.0;
-                solutions[i].workspace_size =
-                    ForwardGetValidWorkSpaceSizeGemm(handle, weightsDesc, inDesc, outDesc);
-                solutions[i].solution_id = solver::Id::gemm().Value();
-            }
-            ++i;
+            interim.emplace_back(
+                -1.0,
+                ForwardGetValidWorkSpaceSizeGemm(handle, weightsDesc, inDesc, outDesc),
+                solver::Id::gemm().Value(),
+                miopenConvolutionAlgoGEMM);
         }
     }
     else if(problem.direction.IsBackwardData())
     {
-        if(IsGemmApplicableBwd(outDesc, weightsDesc, inDesc) && (i < maxSolutionCount))
+        if(IsGemmApplicableBwd(outDesc, weightsDesc, inDesc))
         {
-            if(solutions != nullptr)
-            {
-                solutions[i].algorithm = miopenConvolutionAlgoGEMM;
-                solutions[i].time      = -1.0;
-                solutions[i].workspace_size =
-                    BackwardGetValidWorkSpaceSizeGemm(outDesc, weightsDesc, inDesc);
-                solutions[i].solution_id = solver::Id::gemm().Value();
-            }
-            ++i;
+            interim.emplace_back(-1.0,
+                                 BackwardGetValidWorkSpaceSizeGemm(outDesc, weightsDesc, inDesc),
+                                 solver::Id::gemm().Value(),
+                                 miopenConvolutionAlgoGEMM);
         }
     }
     else if(problem.direction.IsBackwardWrW())
     {
-        if(IsGemmApplicableWrw(outDesc, inDesc, weightsDesc) && (i < maxSolutionCount))
+        if(IsGemmApplicableWrw(outDesc, inDesc, weightsDesc))
         {
-            if(solutions != nullptr)
-            {
-                solutions[i].algorithm = miopenConvolutionAlgoGEMM;
-                solutions[i].time      = -1.0;
-                solutions[i].workspace_size =
-                    WrwGetValidWorkSpaceSizeGemm(outDesc, inDesc, weightsDesc);
-                solutions[i].solution_id = solver::Id::gemm().Value();
-            }
-            ++i;
+            interim.emplace_back(-1.0,
+                                 WrwGetValidWorkSpaceSizeGemm(outDesc, inDesc, weightsDesc),
+                                 solver::Id::gemm().Value(),
+                                 miopenConvolutionAlgoGEMM);
         }
     }
     else
@@ -1620,6 +1590,26 @@ void ConvolutionDescriptor::GetSolutionsFallback(Handle& handle,
         MIOPEN_THROW("Unknown direction");
     }
 
+    MIOPEN_LOG_I2("maxSolutionCount = " << maxSolutionCount << ", available = " << interim.size());
+    for(const auto& s : interim)
+        MIOPEN_LOG_I2("id: " << s.solution_id << " algo: " << s.algorithm << ", time: " << s.time
+                             << " ms, ws: "
+                             << s.workspace_size
+                             << ", name: "
+                             << miopen::solver::Id(s.solution_id).ToString());
+    // Dual purpose variable:
+    // * Used as index for writing into output array (solutions).
+    // * Counts the number of entries written, yielding value for solutionsCount.
+    auto i = std::size_t{0};
+    std::sort(begin(interim), end(interim));
+    for(const auto& entry : interim)
+    {
+        if(i >= maxSolutionCount)
+            break;
+        if(solutions != nullptr)
+            solutions[i] = entry;
+        ++i;
+    }
     *solutionCount = i;
 }
 

--- a/src/solver/conv_bin_wino3x3U.cpp
+++ b/src/solver/conv_bin_wino3x3U.cpp
@@ -40,14 +40,6 @@ MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEBUG_AMD_WINOGRAD_3X3)
 namespace miopen {
 namespace solver {
 
-float ConvBinWinograd3x3U::GetWti(const ConvolutionContext& params) const
-{
-    // Temporary implementation that matches IsWinograd3x3SupportedAndFast().
-    if(params.n_outputs >= 16 && params.n_outputs % 2 == 0)
-        return 2.0;
-    return -2.0;
-}
-
 bool ConvBinWinograd3x3U::IsApplicable(const ConvolutionContext& params) const
 {
     if(miopen::IsDisabled(MIOPEN_DEBUG_AMD_WINOGRAD_3X3{}))

--- a/src/solver/conv_winoRxS_f2x3.cpp
+++ b/src/solver/conv_winoRxS_f2x3.cpp
@@ -302,7 +302,113 @@ ConvBinWinogradRxSf2x3::Search(const ConvolutionContext& context,
     return GenericSearch(*this, context, invoke_ctx);
 }
 
-float ConvBinWinogradRxSf2x3::GetWti(const ConvolutionContext& params) const { return -2.0; }
+struct UnifiedConv2d
+{
+    int64_t K;               // X
+    int64_t S;               // Y
+    int64_t C;               // V
+    int64_t N;               // W
+    int64_t R;               // Z
+    int64_t pad_w;           // AA
+    int64_t pad_h;           // AB
+    int64_t U;               // AC
+    int64_t V;               // AD
+    int64_t out_w;           // AE
+    int64_t out_h;           // AF
+    int64_t input_stride_w;  // AG -p -q
+    int64_t input_stride_h;  // AH
+    int64_t filter_stride_w; // AI -l -j
+    int64_t filter_stride_h; // AJ
+    UnifiedConv2d() = delete;
+
+    // Fwd                  WrW
+    // ----------------------------------------
+    // kernel_size_h        in_height
+    // kernel_size_w        in_width
+    // kernel_stride_h      kernel_dilation_h
+    // kernel_stride_w      kernel_dilation_w
+    // n_inputs_per_group   batch_sz
+    // n_outputs_per_group  n_inputs_per_group
+    // in_height            out_height
+    // in_width             out_width
+    // out_height           kernel_size_h
+    // out_width            kernel_size_w
+    // batch_sz             n_outputs_per_group
+    //
+    // KT      XLS             DRIVER                                  PROBLEM DESCRIPTION
+    // -----------------------------------------------------------------------------------
+    // fdil := filter_stride   -l/j filter dilation                    kernel_dilation
+    // strd := U/V             -u/v convolution stride (output stride) kernel_stride
+    // idil := input dilation  (n/a except transposed convolutions)    ?
+
+    UnifiedConv2d(const ConvolutionContext& params)
+    {
+        const auto n_inputs_per_group  = params.n_inputs / params.group_counts;
+        const auto n_outputs_per_group = params.n_outputs / params.group_counts;
+        if(!params.direction.IsBackwardWrW())
+        {
+            R     = params.kernel_size_h;
+            S     = params.kernel_size_w;
+            U     = params.direction.IsForward() ? params.kernel_stride_h : 1;
+            V     = params.direction.IsForward() ? params.kernel_stride_w : 1;
+            C     = n_inputs_per_group; // Bwd: C and K is reversed in ProblemDescription
+            K     = n_outputs_per_group;
+            out_h = params.out_height; // Bwd: height/width is reversed in ProblemDescription
+            out_w = params.out_width;
+            N     = params.batch_sz;
+            pad_h = params.direction.IsForward() ? params.pad_h : params.GetBackwardPadH();
+            pad_w = params.direction.IsForward() ? params.pad_w : params.GetBackwardPadW();
+            input_stride_h  = params.direction.IsForward() ? 1 : params.kernel_stride_h;
+            input_stride_w  = params.direction.IsForward() ? 1 : params.kernel_stride_w;
+            filter_stride_h = params.kernel_dilation_h;
+            filter_stride_w = params.kernel_dilation_w;
+        }
+        else
+        { // WrW
+            R               = params.in_height;
+            S               = params.in_width;
+            U               = params.kernel_dilation_h;
+            V               = params.kernel_dilation_w;
+            C               = params.batch_sz;
+            K               = n_inputs_per_group;
+            out_h           = params.kernel_size_h;
+            out_w           = params.kernel_size_w;
+            N               = n_outputs_per_group;
+            pad_h           = params.pad_h;
+            pad_w           = params.pad_w;
+            input_stride_h  = 1;
+            input_stride_w  = 1;
+            filter_stride_h = params.kernel_stride_h;
+            filter_stride_w = params.kernel_stride_w;
+        }
+    }
+};
+
+float ConvBinWinogradRxSf2x3::GetWti(const ConvolutionContext& params) const
+{
+    constexpr auto WTI_UNKNOWN = -2.0;
+    UnifiedConv2d u(params);
+    if(!(params.group_counts == 1) || //
+       !(u.pad_h == 1) ||             //
+       !(u.pad_h == 1) ||             //
+       !(u.U == 1) ||                 //
+       !(u.V == 1) ||                 //
+       !(u.input_stride_h == 1) ||    //
+       !(u.input_stride_w == 1) ||    //
+       !(u.filter_stride_h == 1) ||   //
+       !(u.filter_stride_w == 1) ||   //
+       !(u.R <= 5) ||                 //
+       !(u.S <= 5) ||                 //
+       !(u.C >= 16) ||                //
+       !(u.K >= 16))                  //
+        return WTI_UNKNOWN;
+
+    const auto DATATYPE_BITS = 32; // S // 16 for FP16 // FIXME
+    const auto n_groups      = 60; // BQ = 60 // FIXME
+
+    // FIXME // if GUI_ACTIVE clocks > 10^5
+    return WTI_UNKNOWN;
+}
 
 static bool IsApplicableBase(const ConvolutionContext& params)
 {

--- a/src/solver/conv_winoRxS_f2x3.cpp
+++ b/src/solver/conv_winoRxS_f2x3.cpp
@@ -302,44 +302,6 @@ ConvBinWinogradRxSf2x3::Search(const ConvolutionContext& context,
     return GenericSearch(*this, context, invoke_ctx);
 }
 
-inline void FillVarsFromConfig(int& H,
-                               int& W,
-                               int& R,
-                               int& S,
-                               int& R_stride,
-                               int& S_stride,
-                               int& C,
-                               int& K,
-                               int& out_H,
-                               int& out_W,
-                               int& pad_H,
-                               int& pad_W,
-                               int& N,
-                               int& idilation_w,
-                               int& idilation_h,
-                               int& n_groups,
-                               int& group_cnt,
-                               const ConvolutionContext& config)
-{
-    group_cnt   = config.group_counts;
-    n_groups    = config.GetStream().GetMaxComputeUnits();
-    pad_H       = config.direction.IsForward() ? config.pad_h : config.GetBackwardPadH();
-    pad_W       = config.direction.IsForward() ? config.pad_w : config.GetBackwardPadW();
-    H           = config.in_height;
-    W           = config.in_width;
-    R           = config.kernel_size_h;
-    S           = config.kernel_size_w;
-    R_stride    = config.kernel_stride_h;
-    S_stride    = config.kernel_stride_w;
-    C           = config.n_inputs;
-    K           = config.n_outputs;
-    out_H       = config.out_height;
-    out_W       = config.out_width;
-    N           = config.batch_sz;
-    idilation_w = config.kernel_dilation_h;
-    idilation_h = config.kernel_dilation_w;
-}
-
 static bool IsApplicableBase(const ConvolutionContext& params)
 {
     if(!params.Is2d())

--- a/src/solver/conv_winoRxS_f2x3.cpp
+++ b/src/solver/conv_winoRxS_f2x3.cpp
@@ -302,6 +302,8 @@ ConvBinWinogradRxSf2x3::Search(const ConvolutionContext& context,
     return GenericSearch(*this, context, invoke_ctx);
 }
 
+float ConvBinWinogradRxSf2x3::GetWti(const ConvolutionContext& params) const { return -2.0; }
+
 static bool IsApplicableBase(const ConvolutionContext& params)
 {
     if(!params.Is2d())

--- a/src/solver/conv_winoRxS_f2x3.cpp
+++ b/src/solver/conv_winoRxS_f2x3.cpp
@@ -427,11 +427,16 @@ class ShaderModel : public UnifiedDescriptionConv2d
     }
 };
 
-float ConvBinWinogradRxSf2x3::GetWti(const ConvolutionContext& params) const
+static float GetWtiBase(const ConvolutionContext& params)
 {
     constexpr auto WTI_UNKNOWN = -2.0;
     const auto rv              = ShaderModel(params).ComputeWti();
     return rv < 0 ? WTI_UNKNOWN : rv;
+}
+
+float ConvBinWinogradRxSf2x3::GetWti(const ConvolutionContext& params) const
+{
+    return GetWtiBase(params);
 }
 
 static bool IsApplicableBase(const ConvolutionContext& params)
@@ -821,6 +826,11 @@ bool ConvBinWinogradRxSf2x3g1::IsApplicable(const ConvolutionContext& params) co
     if(miopen::IsDisabled(MIOPEN_DEBUG_AMD_WINOGRAD_RXS_F2X3_G1{}))
         return false;
     return IsApplicableBase(params) && params.group_counts == 1;
+}
+
+float ConvBinWinogradRxSf2x3g1::GetWti(const ConvolutionContext& params) const
+{
+    return GetWtiBase(params);
 }
 
 ConvSolution ConvBinWinogradRxSf2x3g1::GetSolution(const ConvolutionContext& params) const

--- a/src/solver/conv_winoRxS_f2x3.cpp
+++ b/src/solver/conv_winoRxS_f2x3.cpp
@@ -161,7 +161,7 @@ inline bool IsShaderContraintsMet(const int R,
 {
     // Padding for bwd data shall not be negative.
     /// \todo Either remove WrW related code or re-use function from RxS
-    if(params.direction.IsBackwardData() || params.direction.IsBackwardWrW()) // FIXME remove WrW
+    if(params.direction.IsBackwardData())
     {
         if(!(0 <= params.GetBackwardPadW() && params.GetBackwardPadW() < std::pow(2, 16)))
             return false;

--- a/src/solver/conv_winoRxS_f2x3.cpp
+++ b/src/solver/conv_winoRxS_f2x3.cpp
@@ -48,6 +48,14 @@ MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEBUG_AMD_WINOGRAD_RXS_F2X3_G1)
 #define WINOFILTER 3
 #define MAX_CU_LIMIT 512
 
+/// \todo The model is well-defined in for filters sized up to 5.
+/// However, it seems producing valid results without this limitation,
+/// when used against simple GEMM WTI model (to select the fastest solver).
+/// This needs to be re-tested/re-considered when we have WTI
+/// models for other solvers, OR when GEMM WTI model is improved.
+/// --atamazov 2020-11-07.
+#define WTI_MODEL_ALLOW_ANY_RS 1
+
 static inline size_t Ceil(const size_t v, const size_t m)
 {
     assert(m > 0);
@@ -323,9 +331,11 @@ class ShaderModel : public UnifiedDescriptionConv2d
                              !(input_stride_w == 1) ||    //
                              !(filter_stride_h == 1) ||   //
                              !(filter_stride_w == 1) ||   //
-                             !(R <= 5) ||                 //
-                             !(S <= 5) ||                 //
-                             !(C >= 16) ||                //
+#if !WTI_MODEL_ALLOW_ANY_RS
+                             !(R <= 5) || //
+                             !(S <= 5) || //
+#endif
+                             !(C >= 16) || //
                              !(K >= 16))
     {
         // Computations do not support negative padding.

--- a/src/solver/conv_winoRxS_f2x3.cpp
+++ b/src/solver/conv_winoRxS_f2x3.cpp
@@ -54,7 +54,10 @@ static inline size_t Ceil(const size_t v, const size_t m)
     return (v + m - 1) / m;
 }
 
-static inline size_t quantize_up(size_t val, size_t factor) { return Ceil(val, factor) * factor; }
+static inline size_t RoundUpToMultiple(size_t val, size_t factor)
+{
+    return Ceil(val, factor) * factor;
+}
 
 static inline int GetBestNGroupParam(const int R,
                                      const int S,
@@ -89,10 +92,10 @@ static inline int GetBestNGroupParam(const int R,
     if(S_stride == 2 || R_stride == 2 || idilation_w == 2 || idilation_h == 2)
         c_factor = 1;
 
-    size_t g_s = quantize_up(S, s_factor);
-    size_t g_r = quantize_up(R, r_factor);
-    size_t g_c = quantize_up(C, c_factor);
-    size_t g_k = quantize_up(K, k_factor);
+    size_t g_s = RoundUpToMultiple(S, s_factor);
+    size_t g_r = RoundUpToMultiple(R, r_factor);
+    size_t g_c = RoundUpToMultiple(C, c_factor);
+    size_t g_k = RoundUpToMultiple(K, k_factor);
     size_t g_w = OW;
     size_t g_h = OH;
 
@@ -101,16 +104,16 @@ static inline int GetBestNGroupParam(const int R,
     if((pad_H % 2 == 1) && (idilation_h > 1 || R_stride > 1))
         g_h += 1;
 
-    g_w            = quantize_up(g_w, w_factor);
-    g_h            = quantize_up(g_h, h_factor);
-    size_t g_n_w_h = quantize_up(g_w * g_h * N, nwh_factor * w_factor * h_factor);
+    g_w            = RoundUpToMultiple(g_w, w_factor);
+    g_h            = RoundUpToMultiple(g_h, h_factor);
+    size_t g_n_w_h = RoundUpToMultiple(g_w * g_h * N, nwh_factor * w_factor * h_factor);
 
     int best_n_groups_cnt = 1;
     double min_param      = 0;
     for(auto i = 1; i < n_groups; ++i)
     {
         size_t g_n_w_h_k =
-            quantize_up(g_n_w_h * g_k, nwh_factor * w_factor * h_factor * k_factor * i);
+            RoundUpToMultiple(g_n_w_h * g_k, nwh_factor * w_factor * h_factor * k_factor * i);
         size_t granulated_mac_count = g_n_w_h_k * g_c * g_s * g_r;
         size_t n_groups_per_cu      = Ceil(i * G, n_groups);
         double perf_metric = static_cast<double>(n_groups_per_cu) * granulated_mac_count / i;
@@ -158,7 +161,7 @@ inline bool IsShaderContraintsMet(const int R,
 {
     // Padding for bwd data shall not be negative.
     /// \todo Either remove WrW related code or re-use function from RxS
-    if(params.direction.IsBackwardData() || params.direction.IsBackwardWrW())
+    if(params.direction.IsBackwardData() || params.direction.IsBackwardWrW()) // FIXME remove WrW
     {
         if(!(0 <= params.GetBackwardPadW() && params.GetBackwardPadW() < std::pow(2, 16)))
             return false;
@@ -302,24 +305,24 @@ ConvBinWinogradRxSf2x3::Search(const ConvolutionContext& context,
     return GenericSearch(*this, context, invoke_ctx);
 }
 
-struct UnifiedConv2d
+struct UnifiedConfigConv2d
 {
-    int64_t K;               // X
-    int64_t S;               // Y
-    int64_t C;               // V
-    int64_t N;               // W
-    int64_t R;               // Z
-    int64_t pad_w;           // AA
-    int64_t pad_h;           // AB
-    int64_t U;               // AC
-    int64_t V;               // AD
-    int64_t out_w;           // AE
-    int64_t out_h;           // AF
-    int64_t input_stride_w;  // AG -p -q
-    int64_t input_stride_h;  // AH
-    int64_t filter_stride_w; // AI -l -j
-    int64_t filter_stride_h; // AJ
-    UnifiedConv2d() = delete;
+    size_t K;               // X
+    size_t S;               // Y
+    size_t C;               // V
+    size_t N;               // W
+    size_t R;               // Z
+    size_t pad_w;           // AA
+    size_t pad_h;           // AB
+    size_t U;               // AC
+    size_t V;               // AD
+    size_t out_w;           // AE
+    size_t out_h;           // AF
+    size_t input_stride_w;  // AG -p -q
+    size_t input_stride_h;  // AH
+    size_t filter_stride_w; // AI -l -j
+    size_t filter_stride_h; // AJ
+    UnifiedConfigConv2d() = delete;
 
     // Fwd                  WrW
     // ----------------------------------------
@@ -341,7 +344,7 @@ struct UnifiedConv2d
     // strd := U/V             -u/v convolution stride (output stride) kernel_stride
     // idil := input dilation  (n/a except transposed convolutions)    ?
 
-    UnifiedConv2d(const ConvolutionContext& params)
+    UnifiedConfigConv2d(const ConvolutionContext& params)
     {
         const auto n_inputs_per_group  = params.n_inputs / params.group_counts;
         const auto n_outputs_per_group = params.n_outputs / params.group_counts;
@@ -351,15 +354,17 @@ struct UnifiedConv2d
             S     = params.kernel_size_w;
             U     = params.direction.IsForward() ? params.kernel_stride_h : 1;
             V     = params.direction.IsForward() ? params.kernel_stride_w : 1;
-            C     = n_inputs_per_group; // Bwd: C and K is reversed in ProblemDescription
-            K     = n_outputs_per_group;
-            out_h = params.out_height; // Bwd: height/width is reversed in ProblemDescription
-            out_w = params.out_width;
+            C     = n_inputs_per_group;  // Bwd: C and K is reversed in ProblemDescription.
+            K     = n_outputs_per_group; // Ditto.
+            out_h = params.out_height;   // Bwd: height/width is reversed in ProblemDescription.
+            out_w = params.out_width;    // Ditto.
             N     = params.batch_sz;
-            pad_h = params.direction.IsForward() ? params.pad_h : params.GetBackwardPadH();
-            pad_w = params.direction.IsForward() ? params.pad_w : params.GetBackwardPadW();
-            input_stride_h  = params.direction.IsForward() ? 1 : params.kernel_stride_h;
-            input_stride_w  = params.direction.IsForward() ? 1 : params.kernel_stride_w;
+            assert(params.direction.IsForward() ||
+                   (params.GetBackwardPadH() >= 0 && params.GetBackwardPadW() >= 0));
+            pad_h          = params.direction.IsForward() ? params.pad_h : params.GetBackwardPadH();
+            pad_w          = params.direction.IsForward() ? params.pad_w : params.GetBackwardPadW();
+            input_stride_h = params.direction.IsForward() ? 1 : params.kernel_stride_h;
+            input_stride_w = params.direction.IsForward() ? 1 : params.kernel_stride_w;
             filter_stride_h = params.kernel_dilation_h;
             filter_stride_w = params.kernel_dilation_w;
         }
@@ -384,30 +389,120 @@ struct UnifiedConv2d
     }
 };
 
+class ShaderModel : public UnifiedConfigConv2d
+{
+    const size_t DATATYPE_BITS;    // S
+    const size_t n_groups;         // BQ ~compute units
+    const bool out_of_model_scope; // Shader model produces unreliable results.
+
+    public:
+    ShaderModel(const ConvolutionContext& ctx)
+        : UnifiedConfigConv2d(ctx),
+          DATATYPE_BITS(ctx.IsFp16() ? 16 : 32),
+          n_groups(ctx.GetStream().GetMaxComputeUnits()), /// \todo Take n_groups from PerfConfig.
+          out_of_model_scope(!(ctx.group_counts == 1) ||  //
+                             !(pad_h == 1) ||             //
+                             !(pad_h == 1) ||             //
+                             !(U == 1) ||                 //
+                             !(V == 1) ||                 //
+                             !(input_stride_h == 1) ||    //
+                             !(input_stride_w == 1) ||    //
+                             !(filter_stride_h == 1) ||   //
+                             !(filter_stride_w == 1) ||   //
+                             !(R <= 5) ||                 //
+                             !(S <= 5) ||                 //
+                             !(C >= 16) ||                //
+                             !(K >= 16))
+    {
+    }
+
+    double ComputeWti() const
+    {
+        if(out_of_model_scope)
+            return -1.0; // Shader model produces unreliable results.
+
+        const auto direct_convolution_macs = C * N * K / 10e+6 *
+                                             RoundUpToMultiple(S * out_w / input_stride_w, 1) *
+                                             RoundUpToMultiple(R * out_h / input_stride_h, 1); // AK
+
+        constexpr size_t TILE_S = WINOFILTER; // AL
+        constexpr size_t TILE_R = WINOFILTER; // AO
+        assert(!(U > 2 || V > 2));
+        const auto granulated_S =
+            (U == 1 && input_stride_w == 1 && filter_stride_w == 1 && S <= TILE_S)
+                ? TILE_S
+                : RoundUpToMultiple(S, 2 * TILE_S); // AM
+        const auto granulated_R = RoundUpToMultiple(
+            R,
+            (((V == 1 && input_stride_h == 1 && filter_stride_h == 1) || (R % (2 * TILE_R) == 1))
+                 ? TILE_R
+                 : 2 * TILE_R)); // AP
+
+        constexpr size_t TILE_OUT_W = WINODATA; // AR
+        constexpr size_t TILE_OUT_H = WINODATA; // AU
+        const auto granulated_out_w =
+            RoundUpToMultiple(out_w + ((input_stride_w == 2 && (pad_w % 2 != 0)) ? 1 : 0),
+                              TILE_OUT_W * input_stride_w); // AS
+        const auto granulated_out_h =
+            RoundUpToMultiple(out_h + ((input_stride_h == 2 && (pad_h % 2 != 0)) ? 1 : 0),
+                              TILE_OUT_H * input_stride_h); // AV
+
+        constexpr size_t GRANULARITY_NHW_TILES = 32; // AY$2
+        constexpr size_t GRANULARITY_K         = 32; // BC$2
+
+        const auto NWH_tiles =
+            granulated_out_w * granulated_out_h * N / TILE_OUT_H / TILE_OUT_W; // AX
+
+        const auto granulated_NWH_tiles = RoundUpToMultiple(
+            NWH_tiles,
+            GRANULARITY_NHW_TILES * ((input_stride_w == 2 && input_stride_h == 2) ? 2 : 1)); // AY
+
+        const auto granulated_C =
+            RoundUpToMultiple(C,
+                              ((U == 1 && S <= 3) ? 2 : 1) * 32 / DATATYPE_BITS); // BA
+
+        const auto granulated_K = RoundUpToMultiple(
+            K,
+            GRANULARITY_K / ((input_stride_w == 2 && input_stride_h == 2) ? 2 : 1)); // BC
+
+        const auto NKWH_tiles = granulated_NWH_tiles * granulated_K; // BE
+
+        const auto granulated_NKWH_tiles =
+            RoundUpToMultiple(NKWH_tiles,
+                              n_groups * granulated_NWH_tiles * granulated_K); // BR
+
+        const auto works_per_CU = granulated_NKWH_tiles / 32 / n_groups; // BY
+
+        constexpr size_t MIN_FE_PER_WORK = 20; // BZ$2
+
+        const auto fe_per_work =
+            std::max(MIN_FE_PER_WORK,
+                     granulated_S * granulated_R * granulated_C * DATATYPE_BITS / 32); // BZ
+
+        const auto phases   = fe_per_work * works_per_CU; // CA
+        const auto fe_calls = phases;                     // CC
+        const auto be_calls = works_per_CU;               // CD
+
+        constexpr double C0      = 43283;                                        // CB$2
+        constexpr double C1      = 1.012;                                        // CC$2
+        constexpr double C2      = 134.14;                                       // CD$2
+        const auto GUI_predicted = (C0 + C1 * fe_calls + C2 * be_calls) / 10e+6; // CE
+
+        if(GUI_predicted <= 10e+5)
+            return -1.0; // Unreliable, too small work to do for the shader.
+
+        const auto N_MACS_PER_CU_PER_CLOCK = 64 * 32 / DATATYPE_BITS;
+        const auto WTI_predicted = direct_convolution_macs / N_MACS_PER_CU_PER_CLOCK / n_groups /
+                                   GUI_predicted; // similar to BW
+        return WTI_predicted;
+    }
+};
+
 float ConvBinWinogradRxSf2x3::GetWti(const ConvolutionContext& params) const
 {
     constexpr auto WTI_UNKNOWN = -2.0;
-    UnifiedConv2d u(params);
-    if(!(params.group_counts == 1) || //
-       !(u.pad_h == 1) ||             //
-       !(u.pad_h == 1) ||             //
-       !(u.U == 1) ||                 //
-       !(u.V == 1) ||                 //
-       !(u.input_stride_h == 1) ||    //
-       !(u.input_stride_w == 1) ||    //
-       !(u.filter_stride_h == 1) ||   //
-       !(u.filter_stride_w == 1) ||   //
-       !(u.R <= 5) ||                 //
-       !(u.S <= 5) ||                 //
-       !(u.C >= 16) ||                //
-       !(u.K >= 16))                  //
-        return WTI_UNKNOWN;
-
-    const auto DATATYPE_BITS = 32; // S // 16 for FP16 // FIXME
-    const auto n_groups      = 60; // BQ = 60 // FIXME
-
-    // FIXME // if GUI_ACTIVE clocks > 10^5
-    return WTI_UNKNOWN;
+    const auto rv              = ShaderModel(params).ComputeWti();
+    return rv < 0 ? WTI_UNKNOWN : rv;
 }
 
 static bool IsApplicableBase(const ConvolutionContext& params)

--- a/src/solver/conv_winoRxS_f2x3.cpp
+++ b/src/solver/conv_winoRxS_f2x3.cpp
@@ -477,9 +477,9 @@ class ShaderModel : public UnifiedConfigConv2d
             std::max(MIN_FE_PER_WORK,
                      granulated_S * granulated_R * granulated_C * DATATYPE_BITS / 32); // BZ
 
-        const auto phases = fe_per_work * works_per_CU; // CA
-        const auto fe_calls = phases;       // CC
-        const auto be_calls = works_per_CU; // CD
+        const auto phases   = fe_per_work * works_per_CU; // CA
+        const auto fe_calls = phases;                     // CC
+        const auto be_calls = works_per_CU;               // CD
 
         constexpr double C0      = 43283;                                       // CB$2
         constexpr double C1      = 1.012;                                       // CC$2

--- a/src/solver/conv_winoRxS_f2x3.cpp
+++ b/src/solver/conv_winoRxS_f2x3.cpp
@@ -348,9 +348,10 @@ class ShaderModel : public UnifiedDescriptionConv2d
         if(out_of_model_scope)
             return -1.0; // Shader model produces unreliable results.
 
-        const auto direct_convolution_macs = C * N * K / 1e+6 *
-                                             RoundUpToMultiple(S * out_w / input_stride_w, 1) *
-                                             RoundUpToMultiple(R * out_h / input_stride_h, 1); // AK
+        const auto direct_convolution_macs =
+            static_cast<double>(C * N * K) / 1e+6 *
+            static_cast<double>(RoundUpToMultiple(S * out_w / input_stride_w, 1)) *
+            static_cast<double>(RoundUpToMultiple(R * out_h / input_stride_h, 1)); // AK
 
         constexpr size_t TILE_S = WINOFILTER; // AL
         constexpr size_t TILE_R = WINOFILTER; // AO
@@ -419,8 +420,9 @@ class ShaderModel : public UnifiedDescriptionConv2d
             return -1.0; // Unreliable, too small work to do for the shader.
 
         const auto N_MACS_PER_CU_PER_CLOCK = 64 * 32 / DATATYPE_BITS;
-        const auto WTI_predicted = direct_convolution_macs / N_MACS_PER_CU_PER_CLOCK / n_groups /
-                                   GUI_predicted; // similar to BW
+        const auto WTI_predicted           = direct_convolution_macs /
+                                   static_cast<double>(N_MACS_PER_CU_PER_CLOCK) /
+                                   static_cast<double>(n_groups) / GUI_predicted; // similar to BW
         return WTI_predicted;
     }
 };

--- a/src/solver/conv_winoRxS_f2x3.cpp
+++ b/src/solver/conv_winoRxS_f2x3.cpp
@@ -172,25 +172,24 @@ inline bool IsShaderContraintsMet(const int R,
     }
 
     // clang-format off
-        // Check implementation limits.
-        return N < std::pow(2, 16)
-            && C < std::pow(2, 16)
-            && K < std::pow(2, 16)
-            && H < std::pow(2, 16)
-            && W < std::pow(2, 16)
-            && OH < std::pow(2, 16)
-            && OW < std::pow(2, 16)
-            && params.pad_w < std::pow(2, 16)
-            && params.pad_h < std::pow(2, 16)
-            && S < std::pow(2, 16)
-            && R < std::pow(2, 16)
-            && grid_workgroup_count_x < std::pow(2, 16)
-            && (C * H * W) <= std::pow(2, 28)
-            && (OH * OW) <= std::pow(2, 23)
-            && (K * OH * OW) <= std::pow(2, 28)
-            && (K * R * S) <= std::pow(2, 28)
-            && (C * R * S) <= std::pow(2, 28);
-    // clang-format on
+    // Check implementation limits.
+    return N < std::pow(2, 16)
+        && C < std::pow(2, 16)
+        && K < std::pow(2, 16)
+        && H < std::pow(2, 16)
+        && W < std::pow(2, 16)
+        && OH < std::pow(2, 16)
+        && OW < std::pow(2, 16)
+        && params.pad_w < std::pow(2, 16)
+        && params.pad_h < std::pow(2, 16)
+        && S < std::pow(2, 16)
+        && R < std::pow(2, 16)
+        && grid_workgroup_count_x < std::pow(2, 16)
+        && (C * H * W) <= std::pow(2, 28)
+        && (OH * OW) <= std::pow(2, 23)
+        && (K * OH * OW) <= std::pow(2, 28)
+        && (K * R * S) <= std::pow(2, 28)
+        && (C * R * S) <= std::pow(2, 28); // clang-format on
 }
 
 } // namespace


### PR DESCRIPTION
Continuation of #424. Implements (30.10) and (20) for WinogradRxS F(2,3) (n_groups=1) from #410.

- Updates the core of the library.
- Expected to allow simpler integration of MLP classifier
- Adds `GetWti()` for 3x3 WinogradRxS F(2,3), all directions.
- Adds very approximate `GetWti()` for GEMM, all directions.

Provides:
- Performance improvements for non-group convolutions, all directions:
  - For Immediate Mode Fallback & FAST Find mode (unseen configs)
  - Significant FP16 improvements because now we utilize Winograd

:warning: ___For detailed understanding of this code, I recommend reviewing each commit individually.___ Each commit has clear description, so the reviewer has luxury to skip what he or she is not interested in (for ex. refactors).

## Summary of code changes

- Updated machinery that uses `GetWti()` in Immediate Mode Fallback.
  - Estimation of Gemm performance is better generalized.
- Implemented shader performance model for ConvBinWinogradRxSf2x3, non-grouped (shader v.21_1_1).
- Added `GetWti()` for `ConvBinWinogradRxSf2x3g1` and for `ConvBinWinogradRxSf2x3`.
  - The latter always returns "unknown" due to WTI model limitations.
- Implemented simple shader performance model for GEMM.
- Removed rudimentary `ConvBinWinograd3x3U::GetWti()`. We have better Winograd shader with good WTI model.

## By-products

- Removed useless applicability limitation for `ConvBinWinogradRxSf2x3`, WrW direction.
- Removed some dead code in `ConvBinWinogradRxSf2x3`.

## :cyclone: Local performance & correctness testing

- Radeon VII, ROCm 3.5.
- 93 known FP32 + 93 known FP16 convolution configs
- Normal Find mode + Immediate mode
- OCL backend (FP32 configs only) + HIP backend

No regressions. Detailed description of the test is available upon request.

## :cyclone: Evaluation of Initial Iteration Time impact

- ___Installable Release build___, binary cache is empty prior each test.
- Radeon VII, ROCm 3.5.
- 93 _unknown_ FP32 convolution configs (find-db miss)
- 93 _unknown_ FP16 convolution configs (find-db miss)
- HIP backend

&nbsp; | Total Wall time, ms | &nbsp; | &nbsp; | GPU perf vs. Normal Find | &nbsp; | &nbsp;
-- | -- | -- | -- | -- | -- | --
**Find Mode** | **Base** | **PR** | **Improvement** | **Base** | **PR** | **Improvement**
FP32 NORMAL | 991102 | 997328 | -1% | - | - | -
FP32 FAST | 3681 | 2941 | 25% | 0.406 | 0.484 | 19%
FP16 NORMAL | 1080194 | 1085724 | -1% | - | - | -
FP16 FAST | 4380 | 3830 | 14% | 0.242 | 0.406 | 68%





