### PR TITLE
[rocm-4.1.x][HOTFIX][WORKAROUND][OCL] Disable MIOpenGEMM for failing configs. Backup GEMM with Naive Direct Solvers for Immediate Fallback.

### DIFF
--- a/src/include/miopen/rocm_features.hpp
+++ b/src/include/miopen/rocm_features.hpp
@@ -39,4 +39,28 @@
 /// To be removed as soon as support for ROCm 3.x is discontinued.
 #define WORKAROUND_MLOPEN_ISSUE_1711 (HIP_PACKAGE_VERSION_FLAT < 4000000000ULL)
 
+/// W/A for MIOpenGEMM issues with ROCm 4.1, most likely related to the
+/// issues in the OpenCL compiler or in MIOpenGEMM itself.
+/// MIOpenGEMM is used only for OCL BE and deprecated.
+/// Related ticket: http://ontrack-internal.amd.com/browse/SWDEV-276757
+///
+/// Some failing cases:
+/// test_immed_conv2d --float --cmode conv --pmode default --group-count 1
+///  --input 1, 3, 224, 224 --weights 1, 3, 11, 11
+///   --pads_strides_dilations 1 1 1 1 1 1 --trans_output_pads 0 0
+///  --input 1, 3, 224, 224 --weights 1, 3, 7, 7
+///   --pads_strides_dilations 3 3 2 2 1 1 --trans_output_pads 0 0
+/// test_immed_conv3d --float --cmode conv --pmode default --group-count 1
+///  --input 1, 4, 4, 161, 700 --weights 1, 4, 3, 11, 11
+///   --pads_strides_dilations 3 3 3 2 2 2 4 4 4 --trans_output_pads 0 0 0
+///
+/// W/A is in effect only when MIOpenGEMM is used (OCL BE) abd includes:
+/// - Disabling GEMM for failing configs.
+/// - Adding Naive Solvers. Naive solvers are inteded for use as backup for
+///   Immediate Mode Fallback when GEMM is disabled.
+/// - Note: When MIOpenGEMM is not in use, Naive Solvers are disabled. This minimizes
+///   impact of the W/A to the HIP backend.
+#define WORKAROUND_MIOPENGEMM_ROCM41 \
+    (MIOPEN_USE_MIOPENGEMM && HIP_PACKAGE_VERSION_MAJOR == 4 && HIP_PACKAGE_VERSION_MINOR == 1)
+
 #endif // GUARD_ROCM_FEATURES_HPP_

--- a/src/include/miopen/solver.hpp
+++ b/src/include/miopen/solver.hpp
@@ -33,6 +33,7 @@
 #include <miopen/logger.hpp>
 #include <miopen/mlo_internal.hpp>
 #include <miopen/legacy_exhaustive_search.hpp>
+#include <miopen/rocm_features.hpp>
 #include <miopen/type_name.hpp>
 #include <miopen/miopen.h>
 #include <miopen/buffer_info.hpp>
@@ -2061,6 +2062,11 @@ struct ConvDirectNaiveConvFwd : SolverBase<ConvolutionContext>
 {
     bool IsApplicable(const ConvolutionContext& ctx) const;
     bool IsDynamic() const { return true; }
+#if WORKAROUND_MIOPENGEMM_ROCM41
+    /// Use very small fixed value enough to backup GEMM for cases when
+    /// GEMM is disabled due to MIOpenGemm or OCL compiler issues.
+    float GetWti(const ConvolutionContext&) const { return 0.01; }
+#endif
     ConvSolution GetSolution(const ConvolutionContext& ctx) const;
 };
 
@@ -2068,6 +2074,11 @@ struct ConvDirectNaiveConvBwd : SolverBase<ConvolutionContext>
 {
     bool IsApplicable(const ConvolutionContext& ctx) const;
     bool IsDynamic() const { return true; }
+#if WORKAROUND_MIOPENGEMM_ROCM41
+    /// Use very small fixed value enough to backup GEMM for cases when
+    /// GEMM is disabled due to MIOpenGemm or OCL compiler issues.
+    float GetWti(const ConvolutionContext&) const { return 0.01; }
+#endif
     ConvSolution GetSolution(const ConvolutionContext& ctx) const;
 };
 
@@ -2075,6 +2086,11 @@ struct ConvDirectNaiveConvWrw : SolverBase<ConvolutionContext>
 {
     bool IsApplicable(const ConvolutionContext& ctx) const;
     bool IsDynamic() const { return true; }
+#if WORKAROUND_MIOPENGEMM_ROCM41
+    /// Use very small fixed value enough to backup GEMM for cases when
+    /// GEMM is disabled due to MIOpenGemm or OCL compiler issues.
+    float GetWti(const ConvolutionContext&) const { return 0.01; }
+#endif
     ConvSolution GetSolution(const ConvolutionContext& ctx) const;
 };
 

--- a/src/solver/conv_direct_naive_conv_bwd.cpp
+++ b/src/solver/conv_direct_naive_conv_bwd.cpp
@@ -37,7 +37,11 @@ namespace solver {
 bool ConvDirectNaiveConvBwd::IsApplicable(const ConvolutionContext& ctx) const
 {
     if(!miopen::debug::AlwaysEnableConvDirectNaive &&
+#if WORKAROUND_MIOPENGEMM_ROCM41
        miopen::IsDisabled(MIOPEN_DEBUG_CONV_DIRECT_NAIVE_CONV_BWD{}))
+#else
+       !miopen::IsEnabled(MIOPEN_DEBUG_CONV_DIRECT_NAIVE_CONV_BWD{}))
+#endif
         return false;
 
     if(!ctx.IsLayoutDefault())

--- a/src/solver/conv_direct_naive_conv_fwd.cpp
+++ b/src/solver/conv_direct_naive_conv_fwd.cpp
@@ -25,6 +25,7 @@
  *******************************************************************************/
 
 #include "conv_direct_naive_conv.hpp"
+#include <miopen/rocm_features.hpp>
 #include <miopen/solver.hpp>
 #include <miopen/conv/data_invoke_params.hpp>
 #include <miopen/env.hpp>
@@ -37,7 +38,11 @@ namespace solver {
 bool ConvDirectNaiveConvFwd::IsApplicable(const ConvolutionContext& ctx) const
 {
     if(!miopen::debug::AlwaysEnableConvDirectNaive &&
+#if WORKAROUND_MIOPENGEMM_ROCM41
        miopen::IsDisabled(MIOPEN_DEBUG_CONV_DIRECT_NAIVE_CONV_FWD{}))
+#else
+       !miopen::IsEnabled(MIOPEN_DEBUG_CONV_DIRECT_NAIVE_CONV_FWD{}))
+#endif
         return false;
 
     if(!ctx.IsLayoutDefault())

--- a/src/solver/conv_direct_naive_conv_wrw.cpp
+++ b/src/solver/conv_direct_naive_conv_wrw.cpp
@@ -37,7 +37,11 @@ namespace solver {
 bool ConvDirectNaiveConvWrw::IsApplicable(const ConvolutionContext& ctx) const
 {
     if(!miopen::debug::AlwaysEnableConvDirectNaive &&
+#if WORKAROUND_MIOPENGEMM_ROCM41
        miopen::IsDisabled(MIOPEN_DEBUG_CONV_DIRECT_NAIVE_CONV_WRW{}))
+#else
+       !miopen::IsEnabled(MIOPEN_DEBUG_CONV_DIRECT_NAIVE_CONV_WRW{}))
+#endif
         return false;
 
     if(!ctx.IsLayoutDefault())


### PR DESCRIPTION
This PR is intended for 4.1 release only. Related ticket: http://ontrack-internal.amd.com/browse/SWDEV-276757

W/A for MIOpenGEMM issues with ROCm 4.1. The exact reason is not known yet, the most likely reason is a bug in MIOpenGEMM. Note that MIOpenGEMM is used only for OCL BE and is deprecated. It is also possible that the reason is an issue in the OpenCL compiler, but I do not see any problems with other OpenCL kernels.

Some failing cases:
```
test_immed_conv2d --float --cmode conv --pmode default --group-count 1 --input 1, 3, 224, 224 --weights 1, 3, 11, 11 --pads_strides_dilations 1 1 1 1 1 1 --trans_output_pads 0 0
test_immed_conv2d --float --cmode conv --pmode default --group-count 1 --input 1, 3, 224, 224 --weights 1, 3, 7, 7 --pads_strides_dilations 3 3 2 2 1 1 --trans_output_pads 0 0
test_immed_conv3d --float --cmode conv --pmode default --group-count 1 --input 1, 4, 4, 161, 700 --weights 1, 4, 3, 11, 11 --pads_strides_dilations 3 3 3 2 2 2 4 4 4 --trans_output_pads 0 0 0
```

W/A is in effect only when MIOpenGEMM is used (OCL BE) and includes:
- Disabling GEMM for failing configs.
- Adding Naive Solvers (already cherrypicked to `rocm-4.1.x-staging` from #583). Naive solvers are inteded for use as backup for Immediate Mode Fallback when GEMM is disabled.
- Note: When MIOpenGEMM is not in use, Naive Solvers are disabled. This minimizes impact of the W/A to the HIP backend.

## Some info about the issue:
- Memory access faults of verification errors during Forward convolutions.
- The issue does NOT happen with DEV builds.
- Seen on gfx906 and gfx908, with both ROCm 4.1 RC3 and RC2.
- When you run a single config after clean installation, the issue does not happen.
- The issue does not happen with even if you run `test_conv2d --all`, even if several instances are launched in parallel (I tried with 8).
- What works for me right now is `CTEST_PARALLEL_LEVEL=4 MIOPEN_CONV_PRECISE_ROCBLAS_TIMING=0 make check -j`
  - Both binary cache (`$HOME/.cache/miopen`) and user-find-db (`$HOME/.config/miopen`) ___must be cleaned___ before reproducing this issue. You can simply remove these directories.
  - `MIOPEN_FIND_MODE` should not be set (i.e. the default Hybrid mode should be used). This is for better reproducibility.
- After initial failure, the command that runs single config will fail permanently. If you remove the binary cache, then error disappears.

CMake command for docker:
```bash
cmake \
-DMIOPEN_TEST_ALL=On \
-DCMAKE_PREFIX_PATH=/root/driver/MLOpen/deps_opencl \
-DCMAKE_BUILD_TYPE=Release \
-DMIOPEN_BACKEND=OpenCL \
-DMIOPEN_TEST_FLAGS="--verbose --disable-verification-cache" \
-DCMAKE_INSTALL_PREFIX=../../install/41rc3.fixing.release.opencl.nodev ../..
```
Testing:
```bash
make MIOpenDriver tests install -j 16 && \
MIOPEN_LOG_LEVEL=6 CTEST_PARALLEL_LEVEL=4 MIOPEN_CONV_PRECISE_ROCBLAS_TIMING=0 make check -j 16 \
2>&1 | tee /dockerx/logfile.txt
```