### PR TITLE
[NFC][SQLite perf-db] Less spam at log level 5

### DIFF
--- a/src/db_record.cpp
+++ b/src/db_record.cpp
@@ -30,6 +30,7 @@
 #include <unordered_map>
 #include <utility>
 
+#include <miopen/config.h>
 #include <miopen/db_record.hpp>
 #include <miopen/logger.hpp>
 
@@ -37,18 +38,21 @@ namespace miopen {
 
 bool DbRecord::SetValues(const std::string& id, const std::string& values)
 {
+    constexpr auto log_level = MIOPEN_ENABLE_SQLITE ? LoggingLevel::Info2 : LoggingLevel::Info;
+
     // No need to update the file if values are the same:
     const auto it = map.find(id);
     if(it == map.end() || it->second != values)
     {
-        MIOPEN_LOG_I(key << ", content " << (it == map.end() ? "inserted" : "overwritten") << ": "
-                         << id
-                         << ':'
-                         << values);
+        MIOPEN_LOG(log_level,
+                   key << ", content " << (it == map.end() ? "inserted" : "overwritten") << ": "
+                       << id
+                       << ':'
+                       << values);
         map[id] = values;
         return true;
     }
-    MIOPEN_LOG_I(key << ", content is the same, not changed:" << id << ':' << values);
+    MIOPEN_LOG(log_level, key << ", content is the same, not changed:" << id << ':' << values);
     return false;
 }
 


### PR DESCRIPTION
Let's move the first three lines (`SetValues`) down from log level 5 to log level 6:
```
MIOpen(HIP): Info [SetValues] , content inserted: ConvAsm1x1U:2,8,4,16,1,4,4,1
MIOpen(HIP): Info [SetValues] , content inserted: ConvOclDirectFwd1x1:1,128,1,1,0,1,4,4,0
MIOpen(HIP): Info [SetValues] , content inserted: ConvBinWinogradRxSf2x3:46
MIOpen(HIP): Info [GetValues] =ConvAsm1x1U:2,8,4,16,1,4,4,1
```
