### PR TITLE
Fix .max_flat_workgroup_size (SWDEV-277901, SWDEV-286069)

### DIFF
--- a/src/kernels/conv5x10u2v2b1.s
+++ b/src/kernels/conv5x10u2v2b1.s
@@ -889,7 +889,7 @@ amdhsa.kernels:
     .kernarg_segment_align: 8
     .wavefront_size: 64
     .reqd_workgroup_size: [ 64, 8, 1 ]
-    .max_flat_workgroup_size: 256
+    .max_flat_workgroup_size: 512
     .args:
     - { .size: 8, .offset:  0, .value_kind: global_buffer, .value_type: f32, .name: in,      .address_space: global, .is_const: true }
     - { .size: 8, .offset:  8, .value_kind: global_buffer, .value_type: f32, .name: weights, .address_space: global, .is_const: true }
@@ -915,7 +915,7 @@ METADATA %SGPR_COUNT, %VGPR_COUNT, %LDS_SIZE
         Attrs:
           { ReqdWorkGroupSize: [ 64, 8, 1 ] }
         CodeProps:
-          { KernargSegmentSize: 56, GroupSegmentFixedSize: 3072, PrivateSegmentFixedSize: 0, KernargSegmentAlign: 8, WavefrontSize: 64, MaxFlatWorkGroupSize: 256 }
+          { KernargSegmentSize: 56, GroupSegmentFixedSize: 3072, PrivateSegmentFixedSize: 0, KernargSegmentAlign: 8, WavefrontSize: 64, MaxFlatWorkGroupSize: 512 }
         Args:
         - { Size: 8, Align: 8, ValueKind: GlobalBuffer, ValueType: F32, TypeName: 'float*', Name: in,          AddrSpaceQual: Global, AccQual: Default, IsConst: true }
         - { Size: 8, Align: 8, ValueKind: GlobalBuffer, ValueType: F32, TypeName: 'float*', Name: weights,     AddrSpaceQual: Global, AccQual: Default, IsConst: true }

--- a/src/kernels/conv5x10u2v2f1.s
+++ b/src/kernels/conv5x10u2v2f1.s
@@ -1258,7 +1258,7 @@ amdhsa.kernels:
     .kernarg_segment_align: 8
     .wavefront_size: 64
     .reqd_workgroup_size: [ 64, 8, 1 ]
-    .max_flat_workgroup_size: 256
+    .max_flat_workgroup_size: 512
     .args:
     - { .size: 8, .offset:  0, .value_kind: global_buffer, .value_type: f32, .name: in,      .address_space: global, .is_const: true }
     - { .size: 8, .offset:  8, .value_kind: global_buffer, .value_type: f32, .name: weights, .address_space: global, .is_const: true }
@@ -1285,7 +1285,7 @@ METADATA %SGPR_COUNT, %VGPR_COUNT, %LDS_SIZE
             Attrs:
               { ReqdWorkGroupSize: [ 64, 8, 1 ] }
             CodeProps:
-              { KernargSegmentSize: 56, GroupSegmentFixedSize: \lds_size, PrivateSegmentFixedSize: 0, KernargSegmentAlign: 8, WavefrontSize: 64, MaxFlatWorkGroupSize: 256 }
+              { KernargSegmentSize: 56, GroupSegmentFixedSize: \lds_size, PrivateSegmentFixedSize: 0, KernargSegmentAlign: 8, WavefrontSize: 64, MaxFlatWorkGroupSize: 512 }
             Args:
             - { Size: 8, Align: 8, ValueKind: GlobalBuffer, ValueType: F32, TypeName: 'float*', Name: in,          AddrSpaceQual: Global, AccQual: Default, IsConst: true }
             - { Size: 8, Align: 8, ValueKind: GlobalBuffer, ValueType: F32, TypeName: 'float*', Name: weights,     AddrSpaceQual: Global, AccQual: Default, IsConst: true }

--- a/src/kernels/conv7x7c3h224w224k64u2v2p3q3f1.s
+++ b/src/kernels/conv7x7c3h224w224k64u2v2p3q3f1.s
@@ -814,7 +814,7 @@ amdhsa.kernels:
     .kernarg_segment_align: 8
     .wavefront_size: 64
     .reqd_workgroup_size: [ 64, 8, 1 ]
-    .max_flat_workgroup_size: 256
+    .max_flat_workgroup_size: 512
     .args:
     - { .size: 8, .offset:  0, .value_kind: global_buffer, .value_type: f32, .name: in,      .address_space: global, .is_const: true }
     - { .size: 8, .offset:  8, .value_kind: global_buffer, .value_type: f32, .name: weights, .address_space: global, .is_const: true }
@@ -834,7 +834,7 @@ METADATA %SGPR_COUNT, %VGPR_COUNT, %LDS_SIZE
         Name: miopenGcnAsmConv7x7c3h224w224k64u2v2p3q3f1, SymbolName: 'miopenGcnAsmConv7x7c3h224w224k64u2v2p3q3f1@kd', Language: OpenCL C, LanguageVersion: [ 1, 2 ],
         Attrs: { ReqdWorkGroupSize: [ 64, 8, 1 ] }
         CodeProps:
-          { KernargSegmentSize: 32, GroupSegmentFixedSize: 7040, PrivateSegmentFixedSize: 0, KernargSegmentAlign: 8, WavefrontSize: 64, MaxFlatWorkGroupSize: 256 }
+          { KernargSegmentSize: 32, GroupSegmentFixedSize: 7040, PrivateSegmentFixedSize: 0, KernargSegmentAlign: 8, WavefrontSize: 64, MaxFlatWorkGroupSize: 512 }
         Args:
         - { Size: 8, Align: 8, ValueKind: GlobalBuffer, ValueType: F32, TypeName: 'float*', Name: in,          AddrSpaceQual: Global, AccQual: Default, IsConst: true }
         - { Size: 8, Align: 8, ValueKind: GlobalBuffer, ValueType: F32, TypeName: 'float*', Name: weights,     AddrSpaceQual: Global, AccQual: Default, IsConst: true }


### PR DESCRIPTION
Fixes value of `.max_flat_workgroup_size` in the metadata of three assembly kernels (`miopenConv5x10u2v2b1`, `miopenConv5x10u2v2f1`, `miopenGcnAsmConv7x7c3h224w224k64u2v2p3q3f1`). Resolves the following issues:
- https://ontrack-internal.amd.com/browse/SWDEV-277901
- https://ontrack-internal.amd.com/browse/SWDEV-286069