### PR TITLE
Handle missing file when embedded build of MIOpen (SWDEV-282133)

### DIFF
--- a/src/binary_cache.cpp
+++ b/src/binary_cache.cpp
@@ -123,8 +123,10 @@ KDb GetDb(const TargetProperties& target, size_t num_cu)
     boost::filesystem::path sys_path = sys_dir / (Handle::GetDbBasename(target, num_cu) + ".kdb");
     if(user_dir.empty())
         user_path = user_dir;
+#if !MIOPEN_EMBED_DB
     if(!boost::filesystem::exists(sys_path))
         sys_path = boost::filesystem::path{};
+#endif
     return {sys_path.string(), user_path.string(), target.DbId(), num_cu};
 }
 #endif

--- a/src/include/miopen/sqlite_db.hpp
+++ b/src/include/miopen/sqlite_db.hpp
@@ -250,6 +250,7 @@ class SQLiteBase
         if(!sql.Valid())
         {
             dbInvalid = true;
+            filename  = "";
             if(!is_system)
                 MIOPEN_THROW(miopenStatusInternalError, "Cannot open database file:" + filename_);
             else

--- a/src/sqlite_db.cpp
+++ b/src/sqlite_db.cpp
@@ -93,10 +93,8 @@ class SQLite::impl
             const auto& it_p = miopen_data().find(filepath.filename().string() + ".o");
             if(it_p == miopen_data().end())
             {
-                // Future: Try to load it from the disk system
-                // Also make a config point if Disk I/O is disabled
-                MIOPEN_THROW(miopenStatusInternalError,
-                             "Unknown database: " + filepath.string() + " in internal file cache");
+                MIOPEN_LOG_I("Unknown database: " + filepath.string() + " in internal file cache");
+                return SQLITE_ERROR;
             }
             const auto& p    = it_p->second;
             ptrdiff_t ptr_sz = p.second - p.first;
@@ -171,8 +169,9 @@ class SQLite::impl
 #else
         rc = CreateFileDb(filepath, is_system);
 #endif
-        sqlite3_busy_timeout(ptrDb.get(), MIOPEN_SQL_BUSY_TIMEOUT_MS);
         isValid = (rc == 0);
+        if(isValid)
+            sqlite3_busy_timeout(ptrDb.get(), MIOPEN_SQL_BUSY_TIMEOUT_MS);
     }
 
     sqlite3_ptr ptrDb = nullptr;


### PR DESCRIPTION
* handle missing embedded files
  * Why: When an embedded file is not found in the internal map, instead of throwing an exception, MIOpen marks the database as invalid effectively converting accesses to that database as No-Op.
* remove file IO when embedded
  * See also [this comment](https://github.com/ROCmSoftwarePlatform/MIOpen/pull/878#issuecomment-825089011).


This PR addresses [SWDEV-282133](http://ontrack-internal.amd.com/browse/SWDEV-282133)