### PR TITLE
[CI] Dismiss Fiji from CI testing.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -260,13 +260,6 @@ pipeline {
                     }
                 }
 
-                stage('OpenCL Debug Fiji') {
-                    agent{ label rocmnode("fiji") }
-                    steps{
-                        buildJob('g++-5', flags: '-DBUILD_DEV=On -DCMAKE_BUILD_TYPE=debug', gpu_arch: "gfx803")
-                    }
-                }
-
                 stage('Hip/hcc Release') {
                     agent{ label rocmnode("vega") }
                     steps{

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,9 +1,7 @@
 
 def rocmnode(name) {
     def node_name = 'rocmtest'
-    if(name == 'fiji') {
-        node_name = 'rocmtest && fiji';
-    } else if(name == 'vega') {
+    if(name == 'vega') {
         node_name = 'rocmtest && vega';
     } else if(name == 'vega10') {
         node_name = 'rocmtest && vega10';
@@ -181,7 +179,7 @@ def buildHipClangJob(compiler, flags, env4make, image, prefixpath="/opt/rocm", c
 ///   * "Subset" corresponds to Target- or BuildTypeModifier-specific subsetting of
 ///     the "All" testset, e.g. -DMIOPEN_TEST_GFX908=On or -DMIOPEN_TEST_MIOTENSILE=On.
 ///   * "Smoke" (-DMIOPEN_TEST_ALL=Off) is the default and usually not specified.
-/// Target := { gfx908 | Vega20 | Vega10 | Fiji | Vega* }
+/// Target := { gfx908 | Vega20 | Vega10 | Vega* }
 ///   * "Vega" (gfx906 or gfx900) is the default and usually not specified.
 
 pipeline {


### PR DESCRIPTION
The gfx803 nodes are malfunction often. This blocks CI testing. We are gong to retire those nodes. 

https://github.com/AMDComputeLibraries/MLOpen/issues/1934 updated.