### PR TITLE
Add missing amdhsa directive for Conv_Winograd_v21_1_2 metadata

### DIFF
--- a/src/kernels/Conv_Winograd_v21_1_2_metadata.inc
+++ b/src/kernels/Conv_Winograd_v21_1_2_metadata.inc
@@ -156,14 +156,14 @@ __dx10_clamp = 0
     .amdhsa_system_sgpr_workgroup_id_y       __sgpr_workgroup_id_y
     .amdhsa_system_sgpr_workgroup_id_z       __sgpr_workgroup_id_y
     .amdhsa_system_vgpr_workitem_id          __vgpr_workitem_id
-    .amdhsa_next_free_vgpr .amdgcn.next_free_vgpr
-    .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+    .amdhsa_next_free_vgpr                   .amdgcn.next_free_vgpr
+    .amdhsa_next_free_sgpr                   .amdgcn.next_free_sgpr
     .amdhsa_reserve_vcc                      __sgpr_reserve_vcc_default
     .amdhsa_reserve_xnack_mask               __sgpr_reserve_xnack_default
     .amdhsa_reserve_flat_scratch             __sgpr_reserve_flatscr_default
     .amdhsa_ieee_mode                        __ieee_mode
     .amdhsa_dx10_clamp                       __dx10_clamp
-    .amdhsa_wavefront_size32 0
+    .amdhsa_wavefront_size32                 0
 .end_amdhsa_kernel
 .else
 .amdhsa_kernel \kernel_name
@@ -175,8 +175,8 @@ __dx10_clamp = 0
     .amdhsa_system_sgpr_workgroup_id_y       __sgpr_workgroup_id_y
     .amdhsa_system_sgpr_workgroup_id_z       __sgpr_workgroup_id_y
     .amdhsa_system_vgpr_workitem_id          __vgpr_workitem_id
-    .amdhsa_next_free_vgpr .amdgcn.next_free_vgpr
-    .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+    .amdhsa_next_free_vgpr                   .amdgcn.next_free_vgpr
+    .amdhsa_next_free_sgpr                   .amdgcn.next_free_sgpr
     .amdhsa_reserve_vcc                      __sgpr_reserve_vcc_default
     .amdhsa_reserve_xnack_mask               __sgpr_reserve_xnack_default
     .amdhsa_reserve_flat_scratch             __sgpr_reserve_flatscr_default

--- a/src/kernels/Conv_Winograd_v21_1_2_metadata.inc
+++ b/src/kernels/Conv_Winograd_v21_1_2_metadata.inc
@@ -133,25 +133,57 @@ __sgpr_reserve_vcc_default = 1
 __sgpr_reserve_xnack_default = 0
 __sgpr_reserve_flatscr_default = 0
 
+__group_segment_fixed_size = 65536
+__sgpr_private_segment_buffer = 1
+__sgpr_dispatch_ptr = 1
+__sgpr_kernarg_segment_ptr = 1
+__sgpr_workgroup_id_x = 1
+__sgpr_workgroup_id_y = 0
+__sgpr_workgroup_id_z = 0
+__vgpr_workitem_id = 0
+__ieee_mode = 0
+__dx10_clamp = 0
+
 .rodata
 .p2align 6
+.if (.amdgcn.gfx_generation_number >= 10)
 .amdhsa_kernel \kernel_name
-    .amdhsa_group_segment_fixed_size 65536
-    .amdhsa_user_sgpr_private_segment_buffer 1
-    .amdhsa_user_sgpr_dispatch_ptr 1
-    .amdhsa_user_sgpr_kernarg_segment_ptr 1
-    .amdhsa_system_sgpr_workgroup_id_x 1
-    .amdhsa_system_sgpr_workgroup_id_y 0
-    .amdhsa_system_sgpr_workgroup_id_z 0
-    .amdhsa_system_vgpr_workitem_id 0
+    .amdhsa_group_segment_fixed_size         __group_segment_fixed_size
+    .amdhsa_user_sgpr_private_segment_buffer __sgpr_private_segment_buffer
+    .amdhsa_user_sgpr_dispatch_ptr           __sgpr_dispatch_ptr
+    .amdhsa_user_sgpr_kernarg_segment_ptr    __sgpr_kernarg_segment_ptr
+    .amdhsa_system_sgpr_workgroup_id_x       __sgpr_workgroup_id_x
+    .amdhsa_system_sgpr_workgroup_id_y       __sgpr_workgroup_id_y
+    .amdhsa_system_sgpr_workgroup_id_z       __sgpr_workgroup_id_y
+    .amdhsa_system_vgpr_workitem_id          __vgpr_workitem_id
     .amdhsa_next_free_vgpr .amdgcn.next_free_vgpr
     .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
-    .amdhsa_reserve_vcc __sgpr_reserve_vcc_default
-    .amdhsa_reserve_xnack_mask __sgpr_reserve_xnack_default
-    .amdhsa_reserve_flat_scratch __sgpr_reserve_flatscr_default
-    .amdhsa_ieee_mode 0
-    .amdhsa_dx10_clamp 0
+    .amdhsa_reserve_vcc                      __sgpr_reserve_vcc_default
+    .amdhsa_reserve_xnack_mask               __sgpr_reserve_xnack_default
+    .amdhsa_reserve_flat_scratch             __sgpr_reserve_flatscr_default
+    .amdhsa_ieee_mode                        __ieee_mode
+    .amdhsa_dx10_clamp                       __dx10_clamp
+    .amdhsa_wavefront_size32 0
 .end_amdhsa_kernel
+.else
+.amdhsa_kernel \kernel_name
+    .amdhsa_group_segment_fixed_size         __group_segment_fixed_size
+    .amdhsa_user_sgpr_private_segment_buffer __sgpr_private_segment_buffer
+    .amdhsa_user_sgpr_dispatch_ptr           __sgpr_dispatch_ptr
+    .amdhsa_user_sgpr_kernarg_segment_ptr    __sgpr_kernarg_segment_ptr
+    .amdhsa_system_sgpr_workgroup_id_x       __sgpr_workgroup_id_x
+    .amdhsa_system_sgpr_workgroup_id_y       __sgpr_workgroup_id_y
+    .amdhsa_system_sgpr_workgroup_id_z       __sgpr_workgroup_id_y
+    .amdhsa_system_vgpr_workitem_id          __vgpr_workitem_id
+    .amdhsa_next_free_vgpr .amdgcn.next_free_vgpr
+    .amdhsa_next_free_sgpr .amdgcn.next_free_sgpr
+    .amdhsa_reserve_vcc                      __sgpr_reserve_vcc_default
+    .amdhsa_reserve_xnack_mask               __sgpr_reserve_xnack_default
+    .amdhsa_reserve_flat_scratch             __sgpr_reserve_flatscr_default
+    .amdhsa_ieee_mode                        __ieee_mode
+    .amdhsa_dx10_clamp                       __dx10_clamp
+.end_amdhsa_kernel
+.endif
 
 total_sgpr_count = .amdgcn.next_free_sgpr + 4 // vcc, xnack
 


### PR DESCRIPTION
This PR fixes Conv_Winograd_v21_1_2 hangs on the gfx10 caused by missing _.amdhsa_wavefront_size32_ directive (due to incorrectly allocated amount of VGPR).
For more information refer to SWDEV-269929

⚠️ _.amdhsa_wavefront_size32_ directive is only available for gfx10+

## Local verification
* gfx1030 ROCm 4.0, gfx906 ROCm 4.0
* fp16, fp32