### PR TITLE
Fix potential bwd immediate crash by add missing setStream() call to context

### DIFF
--- a/src/ocl/convolutionocl.cpp
+++ b/src/ocl/convolutionocl.cpp
@@ -2737,6 +2737,7 @@ void ConvolutionDescriptor::ConvolutionBackwardImmediate(Handle& handle,
         ValidateGroupCount(dxDesc, wDesc, *this);
 
         auto ctx = ConvolutionContext{dxDesc, wDesc, dyDesc, *this, conv::Direction::BackwardData};
+        ctx.SetStream(&handle);
 
         if(CheckInvokerSupport(solver_id, conv::Direction::BackwardData))
         {


### PR DESCRIPTION
This fixes https://github.com/ROCmSoftwarePlatform/MIOpen/issues/639

Right after context is created by `auto ctx=...`, there should be a `ctx.SetStream(&handle);` to set stream of the newly created context (fwd/wrw immediate already have this setStream, but not bwd). Otherwise the `stream` member of this context will always be nullptr, and will likely crash in later software flow.