### PR TITLE
Use FP32 scaling factors in ReduceTensor, regardless of the tensor data type (SWDEV-284921).

### DIFF
--- a/driver/miopen_Reduction.hpp
+++ b/driver/miopen_Reduction.hpp
@@ -75,7 +75,7 @@ class miopenReductionHost
 
     ~miopenReductionHost(){};
 
-    void Run(Tgpu alpha, const Tgpu* in_data, Tgpu beta, Tref* out_data, int* indices)
+    void Run(float alpha, const Tgpu* in_data, float beta, Tref* out_data, int* indices)
     {
         if(compTypeVal == miopenFloat)
         {
@@ -116,7 +116,7 @@ class miopenReductionHost
     bool reduceAllDims;
 
     template <typename compType>
-    void RunImpl(Tgpu alpha, const Tgpu* in_data, Tgpu beta, Tref* out_data, int* indices)
+    void RunImpl(float alpha, const Tgpu* in_data, float beta, Tref* out_data, int* indices)
     {
         bool need_indices =
             (indicesOpt == MIOPEN_REDUCE_TENSOR_FLATTENED_INDICES) &&
@@ -131,7 +131,7 @@ class miopenReductionHost
 
     template <typename compType>
     void
-    RunImpl_with_indices(Tgpu alpha, const Tgpu* in_data, Tgpu beta, Tref* out_data, int* indices)
+    RunImpl_with_indices(float alpha, const Tgpu* in_data, float beta, Tref* out_data, int* indices)
     {
         using reduce::ReduceOpFn2;
         using reduce::PreUnaryOpFn;
@@ -182,7 +182,7 @@ class miopenReductionHost
 
             // scale the prior dst value and add it to the accumulated value
             if(!float_equal_zero(beta))
-                accuVal += convert_type<compType>(out_data[0] * convert_type<Tref>(beta));
+                accuVal += convert_type<compType>(out_data[0]) * convert_type<compType>(beta);
 
             // store the reduced value to dst location
             out_data[0] = convert_type<Tref>(accuVal);
@@ -246,7 +246,7 @@ class miopenReductionHost
                 // scale the prior dst value and add it to the accumulated value
                 if(!float_equal_zero(beta))
                     accuVal +=
-                        convert_type<compType>(out_data[dst_offset] * convert_type<Tref>(beta));
+                        convert_type<compType>(out_data[dst_offset]) * convert_type<compType>(beta);
 
                 // store the reduced value to dst location
                 out_data[dst_offset] = convert_type<Tref>(accuVal);
@@ -256,7 +256,7 @@ class miopenReductionHost
     }; // end of RunImpl_with_indices()
 
     template <typename compType>
-    void RunImpl_no_indices(Tgpu alpha, const Tgpu* in_data, Tgpu beta, Tref* out_data)
+    void RunImpl_no_indices(float alpha, const Tgpu* in_data, float beta, Tref* out_data)
     {
         using reduce::ReduceOpFn;
         using reduce::PreUnaryOpFn;
@@ -305,7 +305,7 @@ class miopenReductionHost
 
             // scale the prior dst value and add it to the accumulated value
             if(!float_equal_zero(beta))
-                accuVal += convert_type<compType>(out_data[0] * convert_type<Tref>(beta));
+                accuVal += convert_type<compType>(out_data[0]) * convert_type<compType>(beta);
 
             // store the reduced value to dst location
             out_data[0] = convert_type<Tref>(accuVal);
@@ -367,7 +367,7 @@ class miopenReductionHost
                 // scale the prior dst value and add it to the accumulated value
                 if(!float_equal_zero(beta))
                     accuVal +=
-                        convert_type<compType>(out_data[dst_offset] * convert_type<Tref>(beta));
+                        convert_type<compType>(out_data[dst_offset]) * convert_type<compType>(beta);
 
                 // store the reduced value to dst location
                 out_data[dst_offset] = convert_type<Tref>(accuVal);

--- a/driver/reduce_driver.hpp
+++ b/driver/reduce_driver.hpp
@@ -362,10 +362,8 @@ int ReduceDriver<Tgpu, Tref>::AllocateBuffersAndCopy()
 template <typename Tgpu, typename Tref>
 int ReduceDriver<Tgpu, Tref>::RunForwardGPU()
 {
-    auto alpha =
-        reduce::convert_type<Tgpu>(static_cast<float>(this->inflags.GetValueDouble("alpha")));
-    auto beta =
-        reduce::convert_type<Tgpu>(static_cast<float>(this->inflags.GetValueDouble("beta")));
+    auto alpha = static_cast<float>(this->inflags.GetValueDouble("alpha"));
+    auto beta  = static_cast<float>(this->inflags.GetValueDouble("beta"));
 
     if(this->need_indices)
     {
@@ -466,8 +464,8 @@ int ReduceDriver<Tgpu, Tref>::VerifyForward()
 
     if(indices_sizeInBytes > 0)
     {
-        alpha = reduce::convert_type<Tgpu>(1.0f);
-        beta  = reduce::convert_type<Tgpu>(0.0f);
+        alpha = 1.0f;
+        beta  = 0.0f;
     };
 
     hostReduction.Run(alpha, in.data(), beta, outhost.data(), outhost_indices.data());

--- a/src/reducetensor.cpp
+++ b/src/reducetensor.cpp
@@ -51,8 +51,6 @@ enum ReductionMethod_t
     Reduce_MultiBlock       = 4
 };
 
-using reduce::convert_type;
-
 namespace detail {
 
 struct get_tunable_reduction_kernel_constants

--- a/src/reducetensor.cpp
+++ b/src/reducetensor.cpp
@@ -592,14 +592,11 @@ void ReduceTensorDescriptor::ReduceTensor(const Handle& handle,
     const std::vector<size_t> vgd_1 = {
         static_cast<size_t>(gridSize * blockSize), size_t{1}, size_t{1}};
 
-    visit_float(srcDataType, [&](auto as_float) {
-        float alphaVal = convert_type<float>(*as_float(alpha));
-        float betaVal  = convert_type<float>(*as_float(beta));
+    float alphaVal = *reinterpret_cast<const float*>(alpha);
+    float betaVal  = *reinterpret_cast<const float*>(beta);
 
-        handle.AddKernel(
-            algo_name, network_config, program_name, kernel_name1, vld_1, vgd_1, param)(
-            alphaVal, A, betaVal, C, ws_buf1_global, ws_buf2_bytes_offset, indices);
-    });
+    handle.AddKernel(algo_name, network_config, program_name, kernel_name1, vld_1, vgd_1, param)(
+        alphaVal, A, betaVal, C, ws_buf1_global, ws_buf2_bytes_offset, indices);
 
     if(useTwoCalls)
     {
@@ -614,14 +611,9 @@ void ReduceTensorDescriptor::ReduceTensor(const Handle& handle,
         // kernel for the second call
         std::string kernel_name2 = "gridwise_generic_reduce_2";
 
-        visit_float(srcDataType, [&](auto as_float) {
-            float alphaVal = convert_type<float>(*as_float(alpha));
-            float betaVal  = convert_type<float>(*as_float(beta));
-
-            handle.AddKernel(
-                algo_name, network_config, program_name, kernel_name2, vld_2, vgd_2, param)(
-                alphaVal, A, betaVal, C, ws_buf1_global, ws_buf2_bytes_offset, indices);
-        });
+        handle.AddKernel(
+            algo_name, network_config, program_name, kernel_name2, vld_2, vgd_2, param)(
+            alphaVal, A, betaVal, C, ws_buf1_global, ws_buf2_bytes_offset, indices);
     };
 };
 


### PR DESCRIPTION
Previous implementation of miopenReduceTensor() assumes alpha/beta has the same data type as the input tensor.  This change assumes/interprets alpha/beta has float type.  The miopenReduceTensor() API does not change.  


<details><summary><b><i>The change has gone through the following tests:</i></b></summary>

Regular MIOpen tests:
```bash
$ ./bin/test_reduce_test --all --float
$ ./bin/test_reduce_test --all --half
```

Manual testing:
```bash
#!/bin/bash

## for fp32
bin/MIOpenDriver reduce -D 64,3,280,81  -R 0 -O 2 -N 0 -I 1
bin/MIOpenDriver reduce -D 64,3,280,81  -R 0 -O 3 -N 0 -I 1
bin/MIOpenDriver reduce -D 64,3,280,81  -R 0 -O 4 -N 0 -I 1
##
bin/MIOpenDriver reduce -D 64,3,280,81  -R 1 -O 2 -N 0 -I 1
bin/MIOpenDriver reduce -D 64,3,280,81  -R 1 -O 3 -N 0 -I 1
bin/MIOpenDriver reduce -D 64,3,280,81  -R 1 -O 4 -N 0 -I 1
##
bin/MIOpenDriver reduce -D 64,3,280,81  -R 2 -O 2 -N 0 -I 1
bin/MIOpenDriver reduce -D 64,3,280,81  -R 2 -O 3 -N 0 -I 1
bin/MIOpenDriver reduce -D 64,3,280,81  -R 2 -O 4 -N 0 -I 1

bin/MIOpenDriver reduce -D 64,3,280,81  -R 3 -O 2 -N 0 -I 1
bin/MIOpenDriver reduce -D 64,3,280,81  -R 3 -O 3 -N 0 -I 1
bin/MIOpenDriver reduce -D 64,3,280,81  -R 3 -O 4 -N 0 -I 1
##
bin/MIOpenDriver reduce -D 64,3,280,81  -R 2,3 -O 2 -N 0 -I 1
bin/MIOpenDriver reduce -D 64,3,280,81  -R 2,3 -O 3 -N 0 -I 1
bin/MIOpenDriver reduce -D 64,3,280,81  -R 2,3 -O 4 -N 0 -I 1

## for fp16
bin/MIOpenDriver reducefp16 -D 64,3,280,81  -R 0 -O 2 -C 0 -N 0 -I 1
bin/MIOpenDriver reducefp16 -D 64,3,280,81  -R 0 -O 3 -C 0 -N 0 -I 1
bin/MIOpenDriver reducefp16 -D 64,3,280,81  -R 0 -O 4 -C 0 -N 0 -I 1

bin/MIOpenDriver reducefp16 -D 64,3,280,81  -R 1 -O 2 -C 0 -N 0 -I 1
bin/MIOpenDriver reducefp16 -D 64,3,280,81  -R 1 -O 3 -C 0 -N 0 -I 1
bin/MIOpenDriver reducefp16 -D 64,3,280,81  -R 1 -O 4 -C 0 -N 0 -I 1

bin/MIOpenDriver reducefp16 -D 64,3,280,81  -R 2 -O 2 -C 0 -N 0 -I 1
bin/MIOpenDriver reducefp16 -D 64,3,280,81  -R 2 -O 3 -C 0 -N 0 -I 1
bin/MIOpenDriver reducefp16 -D 64,3,280,81  -R 2 -O 4 -C 0 -N 0 -I 1

bin/MIOpenDriver reducefp16 -D 64,3,280,81  -R 3 -O 2 -C 0 -N 0 -I 1
bin/MIOpenDriver reducefp16 -D 64,3,280,81  -R 3 -O 3 -C 0 -N 0 -I 1
bin/MIOpenDriver reducefp16 -D 64,3,280,81  -R 3 -O 4 -C 0 -N 0 -I 1

bin/MIOpenDriver reducefp16 -D 64,3,280,81  -R 2,3 -O 2 -C 0 -N 0 -I 1
bin/MIOpenDriver reducefp16 -D 64,3,280,81  -R 2,3 -O 3 -C 0 -N 0 -I 1
bin/MIOpenDriver reducefp16 -D 64,3,280,81  -R 2,3 -O 4 -C 0 -N 0 -I 1

## for very small tensors
bin/MIOpenDriver reducefp16 -D 4  -R 0 -O 3 -C 0 
bin/MIOpenDriver reducefp16 -D 4  -R 0 -O 3 -C 1 
bin/MIOpenDriver reduce -D 4  -R 0 -O 3 -C 0 
bin/MIOpenDriver reduce -D 4  -R 0 -O 3 -C 1 
```
</details>
