### PR TITLE
Implement mlir binary backend - step 2: bwd path

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -234,6 +234,7 @@ set( MIOpen_Source
     solver/conv_hip_implicit_gemm_mlir_cpp_bwd.cpp
     solver/conv_hip_implicit_gemm_mlir_cpp_wrw.cpp
     solver/conv_hip_implicit_gemm_mlir_bin_fwd.cpp
+    solver/conv_hip_implicit_gemm_mlir_bin_bwd.cpp
     solver/conv_hip_implicit_gemm_wrw_v4r4.cpp
     solver/conv_hip_implicit_gemm_fwd_v4r4_xdlops.cpp
     solver/conv_hip_implicit_gemm_xdlops_common.cpp

--- a/src/conv/invokers/mlir_impl_gemm.cpp
+++ b/src/conv/invokers/mlir_impl_gemm.cpp
@@ -191,7 +191,7 @@ InvokerFactory MakeMlirBwdInvokerFactory(const ConvolutionContext& ctx)
     const auto& conv  = ctx.conv_problem.GetConv();
     const auto& wDesc = ctx.conv_problem.GetWeights();
 
-    const bool isFilter1Padding0Stride1 = [=]() {
+    const bool isFilter1Padding0Stride1 = [&]() {
         const auto wei_spatial =
             boost::adaptors::slice(wDesc.GetLengths(), 2, 2 + conv.GetSpatialDimension());
         return miopen::all_of(wei_spatial, [](auto v) { return v == 1; }) &&

--- a/src/include/miopen/conv/invokers/mlir_impl_gemm.hpp
+++ b/src/include/miopen/conv/invokers/mlir_impl_gemm.hpp
@@ -33,6 +33,7 @@ namespace miopen {
 namespace conv {
 
 InvokerFactory MakeMlirFwdInvokerFactory(const ConvolutionContext& ctx);
+InvokerFactory MakeMlirBwdInvokerFactory(const ConvolutionContext& ctx);
 
 } // namespace conv
 } // namespace miopen

--- a/src/include/miopen/solver.hpp
+++ b/src/include/miopen/solver.hpp
@@ -1266,6 +1266,12 @@ struct ConvHipImplicitGemmMlirCppBwd : SolverBase<ConvolutionContext>
     ConvSolution GetSolution(const ConvolutionContext& ctx) const;
 };
 
+struct ConvHipImplicitGemmMlirBinBwd : SolverBase<ConvolutionContext>
+{
+    bool IsApplicable(const ConvolutionContext& ctx) const;
+    ConvSolution GetSolution(const ConvolutionContext& ctx) const;
+};
+
 struct ConvHipImplicitGemmBwdDataV4R1 : SolverBase<ConvolutionContext>
 {
     static int CalculateNumberOfGemm(const ConvolutionContext& ctx);

--- a/src/mlo_dir_conv.cpp
+++ b/src/mlo_dir_conv.cpp
@@ -159,6 +159,7 @@ static auto GetImplicitGemmSolvers()
         miopen::solver::ConvHipImplicitGemmMlirCppFwd,
         miopen::solver::ConvHipImplicitGemmMlirBinFwd,
         miopen::solver::ConvHipImplicitGemmMlirCppBwd,
+        miopen::solver::ConvHipImplicitGemmMlirBinBwd,
         miopen::solver::ConvHipImplicitGemmBwdDataV1R1,
         miopen::solver::ConvHipImplicitGemmBwdDataV4R1,
         miopen::solver::ConvAsmImplicitGemmV4R1DynamicFwd_1x1,

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -409,6 +409,8 @@ inline SolverRegistrar::SolverRegistrar(IdRegistryData& registry)
 
     RegisterWithSolver(
         registry, ++id, ConvHipImplicitGemmMlirBinFwd{}, miopenConvolutionAlgoImplicitGEMM);
+    RegisterWithSolver(
+        registry, ++id, ConvHipImplicitGemmMlirBinBwd{}, miopenConvolutionAlgoImplicitGEMM);
     // IMPORTANT: New solvers should be added to the end of the function!
 }
 

--- a/src/solver/conv_hip_implicit_gemm_mlir_bin_bwd.cpp
+++ b/src/solver/conv_hip_implicit_gemm_mlir_bin_bwd.cpp
@@ -25,9 +25,10 @@
  *******************************************************************************/
 #include <miopen/mlir_build.hpp>
 #include <miopen/conv/invokers/mlir_impl_gemm.hpp>
+#include <miopen/config.h>
+#include <miopen/env.hpp>
 #include <miopen/solver.hpp>
 #include <miopen/solver/implicitgemm_util.hpp>
-#include <miopen/handle.hpp>
 
 MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEBUG_CONV_HIP_IMPLICIT_GEMM_MLIR_BIN_BWD)
 

--- a/src/solver/conv_hip_implicit_gemm_mlir_bin_bwd.cpp
+++ b/src/solver/conv_hip_implicit_gemm_mlir_bin_bwd.cpp
@@ -1,0 +1,164 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2021 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#include <miopen/mlir_build.hpp>
+#include <miopen/conv/invokers/mlir_impl_gemm.hpp>
+#include <miopen/solver.hpp>
+#include <miopen/solver/implicitgemm_util.hpp>
+#include <miopen/handle.hpp>
+
+MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEBUG_CONV_HIP_IMPLICIT_GEMM_MLIR_BIN_BWD)
+
+namespace miopen {
+namespace solver {
+
+namespace {
+#if MIOPEN_USE_MLIR
+std::tuple<int, int, int> CalculateGemmSize(const ConvolutionContext& ctx)
+{
+    const size_t n  = ConvolutionContextInterpreter::GetBatchN(ctx);
+    const size_t k  = ConvolutionContextInterpreter::GetOutputChannelK(ctx);
+    const size_t c  = ConvolutionContextInterpreter::GetInputChannelC(ctx);
+    const size_t ho = ConvolutionContextInterpreter::GetOutputHeightHo(ctx);
+    const size_t wo = ConvolutionContextInterpreter::GetOutputWidthWo(ctx);
+    const size_t y  = ConvolutionContextInterpreter::GetFilterHeightY(ctx);
+    const size_t x  = ConvolutionContextInterpreter::GetFilterWidthX(ctx);
+
+    const auto gemm_m =
+        c * y * x * (ctx.Is3d() ? ConvolutionContextInterpreter::GetFilterDepthZ(ctx) : 1);
+    const auto gemm_n =
+        n * ho * wo * (ctx.Is3d() ? ConvolutionContextInterpreter::GetOutputDepthDo(ctx) : 1);
+    const auto gemm_k = k / GetEPackLength(ctx, false);
+
+    return std::make_tuple(gemm_m, gemm_n, gemm_k);
+}
+#endif
+} // Anonymous namespace
+
+bool ConvHipImplicitGemmMlirBinBwd::IsApplicable(const ConvolutionContext& ctx) const
+{
+#if MIOPEN_USE_MLIR
+    if(miopen::IsDisabled(MIOPEN_DEBUG_CONV_HIP_IMPLICIT_GEMM_MLIR_BIN_BWD{}))
+        return false;
+    // Future: MLIR will support non-default layouts.
+    if(!ctx.IsLayoutDefault())
+        return false;
+    // Future: MLIR will support 3d convolution
+    if(!ctx.Is2d())
+        return false;
+    // Future: MLIR will support multiple data types
+    if(!ctx.IsFp32())
+        return false;
+    if(!IsComposableKernelSupportedHardware(ctx))
+        return false;
+    if(!ctx.direction.IsBackwardData())
+        return false;
+    if(ctx.group_counts != 1)
+        return false;
+
+    const auto k = ConvolutionContextInterpreter::GetOutputChannelK(ctx);
+    if(k % GetEPackLength(ctx, false) != 0)
+        return false;
+
+    int gemm_m = 0;
+    int gemm_n = 0;
+    int gemm_k = 0;
+
+    std::tie(gemm_m, gemm_n, gemm_k) = CalculateGemmSize(ctx);
+
+    return gemm_m % 32 == 0 && gemm_n % 32 == 0 && gemm_k % 4 == 0;
+#else
+    std::ignore = ctx;
+    return false;
+#endif
+}
+
+ConvSolution ConvHipImplicitGemmMlirBinBwd::GetSolution(const ConvolutionContext& ctx) const
+{
+#if MIOPEN_USE_MLIR
+    ConvSolution result;
+    KernelInfo construction_parameters;
+
+    std::string version   = "_v1r1";
+    std::string direction = "_bwd";
+    std::string operation = "conv2d_bwd_data";
+
+    construction_parameters.kernel_name = "mlir_gen_igemm_conv2d" + version + direction;
+    construction_parameters.kernel_file = "mlir_gen_igemm_conv2d" + version + direction + ".mlir";
+
+    // Arguments for mlir-miopen-driver.
+    // clang-format off
+    using CI = ConvolutionContextInterpreter;
+    construction_parameters.comp_options =
+        std::string(" --operation ") + operation +
+        std::string(" --num_cu ") + std::to_string(ctx.GetStream().GetMaxComputeUnits()) +
+        std::string(" --arch ") + ctx.GetStream().GetDeviceName() +
+        std::string(" --fil_layout ") + CI::GetFilterLayout(ctx) +
+        std::string(" --fil_type ") + "fp32" +
+        std::string(" --in_layout ") + CI::GetInputLayout(ctx) +
+        std::string(" --in_type ") + "fp32" +
+        std::string(" --out_layout ") + CI::GetOutputLayout(ctx) +
+        std::string(" --out_type ") + "fp32" +
+        std::string(" --batchsize ") + std::to_string(CI::GetBatchN(ctx)) +
+        std::string(" --in_channels ") + std::to_string(CI::GetInputChannelC(ctx)) +
+        std::string(" --out_channels ") + std::to_string(CI::GetOutputChannelK(ctx)) +
+        std::string(" --in_h ") + std::to_string(CI::GetInputHeightHi(ctx)) +
+        std::string(" --in_w ") + std::to_string(CI::GetInputWidthWi(ctx)) +
+        std::string(" --out_h ") + std::to_string(CI::GetOutputHeightHo(ctx)) +
+        std::string(" --out_w ") + std::to_string(CI::GetOutputWidthWo(ctx)) +
+        std::string(" --fil_h ") + std::to_string(CI::GetFilterHeightY(ctx)) +
+        std::string(" --fil_w ") + std::to_string(CI::GetFilterWidthX(ctx)) +
+        std::string(" --dilation_h ") + std::to_string(CI::GetAdjustedConvolutionDilationH(ctx)) +
+        std::string(" --dilation_w ") + std::to_string(CI::GetAdjustedConvolutionDilationW(ctx)) +
+        std::string(" --conv_stride_h ") + std::to_string(CI::GetAdjustedConvolutionStrideH(ctx)) +
+        std::string(" --conv_stride_w ") + std::to_string(CI::GetAdjustedConvolutionStrideW(ctx)) +
+        std::string(" --padding_h ") + std::to_string(CI::GetInputLeftPadH(ctx)) +
+        std::string(" --padding_w ") + std::to_string(CI::GetInputLeftPadW(ctx)) +
+        std::string(" --kernel_name ") + construction_parameters.kernel_name;
+    // clang-format on
+
+    size_t local_size  = 0;
+    size_t global_size = 0;
+    MiirGenLaunchParams(construction_parameters.comp_options, local_size, global_size);
+
+    construction_parameters.l_wk.push_back(local_size);
+    construction_parameters.l_wk.push_back(1);
+    construction_parameters.l_wk.push_back(1);
+
+    construction_parameters.g_wk.push_back(global_size);
+    construction_parameters.g_wk.push_back(1);
+    construction_parameters.g_wk.push_back(1);
+
+    result.invoker_factory = conv::MakeMlirBwdInvokerFactory(ctx);
+    result.construction_params.push_back(construction_parameters);
+    return result;
+#else
+    std::ignore = ctx;
+    return {};
+#endif
+}
+
+} // namespace solver
+} // namespace miopen

--- a/src/solver/conv_hip_implicit_gemm_mlir_bin_bwd.cpp
+++ b/src/solver/conv_hip_implicit_gemm_mlir_bin_bwd.cpp
@@ -60,7 +60,7 @@ std::tuple<int, int, int> CalculateGemmSize(const ConvolutionContext& ctx)
 bool ConvHipImplicitGemmMlirBinBwd::IsApplicable(const ConvolutionContext& ctx) const
 {
 #if MIOPEN_USE_MLIR
-    if(miopen::IsDisabled(MIOPEN_DEBUG_CONV_HIP_IMPLICIT_GEMM_MLIR_BIN_BWD{}))
+    if(!miopen::IsEnabled(MIOPEN_DEBUG_CONV_HIP_IMPLICIT_GEMM_MLIR_BIN_BWD{}))
         return false;
     // Future: MLIR will support non-default layouts.
     if(!ctx.IsLayoutDefault())

--- a/src/solver/conv_hip_implicit_gemm_mlir_bin_fwd.cpp
+++ b/src/solver/conv_hip_implicit_gemm_mlir_bin_fwd.cpp
@@ -25,9 +25,10 @@
  *******************************************************************************/
 #include <miopen/mlir_build.hpp>
 #include <miopen/conv/invokers/mlir_impl_gemm.hpp>
+#include <miopen/config.h>
+#include <miopen/env.hpp>
 #include <miopen/solver.hpp>
 #include <miopen/solver/implicitgemm_util.hpp>
-#include <miopen/handle.hpp>
 
 MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEBUG_CONV_HIP_IMPLICIT_GEMM_MLIR_BIN_FWD)
 


### PR DESCRIPTION
Refer to #841 for the previous step in the series.

I did the following in this PR:
 - Implemented the MLIR binary backend invoker, bwd path
 - Implemented the MLIR binary backend solver, bwd path

I will work through the remaining work incrementally: This help to reduce the complexity for both myself as developer and the reviewers.

I did not add unit test for mlir binary backend because the corresponding commit does not guarantee correctness for bwd path. This means that I will rework this solver/invoker once I am able to bump the MLIR commit who can guarantee it. 