### PR TITLE
[HIP backend] Remove fat binary unbundling

### DIFF
--- a/src/hip/hip_build_utils.cpp
+++ b/src/hip/hip_build_utils.cpp
@@ -205,15 +205,11 @@ boost::filesystem::path HipBuild(boost::optional<TmpDir>& tmp_dir,
 
         return hsaco->path();
     }
-    else
 #endif
-#ifdef MIOPEN_OFFLOADBUNDLER_BIN
-        // clang-format off
+#if defined(MIOPEN_OFFLOADBUNDLER_BIN) && !MIOPEN_BACKEND_HIP
+    // Unbundling is not required for HIP runtime && hip-clang
     if(IsHipClangCompiler())
     {
-        // clang-format on
-
-        // call clang-offload-bundler
         tmp_dir->Execute(MIOPEN_OFFLOADBUNDLER_BIN,
                          "--type=o --targets=hip-amdgcn-amd-amdhsa-" +
                              (HipCompilerVersion() < external_tool_version_t{4, 0, 20482}


### PR DESCRIPTION
This is by-product of [discussion in SWDEV-268264](http://ontrack-internal.amd.com/browse/SWDEV-268264?focusedCommentId=6818681&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-6818681). The immediate goal is getting rid of useless code. Also this gives some boost of HIP builds.

The by-product of this PR is improved compatibility with different compiler versions (only when built with HIP backend). For example, MIOpen is able to work with build 6326 (HIP version 4.0.20491, TargetID is enabled, at least partially) regardless of whether TargetID stuff in MIOpen is enabled or disabled (tested manually).

[Informative] Un-bundling will be also removed from OpenCL BE as soon as [loading bundled program is added to OpenCL runtime](http://ontrack-internal.amd.com/browse/SWDEV-268562).

