### PR TITLE
[CI] Remove huge generated kernel headers from tidy checks. Accelerate parallel library builds.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -474,6 +474,9 @@ if( MIOPEN_BACKEND MATCHES "OpenCL" OR MIOPEN_BACKEND STREQUAL "HIPOC" OR MIOPEN
         ocl/fusionopconvocl.cpp
         ocl/fusionopbiasbnactivocl.cpp
         ${PROJECT_BINARY_DIR}/db_path.cpp
+        )
+
+    list(INSERT MIOpen_Source 0
         ${PROJECT_BINARY_DIR}/kernel.cpp
         ${PROJECT_BINARY_DIR}/kernel_includes.cpp
         )

--- a/src/kernels/kernel.cpp.in
+++ b/src/kernels/kernel.cpp.in
@@ -23,7 +23,9 @@
  * SOFTWARE.
  *
  *******************************************************************************/
+#ifndef MIOPEN_USE_CLANG_TIDY // Huge generated source
 #include "miopen_kernels.h"
+#endif
 #include <algorithm>
 #include <map>
 #include <miopen/kernel.hpp>
@@ -33,7 +35,11 @@ namespace miopen {
 
 const std::map<std::string, std::string>& kernels()
 {
-    static const std::map<std::string, std::string> data{${INIT_KERNELS}};
+    static const std::map<std::string, std::string> data{
+#ifndef MIOPEN_USE_CLANG_TIDY // Huge generated source
+        ${INIT_KERNELS}
+#endif
+    };
     return data;
 }
 

--- a/src/kernels/kernel_includes.cpp.in
+++ b/src/kernels/kernel_includes.cpp.in
@@ -23,7 +23,9 @@
  * SOFTWARE.
  *
  *******************************************************************************/
+#ifndef MIOPEN_USE_CLANG_TIDY // Huge generated source
 #include "miopen_kernel_includes.h"
+#endif
 #include <algorithm>
 #include <map>
 #include <miopen/kernel.hpp>
@@ -33,7 +35,11 @@ namespace miopen {
 
 const std::map<std::string, std::string>& kernel_includes()
 {
-    static const std::map<std::string, std::string> data{${INIT_KERNELS}};
+    static const std::map<std::string, std::string> data{
+#ifndef MIOPEN_USE_CLANG_TIDY // Huge generated source
+        ${INIT_KERNELS}
+#endif
+    };
     return data;
 }
 


### PR DESCRIPTION
- Removes huge generated kernel headers from tidy checks. On current develop, `make tidy` progressed from ~40 minutes to 15 mins. Without this, #680 takes >5 hours to complete.
- Moves builds of generated kernel sources to the beginning of `MIOpen_source`. This saves ~1 minute during library build.




