### PR TITLE
[OCL BE] Fix ROCM 4.0 build warnings. [COMGR] Use OpenCL 1.2

### DIFF
--- a/include/miopen/miopen.h
+++ b/include/miopen/miopen.h
@@ -37,6 +37,7 @@
 #include <miopen/export.h>
 
 #if MIOPEN_BACKEND_OPENCL
+#define CL_TARGET_OPENCL_VERSION 120
 #if defined(__APPLE__) || defined(__MACOSX)
 #include <OpenCL/cl.h>
 #else

--- a/src/comgr.cpp
+++ b/src/comgr.cpp
@@ -194,12 +194,7 @@ static void AddCompilerOptions(OptionList& list, const miopen::TargetProperties&
     list.push_back("-cl-fast-relaxed-math");
 #endif
     list.push_back("-D__IMAGE_SUPPORT__=1");
-#if OCL_STANDARD == 120
-    list.push_back("-cl-std=CL1.2")
-#elif OCL_STANDARD == 200
-    list.push_back("-cl-std=CL2.0")
-#endif
-        list.push_back("-D__OPENCL_VERSION__=" MIOPEN_STRINGIZE(OCL_STANDARD));
+    list.push_back("-D__OPENCL_VERSION__=" MIOPEN_STRINGIZE(OCL_STANDARD));
 #if OCL_EARLY_INLINE
     list.push_back("-mllvm");
     list.push_back("-amdgpu-early-inline-all");

--- a/src/comgr.cpp
+++ b/src/comgr.cpp
@@ -180,7 +180,7 @@ namespace ocl {
 
 #define OCL_EARLY_INLINE 1
 
-#define OCL_STANDARD 200 // For experiments.
+#define OCL_STANDARD 120 // For experiments.
 
 #if !(OCL_STANDARD == 200 || OCL_STANDARD == 120)
 #error "Wrong OCL_STANDARD"
@@ -194,7 +194,12 @@ static void AddCompilerOptions(OptionList& list, const miopen::TargetProperties&
     list.push_back("-cl-fast-relaxed-math");
 #endif
     list.push_back("-D__IMAGE_SUPPORT__=1");
-    list.push_back("-D__OPENCL_VERSION__=" MIOPEN_STRINGIZE(OCL_STANDARD));
+#if OCL_STANDARD == 120
+    list.push_back("-cl-std=CL1.2")
+#elif OCL_STANDARD == 200
+    list.push_back("-cl-std=CL2.0")
+#endif
+        list.push_back("-D__OPENCL_VERSION__=" MIOPEN_STRINGIZE(OCL_STANDARD));
 #if OCL_EARLY_INLINE
     list.push_back("-mllvm");
     list.push_back("-amdgpu-early-inline-all");

--- a/src/include/miopen/mlo_internal.hpp
+++ b/src/include/miopen/mlo_internal.hpp
@@ -73,6 +73,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <miopen/problem_description.hpp>
 
 #if MIOPEN_BACKEND_OPENCL
+#define CL_TARGET_OPENCL_VERSION 120
 #ifdef __APPLE__
 #include <OpenCL/opencl.h>
 #else


### PR DESCRIPTION
- OCL BE: Fixed ROCm 4.0 build warnings like "CL_TARGET_OPENCL_VERSION is not defined. Defaulting to 220"
- COMGR: Use "-cl-std=CL1.2", just like in other build paths.
