### PR TITLE
Generic Tensor Reduction for Double (SWDEV-284915)

### DIFF
--- a/driver/driver.hpp
+++ b/driver/driver.hpp
@@ -130,7 +130,7 @@ void PadBufferSize(size_t& sz, int datatype_sz)
     printf(
         "Supported Base Arguments: conv[fp16|int8|bfp16], CBAInfer[fp16], pool[fp16], lrn[fp16], "
         "activ[fp16], softmax[fp16], bnorm[fp16], rnn[fp16], gemm, ctc, dropout[fp16], "
-        "tensorop[fp16], reduce[fp16]\n");
+        "tensorop[fp16], reduce[fp16,fp64]\n");
     exit(0);
 }
 
@@ -150,7 +150,7 @@ std::string ParseBaseArg(int argc, char* argv[])
        arg != "softmax" && arg != "softmaxfp16" && arg != "bnorm" && arg != "bnormfp16" &&
        arg != "rnn" && arg != "rnnfp16" && arg != "gemm" /*&& arg != "gemmfp16"*/ && arg != "ctc" &&
        arg != "dropout" && arg != "dropoutfp16" && arg != "tensorop" && arg != "tensoropfp16" &&
-       arg != "reduce" && arg != "reducefp16" && arg != "--version")
+       arg != "reduce" && arg != "reducefp16" && arg != "reducefp64" && arg != "--version")
     {
         printf("Invalid Base Input Argument\n");
         Usage();

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -174,6 +174,10 @@ int main(int argc, char* argv[])
     {
         drv = new ReduceDriver<float16, float>();
     }
+    else if(base_arg == "reducefp64")
+    {
+        drv = new ReduceDriver<double, double>();
+    }
     else
     {
         printf("Incorrect BaseArg\n");

--- a/driver/miopen_Reduction.hpp
+++ b/driver/miopen_Reduction.hpp
@@ -90,8 +90,9 @@ class miopenReductionHost
                 RunImpl<Tref>(alpha, in_data, beta, out_data, indices);
             else
                 RunImpl<float16>(alpha, in_data, beta, out_data, indices);
-        };
-
+        }
+        else if(compTypeVal == miopenDouble)
+            RunImpl<double>(alpha, in_data, beta, out_data, indices);
         return;
     };
 

--- a/driver/reduce_driver.hpp
+++ b/driver/reduce_driver.hpp
@@ -383,11 +383,11 @@ int ReduceDriver<Tgpu, Tref>::RunForwardGPU()
     const double alpha64       = alpha;
     const double beta64        = beta;
     const void* const alphaPtr = std::is_same<Tgpu, double>::value
-                                     ? reinterpret_cast<const void*>(&alpha64)
-                                     : reinterpret_cast<const void*>(&alpha);
+                                     ? static_cast<const void*>(&alpha64)
+                                     : static_cast<const void*>(&alpha);
     const void* const betaPtr = std::is_same<Tgpu, double>::value
-                                    ? reinterpret_cast<const void*>(&beta64)
-                                    : reinterpret_cast<const void*>(&beta);
+                                    ? static_cast<const void*>(&beta64)
+                                    : static_cast<const void*>(&beta);
 
     miopenReduceTensor(GetHandle(),
                        reduceDesc,

--- a/driver/reduce_driver.hpp
+++ b/driver/reduce_driver.hpp
@@ -374,8 +374,8 @@ int ReduceDriver<Tgpu, Tref>::RunForwardGPU()
 
     if(this->need_indices)
     {
-        alpha = reduce::convert_type<Tgpu>(1.0f);
-        beta  = reduce::convert_type<Tgpu>(0.0f);
+        alpha = 1.0f;
+        beta  = 0.0f;
     };
 
     bool output_accumulate = !(reduce::float_equal_one(alpha) && reduce::float_equal_zero(beta));

--- a/include/miopen/miopen.h
+++ b/include/miopen/miopen.h
@@ -334,6 +334,7 @@ typedef enum {
         4, /*!< Pack of four 8-bit int points in NCHW_VECT_C format (Partially supported) */
     miopenBFloat16 = 5, /*!< 16-bit binary floating point (8-bit exponent, 7-bit fraction)
                            (Partially supported) */
+    miopenDouble = 6,   /*!< 64-bit floating point (Partially supported) */
 } miopenDataType_t;
 
 /*! @ingroup pooling

--- a/src/gemm_v2.cpp
+++ b/src/gemm_v2.cpp
@@ -297,6 +297,8 @@ miopenStatus_t CallGemmMIOpenTensile(const Handle& handle,
         ptrA            = Data_t(reinterpret_cast<const int8_t*>(A) + a_offset);
         ptrB            = Data_t(reinterpret_cast<const int8_t*>(B) + b_offset);
         ptrC            = Data_t(reinterpret_cast<int32_t*>(C) + c_offset);
+    case miopenDouble:
+        MIOPEN_THROW(miopenStatusBadParm, "miopenDouble data type not supported by MIOpenGEMM.");
     }
     if(gemm_desc.dataType == miopenInt8 || gemm_desc.dataType == miopenInt8x4)
     {
@@ -569,6 +571,13 @@ miopenStatus_t CallGemm(const Handle& handle,
                 0,
                 0);
         }
+        break;
+
+        case miopenDouble:
+        {
+            MIOPEN_THROW(miopenStatusBadParm,
+                         "miopenDouble data type not supported by MIOpenGEMM.");
+        };
         break;
         }
 
@@ -887,6 +896,13 @@ miopenStatus_t CallGemmStridedBatched(const Handle& handle,
                 0);
         }
         break;
+
+        case miopenDouble:
+        {
+            MIOPEN_THROW(miopenStatusBadParm,
+                         "miopenDouble data type not supported by MIOpenGEMM.");
+        }
+        break;
         }
 
         if(handle.IsProfilingEnabled())
@@ -1121,6 +1137,13 @@ miopenStatus_t CallGemmStridedBatchedSequential(const Handle& handle,
                     0,
                     0);
             }
+        }
+        break;
+
+        case miopenDouble:
+        {
+            MIOPEN_THROW(miopenStatusBadParm,
+                         "miopenDouble data type not supported by MIOpenGEMM.");
         }
         break;
         }

--- a/src/gemm_v2.cpp
+++ b/src/gemm_v2.cpp
@@ -297,6 +297,7 @@ miopenStatus_t CallGemmMIOpenTensile(const Handle& handle,
         ptrA            = Data_t(reinterpret_cast<const int8_t*>(A) + a_offset);
         ptrB            = Data_t(reinterpret_cast<const int8_t*>(B) + b_offset);
         ptrC            = Data_t(reinterpret_cast<int32_t*>(C) + c_offset);
+        break;
     case miopenDouble:
         MIOPEN_THROW(miopenStatusBadParm, "miopenDouble data type not supported by MIOpenGEMM.");
     }

--- a/src/include/miopen/conv/problem_description.hpp
+++ b/src/include/miopen/conv/problem_description.hpp
@@ -49,6 +49,7 @@ inline std::string GetDataTypeName(miopenDataType_t data_type)
     case miopenInt8x4: return "INT8x4";
     case miopenInt32: return "INT32";
     case miopenBFloat16: return "BF16";
+    case miopenDouble: return "FP64";
     }
 
     return "Unknown(" + std::to_string(data_type) + ")";

--- a/src/include/miopen/datatype.hpp
+++ b/src/include/miopen/datatype.hpp
@@ -132,6 +132,7 @@ inline std::string GetDataTypeKernelParams(miopenDataType_t type)
     ss << " -DMIOPEN_USE_BFP16=" << use_bfp16;
     ss << " -DMIOPEN_USE_INT32=" << use_int32;
     ss << " -DMIOPEN_USE_RNE_BFLOAT16=" << use_rne_bfloat16;
+    ss << " -DMIOPEN_USE_FP64=" << use_fp64;
     return ss.str();
 }
 

--- a/src/include/miopen/datatype.hpp
+++ b/src/include/miopen/datatype.hpp
@@ -132,7 +132,8 @@ inline std::string GetDataTypeKernelParams(miopenDataType_t type)
     ss << " -DMIOPEN_USE_BFP16=" << use_bfp16;
     ss << " -DMIOPEN_USE_INT32=" << use_int32;
     ss << " -DMIOPEN_USE_RNE_BFLOAT16=" << use_rne_bfloat16;
-    ss << " -DMIOPEN_USE_FP64=" << use_fp64;
+    if(use_fp64)
+        ss << " -DMIOPEN_USE_FP64=" << use_fp64;
     return ss.str();
 }
 

--- a/src/include/miopen/datatype.hpp
+++ b/src/include/miopen/datatype.hpp
@@ -53,6 +53,9 @@ inline std::string GetDataType(miopenDataType_t type)
     case miopenInt32: { type_str = "int";
     }
     break;
+    case miopenDouble: { type_str = "double";
+    }
+    break;
     }
     return type_str;
 }
@@ -104,6 +107,7 @@ inline std::string GetDataTypeKernelParams(miopenDataType_t type)
     int use_int8x4             = 0;
     int use_int32              = 0;
     int use_bfp16              = 0;
+    int use_fp64               = 0;
     const int use_rne_bfloat16 = MIOPEN_USE_RNE_BFLOAT16;
 
     switch(type)
@@ -114,6 +118,7 @@ inline std::string GetDataTypeKernelParams(miopenDataType_t type)
     case miopenInt8x4: use_int8x4  = 1; break;
     case miopenBFloat16: use_bfp16 = 1; break;
     case miopenInt32: use_int32    = 1; break;
+    case miopenDouble: use_fp64    = 1; break;
     default:
         MIOPEN_THROW("Only float, half, bfloat16, int8, int8x4 data type is supported.");
         break;

--- a/src/include/miopen/datatype.hpp
+++ b/src/include/miopen/datatype.hpp
@@ -132,7 +132,7 @@ inline std::string GetDataTypeKernelParams(miopenDataType_t type)
     ss << " -DMIOPEN_USE_BFP16=" << use_bfp16;
     ss << " -DMIOPEN_USE_INT32=" << use_int32;
     ss << " -DMIOPEN_USE_RNE_BFLOAT16=" << use_rne_bfloat16;
-    if(use_fp64)
+    if(use_fp64 != 0)
         ss << " -DMIOPEN_USE_FP64=" << use_fp64;
     return ss.str();
 }

--- a/src/include/miopen/tensor.hpp
+++ b/src/include/miopen/tensor.hpp
@@ -99,6 +99,7 @@ inline std::size_t GetTypeSize(miopenDataType_t d)
     case miopenBFloat16: return 2;
     case miopenInt8x4:
     case miopenInt8: return 1;
+    case miopenDouble: return 8;
     }
     MIOPEN_THROW("Unknown data type");
 }

--- a/src/include/miopen/visit_float.hpp
+++ b/src/include/miopen/visit_float.hpp
@@ -87,6 +87,11 @@ void visit_float(miopenDataType_t t, F f)
         f(as_float<int>{});
         break;
     }
+    case miopenDouble:
+    {
+        f(as_float<double>{});
+        break;
+    }
     }
 }
 

--- a/src/kernels/composable_kernel/include/kernel_algorithm/reduction_functions.hpp
+++ b/src/kernels/composable_kernel/include/kernel_algorithm/reduction_functions.hpp
@@ -167,7 +167,8 @@ struct WarpReduce
 {
     using compType = typename opReduce::dataType;
     using binop    = detail::binop_with_nan_check<nanPropaOpt, opReduce, compType>;
-    constexpr static bool have_builtin_shuffle = std::is_same<compType, float>::value;
+    constexpr static bool have_builtin_shuffle =
+        std::is_same<compType, float>::value || std::is_same<compType, double>::value;
 
     // This interface does not accumulate on indices
     __device__ static void Reduce(const DataType* p_thread_buffer, compType& accuData)

--- a/src/ocl/tensorocl.cpp
+++ b/src/ocl/tensorocl.cpp
@@ -1924,6 +1924,9 @@ std::string GetCastTensorBuildOptionFromType(const std::string& buildOption, mio
     case miopenHalf: return option += "2";
     case miopenFloat: return option += "3";
     case miopenBFloat16: return option += "4";
+    case miopenDouble:
+        // TODO
+        MIOPEN_THROW(miopenStatusBadParm, "miopenDouble data type not supported in cast tensor.");
     case miopenInt8x4:
         MIOPEN_THROW(miopenStatusBadParm, "miopenInt8x4 data type not supported in cast tensor.");
     default: MIOPEN_THROW(miopenStatusBadParm, "Invalid data type in cast tensor desc.");

--- a/src/reducetensor.cpp
+++ b/src/reducetensor.cpp
@@ -570,9 +570,13 @@ void ReduceTensorDescriptor::ReduceTensor(const Handle& handle,
 #if WORKAROUND_MIOPEN_ISSUE_557
     if(StartsWith(handle.GetDeviceName(), "gfx10"))
         param += " -DCK_USE_AMD_BUFFER_ADDRESSING=0 ";
-    else if(srcDataType == miopenDouble)
-        // TODO: support from composable kernel utility for using AMD Buffer Addressing for double
-        param += " -DCK_USE_AMD_BUFFER_ADDRESSING=0 ";
+    else
+    {
+        if(srcDataType == miopenDouble)
+            // TODO: support from composable kernel utility for using AMD Buffer Addressing for
+            // double
+            param += " -DCK_USE_AMD_BUFFER_ADDRESSING=0 ";
+    };
 #else
     if(srcDataType == miopenDouble)
         // TODO: support from composable kernel utility for using AMD Buffer Addressing for double

--- a/src/reducetensor.cpp
+++ b/src/reducetensor.cpp
@@ -224,12 +224,13 @@ inline int GetDataTypeSize(miopenDataType_t t)
     {
     case miopenHalf: return (2);
     case miopenFloat: return (4);
+    case miopenDouble: return (8);
     case miopenInt8: return (1);
     case miopenInt8x4: return (4);
     case miopenBFloat16: return (2);
     case miopenInt32: return (4);
     default:
-        MIOPEN_THROW("Only float, half, bfloat16, int8, int8x4 data type is supported.");
+        MIOPEN_THROW("Only float, half, double, bfloat16, int8, int8x4 data type is supported.");
         break;
     };
 };
@@ -241,6 +242,7 @@ inline int GetDataTypeId(miopenDataType_t t)
     case miopenHalf: return (static_cast<int>('H'));
     case miopenFloat: return (static_cast<int>('F'));
     case miopenBFloat16: return (static_cast<int>('B'));
+    case miopenDouble: return (static_cast<int>('D'));
     case miopenInt8:
     case miopenInt8x4:
     case miopenInt32: return (static_cast<int>('O'));
@@ -568,6 +570,13 @@ void ReduceTensorDescriptor::ReduceTensor(const Handle& handle,
 #if WORKAROUND_MIOPEN_ISSUE_557
     if(StartsWith(handle.GetDeviceName(), "gfx10"))
         param += " -DCK_USE_AMD_BUFFER_ADDRESSING=0 ";
+    else if(srcDataType == miopenDouble)
+        // TODO: support from composable kernel utility for using AMD Buffer Addressing for double
+        param += " -DCK_USE_AMD_BUFFER_ADDRESSING=0 ";
+#else
+    if(srcDataType == miopenDouble)
+        // TODO: support from composable kernel utility for using AMD Buffer Addressing for double
+        param += " -DCK_USE_AMD_BUFFER_ADDRESSING=0 ";
 #endif
 
     std::string program_name = "gridwise_generic_reduction.cpp";
@@ -590,8 +599,12 @@ void ReduceTensorDescriptor::ReduceTensor(const Handle& handle,
     const std::vector<size_t> vgd_1 = {
         static_cast<size_t>(gridSize * blockSize), size_t{1}, size_t{1}};
 
-    float alphaVal = *reinterpret_cast<const float*>(alpha);
-    float betaVal  = *reinterpret_cast<const float*>(beta);
+    float alphaVal = (srcDataType == miopenDouble)
+                         ? static_cast<float>(*reinterpret_cast<const double*>(alpha))
+                         : *reinterpret_cast<const float*>(alpha);
+    float betaVal = (srcDataType == miopenDouble)
+                        ? static_cast<float>(*reinterpret_cast<const double*>(beta))
+                        : *reinterpret_cast<const float*>(beta);
 
     handle.AddKernel(algo_name, network_config, program_name, kernel_name1, vld_1, vgd_1, param)(
         alphaVal, A, betaVal, C, ws_buf1_global, ws_buf2_bytes_offset, indices);

--- a/src/reducetensor.cpp
+++ b/src/reducetensor.cpp
@@ -622,6 +622,8 @@ void ReduceTensorDescriptor::ReduceTensor(const Handle& handle,
 
         std::string param2 = param + " -DCK_PARAM_GRIDSIZE=" + std::to_string(gridSize_2) + " ";
 
+        std::string network_config2 = network_config + "_C2";
+
         // compile option and network config for the second-time call
         const std::vector<size_t> vld_2 = {static_cast<size_t>(blockSize), size_t{1}, size_t{1}};
         const std::vector<size_t> vgd_2 = {
@@ -631,7 +633,7 @@ void ReduceTensorDescriptor::ReduceTensor(const Handle& handle,
         std::string kernel_name2 = "gridwise_generic_reduce_2";
 
         handle.AddKernel(
-            algo_name, network_config, program_name, kernel_name2, vld_2, vgd_2, param2)(
+            algo_name, network_config2, program_name, kernel_name2, vld_2, vgd_2, param2)(
             alphaVal, A, betaVal, C, ws_buf1_global, ws_buf2_bytes_offset, indices);
     };
 };

--- a/src/solver/conv_asm_1x1u.cpp
+++ b/src/solver/conv_asm_1x1u.cpp
@@ -308,6 +308,9 @@ bool PerformanceConfigConvAsm1x1U::IsValid(const ConvolutionContext& config) con
 
 void PerformanceConfigConvAsm1x1U::HeuristicInit(const ConvolutionContext& config)
 {
+    if(config.in_data_type == miopenDouble)
+        MIOPEN_THROW("Double data type is not supported by ConvAsm1x1U");
+
     const auto elements_in_dword = 4 / GetTypeSize(config.in_data_type);
     read_size                    = 4;
     k_mult                       = 16;

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -141,6 +141,7 @@ std::size_t TensorDescriptor::GetNumBytes() const
     case miopenHalf: typesize = 2; break;
     case miopenInt32:
     case miopenFloat: typesize = 4; break;
+    case miopenDouble: typesize = 8; break;
     }
     return typesize * this->GetElementSpace();
 }

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -140,7 +140,7 @@ std::size_t TensorDescriptor::GetNumBytes() const
     case miopenBFloat16:
     case miopenHalf: typesize = 2; break;
     case miopenInt32:
-    case miopenFloat: typesize = 4; break;
+    case miopenFloat: typesize  = 4; break;
     case miopenDouble: typesize = 8; break;
     }
     return typesize * this->GetElementSpace();

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -217,7 +217,6 @@ set( LONG_TESTS
     pooling3d.cpp
     soft_max.cpp
     lrn_test.cpp
-    reduce_test.cpp
     )
 
 foreach(TEST ${TESTS})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1052,3 +1052,7 @@ if(MIOPEN_TEST_CONV)
     COMMAND	$<TARGET_FILE:test_conv2d>	--verbose	--input	1	48	7	7	--weights	1	48	5	5	--pads_strides_dilations	0	0	4	4	1	1
 )
 endif()
+
+if(MIOPEN_TEST_FLOAT)
+    add_custom_test(test_reduce_double SKIP_UNLESS_ALL FLOAT_ENABLED COMMAND  $<TARGET_FILE:test_reduce_test> --double --all)
+endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1054,5 +1054,5 @@ if(MIOPEN_TEST_CONV)
 endif()
 
 if(MIOPEN_TEST_FLOAT)
-    add_custom_test(test_reduce_double SKIP_UNLESS_ALL FLOAT_ENABLED COMMAND  $<TARGET_FILE:test_reduce_test> --double --all)
+    add_custom_test(test_reduce_double SKIP_UNLESS_ALL GFX908_ENABLED COMMAND  $<TARGET_FILE:test_reduce_test> --double --all --verbose)
 endif()

--- a/test/driver.hpp
+++ b/test/driver.hpp
@@ -1115,10 +1115,7 @@ void test_drive_impl_2(std::string program_name, std::vector<std::string> as)
         return;
     }
 
-    if(program_name.find("reduce") != std::string::npos)
-        set_driver_datatype<Driver>(d, arg_map);
-    else
-        throw std::runtime_error("Double is not supported");
+    set_driver_datatype<Driver>(d, arg_map);
 
     std::vector<std::vector<std::string>> configs = build_configs<Driver>(d, arg_map, keywords);
     size_t config_count                           = configs.size();
@@ -1175,10 +1172,7 @@ void test_drive_impl_1(std::string program_name, std::vector<std::string> as)
     }
     else if(arg_map.count("--double") > 0)
     {
-        if(program_name.find("reduce") == std::string::npos)
-            throw std::runtime_error("Double is not supported");
-        else
-            d.type = miopenDouble;
+        d.type = miopenDouble;
     }
     else
     {

--- a/test/driver.hpp
+++ b/test/driver.hpp
@@ -282,6 +282,7 @@ struct test_driver
         case miopenInt8: ss << "--int8 "; break;
         case miopenInt32: ss << "--int32 "; break;
         case miopenFloat: ss << "--float "; break;
+        case miopenDouble: ss << "--double "; break;
         }
         for(auto&& arg : this->arguments)
         {
@@ -308,6 +309,7 @@ struct test_driver
         case miopenInt8: ret.emplace_back("--int8"); break;
         case miopenInt32: ret.emplace_back("--int32"); break;
         case miopenFloat: ret.emplace_back("--float"); break;
+        case miopenDouble: ret.emplace_back("--double"); break;
         }
 
         for(auto&& arg : this->arguments)
@@ -1008,7 +1010,7 @@ void set_driver_datatype(Driver& d,
     }
     else if(arg_map.count("--double") > 0)
     {
-        throw std::runtime_error("Double is not supported");
+        d.type = miopenDouble;
     }
     else
     {
@@ -1113,7 +1115,11 @@ void test_drive_impl_2(std::string program_name, std::vector<std::string> as)
         return;
     }
 
-    set_driver_datatype<Driver>(d, arg_map);
+    if(program_name.find("reduce") != std::string::npos)
+        set_driver_datatype<Driver>(d, arg_map);
+    else
+        throw std::runtime_error("Double is not supported");
+
     std::vector<std::vector<std::string>> configs = build_configs<Driver>(d, arg_map, keywords);
     size_t config_count                           = configs.size();
     double running_average                        = 0;
@@ -1169,7 +1175,10 @@ void test_drive_impl_1(std::string program_name, std::vector<std::string> as)
     }
     else if(arg_map.count("--double") > 0)
     {
-        throw std::runtime_error("Double is not supported");
+        if(program_name.find("reduce") == std::string::npos)
+            throw std::runtime_error("Double is not supported");
+        else
+            d.type = miopenDouble;
     }
     else
     {
@@ -1310,7 +1319,7 @@ void test_drive(int argc, const char* argv[])
         }
         if(arg == "--double")
         {
-            // test_drive_impl<Driver<double>>(argv[0], std::move(as));
+            test_drive_impl<Driver<double>>(argv[0], std::move(as));
             break;
         }
     }

--- a/test/reduce_test.cpp
+++ b/test/reduce_test.cpp
@@ -347,21 +347,15 @@ struct verify_reduce_with_indices
         std::size_t ws_sizeInBytes      = workspace.desc.GetElementSize() * sizeof(T);
         std::size_t indices_sizeInBytes = indices.desc.GetElementSize() * sizeof(int);
 
-        double alphaData, betaData;
+        const double alpha64 = alpha;
+        const double beta64  = beta;
 
-        void* alphaPara = reinterpret_cast<void*>(&alphaData);
-        void* betaPara  = reinterpret_cast<void*>(&betaData);
-
-        if(std::is_same<T, double>::value)
-        {
-            *reinterpret_cast<double*>(alphaPara) = static_cast<double>(alpha);
-            *reinterpret_cast<double*>(betaPara)  = static_cast<double>(beta);
-        }
-        else
-        {
-            *reinterpret_cast<float*>(alphaPara) = alpha;
-            *reinterpret_cast<float*>(betaPara)  = beta;
-        };
+        const void* const alphaPtr = (std::is_same<T, double>::value)
+                                         ? reinterpret_cast<const void*>(&alpha64)
+                                         : reinterpret_cast<const void*>(&alpha);
+        const void* const betaPtr = (std::is_same<T, double>::value)
+                                        ? reinterpret_cast<const void*>(&beta64)
+                                        : reinterpret_cast<const void*>(&beta);
 
         if(ws_sizeInBytes > 0)
         {
@@ -372,10 +366,10 @@ struct verify_reduce_with_indices
                                 indices_sizeInBytes,
                                 workspace_dev.get(),
                                 ws_sizeInBytes,
-                                const_cast<const void*>(alphaPara),
+                                alphaPtr,
                                 input.desc,
                                 input_dev.get(),
-                                const_cast<const void*>(betaPara),
+                                betaPtr,
                                 output.desc,
                                 output_dev.get());
         }
@@ -386,10 +380,10 @@ struct verify_reduce_with_indices
                                 indices_sizeInBytes,
                                 nullptr,
                                 0,
-                                const_cast<const void*>(alphaPara),
+                                alphaPtr,
                                 input.desc,
                                 input_dev.get(),
-                                const_cast<const void*>(betaPara),
+                                betaPtr,
                                 output.desc,
                                 output_dev.get());
         };
@@ -650,21 +644,15 @@ struct verify_reduce_no_indices
 
         std::size_t ws_sizeInBytes = workspace.desc.GetElementSize() * sizeof(T);
 
-        double alphaData, betaData;
+        const double alpha64 = alpha;
+        const double beta64  = beta;
 
-        void* alphaPara = reinterpret_cast<void*>(&alphaData);
-        void* betaPara  = reinterpret_cast<void*>(&betaData);
-
-        if(std::is_same<T, double>::value)
-        {
-            *reinterpret_cast<double*>(alphaPara) = static_cast<double>(alpha);
-            *reinterpret_cast<double*>(betaPara)  = static_cast<double>(beta);
-        }
-        else
-        {
-            *reinterpret_cast<float*>(alphaPara) = alpha;
-            *reinterpret_cast<float*>(betaPara)  = beta;
-        };
+        const void* const alphaPtr = (std::is_same<T, double>::value)
+                                         ? reinterpret_cast<const void*>(&alpha64)
+                                         : reinterpret_cast<const void*>(&alpha);
+        const void* const betaPtr = (std::is_same<T, double>::value)
+                                        ? reinterpret_cast<const void*>(&beta64)
+                                        : reinterpret_cast<const void*>(&beta);
 
         if(ws_sizeInBytes > 0)
         {
@@ -675,10 +663,10 @@ struct verify_reduce_no_indices
                                 0,
                                 workspace_dev.get(),
                                 ws_sizeInBytes,
-                                static_cast<const void*>(alphaPara),
+                                alphaPtr,
                                 input.desc,
                                 input_dev.get(),
-                                static_cast<const void*>(betaPara),
+                                betaPtr,
                                 output.desc,
                                 output_dev.get());
         }
@@ -689,10 +677,10 @@ struct verify_reduce_no_indices
                                 0,
                                 nullptr,
                                 0,
-                                static_cast<const void*>(alphaPara),
+                                alphaPtr,
                                 input.desc,
                                 input_dev.get(),
-                                static_cast<const void*>(betaPara),
+                                betaPtr,
                                 output.desc,
                                 output_dev.get());
         };

--- a/test/reduce_test.cpp
+++ b/test/reduce_test.cpp
@@ -351,11 +351,11 @@ struct verify_reduce_with_indices
         const double beta64  = beta;
 
         const void* const alphaPtr = (std::is_same<T, double>::value)
-                                         ? reinterpret_cast<const void*>(&alpha64)
-                                         : reinterpret_cast<const void*>(&alpha);
+                                         ? static_cast<const void*>(&alpha64)
+                                         : static_cast<const void*>(&alpha);
         const void* const betaPtr = (std::is_same<T, double>::value)
-                                        ? reinterpret_cast<const void*>(&beta64)
-                                        : reinterpret_cast<const void*>(&beta);
+                                        ? static_cast<const void*>(&beta64)
+                                        : static_cast<const void*>(&beta);
 
         if(ws_sizeInBytes > 0)
         {
@@ -648,11 +648,11 @@ struct verify_reduce_no_indices
         const double beta64  = beta;
 
         const void* const alphaPtr = (std::is_same<T, double>::value)
-                                         ? reinterpret_cast<const void*>(&alpha64)
-                                         : reinterpret_cast<const void*>(&alpha);
+                                         ? static_cast<const void*>(&alpha64)
+                                         : static_cast<const void*>(&alpha);
         const void* const betaPtr = (std::is_same<T, double>::value)
-                                        ? reinterpret_cast<const void*>(&beta64)
-                                        : reinterpret_cast<const void*>(&beta);
+                                        ? static_cast<const void*>(&beta64)
+                                        : static_cast<const void*>(&beta);
 
         if(ws_sizeInBytes > 0)
         {

--- a/test/reduce_test.cpp
+++ b/test/reduce_test.cpp
@@ -46,6 +46,10 @@
 #define WORKAROUND_GPU_MEM_ACCESS_FAULT \
     (HIP_PACKAGE_VERSION_MAJOR == 3 && HIP_PACKAGE_VERSION_MINOR == 7)
 
+/// Not reproducible with ROCm 4.1 and 4.2.
+#define WORKAROUND_GPU_NUMERIC_ERROR \
+    (HIP_PACKAGE_VERSION_MAJOR == 3 && HIP_PACKAGE_VERSION_MINOR == 7)
+
 template <class T, bool toVerifyData>
 struct verify_reduce_with_indices
 {
@@ -782,6 +786,20 @@ struct reduce_driver : test_driver
             }
         }
 #endif
+
+#if WORKAROUND_GPU_NUMERIC_ERROR
+        if(std::is_same<T, double>::value)
+        {
+            if(inLengths == std::vector<std::size_t>{64, 3, 280, 81} &&
+               toReduceDims == std::vector<int>{0, 1, 2, 3} && (reduceOp == 3 || reduceOp == 4) &&
+               indicesOpt == 1)
+            {
+                std::cout << "Workaround: Skipping the test." << std::endl;
+                return;
+            };
+        }
+#endif
+
         miopen::ReduceTensorDescriptor reduceDesc(
             static_cast<miopenReduceTensorOp_t>(reduceOp),
             static_cast<miopenDataType_t>(compTypeVal),

--- a/test/reduce_test.cpp
+++ b/test/reduce_test.cpp
@@ -871,6 +871,9 @@ struct reduce_driver : test_driver
             return rand_upper * sign_value * rand_ratio;
         };
 
+        // default tolerance (refer to driver.hpp)
+        this->tolerance = 80;
+
         if(reduceOp == MIOPEN_REDUCE_TENSOR_MUL)
             this->tolerance = 80 * 300;
         else if(reduceOp == MIOPEN_REDUCE_TENSOR_NORM1 || reduceOp == MIOPEN_REDUCE_TENSOR_NORM2)

--- a/test/tensor_holder.hpp
+++ b/test/tensor_holder.hpp
@@ -86,6 +86,11 @@ struct miopen_type<float> : std::integral_constant<miopenDataType_t, miopenFloat
 };
 
 template <>
+struct miopen_type<double> : std::integral_constant<miopenDataType_t, miopenDouble>
+{
+};
+
+template <>
 struct miopen_type<half_float::half> : std::integral_constant<miopenDataType_t, miopenHalf>
 {
 };

--- a/test/tensor_vec.cpp
+++ b/test/tensor_vec.cpp
@@ -319,6 +319,12 @@ struct tensor_vec_driver : test_driver
             return;
         }
 
+        if(std::is_same<T, double>::value)
+        {
+            std::cout << "VEC2 transpose does not support double type" << std::endl;
+            return;
+        }
+
         if(!(miopen::float_equal(static_cast<const float>(alpha), 1.0) &&
              miopen::float_equal(static_cast<const float>(beta), 0.0)))
             return;


### PR DESCRIPTION
Adds `miopenDouble` to the public API.

Adds support for miopenReduceTensor() to be used on Tensors of double type data. All the 8 Reduction Operations which are supported with fp32/fp16 Tensors can be used with double Tensors. The alpha/beta scaling factors follow the same specification as what is used by cuddnReduceTensor(),  that is,  for fp32/fp16, alpha/beta should be float type passed by the application; for double, alpha/beta should be double type passed by the application.

This is expected to resolve https://ontrack-internal.amd.com/browse/SWDEV-284915.

<details><summary><b><i>The commits have gone through the following tests:</i></b></summary>

Regular MIOpen tests:
```bash
$ ./bin/test_reduce_test --double --all
$ ./bin/test_reduce_test --all
$ ./bin/test_reduce_test --half --all
```
Manual testing:
```bash
#!/bin/bash

### for fp64
bin/MIOpenDriver reducefp64 -D 64,3,280,81  -R 0 -O 0 
bin/MIOpenDriver reducefp64 -D 64,3,280,81  -R 0,1 -O 0 
bin/MIOpenDriver reducefp64 -D 64,3,280,81  -R 0,1,2 -O 0 
bin/MIOpenDriver reducefp64 -D 64,3,280,81  -R 0,1,2,3 -O 0 

bin/MIOpenDriver reducefp64 -D 64,3,280,81  -R 0 -O 1 
bin/MIOpenDriver reducefp64 -D 64,3,280,81  -R 0,1 -O 1 
bin/MIOpenDriver reducefp64 -D 64,3,280,81  -R 0,1,2 -O 1 
bin/MIOpenDriver reducefp64 -D 64,3,280,81  -R 0,1,2,3 -O 1 

bin/MIOpenDriver reducefp64 -D 64,3,280,81  -R 0 -O 2 -N 0 -I 1 
bin/MIOpenDriver reducefp64 -D 64,3,280,81  -R 0 -O 3 -N 0 -I 1 
bin/MIOpenDriver reducefp64 -D 64,3,280,81  -R 0 -O 4 -N 0 -I 1 

bin/MIOpenDriver reducefp64 -D 64,3,280,81  -R 0,1 -O 2 -N 0 -I 1 
bin/MIOpenDriver reducefp64 -D 64,3,280,81  -R 0,1 -O 3 -N 0 -I 1 
bin/MIOpenDriver reducefp64 -D 64,3,280,81  -R 0,1 -O 4 -N 0 -I 1 

bin/MIOpenDriver reducefp64 -D 64,3,280,81  -R 0,1,2 -O 2 -N 0 -I 1 
bin/MIOpenDriver reducefp64 -D 64,3,280,81  -R 0,1,2 -O 3 -N 0 -I 1 
bin/MIOpenDriver reducefp64 -D 64,3,280,81  -R 0,1,2 -O 4 -N 0 -I 1 

bin/MIOpenDriver reducefp64 -D 64,3,280,81  -R 0,1,2,3 -O 2 -N 0 -I 1 

## skip this on ROCm 3.7 due to unexpected numeric error
bin/MIOpenDriver reducefp64 -D 64,3,280,81  -R 0,1,2,3 -O 3 -N 0 -I 1 
## skip this on ROCm 3.7 due to unexpected numeric error
bin/MIOpenDriver reducefp64 -D 64,3,280,81  -R 0,1,2,3 -O 4 -N 0 -I 1 

bin/MIOpenDriver reducefp64 -D 64,3,280,81  -R 0 -O 5 
bin/MIOpenDriver reducefp64 -D 64,3,280,81  -R 0 -O 6 
bin/MIOpenDriver reducefp64 -D 64,3,280,81  -R 0 -O 7 

bin/MIOpenDriver reducefp64 -D 64,3,280,81  -R 0,1 -O 5 
bin/MIOpenDriver reducefp64 -D 64,3,280,81  -R 0,1 -O 6 
bin/MIOpenDriver reducefp64 -D 64,3,280,81  -R 0,1 -O 7 

bin/MIOpenDriver reducefp64 -D 64,3,280,81  -R 0,1,2 -O 5 
bin/MIOpenDriver reducefp64 -D 64,3,280,81  -R 0,1,2 -O 6 
bin/MIOpenDriver reducefp64 -D 64,3,280,81  -R 0,1,2 -O 7 

bin/MIOpenDriver reducefp64 -D 64,3,280,81  -R 0,1,2,3 -O 5 
bin/MIOpenDriver reducefp64 -D 64,3,280,81  -R 0,1,2,3 -O 6 
bin/MIOpenDriver reducefp64 -D 64,3,280,81  -R 0,1,2,3 -O 7 

### for fp32
bin/MIOpenDriver reduce -D 64,3,280,81  -R 0 -O 0
bin/MIOpenDriver reduce -D 64,3,280,81  -R 0,1 -O 0 
bin/MIOpenDriver reduce -D 64,3,280,81  -R 0,1,2 -O 0 
bin/MIOpenDriver reduce -D 64,3,280,81  -R 0,1,2,3 -O 0 

bin/MIOpenDriver reduce -D 64,3,280,81  -R 0 -O 1 
bin/MIOpenDriver reduce -D 64,3,280,81  -R 0,1 -O 1 
bin/MIOpenDriver reduce -D 64,3,280,81  -R 0,1,2 -O 1 
bin/MIOpenDriver reduce -D 64,3,280,81  -R 0,1,2,3 -O 1

bin/MIOpenDriver reduce -D 64,3,280,81  -R 0 -O 2 -N 0 -I 1
bin/MIOpenDriver reduce -D 64,3,280,81  -R 0 -O 3 -N 0 -I 1
bin/MIOpenDriver reduce -D 64,3,280,81  -R 0 -O 4 -N 0 -I 1

bin/MIOpenDriver reduce -D 64,3,280,81  -R 0,1 -O 2 -N 0 -I 1
bin/MIOpenDriver reduce -D 64,3,280,81  -R 0,1 -O 3 -N 0 -I 1
bin/MIOpenDriver reduce -D 64,3,280,81  -R 0,1 -O 4 -N 0 -I 1

bin/MIOpenDriver reduce -D 64,3,280,81  -R 0,1,2 -O 2 -N 0 -I 1
bin/MIOpenDriver reduce -D 64,3,280,81  -R 0,1,2 -O 3 -N 0 -I 1
bin/MIOpenDriver reduce -D 64,3,280,81  -R 0,1,2 -O 4 -N 0 -I 1

bin/MIOpenDriver reduce -D 64,3,280,81  -R 0,1,2,3 -O 2 -N 0 -I 1
bin/MIOpenDriver reduce -D 64,3,280,81  -R 0,1,2,3 -O 3 -N 0 -I 1
bin/MIOpenDriver reduce -D 64,3,280,81  -R 0,1,2,3 -O 4 -N 0 -I 1

bin/MIOpenDriver reduce -D 64,3,280,81  -R 0 -O 5 
bin/MIOpenDriver reduce -D 64,3,280,81  -R 0 -O 6
bin/MIOpenDriver reduce -D 64,3,280,81  -R 0 -O 7 

bin/MIOpenDriver reduce -D 64,3,280,81  -R 0,1 -O 5 
bin/MIOpenDriver reduce -D 64,3,280,81  -R 0,1 -O 6 
bin/MIOpenDriver reduce -D 64,3,280,81  -R 0,1 -O 7 

bin/MIOpenDriver reduce -D 64,3,280,81  -R 0,1,2 -O 5 
bin/MIOpenDriver reduce -D 64,3,280,81  -R 0,1,2 -O 6 
bin/MIOpenDriver reduce -D 64,3,280,81  -R 0,1,2 -O 7 

bin/MIOpenDriver reduce -D 64,3,280,81  -R 0,1,2,3 -O 5
bin/MIOpenDriver reduce -D 64,3,280,81  -R 0,1,2,3 -O 6 
bin/MIOpenDriver reduce -D 64,3,280,81  -R 0,1,2,3 -O 7 

### for fp16
bin/MIOpenDriver reducefp16 -D 4,3,60,50  -R 0 -O 0
bin/MIOpenDriver reducefp16 -D 4,3,60,50  -R 0,1 -O 0 
bin/MIOpenDriver reducefp16 -D 4,3,60,50  -R 0,1,2 -O 0 
bin/MIOpenDriver reducefp16 -D 4,3,60,50  -R 0,1,2,3 -O 0 

bin/MIOpenDriver reducefp16 -D 4,3,60,50  -R 0 -O 1 
bin/MIOpenDriver reducefp16 -D 4,3,60,50  -R 0,1 -O 1 
bin/MIOpenDriver reducefp16 -D 4,3,60,50  -R 0,1,2 -O 1 
bin/MIOpenDriver reducefp16 -D 4,3,60,50  -R 0,1,2,3 -O 1

bin/MIOpenDriver reducefp16 -D 4,3,60,50  -R 0 -O 2 -N 0 -I 1
bin/MIOpenDriver reducefp16 -D 4,3,60,50  -R 0 -O 3 -N 0 -I 1
bin/MIOpenDriver reducefp16 -D 4,3,60,50  -R 0 -O 4 -N 0 -I 1

bin/MIOpenDriver reducefp16 -D 4,3,60,50  -R 0,1 -O 2 -N 0 -I 1
bin/MIOpenDriver reducefp16 -D 4,3,60,50  -R 0,1 -O 3 -N 0 -I 1
bin/MIOpenDriver reducefp16 -D 4,3,60,50  -R 0,1 -O 4 -N 0 -I 1

bin/MIOpenDriver reducefp16 -D 4,3,60,50  -R 0,1,2 -O 2 -N 0 -I 1
bin/MIOpenDriver reducefp16 -D 4,3,60,50  -R 0,1,2 -O 3 -N 0 -I 1
bin/MIOpenDriver reducefp16 -D 4,3,60,50  -R 0,1,2 -O 4 -N 0 -I 1

bin/MIOpenDriver reducefp16 -D 4,3,60,50  -R 0,1,2,3 -O 2 -N 0 -I 1
bin/MIOpenDriver reducefp16 -D 4,3,60,50  -R 0,1,2,3 -O 3 -N 0 -I 1
bin/MIOpenDriver reducefp16 -D 4,3,60,50  -R 0,1,2,3 -O 4 -N 0 -I 1

bin/MIOpenDriver reducefp16 -D 4,3,60,50  -R 0 -O 5 
bin/MIOpenDriver reducefp16 -D 4,3,60,50  -R 0 -O 6
bin/MIOpenDriver reducefp16 -D 4,3,60,50  -R 0 -O 7 

bin/MIOpenDriver reducefp16 -D 4,3,60,50  -R 0,1 -O 5 
bin/MIOpenDriver reducefp16 -D 4,3,60,50  -R 0,1 -O 6 
bin/MIOpenDriver reducefp16 -D 4,3,60,50  -R 0,1 -O 7 

bin/MIOpenDriver reducefp16 -D 4,3,60,50  -R 0,1,2 -O 5 
bin/MIOpenDriver reducefp16 -D 4,3,60,50  -R 0,1,2 -O 6 
bin/MIOpenDriver reducefp16 -D 4,3,60,50  -R 0,1,2 -O 7 

bin/MIOpenDriver reducefp16 -D 4,3,60,50  -R 0,1,2,3 -O 5
bin/MIOpenDriver reducefp16 -D 4,3,60,50  -R 0,1,2,3 -O 6 
bin/MIOpenDriver reducefp16 -D 4,3,60,50  -R 0,1,2,3 -O 7 
```