### PR TITLE
[MLIR] Binary backend - step 6 - Introduce GetKernelCount API

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,7 +97,7 @@ RUN if [ "$USE_TARGETID" = "ON" ] ; then export HIPCC_LINK_FLAGS_APPEND='-O3 -pa
 RUN if [ "$USE_TARGETID" = "OFF" ] ; then echo "MIOpenTensile is not installed."; elif [ "$MIOTENSILE_VER" = "latest" ] ; then cget -p $PREFIX install ROCmSoftwarePlatform/MIOpenTensile@be26d30d3d7509a414134a45f4a6d49e5da250b8; else cget -p $PREFIX install ROCmSoftwarePlatform/MIOpenTensile@4bfe00a8de61d12862d9fa803b8ea9a981a50f97; fi
 
 RUN cd ~ && \
-    export MLIR_COMMIT=3ddffc0056cf5ad7675486428dff13a4e335601d && \
+    export MLIR_COMMIT=bbce2f3216e013efe59d7e9c021b4896f89176b0 && \
     wget https://github.com/ROCmSoftwarePlatform/llvm-project-mlir/archive/$MLIR_COMMIT.tar.gz && \
     tar -xvzf $MLIR_COMMIT.tar.gz && \
     rm -rf $MLIR_COMMIT.tar.gz && \

--- a/src/include/miopen/mlir_build.hpp
+++ b/src/include/miopen/mlir_build.hpp
@@ -47,6 +47,8 @@ void MiirGenLaunchParams(const std::string& params, size_t& local_size, size_t& 
 
 bool MiirIsConfigApplicable(const std::string& params);
 
+int MiirGetKernelCount(const std::string& params);
+
 void MiirGenBin(const std::string& params, std::vector<char>& buffer);
 } // namespace miopen
 

--- a/src/mlir_build.cpp
+++ b/src/mlir_build.cpp
@@ -170,9 +170,9 @@ void MiirGenBin(const std::string& params, std::vector<char>& buffer)
 int MiirGetKernelCount(const std::string& params)
 {
     AutoMiirHandle handle(params);
-    int kernel_count = miirGetKernelCount(handle());
+    const auto kernel_count = miirGetKernelCount(handle());
     if(kernel_count < 1)
-        MIOPEN_THROW("miirGetKernelCount invalid count");
+        MIOPEN_THROW("miirGetKernelCount invalid count: " + std::to_string(kernel_count));
     return kernel_count;
 }
 

--- a/src/mlir_build.cpp
+++ b/src/mlir_build.cpp
@@ -167,4 +167,13 @@ void MiirGenBin(const std::string& params, std::vector<char>& buffer)
     check_miir_error(status, "miirBufferGet");
 }
 
+int MiirGetKernelCount(const std::string& params)
+{
+    AutoMiirHandle handle(params);
+    int kernel_count = miirGetKernelCount(handle());
+    if(kernel_count < 1)
+        MIOPEN_THROW("miirGetKernelCount invalid count");
+    return kernel_count;
+}
+
 } // namespace miopen

--- a/src/solver/conv_mlir_igemm_bwd.cpp
+++ b/src/solver/conv_mlir_igemm_bwd.cpp
@@ -58,6 +58,15 @@ std::tuple<int, int, int> CalculateGemmSize(const ConvolutionContext& ctx)
 
     return std::make_tuple(gemm_m, gemm_n, gemm_k_total);
 }
+
+std::string GetKernelName()
+{
+    std::string version   = "_v1r1";
+    std::string direction = "_bwd";
+    return "mlir_gen_igemm_conv2d" + version + direction;
+}
+
+std::string GetOperation() { return "conv2d_bwd_data"; }
 #endif
 } // Anonymous namespace
 
@@ -88,7 +97,11 @@ bool ConvMlirIgemmBwd::IsApplicable(const ConvolutionContext& ctx) const
 
     std::tie(gemm_m, gemm_n, gemm_k) = CalculateGemmSize(ctx);
 
-    return gemm_m % 32 == 0 && gemm_n % 32 == 0 && gemm_k % 4 == 0;
+    if(!(gemm_m % 32 == 0 && gemm_n % 32 == 0 && gemm_k % 4 == 0))
+        return false;
+
+    return MiirIsConfigApplicable(
+        mlir::PopulateHandle(ctx, GetOperation(), GetKernelName(), false));
 #else
     std::ignore = ctx;
     return false;
@@ -101,51 +114,10 @@ ConvSolution ConvMlirIgemmBwd::GetSolution(const ConvolutionContext& ctx) const
     ConvSolution result;
     KernelInfo construction_parameters;
 
-    std::string version   = "_v1r1";
-    std::string direction = "_bwd";
-    std::string operation = "conv2d_bwd_data";
-
-    construction_parameters.kernel_name = "mlir_gen_igemm_conv2d" + version + direction;
+    construction_parameters.kernel_name = GetKernelName();
     construction_parameters.kernel_file = construction_parameters.kernel_name + ".mlir";
-
-    // Arguments for mlir-miopen-driver.
-    // clang-format off
-    using CI = ConvolutionContextInterpreter;
-
-    std::string in_layout = mlir::InsertGToLayout(CI::GetInputLayout(ctx), 'C');
-    std::string fil_layout = mlir::InsertGToLayout(CI::GetFilterLayout(ctx), 'N');
-    std::string out_layout = mlir::InsertGToLayout(CI::GetOutputLayout(ctx), 'C');
-
-    std::string data_type = ctx.IsFp32() ? "fp32" : "fp16";
-
     construction_parameters.comp_options =
-        std::string(" --operation ") + operation +
-        std::string(" --num_cu ") + std::to_string(ctx.GetStream().GetMaxComputeUnits()) +
-        std::string(" --arch ") + ctx.GetStream().GetDeviceName() +
-        std::string(" --groupsize ") + std::to_string(CI::GetGroupCountG(ctx)) +
-        std::string(" --fil_layout ") + fil_layout +
-        std::string(" --fil_type ") + data_type +
-        std::string(" --in_layout ") + in_layout +
-        std::string(" --in_type ") + data_type +
-        std::string(" --out_layout ") + out_layout +
-        std::string(" --out_type ") + data_type +
-        std::string(" --batchsize ") + std::to_string(CI::GetBatchN(ctx)) +
-        std::string(" --in_channels ") + std::to_string(CI::GetInputChannelC(ctx)) +
-        std::string(" --out_channels ") + std::to_string(CI::GetOutputChannelK(ctx)) +
-        std::string(" --in_h ") + std::to_string(CI::GetInputHeightHi(ctx)) +
-        std::string(" --in_w ") + std::to_string(CI::GetInputWidthWi(ctx)) +
-        std::string(" --out_h ") + std::to_string(CI::GetOutputHeightHo(ctx)) +
-        std::string(" --out_w ") + std::to_string(CI::GetOutputWidthWo(ctx)) +
-        std::string(" --fil_h ") + std::to_string(CI::GetFilterHeightY(ctx)) +
-        std::string(" --fil_w ") + std::to_string(CI::GetFilterWidthX(ctx)) +
-        std::string(" --dilation_h ") + std::to_string(CI::GetAdjustedConvolutionDilationH(ctx)) +
-        std::string(" --dilation_w ") + std::to_string(CI::GetAdjustedConvolutionDilationW(ctx)) +
-        std::string(" --conv_stride_h ") + std::to_string(CI::GetAdjustedConvolutionStrideH(ctx)) +
-        std::string(" --conv_stride_w ") + std::to_string(CI::GetAdjustedConvolutionStrideW(ctx)) +
-        std::string(" --padding_h ") + std::to_string(CI::GetInputLeftPadH(ctx)) +
-        std::string(" --padding_w ") + std::to_string(CI::GetInputLeftPadW(ctx)) +
-        std::string(" --kernel_name ") + construction_parameters.kernel_name;
-    // clang-format on
+        mlir::PopulateHandle(ctx, GetOperation(), GetKernelName(), false);
 
     size_t local_size  = 0;
     size_t global_size = 0;

--- a/src/solver/conv_mlir_igemm_fwd.cpp
+++ b/src/solver/conv_mlir_igemm_fwd.cpp
@@ -58,6 +58,15 @@ std::tuple<int, int, int> CalculateGemmSize(const ConvolutionContext& ctx)
 
     return std::make_tuple(gemm_m, gemm_n, gemm_k_total);
 }
+
+std::string GetKernelName()
+{
+    std::string version   = "_v4r4";
+    std::string direction = "_fwd";
+    return "mlir_gen_igemm_conv2d" + version + direction;
+}
+
+std::string GetOperation() { return "conv2d"; }
 #endif
 } // Anonymous namespace
 
@@ -83,7 +92,11 @@ bool ConvMlirIgemmFwd::IsApplicable(const ConvolutionContext& ctx) const
     int gemm_k = 0;
 
     std::tie(gemm_m, gemm_n, gemm_k) = CalculateGemmSize(ctx);
-    return gemm_m % 32 == 0 && gemm_n % 32 == 0 && gemm_k % 4 == 0;
+    if(!(gemm_m % 32 == 0 && gemm_n % 32 == 0 && gemm_k % 4 == 0))
+        return false;
+
+    return MiirIsConfigApplicable(
+        mlir::PopulateHandle(ctx, GetOperation(), GetKernelName(), false));
 #else
     std::ignore = ctx;
     return false;
@@ -96,51 +109,10 @@ ConvSolution ConvMlirIgemmFwd::GetSolution(const ConvolutionContext& ctx) const
     ConvSolution result;
     KernelInfo construction_parameters;
 
-    std::string version   = "_v4r4";
-    std::string direction = "_fwd";
-    std::string operation = "conv2d";
-
-    construction_parameters.kernel_name = "mlir_gen_igemm_conv2d" + version + direction;
+    construction_parameters.kernel_name = GetKernelName();
     construction_parameters.kernel_file = construction_parameters.kernel_name + ".mlir";
-
-    // Arguments for mlir-miopen-driver.
-    // clang-format off
-    using CI = ConvolutionContextInterpreter;
-
-    std::string in_layout = mlir::InsertGToLayout(CI::GetInputLayout(ctx), 'C');
-    std::string fil_layout = mlir::InsertGToLayout(CI::GetFilterLayout(ctx), 'N');
-    std::string out_layout = mlir::InsertGToLayout(CI::GetOutputLayout(ctx), 'C');
-
-    std::string data_type = ctx.IsFp32() ? "fp32" : "fp16";
-
     construction_parameters.comp_options =
-        std::string(" --operation ") + operation +
-        std::string(" --num_cu ") + std::to_string(ctx.GetStream().GetMaxComputeUnits()) +
-        std::string(" --arch ") + ctx.GetStream().GetDeviceName() +
-        std::string(" --groupsize ") + std::to_string(CI::GetGroupCountG(ctx)) +
-        std::string(" --fil_layout ") + fil_layout +
-        std::string(" --fil_type ") + data_type +
-        std::string(" --in_layout ") + in_layout +
-        std::string(" --in_type ") + data_type +
-        std::string(" --out_layout ") + out_layout +
-        std::string(" --out_type ") + data_type +
-        std::string(" --batchsize ") + std::to_string(CI::GetBatchN(ctx)) +
-        std::string(" --in_channels ") + std::to_string(CI::GetInputChannelC(ctx)) +
-        std::string(" --out_channels ") + std::to_string(CI::GetOutputChannelK(ctx)) +
-        std::string(" --in_h ") + std::to_string(CI::GetInputHeightHi(ctx)) +
-        std::string(" --in_w ") + std::to_string(CI::GetInputWidthWi(ctx)) +
-        std::string(" --out_h ") + std::to_string(CI::GetOutputHeightHo(ctx)) +
-        std::string(" --out_w ") + std::to_string(CI::GetOutputWidthWo(ctx)) +
-        std::string(" --fil_h ") + std::to_string(CI::GetFilterHeightY(ctx)) +
-        std::string(" --fil_w ") + std::to_string(CI::GetFilterWidthX(ctx)) +
-        std::string(" --dilation_h ") + std::to_string(CI::GetAdjustedConvolutionDilationH(ctx)) +
-        std::string(" --dilation_w ") + std::to_string(CI::GetAdjustedConvolutionDilationW(ctx)) +
-        std::string(" --conv_stride_h ") + std::to_string(CI::GetAdjustedConvolutionStrideH(ctx)) +
-        std::string(" --conv_stride_w ") + std::to_string(CI::GetAdjustedConvolutionStrideW(ctx)) +
-        std::string(" --padding_h ") + std::to_string(CI::GetInputLeftPadH(ctx)) +
-        std::string(" --padding_w ") + std::to_string(CI::GetInputLeftPadW(ctx)) +
-        std::string(" --kernel_name ") + construction_parameters.kernel_name;
-    // clang-format on
+        mlir::PopulateHandle(ctx, GetOperation(), GetKernelName(), false);
 
     size_t local_size  = 0;
     size_t global_size = 0;

--- a/src/solver/conv_mlir_igemm_wrw_xdlops.cpp
+++ b/src/solver/conv_mlir_igemm_wrw_xdlops.cpp
@@ -117,7 +117,6 @@ ConvSolution ConvMlirIgemmWrWXdlops::GetSolution(const ConvolutionContext& ctx) 
 
     construction_parameters.kernel_name = GetKernelName();
     construction_parameters.kernel_file = construction_parameters.kernel_name + ".mlir";
-
     construction_parameters.comp_options =
         mlir::PopulateHandle(ctx, GetOperation(), GetKernelName(), true);
 


### PR DESCRIPTION
This PR does the following:
 - Refactored all non-xdlops solvers to take advantage the `MiirIsConfigApplicable()` check to make sure no false positive exist
 - Bumped the MLIR commit
 - Introduced the MiirGetKernelCount() API to pave road for multi-kernel compilation

---

Previous PRs in the series:

https://github.com/ROCmSoftwarePlatform/MIOpen/pull/841
https://github.com/ROCmSoftwarePlatform/MIOpen/pull/889
https://github.com/ROCmSoftwarePlatform/MIOpen/pull/892
https://github.com/ROCmSoftwarePlatform/MIOpen/pull/902
https://github.com/ROCmSoftwarePlatform/MIOpen/pull/912