### PR TITLE
[HOTFIX][TargetID] Unblock MIOpen for ROCm 4.0 and 4.0.1 RC. Possibility for unblock for mainline.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,8 +85,6 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 endif()
 
 
-
-
 ############################################################
 # require C++14
 add_compile_options(-std=c++14)
@@ -185,10 +183,29 @@ target_flags(HIP_COMPILER_FLAGS hip::device)
 string(REGEX REPLACE --cuda-gpu-arch=[a-z0-9]+ "" HIP_COMPILER_FLAGS "${HIP_COMPILER_FLAGS}")
 string(REGEX REPLACE --offload-arch=[a-z0-9]+ "" HIP_COMPILER_FLAGS "${HIP_COMPILER_FLAGS}")
 
+# Override HIP version in config.h, if necessary.
+# The variables set by find_package() can't be overwritten,
+# therefore let's use intermediate variables.
+set(MIOPEN_hip_VERSION_MAJOR "${hip_VERSION_MAJOR}")
+set(MIOPEN_hip_VERSION_MINOR "${hip_VERSION_MINOR}")
+set(MIOPEN_hip_VERSION_PATCH "${hip_VERSION_PATCH}")
+if( DEFINED MIOPEN_OVERRIDE_HIP_VERSION_MAJOR )
+    set(MIOPEN_hip_VERSION_MAJOR "${MIOPEN_OVERRIDE_HIP_VERSION_MAJOR}")
+    message(STATUS "MIOPEN_hip_VERSION_MAJOR overriden with ${MIOPEN_OVERRIDE_HIP_VERSION_MAJOR}")
+endif()
+if( DEFINED MIOPEN_OVERRIDE_HIP_VERSION_MINOR )
+    set(MIOPEN_hip_VERSION_MINOR "${MIOPEN_OVERRIDE_HIP_VERSION_MINOR}")
+    message(STATUS "MIOPEN_hip_VERSION_MINOR overriden with ${MIOPEN_OVERRIDE_HIP_VERSION_MINOR}")
+endif()
+if( DEFINED MIOPEN_OVERRIDE_HIP_VERSION_PATCH )
+    set(MIOPEN_hip_VERSION_PATCH "${MIOPEN_OVERRIDE_HIP_VERSION_PATCH}")
+    message(STATUS "MIOPEN_hip_VERSION_PATCH overriden with ${MIOPEN_OVERRIDE_HIP_VERSION_PATCH}")
+endif()
+
+
 message(STATUS "Hip compiler flags: ${HIP_COMPILER_FLAGS}")
 
 add_definitions("-DHIP_COMPILER_FLAGS=${HIP_COMPILER_FLAGS}")
-
 
 
 # HIP

--- a/include/miopen/config.h.in
+++ b/include/miopen/config.h.in
@@ -49,9 +49,9 @@
 // "_PACKAGE_" to avoid name contentions: the macros like
 // HIP_VERSION_MAJOR are defined in hip_version.h.
 // clang-format off
-#define HIP_PACKAGE_VERSION_MAJOR @hip_VERSION_MAJOR@
-#define HIP_PACKAGE_VERSION_MINOR @hip_VERSION_MINOR@
-#define HIP_PACKAGE_VERSION_PATCH @hip_VERSION_PATCH@
+#define HIP_PACKAGE_VERSION_MAJOR @MIOPEN_hip_VERSION_MAJOR@
+#define HIP_PACKAGE_VERSION_MINOR @MIOPEN_hip_VERSION_MINOR@
+#define HIP_PACKAGE_VERSION_PATCH @MIOPEN_hip_VERSION_PATCH@
 // clang-format on
 
 // clang-format off

--- a/src/hip/hip_build_utils.cpp
+++ b/src/hip/hip_build_utils.cpp
@@ -130,7 +130,7 @@ boost::filesystem::path HipBuild(boost::optional<TmpDir>& tmp_dir,
         if(params.find("-std=") == std::string::npos)
             params += " --std=c++11";
 
-        if(HipCompilerVersion() < external_tool_version_t{4, 0, 20482})
+        if(HipCompilerVersion() < external_tool_version_t{4, 1, 0})
             params += " --cuda-gpu-arch=" + lots.device;
         else
             params += " --cuda-gpu-arch=" + lots.device + lots.xnack;
@@ -212,7 +212,7 @@ boost::filesystem::path HipBuild(boost::optional<TmpDir>& tmp_dir,
     {
         tmp_dir->Execute(MIOPEN_OFFLOADBUNDLER_BIN,
                          "--type=o --targets=hip-amdgcn-amd-amdhsa-" +
-                             (HipCompilerVersion() < external_tool_version_t{4, 0, 20482}
+                             (HipCompilerVersion() < external_tool_version_t{4, 1, 0}
                                   ? lots.device
                                   : (std::string{'-'} + lots.device + lots.xnack)) +
                              " --inputs=" + bin_file.string() + " --outputs=" + bin_file.string() +

--- a/src/hipoc/hipoc_program.cpp
+++ b/src/hipoc/hipoc_program.cpp
@@ -78,7 +78,7 @@ int DetectCodeObjectOptionSyntax()
 
     if(syntax == 0)
     {
-        if(HipCompilerVersion() >= external_tool_version_t{4, 0, 20482})
+        if(HipCompilerVersion() >= external_tool_version_t{4, 1, 0})
             return 4;
         else
             return 1;
@@ -99,7 +99,7 @@ int DetectCodeObjectVersion()
 
     if(co_version == 0)
     {
-        if(HipCompilerVersion() >= external_tool_version_t{4, 0, 20482})
+        if(HipCompilerVersion() >= external_tool_version_t{4, 1, 0})
             return 4;
         else if(HipCompilerVersion() >= external_tool_version_t{3, 0, -1})
             return 3;


### PR DESCRIPTION
This resolves issue #684.

Also this PR allows for `cmake ... -DMIOPEN_OVERRIDE_HIP_VERSION_MINOR=1 ...` when building MIOpen. This technique resolves current TargetID and CO V4 issues with mainline compiler & library.

## Testing

Radeon VII.

| Compiler & libs | HIP version | Backend | Result | Notes
| -- | -- | -- | -- | --
| ROCm 4.0 | 4.0.20496 | HIP | Ok
|  |  | OpenCL | Ok
| Mainline build 6326 | 4.0.20491 | HIP | Ok
|  |  | OpenCL | FAIL | Result is actually Ok but `test_lstm` is failing due to OpenCL kernel build warning: `error: result of comparison of unsigned expression < 0 is always false` for `...(group_id_z < n_work_groups_with_1_more)...` <br><br>***Must be built*** with `-DMIOPEN_OVERRIDE_HIP_VERSION_MINOR=1`, otherwise fails on each OCL progrem load with `Error creating code object program (cl_program) in LoadProgramFromBinary()`.  
| Mainline build 6416 (***the most recent***) | 4.0.21013 | HIP | Ok
|  |  | OpenCL | FAIL | Same as the notes of mainline build 6326
