### PR TITLE
[Fix] test_handle_test failure on gfx1030

### DIFF
--- a/test/handle_test.cpp
+++ b/test/handle_test.cpp
@@ -240,7 +240,7 @@ void test_warnings(kernel_type_t kern_type)
 void test_arch_name()
 {
     auto&& h        = get_handle();
-    auto known_arch = {"gfx908", "gfx906", "gfx900", "gfx803"};
+    auto known_arch = {"gfx908", "gfx906", "gfx900", "gfx803", "gfx1030"};
     auto this_arch  = h.GetDeviceName();
     EXPECT(std::any_of(
         known_arch.begin(), known_arch.end(), [&](std::string arch) { return arch == this_arch; }));


### PR DESCRIPTION
- Fixed test_handle_test failure on gfx1030 due to unknown arch
- Added gfx1030 into the known_arch list