### PR TITLE
[HOTFIX][4.1.x] Lower logging level from Warning to Info for incorrect PerfConfigs loaded from db

### DIFF
--- a/src/include/miopen/find_solution.hpp
+++ b/src/include/miopen/find_solution.hpp
@@ -75,7 +75,7 @@ auto FindSolutionImpl(
                 {
                     return s.GetSolution(context, config);
                 }
-                MIOPEN_LOG_WE(
+                MIOPEN_LOG_IE(
                     "Invalid config loaded from Perf Db: " << SolverDbId(s) << ": " << config
                                                            << ". Performance may degrade.");
             }

--- a/src/include/miopen/logger.hpp
+++ b/src/include/miopen/logger.hpp
@@ -191,6 +191,9 @@ enum class LoggingLevel
 constexpr const LoggingLevel LogWELevel =
     MIOPEN_INSTALLABLE ? miopen::LoggingLevel::Warning : miopen::LoggingLevel::Error;
 
+constexpr const LoggingLevel LogIELevel =
+    MIOPEN_INSTALLABLE ? miopen::LoggingLevel::Info : miopen::LoggingLevel::Error;
+
 namespace debug {
 
 /// Quiet mode for debugging/testing purposes. All logging (including MIOPEN_ENABLE_LOGGING*)
@@ -330,6 +333,7 @@ std::string LoggingParseFunction(const char* func, const char* pretty_func);
 
 // Warnings in installable builds, errors otherwise.
 #define MIOPEN_LOG_WE(...) MIOPEN_LOG(LogWELevel, __VA_ARGS__)
+#define MIOPEN_LOG_IE(...) MIOPEN_LOG(LogIELevel, __VA_ARGS__)
 
 #define MIOPEN_LOG_DRIVER_CMD(...)                                                      \
     do                                                                                  \


### PR DESCRIPTION
This is 4.1.x specific hack to resolve SWDEV-270790. Should not be back-propagated to develop, staging or mainline.