### PR TITLE
[rocm-4.2.x][HOTFIX][WORKAROUND][OCL] Disable MIOpenGEMM for failing configs. Backup GEMM with Naive Direct Solvers for Immediate Fallback.

### DIFF
--- a/src/include/miopen/rocm_features.hpp
+++ b/src/include/miopen/rocm_features.hpp
@@ -39,6 +39,31 @@
 /// To be removed as soon as support for ROCm 3.x is discontinued.
 #define WORKAROUND_MLOPEN_ISSUE_1711 (HIP_PACKAGE_VERSION_FLAT < 4000000000ULL)
 
+/// W/A for MIOpenGEMM issues with ROCm 4.1 and newer ROCm
+/// versions. The issue is highly likely related to the
+/// issues in the OpenCL compiler or in MIOpenGEMM itself.
+/// MIOpenGEMM is used only for OCL BE and deprecated.
+/// Related ticket: http://ontrack-internal.amd.com/browse/SWDEV-276757
+///
+/// Some failing cases:
+/// test_immed_conv2d --float --cmode conv --pmode default --group-count 1
+///  --input 1, 3, 224, 224 --weights 1, 3, 11, 11
+///   --pads_strides_dilations 1 1 1 1 1 1 --trans_output_pads 0 0
+///  --input 1, 3, 224, 224 --weights 1, 3, 7, 7
+///   --pads_strides_dilations 3 3 2 2 1 1 --trans_output_pads 0 0
+/// test_immed_conv3d --float --cmode conv --pmode default --group-count 1
+///  --input 1, 4, 4, 161, 700 --weights 1, 4, 3, 11, 11
+///   --pads_strides_dilations 3 3 3 2 2 2 4 4 4 --trans_output_pads 0 0 0
+///
+/// W/A is in effect only when MIOpenGEMM is used (OCL BE) abd includes:
+/// - Disabling GEMM for failing configs.
+/// - Adding Naive Solvers. Naive solvers are inteded for use as backup for
+///   Immediate Mode Fallback when GEMM is disabled.
+/// - Note: When MIOpenGEMM is not in use, Naive Solvers are disabled. This minimizes
+///   impact of the W/A to the HIP backend.
+#define WORKAROUND_MIOPENGEMM_SINCE_ROCM41 \
+    (MIOPEN_USE_MIOPENGEMM && (HIP_PACKAGE_VERSION_FLAT >= 4001000000ULL))
+
 #define ROCM_FEATURE_TARGETID_OFF (HIP_PACKAGE_VERSION_FLAT < 4001000000ULL)
 
 /// Return type of llvm.amdgcn.buffer.atomic.fadd.f32 can't be detected.

--- a/src/include/miopen/solver.hpp
+++ b/src/include/miopen/solver.hpp
@@ -33,6 +33,7 @@
 #include <miopen/logger.hpp>
 #include <miopen/mlo_internal.hpp>
 #include <miopen/legacy_exhaustive_search.hpp>
+#include <miopen/rocm_features.hpp>
 #include <miopen/type_name.hpp>
 #include <miopen/miopen.h>
 #include <miopen/buffer_info.hpp>
@@ -2061,6 +2062,11 @@ struct ConvDirectNaiveConvFwd : SolverBase<ConvolutionContext>
 {
     bool IsApplicable(const ConvolutionContext& ctx) const;
     bool IsDynamic() const { return true; }
+#if WORKAROUND_MIOPENGEMM_SINCE_ROCM41
+    /// Use very small fixed value enough to backup GEMM for cases when
+    /// GEMM is disabled due to MIOpenGemm or OCL compiler issues.
+    float GetWti(const ConvolutionContext&) const { return 0.01; }
+#endif
     ConvSolution GetSolution(const ConvolutionContext& ctx) const;
 };
 
@@ -2068,6 +2074,11 @@ struct ConvDirectNaiveConvBwd : SolverBase<ConvolutionContext>
 {
     bool IsApplicable(const ConvolutionContext& ctx) const;
     bool IsDynamic() const { return true; }
+#if WORKAROUND_MIOPENGEMM_SINCE_ROCM41
+    /// Use very small fixed value enough to backup GEMM for cases when
+    /// GEMM is disabled due to MIOpenGemm or OCL compiler issues.
+    float GetWti(const ConvolutionContext&) const { return 0.01; }
+#endif
     ConvSolution GetSolution(const ConvolutionContext& ctx) const;
 };
 
@@ -2075,6 +2086,11 @@ struct ConvDirectNaiveConvWrw : SolverBase<ConvolutionContext>
 {
     bool IsApplicable(const ConvolutionContext& ctx) const;
     bool IsDynamic() const { return true; }
+#if WORKAROUND_MIOPENGEMM_SINCE_ROCM41
+    /// Use very small fixed value enough to backup GEMM for cases when
+    /// GEMM is disabled due to MIOpenGemm or OCL compiler issues.
+    float GetWti(const ConvolutionContext&) const { return 0.01; }
+#endif
     ConvSolution GetSolution(const ConvolutionContext& ctx) const;
 };
 

--- a/src/ocl/convolutionocl.cpp
+++ b/src/ocl/convolutionocl.cpp
@@ -38,6 +38,7 @@
 #include <miopen/float_equal.hpp>
 #include <miopen/invoker.hpp>
 #include <miopen/kernel.hpp>
+#include <miopen/rocm_features.hpp>
 #include <miopen/solver.hpp>
 #include <miopen/tensor_ops.hpp>
 #include <miopen/tensor.hpp>
@@ -355,19 +356,23 @@ static void DirConvFindCore(Handle& handle,
     ValidateGroupCount(xDesc, wDesc, conv);
 
 #if MIOPEN_USE_GEMM
+    const std::size_t spatial_dim = conv.GetSpatialDimension();
+    const auto in_spatial         = boost::adaptors::slice(xDesc.GetLengths(), 2, 2 + spatial_dim);
+    const auto wei_spatial        = boost::adaptors::slice(wDesc.GetLengths(), 2, 2 + spatial_dim);
+    const auto out_spatial        = boost::adaptors::slice(yDesc.GetLengths(), 2, 2 + spatial_dim);
+
     if(!use_winograd_only && !miopen::IsDisabled(MIOPEN_DEBUG_CONV_GEMM{}) &&
-       !(IsAnyBufferBF16(xDesc, yDesc, wDesc) && !IsUseRocBlas))
+       !(IsAnyBufferBF16(xDesc, yDesc, wDesc) && !IsUseRocBlas)
+#if WORKAROUND_MIOPENGEMM_SINCE_ROCM41
+       &&
+       !(miopen::any_of(in_spatial, [](auto v) { return v >= 161; }) &&
+         miopen::any_of(wei_spatial, [](auto v) { return v >= 7; }))
+#endif
+           )
     { // GEMM algo
         std::size_t in_n, in_c;
         std::tie(in_n, in_c) = tie_pick<0, 1>()(xDesc.GetLengths());
-
         std::size_t wei_k = wDesc.GetLengths()[0];
-
-        std::size_t spatial_dim = conv.GetSpatialDimension();
-
-        auto in_spatial  = boost::adaptors::slice(xDesc.GetLengths(), 2, 2 + spatial_dim);
-        auto wei_spatial = boost::adaptors::slice(wDesc.GetLengths(), 2, 2 + spatial_dim);
-        auto out_spatial = boost::adaptors::slice(yDesc.GetLengths(), 2, 2 + spatial_dim);
 
         float time_gemm           = 0;
         const bool time_precision = (!IsDisabled(MIOPEN_CONV_PRECISE_ROCBLAS_TIMING{}));
@@ -1552,6 +1557,13 @@ float ConvolutionDescriptor::ComputeGemmWtiFwd(const TensorDescriptor& wDesc,
     std::tie(in_n, in_c) = tie_pick<0, 1>()(xDesc.GetLengths());
     std::size_t spatial_dim = GetSpatialDimension();
     auto wei_spatial        = boost::adaptors::slice(wDesc.GetLengths(), 2, 2 + spatial_dim);
+
+#if WORKAROUND_MIOPENGEMM_SINCE_ROCM41
+    const auto in_spatial = boost::adaptors::slice(xDesc.GetLengths(), 2, 2 + spatial_dim);
+    if(miopen::any_of(in_spatial, [](auto v) { return v >= 161; }) &&
+       miopen::any_of(wei_spatial, [](auto v) { return v >= 7; }))
+        return -2.0;
+#endif
 
     // Use transpose path 1x1, stride=2
     if(GetSpatialDimension() == 2 && miopen::all_of(wei_spatial, [](auto v) { return v == 1; }) &&


### PR DESCRIPTION
This is basically a replica of #798 cherry-picked for `rocm-4.2.x-staging`. The MIopenGEMM issue with the ROCm 4.1 compiler did not go away when using the ROCm 4.2 compiler. More info at #798.

I plan to create similar PR for `develop`.