### PR TITLE
[HIP build] Do not write unnecessary files to disk.

### DIFF
--- a/src/hip/hip_build_utils.cpp
+++ b/src/hip/hip_build_utils.cpp
@@ -110,7 +110,7 @@ static boost::filesystem::path HipBuildImpl(boost::optional<TmpDir>& tmp_dir,
     // Let's assume includes are overkill for feature tests & optimize'em out.
     if(!testing_mode)
     {
-        auto inc_list = GetKernelIncList();
+        auto inc_list = GetHipKernelIncList();
         auto inc_path = tmp_dir->path;
         boost::filesystem::create_directories(inc_path);
         for(auto inc_file : inc_list)


### PR DESCRIPTION
Each time when HIP kernel is being compiled, the library writes to disk all include files. The total size of this with #680 is ~81MB. ~80 MB of those are assembly `.inc` files, which are irrelevant. This affects performance. HDD write speed on my machine:
```bash
$ sudo dd if=/dev/zero of=/mnt/hdd/dd-test bs=330k count=25000
25000+0 records in
25000+0 records out
8448000000 bytes (8.4 GB, 7.9 GiB) copied, 58.5778 s, 144 MB/s
```
Which means that 80MB of useless files adds ~0.55 sec at least.

This PR writes to disk only HIP headers thus reducing to total size down to ~1MB.
