### PR TITLE
[CI][rocm-4.2.x] Unblock our CI for rocm-4.2.x branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -269,7 +269,7 @@ pipeline {
             when { expression { params.STATIC_CHECKS } }
             parallel{
                 stage('Clang Tidy') {
-                    agent{  label rocmnode("rocmtest") }
+                    agent{  label rocmnode("nogpu") }
                     environment{
                         cmd = "cd build; CXX='clang++-3.8' cmake -DBUILD_DEV=On ..; make -j\$(nproc) -k analyze;"
                     }
@@ -288,7 +288,7 @@ pipeline {
                 }
 
                 stage('Clang Format') {
-                    agent{ label rocmnode("rocmtest") }
+                    agent{ label rocmnode("nogpu") }
                     environment{
                         cmd = "find . -iname \'*.h\' \
                                 -o -iname \'*.hpp\' \
@@ -315,7 +315,7 @@ pipeline {
                 }
 
                 stage('Hip Tidy') {
-                    agent{ label rocmnode("rocmtest") }
+                    agent{ label rocmnode("nogpu") }
                     environment{
                         cmd = "cd build; CXX=/usr/local/bin/hcc cmake -DBUILD_DEV=On ..; make -j\$(nproc) -k analyze;"
                     }
@@ -452,7 +452,7 @@ pipeline {
             when { expression { params.SMOKE_TESTS } }
             parallel{
                 stage('HipNoGPU Debug') {
-                    agent{  label rocmnode("rocmtest") }
+                    agent{  label rocmnode("nogpu") }
                     environment{
                         cmd = """
                             ulimit -c unlimited
@@ -1073,7 +1073,7 @@ pipeline {
             when { expression { params.PACKAGES } }
             parallel {
                 stage('OpenCL Release Package') {
-                    agent{ label rocmnode("rocmtest") }
+                    agent{ label rocmnode("nogpu") }
                     steps{
                         script{
                             try{
@@ -1091,7 +1091,7 @@ pipeline {
                     }
                 }
                 stage("HIP Release Package /opt/rocm"){
-                    agent{ label rocmnode("rocmtest") }
+                    agent{ label rocmnode("nogpu") }
                     steps{
                         script{
                             try{

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,18 +1,5 @@
-
 def rocmnode(name) {
-    def node_name = 'rocmtest'
-    if(name == 'vega') {
-        node_name = 'rocmtest && vega';
-    } else if(name == 'vega10') {
-        node_name = 'rocmtest && vega10';
-    } else if(name == 'vega20') {
-        node_name = 'rocmtest && vega20';
-    } else if(name == 'gfx908') {
-        node_name = 'gfx908';
-    } else {
-        node_name = name
-    }
-    return node_name
+    return 'rocmtest && miopen && ' + name
 }
 
 def default_image_name() {
@@ -50,8 +37,6 @@ def cmake_build(compiler, flags, env4make, extradebugflags, prefixpath){
     def cmd = """
         echo \$HSA_ENABLE_SDMA
         ulimit -c unlimited
-        rm -rf build
-        mkdir build
         cd build
         CXX=${compilerpath} CXXFLAGS='-Werror' cmake ${configargs} -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS='${test_flags}' -DCMAKE_CXX_FLAGS_DEBUG='${debug_flags}' ${flags} ..
         MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_XDLOPS=1 CTEST_PARALLEL_LEVEL=4 MIOPEN_VERIFY_CACHE_PATH=${vcache} MIOPEN_CONV_PRECISE_ROCBLAS_TIMING=0 ${env4make} dumb-init make -j\$(nproc) ${config_targets}
@@ -112,6 +97,14 @@ def buildJob(Map conf, compiler){
             withDockerContainer(image: image, args: dockerOpts + ' -v=/var/jenkins/:/var/jenkins') {
                 timeout(time: 5, unit: 'HOURS')
                 {
+                    sh '''
+                        rm -rf build
+                        mkdir build
+                        rm -rf install
+                        mkdir install
+                        rm -f src/kernels/*.ufdb.txt
+                        rm -f src/kernels/miopen*.udb
+                    '''
                     if(cmd == ""){
                         cmake_build(compiler, flags, env4make, extradebugflags, prefixpath)
                     }else{
@@ -182,6 +175,14 @@ def buildHipClangJob(Map conf, compiler){
             withDockerContainer(image: image, args: dockerOpts + ' -v=/var/jenkins/:/var/jenkins') {
                 timeout(time: 5, unit: 'HOURS')
                 {
+                    sh '''
+                        rm -rf build
+                        mkdir build
+                        rm -rf install
+                        mkdir install
+                        rm -f src/kernels/*.ufdb.txt
+                        rm -f src/kernels/miopen*.udb
+                    '''
                     if(cmd == ""){
                         cmake_build(compiler, flags, env4make, extradebugflags, prefixpath)
                     }else{
@@ -240,14 +241,37 @@ pipeline {
     environment{
         image = default_image_name()
     }
+    parameters {
+        booleanParam(
+            name: "STATIC_CHECKS",
+            defaultValue: true,
+            description: "")
+        booleanParam(
+            name: "SMOKE_TESTS",
+            defaultValue: true,
+            description: "")
+        booleanParam(
+            name: "FULL_TESTS",
+            defaultValue: true,
+            description: "")
+        booleanParam(
+            name: "MIOPENTENSILE",
+            defaultValue: false,
+            description: "")
+        booleanParam(
+            name: "PACKAGES",
+            defaultValue: true,
+            description: "")
+    }
     stages{
         // Run all static analysis tests
         stage("Static checks"){
+            when { expression { params.STATIC_CHECKS } }
             parallel{
                 stage('Clang Tidy') {
                     agent{  label rocmnode("rocmtest") }
                     environment{
-                        cmd = "rm -rf build; mkdir build; cd build; CXX='clang++-3.8' cmake -DBUILD_DEV=On ..; make -j\$(nproc) -k analyze;"
+                        cmd = "cd build; CXX='clang++-3.8' cmake -DBUILD_DEV=On ..; make -j\$(nproc) -k analyze;"
                     }
                     steps{
                         script{
@@ -293,7 +317,7 @@ pipeline {
                 stage('Hip Tidy') {
                     agent{ label rocmnode("rocmtest") }
                     environment{
-                        cmd = "rm -rf build; mkdir build; cd build; CXX=/usr/local/bin/hcc cmake -DBUILD_DEV=On ..; make -j\$(nproc) -k analyze;"
+                        cmd = "cd build; CXX=/usr/local/bin/hcc cmake -DBUILD_DEV=On ..; make -j\$(nproc) -k analyze;"
                     }
                     steps{
                         script{
@@ -313,6 +337,7 @@ pipeline {
 
         // Run quick fp32 tests
         stage("Fast full precision"){
+            when { expression { params.SMOKE_TESTS } }
             parallel{
                stage('OpenCL Debug') {
                     agent{ label rocmnode("vega") }
@@ -376,8 +401,6 @@ pipeline {
                     environment{
                         cmd = """
                             ulimit -c unlimited
-                            rm -rf build
-                            mkdir build
                             cd build
                             CXX=/opt/rocm/llvm/bin/clang++ cmake -DBUILD_DEV=On -DCMAKE_BUILD_TYPE=debug -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS=--disable-verification-cache ..
                             CTEST_PARALLEL_LEVEL=4 MIOPEN_DEBUG_IMPLICIT_GEMM_NON_XDLOPS_INLINE_ASM=0 MIOPEN_CONV_PRECISE_ROCBLAS_TIMING=0 make -j\$(nproc) check
@@ -426,14 +449,13 @@ pipeline {
 
         // Misc tests
         stage("Aux tests"){
+            when { expression { params.SMOKE_TESTS } }
             parallel{
                 stage('HipNoGPU Debug') {
                     agent{  label rocmnode("rocmtest") }
                     environment{
                         cmd = """
                             ulimit -c unlimited
-                            rm -rf build
-                            mkdir build
                             cd build
                             CXX=/opt/rocm/llvm/bin/clang++ cmake -DBUILD_DEV=On -DCMAKE_BUILD_TYPE=debug -DMIOPEN_BACKEND=HIPNOGPU -DMIOPEN_INSTALL_CXX_HEADERS=On ..
                             make -j\$(nproc)
@@ -448,8 +470,6 @@ pipeline {
                     environment{
                         cmd = """
                             ulimit -c unlimited
-                            rm -rf build
-                            mkdir build
                             cd build
                             CXX=/opt/rocm/llvm/bin/clang++ cmake -DMIOPEN_USE_COMGR=On -DBUILD_DEV=On -DCMAKE_BUILD_TYPE=debug -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS='--verbose --disable-verification-cache' ..
                             CTEST_PARALLEL_LEVEL=2 MIOPEN_DEBUG_IMPLICIT_GEMM_NON_XDLOPS_INLINE_ASM=0 MIOPEN_CONV_PRECISE_ROCBLAS_TIMING=0 MIOPEN_LOG_LEVEL=5 make -j\$(nproc) check
@@ -477,8 +497,6 @@ pipeline {
                     environment{
                         cmd = """
                             ulimit -c unlimited
-                            rm -rf build
-                            mkdir build
                             cd build
                             CXX=/opt/rocm/llvm/bin/clang++ cmake -DMIOPEN_EMBED_DB="gfx906_60;gfx906_64" -DBUILD_DEV=On -DCMAKE_BUILD_TYPE=debug -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS='--verbose --disable-verification-cache' ..
                             MIOPEN_LOG_LEVEL=5 make -j\$(nproc) check
@@ -509,8 +527,6 @@ pipeline {
                     environment{
                         cmd = """
                             ulimit -c unlimited
-                            rm -rf build
-                            mkdir build
                             cd build
                             CXX=/opt/rocm/llvm/bin/clang++ cmake -DBUILD_DEV=On -DBUILD_SHARED_LIBS=Off -DCMAKE_BUILD_TYPE=release -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS=--disable-verification-cache ..
                             CTEST_PARALLEL_LEVEL=4 MIOPEN_DEBUG_IMPLICIT_GEMM_NON_XDLOPS_INLINE_ASM=0 MIOPEN_CONV_PRECISE_ROCBLAS_TIMING=0 make -j\$(nproc) check
@@ -539,8 +555,6 @@ pipeline {
                     environment{
                         cmd = """
                             ulimit -c unlimited
-                            rm -rf build
-                            mkdir build
                             cd build
                             CXX=/opt/rocm/llvm/bin/clang++ cmake -DBUILD_DEV=On -DCMAKE_BUILD_TYPE=release -DMIOPEN_GPU_SYNC=On ..
                             make -j test_conv2d
@@ -569,8 +583,6 @@ pipeline {
                     environment{
                         cmd = """
                             ulimit -c unlimited
-                            rm -rf build
-                            mkdir build
                             cd build
                             CXX=/opt/rocm/llvm/bin/clang++ cmake -DBUILD_DEV=On -DCMAKE_BUILD_TYPE=release -DMIOPEN_GPU_SYNC=On ..
                             make -j test_conv2d
@@ -618,6 +630,7 @@ pipeline {
 
         // Run fp16, bfp16, and int8 quick tests
         stage("Fast low precision"){
+            when { expression { params.SMOKE_TESTS } }
             parallel{
                 stage('Half Hip Release Vega20 /opt/rocm') {
                     agent{ label rocmnode("vega20") }
@@ -733,6 +746,7 @@ pipeline {
         }
 
         stage("Full tests I"){
+            when { expression { params.FULL_TESTS } }
             parallel{
 
                 stage('OpenCL Debug + Codecov') {
@@ -778,8 +792,6 @@ pipeline {
                     environment{
                         cmd = """
                             ulimit -c unlimited
-                            rm -rf build
-                            mkdir build
                             cd build
                             CXX=/opt/rocm/llvm/bin/clang++ cmake -DMIOPEN_TEST_BFLOAT16=On -DMIOPEN_TEST_GFX908=On -DMIOPEN_TEST_ALL=On -DBUILD_DEV=On -DCMAKE_BUILD_TYPE=release -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS='--verbose --disable-verification-cache' ..
                             MIOPEN_LOG_LEVEL=5 CTEST_PARALLEL_LEVEL=4 MIOPEN_DEBUG_IMPLICIT_GEMM_NON_XDLOPS_INLINE_ASM=0 MIOPEN_CONV_PRECISE_ROCBLAS_TIMING=0 make -j\$(nproc) check
@@ -805,6 +817,7 @@ pipeline {
         }
 
         stage("Full tests II"){
+            when { expression { params.FULL_TESTS } }
             parallel{
                 stage('OpenCL Release All') {
                     agent{ label rocmnode("vega") }
@@ -830,8 +843,6 @@ pipeline {
                     environment{
                         cmd = """
                             ulimit -c unlimited
-                            rm -rf build
-                            mkdir build
                             cd build
                             CXX=/opt/rocm/llvm/bin/clang++ cmake -DMIOPEN_TEST_GFX908=On -DMIOPEN_TEST_ALL=On -DBUILD_DEV=On -DCMAKE_BUILD_TYPE=release -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS='--verbose --disable-verification-cache' ..
                             MIOPEN_LOG_LEVEL=5 CTEST_PARALLEL_LEVEL=4 MIOPEN_DEBUG_IMPLICIT_GEMM_NON_XDLOPS_INLINE_ASM=0 MIOPEN_CONV_PRECISE_ROCBLAS_TIMING=0 make -j\$(nproc) check
@@ -859,8 +870,6 @@ pipeline {
                     environment{
                         cmd = """
                             ulimit -c unlimited
-                            rm -rf build
-                            mkdir build
                             cd build
                             CXX=/opt/rocm/llvm/bin/clang++ cmake -DMIOPEN_TEST_HALF=On -DMIOPEN_TEST_GFX908=On -DMIOPEN_TEST_ALL=On -DBUILD_DEV=On -DCMAKE_BUILD_TYPE=release -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS='--verbose --disable-verification-cache' ..
                             MIOPEN_LOG_LEVEL=5 CTEST_PARALLEL_LEVEL=4 MIOPEN_DEBUG_IMPLICIT_GEMM_NON_XDLOPS_INLINE_ASM=0 MIOPEN_CONV_PRECISE_ROCBLAS_TIMING=0 make -j\$(nproc) check
@@ -886,14 +895,13 @@ pipeline {
         }
 
         stage("Full tests III"){
+            when { expression { params.FULL_TESTS } }
             parallel{
                 stage('Half Hip Release All Vega20') {
                     agent{ label rocmnode("vega20") }
                     environment{
                         cmd = """
                             ulimit -c unlimited
-                            rm -rf build
-                            mkdir build
                             cd build
                             CXX=/opt/rocm/llvm/bin/clang++ cmake -DBUILD_DEV=On -DCMAKE_BUILD_TYPE=release -DMIOPEN_TEST_HALF=On -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_ALL=On -DMIOPEN_TEST_FLAGS=--disable-verification-cache ..
                             CTEST_PARALLEL_LEVEL=4 MIOPEN_DEBUG_IMPLICIT_GEMM_NON_XDLOPS_INLINE_ASM=0 MIOPEN_CONV_PRECISE_ROCBLAS_TIMING=0 make -j\$(nproc) check
@@ -922,8 +930,6 @@ pipeline {
                     environment{
                         cmd = """
                             ulimit -c unlimited
-                            rm -rf build
-                            mkdir build
                             cd build
                             CXX=/opt/rocm/llvm/bin/clang++ cmake -DBUILD_DEV=On -DCMAKE_BUILD_TYPE=release -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_ALL=On -DMIOPEN_TEST_FLAGS=--disable-verification-cache ..
                             CTEST_PARALLEL_LEVEL=4 MIOPEN_DEBUG_IMPLICIT_GEMM_NON_XDLOPS_INLINE_ASM=0 MIOPEN_CONV_PRECISE_ROCBLAS_TIMING=0 make -j\$(nproc) check
@@ -950,14 +956,13 @@ pipeline {
         }
 
         stage("MIOpenTensile"){
+            when { expression { params.MIOPENTENSILE } }
             parallel{
                 stage('Hip Release Tensile Subset Vega20') {
                     agent{ label rocmnode("vega20") }
                     environment{
                         cmd = """
                             ulimit -c unlimited
-                            rm -rf build
-                            mkdir build
                             cd build
                             CXX=/opt/rocm/llvm/bin/clang++ cmake -DBUILD_DEV=On -DCMAKE_BUILD_TYPE=release -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_ALL=On -DMIOPEN_TEST_MIOTENSILE=ON -DMIOPEN_USE_MIOPENTENSILE=ON -DMIOPEN_USE_ROCBLAS=OFF -DMIOPEN_TEST_FLAGS=--disable-verification-cache ..
                             MIOPEN_DEBUG_HIP_KERNELS=0 CTEST_PARALLEL_LEVEL=4 MIOPEN_DEBUG_IMPLICIT_GEMM_NON_XDLOPS_INLINE_ASM=0 MIOPEN_CONV_PRECISE_ROCBLAS_TIMING=0 make -j\$(nproc) check
@@ -985,8 +990,6 @@ pipeline {
                     environment{
                         cmd = """
                             ulimit -c unlimited
-                            rm -rf build
-                            mkdir build
                             cd build
                             CXX=/opt/rocm/llvm/bin/clang++ cmake -DBUILD_DEV=On -DCMAKE_BUILD_TYPE=release -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_GFX908=On -DMIOPEN_TEST_ALL=On -DMIOPEN_TEST_MIOTENSILE=ON -DMIOPEN_USE_MIOPENTENSILE=ON -DMIOPEN_USE_ROCBLAS=OFF -DMIOPEN_TEST_FLAGS='--verbose --disable-verification-cache' ..
                             MIOPEN_DEBUG_HIP_KERNELS=0 MIOPEN_LOG_LEVEL=5 CTEST_PARALLEL_LEVEL=4 MIOPEN_DEBUG_IMPLICIT_GEMM_NON_XDLOPS_INLINE_ASM=0 MIOPEN_CONV_PRECISE_ROCBLAS_TIMING=0 make -j\$(nproc) check
@@ -1014,8 +1017,6 @@ pipeline {
                     environment{
                         cmd = """
                             ulimit -c unlimited
-                            rm -rf build
-                            mkdir build
                             cd build
                             CXX=/opt/rocm/llvm/bin/clang++ cmake -DBUILD_DEV=On -DCMAKE_BUILD_TYPE=release -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_ALL=On -DMIOPEN_TEST_MIOTENSILE=ON -DMIOPEN_USE_MIOPENTENSILE=ON -DMIOPEN_USE_ROCBLAS=OFF -DMIOPEN_TEST_FLAGS=--disable-verification-cache ..
                             MIOPEN_DEBUG_HIP_KERNELS=0 CTEST_PARALLEL_LEVEL=4 MIOPEN_DEBUG_IMPLICIT_GEMM_NON_XDLOPS_INLINE_ASM=0 MIOPEN_CONV_PRECISE_ROCBLAS_TIMING=0 make -j\$(nproc) check
@@ -1043,8 +1044,6 @@ pipeline {
                     environment{
                         cmd = """
                             ulimit -c unlimited
-                            rm -rf build
-                            mkdir build
                             cd build
                             CXX=/opt/rocm/llvm/bin/clang++ cmake -DBUILD_DEV=On -DCMAKE_BUILD_TYPE=release -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_GFX908=On -DMIOPEN_TEST_ALL=On -DMIOPEN_TEST_MIOTENSILE=ON -DMIOPEN_USE_MIOPENTENSILE=ON -DMIOPEN_USE_ROCBLAS=OFF -DMIOPEN_TEST_FLAGS='--verbose --disable-verification-cache' ..
                             MIOPEN_DEBUG_HIP_KERNELS=0 MIOPEN_LOG_LEVEL=5 CTEST_PARALLEL_LEVEL=4 MIOPEN_DEBUG_IMPLICIT_GEMM_NON_XDLOPS_INLINE_ASM=0 MIOPEN_CONV_PRECISE_ROCBLAS_TIMING=0 make -j\$(nproc) check
@@ -1071,6 +1070,7 @@ pipeline {
 
        // Run package building
         stage("Packages"){
+            when { expression { params.PACKAGES } }
             parallel {
                 stage('OpenCL Release Package') {
                     agent{ label rocmnode("rocmtest") }


### PR DESCRIPTION
Some recent Jenkinsfile improvements (mainly, node selection updates) must be merged into `rocm-4.2.x`. This is necessary to enable testing of `rocm-4.2.x` on our CI. This change is NFC for CQE and users.