### PR TITLE
[CI] Select image names and docker build args to get rid of useless image rebuilds. [tests][FP16][MI100] Remove useless tests.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -211,7 +211,7 @@ pipeline {
         parallelsAlwaysFailFast()
     }
     environment{
-        image = "miopen"
+        image = "miopen-hip-clang"
     }
     stages{
         // Run all static analysis tests
@@ -225,8 +225,8 @@ pipeline {
                     steps{
                         script{
                             try{
-                                buildJob('hcc', flags: '-DCMAKE_BUILD_TYPE=release', cmd: cmd, gpu_arch: "all")
-                            } 
+                                buildJob('hcc', flags: '-DCMAKE_BUILD_TYPE=release', cmd: cmd, gpu_arch: "all", image: 'miopen')
+                            }
                             catch(e){
                                 echo "throwing error exception for the stage"
                                 echo 'Exception occurred: ' + e.toString()
@@ -252,8 +252,8 @@ pipeline {
                     steps{
                         script{
                             try{
-                                buildJob('hcc', flags: '-DCMAKE_BUILD_TYPE=release', cmd: cmd, gpu_arch: "all")
-                            } 
+                                buildJob('hcc', flags: '-DCMAKE_BUILD_TYPE=release', cmd: cmd, gpu_arch: "all", image: 'miopen')
+                            }
                             catch(e){
                                 echo "throwing error exception for the stage"
                                 echo 'Exception occurred: ' + e.toString()
@@ -271,8 +271,8 @@ pipeline {
                     steps{
                         script{
                             try{
-                                buildJob('hcc', flags: '-DCMAKE_BUILD_TYPE=release', cmd: cmd, gpu_arch: "all")
-                            } 
+                                buildJob('hcc', flags: '-DCMAKE_BUILD_TYPE=release', cmd: cmd, gpu_arch: "all", image: 'miopen')
+                            }
                             catch(e){
                                 echo "throwing error exception for the stage"
                                 echo 'Exception occurred: ' + e.toString()
@@ -325,12 +325,12 @@ pipeline {
                     }
                 }
 
-                stage('Hip Release') {
+                stage('Hip Release /opt/rocm') {
                     agent{ label rocmnode("vega") }
                     steps{
                         script{
                             try{
-                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', flags: '-DBUILD_DEV=On -DCMAKE_BUILD_TYPE=release', image: image + "rocm", prefixpath: '/opt/rocm', gpu_arch: "gfx900;gfx906")
+                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', flags: '-DBUILD_DEV=On -DCMAKE_BUILD_TYPE=release', image: image+'rocm', prefixpath: '/opt/rocm', gpu_arch: "gfx900;gfx906")
                             }
                             catch(e){
                                 echo "throwing error exception for the stage"
@@ -360,7 +360,7 @@ pipeline {
                     steps{
                         script{
                             try{
-                                 buildHipClangJob('/opt/rocm/llvm/bin/clang++', image: image+'-hip-clang', cmd: cmd, gpu_arch: "gfx900;gfx906")
+                                 buildHipClangJob('/opt/rocm/llvm/bin/clang++', cmd: cmd, gpu_arch: "gfx900;gfx906")
                             }
                             catch(e){
                                 echo "throwing error exception for the stage"
@@ -376,12 +376,12 @@ pipeline {
 
 
 
-                stage('Hip Debug gfx908') {
+                stage('Hip Debug gfx908 /opt/rocm') {
                     agent{ label rocmnode("gfx908") }
                     steps{
                         script{
                             try{
-                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', flags: '-DMIOPEN_TEST_GFX908=On -DBUILD_DEV=On -DCMAKE_BUILD_TYPE=debug', image: image+"rocm", prefixpath: '/opt/rocm', gpu_arch: "gfx908")
+                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', flags: '-DMIOPEN_TEST_GFX908=On -DBUILD_DEV=On -DCMAKE_BUILD_TYPE=debug', image: image+'rocm', prefixpath: '/opt/rocm', gpu_arch: "gfx908")
                             }
                             catch(e){
                                 echo "throwing error exception for the stage"
@@ -413,7 +413,7 @@ pipeline {
                         """
                     }
                     steps{
-                        buildHipClangJob('/opt/rocm/llvm/bin/clang++', env4make: "MIOPEN_LOG_LEVEL=5 MIOPEN_COMPILE_PARALLEL_LEVEL=1", image: image+'-hipnogpu-clang', cmd: cmd, gpu_arch: "gfx900;gfx906")
+                        buildHipClangJob('/opt/rocm/llvm/bin/clang++', env4make: "MIOPEN_LOG_LEVEL=5 MIOPEN_COMPILE_PARALLEL_LEVEL=1", cmd: cmd, gpu_arch: "gfx900;gfx906")
                     }
                 }
                 stage('Hip Debug COMGR') {
@@ -432,7 +432,7 @@ pipeline {
                     steps{
                         script{
                             try{
-                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', image: image+'-hip-clang', cmd: cmd, gpu_arch: "gfx900;gfx906")
+                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', cmd: cmd, gpu_arch: "gfx900;gfx906")
                             }
                             catch(e){
                                 echo "throwing error exception for the stage"
@@ -461,7 +461,7 @@ pipeline {
                     steps{
                         script{
                             try{
-                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', image: image+'-hip-clang', cmd: cmd, gpu_arch: "gfx906")
+                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', cmd: cmd, gpu_arch: "gfx900;gfx906")
                             }
                             catch(e){
                                 echo "throwing error exception for the stage"
@@ -493,7 +493,7 @@ pipeline {
                     steps{
                         script{
                             try{
-                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', image: image+'-hip-clang', cmd: cmd, gpu_arch: "gfx900;gfx906")
+                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', cmd: cmd, gpu_arch: "gfx900;gfx906")
                             }
                             catch(e){
                                 echo "throwing error exception for the stage"
@@ -523,7 +523,7 @@ pipeline {
                     steps{
                         script{
                             try{
-                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', image: image+'-hip-clang', cmd: cmd, gpu_arch: "gfx900;gfx906")
+                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', cmd: cmd, gpu_arch: "gfx900;gfx906")
                             }
                             catch(e){
                                 echo "throwing error exception for the stage"
@@ -553,7 +553,7 @@ pipeline {
                     steps{
                         script{
                             try{
-                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', image: image+'-hip-clang', cmd: cmd, gpu_arch: "gfx900;gfx906")
+                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', cmd: cmd, gpu_arch: "gfx900;gfx906")
                             }
                             catch(e){
                                 echo "throwing error exception for the stage"
@@ -567,7 +567,7 @@ pipeline {
                     }
                 }
 
-                stage('Hip Release on /usr/local') {
+                stage('Hip Release') {
                     agent{ label rocmnode("vega") }
                     steps{
                         script{
@@ -592,12 +592,12 @@ pipeline {
         // Run fp16, bfp16, and int8 quick tests
         stage("Fast low precision"){
             parallel{
-                stage('Half Hip Release Vega20') {
+                stage('Half Hip Release Vega20 /opt/rocm') {
                     agent{ label rocmnode("vega20") }
                     steps{
                         script{
                             try{
-                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', flags: '-DMIOPEN_TEST_HALF=On -DBUILD_DEV=On -DCMAKE_BUILD_TYPE=release', image: image+"rocm", prefixpath: '/opt/rocm', gpu_arch: "gfx906")
+                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', flags: '-DMIOPEN_TEST_HALF=On -DBUILD_DEV=On -DCMAKE_BUILD_TYPE=release', image: image+'rocm', prefixpath: '/opt/rocm', gpu_arch: "gfx900;gfx906")
                             }
                             catch(e){
                                 echo "throwing error exception for the stage"
@@ -615,7 +615,7 @@ pipeline {
                     steps{
                         script{
                             try{
-                                buildHipClangJob('g++', flags: '-DMIOPEN_TEST_HALF=On -DBUILD_DEV=On -DCMAKE_BUILD_TYPE=release', gpu_arch: "gfx906")
+                                buildHipClangJob('g++', flags: '-DMIOPEN_TEST_HALF=On -DBUILD_DEV=On -DCMAKE_BUILD_TYPE=release', gpu_arch: "gfx900;gfx906")
                             }
                             catch(e){
                                 echo "throwing error exception for the stage"
@@ -633,7 +633,7 @@ pipeline {
                     steps{
                         script{
                             try{
-                                buildHipClangJob('g++', flags: '-DMIOPEN_TEST_INT8=On -DBUILD_DEV=On -DCMAKE_BUILD_TYPE=release', gpu_arch: "gfx906")
+                                buildHipClangJob('g++', flags: '-DMIOPEN_TEST_INT8=On -DBUILD_DEV=On -DCMAKE_BUILD_TYPE=release', gpu_arch: "gfx900;gfx906")
                             }
                             catch(e){
                                 echo "throwing error exception for the stage"
@@ -647,12 +647,12 @@ pipeline {
                     }
                 }
 
-                stage('BF16 Hip Release Vega20') {
+                stage('BF16 Hip Release Vega20 /opt/rocm') {
                     agent{ label rocmnode("vega20") }
                     steps{
                         script{
                             try{
-                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', flags: '-DMIOPEN_TEST_BFLOAT16=On -DBUILD_DEV=On -DCMAKE_BUILD_TYPE=release', image: image+"rocm", prefixpath: '/opt/rocm', gpu_arch: "gfx906")
+                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', flags: '-DMIOPEN_TEST_BFLOAT16=On -DBUILD_DEV=On -DCMAKE_BUILD_TYPE=release', image: image+'rocm', prefixpath: '/opt/rocm', gpu_arch: "gfx900;gfx906")
                             }
                             catch(e){
                                 echo "throwing error exception for the stage"
@@ -666,12 +666,12 @@ pipeline {
                     }
                 }
 
-                stage('BF16 Hip Debug gfx908') {
+                stage('BF16 Hip Debug gfx908 /opt/rocm') {
                     agent{ label rocmnode("gfx908") }
                     steps{
                         script{
                             try{
-                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', flags: '-DMIOPEN_TEST_BFLOAT16=On -DMIOPEN_TEST_GFX908=On -DBUILD_DEV=On -DCMAKE_BUILD_TYPE=debug', image: image+"rocm", prefixpath: '/opt/rocm', gpu_arch: "gfx908")
+                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', flags: '-DMIOPEN_TEST_BFLOAT16=On -DMIOPEN_TEST_GFX908=On -DBUILD_DEV=On -DCMAKE_BUILD_TYPE=debug', image: image+'rocm', prefixpath: '/opt/rocm', gpu_arch: "gfx908")
                             }
                             catch(e){
                                 echo "throwing error exception for the stage"
@@ -684,12 +684,12 @@ pipeline {
                         }
                     }
                 }
-                stage('Half Hip Debug gfx908') {
+                stage('Half Hip Debug gfx908 /opt/rocm') {
                     agent{ label rocmnode("gfx908") }
                     steps{
                         script{
                             try{
-                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', flags: '-DMIOPEN_TEST_BFLOAT16=On -DMIOPEN_TEST_GFX908=On -DBUILD_DEV=On -DCMAKE_BUILD_TYPE=debug', image: image+"rocm", prefixpath: '/opt/rocm', gpu_arch: "gfx908")
+                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', flags: '-DMIOPEN_TEST_BFLOAT16=On -DMIOPEN_TEST_GFX908=On -DBUILD_DEV=On -DCMAKE_BUILD_TYPE=debug', image: image+'rocm', prefixpath: '/opt/rocm', gpu_arch: "gfx908")
                             }
                             catch(e){
                                 echo "throwing error exception for the stage"
@@ -727,12 +727,12 @@ pipeline {
                     }
                 }
 
-                stage('Int8 Hip Release All Vega20') {
+                stage('Int8 Hip Release All Vega20 /opt/rocm') {
                     agent{ label rocmnode("vega20") }
                     steps{
                         script{
                             try{
-                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', flags: '-DMIOPEN_TEST_INT8=On -DBUILD_DEV=On -DMIOPEN_TEST_ALL=On -DCMAKE_BUILD_TYPE=release', image: image+"rocm", prefixpath: '/opt/rocm', gpu_arch: "gfx906")
+                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', flags: '-DMIOPEN_TEST_INT8=On -DBUILD_DEV=On -DMIOPEN_TEST_ALL=On -DCMAKE_BUILD_TYPE=release', image: image+'rocm', prefixpath: '/opt/rocm', gpu_arch: "gfx900;gfx906")
                             }
                             catch(e){
                                 echo "throwing error exception for the stage"
@@ -761,7 +761,7 @@ pipeline {
                     steps{
                         script{
                             try{
-                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', image: image+'-hip-clang', cmd: cmd, gpu_arch: "gfx908")
+                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', cmd: cmd, gpu_arch: "gfx908")
                             }
                             catch(e){
                                 echo "throwing error exception for the stage"
@@ -813,7 +813,7 @@ pipeline {
                     steps{
                         script{
                             try{
-                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', image: image + "-hip-clang", cmd: cmd, gpu_arch: "gfx908")
+                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', cmd: cmd, gpu_arch: "gfx908")
                             }
                             catch(e){
                                 echo "throwing error exception for the stage"
@@ -842,7 +842,7 @@ pipeline {
                     steps{
                         script{
                             try{
-                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', image: image + "-hip-clang", cmd: cmd, gpu_arch: "gfx908")
+                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', cmd: cmd, gpu_arch: "gfx908")
                             }
                             catch(e){
                                 echo "throwing error exception for the stage"
@@ -876,7 +876,7 @@ pipeline {
                     steps{
                         script{
                             try{
-                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', image: image + "-hip-clang", cmd: cmd, gpu_arch: "gfx906")
+                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', cmd: cmd, gpu_arch: "gfx900;gfx906")
                             }
                             catch(e){
                                 echo "throwing error exception for the stage"
@@ -906,7 +906,7 @@ pipeline {
                     steps{
                         script{
                             try{
-                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', image: image+'-hip-clang', cmd: cmd, gpu_arch: "gfx906")
+                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', cmd: cmd, gpu_arch: "gfx900;gfx906")
                             }
                             catch(e){
                                 echo "throwing error exception for the stage"
@@ -939,7 +939,7 @@ pipeline {
                     steps{
                         script{
                             try{
-                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', image: image+'-hip-clang', cmd: cmd, gpu_arch: "gfx906")
+                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', cmd: cmd, gpu_arch: "gfx900;gfx906")
                             }
                             catch(e){
                                 echo "throwing error exception for the stage"
@@ -968,7 +968,7 @@ pipeline {
                     steps{
                         script{
                             try{
-                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', image: image+'-hip-clang', cmd: cmd, gpu_arch: "gfx908")
+                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', cmd: cmd, gpu_arch: "gfx908")
                             }
                             catch(e){
                                 echo "throwing error exception for the stage"
@@ -997,7 +997,7 @@ pipeline {
                     steps{
                         script{
                             try{
-                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', image: image+'-hip-clang', cmd: cmd, gpu_arch: "gfx906", miotensile_version: "latest")
+                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', image: image+'-gfx906-miotensilelatest', cmd: cmd, gpu_arch: "gfx906", miotensile_version: "latest")
                             }
                             catch(e){
                                 echo "throwing error exception for the stage"
@@ -1026,7 +1026,7 @@ pipeline {
                     steps{
                         script{
                             try{
-                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', image: image+'-hip-clang', cmd: cmd, gpu_arch: "gfx908", miotensile_version: "latest")
+                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', image: image+'-miotensilelatest', cmd: cmd, gpu_arch: "gfx908", miotensile_version: "latest")
                             }
                             catch(e){
                                 echo "throwing error exception for the stage"
@@ -1050,7 +1050,7 @@ pipeline {
                     steps{
                         script{
                             try{
-                                buildHipClangJob('g++', flags: '-DCMAKE_BUILD_TYPE=release')
+                                buildHipClangJob('g++', flags: '-DCMAKE_BUILD_TYPE=release', image: image+'-gfxall')
                             }
                             catch(e){
                                 echo "throwing error exception for the stage"
@@ -1063,12 +1063,12 @@ pipeline {
                         }
                     }
                 }
-                stage("HIP Release Package"){
+                stage("HIP Release Package /opt/rocm"){
                     agent{ label rocmnode("rocmtest") }
                     steps{
                         script{
                             try{
-                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', flags: '-DCMAKE_BUILD_TYPE=release', image: image+"rocm", prefixpath: '/opt/rocm')
+                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', flags: '-DCMAKE_BUILD_TYPE=release', image: image+'rocm-gfxall', prefixpath: '/opt/rocm')
                             }
                             catch(e){
                                 echo "throwing error exception for the stage"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -59,7 +59,7 @@ def buildJob(Map conf, compiler){
         def env4make = conf.get("env4make", "")
         def image = conf.get("image", "miopen")
         def cmd = conf.get("cmd", "")
-        def gpu_arch = conf.get("gpu_arch", "all")
+        def gpu_arch = conf.get("gpu_arch", "gfx900;gfx906")
         def codecov = conf.get("codecov", false)
         def dockerOpts="--device=/dev/kfd --device=/dev/dri --group-add video --cap-add=SYS_PTRACE --security-opt seccomp=unconfined"
         def dockerArgs = "--build-arg PREFIX=${prefixpath} --build-arg GPU_ARCH='${gpu_arch}' "
@@ -122,7 +122,7 @@ def buildHipClangJob(Map conf, compiler){
         def env4make = conf.get("env4make", "")
         def image = conf.get("image", "miopen")
         def cmd = conf.get("cmd", "")
-        def gpu_arch = conf.get("gpu_arch", "all")
+        def gpu_arch = conf.get("gpu_arch", "gfx900;gfx906")
         def codecov = conf.get("codecov", false)
         def miotensile_version = conf.get("miotensile_version", "default")
         def dockerOpts="--device=/dev/kfd --device=/dev/dri --group-add video --cap-add=SYS_PTRACE --security-opt seccomp=unconfined"
@@ -292,7 +292,7 @@ pipeline {
                     steps{
                         script{
                             try{
-                                buildHipClangJob('g++', flags: '-DBUILD_DEV=On -DCMAKE_BUILD_TYPE=debug', gpu_arch: "gfx900;gfx906")
+                                buildHipClangJob('g++', flags: '-DBUILD_DEV=On -DCMAKE_BUILD_TYPE=debug')
                             }
                             catch(e){
                                 echo "throwing error exception for the stage"
@@ -311,7 +311,7 @@ pipeline {
                     steps{
                         script{
                             try{
-                                buildHipClangJob('g++', flags: '-DBUILD_DEV=On -DCMAKE_BUILD_TYPE=release', gpu_arch: "gfx900;gfx906")
+                                buildHipClangJob('g++', flags: '-DBUILD_DEV=On -DCMAKE_BUILD_TYPE=release')
                             }
                             catch(e){
                                 echo "throwing error exception for the stage"
@@ -330,7 +330,7 @@ pipeline {
                     steps{
                         script{
                             try{
-                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', flags: '-DBUILD_DEV=On -DCMAKE_BUILD_TYPE=release', image: image+'rocm', prefixpath: '/opt/rocm', gpu_arch: "gfx900;gfx906")
+                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', flags: '-DBUILD_DEV=On -DCMAKE_BUILD_TYPE=release', image: image+'rocm', prefixpath: '/opt/rocm')
                             }
                             catch(e){
                                 echo "throwing error exception for the stage"
@@ -360,7 +360,7 @@ pipeline {
                     steps{
                         script{
                             try{
-                                 buildHipClangJob('/opt/rocm/llvm/bin/clang++', cmd: cmd, gpu_arch: "gfx900;gfx906")
+                                 buildHipClangJob('/opt/rocm/llvm/bin/clang++', cmd: cmd)
                             }
                             catch(e){
                                 echo "throwing error exception for the stage"
@@ -413,7 +413,7 @@ pipeline {
                         """
                     }
                     steps{
-                        buildHipClangJob('/opt/rocm/llvm/bin/clang++', env4make: "MIOPEN_LOG_LEVEL=5 MIOPEN_COMPILE_PARALLEL_LEVEL=1", cmd: cmd, gpu_arch: "gfx900;gfx906")
+                        buildHipClangJob('/opt/rocm/llvm/bin/clang++', env4make: "MIOPEN_LOG_LEVEL=5 MIOPEN_COMPILE_PARALLEL_LEVEL=1", cmd: cmd)
                     }
                 }
                 stage('Hip Debug COMGR') {
@@ -432,7 +432,7 @@ pipeline {
                     steps{
                         script{
                             try{
-                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', cmd: cmd, gpu_arch: "gfx900;gfx906")
+                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', cmd: cmd)
                             }
                             catch(e){
                                 echo "throwing error exception for the stage"
@@ -461,7 +461,7 @@ pipeline {
                     steps{
                         script{
                             try{
-                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', cmd: cmd, gpu_arch: "gfx900;gfx906")
+                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', cmd: cmd)
                             }
                             catch(e){
                                 echo "throwing error exception for the stage"
@@ -493,7 +493,7 @@ pipeline {
                     steps{
                         script{
                             try{
-                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', cmd: cmd, gpu_arch: "gfx900;gfx906")
+                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', cmd: cmd)
                             }
                             catch(e){
                                 echo "throwing error exception for the stage"
@@ -523,7 +523,7 @@ pipeline {
                     steps{
                         script{
                             try{
-                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', cmd: cmd, gpu_arch: "gfx900;gfx906")
+                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', cmd: cmd)
                             }
                             catch(e){
                                 echo "throwing error exception for the stage"
@@ -553,7 +553,7 @@ pipeline {
                     steps{
                         script{
                             try{
-                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', cmd: cmd, gpu_arch: "gfx900;gfx906")
+                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', cmd: cmd)
                             }
                             catch(e){
                                 echo "throwing error exception for the stage"
@@ -572,7 +572,7 @@ pipeline {
                     steps{
                         script{
                             try{
-                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', flags: '-DBUILD_DEV=On -DCMAKE_BUILD_TYPE=release', gpu_arch: "gfx900;gfx906")
+                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', flags: '-DBUILD_DEV=On -DCMAKE_BUILD_TYPE=release')
                             }
                             catch(e){
                                 echo "throwing error exception for the stage"
@@ -597,7 +597,7 @@ pipeline {
                     steps{
                         script{
                             try{
-                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', flags: '-DMIOPEN_TEST_HALF=On -DBUILD_DEV=On -DCMAKE_BUILD_TYPE=release', image: image+'rocm', prefixpath: '/opt/rocm', gpu_arch: "gfx900;gfx906")
+                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', flags: '-DMIOPEN_TEST_HALF=On -DBUILD_DEV=On -DCMAKE_BUILD_TYPE=release', image: image+'rocm', prefixpath: '/opt/rocm')
                             }
                             catch(e){
                                 echo "throwing error exception for the stage"
@@ -615,7 +615,7 @@ pipeline {
                     steps{
                         script{
                             try{
-                                buildHipClangJob('g++', flags: '-DMIOPEN_TEST_HALF=On -DBUILD_DEV=On -DCMAKE_BUILD_TYPE=release', gpu_arch: "gfx900;gfx906")
+                                buildHipClangJob('g++', flags: '-DMIOPEN_TEST_HALF=On -DBUILD_DEV=On -DCMAKE_BUILD_TYPE=release')
                             }
                             catch(e){
                                 echo "throwing error exception for the stage"
@@ -633,7 +633,7 @@ pipeline {
                     steps{
                         script{
                             try{
-                                buildHipClangJob('g++', flags: '-DMIOPEN_TEST_INT8=On -DBUILD_DEV=On -DCMAKE_BUILD_TYPE=release', gpu_arch: "gfx900;gfx906")
+                                buildHipClangJob('g++', flags: '-DMIOPEN_TEST_INT8=On -DBUILD_DEV=On -DCMAKE_BUILD_TYPE=release')
                             }
                             catch(e){
                                 echo "throwing error exception for the stage"
@@ -652,7 +652,7 @@ pipeline {
                     steps{
                         script{
                             try{
-                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', flags: '-DMIOPEN_TEST_BFLOAT16=On -DBUILD_DEV=On -DCMAKE_BUILD_TYPE=release', image: image+'rocm', prefixpath: '/opt/rocm', gpu_arch: "gfx900;gfx906")
+                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', flags: '-DMIOPEN_TEST_BFLOAT16=On -DBUILD_DEV=On -DCMAKE_BUILD_TYPE=release', image: image+'rocm', prefixpath: '/opt/rocm')
                             }
                             catch(e){
                                 echo "throwing error exception for the stage"
@@ -713,7 +713,7 @@ pipeline {
                     steps{
                         script{
                             try{
-                                buildHipClangJob('g++', flags: '-DBUILD_DEV=On -DCMAKE_BUILD_TYPE=debug', codecov: true, gpu_arch: "gfx900;gfx906")
+                                buildHipClangJob('g++', flags: '-DBUILD_DEV=On -DCMAKE_BUILD_TYPE=debug', codecov: true)
                             }
                             catch(e){
                                 echo "throwing error exception for the stage"
@@ -732,7 +732,7 @@ pipeline {
                     steps{
                         script{
                             try{
-                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', flags: '-DMIOPEN_TEST_INT8=On -DBUILD_DEV=On -DMIOPEN_TEST_ALL=On -DCMAKE_BUILD_TYPE=release', image: image+'rocm', prefixpath: '/opt/rocm', gpu_arch: "gfx900;gfx906")
+                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', flags: '-DMIOPEN_TEST_INT8=On -DBUILD_DEV=On -DMIOPEN_TEST_ALL=On -DCMAKE_BUILD_TYPE=release', image: image+'rocm', prefixpath: '/opt/rocm')
                             }
                             catch(e){
                                 echo "throwing error exception for the stage"
@@ -784,7 +784,7 @@ pipeline {
                     steps{
                         script{
                             try{
-                                buildHipClangJob('g++', flags: '-DBUILD_DEV=On -DMIOPEN_TEST_ALL=On -DCMAKE_BUILD_TYPE=release', gpu_arch: "gfx900;gfx906")
+                                buildHipClangJob('g++', flags: '-DBUILD_DEV=On -DMIOPEN_TEST_ALL=On -DCMAKE_BUILD_TYPE=release')
                             }
                             catch(e){
                                 echo "throwing error exception for the stage"
@@ -876,7 +876,7 @@ pipeline {
                     steps{
                         script{
                             try{
-                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', cmd: cmd, gpu_arch: "gfx900;gfx906")
+                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', cmd: cmd)
                             }
                             catch(e){
                                 echo "throwing error exception for the stage"
@@ -906,7 +906,7 @@ pipeline {
                     steps{
                         script{
                             try{
-                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', cmd: cmd, gpu_arch: "gfx900;gfx906")
+                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', cmd: cmd)
                             }
                             catch(e){
                                 echo "throwing error exception for the stage"
@@ -939,7 +939,7 @@ pipeline {
                     steps{
                         script{
                             try{
-                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', cmd: cmd, gpu_arch: "gfx900;gfx906")
+                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', cmd: cmd)
                             }
                             catch(e){
                                 echo "throwing error exception for the stage"
@@ -1050,7 +1050,7 @@ pipeline {
                     steps{
                         script{
                             try{
-                                buildHipClangJob('g++', flags: '-DCMAKE_BUILD_TYPE=release', image: image+'-gfxall')
+                                buildHipClangJob('g++', flags: '-DCMAKE_BUILD_TYPE=release', image: image+'-gfxall', gpu_arch: "all")
                             }
                             catch(e){
                                 echo "throwing error exception for the stage"
@@ -1068,7 +1068,7 @@ pipeline {
                     steps{
                         script{
                             try{
-                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', flags: '-DCMAKE_BUILD_TYPE=release', image: image+'rocm-gfxall', prefixpath: '/opt/rocm')
+                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', flags: '-DCMAKE_BUILD_TYPE=release', image: image+'rocm-gfxall', prefixpath: '/opt/rocm', gpu_arch: "all")
                             }
                             catch(e){
                                 echo "throwing error exception for the stage"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -53,15 +53,13 @@ find_package(Threads REQUIRED)
 add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure -C ${CMAKE_CFG_INTDIR})
 add_custom_target(tests)
 
-set(SKIP_TESTS)
+set(SKIP_TESTS dummy) # dummy is for REMOVE_DUPLICATES
+set(SKIP_ALL_EXCEPT_TESTS dummy)
 set(MIOPEN_TEST_FLOAT_ARG)
 
 if(MIOPEN_TEST_HALF)
     if(MIOPEN_BACKEND_OPENCL)
         set(SKIP_TESTS test_gru test_rnn_vanilla test_lstm test_conv_igemm_dynamic)
-    endif()
-    if(MIOPEN_TEST_GFX908)
-       set(SKIP_TESTS test_immed_conv3d test_conv3d test_fusion_aux test_activation test_lrn_test test_ctc test_conv2d_bias test_conv3d_bias test_cba_inference test_cbna_inference test_pooling2d test_na_train test_na_inference test_bn_aux test_conv_igemm_dynamic)
     endif()
     set(MIOPEN_TEST_FLOAT_ARG --half)
 elseif(MIOPEN_TEST_INT8)
@@ -70,11 +68,13 @@ elseif(MIOPEN_TEST_INT8)
 elseif(MIOPEN_TEST_BFLOAT16)
     set(SKIP_ALL_EXCEPT_TESTS test_conv2d test_tensor_copy test_tensor_set test_tensor_vec test_immed_conv2d test_check_numerics_test)
     if(MIOPEN_TEST_GFX908)
-        set(SKIP_ALL_EXCEPT_TESTS test_conv_extra test_conv_for_implicit_gemm test_miopen_conv test_deepbench_conv ${SKIP_ALL_EXCEPT_TESTS})
+        list(APPEND SKIP_ALL_EXCEPT_TESTS test_conv_extra test_conv_for_implicit_gemm test_miopen_conv test_deepbench_conv)
     endif()
     set(MIOPEN_TEST_FLOAT_ARG --bfloat16)
-elseif(MIOPEN_TEST_GFX908)
-    set(SKIP_TESTS test_main test_tensor_scale test_tensor_set test_tensor_transform test_tensor_vec test_w_supertensor test_dropout test_immed_conv3d test_conv3d test_soft_max test_fusion_aux test_activation test_lrn_test test_ctc test_conv2d_bias test_conv3d_bias test_cba_inference test_cbna_inference test_pooling2d test_na_train test_na_inference test_bn_aux test_conv_igemm_dynamic)
+endif()
+
+if(MIOPEN_TEST_GFX908)
+    list(APPEND SKIP_TESTS test_main test_tensor_scale test_tensor_set test_tensor_transform test_tensor_vec test_w_supertensor test_dropout test_immed_conv3d test_conv3d test_soft_max test_fusion_aux test_activation test_lrn_test test_ctc test_conv2d_bias test_conv3d_bias test_cba_inference test_cbna_inference test_pooling2d test_na_train test_na_inference test_bn_aux test_conv_igemm_dynamic)
 endif()
 
 if(MIOPEN_TEST_MIOTENSILE)
@@ -82,8 +82,11 @@ if(MIOPEN_TEST_MIOTENSILE)
     list(APPEND SKIP_TESTS test_conv_igemm_dynamic test_conv_igemm_dynamic_small test_conv_for_implicit_gemm)
 endif()
 
+list(REMOVE_DUPLICATES SKIP_TESTS)
+list(REMOVE_DUPLICATES SKIP_ALL_EXCEPT_TESTS)
+
 function(add_test_command NAME EXE)
-    # Restrict the use of SKIP_ALL_EXCEPT_TESTS list in the low-precision and miopentensile tests
+    # Restrict the use of SKIP_ALL_EXCEPT_TESTS list in the Int8, BF16 and MIOpenTensile tests
     if((NOT (NAME IN_LIST SKIP_ALL_EXCEPT_TESTS)) AND (MIOPEN_TEST_INT8 OR MIOPEN_TEST_BFLOAT16 OR MIOPEN_TEST_MIOTENSILE))
         add_test(NAME ${NAME} COMMAND echo skipped)
         set_tests_properties(${NAME} PROPERTIES DISABLED On)


### PR DESCRIPTION
- [Optimization] Even if stage is intended to run only on Vega10 node, build docker image as if it is intended to run on any Vega GPU.
  - Currently things like `gpu_arch: gfx900` are used with "standard" image names. This leads to many useless image rebuilds.
- [Optimization] Same for Vega20 stages
- [Optimization] [Fix] Use `miopen-hip-clang` as a basename for hip-clang based docker image.
  -  Note: Currently Jenkinsfile uses `miopen` which is actually intended for hcc-based dockers. This issue was introduced in #759
- [Optimization] Use the same image name for `HipNoGPU` -- it actually uses the same image
- [Optimization] Use different images names for MIOpenTensile "latest" docker image
  - Currently we use "standard" name and that leads to useless image rebuilds per each job.
- [Optimization] Use distinct image names for "Packages" as docker build options are different.
- Some refactors.

All of the above optimizations can be considered as fixes for issues that reduce docker cache efficiency.

The expected side effect is ~2X better throughoutput of our CI.

Also skips useless FP16 tests from MI100 targets. Why: If some test is not run on MI100 with FP32 (float), then all the more it should not be run with FP16 (half). But currently this is not so. For example, `test_dropout` takes about of 2 hours to complete on MI100 with FP16 datatype, thus wasting ~2 hours of total CI job time.