### PR TITLE
[NFC][ROCm 4.2] Workarounds for OpenCL build errors in DEV builds (SWDEV-270602)

### DIFF
--- a/src/hipoc/hipoc_program.cpp
+++ b/src/hipoc/hipoc_program.cpp
@@ -325,7 +325,8 @@ void HIPOCProgramImpl::BuildCodeObject(std::string params,
     else if(miopen::EndsWith(filename, ".cl"))
     {
 #if MIOPEN_BUILD_DEV
-        params += " -Werror" + OclKernelWarningsString();
+        params +=
+            " -Werror" + (is_kernel_str ? MiopengemmWarningsString() : OclKernelWarningsString());
 #else
         params += " -Wno-everything";
 #endif

--- a/src/include/miopen/kernel_warnings.hpp
+++ b/src/include/miopen/kernel_warnings.hpp
@@ -31,6 +31,7 @@
 
 namespace miopen {
 
+const std::string& MiopengemmWarningsString();
 const std::string& OclKernelWarningsString();
 const std::string& HipKernelWarningsString();
 

--- a/src/kernel_warnings.cpp
+++ b/src/kernel_warnings.cpp
@@ -32,9 +32,9 @@
 
 namespace miopen {
 
-std::vector<std::string> OclKernelWarnings()
+static std::vector<std::string> OclKernelWarnings(const bool is_miopengemm)
 {
-    return {
+    std::vector<std::string> rv = {
         "-Weverything",
         "-Wno-cast-align",
         "-Wno-cast-qual",
@@ -51,9 +51,13 @@ std::vector<std::string> OclKernelWarnings()
         "-Wno-unused-function",
         "-Wno-unused-macros",
     };
+    // W/A for SWDEV-270602. We'll remove this when we stop using MIOpenGEMM (deprecated).
+    if(is_miopengemm)
+        rv.push_back("-Wno-tautological-unsigned-zero-compare");
+    return rv;
 }
 
-std::vector<std::string> HipKernelWarnings()
+static std::vector<std::string> HipKernelWarnings()
 {
     return {
         "-Weverything",
@@ -88,6 +92,18 @@ static std::string MakeKernelWarningsString(const std::vector<std::string>& kern
     return prefix + JoinStrings(kernel_warnings, prefix);
 }
 
+const std::string& MiopengemmWarningsString()
+{
+#if MIOPEN_BACKEND_OPENCL
+    std::string prefix = " -Wf,";
+#else
+    std::string prefix = " ";
+#endif
+
+    static const std::string result = MakeKernelWarningsString(OclKernelWarnings(true), prefix);
+    return result;
+}
+
 const std::string& OclKernelWarningsString()
 {
 #if MIOPEN_BACKEND_OPENCL
@@ -96,7 +112,7 @@ const std::string& OclKernelWarningsString()
     std::string prefix = " ";
 #endif
 
-    static const std::string result = MakeKernelWarningsString(OclKernelWarnings(), prefix);
+    static const std::string result = MakeKernelWarningsString(OclKernelWarnings(false), prefix);
     return result;
 }
 

--- a/src/kernel_warnings.cpp
+++ b/src/kernel_warnings.cpp
@@ -36,19 +36,20 @@ std::vector<std::string> OclKernelWarnings()
 {
     return {
         "-Weverything",
-        "-Wno-shorten-64-to-32",
-        "-Wno-unused-macros",
-        "-Wno-unused-function",
-        "-Wno-sign-compare",
-        "-Wno-reserved-id-macro",
-        "-Wno-sign-conversion",
-        "-Wno-missing-prototypes",
-        "-Wno-cast-qual",
         "-Wno-cast-align",
+        "-Wno-cast-qual",
         "-Wno-conversion",
         "-Wno-double-promotion",
         "-Wno-float-equal",
-        "-Wno-pass-failed", // Disable "loop not unrolled" warnings. See #1735.
+        "-Wno-missing-prototypes",
+        "-Wno-pass-failed",            // Disable "loop not unrolled" warnings. See #1735.
+        "-Wno-pedantic-core-features", // Cases like "#pragma OPENCL EXTENSION cl_khr_fp64 : enable"
+        "-Wno-reserved-id-macro",
+        "-Wno-shorten-64-to-32",
+        "-Wno-sign-compare",
+        "-Wno-sign-conversion",
+        "-Wno-unused-function",
+        "-Wno-unused-macros",
     };
 }
 
@@ -81,8 +82,8 @@ std::vector<std::string> HipKernelWarnings()
     };
 }
 
-std::string MakeKernelWarningsString(const std::vector<std::string>& kernel_warnings,
-                                     const std::string& prefix)
+static std::string MakeKernelWarningsString(const std::vector<std::string>& kernel_warnings,
+                                            const std::string& prefix)
 {
     return prefix + JoinStrings(kernel_warnings, prefix);
 }

--- a/src/kernel_warnings.cpp
+++ b/src/kernel_warnings.cpp
@@ -53,7 +53,7 @@ static std::vector<std::string> OclKernelWarnings(const bool is_miopengemm)
     };
     // W/A for SWDEV-270602. We'll remove this when we stop using MIOpenGEMM (deprecated).
     if(is_miopengemm)
-        rv.push_back("-Wno-tautological-unsigned-zero-compare");
+        rv.emplace_back("-Wno-tautological-unsigned-zero-compare");
     return rv;
 }
 

--- a/src/ocl/clhelper.cpp
+++ b/src/ocl/clhelper.cpp
@@ -195,7 +195,7 @@ ClProgramPtr LoadProgram(cl_context ctx,
 #if MIOPEN_BUILD_DEV
         params += " -Werror";
 #ifdef __linux__
-        params += OclKernelWarningsString();
+        params += is_kernel_str ? MiopengemmWarningsString() : OclKernelWarningsString();
 #endif
 #endif
         params += " -cl-std=CL1.2";


### PR DESCRIPTION
Resolves http://ontrack-internal.amd.com/browse/SWDEV-270602 and some other OpenCL build errors that happen with ROCm 4.2 when `BUILD_DEV=On`.