### PR TITLE
Report correct CU count for gfx10

### DIFF
--- a/src/include/miopen/handle.hpp
+++ b/src/include/miopen/handle.hpp
@@ -37,6 +37,7 @@
 #include <miopen/allocator.hpp>
 #include <miopen/simple_hash.hpp>
 #include <miopen/solver_id.hpp>
+#include <miopen/stringutils.hpp>
 
 #include <boost/range/adaptor/transformed.hpp>
 
@@ -137,9 +138,15 @@ struct Handle : miopenHandle
 
     std::size_t GetLocalMemorySize() const;
     std::size_t GetGlobalMemorySize() const;
-    std::size_t GetMaxComputeUnits() const;
     std::size_t GetImage3dMaxWidth() const;
     std::size_t GetWavefrontWidth() const;
+    std::size_t GetMaxComputeUnits() const;
+    std::size_t GetMaxHardwareComputeUnits() const
+    {
+        std::size_t num_cu = this->GetMaxComputeUnits();
+        std::string name   = this->GetDeviceName();
+        return StartsWith(name, "gfx1") ? num_cu * 2 /* CUs per WGP */ : num_cu;
+    }
 
     std::size_t m_MaxMemoryAllocSizeCached = 0;
     std::size_t GetMaxMemoryAllocSize();


### PR DESCRIPTION
Resolves issue #654 

Continuation of #653.
This PR provides a function in the Handle to get actual number of _CUs_. This is important for gfx10 GPUs since this generation introduced the concept of _WGP_ (wrokgroup processor), which contain 2 _CUs_. In this case, the OCL and HIP backends report the **number of WGPs instead of CUs**.  Using the number of _WPGs_ instead of _CUs_ in winogradRxSf2x3 gfx10 may have performance regression as mentioned in #654.

## Summary of code changes
* Added `GetMaxHardwareComputeUnits()` to get actual number of CUs instead of WGPs
* Replaced `GetMaxComputeUnits()` with `GetMaxHardwareComputeUnits()` in the winoRxS_f2x3 solver

## Local performance testing
Convolution time improvements for gfx10 compared with #653.  There is no regression with gfx906, ROCm 3.5.1.
* gfx1030, ROCm 3.9
* OCL + HIP backend
* fp16 + fp32

W | H | c | n | k | x | y | p | q | u | v | g | dir | | perf
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
14 | 14 | 1024 | 64 | 1024 | 3 | 3 | 1 | 1 | 1 | 1 | 1 | fwd | | -8%
14 | 14 | 1024 | 64 | 1024 | 3 | 3 | 1 | 1 | 2 | 2 | 1 | fwd | | -8%
14 | 14 | 1024 | 64 | 1024 | 3 | 3 | 1 | 1 | 1 | 1 | 1 | wrw | | 0%
14 | 14 | 1024 | 64 | 1024 | 3 | 3 | 1 | 1 | 1 | 1 | 1 | bwd | | 0%
14 | 14 | 1024 | 64 | 1024 | 3 | 3 | 1 | 1 | 2 | 2 | 1 | bwd | | -8%
56 | 56 | 2048 | 128 | 2048 | 3 | 3 | 1 | 1 | 1 | 1 | 1 | fwd | | 49%
56 | 56 | 2048 | 128 | 2048 | 3 | 3 | 1 | 1 | 2 | 2 | 1 | fwd | | 61%
56 | 56 | 2048 | 128 | 2048 | 3 | 3 | 1 | 1 | 1 | 1 | 1 | bwd | | 49%
56 | 56 | 2048 | 128 | 2048 | 3 | 3 | 1 | 1 | 2 | 2 | 1 | bwd | | 50%
56 | 56 | 2048 | 128 | 2048 | 3 | 3 | 1 | 1 | 1 | 1 | 1 | wrw | | 0%
224 | 224 | 512 | 64 | 512 | 3 | 3 | 1 | 1 | 1 | 1 | 1 | fwd | | 47%
224 | 224 | 512 | 64 | 512 | 3 | 3 | 1 | 1 | 2 | 2 | 1 | fwd | | 47%
224 | 224 | 512 | 64 | 512 | 3 | 3 | 1 | 1 | 1 | 1 | 1 | bwd | | 47%
224 | 224 | 512 | 64 | 512 | 3 | 3 | 1 | 1 | 2 | 2 | 1 | bwd | | 47%
224 | 224 | 512 | 64 | 512 | 3 | 3 | 1 | 1 | 1 | 1 | 1 | wrw | | 32%