### PR TITLE
[CI][rocm-4.2.x][BF16] Disable V4R4 padded_gemm Solvers for BF16 with ROCm 3.7 due to fatal HIP compiler errors.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -244,11 +244,11 @@ pipeline {
     parameters {
         booleanParam(
             name: "STATIC_CHECKS",
-            defaultValue: false,
+            defaultValue: true,
             description: "")
         booleanParam(
             name: "SMOKE_TESTS",
-            defaultValue: false,
+            defaultValue: true,
             description: "")
         booleanParam(
             name: "FULL_TESTS",
@@ -260,7 +260,7 @@ pipeline {
             description: "")
         booleanParam(
             name: "PACKAGES",
-            defaultValue: false,
+            defaultValue: true,
             description: "")
     }
     stages{
@@ -749,6 +749,44 @@ pipeline {
             when { expression { params.FULL_TESTS } }
             parallel{
 
+                stage('OpenCL Debug + Codecov') {
+                    agent{ label rocmnode("vega") }
+                    steps{
+                        script{
+                            try{
+                                buildHipClangJob('g++', flags: '-DBUILD_DEV=On -DCMAKE_BUILD_TYPE=debug', codecov: true)
+                            }
+                            catch(e){
+                                echo "throwing error exception for the stage"
+                                echo 'Exception occurred: ' + e.toString()
+                                throw e
+                            }
+                            finally{
+                                reboot()
+                            }
+                        }
+                    }
+                }
+
+                stage('Int8 Hip Release All Vega20 /opt/rocm') {
+                    agent{ label rocmnode("vega20") }
+                    steps{
+                        script{
+                            try{
+                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', flags: '-DMIOPEN_TEST_INT8=On -DBUILD_DEV=On -DMIOPEN_TEST_ALL=On -DCMAKE_BUILD_TYPE=release', image: image+'rocm', prefixpath: '/opt/rocm')
+                            }
+                            catch(e){
+                                echo "throwing error exception for the stage"
+                                echo 'Exception occurred: ' + e.toString()
+                                throw e
+                            }
+                            finally{
+                                reboot()
+                            }
+                        }
+                    }
+                }
+
                 stage('BF16 Hip Release Subset gfx908') {
                     agent{ label rocmnode("gfx908") }
                     environment{
@@ -778,7 +816,144 @@ pipeline {
             }
         }
 
+        stage("Full tests II"){
+            when { expression { params.FULL_TESTS } }
+            parallel{
+                stage('OpenCL Release All') {
+                    agent{ label rocmnode("vega") }
+                    steps{
+                        script{
+                            try{
+                                buildHipClangJob('g++', flags: '-DBUILD_DEV=On -DMIOPEN_TEST_ALL=On -DCMAKE_BUILD_TYPE=release')
+                            }
+                            catch(e){
+                                echo "throwing error exception for the stage"
+                                echo 'Exception occurred: ' + e.toString()
+                                throw e
+                            }
+                            finally{
+                                reboot()
+                            }
+                        }
+                    }
+                }
 
+                stage('Hip Release Subset gfx908') {
+                    agent{ label rocmnode("gfx908") }
+                    environment{
+                        cmd = """
+                            ulimit -c unlimited
+                            cd build
+                            CXX=/opt/rocm/llvm/bin/clang++ cmake -DMIOPEN_TEST_GFX908=On -DMIOPEN_TEST_ALL=On -DBUILD_DEV=On -DCMAKE_BUILD_TYPE=release -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS='--verbose --disable-verification-cache' ..
+                            MIOPEN_LOG_LEVEL=5 CTEST_PARALLEL_LEVEL=4 MIOPEN_DEBUG_IMPLICIT_GEMM_NON_XDLOPS_INLINE_ASM=0 MIOPEN_CONV_PRECISE_ROCBLAS_TIMING=0 make -j\$(nproc) check
+                        """
+                    }
+                    steps{
+                        script{
+                            try{
+                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', cmd: cmd, gpu_arch: "gfx908")
+                            }
+                            catch(e){
+                                echo "throwing error exception for the stage"
+                                echo 'Exception occurred: ' + e.toString()
+                                throw e
+                            }
+                            finally{
+                                reboot()
+                            }
+                        }
+                    }
+                }
+
+                stage('Half Hip Release Subset gfx908') {
+                    agent{ label rocmnode("gfx908") }
+                    environment{
+                        cmd = """
+                            ulimit -c unlimited
+                            cd build
+                            CXX=/opt/rocm/llvm/bin/clang++ cmake -DMIOPEN_TEST_HALF=On -DMIOPEN_TEST_GFX908=On -DMIOPEN_TEST_ALL=On -DBUILD_DEV=On -DCMAKE_BUILD_TYPE=release -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS='--verbose --disable-verification-cache' ..
+                            MIOPEN_LOG_LEVEL=5 CTEST_PARALLEL_LEVEL=4 MIOPEN_DEBUG_IMPLICIT_GEMM_NON_XDLOPS_INLINE_ASM=0 MIOPEN_CONV_PRECISE_ROCBLAS_TIMING=0 make -j\$(nproc) check
+                        """
+                    }
+                    steps{
+                        script{
+                            try{
+                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', cmd: cmd, gpu_arch: "gfx908")
+                            }
+                            catch(e){
+                                echo "throwing error exception for the stage"
+                                echo 'Exception occurred: ' + e.toString()
+                                throw e
+                            }
+                            finally{
+                                reboot()
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        stage("Full tests III"){
+            when { expression { params.FULL_TESTS } }
+            parallel{
+                stage('Half Hip Release All Vega20') {
+                    agent{ label rocmnode("vega20") }
+                    environment{
+                        cmd = """
+                            ulimit -c unlimited
+                            cd build
+                            CXX=/opt/rocm/llvm/bin/clang++ cmake -DBUILD_DEV=On -DCMAKE_BUILD_TYPE=release -DMIOPEN_TEST_HALF=On -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_ALL=On -DMIOPEN_TEST_FLAGS=--disable-verification-cache ..
+                            CTEST_PARALLEL_LEVEL=4 MIOPEN_DEBUG_IMPLICIT_GEMM_NON_XDLOPS_INLINE_ASM=0 MIOPEN_CONV_PRECISE_ROCBLAS_TIMING=0 make -j\$(nproc) check
+                        """
+
+                    }
+                    steps{
+                        script{
+                            try{
+                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', cmd: cmd)
+                            }
+                            catch(e){
+                                echo "throwing error exception for the stage"
+                                echo 'Exception occurred: ' + e.toString()
+                                throw e
+                            }
+                            finally{
+                                reboot()
+                            }
+                        }
+                    }
+                }
+
+                stage('Hip Release All Vega20') {
+                    agent{ label rocmnode("vega20") }
+                    environment{
+                        cmd = """
+                            ulimit -c unlimited
+                            cd build
+                            CXX=/opt/rocm/llvm/bin/clang++ cmake -DBUILD_DEV=On -DCMAKE_BUILD_TYPE=release -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_ALL=On -DMIOPEN_TEST_FLAGS=--disable-verification-cache ..
+                            CTEST_PARALLEL_LEVEL=4 MIOPEN_DEBUG_IMPLICIT_GEMM_NON_XDLOPS_INLINE_ASM=0 MIOPEN_CONV_PRECISE_ROCBLAS_TIMING=0 make -j\$(nproc) check
+                        """
+
+                    }
+                    steps{
+                        script{
+                            try{
+                                buildHipClangJob('/opt/rocm/llvm/bin/clang++', cmd: cmd)
+                            }
+                            catch(e){
+                                echo "throwing error exception for the stage"
+                                echo 'Exception occurred: ' + e.toString()
+                                throw e
+                            }
+                            finally{
+                                reboot()
+                            }
+                        }
+                    }
+                }
+            }
+        }
 
         stage("MIOpenTensile"){
             when { expression { params.MIOPENTENSILE } }

--- a/src/solver/conv_hip_implicit_gemm_fwd_v4r4_xdlops_padded_gemm.cpp
+++ b/src/solver/conv_hip_implicit_gemm_fwd_v4r4_xdlops_padded_gemm.cpp
@@ -38,6 +38,10 @@
 #define WORKAROUND_MI100_CONV_IMPLICIT_GEMM_HIP_FWD_V4R4_PADDED_GEMM_XDLOPS \
     (HIP_PACKAGE_VERSION_FLAT >= 3007000000 && HIP_PACKAGE_VERSION_FLAT <= 4000999999)
 
+/// Fatal compiler errors with ROCm 3.7 on some BF16 configs.
+#define WORKAROUND_MI100_BF16_FATAL_COMPILER_ERRORS \
+    (HIP_PACKAGE_VERSION_FLAT >= 3007000000 && HIP_PACKAGE_VERSION_FLAT <= 3007999999)
+
 MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_FWD_V4R4_PADDED_GEMM_XDLOPS)
 
 /* this fix is for fp16 xdlops vectorizable kernels due to followings, we may revisit this fix after
@@ -1096,6 +1100,10 @@ bool ConvHipImplicitGemmForwardV4R4Xdlops_Padded_Gemm::IsApplicable(
             return false;
         }
     }
+#endif
+#if WORKAROUND_MI100_BF16_FATAL_COMPILER_ERRORS
+    if(ctx.GetStream().GetDeviceName() == "gfx908" && ctx.IsBfp16())
+        return false;
 #endif
 
     // this particular EuristicInit is so comprehensive, that if it cannot predict a valid

--- a/src/solver/conv_hip_implicit_gemm_wrw_v4r4_xdlops_padded_gemm.cpp
+++ b/src/solver/conv_hip_implicit_gemm_wrw_v4r4_xdlops_padded_gemm.cpp
@@ -35,6 +35,10 @@
 #include <miopen/tensor_ops.hpp>
 #include <miopen/implicitgemm_params.hpp>
 
+/// Fatal compiler errors with ROCm 3.7 on some BF16 configs.
+#define WORKAROUND_MI100_BF16_FATAL_COMPILER_ERRORS \
+    (HIP_PACKAGE_VERSION_FLAT >= 3007000000 && HIP_PACKAGE_VERSION_FLAT <= 3007999999)
+
 MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_WRW_V4R4_PADDED_GEMM_XDLOPS)
 
 namespace miopen {
@@ -1129,6 +1133,11 @@ bool ConvHipImplicitGemmWrwV4R4Xdlops_Padded_Gemm::IsApplicable(const Convolutio
     {
         return false;
     }
+
+#if WORKAROUND_MI100_BF16_FATAL_COMPILER_ERRORS
+    if(ctx.GetStream().GetDeviceName() == "gfx908" && ctx.IsBfp16())
+        return false;
+#endif
 
     // this particular EuristicInit is so comprehensive, that if it cannot predict a valid
     // performance config, the problem is probably not applicable


### PR DESCRIPTION
Some failing configs:
```
./bin/test_conv2d --bfloat16 --cmode conv --pmode default --group-count 1 --input 1, 320, 28, 28 --weights 1, 320, 1, 1 --pads_strides_dilations 1 1 1 1 1 1 --trans_output_pads 0 0 
./bin/test_conv2d --bfloat16 --cmode conv --pmode default --group-count 1 --input 1, 32, 14, 14 --weights 1, 32, 5, 5 --pads_strides_dilations 2 2 1 1 1 1 --trans_output_pads 0 0 
./bin/test_conv2d --bfloat16 --cmode conv --pmode default --group-count 1 --input 1, 32, 16, 16 --weights 1, 32, 5, 5 --pads_strides_dilations 1 1 1 1 1 1 --trans_output_pads 0 0 
```
<details><summary><b><i>Example failing log:</i></b></summary>

```
2021-05-10T01:06:38.937Z] /home/jenkins/workspace/MLLibs_MIOpen_swdev-2848484/build/bin/test_conv2d --bfloat16 --cmode conv --pmode default --group-count 1 --input 1, 320, 28, 28 --weights 1, 320, 1, 1 --pads_strides_dilations 1 1 1 1 1 1 --trans_output_pads 0 0 
[2021-05-10T01:06:38.937Z] MIOpen(HIP): Info [ForwardGetWorkSpaceSize] 
[2021-05-10T01:06:38.937Z] MIOpen(HIP): Info [GetForwardSolutions] 
[2021-05-10T01:06:38.937Z] MIOpen(HIP): Info [EuristicInit] 16,64,8,16,16,8,16,64,16,0,1,8
[2021-05-10T01:06:38.937Z] MIOpen(HIP): Info [FindConvFwdAlgorithm] requestAlgoCount = 1, workspace = 576000
[2021-05-10T01:06:38.937Z] MIOpen(HIP): Info [GetForwardSolutions] 
[2021-05-10T01:06:38.937Z] MIOpen(HIP): Info [TryLoad] Find-db regenerating.
[2021-05-10T01:06:38.937Z] MIOpen(HIP): Info [FindSolutionImpl] ConvDirectNaiveConvFwd (not searchable)
[2021-05-10T01:06:38.937Z] MIOpen(HIP): Info [EvaluateInvokers] ConvDirectNaiveConvFwd: naive_conv_fwd_nchw_bf16: 0.863678 < 3.40282e+38
[2021-05-10T01:06:38.937Z] MIOpen(HIP): Info [EvaluateInvokers] Selected: ConvDirectNaiveConvFwd: naive_conv_fwd_nchw_bf16: 0.863678, workspce_sz = 0
[2021-05-10T01:06:38.937Z] MIOpen(HIP): Info [EuristicInit] 16,64,8,16,16,8,16,64,16,0,1,8
[2021-05-10T01:06:38.937Z] MIOpen(HIP): Info [FindSolutionImpl] ConvHipImplicitGemmForwardV4R4Xdlops_Padded_Gemm
[2021-05-10T01:06:38.937Z] MIOpen(HIP): Info [FindSolutionImpl] Perf Db: record not found for: ConvHipImplicitGemmForwardV4R4Xdlops_Padded_Gemm
[2021-05-10T01:06:38.937Z] MIOpen(HIP): Info [EuristicInit] 16,64,8,16,16,8,16,64,16,0,1,8
[2021-05-10T01:06:38.937Z] MIOpen(HIP): Info [GetPerformanceConfig] 16,64,8,16,16,8,16,64,16,0,1,8
[2021-05-10T01:06:38.937Z] PLEASE submit a bug report to https://bugs.llvm.org/ and include the crash backtrace, preprocessed source, and associated run script.
[2021-05-10T01:06:38.937Z] Stack dump:
[2021-05-10T01:06:38.937Z] 0.	Program arguments: /opt/rocm-3.7.0/llvm/bin/clang-11 -cc1 -triple amdgcn-amd-amdhsa -aux-triple x86_64-unknown-linux-gnu -emit-llvm-bc -emit-llvm-uselists -disable-free -disable-llvm-verifier -discard-value-names -main-file-name gridwise_convolution_forward_implicit_gemm_v4r4_xdlops_nchw_kcyx_nkhw_padded_gemm.cpp -mrelocation-model pic -pic-level 1 -mthread-model posix -mframe-pointer=none -fno-rounding-math -mconstructor-aliases -aux-target-cpu x86-64 -target-cpu gfx908 -fcuda-is-device -fcuda-allow-variadic-functions -fvisibility hidden -fapply-global-visibility-to-externs -mlink-builtin-bitcode /opt/rocm/lib/hip.amdgcn.bc -mlink-builtin-bitcode /opt/rocm/lib/ocml.amdgcn.bc -mlink-builtin-bitcode /opt/rocm/lib/ockl.amdgcn.bc -mlink-builtin-bitcode /opt/rocm/lib/oclc_finite_only_off.amdgcn.bc -mlink-builtin-bitcode /opt/rocm/lib/oclc_daz_opt_off.amdgcn.bc -mlink-builtin-bitcode /opt/rocm/lib/oclc_correctly_rounded_sqrt_on.amdgcn.bc -mlink-builtin-bitcode /opt/rocm/lib/oclc_unsafe_math_off.amdgcn.bc -mlink-builtin-bitcode /opt/rocm/lib/oclc_isa_version_908.amdgcn.bc -mlink-builtin-bitcode /opt/rocm/lib/oclc_wavefrontsize64_on.amdgcn.bc -target-cpu gfx908 -dwarf-column-info -fno-split-dwarf-inlining -debugger-tuning=gdb -resource-dir /opt/rocm-3.7.0/llvm/lib/clang/11.0.0 -isystem /opt/rocm-3.7.0/hip/../include -isystem /opt/rocm/llvm/lib/clang/11.0.0/include/.. -isystem /opt/rocm-3.7.0/hip/include -isystem /opt/rocm/include -D CK_PARAM_PROBLEM_G=1 -D CK_PARAM_PROBLEM_N=1 -D CK_PARAM_PROBLEM_K=1 -D CK_PARAM_PROBLEM_C=320 -D CK_PARAM_PROBLEM_HI=28 -D CK_PARAM_PROBLEM_WI=28 -D CK_PARAM_PROBLEM_HO=30 -D CK_PARAM_PROBLEM_WO=30 -D CK_PARAM_PROBLEM_Y=1 -D CK_PARAM_PROBLEM_X=1 -D CK_PARAM_PROBLEM_CONV_STRIDE_H=1 -D CK_PARAM_PROBLEM_CONV_STRIDE_W=1 -D CK_PARAM_PROBLEM_CONV_DILATION_H=1 -D CK_PARAM_PROBLEM_CONV_DILATION_W=1 -D CK_PARAM_PROBLEM_IN_LEFT_PAD_H=1 -D CK_PARAM_PROBLEM_IN_LEFT_PAD_W=1 -D CK_PARAM_PROBLEM_IN_RIGHT_PAD_H=1 -D CK_PARAM_PROBLEM_IN_RIGHT_PAD_W=1 -D CK_PARAM_TUNABLE_GEMM_M_PER_BLOCK=16 -D CK_PARAM_TUNABLE_GEMM_N_PER_BLOCK=64 -D CK_PARAM_TUNABLE_GEMM_K_PER_BLOCK=8 -D CK_PARAM_TUNABLE_GEMM_M_PER_WAVE=16 -D CK_PARAM_TUNABLE_GEMM_N_PER_WAVE=16 -D CK_PARAM_TUNABLE_GEMM_KPACK=8 -D CK_PARAM_DEPENDENT_BLOCK_SIZE=256 -D CK_PARAM_DEPENDENT_GRID_SIZE=15 -D CK_PARAM_DEPENDENT_GEMM_A_BLOCK_COPY_CLUSTER_LENGTHS_GEMM_K=8 -D CK_PARAM_DEPENDENT_GEMM_A_BLOCK_COPY_CLUSTER_LENGTHS_GEMM_M=16 -D CK_PARAM_DEPENDENT_GEMM_A_BLOCK_COPY_CLUSTER_LENGTHS_GEMM_KPACK=1 -D CK_PARAM_DEPENDENT_GEMM_A_BLOCK_COPY_SRC_DATA_PER_READ_GEMM_KPACK=8 -D CK_PARAM_DEPENDENT_GEMM_A_BLOCK_COPY_DST_DATA_PER_WRITE_GEMM_KPACK=8 -D CK_PARAM_DEPENDENT_GEMM_B_BLOCK_COPY_CLUSTER_LENGTHS_GEMM_K=4 -D CK_PARAM_DEPENDENT_GEMM_B_BLOCK_COPY_CLUSTER_LENGTHS_GEMM_N=64 -D CK_PARAM_DEPENDENT_GEMM_B_BLOCK_COPY_CLUSTER_LENGTHS_GEMM_KPACK=1 -D CK_PARAM_DEPENDENT_GEMM_B_BLOCK_COPY_SRC_DATA_PER_READ_GEMM_N=1 -D CK_PARAM_DEPENDENT_GEMM_B_BLOCK_COPY_DST_DATA_PER_WRITE_GEMM_KPACK=8 -D CK_GEMM_M_PAD=15 -D CK_GEMM_N_PAD=60 -D CK_GEMM_K_PAD=0 -D CK_USE_AMD_XDLOPS=1 -D CK_USE_AMD_XDLOPS_INLINE_ASM=0 -D CK_USE_AMD_XDLOPS_EMULATE=0 -D CK_USE_AMD_BUFFER_ATOMIC_FADD=1 -D CK_BLOCK_SYNC_LDS_WITHOUT_SYNC_VMEM=1 -D CK_WORKAROUND_SWDEV_229564=1 -D CK_WORKAROUND_SWDEV_231101=1 -D CK_USE_AMD_BUFFER_ADDRESSING=1 -D CK_USE_AMD_V_FMAC_F32=0 -D MIOPEN_USE_FP16=0 -D MIOPEN_USE_FP32=0 -D MIOPEN_USE_INT8=0 -D MIOPEN_USE_INT8x4=0 -D MIOPEN_USE_BFP16=1 -D MIOPEN_USE_INT32=0 -D MIOPEN_USE_RNE_BFLOAT16=1 -I . -D __HIP_ROCclr__=1 -D __HIP_PLATFORM_HCC__=1 -D __HIP_ROCclr__=1 -D HIP_PACKAGE_VERSION_FLAT=3007020315 -internal-isystem /usr/lib/gcc/x86_64-linux-gnu/7.5.0/../../../../include/c++/7.5.0 -internal-isystem /usr/lib/gcc/x86_64-linux-gnu/7.5.0/../../../../include/x86_64-linux-gnu/c++/7.5.0 -internal-isystem /usr/lib/gcc/x86_64-linux-gnu/7.5.0/../../../../include/x86_64-linux-gnu/c++/7.5.0 -internal-isystem /usr/lib/gcc/x86_64-linux-gnu/7.5.0/../../../../include/c++/7.5.0/backward -internal-isystem /usr/lib/gcc/x86_64-linux-gnu/7.5.0/../../../../include/c++/7.5.0 -internal-isystem /usr/lib/gcc/x86_64-linux-gnu/7.5.0/../../../../include/x86_64-linux-gnu/c++/7.5.0 -internal-isystem /usr/lib/gcc/x86_64-linux-gnu/7.5.0/../../../../include/x86_64-linux-gnu/c++/7.5.0 -internal-isystem /usr/lib/gcc/x86_64-linux-gnu/7.5.0/../../../../include/c++/7.5.0/backward -internal-isystem /usr/local/include -internal-isystem /opt/rocm-3.7.0/llvm/lib/clang/11.0.0/include -internal-externc-isystem /usr/include/x86_64-linux-gnu -internal-externc-isystem /include -internal-externc-isystem /usr/include -internal-isystem /usr/local/include -internal-isystem /opt/rocm-3.7.0/llvm/lib/clang/11.0.0/include -internal-externc-isystem /usr/include/x86_64-linux-gnu -internal-externc-isystem /include -internal-externc-isystem /usr/include -O3 -Werror -Weverything -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-conversion -Wno-double-promotion -Wno-exit-time-destructors -Wno-extra-semi -Wno-float-conversion -Wno-gnu-anonymous-struct -Wno-gnu-zero-variadic-macro-arguments -Wno-missing-noreturn -Wno-missing-prototypes -Wno-nested-anon-types -Wno-padded -Wno-return-std-move-in-c++11 -Wno-shorten-64-to-32 -Wno-sign-conversion -Wno-unknown-warning-option -Wno-unused-command-line-argument -Wno-weak-vtables -Wno-covered-switch-default -Wno-disabled-macro-expansion -Wno-undefined-reinterpret-cast -Wno-unused-command-line-argument --std=c++14 -fdeprecated-macro -fno-autolink -fdebug-compilation-dir /tmp/miopen-gridwise_convolution_forward_implicit_gemm_v4r4_xdlops_nchw_kcyx_nkhw_padded_gemm.cpp-9b4d-2d12-0a05-0333 -ferror-limit 19 -fgnuc-version=4.2.1 -fcxx-exceptions -fexceptions -vectorize-loops -vectorize-slp -mllvm -amdgpu-early-inline-all=true -mllvm -amdgpu-function-calls=false -mllvm --amdgpu-spill-vgpr-to-agpr=0 -fcuda-allow-variadic-functions -faddrsig -o /tmp/gridwise_convolution_forward_implicit_gemm_v4r4_xdlops_nchw_kcyx_nkhw_padded_gemm-6c073c.bc -x hip gridwise_convolution_forward_implicit_gemm_v4r4_xdlops_nchw_kcyx_nkhw_padded_gemm.cpp 
[2021-05-10T01:06:38.937Z] 1.	<eof> parser at end of file
[2021-05-10T01:06:38.937Z] 2.	Per-module optimization passes
[2021-05-10T01:06:38.937Z] 3.	Running pass 'CallGraph Pass Manager' on module 'gridwise_convolution_forward_implicit_gemm_v4r4_xdlops_nchw_kcyx_nkhw_padded_gemm.cpp'.
[2021-05-10T01:06:38.937Z]  #0 0x0000556919fd3c2a llvm::sys::PrintStackTrace(llvm::raw_ostream&) (/opt/rocm-3.7.0/llvm/bin/clang-11+0x1e16c2a)
[2021-05-10T01:06:38.937Z]  #1 0x0000556919fd1884 llvm::sys::RunSignalHandlers() (/opt/rocm-3.7.0/llvm/bin/clang-11+0x1e14884)
[2021-05-10T01:06:38.937Z]  #2 0x0000556919fd19d3 SignalHandler(int) (/opt/rocm-3.7.0/llvm/bin/clang-11+0x1e149d3)
[2021-05-10T01:06:38.937Z]  #3 0x00007fab3ad56980 __restore_rt (/lib/x86_64-linux-gnu/libpthread.so.0+0x12980)
[2021-05-10T01:06:38.937Z]  #4 0x000055691993d40f llvm::Instruction::clearMetadataHashEntries() (/opt/rocm-3.7.0/llvm/bin/clang-11+0x178040f)
[2021-05-10T01:06:38.937Z]  #5 0x0000556919902ba5 llvm::Instruction::~Instruction() (/opt/rocm-3.7.0/llvm/bin/clang-11+0x1745ba5)
[2021-05-10T01:06:38.937Z]  #6 0x0000556919982500 llvm::Value::deleteValue() (/opt/rocm-3.7.0/llvm/bin/clang-11+0x17c5500)
[2021-05-10T01:06:38.937Z]  #7 0x0000556919869feb llvm::BasicBlock::~BasicBlock() (/opt/rocm-3.7.0/llvm/bin/clang-11+0x16acfeb)
[2021-05-10T01:06:38.937Z]  #8 0x000055691986a124 llvm::BasicBlock::eraseFromParent() (/opt/rocm-3.7.0/llvm/bin/clang-11+0x16ad124)
[2021-05-10T01:06:38.937Z]  #9 0x00005569198e237f llvm::Function::dropAllReferences() (/opt/rocm-3.7.0/llvm/bin/clang-11+0x172537f)
[2021-05-10T01:06:38.937Z] #10 0x00005569198e9e70 llvm::Function::~Function() (/opt/rocm-3.7.0/llvm/bin/clang-11+0x172ce70)
[2021-05-10T01:06:38.937Z] #11 0x0000556919a5107b llvm::LegacyInlinerBase::removeDeadFunctions(llvm::CallGraph&, bool) (/opt/rocm-3.7.0/llvm/bin/clang-11+0x189407b)
[2021-05-10T01:06:38.937Z] #12 0x000055691928dc59 (anonymous namespace)::CGPassManager::runOnModule(llvm::Module&) (/opt/rocm-3.7.0/llvm/bin/clang-11+0x10d0c59)
[2021-05-10T01:06:38.937Z] #13 0x0000556919936381 llvm::legacy::PassManagerImpl::run(llvm::Module&) (/opt/rocm-3.7.0/llvm/bin/clang-11+0x1779381)
[2021-05-10T01:06:38.937Z] #14 0x000055691a23974d (anonymous namespace)::EmitAssemblyHelper::EmitAssembly(clang::BackendAction, std::unique_ptr<llvm::raw_pwrite_stream, std::default_delete<llvm::raw_pwrite_stream> >) (/opt/rocm-3.7.0/llvm/bin/clang-11+0x207c74d)
[2021-05-10T01:06:38.937Z] #15 0x000055691a23b25f clang::EmitBackendOutput(clang::DiagnosticsEngine&, clang::HeaderSearchOptions const&, clang::CodeGenOptions const&, clang::TargetOptions const&, clang::LangOptions const&, llvm::DataLayout const&, llvm::Module*, clang::BackendAction, std::unique_ptr<llvm::raw_pwrite_stream, std::default_delete<llvm::raw_pwrite_stream> >) (/opt/rocm-3.7.0/llvm/bin/clang-11+0x207e25f)
[2021-05-10T01:06:38.937Z] #16 0x000055691ad5594c clang::BackendConsumer::HandleTranslationUnit(clang::ASTContext&) (/opt/rocm-3.7.0/llvm/bin/clang-11+0x2b9894c)
[2021-05-10T01:06:38.937Z] #17 0x000055691b789069 clang::ParseAST(clang::Sema&, bool, bool) (/opt/rocm-3.7.0/llvm/bin/clang-11+0x35cc069)
[2021-05-10T01:06:38.937Z] #18 0x000055691a7889a9 clang::FrontendAction::Execute() (/opt/rocm-3.7.0/llvm/bin/clang-11+0x25cb9a9)
[2021-05-10T01:06:38.937Z] #19 0x000055691a74522a clang::CompilerInstance::ExecuteAction(clang::FrontendAction&) (/opt/rocm-3.7.0/llvm/bin/clang-11+0x258822a)
[2021-05-10T01:06:38.937Z] #20 0x000055691a84db4b clang::ExecuteCompilerInvocation(clang::CompilerInstance*) (/opt/rocm-3.7.0/llvm/bin/clang-11+0x2690b4b)
[2021-05-10T01:06:38.937Z] #21 0x0000556918cbee2c cc1_main(llvm::ArrayRef<char const*>, char const*, void*) (/opt/rocm-3.7.0/llvm/bin/clang-11+0xb01e2c)
[2021-05-10T01:06:38.937Z] #22 0x0000556918cbb71d ExecuteCC1Tool(llvm::SmallVectorImpl<char const*>&) (/opt/rocm-3.7.0/llvm/bin/clang-11+0xafe71d)
[2021-05-10T01:06:38.937Z] #23 0x0000556918c3f56d main (/opt/rocm-3.7.0/llvm/bin/clang-11+0xa8256d)
[2021-05-10T01:06:38.937Z] #24 0x00007fab399eabf7 __libc_start_main /build/glibc-S9d2JN/glibc-2.27/csu/../csu/libc-start.c:344:0
[2021-05-10T01:06:38.937Z] #25 0x0000556918cbb29a _start (/opt/rocm-3.7.0/llvm/bin/clang-11+0xafe29a)
[2021-05-10T01:06:38.937Z] clang-11: error: unable to execute command: Bus error (core dumped)
[2021-05-10T01:06:38.937Z] clang-11: error: clang frontend command failed due to signal (use -v to see invocation)
[2021-05-10T01:06:38.937Z] clang version 11.0.0 (/src/external/llvm-project/clang ee4e4ebbadcc8ea14ce99e34ed31ab31e94827ac)
[2021-05-10T01:06:38.937Z] Target: x86_64-unknown-linux-gnu
[2021-05-10T01:06:38.937Z] Thread model: posix
[2021-05-10T01:06:38.937Z] InstalledDir: /opt/rocm/llvm/bin
[2021-05-10T01:06:38.937Z] clang-11: note: diagnostic msg: 
[2021-05-10T01:06:38.937Z] ********************
[2021-05-10T01:06:38.937Z] 
[2021-05-10T01:06:38.937Z] PLEASE ATTACH THE FOLLOWING FILES TO THE BUG REPORT:
[2021-05-10T01:06:38.937Z] Preprocessed source(s) and associated run script(s) are located at:
[2021-05-10T01:06:38.937Z] clang-11: note: diagnostic msg: /tmp/gridwise_convolution_forward_implicit_gemm_v4r4_xdlops_nchw_kcyx_nkhw_padded_gemm-ac8a4b.cu
[2021-05-10T01:06:38.937Z] clang-11: note: diagnostic msg: /tmp/gridwise_convolution_forward_implicit_gemm_v4r4_xdlops_nchw_kcyx_nkhw_padded_gemm-ac8a4b.sh
[2021-05-10T01:06:38.937Z] clang-11: note: diagnostic msg: 
[2021-05-10T01:06:38.937Z] 
[2021-05-10T01:06:38.937Z] ********************
[2021-05-10T01:06:38.937Z] /home/jenkins/workspace/MLLibs_MIOpen_swdev-2848484/build/bin/test_conv2d --bfloat16 --cmode conv --pmode default --group-count 1 --input 1, 320, 28, 28 --weights 1, 320, 1, 1 --pads_strides_dilations 1 1 1 1 1 1 --trans_output_pads 0 0 
[2021-05-10T01:06:38.938Z] FAILED: /home/jenkins/workspace/MLLibs_MIOpen_swdev-2848484/src/tmp_dir.cpp:45: Can't execute cd /tmp/miopen-gridwise_convolution_forward_implicit_gemm_v4r4_xdlops_nchw_kcyx_nkhw_padded_gemm.cpp-9b4d-2d12-0a05-0333;  /opt/rocm/llvm/bin/clang++  -DCK_PARAM_PROBLEM_G=1 -DCK_PARAM_PROBLEM_N=1 -DCK_PARAM_PROBLEM_K=1 -DCK_PARAM_PROBLEM_C=320 -DCK_PARAM_PROBLEM_HI=28 -DCK_PARAM_PROBLEM_WI=28 -DCK_PARAM_PROBLEM_HO=30 -DCK_PARAM_PROBLEM_WO=30 -DCK_PARAM_PROBLEM_Y=1 -DCK_PARAM_PROBLEM_X=1 -DCK_PARAM_PROBLEM_CONV_STRIDE_H=1 -DCK_PARAM_PROBLEM_CONV_STRIDE_W=1 -DCK_PARAM_PROBLEM_CONV_DILATION_H=1 -DCK_PARAM_PROBLEM_CONV_DILATION_W=1 -DCK_PARAM_PROBLEM_IN_LEFT_PAD_H=1 -DCK_PARAM_PROBLEM_IN_LEFT_PAD_W=1 -DCK_PARAM_PROBLEM_IN_RIGHT_PAD_H=1 -DCK_PARAM_PROBLEM_IN_RIGHT_PAD_W=1 -DCK_PARAM_TUNABLE_GEMM_M_PER_BLOCK=16 -DCK_PARAM_TUNABLE_GEMM_N_PER_BLOCK=64 -DCK_PARAM_TUNABLE_GEMM_K_PER_BLOCK=8 -DCK_PARAM_TUNABLE_GEMM_M_PER_WAVE=16 -DCK_PARAM_TUNABLE_GEMM_N_PER_WAVE=16 -DCK_PARAM_TUNABLE_GEMM_KPACK=8 -DCK_PARAM_DEPENDENT_BLOCK_SIZE=256 -DCK_PARAM_DEPENDENT_GRID_SIZE=15 -DCK_PARAM_DEPENDENT_GEMM_A_BLOCK_COPY_CLUSTER_LENGTHS_GEMM_K=8 -DCK_PARAM_DEPENDENT_GEMM_A_BLOCK_COPY_CLUSTER_LENGTHS_GEMM_M=16 -DCK_PARAM_DEPENDENT_GEMM_A_BLOCK_COPY_CLUSTER_LENGTHS_GEMM_KPACK=1 -DCK_PARAM_DEPENDENT_GEMM_A_BLOCK_COPY_SRC_DATA_PER_READ_GEMM_KPACK=8 -DCK_PARAM_DEPENDENT_GEMM_A_BLOCK_COPY_DST_DATA_PER_WRITE_GEMM_KPACK=8 -DCK_PARAM_DEPENDENT_GEMM_B_BLOCK_COPY_CLUSTER_LENGTHS_GEMM_K=4 -DCK_PARAM_DEPENDENT_GEMM_B_BLOCK_COPY_CLUSTER_LENGTHS_GEMM_N=64 -DCK_PARAM_DEPENDENT_GEMM_B_BLOCK_COPY_CLUSTER_LENGTHS_GEMM_KPACK=1 -DCK_PARAM_DEPENDENT_GEMM_B_BLOCK_COPY_SRC_DATA_PER_READ_GEMM_N=1 -DCK_PARAM_DEPENDENT_GEMM_B_BLOCK_COPY_DST_DATA_PER_WRITE_GEMM_KPACK=8 -DCK_GEMM_M_PAD=15 -DCK_GEMM_N_PAD=60 -DCK_GEMM_K_PAD=0 -DCK_USE_AMD_XDLOPS=1 -DCK_USE_AMD_XDLOPS_INLINE_ASM=0 -DCK_USE_AMD_XDLOPS_EMULATE=0 --std=c++14 -DCK_USE_AMD_BUFFER_ATOMIC_FADD=1 -DCK_BLOCK_SYNC_LDS_WITHOUT_SYNC_VMEM=1 -DCK_WORKAROUND_SWDEV_229564=1 -DCK_WORKAROUND_SWDEV_231101=1 -DCK_USE_AMD_BUFFER_ADDRESSING=1 -DCK_USE_AMD_V_FMAC_F32=0 -DMIOPEN_USE_FP16=0 -DMIOPEN_USE_FP32=0 -DMIOPEN_USE_INT8=0 -DMIOPEN_USE_INT8x4=0 -DMIOPEN_USE_BFP16=1 -DMIOPEN_USE_INT32=0 -DMIOPEN_USE_RNE_BFLOAT16=1 -mcpu=gfx908 -Werror -Weverything -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-conversion -Wno-double-promotion -Wno-exit-time-destructors -Wno-extra-semi -Wno-float-conversion -Wno-gnu-anonymous-struct -Wno-gnu-zero-variadic-macro-arguments -Wno-missing-noreturn -Wno-missing-prototypes -Wno-nested-anon-types -Wno-padded -Wno-return-std-move-in-c++11 -Wno-shorten-64-to-32 -Wno-sign-conversion -Wno-unknown-warning-option -Wno-unused-command-line-argument -Wno-weak-vtables -Wno-covered-switch-default -Wno-disabled-macro-expansion -Wno-undefined-reinterpret-cast --cuda-gpu-arch=gfx908 --cuda-device-only -c -O3  -Wno-unused-command-line-argument -I. -mllvm -amdgpu-early-inline-all=true -mllvm -amdgpu-function-calls=false -x hip --hip-device-lib-path=/opt/rocm/lib -L/opt/rocm/llvm/lib/clang/11.0.0/include/../lib/linux -lclang_rt.builtins-x86_64 -D__HIP_ROCclr__=1 -isystem /opt/rocm-3.7.0/hip/../include -isystem /opt/rocm/llvm/lib/clang/11.0.0/include/.. -L/opt/rocm/llvm/lib/clang/11.0.0/include/../lib/linux -lclang_rt.builtins-x86_64 -D__HIP_PLATFORM_HCC__=1 -D__HIP_ROCclr__=1 -isystem /opt/rocm-3.7.0/hip/include -isystem /opt/rocm/include -L/opt/rocm/llvm/lib/clang/11.0.0/include/../lib/linux -lclang_rt.builtins-x86_64 --hip-link -L/opt/rocm/llvm/lib/clang/11.0.0/include/../lib/linux -lclang_rt.builtins-x86_64 -mllvm --amdgpu-spill-vgpr-to-agpr=0 -DHIP_PACKAGE_VERSION_FLAT=3007020315 gridwise_convolution_forward_implicit_gemm_v4r4_xdlops_nchw_kcyx_nkhw_padded_gemm.cpp -o /tmp/miopen-gridwise_convolution_forward_implicit_gemm_v4r4_xdlops_nchw_kcyx_nkhw_padded_gemm.cpp-9b4d-2d12-0a05-0333/gridwise_convolution_forward_implicit_gemm_v4r4_xdlops_nchw_kcyx_nkhw_padded_gemm.cpp.o
```
</details>
