### PR TITLE
Fix restrictions for vecload condition (iGemm v4r1 Bwd, 1x1)

### DIFF
--- a/src/solver/conv_hip_implicit_gemm_bwd_v4r1.cpp
+++ b/src/solver/conv_hip_implicit_gemm_bwd_v4r1.cpp
@@ -258,6 +258,10 @@ PerformanceImplicitGemmBwdDataV4R1::CalculateGemmBBlockCopyPerformanceParameters
         // calculate vector length on gemmn dimension
         const auto y = ConvolutionContextInterpreter::GetFilterHeightY(ctx);
         const auto x = ConvolutionContextInterpreter::GetFilterWidthX(ctx);
+        const auto left_pad_h = ConvolutionContextInterpreter::GetInputLeftPadH(ctx);
+        const auto left_pad_w = ConvolutionContextInterpreter::GetInputLeftPadW(ctx);
+        const auto right_pad_h = ConvolutionContextInterpreter::GetAdjustedInputRightPadH(ctx);
+        const auto right_pad_w = ConvolutionContextInterpreter::GetAdjustedInputRightPadW(ctx);
 
         // \todo too conversative
         if(ctx.Is3d())
@@ -278,7 +282,7 @@ PerformanceImplicitGemmBwdDataV4R1::CalculateGemmBBlockCopyPerformanceParameters
         }
         else
         {
-            if(y == 1 && x == 1)
+            if(y == 1 && x == 1 && left_pad_h == 0 && left_pad_w == 0 && right_pad_h == 0 && right_pad_w == 0)
             {
                 const auto ho = ConvolutionContextInterpreter::GetOutputHeightHo(ctx);
                 const auto wo = ConvolutionContextInterpreter::GetOutputWidthWo(ctx);

--- a/src/solver/conv_hip_implicit_gemm_bwd_v4r1.cpp
+++ b/src/solver/conv_hip_implicit_gemm_bwd_v4r1.cpp
@@ -256,18 +256,21 @@ PerformanceImplicitGemmBwdDataV4R1::CalculateGemmBBlockCopyPerformanceParameters
         SrcDataPerRead_GemmN = gcd(SrcDataPerRead_GemmN, GemmNPerBlock);
 
         // calculate vector length on gemmn dimension
-        const auto y = ConvolutionContextInterpreter::GetFilterHeightY(ctx);
-        const auto x = ConvolutionContextInterpreter::GetFilterWidthX(ctx);
-        const auto left_pad_h = ConvolutionContextInterpreter::GetInputLeftPadH(ctx);
-        const auto left_pad_w = ConvolutionContextInterpreter::GetInputLeftPadW(ctx);
+        const auto y           = ConvolutionContextInterpreter::GetFilterHeightY(ctx);
+        const auto x           = ConvolutionContextInterpreter::GetFilterWidthX(ctx);
+        const auto left_pad_h  = ConvolutionContextInterpreter::GetInputLeftPadH(ctx);
+        const auto left_pad_w  = ConvolutionContextInterpreter::GetInputLeftPadW(ctx);
         const auto right_pad_h = ConvolutionContextInterpreter::GetAdjustedInputRightPadH(ctx);
         const auto right_pad_w = ConvolutionContextInterpreter::GetAdjustedInputRightPadW(ctx);
 
         // \todo too conversative
         if(ctx.Is3d())
         {
-            const auto z = ConvolutionContextInterpreter::GetFilterDepthZ(ctx);
-            if(z == 1 && y == 1 && x == 1)
+            const auto z           = ConvolutionContextInterpreter::GetFilterDepthZ(ctx);
+            const auto left_pad_d  = ConvolutionContextInterpreter::GetInputLeftPadD(ctx);
+            const auto right_pad_d = ConvolutionContextInterpreter::GetAdjustedInputRightPadD(ctx);
+            if(z == 1 && y == 1 && x == 1 && left_pad_h == 0 && left_pad_w == 0 &&
+               left_pad_d == 0 && right_pad_h == 0 && right_pad_w == 0 && right_pad_d == 0)
             {
                 const auto dout = ConvolutionContextInterpreter::GetOutputDepthDo(ctx);
                 const auto ho   = ConvolutionContextInterpreter::GetOutputHeightHo(ctx);
@@ -282,7 +285,8 @@ PerformanceImplicitGemmBwdDataV4R1::CalculateGemmBBlockCopyPerformanceParameters
         }
         else
         {
-            if(y == 1 && x == 1 && left_pad_h == 0 && left_pad_w == 0 && right_pad_h == 0 && right_pad_w == 0)
+            if(y == 1 && x == 1 && left_pad_h == 0 && left_pad_w == 0 && right_pad_h == 0 &&
+               right_pad_w == 0)
             {
                 const auto ho = ConvolutionContextInterpreter::GetOutputHeightHo(ctx);
                 const auto wo = ConvolutionContextInterpreter::GetOutputWidthWo(ctx);

--- a/src/solver/conv_hip_implicit_gemm_bwd_v4r1_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_bwd_v4r1_xdlops.cpp
@@ -176,11 +176,15 @@ PerformanceImplicitGemmBwdDataV4R1Xdlops::CalculateGemmBBlockCopyPerformancePara
         SrcDataPerRead_GemmN = gcd(SrcDataPerRead_GemmN, GemmNPerBlock);
 
         // calculate vector length on gemmn dimension
-        const auto y = ConvolutionContextInterpreter::GetFilterHeightY(ctx);
-        const auto x = ConvolutionContextInterpreter::GetFilterWidthX(ctx);
+        const auto y     = ConvolutionContextInterpreter::GetFilterHeightY(ctx);
+        const auto x     = ConvolutionContextInterpreter::GetFilterWidthX(ctx);
+        const auto left_pad_h = ConvolutionContextInterpreter::GetInputLeftPadH(ctx);
+        const auto left_pad_w = ConvolutionContextInterpreter::GetInputLeftPadW(ctx);
+        const auto right_pad_h = ConvolutionContextInterpreter::GetAdjustedInputRightPadH(ctx);
+        const auto right_pad_w = ConvolutionContextInterpreter::GetAdjustedInputRightPadW(ctx);
 
         // \todo too conversative
-        if(y == 1 && x == 1)
+        if(y == 1 && x == 1 && left_pad_h == 0 && left_pad_w == 0 && right_pad_h == 0 && right_pad_w == 0)
         {
             const auto ho        = ConvolutionContextInterpreter::GetOutputHeightHo(ctx);
             const auto wo        = ConvolutionContextInterpreter::GetOutputWidthWo(ctx);

--- a/src/solver/conv_hip_implicit_gemm_bwd_v4r1_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_bwd_v4r1_xdlops.cpp
@@ -176,15 +176,16 @@ PerformanceImplicitGemmBwdDataV4R1Xdlops::CalculateGemmBBlockCopyPerformancePara
         SrcDataPerRead_GemmN = gcd(SrcDataPerRead_GemmN, GemmNPerBlock);
 
         // calculate vector length on gemmn dimension
-        const auto y     = ConvolutionContextInterpreter::GetFilterHeightY(ctx);
-        const auto x     = ConvolutionContextInterpreter::GetFilterWidthX(ctx);
-        const auto left_pad_h = ConvolutionContextInterpreter::GetInputLeftPadH(ctx);
-        const auto left_pad_w = ConvolutionContextInterpreter::GetInputLeftPadW(ctx);
+        const auto y           = ConvolutionContextInterpreter::GetFilterHeightY(ctx);
+        const auto x           = ConvolutionContextInterpreter::GetFilterWidthX(ctx);
+        const auto left_pad_h  = ConvolutionContextInterpreter::GetInputLeftPadH(ctx);
+        const auto left_pad_w  = ConvolutionContextInterpreter::GetInputLeftPadW(ctx);
         const auto right_pad_h = ConvolutionContextInterpreter::GetAdjustedInputRightPadH(ctx);
         const auto right_pad_w = ConvolutionContextInterpreter::GetAdjustedInputRightPadW(ctx);
 
         // \todo too conversative
-        if(y == 1 && x == 1 && left_pad_h == 0 && left_pad_w == 0 && right_pad_h == 0 && right_pad_w == 0)
+        if(y == 1 && x == 1 && left_pad_h == 0 && left_pad_w == 0 && right_pad_h == 0 &&
+           right_pad_w == 0)
         {
             const auto ho        = ConvolutionContextInterpreter::GetOutputHeightHo(ctx);
             const auto wo        = ConvolutionContextInterpreter::GetOutputWidthWo(ctx);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -408,6 +408,7 @@ COMMAND $<TARGET_FILE:test_conv2d> ${IMPLICITGEMM_ARGS} --verbose   --input 128 
 COMMAND $<TARGET_FILE:test_conv2d> ${IMPLICITGEMM_ARGS} --verbose   --input 128  832    7  7  --weights   128  832  1   1   --pads_strides_dilations    0   0   1   1   2   2
 COMMAND $<TARGET_FILE:test_conv2d> ${IMPLICITGEMM_ARGS} --verbose   --input 16  2048    7  7  --weights   192  2048 1   1   --pads_strides_dilations    0   0   1   1   2   2
 COMMAND	$<TARGET_FILE:test_conv2d> ${IMPLICITGEMM_ARGS} --verbose   --input 64	 32	28 28 --weights   192  32   3	3   --pads_strides_dilations	1   1	2   2	1   1
+COMMAND	$<TARGET_FILE:test_conv2d> ${IMPLICITGEMM_ARGS} --verbose   --input 8    16 14 14 --weights   32   16   1   1   --pads_strides_dilations	1   1	1   1	1   1
 COMMAND	$<TARGET_FILE:test_conv2d> ${IMPLICITGEMM_ARGS} --verbose   --input 64	 32	14 14 --weights   192  32   3	3   --pads_strides_dilations	1   1	2   2	1   1
 COMMAND	$<TARGET_FILE:test_conv2d> ${IMPLICITGEMM_ARGS} --verbose   --input 64	 32	7 7   --weights   192  32   3	3   --pads_strides_dilations	1   1	2   2	1   1
 COMMAND	$<TARGET_FILE:test_conv2d> ${IMPLICITGEMM_ARGS} --verbose   --input 64	 32	28 28 --weights   192  32   3	3   --pads_strides_dilations	2   2	2   2	1   1


### PR DESCRIPTION
To fix issue: #917 

test by :
```
MIOPEN_FIND_MODE=normal MIOPEN_DEBUG_FIND_ONLY_SOLVER=ConvHipImplicitGemmBwdDataV4R1Xdlops MIOPEN_LOG_LEVEL=5 ./bin/test_conv2d --half --input 8 16 14 14 --weights 32 16 1 1 -v --disable-backward-weights --disable-forward --pads_strides_dilations 1 1 1 1 1 1
```
and get output:
```
./bin/test_conv2d --half --cmode conv --pmode default --group-count 1 --disable-forward --disable-backward-weights --input 8, 16, 14, 14 --weights 32, 16, 1, 1 --pads_strides_dilations 1 1 1 1 1 1 --trans_output_pads 0 0 --in_layout NCHW --fil_layout NCHW --out_layout NCHW
error: 0
Max diff: 0
Backward convolution: ConvHipImplicitGemmBwdDataV4R1Xdlops
Input tensor: 8, 16, 14, 14
Weights tensor: 32, 16, 1, 1
Output tensor: 8, 32, 16, 16
```



