### PR TITLE
[iGemm] Workaround a tuning issue of non-xdlops gemm

### DIFF
--- a/src/solver/conv_hip_implicit_gemm_nonxdlops_common.cpp
+++ b/src/solver/conv_hip_implicit_gemm_nonxdlops_common.cpp
@@ -93,7 +93,7 @@ bool PerformanceImplicitGemm::IsValid(const ConvolutionContext& ctx) const
     }
 
     // divide block work by [K, B]
-    if(!(K % KPerBlock == 0 && B % BPerBlock == 0 && E % EPerBlock == 0))
+    if(!(K % KPerBlock == 0 && B % BPerBlock == 0 && E % (2 * EPerBlock) == 0))
         return false; // wrong! cannot divice N evenly among thread
 
     const auto KBlockWork = K / KPerBlock;


### PR DESCRIPTION
- When E == EPerBlock, the non-xdlops v4r1 fwd kernel failed on Vega20 (ROCm 3.5/3.7) with scratch memory
- Added a restrict that E (i.e., GemmK) must be multiple of 2 x EPerBlock