### PR TITLE
[OCL BE][HIP] Use "hipv4" for unbundler in 4.1 and in 4.2 starting from 21072.

### DIFF
--- a/src/hip/hip_build_utils.cpp
+++ b/src/hip/hip_build_utils.cpp
@@ -217,7 +217,13 @@ static boost::filesystem::path HipBuildImpl(boost::optional<TmpDir>& tmp_dir,
     if(IsHipClangCompiler())
     {
         tmp_dir->Execute(MIOPEN_OFFLOADBUNDLER_BIN,
-                         "--type=o --targets=hip-amdgcn-amd-amdhsa-" +
+                         "--type=o "
+#if HIP_PACKAGE_VERSION_FLAT >= 4001021081
+                         "--targets=hipv4-amdgcn-amd-amdhsa-"
+#else
+                         "--targets=hip-amdgcn-amd-amdhsa-"
+#endif
+                             +
                              (HipCompilerVersion() < external_tool_version_t{4, 1, 0}
                                   ? lots.device
                                   : (std::string{'-'} + lots.device + lots.xnack)) +

--- a/src/hip/hip_build_utils.cpp
+++ b/src/hip/hip_build_utils.cpp
@@ -218,7 +218,8 @@ static boost::filesystem::path HipBuildImpl(boost::optional<TmpDir>& tmp_dir,
     {
         tmp_dir->Execute(MIOPEN_OFFLOADBUNDLER_BIN,
                          "--type=o "
-#if HIP_PACKAGE_VERSION_FLAT >= 4001021081
+#if(HIP_PACKAGE_VERSION_FLAT >= 4001021072 && HIP_PACKAGE_VERSION_FLAT < 4002000000) || \
+    HIP_PACKAGE_VERSION_FLAT >= 4002021072
                          "--targets=hipv4-amdgcn-amd-amdhsa-"
 #else
                          "--targets=hip-amdgcn-amd-amdhsa-"


### PR DESCRIPTION
#786 cherry-picked for develop (cherry picked from commit 0c27e45c20c18a620d08422347c59f3096c12f81). Should resolve http://ontrack-internal.amd.com/browse/SWDEV-274497.

UPDATE: includes additional check that prevents failures with 4.2 before patch 21072.