### PR TITLE
Remove outdated (and now wrong & harmful) workaround for apple

### DIFF
--- a/src/kernel_cache.cpp
+++ b/src/kernel_cache.cpp
@@ -52,19 +52,6 @@ MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEVICE_ARCH)
 
 namespace miopen {
 
-static void ProcessParams(std::string& params)
-{
-    if(params.length() > 0)
-    {
-        // Ensure only one space after the -cl-std.
-        // >1 space can cause an Apple compiler bug. See clSPARSE issue #141.
-        if(params.at(0) != ' ')
-        {
-            params = " " + params;
-        }
-    }
-}
-
 const std::vector<Kernel>& KernelCache::GetKernels(const std::string& algorithm,
                                                    const std::string& network_config)
 {
@@ -110,7 +97,6 @@ bool KernelCache::HasProgram(const std::string& name, const std::string& params)
 
 void KernelCache::AddProgram(Program prog, const std::string& program_name, std::string params)
 {
-    ProcessParams(params);
     program_map[std::make_pair(program_name, params)] = prog;
 }
 
@@ -126,8 +112,6 @@ Kernel KernelCache::AddKernel(const Handle& h,
                               bool is_kernel_miopengemm_str,
                               const std::string& kernel_src)
 {
-    ProcessParams(params);
-
     const std::pair<std::string, std::string> key = std::make_pair(algorithm, network_config);
     if(!network_config.empty() || !algorithm.empty()) // Don't log only _empty_ keys.
         MIOPEN_LOG_I2("Key: " << key.first << " \"" << key.second << '\"');


### PR DESCRIPTION
The reason of the issue: https://github.com/AMDComputeLibraries/MLOpen/pull/2400/files#r572106557. Unlike `AddProgram` and `AddKernel`, `HasProgram` does not use the `ProcessParams` trick, that adds a space to the compile args. That is why `HasProgram` fails to find existing program, if it has been added by `AddProgram` or `AddKernel`. Consequently, `PrecompileSolutions` rebuilds programs that already reside in the binary cache.

However we do not need `ProcessParams` at all, because currently -cl-std is appended to the end or params ([see comment in `ProcessParams`](https://github.com/AMDComputeLibraries/MLOpen/commit/2358609cfcc3d6d84245d89636b61b5b14d8d733#r46885082) that explains why it is required).