### PR TITLE
[HIP BE] Use hipDeviceProp_t.gcnArchName instead of gcnArch

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -116,7 +116,6 @@ set( MIOpen_Source
     ctc_api.cpp
     temp_file.cpp
     problem_description.cpp
-    include/miopen/sequences.hpp
     kernel_build_params.cpp
     find_db.cpp
     conv_algo_name.cpp
@@ -180,6 +179,8 @@ set( MIOpen_Source
     include/miopen/numeric.hpp
     include/miopen/reducetensor.hpp
     include/miopen/reduce_common.hpp
+    include/miopen/sequences.hpp
+    include/miopen/rocm_features.hpp
     md_graph.cpp
     mdg_expr.cpp
     conv/invokers/gcn_asm_1x1u.cpp

--- a/src/hip/handlehip.cpp
+++ b/src/hip/handlehip.cpp
@@ -187,7 +187,9 @@ struct HandleImpl
     {
         hipDeviceProp_t props{};
         hipGetDeviceProperties(&props, device);
-        return {"gfx" + std::to_string(props.gcnArch)};
+        const std::string name("gfx" + std::to_string(props.gcnArch));
+        MIOPEN_LOG_NQI("Raw device name: " << name);
+        return name;
     }
 
     bool enable_profiling  = false;

--- a/src/hip/handlehip.cpp
+++ b/src/hip/handlehip.cpp
@@ -35,6 +35,7 @@
 #include <miopen/invoker.hpp>
 #include <miopen/kernel_cache.hpp>
 #include <miopen/logger.hpp>
+#include <miopen/rocm_features.hpp>
 #include <miopen/target_properties.hpp>
 #include <miopen/timer.hpp>
 
@@ -187,7 +188,11 @@ struct HandleImpl
     {
         hipDeviceProp_t props{};
         hipGetDeviceProperties(&props, device);
+#if ROCM_FEATURE_HIP_GCNARCHNAME_RETURNS_CODENAME
         const std::string name("gfx" + std::to_string(props.gcnArch));
+#else
+        const std::string name(props.gcnArchName);
+#endif
         MIOPEN_LOG_NQI("Raw device name: " << name);
         return name;
     }

--- a/src/include/miopen/ocldeviceinfo.hpp
+++ b/src/include/miopen/ocldeviceinfo.hpp
@@ -35,6 +35,7 @@
 #endif
 
 #include <miopen/errors.hpp>
+#include <miopen/rocm_features.hpp>
 #include <string>
 #include <type_traits>
 
@@ -566,10 +567,9 @@ template <int N>
 auto GetPlatformInfo(cl_platform_id platform) MIOPEN_RETURNS(
     detail::GetPlatformInfoImpl<detail::PlatformAttributeReturnType<N>>::apply(N, platform));
 
-/// Workaround for https://github.com/AMDComputeLibraries/MLOpen/issues/1711:
-/// Since ROCM 2.4 rc1, OCL returns "gfx906+sram-ecc" on a gfx906 machine.
-/// See also rejected SWDEV-188028.
+#if WORKAROUND_MLOPEN_ISSUE_1711
 void WorkaroundIssue1711(std::string& name);
+#endif
 
 } // namespace miopen
 #endif // GUARD_MIOPEN_OCLDEVICE_HPP

--- a/src/include/miopen/rocm_features.hpp
+++ b/src/include/miopen/rocm_features.hpp
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2021 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#ifndef GUARD_ROCM_FEATURES_HPP_
+#define GUARD_ROCM_FEATURES_HPP_
+
+#include <miopen/config.h>
+
+/// Workaround for https://github.com/AMDComputeLibraries/MLOpen/issues/1711:
+/// Since ROCM 2.4 rc1, OCL returns "gfx906+sram-ecc" on a gfx906 machine.
+/// See also rejected SWDEV-188028. Fixed since ROCm 4.0 or even sooner.
+/// To be removed as soon as support for ROCm 3.x is discontinued.
+#define WORKAROUND_MLOPEN_ISSUE_1711 (HIP_PACKAGE_VERSION_FLAT < 4000000000ULL)
+
+#endif // GUARD_ROCM_FEATURES_HPP_

--- a/src/include/miopen/rocm_features.hpp
+++ b/src/include/miopen/rocm_features.hpp
@@ -28,6 +28,11 @@
 
 #include <miopen/config.h>
 
+/// Older HIP runtimes return hipDeviceProp_t.gcnArchName with codenames
+/// of GPUs instead of valid names, e.g. "Vega 20" instead of "gfx906".
+/// To be removed as soon as support for ROCm 3.x is discontinued.
+#define ROCM_FEATURE_HIP_GCNARCHNAME_RETURNS_CODENAME (HIP_PACKAGE_VERSION_FLAT < 4000000000ULL)
+
 /// Workaround for https://github.com/AMDComputeLibraries/MLOpen/issues/1711:
 /// Since ROCM 2.4 rc1, OCL returns "gfx906+sram-ecc" on a gfx906 machine.
 /// See also rejected SWDEV-188028. Fixed since ROCm 4.0 or even sooner.

--- a/src/ocl/clhelper.cpp
+++ b/src/ocl/clhelper.cpp
@@ -23,9 +23,6 @@
  * SOFTWARE.
  *
  *******************************************************************************/
-#include <cstdio>
-#include <cstring>
-#include <fstream>
 #include <miopen/clhelper.hpp>
 #include <miopen/errors.hpp>
 #include <miopen/gcn_asm_utils.hpp>
@@ -35,20 +32,27 @@
 #include <miopen/logger.hpp>
 #include <miopen/stringutils.hpp>
 #include <miopen/ocldeviceinfo.hpp>
+#include <miopen/rocm_features.hpp>
 #include <miopen/tmp_dir.hpp>
 #include <miopen/write_file.hpp>
 #include <miopen/env.hpp>
+
+#include <cstdio>
+#include <cstring>
+#include <fstream>
 #include <string>
 #include <vector>
 
 namespace miopen {
 
+#if WORKAROUND_MLOPEN_ISSUE_1711
 void WorkaroundIssue1711(std::string& name)
 {
     auto loc_p = name.find('+');
     if(loc_p != std::string::npos)
         name = name.substr(0, loc_p);
 }
+#endif
 
 static cl_program CreateProgram(cl_context ctx, const char* char_source, size_t size)
 {
@@ -68,7 +72,9 @@ static std::string
 ClAssemble(cl_device_id device, const std::string& source, const std::string& params)
 {
     std::string name = miopen::GetDeviceInfo<CL_DEVICE_NAME>(device);
+#if WORKAROUND_MLOPEN_ISSUE_1711
     WorkaroundIssue1711(name);
+#endif
     return AmdgcnAssemble(source, std::string("-mcpu=") + name + " " + params);
 }
 

--- a/src/ocl/handleocl.cpp
+++ b/src/ocl/handleocl.cpp
@@ -90,6 +90,7 @@ struct HandleImpl
     std::string get_device_name() const
     {
         std::string name = miopen::GetDeviceInfo<CL_DEVICE_NAME>(device);
+        MIOPEN_LOG_NQI("Raw device name: " << name);
         WorkaroundIssue1711(name);
         return name;
     }
@@ -232,12 +233,6 @@ Handle::Handle() : impl(new HandleImpl())
     auto pid = ::getpid();
     assert(pid > 0);
     impl->device  = devices.at(pid % devices.size());
-#endif
-
-#if !MIOPEN_INSTALLABLE
-    // TODO: Store device name in handle
-    std::string deviceName = miopen::GetDeviceInfo<CL_DEVICE_NAME>(impl->device);
-    MIOPEN_LOG_NQI("Device name: " << deviceName);
 #endif
 
     /////////////////////////////////////////////////////////////////

--- a/src/ocl/handleocl.cpp
+++ b/src/ocl/handleocl.cpp
@@ -91,7 +91,9 @@ struct HandleImpl
     {
         std::string name = miopen::GetDeviceInfo<CL_DEVICE_NAME>(device);
         MIOPEN_LOG_NQI("Raw device name: " << name);
+#if WORKAROUND_MLOPEN_ISSUE_1711
         WorkaroundIssue1711(name);
+#endif
         return name;
     }
 

--- a/src/target_properties.cpp
+++ b/src/target_properties.cpp
@@ -23,8 +23,6 @@
  * SOFTWARE.
  *
  *******************************************************************************/
-#define WORKAROUND_SWDEV_262823 1
-
 #include <miopen/env.hpp>
 #include <miopen/handle.hpp>
 #include <miopen/stringutils.hpp>
@@ -59,11 +57,7 @@ static std::string GetDeviceNameFromMap(const std::string& in)
     if(p_asciz != nullptr && strlen(p_asciz) > 0)
         return {p_asciz};
 
-#if WORKAROUND_SWDEV_262823
     const auto name = in.substr(0, in.find(':')); // str.substr(0, npos) returns str.
-#else
-    const auto name(in);
-#endif
 
     auto match = device_name_map.find(name);
     if(match != device_name_map.end())


### PR DESCRIPTION
- Added logging of raw device name.
- Introduced the 'rocm_features' module.
- Formalized W/A for issue 1711.
- Removed useless workaround macro
- Used gcnArchName instead of gcnArch since ROCm 4.0

