### PR TITLE
Fix miminum requirements boost package download

### DIFF
--- a/min-requirements.txt
+++ b/min-requirements.txt
@@ -1,3 +1,3 @@
 sqlite3,https://sqlite.org/2017/sqlite-autoconf-3170000.tar.gz -H sha256:a4e485ad3a16e054765baf6371826b5000beed07e626510896069c0bf013874c -X autotools -DCMAKE_POSITION_INDEPENDENT_CODE=On
-boost@1.72 -DCMAKE_POSITION_INDEPENDENT_CODE=On --build
+https://sourceforge.net/projects/boost/files/boost/1.72.0/boost_1_72_0.tar.bz2 -H sha256:59c9b274bc451cf91a9ba1dd2c7fdcaf5d60b1b3aa83f2c9fa143417cc660722 -X boost -DBOOST_WITHOUT_CONTEXT=1 -DBOOST_WITHOUT_COROUTINE=1 -DBOOST_WITHOUT_PYTHON=1
 half,https://github.com/pfultz2/half/archive/1.12.0.tar.gz -X header -H sha256:0a08660b68abb176ebc2a0cdf8de46e3182a7f46c66443bb80dbfaaec98cf969 --build


### PR DESCRIPTION
From Paul's change [here](https://github.com/pfultz2/rocm-recipes/blob/master/recipes/boost/1.72/package.txt).

This fix #856 when client try to `cmake -P install_deps.cmake --minimum`