### PR TITLE
[HOTFIX] Fix build error due to missing `Miir.h` when MIOPEN_USE_MLIR=0 and MLIR library is not available

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -195,7 +195,6 @@ set( MIOpen_Source
     conv/invokers/gen_x_w_y_pad.cpp
     conv/invokers/ocl_wrw_rdc.cpp
     conv/invokers/impl_gemm.cpp
-    conv/invokers/mlir_impl_gemm.cpp
     conv/invokers/impl_gemm_dynamic.cpp
     invoker_cache.cpp
     tensor.cpp
@@ -585,6 +584,7 @@ endif()
 
 if(MIOPEN_USE_MLIR)
     list(APPEND MIOpen_Source mlir_build.cpp)
+    list(APPEND MIOpen_Source mlir_impl_gemm.cpp)
 endif()
 
 # build library

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -583,8 +583,7 @@ if(MIOPEN_USE_COMGR)
 endif()
 
 if(MIOPEN_USE_MLIR)
-    list(APPEND MIOpen_Source mlir_build.cpp)
-    list(APPEND MIOpen_Source mlir_impl_gemm.cpp)
+    list(APPEND MIOpen_Source mlir_build.cpp mlir_impl_gemm.cpp)
 endif()
 
 # build library

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -583,7 +583,7 @@ if(MIOPEN_USE_COMGR)
 endif()
 
 if(MIOPEN_USE_MLIR)
-    list(APPEND MIOpen_Source mlir_build.cpp mlir_impl_gemm.cpp)
+    list(APPEND MIOpen_Source mlir_build.cpp conv/invokers/mlir_impl_gemm.cpp)
 endif()
 
 # build library

--- a/src/conv/invokers/mlir_impl_gemm.cpp
+++ b/src/conv/invokers/mlir_impl_gemm.cpp
@@ -32,9 +32,7 @@
 #include <miopen/handle.hpp>
 #include <miopen/tensor_ops.hpp>
 
-#if MIOPEN_USE_MLIR
 #include <Miir.h>
-#endif
 
 #include <boost/any.hpp>
 #include <boost/range/adaptors.hpp>

--- a/src/conv/invokers/mlir_impl_gemm.cpp
+++ b/src/conv/invokers/mlir_impl_gemm.cpp
@@ -41,7 +41,6 @@ namespace miopen {
 namespace conv {
 
 namespace {
-#if MIOPEN_USE_MLIR
 struct MlirConvArgs
 {
     StridedMemRef5D filter;
@@ -177,12 +176,10 @@ void SetMlirConvArgsPtr(ConstData_t in, ConstData_t out, ConstData_t w, MlirConv
     args.output.basePtr = output;
     args.output.data    = output;
 }
-#endif
 } // Anonymous namespace
 
 InvokerFactory MakeMlirFwdInvokerFactory(const ConvolutionContext& ctx)
 {
-#if MIOPEN_USE_MLIR
     assert((ctx.direction.IsForward()));
 
     std::vector<size_t> in_dims, in_strides;
@@ -209,15 +206,10 @@ InvokerFactory MakeMlirFwdInvokerFactory(const ConvolutionContext& ctx)
             handle.Run(kernels[0])(args);
         };
     };
-#else
-    std::ignore = ctx;
-    return {};
-#endif
 }
 
 InvokerFactory MakeMlirBwdInvokerFactory(const ConvolutionContext& ctx)
 {
-#if MIOPEN_USE_MLIR
     assert(ctx.direction.IsBackwardData());
 
     std::vector<size_t> in_dims, in_strides;
@@ -269,15 +261,10 @@ InvokerFactory MakeMlirBwdInvokerFactory(const ConvolutionContext& ctx)
             }
         };
     };
-#else
-    std::ignore = ctx;
-    return {};
-#endif
 }
 
 InvokerFactory MakeMlirWrWInvokerFactory(const ConvolutionContext& ctx)
 {
-#if MIOPEN_USE_MLIR
     assert((ctx.direction.IsBackwardWrW()));
 
     std::vector<size_t> in_dims, in_strides;
@@ -302,10 +289,6 @@ InvokerFactory MakeMlirWrWInvokerFactory(const ConvolutionContext& ctx)
             handle.Run(kernels[0])(args);
         };
     };
-#else
-    std::ignore = ctx;
-    return {};
-#endif
 }
 
 } // namespace conv

--- a/src/conv/invokers/mlir_impl_gemm.cpp
+++ b/src/conv/invokers/mlir_impl_gemm.cpp
@@ -32,7 +32,9 @@
 #include <miopen/handle.hpp>
 #include <miopen/tensor_ops.hpp>
 
+#if MIOPEN_USE_MLIR
 #include <Miir.h>
+#endif
 
 #include <boost/any.hpp>
 #include <boost/range/adaptors.hpp>
@@ -164,7 +166,7 @@ void SetMlirConvArgsPtr(ConstData_t in, ConstData_t out, ConstData_t w, MlirConv
     // NOLINTNEXTLINE (cppcoreguidelines-pro-type-const-cast)
     input = const_cast<void*>(in);
     // NOLINTNEXTLINE (cppcoreguidelines-pro-type-const-cast)
-    output      = const_cast<void*>(out);
+    output = const_cast<void*>(out);
 #endif
 
     if((filter == nullptr) || (input == nullptr) || (output == nullptr))


### PR DESCRIPTION
From #908 

I compared this case and the `mlir_build.h` case, I honestly don't see a reason why compiler want to compile this cpp file (therefore the need to find the dependent `Miir.h`). When `MIOPEN_USE_MLIR` is not turned on, the compiler should not have visibility into any of the `mlir_impl_gemm.hpp` header functions.

However, it is what it is. Adding a macro to make sure when compiler does compile this implementation file, it does not require the `Miir.h` header.