### PR TITLE
[MIOpenDriver] 3d conv set default layout as NCDHW

### DIFF
--- a/driver/InputFlags.cpp
+++ b/driver/InputFlags.cpp
@@ -183,3 +183,9 @@ double InputFlags::GetValueDouble(const std::string& long_name) const
 
     return value;
 }
+
+void InputFlags::SetValue(const std::string& long_name, const std::string& new_value)
+{
+    char short_name                = FindShortName(long_name);
+    MapInputs.at(short_name).value = new_value;
+}

--- a/driver/InputFlags.hpp
+++ b/driver/InputFlags.hpp
@@ -57,6 +57,7 @@ class InputFlags
     int GetValueInt(const std::string& _long_name) const;
     uint64_t GetValueUint64(const std::string& _long_name) const;
     double GetValueDouble(const std::string& _long_name) const;
+    void SetValue(const std::string& _long_name, const std::string& _new_value);
 
     virtual ~InputFlags() {}
 };

--- a/driver/InputFlags.hpp
+++ b/driver/InputFlags.hpp
@@ -57,7 +57,7 @@ class InputFlags
     int GetValueInt(const std::string& _long_name) const;
     uint64_t GetValueUint64(const std::string& _long_name) const;
     double GetValueDouble(const std::string& _long_name) const;
-    void SetValue(const std::string& _long_name, const std::string& _new_value);
+    void SetValue(const std::string& long_name, const std::string& new_value);
 
     virtual ~InputFlags() {}
 };

--- a/driver/conv_driver.hpp
+++ b/driver/conv_driver.hpp
@@ -439,6 +439,17 @@ int ConvDriver<Tgpu, Tref>::ParseCmdLineArgs(int argc, char* argv[])
 {
     inflags.Parse(argc, argv);
 
+    // try to set a default layout value for 3d conv if not specified from cmd line
+    int spatial_dim = inflags.GetValueInt("spatial_dim");
+    if(spatial_dim == 3 &&
+       (inflags.GetValueStr("in_layout") == "NCHW" && inflags.GetValueStr("fil_layout") == "NCHW" &&
+        inflags.GetValueStr("out_layout") == "NCHW"))
+    {
+        inflags.SetValue("in_layout", "NCDHW");
+        inflags.SetValue("fil_layout", "NCDHW");
+        inflags.SetValue("out_layout", "NCDHW");
+    }
+
     num_iterations = inflags.GetValueInt("iter");
     if(num_iterations < 1)
     {

--- a/driver/conv_driver.hpp
+++ b/driver/conv_driver.hpp
@@ -440,27 +440,16 @@ int ConvDriver<Tgpu, Tref>::ParseCmdLineArgs(int argc, char* argv[])
     inflags.Parse(argc, argv);
 
     // try to set a default layout value for 3d conv if not specified from cmd line
-    int spatial_dim             = inflags.GetValueInt("spatial_dim");
-    bool layout_not_initialized = inflags.GetValueStr("in_layout").empty() &&
-                                  inflags.GetValueStr("fil_layout").empty() &&
-                                  inflags.GetValueStr("out_layout").empty();
+    int spatial_dim = inflags.GetValueInt("spatial_dim");
 
-    if(layout_not_initialized && spatial_dim == 2)
-    {
-        inflags.SetValue("in_layout", "NCHW");
-        inflags.SetValue("fil_layout", "NCHW");
-        inflags.SetValue("out_layout", "NCHW");
-    }
-    else if(layout_not_initialized && spatial_dim == 3)
-    {
-        inflags.SetValue("in_layout", "NCDHW");
-        inflags.SetValue("fil_layout", "NCDHW");
-        inflags.SetValue("out_layout", "NCDHW");
-    }
-    else if(layout_not_initialized)
-    {
-        MIOPEN_THROW("unsupported spatial_dim to set default tensor layout");
-    }
+    const std::string default_layout = (spatial_dim == 2) ? "NCHW" : "NCDHW";
+
+    if(inflags.GetValueStr("in_layout").empty())
+        inflags.SetValue("in_layout", default_layout);
+    if(inflags.GetValueStr("fil_layout").empty())
+        inflags.SetValue("fil_layout", default_layout);
+    if(inflags.GetValueStr("out_layout").empty())
+        inflags.SetValue("out_layout", default_layout);
 
     num_iterations = inflags.GetValueInt("iter");
     if(num_iterations < 1)


### PR DESCRIPTION
After https://github.com/ROCmSoftwarePlatform/MIOpen/pull/343, if user try MIOpenDriver with 3d convolution, it must specify the `in_layout`, `fil_layout`, `out_layout`, explicitly, otherwise it will use the default layout as `NCHW` (2d layout) while[ initialize cmd line arg](https://github.com/ROCmSoftwarePlatform/MIOpen/blob/develop/driver/conv_driver.hpp#L570), and result in fail.

More over, if enable `MIOPEN_ENABLE_LOGGING_CMD` and dump a 3d conv, it will not log the `in_layout`, `fil_layout`, `out_layout` if current layout is default (NCDHW). So to unify the behavior with 2d conv, this PR fix this problem by providing a default value(NCDHW) for 3d convolution in MIOpenDriver.

e.g:
A 3d conv config as below:
`./bin/MIOpenDriver conv  -n 2 -c 2 --in_d 5 -H 4 -W 3 -k 3 --fil_d 5 -y 4 -x 3 --pad_d 0 -p 0 -q 0 --conv_stride_d 1 -u 1 -v 1 --dilation_d 1 -l 1 -j 1  --spatial_dim 3  -m conv -g 1 -F 2 -t 1`
This will fail to execute, have following fail log:
```
terminate called after throwing an instance of 'miopen::Exception'
  what():  /dockerx/repo/MIOpen/driver/tensor_driver.hpp:124: unmatched layout and dimension size
Aborted (core dumped)
```

This PR can fix this problem.