### PR TITLE
[WORKAROUND][OCL] Disable MIOpenGEMM for failing configs.

### DIFF
--- a/src/include/miopen/rocm_features.hpp
+++ b/src/include/miopen/rocm_features.hpp
@@ -39,6 +39,31 @@
 /// To be removed as soon as support for ROCm 3.x is discontinued.
 #define WORKAROUND_MLOPEN_ISSUE_1711 (HIP_PACKAGE_VERSION_FLAT < 4000000000ULL)
 
+/// W/A for MIOpenGEMM issues with ROCm 4.1 and newer ROCm
+/// versions. The issue is highly likely related to the
+/// issues in the OpenCL compiler or in MIOpenGEMM itself.
+/// MIOpenGEMM is used only for OCL BE and deprecated.
+/// Related ticket: http://ontrack-internal.amd.com/browse/SWDEV-276757
+///
+/// Some failing cases:
+/// test_immed_conv2d --float --cmode conv --pmode default --group-count 1
+///  --input 1, 3, 224, 224 --weights 1, 3, 11, 11
+///   --pads_strides_dilations 1 1 1 1 1 1 --trans_output_pads 0 0
+///  --input 1, 3, 224, 224 --weights 1, 3, 7, 7
+///   --pads_strides_dilations 3 3 2 2 1 1 --trans_output_pads 0 0
+/// test_immed_conv3d --float --cmode conv --pmode default --group-count 1
+///  --input 1, 4, 4, 161, 700 --weights 1, 4, 3, 11, 11
+///   --pads_strides_dilations 3 3 3 2 2 2 4 4 4 --trans_output_pads 0 0 0
+///
+/// W/A is in effect only when MIOpenGEMM is used (OCL BE) abd includes:
+/// - Disabling GEMM for failing configs.
+/// - Adding Naive Solvers. Naive solvers are inteded for use as backup for
+///   Immediate Mode Fallback when GEMM is disabled.
+/// - Note: When MIOpenGEMM is not in use, Naive Solvers are disabled. This minimizes
+///   impact of the W/A to the HIP backend.
+#define WORKAROUND_MIOPENGEMM_SINCE_ROCM41 \
+    (MIOPEN_USE_MIOPENGEMM && (HIP_PACKAGE_VERSION_FLAT >= 4001000000ULL))
+
 #define ROCM_FEATURE_TARGETID_OFF (HIP_PACKAGE_VERSION_FLAT < 4001000000ULL)
 
 /// Return type of llvm.amdgcn.buffer.atomic.fadd.f32 can't be detected.

--- a/src/include/miopen/solver.hpp
+++ b/src/include/miopen/solver.hpp
@@ -33,6 +33,7 @@
 #include <miopen/logger.hpp>
 #include <miopen/mlo_internal.hpp>
 #include <miopen/legacy_exhaustive_search.hpp>
+#include <miopen/rocm_features.hpp>
 #include <miopen/type_name.hpp>
 #include <miopen/miopen.h>
 #include <miopen/buffer_info.hpp>
@@ -2089,6 +2090,11 @@ struct ConvDirectNaiveConvFwd : SolverBase<ConvolutionContext>
 {
     bool IsApplicable(const ConvolutionContext& ctx) const;
     bool IsDynamic() const { return true; }
+#if WORKAROUND_MIOPENGEMM_SINCE_ROCM41
+    /// Use very small fixed value enough to backup GEMM for cases when
+    /// GEMM is disabled due to MIOpenGemm or OCL compiler issues.
+    float GetWti(const ConvolutionContext&) const { return 0.01; }
+#endif
     ConvSolution GetSolution(const ConvolutionContext& ctx) const;
 };
 
@@ -2096,6 +2102,11 @@ struct ConvDirectNaiveConvBwd : SolverBase<ConvolutionContext>
 {
     bool IsApplicable(const ConvolutionContext& ctx) const;
     bool IsDynamic() const { return true; }
+#if WORKAROUND_MIOPENGEMM_SINCE_ROCM41
+    /// Use very small fixed value enough to backup GEMM for cases when
+    /// GEMM is disabled due to MIOpenGemm or OCL compiler issues.
+    float GetWti(const ConvolutionContext&) const { return 0.01; }
+#endif
     ConvSolution GetSolution(const ConvolutionContext& ctx) const;
 };
 
@@ -2103,6 +2114,11 @@ struct ConvDirectNaiveConvWrw : SolverBase<ConvolutionContext>
 {
     bool IsApplicable(const ConvolutionContext& ctx) const;
     bool IsDynamic() const { return true; }
+#if WORKAROUND_MIOPENGEMM_SINCE_ROCM41
+    /// Use very small fixed value enough to backup GEMM for cases when
+    /// GEMM is disabled due to MIOpenGemm or OCL compiler issues.
+    float GetWti(const ConvolutionContext&) const { return 0.01; }
+#endif
     ConvSolution GetSolution(const ConvolutionContext& ctx) const;
 };
 

--- a/src/ocl/convolutionocl.cpp
+++ b/src/ocl/convolutionocl.cpp
@@ -38,7 +38,6 @@
 #include <miopen/float_equal.hpp>
 #include <miopen/invoker.hpp>
 #include <miopen/kernel.hpp>
-#include <miopen/rocm_features.hpp>
 #include <miopen/solver.hpp>
 #include <miopen/tensor_ops.hpp>
 #include <miopen/tensor.hpp>

--- a/src/ocl/convolutionocl.cpp
+++ b/src/ocl/convolutionocl.cpp
@@ -38,6 +38,7 @@
 #include <miopen/float_equal.hpp>
 #include <miopen/invoker.hpp>
 #include <miopen/kernel.hpp>
+#include <miopen/rocm_features.hpp>
 #include <miopen/solver.hpp>
 #include <miopen/tensor_ops.hpp>
 #include <miopen/tensor.hpp>

--- a/src/solver/gemm.cpp
+++ b/src/solver/gemm.cpp
@@ -31,6 +31,7 @@
 #include <miopen/gemm_v2.hpp>
 #include <miopen/handle.hpp>
 #include <miopen/kernel.hpp>
+#include <miopen/rocm_features.hpp>
 #include <miopen/tensor.hpp>
 #include <miopen/tensor_ops.hpp>
 #include <miopen/util.hpp>
@@ -888,23 +889,40 @@ bool GemmFwdRest::IsApplicable(const ExecutionContext& context,
         return false;
 
 #if WORKAROUND_MIOPENGEMM_ROCM37
-    decltype(auto) conv  = problem.GetConv();
-    decltype(auto) xDesc = problem.GetIn();
-    decltype(auto) wDesc = problem.GetWeights();
+    {
+        decltype(auto) conv  = problem.GetConv();
+        decltype(auto) xDesc = problem.GetIn();
+        decltype(auto) wDesc = problem.GetWeights();
 
-    const auto spatial_dim  = conv.GetSpatialDimension();
-    const auto& in_spatial  = boost::adaptors::slice(xDesc.GetLengths(), 2, 2 + spatial_dim);
-    const auto& wei_spatial = boost::adaptors::slice(wDesc.GetLengths(), 2, 2 + spatial_dim);
+        const auto spatial_dim  = conv.GetSpatialDimension();
+        const auto& in_spatial  = boost::adaptors::slice(xDesc.GetLengths(), 2, 2 + spatial_dim);
+        const auto& wei_spatial = boost::adaptors::slice(wDesc.GetLengths(), 2, 2 + spatial_dim);
 
-    const auto in_c = xDesc.GetLengths()[1];
+        const auto in_c = xDesc.GetLengths()[1];
 
-    if(conv.GetSpatialDimension() == 2 && conv.group_count == 4 && in_c == 4 &&
-       in_spatial[0] == 161 && in_spatial[1] == 700 && wDesc.GetLengths()[0] == 32 &&
-       wDesc.GetLengths()[1] == 1 && wei_spatial[0] == 5 && wei_spatial[1] == 20 &&
-       miopen::all_of(conv.GetConvPads(), [](auto v) { return v == 0; }) &&
-       miopen::all_of(conv.GetConvStrides(), [](auto v) { return v == 2; }) &&
-       miopen::all_of(conv.GetConvDilations(), [](auto v) { return v == 1; }))
-        return false;
+        if(conv.GetSpatialDimension() == 2 && conv.group_count == 4 && in_c == 4 &&
+           in_spatial[0] == 161 && in_spatial[1] == 700 && wDesc.GetLengths()[0] == 32 &&
+           wDesc.GetLengths()[1] == 1 && wei_spatial[0] == 5 && wei_spatial[1] == 20 &&
+           miopen::all_of(conv.GetConvPads(), [](auto v) { return v == 0; }) &&
+           miopen::all_of(conv.GetConvStrides(), [](auto v) { return v == 2; }) &&
+           miopen::all_of(conv.GetConvDilations(), [](auto v) { return v == 1; }))
+            return false;
+    }
+#endif
+#if WORKAROUND_MIOPENGEMM_SINCE_ROCM41
+    {
+        decltype(auto) conv  = problem.GetConv();
+        decltype(auto) xDesc = problem.GetIn();
+        decltype(auto) wDesc = problem.GetWeights();
+
+        const std::size_t spatial_dim = conv.GetSpatialDimension();
+        const auto in_spatial  = boost::adaptors::slice(xDesc.GetLengths(), 2, 2 + spatial_dim);
+        const auto wei_spatial = boost::adaptors::slice(wDesc.GetLengths(), 2, 2 + spatial_dim);
+
+        if(miopen::any_of(in_spatial, [](auto v) { return v >= 161; }) &&
+           miopen::any_of(wei_spatial, [](auto v) { return v >= 7; }))
+            return false;
+    }
 #endif
 
     // Todo: This is a rest-of kind of logic. Should be revised later.


### PR DESCRIPTION
Fixes #845. This is basically a replica of #798 backported to `develop`.