### PR TITLE
[rocm-4.1.x][OCL BE][HIP] Use "hipv4" instead of "hip" in unbundler options starting from 4.1.210801

### DIFF
--- a/src/hip/hip_build_utils.cpp
+++ b/src/hip/hip_build_utils.cpp
@@ -217,7 +217,13 @@ static boost::filesystem::path HipBuildImpl(boost::optional<TmpDir>& tmp_dir,
     if(IsHipClangCompiler())
     {
         tmp_dir->Execute(MIOPEN_OFFLOADBUNDLER_BIN,
-                         "--type=o --targets=hip-amdgcn-amd-amdhsa-" +
+                         "--type=o "
+#if HIP_PACKAGE_VERSION_FLAT >= 4001021081
+                         "--targets=hipv4-amdgcn-amd-amdhsa-"
+#else
+                         "--targets=hip-amdgcn-amd-amdhsa-"
+#endif
+                             +
                              (HipCompilerVersion() < external_tool_version_t{4, 1, 0}
                                   ? lots.device
                                   : (std::string{'-'} + lots.device + lots.xnack)) +


### PR DESCRIPTION
This is fix for [SWDEV-276206](http://ontrack-internal.amd.com/browse/SWDEV-276206).