### PR TITLE
promote tensor descriptor api int type to size_t

### DIFF
--- a/include/miopen/miopen.h
+++ b/include/miopen/miopen.h
@@ -595,6 +595,23 @@ MIOPEN_EXPORT miopenStatus_t miopenSetTensorDescriptor(miopenTensorDescriptor_t 
 
 /*! @brief Set shape of N-dimensional tensor
  *
+ * Interface for setting tensor shape. MIOpen has support for 1, 2, 3, 4, 5 dimensional tensor of
+ * layout.
+ * @param tensorDesc   Tensor descriptor type (input)
+ * @param dataType     MIOpen datatype (input)
+ * @param nbDims       Number of dimensions in the dimsA array (input)
+ * @param dimsA        Array containing the size of dimensions (input)
+ * @param stridesA     Array containing the size of stride (input)
+ * @return             miopenStatus_t
+*/
+MIOPEN_EXPORT miopenStatus_t miopenSetTensorDescriptorV2(miopenTensorDescriptor_t tensorDesc,
+                                                         miopenDataType_t dataType,
+                                                         int nbDims,
+                                                         size_t* dimsA,
+                                                         size_t* stridesA);
+
+/*! @brief Set shape of N-dimensional tensor
+ *
  * Interface for querying tensor size. MIOpen has support for 1, 2, 3, 4, 5 dimensional tensor of
  * layout.
  * @param tensorDesc   Tensor descriptor type (input)
@@ -616,6 +633,19 @@ MIOPEN_EXPORT miopenStatus_t miopenGetTensorDescriptor(miopenTensorDescriptor_t 
                                                        miopenDataType_t* dataType,
                                                        int* dimsA,
                                                        int* stridesA);
+
+/*! @brief Get the details of the N-dimensional tensor descriptor.
+ *
+ * @param tensorDesc Tensor descriptor type (input)
+ * @param dataType   MIOpen datatype (input)
+ * @param dimsA      Array containing the size of dimensions (output)
+ * @param stridesA   Array containing the size of stride (output)
+ * @return           miopenStatus_t
+ */
+MIOPEN_EXPORT miopenStatus_t miopenGetTensorDescriptorV2(miopenTensorDescriptor_t tensorDesc,
+                                                         miopenDataType_t* dataType,
+                                                         size_t* dimsA,
+                                                         size_t* stridesA);
 
 /*! @brief Destroys the tensor descriptor
  *

--- a/src/batch_norm.cpp
+++ b/src/batch_norm.cpp
@@ -44,7 +44,7 @@ void DeriveBNTensorDescriptor(TensorDescriptor& derivedBnDesc,
 {
 
     auto lengths = xDesc.GetLengths();
-    std::vector<int> newlens(lengths.size());
+    std::vector<size_t> newlens(lengths.size());
     newlens[1] = lengths[1];
     if(bn_mode == miopenBNSpatial)
     {

--- a/src/include/miopen/rnn.hpp
+++ b/src/include/miopen/rnn.hpp
@@ -107,7 +107,7 @@ struct RNNDescriptor : miopenRNNDescriptor
 
     size_t paramsOffsetCalculation(const TensorDescriptor& xDesc, int layer, int paramID) const;
 
-    std::vector<int>
+    std::vector<size_t>
     pTensorLengthsCalculation(const TensorDescriptor& xDesc, int layer, int paramID) const;
 
     size_t GetWorkspaceSize(Handle& handle,

--- a/src/include/miopen/tensor.hpp
+++ b/src/include/miopen/tensor.hpp
@@ -124,8 +124,8 @@ struct TensorDescriptor : miopenTensorDescriptor
     TensorDescriptor(miopenDataType_t t,
                      std::initializer_list<std::size_t> plens,
                      std::initializer_list<std::size_t> pstrides);
-    TensorDescriptor(miopenDataType_t t, const int* plens, int size);
-    TensorDescriptor(miopenDataType_t t, const int* plens, const int* pstrides, int size);
+    TensorDescriptor(miopenDataType_t t, const size_t* plens, int size);
+    TensorDescriptor(miopenDataType_t t, const size_t* plens, const size_t* pstrides, int size);
 
     TensorDescriptor(miopenDataType_t t,
                      std::vector<std::size_t> lens_in,

--- a/src/ocl/ctcocl.cpp
+++ b/src/ocl/ctcocl.cpp
@@ -185,7 +185,7 @@ void CTCLossDescriptor::CTCLoss(const Handle& handle,
     float time = 0.;
     if(apply_softmax_layer)
     {
-        std::vector<int> sfm_size(4, 1);
+        std::vector<size_t> sfm_size(4, 1);
         sfm_size[0]   = max_time_step * batch_size;
         sfm_size[1]   = class_sz;
         auto sfm_desc = miopen::TensorDescriptor(probsDesc.GetType(), sfm_size.data(), 4);

--- a/src/ocl/rnnocl.cpp
+++ b/src/ocl/rnnocl.cpp
@@ -148,7 +148,7 @@ void RNNDescriptor::RNNForwardInference(Handle& handle,
     float alpha0, alpha1, beta_t;
     float alpha = 1, beta = 0;
 
-    std::vector<int> sp_size(3, 1), sp_stride(3, 1), w_size(3, 1), w_stride(3, 1), x_size(3, 1),
+    std::vector<size_t> sp_size(3, 1), sp_stride(3, 1), w_size(3, 1), w_stride(3, 1), x_size(3, 1),
         x_stride(3, 1), y_size(3, 1), y_stride(3, 1), hx_size(3, 1), hx_stride(3, 1);
     miopen::TensorDescriptor sp_desc, w_desc, x_desc, y_desc, hx_desc;
 
@@ -1378,7 +1378,7 @@ void RNNDescriptor::RNNForwardTraining(Handle& handle,
     float alpha0, alpha1, beta_t;
     float alpha = 1, beta = 0;
 
-    std::vector<int> sp_size(3, 1), sp_stride(3, 1), w_size(3, 1), w_stride(3, 1), x_size(3, 1),
+    std::vector<size_t> sp_size(3, 1), sp_stride(3, 1), w_size(3, 1), w_stride(3, 1), x_size(3, 1),
         x_stride(3, 1), y_size(3, 1), y_stride(3, 1), hx_size(3, 1), hx_stride(3, 1);
     miopen::TensorDescriptor sp_desc, w_desc, x_desc, y_desc, hx_desc;
 
@@ -1538,7 +1538,7 @@ void RNNDescriptor::RNNForwardTraining(Handle& handle,
             bool use_dropout = !float_equal(miopen::deref(dropoutDesc).dropout, 0);
             if(use_dropout)
             {
-                std::vector<int> drop_size(2), drop_in_str(2, 1), drop_out_str(2, 1);
+                std::vector<size_t> drop_size(2), drop_in_str(2, 1), drop_out_str(2, 1);
                 drop_size[0]    = batch_n;
                 drop_size[1]    = hy_h * bi;
                 drop_in_str[0]  = hy_stride;
@@ -2687,7 +2687,7 @@ void RNNDescriptor::RNNBackwardData(Handle& handle,
     float alpha0, alpha1, beta_t;
     float alpha = 1, beta = 0;
 
-    std::vector<int> sp_size(3, 1), sp_stride(3, 1), x_size(3, 1), x_stride(3, 1), y_size(3, 1),
+    std::vector<size_t> sp_size(3, 1), sp_stride(3, 1), x_size(3, 1), x_stride(3, 1), y_size(3, 1),
         y_stride(3, 1), hx_size(3, 1), hx_stride(3, 1);
     miopen::TensorDescriptor sp_desc, x_desc, y_desc, hx_desc;
 
@@ -2842,7 +2842,7 @@ void RNNDescriptor::RNNBackwardData(Handle& handle,
 
             if(!float_equal(miopen::deref(dropoutDesc).dropout, 0))
             {
-                std::vector<int> drop_size(2), drop_in_str(2, 1);
+                std::vector<size_t> drop_size(2), drop_in_str(2, 1);
                 drop_size[0]   = batch_n;
                 drop_size[1]   = hy_h * bi;
                 drop_in_str[0] = hy_stride;
@@ -4163,7 +4163,7 @@ void RNNDescriptor::RNNBackwardWeights(Handle& handle,
 
     float alpha0, alpha1, beta_t = 0;
 
-    std::vector<int> sp_size(3, 1), sp_stride(3, 1), w_size(3, 1), w_stride(3, 1);
+    std::vector<size_t> sp_size(3, 1), sp_stride(3, 1), w_size(3, 1), w_stride(3, 1);
     miopen::TensorDescriptor sp_desc, w_desc;
 
     sp_stride[0] = batch_n * hy_stride;

--- a/src/pooling.cpp
+++ b/src/pooling.cpp
@@ -220,10 +220,11 @@ TensorDescriptor PoolingDescriptor::GetForwardOutputTensor(const TensorDescripto
 
     const std::string default_layout = tensor_layout_get_default(xDesc.GetSize());
     const std::string in_layout      = xDesc.GetLayout(default_layout);
-    std::vector<int> out_strides;
-    tensor_layout_to_strides(out_dim, default_layout, in_layout, out_strides);
+    std::vector<size_t> out_dim_(out_dim.begin(), out_dim.end());
+    std::vector<size_t> out_strides;
+    tensor_layout_to_strides(out_dim_, default_layout, in_layout, out_strides);
 
-    return TensorDescriptor(xDesc.GetType(), out_dim, out_strides);
+    return TensorDescriptor(xDesc.GetType(), out_dim_, out_strides);
 }
 
 std::size_t PoolingDescriptor::GetWorkSpaceSize(const TensorDescriptor& yDesc) const

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -50,22 +50,22 @@ TensorDescriptor::TensorDescriptor(miopenDataType_t t,
     packed = (this->GetElementSize() == this->GetElementSpace());
 }
 
-TensorDescriptor::TensorDescriptor(miopenDataType_t t, const int* plens, int size)
+TensorDescriptor::TensorDescriptor(miopenDataType_t t, const size_t* plens, int size)
     : lens(plens, plens + size), packed(true), type(t)
 {
-    if(!std::all_of(plens, plens + size, [](int x) { return x >= 0; }))
+    if(!std::all_of(plens, plens + size, [](size_t x) { return x >= 0; }))
         MIOPEN_THROW("Invalid length. Length must be greater than 0.");
     this->CalculateStrides();
 }
 TensorDescriptor::TensorDescriptor(miopenDataType_t t,
-                                   const int* plens,
-                                   const int* pstrides,
+                                   const size_t* plens,
+                                   const size_t* pstrides,
                                    int size)
     : lens(plens, plens + size), strides(pstrides, pstrides + size), type(t)
 {
-    if(!std::all_of(plens, plens + size, [](int x) { return x >= 0; }))
+    if(!std::all_of(plens, plens + size, [](size_t x) { return x >= 0; }))
         MIOPEN_THROW("Invalid length. Length must be greater than 0.");
-    if(!std::all_of(pstrides, pstrides + size, [](int x) { return x >= 0; }))
+    if(!std::all_of(pstrides, pstrides + size, [](size_t x) { return x >= 0; }))
         MIOPEN_THROW("Invalid strides. Strides must be greater than 0.");
     packed = (this->GetElementSize() == this->GetElementSpace());
 }

--- a/test/gru_common.hpp
+++ b/test/gru_common.hpp
@@ -1995,13 +1995,13 @@ struct verify_forward_infer_gru
 
         auto workSpace_dev = handle.Write(workSpace);
 
-        std::vector<int> hlens(3, 0);
+        std::vector<size_t> hlens(3, 0);
         hlens[0] = nLayers * (dirMode != 0 ? 2 : 1);
         hlens[1] = batch_seq[0];
         hlens[2] = hiddenSize;
         miopen::TensorDescriptor hiddenDesc(miopen::deref(rnnDesc).dataType, hlens.data(), 3);
 
-        std::vector<int> wlen(1, 0);
+        std::vector<size_t> wlen(1, 0);
         wlen[0] = weights.size();
         miopen::TensorDescriptor weightDesc(miopen::deref(rnnDesc).dataType, wlen.data(), 1);
 
@@ -2286,13 +2286,13 @@ struct verify_forward_train_gru
         auto workSpace_dev    = handle.Write(workSpace);
         auto reserveSpace_dev = handle.Write(reserveSpace);
 
-        std::vector<int> hlens(3, 0);
+        std::vector<size_t> hlens(3, 0);
         hlens[0] = nLayers * (dirMode != 0 ? 2 : 1);
         hlens[1] = batch_seq[0];
         hlens[2] = hiddenSize;
         miopen::TensorDescriptor hiddenDesc(miopen::deref(rnnDesc).dataType, hlens.data(), 3);
 
-        std::vector<int> wlen(1, 0);
+        std::vector<size_t> wlen(1, 0);
         wlen[0] = weights.size();
         miopen::TensorDescriptor weightDesc(miopen::deref(rnnDesc).dataType, wlen.data(), 1);
 
@@ -2587,13 +2587,13 @@ struct verify_backward_data_gru
         auto reserveSpace_dev = handle.Write(reserveSpace);
         auto weights_dev      = handle.Write(weights);
 
-        std::vector<int> hlens(3, 0);
+        std::vector<size_t> hlens(3, 0);
         hlens[0] = nLayers * (dirMode != 0 ? 2 : 1);
         hlens[1] = batch_seq[0];
         hlens[2] = hiddenSize;
         miopen::TensorDescriptor hiddenDesc(miopen::deref(rnnDesc).dataType, hlens.data(), 3);
 
-        std::vector<int> wlen(1, 0);
+        std::vector<size_t> wlen(1, 0);
         wlen[0] = weights.size();
         miopen::TensorDescriptor weightDesc(miopen::deref(rnnDesc).dataType, wlen.data(), 1);
 
@@ -2844,10 +2844,11 @@ struct verify_backward_weights_gru
         auto workSpace_dev    = handle.Write(workSpace);
         auto reserveSpace_dev = handle.Write(reserveSpace);
         std::vector<T> dweights(weightSize);
-        auto dweights_dev = handle.Write(dweights);
-        miopen::TensorDescriptor weightDesc(miopen::deref(rnnDesc).dataType, &weightSize, 1);
+        auto dweights_dev  = handle.Write(dweights);
+        size_t weightSize_ = static_cast<size_t>(weightSize);
+        miopen::TensorDescriptor weightDesc(miopen::deref(rnnDesc).dataType, &weightSize_, 1);
 
-        std::vector<int> hlens(3, 0);
+        std::vector<size_t> hlens(3, 0);
         hlens[0] = nLayers * (dirMode != 0 ? 2 : 1);
         hlens[1] = batch_seq[0];
         hlens[2] = hiddenSize;
@@ -3068,7 +3069,7 @@ struct gru_basic_driver : test_driver
         std::vector<T> dhyin(hx_sz);
 
         size_t wei_bytes = 0;
-        std::vector<int> inlens(2, 0);
+        std::vector<size_t> inlens(2, 0);
         inlens.at(0) = batchSeq.at(0);
         inlens.at(1) = inVecReal;
         auto firstInputDesc =

--- a/test/lstm_common.hpp
+++ b/test/lstm_common.hpp
@@ -2469,13 +2469,13 @@ struct verify_forward_train_lstm : verify_forward_lstm<T>
         auto workSpace_dev    = handle.Write(workSpace);
         auto reserveSpace_dev = handle.Write(reserveSpace);
 
-        std::vector<int> hlens(3, 0);
+        std::vector<size_t> hlens(3, 0);
         hlens[0] = nLayers * (dirMode != 0 ? 2 : 1);
         hlens[1] = batch_seq[0];
         hlens[2] = hiddenSize;
         miopen::TensorDescriptor hiddenDesc(miopen::deref(rnnDesc).dataType, hlens.data(), 3);
 
-        std::vector<int> wlen(1, 0);
+        std::vector<size_t> wlen(1, 0);
         wlen[0] = weights.size();
         miopen::TensorDescriptor weightDesc(miopen::deref(rnnDesc).dataType, wlen.data(), 1);
 
@@ -2707,13 +2707,13 @@ verify_backward_data_lstm<T>::gpu() const
     auto reserveSpace_dev = handle.Write(reserveSpace);
     auto weights_dev      = handle.Write(weights);
 
-    std::vector<int> hlens(3, 0);
+    std::vector<size_t> hlens(3, 0);
     hlens[0] = nLayers * (dirMode != 0 ? 2 : 1);
     hlens[1] = batch_seq[0];
     hlens[2] = hiddenSize;
     miopen::TensorDescriptor hiddenDesc(miopen::deref(rnnDesc).dataType, hlens.data(), 3);
 
-    std::vector<int> wlen(1, 0);
+    std::vector<size_t> wlen(1, 0);
     wlen[0] = weights.size();
     miopen::TensorDescriptor weightDesc(miopen::deref(rnnDesc).dataType, wlen.data(), 1);
 
@@ -2856,10 +2856,11 @@ std::vector<T> verify_backward_weights_lstm<T>::gpu() const
     auto workSpace_dev    = handle.Write(workSpace);
     auto reserveSpace_dev = handle.Write(reserveSpace_gpu);
     std::vector<T> dweights(weightSize);
-    auto dweights_dev = handle.Write(dweights);
-    miopen::TensorDescriptor weightDesc(miopen::deref(rnnDesc).dataType, &weightSize, 1);
+    auto dweights_dev  = handle.Write(dweights);
+    size_t weightSize_ = static_cast<size_t>(weightSize);
+    miopen::TensorDescriptor weightDesc(miopen::deref(rnnDesc).dataType, &weightSize_, 1);
 
-    std::vector<int> hlens(3, 0);
+    std::vector<size_t> hlens(3, 0);
     hlens[0] = nLayers * (dirMode != 0 ? 2 : 1);
     hlens[1] = batch_seq[0];
     hlens[2] = hiddenSize;
@@ -3055,7 +3056,7 @@ struct lstm_basic_driver : test_driver
         std::vector<T> dcyin(hx_sz);
 
         size_t wei_bytes = 0;
-        std::vector<int> inlens(2, 0);
+        std::vector<size_t> inlens(2, 0);
         inlens.at(0) = batchSeq.at(0);
         inlens.at(1) = inVecReal;
         auto firstInputDesc =

--- a/test/pooling_common.hpp
+++ b/test/pooling_common.hpp
@@ -599,8 +599,8 @@ struct pooling_driver : test_driver
             break;
         }
         }
-
-        auto input_desc = miopen::TensorDescriptor(this->type, in_shape.data(), in_shape.size());
+        std::vector<size_t> in_shape_(in_shape.begin(), in_shape.end());
+        auto input_desc = miopen::TensorDescriptor(this->type, in_shape_.data(), in_shape_.size());
 
         if(spt_dim != 2 && spt_dim != 3)
         {

--- a/test/rnn_vanilla_common.hpp
+++ b/test/rnn_vanilla_common.hpp
@@ -1435,13 +1435,13 @@ struct verify_forward_infer_rnn
 
         auto workSpace_dev = handle.Write(workSpace);
 
-        std::vector<int> hlens(3, 0);
+        std::vector<size_t> hlens(3, 0);
         hlens[0] = nLayers * ((dirMode != 0) ? 2 : 1);
         hlens[1] = batch_seq[0];
         hlens[2] = hiddenSize;
         miopen::TensorDescriptor hiddenDesc(miopen::deref(rnnDesc).dataType, hlens.data(), 3);
 
-        std::vector<int> wlen(1, 0);
+        std::vector<size_t> wlen(1, 0);
         wlen[0] = weights.size();
         miopen::TensorDescriptor weightDesc(miopen::deref(rnnDesc).dataType, wlen.data(), 1);
 
@@ -1712,13 +1712,13 @@ struct verify_forward_train_rnn
         auto workSpace_dev    = handle.Write(workSpace);
         auto reserveSpace_dev = handle.Write(reserveSpace);
 
-        std::vector<int> hlens(3, 0);
+        std::vector<size_t> hlens(3, 0);
         hlens[0] = nLayers * ((dirMode != 0) ? 2 : 1);
         hlens[1] = batch_seq[0];
         hlens[2] = hiddenSize;
         miopen::TensorDescriptor hiddenDesc(miopen::deref(rnnDesc).dataType, hlens.data(), 3);
 
-        std::vector<int> wlen(1, 0);
+        std::vector<size_t> wlen(1, 0);
         wlen[0] = weights.size();
         miopen::TensorDescriptor weightDesc(miopen::deref(rnnDesc).dataType, wlen.data(), 1);
 
@@ -1996,13 +1996,13 @@ struct verify_backward_data_rnn
         auto weights_dev      = handle.Write(weights);
         // auto hx_dev           = handle.Write(initHidden);
 
-        std::vector<int> hlens(3, 0);
+        std::vector<size_t> hlens(3, 0);
         hlens[0] = nLayers * ((dirMode != 0) ? 2 : 1);
         hlens[1] = batch_seq[0];
         hlens[2] = hiddenSize;
         miopen::TensorDescriptor hiddenDesc(miopen::deref(rnnDesc).dataType, hlens.data(), 3);
 
-        std::vector<int> wlen(1, 0);
+        std::vector<size_t> wlen(1, 0);
         wlen[0] = weights.size();
         miopen::TensorDescriptor weightDesc(miopen::deref(rnnDesc).dataType, wlen.data(), 1);
 
@@ -2243,10 +2243,11 @@ struct verify_backward_weights_rnn
         auto workSpace_dev    = handle.Write(workSpace);
         auto reserveSpace_dev = handle.Write(reserveSpace);
         std::vector<T> dweights(weightSize);
-        auto dweights_dev = handle.Write(dweights);
-        miopen::TensorDescriptor weightDesc(miopen::deref(rnnDesc).dataType, &weightSize, 1);
+        auto dweights_dev  = handle.Write(dweights);
+        size_t weightSize_ = static_cast<size_t>(weightSize);
+        miopen::TensorDescriptor weightDesc(miopen::deref(rnnDesc).dataType, &weightSize_, 1);
 
-        std::vector<int> hlens(3, 0);
+        std::vector<size_t> hlens(3, 0);
         hlens[0] = nLayers * ((dirMode != 0) ? 2 : 1);
         hlens[1] = batch_seq[0];
         hlens[2] = hiddenSize;
@@ -2465,7 +2466,7 @@ struct rnn_basic_vanilla_driver : test_driver
             dhyin.resize(hx_sz);
 
         size_t wei_bytes = 0;
-        std::vector<int> inlens(2, 0);
+        std::vector<size_t> inlens(2, 0);
         inlens.at(0) = batchSeq.at(0);
         inlens.at(1) = inVecReal;
         auto firstInputDesc =

--- a/test/tensor_cast.cpp
+++ b/test/tensor_cast.cpp
@@ -184,17 +184,18 @@ struct tensor_cast_driver : test_driver
 
         std::vector<size_t> srcSuperStrides = srcSuper.desc.GetStrides();
         std::vector<size_t> dstSuperStrides = dstSuper.desc.GetStrides();
-        std::vector<int> src_super_strides(srcSuperStrides.begin() +
-                                               (srcSuper.desc.GetSize() - castLens.size()),
-                                           srcSuperStrides.end());
-        std::vector<int> dst_super_strides(dstSuperStrides.begin() +
-                                               (dstSuper.desc.GetSize() - castLens.size()),
-                                           dstSuperStrides.end());
+        std::vector<size_t> src_super_strides(srcSuperStrides.begin() +
+                                                  (srcSuper.desc.GetSize() - castLens.size()),
+                                              srcSuperStrides.end());
+        std::vector<size_t> dst_super_strides(dstSuperStrides.begin() +
+                                                  (dstSuper.desc.GetSize() - castLens.size()),
+                                              dstSuperStrides.end());
+        std::vector<size_t> castLens_(castLens.begin(), castLens.end());
 
         srcDesc = miopen::TensorDescriptor(
-            miopenInt32, castLens.data(), src_super_strides.data(), castLens.size());
+            miopenInt32, castLens_.data(), src_super_strides.data(), castLens_.size());
         dstDesc = miopen::TensorDescriptor(
-            miopen_type<T>{}, castLens.data(), dst_super_strides.data(), castLens.size());
+            miopen_type<T>{}, castLens_.data(), dst_super_strides.data(), castLens_.size());
 
         if(srcDesc.GetLengths().size() == dstDesc.GetLengths().size())
         {

--- a/test/tensor_copy.cpp
+++ b/test/tensor_copy.cpp
@@ -162,17 +162,18 @@ struct tensor_copy_driver : test_driver
 
         std::vector<size_t> srcSuperStrides = srcSuper.desc.GetStrides();
         std::vector<size_t> dstSuperStrides = dstSuper.desc.GetStrides();
-        std::vector<int> src_super_strides(srcSuperStrides.begin() +
-                                               (srcSuper.desc.GetSize() - copyLens.size()),
-                                           srcSuperStrides.end());
-        std::vector<int> dst_super_strides(dstSuperStrides.begin() +
-                                               (dstSuper.desc.GetSize() - copyLens.size()),
-                                           dstSuperStrides.end());
+        std::vector<size_t> src_super_strides(srcSuperStrides.begin() +
+                                                  (srcSuper.desc.GetSize() - copyLens.size()),
+                                              srcSuperStrides.end());
+        std::vector<size_t> dst_super_strides(dstSuperStrides.begin() +
+                                                  (dstSuper.desc.GetSize() - copyLens.size()),
+                                              dstSuperStrides.end());
 
+        std::vector<size_t> copyLens_(copyLens.begin(), copyLens.end());
         srcDesc = miopen::TensorDescriptor(
-            this->type, copyLens.data(), src_super_strides.data(), copyLens.size());
+            this->type, copyLens_.data(), src_super_strides.data(), copyLens_.size());
         dstDesc = miopen::TensorDescriptor(
-            this->type, copyLens.data(), dst_super_strides.data(), copyLens.size());
+            this->type, copyLens_.data(), dst_super_strides.data(), copyLens_.size());
 
         if(srcDesc.GetLengths().size() == dstDesc.GetLengths().size())
         {

--- a/test/tensor_holder.hpp
+++ b/test/tensor_holder.hpp
@@ -334,15 +334,8 @@ tensor<T> make_tensor(std::initializer_list<std::size_t> dims, G g)
 template <class T>
 tensor<T> make_tensor(const std::vector<std::size_t>& dims)
 {
-    std::vector<int> tmpDims;
-
-    tmpDims.resize(dims.size());
-
-    for(int i      = 0; i < tmpDims.size(); i++)
-        tmpDims[i] = static_cast<int>(dims[i]);
-
-    return tensor<T>{miopen::TensorDescriptor{
-        miopen_type<T>{}, tmpDims.data(), static_cast<int>(tmpDims.size())}};
+    return tensor<T>{
+        miopen::TensorDescriptor{miopen_type<T>{}, dims.data(), static_cast<int>(dims.size())}};
 };
 
 template <class T, class X>

--- a/test/tensor_scale.cpp
+++ b/test/tensor_scale.cpp
@@ -128,11 +128,12 @@ struct tensor_scale_driver : test_driver
         super = tensor<T>{superLens}.generate(tensor_elem_gen_integer{max_value});
 
         std::vector<size_t> superStrides = super.desc.GetStrides();
-        std::vector<int> subStrides(superStrides.begin() + (super.desc.GetSize() - subLens.size()),
-                                    superStrides.end());
+        std::vector<size_t> subStrides(
+            superStrides.begin() + (super.desc.GetSize() - subLens.size()), superStrides.end());
 
-        subDesc =
-            miopen::TensorDescriptor(this->type, subLens.data(), subStrides.data(), subLens.size());
+        std::vector<size_t> subLens_(subLens.begin(), subLens.end());
+        subDesc = miopen::TensorDescriptor(
+            this->type, subLens_.data(), subStrides.data(), subLens_.size());
 
         verify_equals(verify_tensor_scale<T>{super, subDesc, offset, T(2.048)});
     }

--- a/test/tensor_set.cpp
+++ b/test/tensor_set.cpp
@@ -128,11 +128,12 @@ struct tensor_set_driver : test_driver
         super = tensor<T>{superLens}.generate(tensor_elem_gen_integer{max_value});
 
         std::vector<size_t> superStrides = super.desc.GetStrides();
-        std::vector<int> subStrides(superStrides.begin() + (super.desc.GetSize() - subLens.size()),
-                                    superStrides.end());
+        std::vector<size_t> subStrides(
+            superStrides.begin() + (super.desc.GetSize() - subLens.size()), superStrides.end());
 
-        subDesc =
-            miopen::TensorDescriptor(this->type, subLens.data(), subStrides.data(), subLens.size());
+        std::vector<size_t> subLens_(subLens.begin(), subLens.end());
+        subDesc = miopen::TensorDescriptor(
+            this->type, subLens_.data(), subStrides.data(), subLens_.size());
 
         verify_equals(verify_tensor_set<T>{super, subDesc, offset, T(1.111)});
     }

--- a/test/tensor_transform.cpp
+++ b/test/tensor_transform.cpp
@@ -397,17 +397,19 @@ struct tensor_transform_driver : test_driver
         bool skip_layout = !(miopen::float_equal(static_cast<const float>(alpha), 1.0) &&
                              miopen::float_equal(static_cast<const float>(beta), 0.0) &&
                              std::is_same<T, int8_t>{});
+        std::vector<size_t> srcLens_(srcLens.begin(), srcLens.end());
         if(!skip_layout)
         {
             // Test tensor layout transform
+
             srcSuper_pad   = tensor<T>{srcLens}.generate(tensor_elem_gen_integer{max_value});
             dstSuper_depad = tensor<T>{srcLens}.generate(tensor_elem_gen_integer{max_value});
-            srcDesc        = miopen::TensorDescriptor(this->type, srcLens.data(), srcLens.size());
+            srcDesc        = miopen::TensorDescriptor(this->type, srcLens_.data(), srcLens_.size());
 
             srcLens[1]     = (srcLens[1] % 4 == 0) ? srcLens[1] : ((srcLens[1] + 3) / 4) * 4;
             dstSuper_pad   = tensor<T>{srcLens}.generate(tensor_elem_gen_integer{max_value});
             srcSuper_depad = tensor<T>{srcLens}.generate(tensor_elem_gen_integer{max_value});
-            dstDesc        = miopen::TensorDescriptor(this->type, srcLens.data(), srcLens.size());
+            dstDesc        = miopen::TensorDescriptor(this->type, srcLens_.data(), srcLens_.size());
 
             if(srcDesc.GetLengths().size() == dstDesc.GetLengths().size() && !skip_layout)
             {
@@ -434,17 +436,17 @@ struct tensor_transform_driver : test_driver
 #endif
         std::vector<size_t> superStrides_src = super_src.desc.GetStrides();
         std::vector<size_t> superStrides_dst = super_dst.desc.GetStrides();
-        std::vector<int> subStrides_src(superStrides_src.begin() +
-                                            (super_src.desc.GetSize() - subLens.size()),
-                                        superStrides_src.end());
-        std::vector<int> subStrides_dst(superStrides_dst.begin() +
-                                            (super_dst.desc.GetSize() - subLens.size()),
-                                        superStrides_dst.end());
+        std::vector<size_t> subStrides_src(superStrides_src.begin() +
+                                               (super_src.desc.GetSize() - subLens.size()),
+                                           superStrides_src.end());
+        std::vector<size_t> subStrides_dst(superStrides_dst.begin() +
+                                               (super_dst.desc.GetSize() - subLens.size()),
+                                           superStrides_dst.end());
 
         subDesc_src = miopen::TensorDescriptor(
-            this->type, subLens.data(), subStrides_src.data(), subLens.size());
+            this->type, srcLens_.data(), subStrides_src.data(), srcLens_.size());
         subDesc_dst = miopen::TensorDescriptor(
-            this->type, subLens.data(), subStrides_dst.data(), subLens.size());
+            this->type, srcLens_.data(), subStrides_dst.data(), srcLens_.size());
 
         verify_equals(verify_tensor_transform_scale<T>{
             super_src, subDesc_src, super_dst, subDesc_dst, offset, offset, T(alpha), T(beta)});


### PR DESCRIPTION
This PR is one of the solution to solve https://github.com/ROCmSoftwarePlatform/MIOpen/issues/847, by add V2 api of public tensor descriptor, and change internally all `miopen::TensorDesciptor()` constructor using `size_t`

The New V2 API looks like:
```
MIOPEN_EXPORT miopenStatus_t miopenSetTensorDescriptorV2(miopenTensorDescriptor_t tensorDesc,
                                                         miopenDataType_t dataType,
                                                         int nbDims,
                                                         size_t* dimsA,
                                                         size_t* stridesA);

MIOPEN_EXPORT miopenStatus_t miopenGetTensorDescriptorV2(miopenTensorDescriptor_t tensorDesc,
                                                         miopenDataType_t* dataType,
                                                         size_t* dimsA,
                                                         size_t* stridesA);
```

- change internal `miopen::TensorDesciptor()` constructor using `size_t`
- change all internal related code that using `miopen::TensorDesciptor()` constructor
- add new V2 public API
