### PR TITLE
Fix issue 846 - Make GEMM Fwd/Bwd solvers non-applicable when MAX_MEM_ALLOC_SZ exceeded

### DIFF
--- a/src/solver/gemm.cpp
+++ b/src/solver/gemm.cpp
@@ -205,7 +205,10 @@ size_t GemmFwd1x1_0_2::GetWorkspaceSize(const ExecutionContext& context,
     const auto gemm_trans = x_t_size + y_t_size;
 
     if(gemm_trans > MAX_MEM_ALLOC_SZ)
+    {
+        MIOPEN_LOG_I2(gemm_trans << " > " << MAX_MEM_ALLOC_SZ);
         return 0;
+    }
     return gemm_trans;
 #else
     std::ignore = context;
@@ -459,7 +462,10 @@ size_t GemmFwd1x1_0_1_int8::GetWorkspaceSize(const ExecutionContext& context,
                          GetTypeSize(wDesc.GetType()) * conv.group_count;
 
     if(ws_size > MAX_MEM_ALLOC_SZ)
+    {
+        MIOPEN_LOG_I2(ws_size << " > " << MAX_MEM_ALLOC_SZ);
         return 0;
+    }
     return ws_size;
 #else
     std::ignore = context;
@@ -860,7 +866,10 @@ size_t GemmFwdRest::GetWorkspaceSize(const ExecutionContext& context,
     const auto ws_sz = (wDesc.GetType() == miopenInt8 ? 2 * workspace_size : workspace_size);
 
     if(ws_sz > MAX_MEM_ALLOC_SZ)
+    {
+        MIOPEN_LOG_I2(ws_sz << " > " << MAX_MEM_ALLOC_SZ);
         return 0;
+    }
     return ws_sz;
 #else
     std::ignore = context;

--- a/src/solver/gemm.cpp
+++ b/src/solver/gemm.cpp
@@ -233,7 +233,8 @@ bool GemmFwd1x1_0_2::IsApplicable(const ExecutionContext& context,
     return conv.GetSpatialDimension() == 2 &&
            miopen::all_of(wei_spatial, [](auto v) { return v == 1; }) &&
            miopen::all_of(conv.GetConvPads(), [](auto v) { return v == 0; }) &&
-           miopen::all_of(conv.GetConvStrides(), [](auto v) { return v == 2; });
+           miopen::all_of(conv.GetConvStrides(), [](auto v) { return v == 2; }) &&
+           GetWorkspaceSize(context, problem) > 0;
 #else
     std::ignore = context;
     std::ignore = problem;
@@ -490,7 +491,8 @@ bool GemmFwd1x1_0_1_int8::IsApplicable(const ExecutionContext& context,
     return miopen::all_of(wei_spatial, [](auto v) { return v == 1; }) &&
            miopen::all_of(conv.GetConvPads(), [](auto v) { return v == 0; }) &&
            miopen::all_of(conv.GetConvStrides(), [](auto v) { return v == 1; }) &&
-           wDesc.GetType() == miopenInt8 && conv.group_count == 1;
+           wDesc.GetType() == miopenInt8 && conv.group_count == 1 &&
+           GetWorkspaceSize(context, problem) > 0;
 #else
     std::ignore = context;
     std::ignore = problem;
@@ -913,7 +915,7 @@ bool GemmFwdRest::IsApplicable(const ExecutionContext& context,
     if(GemmFwd1x1_0_2{}.IsApplicable(context, problem))
         return false;
 
-    return true;
+    return GetWorkspaceSize(context, problem) > 0;
 #else
     std::ignore = context;
     std::ignore = problem;

--- a/src/solver/gemm_bwd.cpp
+++ b/src/solver/gemm_bwd.cpp
@@ -175,7 +175,10 @@ size_t GemmBwd1x1_stride2::GetWorkspaceSize(const ExecutionContext& context,
     const auto gemm_trans = dx_t_size + dy_t_size;
 
     if(gemm_trans > MAX_MEM_ALLOC_SZ)
+    {
+        MIOPEN_LOG_I2(gemm_trans << " > " << MAX_MEM_ALLOC_SZ);
         return 0;
+    }
     return gemm_trans;
 #else
     std::ignore = context;
@@ -549,7 +552,10 @@ size_t GemmBwdRest::GetWorkspaceSize(const ExecutionContext& context,
                            GetTypeSize(dyDesc.GetType()) * conv.group_count;
 
     if(gemm_size > MAX_MEM_ALLOC_SZ)
+    {
+        MIOPEN_LOG_I2(gemm_size << " > " << MAX_MEM_ALLOC_SZ);
         return 0;
+    }
     return gemm_size;
 #else
     std::ignore = context;

--- a/src/solver/gemm_bwd.cpp
+++ b/src/solver/gemm_bwd.cpp
@@ -204,7 +204,8 @@ bool GemmBwd1x1_stride2::IsApplicable(const ExecutionContext& context,
     return conv.GetSpatialDimension() == 2 &&
            miopen::all_of(wei_spatial, [](auto v) { return v == 1; }) &&
            miopen::all_of(conv.GetConvPads(), [](auto v) { return v == 0; }) &&
-           miopen::all_of(conv.GetConvStrides(), [](auto v) { return v == 2; });
+           miopen::all_of(conv.GetConvStrides(), [](auto v) { return v == 2; }) &&
+           GetWorkspaceSize(context, problem) > 0;
 #else
     std::ignore = context;
     std::ignore = problem;
@@ -573,7 +574,8 @@ bool GemmBwdRest::IsApplicable(const ExecutionContext& context,
         return false;
 
     return !GemmBwd1x1_stride2{}.IsApplicable(context, problem) &&
-           !GemmBwd1x1_stride1{}.IsApplicable(context, problem);
+           !GemmBwd1x1_stride1{}.IsApplicable(context, problem) &&
+           GetWorkspaceSize(context, problem) > 0;
 #else
     std::ignore = context;
     std::ignore = problem;


### PR DESCRIPTION
Fixes issue #846.

Blocker for Mainline update. The faulty code is now in Staging, and we should not promote it to Mainline until this fix is arrived to Staging.