### PR TITLE
[HOTFIX] Do not reserve xnack mask SGPR in the 3x3 asm kernel.

### DIFF
--- a/src/kernels/conv3x3.s
+++ b/src/kernels/conv3x3.s
@@ -201,7 +201,8 @@ output_buffer_window = 4 * img_height * img_width
 .if limit_wave_cnt
   .SET_MAX_WAVES_LIMIT limit_wave_cnt
 .endif
-.SGPR_RESERVE_XNACK
+//xnack disabled by default
+//.SGPR_RESERVE_XNACK
 
 // allocate filters
 filter_part_size = weights_per_filter & 0x3


### PR DESCRIPTION
Fixed assembly error in ROCm >= 4.1, see https://github.com/ROCmSoftwarePlatform/MIOpen/pull/665/files#r549486324 for more info.