### PR TITLE
[Nv21][HOTFIX][TargetId] Support features disabled on target (SWDEV-278900)

### DIFF
--- a/src/comgr.cpp
+++ b/src/comgr.cpp
@@ -202,10 +202,13 @@ static void AddCompilerOptions(OptionList& list, const miopen::TargetProperties&
 #if ROCM_FEATURE_TARGETID_OFF
     // It seems like these options are used only in codegen.
     // However it seems ok to pass these to compiler.
-    if(target.Sramecc())
-        list.push_back("-msram-ecc");
-    else
-        list.push_back("-mno-sram-ecc");
+    if(target.IsSramecc())
+    {
+        if(*target.IsSramecc())
+            list.push_back("-msram-ecc");
+        else
+            list.push_back("-mno-sram-ecc");
+    }
 #else
     std::ignore = target;
 #endif
@@ -306,7 +309,7 @@ static void RemoveLinkOptionsUnwanted(OptionList& list)
 static std::string GetIsaName(const miopen::TargetProperties& target)
 {
 #if ROCM_FEATURE_TARGETID_OFF
-    const char* const ecc_suffix = target.Sramecc() ? "+sram-ecc" : "";
+    const char* const ecc_suffix = (target.IsSramecc() && *target.IsSramecc()) ? "+sram-ecc" : "";
     return {"amdgcn-amd-amdhsa--" + target.Name() + ecc_suffix};
 #else
     const LcOptionTargetStrings lots(target);

--- a/src/comgr.cpp
+++ b/src/comgr.cpp
@@ -202,9 +202,9 @@ static void AddCompilerOptions(OptionList& list, const miopen::TargetProperties&
 #if ROCM_FEATURE_TARGETID_OFF
     // It seems like these options are used only in codegen.
     // However it seems ok to pass these to compiler.
-    if(target.IsSramecc())
+    if(target.Sramecc())
     {
-        if(*target.IsSramecc())
+        if(*target.Sramecc())
             list.push_back("-msram-ecc");
         else
             list.push_back("-mno-sram-ecc");
@@ -309,7 +309,7 @@ static void RemoveLinkOptionsUnwanted(OptionList& list)
 static std::string GetIsaName(const miopen::TargetProperties& target)
 {
 #if ROCM_FEATURE_TARGETID_OFF
-    const char* const ecc_suffix = (target.IsSramecc() && *target.IsSramecc()) ? "+sram-ecc" : "";
+    const char* const ecc_suffix = (target.Sramecc() && *target.Sramecc()) ? "+sram-ecc" : "";
     return {"amdgcn-amd-amdhsa--" + target.Name() + ecc_suffix};
 #else
     const LcOptionTargetStrings lots(target);
@@ -925,7 +925,7 @@ void BuildAsm(const std::string& name,
         auto optAsm = miopen::SplitSpaceSeparated(options);
 #if WORKAROUND_SWDEV_255735
         if(miopen::HipCompilerVersion() >= miopen::external_tool_version_t{3, 8, 20403})
-            if(target.IsXnack() && !*target.IsXnack())
+            if(target.Xnack() && !*target.Xnack())
                 optAsm.push_back("-mno-xnack");
 #endif
         compiler::lc::gcnasm::RemoveOptionsUnwanted(optAsm);

--- a/src/comgr.cpp
+++ b/src/comgr.cpp
@@ -922,7 +922,8 @@ void BuildAsm(const std::string& name,
         auto optAsm = miopen::SplitSpaceSeparated(options);
 #if WORKAROUND_SWDEV_255735
         if(miopen::HipCompilerVersion() >= miopen::external_tool_version_t{3, 8, 20403})
-            optAsm.push_back("-mno-xnack");
+            if(target.IsXnack() && !*target.IsXnack())
+                optAsm.push_back("-mno-xnack");
 #endif
         compiler::lc::gcnasm::RemoveOptionsUnwanted(optAsm);
         action.SetOptionList(optAsm);

--- a/src/hipoc/hipoc_program.cpp
+++ b/src/hipoc/hipoc_program.cpp
@@ -243,7 +243,7 @@ struct HIPOCProgramImpl
         }
         else if(miopen::EndsWith(filename, ".s"))
         {
-            const auto assembled = AmdgcnAssemble(src, params); // FIXME
+            const auto assembled = AmdgcnAssemble(src, params, target); // FIXME
             WriteFile(assembled, hsaco_file);
         }
         else if(miopen::EndsWith(filename, ".cpp"))

--- a/src/hipoc/hipoc_program.cpp
+++ b/src/hipoc/hipoc_program.cpp
@@ -243,7 +243,7 @@ struct HIPOCProgramImpl
         }
         else if(miopen::EndsWith(filename, ".s"))
         {
-            const auto assembled = AmdgcnAssemble(src, params, target); // FIXME
+            const auto assembled = AmdgcnAssemble(src, params, target);
             WriteFile(assembled, hsaco_file);
         }
         else if(miopen::EndsWith(filename, ".cpp"))

--- a/src/include/miopen/gcn_asm_utils.hpp
+++ b/src/include/miopen/gcn_asm_utils.hpp
@@ -26,9 +26,10 @@
 #ifndef GCN_ASM_UTILS_H
 #define GCN_ASM_UTILS_H
 
-#include <string>
-#include <sstream>
 #include <miopen/config.h>
+#include <miopen/target_properties.hpp>
+#include <sstream>
+#include <string>
 
 /// Since 3.8.20403, ".amdhsa_reserve_xnack_mask 0" is not working without
 /// explicit "-mno-xnack" option.
@@ -36,7 +37,9 @@
 
 bool ValidateGcnAssembler();
 #if !MIOPEN_USE_COMGR
-std::string AmdgcnAssemble(const std::string& source, const std::string& params);
+std::string AmdgcnAssemble(const std::string& source,
+                           const std::string& params,
+                           const miopen::TargetProperties& target);
 #endif
 
 template <typename TValue>

--- a/src/include/miopen/hip_build_utils.hpp
+++ b/src/include/miopen/hip_build_utils.hpp
@@ -76,18 +76,18 @@ class LcOptionTargetStrings
     LcOptionTargetStrings(const TargetProperties& target)
         : device(target.Name()),
           xnack([&]() -> std::string {
-              if(target.IsXnack())
-                  return std::string{":xnack"} + (*target.IsXnack() ? "+" : "-");
+              if(target.Xnack())
+                  return std::string{":xnack"} + (*target.Xnack() ? "+" : "-");
               return {};
           }()),
           sramecc([&]() -> std::string {
-              if(target.IsSramecc())
-                  return std::string{":sramecc"} + (*target.IsSramecc() ? "+" : "-");
+              if(target.Sramecc())
+                  return std::string{":sramecc"} + (*target.Sramecc() ? "+" : "-");
               return {};
           }()),
           sramecc_reported([&]() -> std::string {
-              if(target.IsSrameccReported())
-                  return std::string{":sramecc"} + (*target.IsSrameccReported() ? "+" : "-");
+              if(target.SrameccReported())
+                  return std::string{":sramecc"} + (*target.SrameccReported() ? "+" : "-");
               return {};
           }()),
 #if MIOPEN_USE_COMGR

--- a/src/include/miopen/hip_build_utils.hpp
+++ b/src/include/miopen/hip_build_utils.hpp
@@ -61,19 +61,37 @@ external_tool_version_t HipCompilerVersion();
 bool IsHccCompiler();
 bool IsHipClangCompiler();
 
-struct LcOptionTargetStrings
+class LcOptionTargetStrings
 {
+    public:
     const std::string& device;
     const std::string xnack;
+
+    private:
     const std::string sramecc;
+    const std::string sramecc_reported;
+
+    public:
     const std::string targetId;
     LcOptionTargetStrings(const TargetProperties& target)
         : device(target.Name()),
-          xnack(std::string{":xnack"} + (target.Xnack() ? "+" : "-")),
-          sramecc(std::string{":sramecc"} + (target.Sramecc() ? "+" : "-")),
+          xnack([&]() -> std::string {
+              if(target.IsXnack())
+                  return std::string{":xnack"} + (*target.IsXnack() ? "+" : "-");
+              return {};
+          }()),
+          sramecc([&]() -> std::string {
+              if(target.IsSramecc())
+                  return std::string{":sramecc"} + (*target.IsSramecc() ? "+" : "-");
+              return {};
+          }()),
+          sramecc_reported([&]() -> std::string {
+              if(target.IsSrameccReported())
+                  return std::string{":sramecc"} + (*target.IsSrameccReported() ? "+" : "-");
+              return {};
+          }()),
 #if MIOPEN_USE_COMGR
-          targetId(device + (std::string{":sramecc"} + (target.SrameccReported() ? "+" : "-")) +
-                   xnack)
+          targetId(device + sramecc_reported + xnack)
 #else
           targetId(device + sramecc + xnack)
 #endif

--- a/src/include/miopen/target_properties.hpp
+++ b/src/include/miopen/target_properties.hpp
@@ -26,6 +26,7 @@
 #ifndef GUARD_TARGET_PROPERTIES_HPP
 #define GUARD_TARGET_PROPERTIES_HPP
 
+#include <boost/optional.hpp>
 #include <string>
 
 namespace miopen {
@@ -36,18 +37,18 @@ struct TargetProperties
 {
     const std::string& Name() const { return name; }
     const std::string& DbId() const { return dbId; }
-    bool Xnack() const { return xnack; }
-    bool Sramecc() const { return sramecc; }
-    bool SrameccReported() const { return sramecc_reported; }
+    boost::optional<bool> IsXnack() const { return xnack; }
+    boost::optional<bool> IsSramecc() const { return sramecc; }
+    boost::optional<bool> IsSrameccReported() const { return sramecc_reported; }
     void Init(const Handle*);
 
     private:
     void InitDbId();
     std::string name;
     std::string dbId;
-    bool xnack            = false;
-    bool sramecc          = false;
-    bool sramecc_reported = false;
+    boost::optional<bool> xnack            = boost::none;
+    boost::optional<bool> sramecc          = boost::none;
+    boost::optional<bool> sramecc_reported = boost::none;
 };
 
 } // namespace miopen

--- a/src/include/miopen/target_properties.hpp
+++ b/src/include/miopen/target_properties.hpp
@@ -37,9 +37,9 @@ struct TargetProperties
 {
     const std::string& Name() const { return name; }
     const std::string& DbId() const { return dbId; }
-    boost::optional<bool> IsXnack() const { return xnack; }
-    boost::optional<bool> IsSramecc() const { return sramecc; }
-    boost::optional<bool> IsSrameccReported() const { return sramecc_reported; }
+    boost::optional<bool> Xnack() const { return xnack; }
+    boost::optional<bool> Sramecc() const { return sramecc; }
+    boost::optional<bool> SrameccReported() const { return sramecc_reported; }
     void Init(const Handle*);
 
     private:

--- a/src/ocl/clhelper.cpp
+++ b/src/ocl/clhelper.cpp
@@ -34,6 +34,7 @@
 #include <miopen/ocldeviceinfo.hpp>
 #include <miopen/rocm_features.hpp>
 #include <miopen/tmp_dir.hpp>
+#include <miopen/target_properties.hpp>
 #include <miopen/write_file.hpp>
 #include <miopen/env.hpp>
 
@@ -68,14 +69,16 @@ static cl_program CreateProgram(cl_context ctx, const char* char_source, size_t 
     return result;
 }
 
-static std::string
-ClAssemble(cl_device_id device, const std::string& source, const std::string& params)
+static std::string ClAssemble(cl_device_id device,
+                              const std::string& source,
+                              const std::string& params,
+                              const TargetProperties& target)
 {
     std::string name = miopen::GetDeviceInfo<CL_DEVICE_NAME>(device);
 #if WORKAROUND_MLOPEN_ISSUE_1711
     WorkaroundIssue1711(name);
 #endif
-    return AmdgcnAssemble(source, std::string("-mcpu=") + name + " " + params);
+    return AmdgcnAssemble(source, std::string("-mcpu=") + name + " " + params, target);
 }
 
 static cl_program
@@ -164,7 +167,7 @@ ClProgramPtr LoadProgram(cl_context ctx,
     bool load_binary = false;
     if(miopen::EndsWith(program_name, ".s"))
     {
-        source      = ClAssemble(device, source, params); // Puts output binary into source.
+        source      = ClAssemble(device, source, params, target); // Puts output binary into source.
         load_binary = true;
     }
 

--- a/src/ocl/gcn_asm_utils.cpp
+++ b/src/ocl/gcn_asm_utils.cpp
@@ -179,7 +179,9 @@ static std::string CleanupPath(const char* p)
  * Not intended to be used in production code, so error handling is very straghtforward,
  * just catch whatever possible and throw an exception.
  */
-std::string AmdgcnAssemble(const std::string& source, const std::string& params)
+std::string AmdgcnAssemble(const std::string& source,
+                           const std::string& params,
+                           const miopen::TargetProperties& target)
 {
 #ifdef __linux__
     miopen::TempFile outfile("amdgcn-asm-out-XXXXXX");
@@ -188,7 +190,8 @@ std::string AmdgcnAssemble(const std::string& source, const std::string& params)
     options << " -x assembler -target amdgcn--amdhsa";
 #if WORKAROUND_SWDEV_255735
     if(miopen::HipCompilerVersion() >= miopen::external_tool_version_t{3, 8, 20403})
-        options << " -mno-xnack";
+        if(target.IsXnack() && !*target.IsXnack())
+            options << " -mno-xnack";
 #endif
     /// \todo Hacky way to find out which CO version we need to assemble for.
     if(params.find("ROCM_METADATA_VERSION=5", 0) == std::string::npos) // Assume that !COv3 == COv2.

--- a/src/ocl/gcn_asm_utils.cpp
+++ b/src/ocl/gcn_asm_utils.cpp
@@ -190,7 +190,7 @@ std::string AmdgcnAssemble(const std::string& source,
     options << " -x assembler -target amdgcn--amdhsa";
 #if WORKAROUND_SWDEV_255735
     if(miopen::HipCompilerVersion() >= miopen::external_tool_version_t{3, 8, 20403})
-        if(target.IsXnack() && !*target.IsXnack())
+        if(target.Xnack() && !*target.Xnack())
             options << " -mno-xnack";
 #endif
     /// \todo Hacky way to find out which CO version we need to assemble for.

--- a/src/target_properties.cpp
+++ b/src/target_properties.cpp
@@ -76,43 +76,49 @@ void TargetProperties::Init(const Handle* const handle)
     }();
     name = GetDeviceNameFromMap(rawName);
     // DKMS driver older than 5.9 may report incorrect state of SRAMECC feature.
-    // Therefore we compute and rely on default SRAMECC for now.
-    sramecc = StartsWith(name, "gfx906") || StartsWith(name, "gfx908");
+    // Therefore we compute default SRAMECC and rely on it for now.
+    sramecc = [&]() -> boost::optional<bool> {
+        if(name == "gfx906" || name == "gfx908")
+            return {true};
+        return {};
+    }();
     // However we need to store the reported state, even if it is incorrect,
     // to use together with COMGR.
-    sramecc_reported = [&]() {
+    sramecc_reported = [&]() -> boost::optional<bool> {
         if(rawName.find(":sramecc+") != std::string::npos)
             return true;
         if(rawName.find(":sramecc-") != std::string::npos)
             return false;
         return sramecc; // default
     }();
-    xnack = [&]() {
+    xnack = [&]() -> boost::optional<bool> {
         if(rawName.find(":xnack+") != std::string::npos)
             return true;
         if(rawName.find(":xnack-") != std::string::npos)
             return false;
-        return false; // default
+        return {}; // default
     }();
     InitDbId();
 }
 
 void TargetProperties::InitDbId()
 {
-    // Let's stay compatible with existing databases:
-    // When feature equal to the default, do not append feature suffice.
     dbId = name;
-    if(StartsWith(name, "gfx906") || StartsWith(name, "gfx908"))
+    if(name == "gfx906" || name == "gfx908")
     {
-        if(!sramecc)
+        // Let's stay compatible with existing gfx906/908 databases.
+        // When feature equal to the default (SRAMECC ON), do not
+        // append feature suffix. This is for backward compatibility
+        // with legacy databases ONLY!
+        if(!sramecc || !(*sramecc))
             dbId += "_nosramecc";
     }
     else
     {
-        if(sramecc)
+        if(sramecc && *sramecc)
             dbId += "_sramecc";
     }
-    if(xnack)
+    if(xnack && *xnack)
         dbId += "_xnack";
 }
 


### PR DESCRIPTION
This should fix http://ontrack-internal.amd.com/browse/SWDEV-278900 and unblock mainline. The problem is caused by recent changes in the compiler. Now the compiler does not allow you to disable features that do not exist on the target device.

For example, if a target does not have the XNACK feature (like Navi 21), then you can't explicitly tell the compiler to not generate extra code for XNACK. The compiler is smarter than you, it decides itself and beat your a** if you try to suggest it to do the same.