### PR TITLE
[OCL][FP16] Fix: Disable GEMM/MIOpenGEMM. [Immediate Mode] Always use Naive Direct in Fallback.

### DIFF
--- a/src/include/miopen/solver.hpp
+++ b/src/include/miopen/solver.hpp
@@ -2097,11 +2097,9 @@ struct ConvDirectNaiveConvFwd : SolverBase<ConvolutionContext>
 {
     bool IsApplicable(const ConvolutionContext& ctx) const;
     bool IsDynamic() const { return true; }
-#if WORKAROUND_MIOPENGEMM_SINCE_ROCM41
     /// Use very small fixed value enough to backup GEMM for cases when
     /// GEMM is disabled due to MIOpenGemm or OCL compiler issues.
     float GetWti(const ConvolutionContext&) const { return 0.01; }
-#endif
     ConvSolution GetSolution(const ConvolutionContext& ctx) const;
 };
 
@@ -2109,11 +2107,9 @@ struct ConvDirectNaiveConvBwd : SolverBase<ConvolutionContext>
 {
     bool IsApplicable(const ConvolutionContext& ctx) const;
     bool IsDynamic() const { return true; }
-#if WORKAROUND_MIOPENGEMM_SINCE_ROCM41
     /// Use very small fixed value enough to backup GEMM for cases when
     /// GEMM is disabled due to MIOpenGemm or OCL compiler issues.
     float GetWti(const ConvolutionContext&) const { return 0.01; }
-#endif
     ConvSolution GetSolution(const ConvolutionContext& ctx) const;
 };
 
@@ -2121,11 +2117,9 @@ struct ConvDirectNaiveConvWrw : SolverBase<ConvolutionContext>
 {
     bool IsApplicable(const ConvolutionContext& ctx) const;
     bool IsDynamic() const { return true; }
-#if WORKAROUND_MIOPENGEMM_SINCE_ROCM41
     /// Use very small fixed value enough to backup GEMM for cases when
     /// GEMM is disabled due to MIOpenGemm or OCL compiler issues.
     float GetWti(const ConvolutionContext&) const { return 0.01; }
-#endif
     ConvSolution GetSolution(const ConvolutionContext& ctx) const;
 };
 

--- a/src/solver/gemm.cpp
+++ b/src/solver/gemm.cpp
@@ -53,10 +53,11 @@ namespace solver {
 #if MIOPEN_USE_GEMM
 #ifdef CPPCHECK
 // Keep the value unknown in cppcheck since this can differ between opencl and hip
-static bool IsBF16PathValid;
+static bool IsBf16Supported;
+static bool IsFp16Supported;
 #else
-static constexpr const bool IsBF16PathValid =
-    (MIOPEN_USE_ROCBLAS == 1 || MIOPEN_USE_MIOPENTENSILE == 1);
+static constexpr const bool IsBf16Supported = (MIOPEN_USE_ROCBLAS || MIOPEN_USE_MIOPENTENSILE);
+static constexpr const bool IsFp16Supported = (MIOPEN_USE_ROCBLAS || MIOPEN_USE_MIOPENTENSILE);
 #endif
 
 static inline bool IsAnyBufferBF16(const TensorDescriptor& xDesc,
@@ -65,6 +66,14 @@ static inline bool IsAnyBufferBF16(const TensorDescriptor& xDesc,
 {
     return xDesc.GetType() == miopenBFloat16 || yDesc.GetType() == miopenBFloat16 ||
            wDesc.GetType() == miopenBFloat16;
+}
+
+static inline bool IsAnyBufferFp16(const TensorDescriptor& xDesc,
+                                   const TensorDescriptor& yDesc,
+                                   const TensorDescriptor& wDesc)
+{
+    return xDesc.GetType() == miopenHalf || yDesc.GetType() == miopenHalf ||
+           wDesc.GetType() == miopenHalf;
 }
 #endif
 
@@ -75,10 +84,12 @@ bool GemmFwdBase::IsApplicable(const ExecutionContext&,
     const auto& xDesc = problem.GetIn();
     const auto& wDesc = problem.GetWeights();
     const auto& yDesc = problem.GetOut();
-    return problem.GetDirection() == conv::Direction::Forward && problem.IsLayoutDefault() &&
-           !(IsAnyBufferBF16(xDesc, yDesc, wDesc) && !IsBF16PathValid);
+    return problem.GetDirection() == conv::Direction::Forward &&          //
+           problem.IsLayoutDefault() &&                                   //
+           !(IsAnyBufferBF16(xDesc, yDesc, wDesc) && !IsBf16Supported) && //
+           !(IsAnyBufferFp16(xDesc, yDesc, wDesc) && !IsFp16Supported);
 #else
-    std::ignore = problem;
+    std::ignore                             = problem;
     return false;
 #endif
 };

--- a/src/solver/gemm.cpp
+++ b/src/solver/gemm.cpp
@@ -84,9 +84,8 @@ bool GemmFwdBase::IsApplicable(const ExecutionContext&,
     const auto& xDesc = problem.GetIn();
     const auto& wDesc = problem.GetWeights();
     const auto& yDesc = problem.GetOut();
-    return problem.GetDirection() == conv::Direction::Forward &&          //
-           problem.IsLayoutDefault() &&                                   //
-           !(IsAnyBufferBF16(xDesc, yDesc, wDesc) && !IsBf16Supported) && //
+    return problem.GetDirection() == conv::Direction::Forward && problem.IsLayoutDefault() &&
+           !(IsAnyBufferBF16(xDesc, yDesc, wDesc) && !IsBf16Supported) &&
            !(IsAnyBufferFp16(xDesc, yDesc, wDesc) && !IsFp16Supported);
 #else
     std::ignore                             = problem;


### PR DESCRIPTION
- Resolves #890
  - @DrizztDoUrden Please take in to account this when implementing WrW GEMM Invokers.
- From now on, Naive Direct always backs up GEMM on Immediate Mode Fallback path.

