### PR TITLE
[OCL BE] Fix: Restore llvm-specific HIP build options to reclaim GPU performance.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,6 +177,11 @@ if( MIOPEN_BACKEND STREQUAL "OpenCL")
     if(MIOPEN_USE_COMGR)
         message(FATAL_ERROR "comgr cannot be used with OpenCL backend")
     endif()
+
+    # This is to pass all necessary build flags to HIP compiler
+    # for device code compilation. Used within "find_package(hip...".
+    # See https://github.com/ROCm-Developer-Tools/HIP/pull/2035#issuecomment-616861118.
+    set (HIP_CXX_COMPILER ${MIOPEN_HIP_COMPILER})
 endif()
 
 


### PR DESCRIPTION
Resolves issue #666.

The logic or removal of internal llvm options has been introduced in HIP in https://github.com/ROCm-Developer-Tools/HIP/pull/2035#issuecomment-616861118. Relevant support in MIOpen was added at https://github.com/ROCmSoftwarePlatform/MIOpen/pull/165/files#r571645949, but then has been removed in #190 by mistake. This PR restores it and adds necessary comments to avoid removal by mistake in the future.

Tested with:
```
export MIOPEN_DEBUG_CONV_FFT=0
export MIOPEN_DEBUG_CONV_GEMM=0
export MIOPEN_DEBUG_GCN_ASM_KERNELS=0
export MIOPEN_DEBUG_OPENCL_CONVOLUTIONS=0
```
___Average FP32 performance gain: 3.5X___