### PR TITLE
[COMGR] Fix UB: reference binding to null pointer of type 'char'

### DIFF
--- a/src/comgr.cpp
+++ b/src/comgr.cpp
@@ -548,6 +548,8 @@ class Data : ComgrOwner
     std::string GetString() const
     {
         std::vector<char> bytes;
+        if(GetSize() == 0)
+            return {};
         const auto sz = GetBytes(bytes);
         return {&bytes[0], sz};
     }


### PR DESCRIPTION
Fix for COMGR. Resolves #877