### PR TITLE
[MLIR] Binary backend - step 7 - Implement v4r1 algorithm for bwd solvers

### DIFF
--- a/src/include/miopen/solver/mlir_common.hpp
+++ b/src/include/miopen/solver/mlir_common.hpp
@@ -36,11 +36,11 @@ namespace solver {
 namespace mlir {
 
 std::string InsertGToLayout(const std::string& layout, char dim);
-std::string PopulateHandle(const ConvolutionContext& ctx,
-                           const std::string& operation,
-                           const std::string& kernel_name,
-                           bool is_xdlops,
-                           int kernel_id = 0);
+std::string ConstructBuildOptions(const ConvolutionContext& ctx,
+                                  const std::string& operation,
+                                  const std::string& kernel_name,
+                                  bool is_xdlops,
+                                  int kernel_id = 0);
 
 } // namespace mlir
 } // namespace solver

--- a/src/include/miopen/solver/mlir_common.hpp
+++ b/src/include/miopen/solver/mlir_common.hpp
@@ -39,7 +39,8 @@ std::string InsertGToLayout(const std::string& layout, char dim);
 std::string PopulateHandle(const ConvolutionContext& ctx,
                            const std::string& operation,
                            const std::string& kernel_name,
-                           bool isXdlops);
+                           bool is_xdlops,
+                           int kernel_id = 0);
 
 } // namespace mlir
 } // namespace solver

--- a/src/solver/conv_mlir_igemm_bwd.cpp
+++ b/src/solver/conv_mlir_igemm_bwd.cpp
@@ -101,7 +101,7 @@ bool ConvMlirIgemmBwd::IsApplicable(const ConvolutionContext& ctx) const
         return false;
 
     return MiirIsConfigApplicable(
-        mlir::PopulateHandle(ctx, GetOperation(), GetKernelName(), false));
+        mlir::ConstructBuildOptions(ctx, GetOperation(), GetKernelName(), false));
 #else
     std::ignore = ctx;
     return false;
@@ -112,16 +112,16 @@ ConvSolution ConvMlirIgemmBwd::GetSolution(const ConvolutionContext& ctx) const
 {
 #if MIOPEN_USE_MLIR
     ConvSolution result;
-    int kernel_count =
-        MiirGetKernelCount(mlir::PopulateHandle(ctx, GetOperation(), GetKernelName(), false));
+    int kernel_count = MiirGetKernelCount(
+        mlir::ConstructBuildOptions(ctx, GetOperation(), GetKernelName(), false));
 
-    for(std::size_t kernel_id = 0; kernel_id < kernel_count; ++kernel_id)
+    for(int kernel_id = 0; kernel_id < kernel_count; ++kernel_id)
     {
         KernelInfo construction_parameters;
 
         construction_parameters.kernel_name  = GetKernelName() + std::to_string(kernel_id);
         construction_parameters.kernel_file  = construction_parameters.kernel_name + ".mlir";
-        construction_parameters.comp_options = mlir::PopulateHandle(
+        construction_parameters.comp_options = mlir::ConstructBuildOptions(
             ctx, GetOperation(), construction_parameters.kernel_name, false, kernel_id);
 
         size_t local_size  = 0;

--- a/src/solver/conv_mlir_igemm_bwd_xdlops.cpp
+++ b/src/solver/conv_mlir_igemm_bwd_xdlops.cpp
@@ -99,7 +99,8 @@ bool ConvMlirIgemmBwdXdlops::IsApplicable(const ConvolutionContext& ctx) const
     if(!IsValidGridGemmXdlops(gemm_m, gemm_n, gemm_k))
         return false;
 
-    return MiirIsConfigApplicable(mlir::PopulateHandle(ctx, GetOperation(), GetKernelName(), true));
+    return MiirIsConfigApplicable(
+        mlir::ConstructBuildOptions(ctx, GetOperation(), GetKernelName(), true));
 #else
     std::ignore = ctx;
     return false;
@@ -111,16 +112,16 @@ ConvSolution ConvMlirIgemmBwdXdlops::GetSolution(const ConvolutionContext& ctx) 
 #if MIOPEN_USE_MLIR
     ConvSolution result;
     int kernel_count =
-        MiirGetKernelCount(mlir::PopulateHandle(ctx, GetOperation(), GetKernelName(), true));
+        MiirGetKernelCount(mlir::ConstructBuildOptions(ctx, GetOperation(), GetKernelName(), true));
 
-    for(std::size_t kernel_id = 0; kernel_id < kernel_count; ++kernel_id)
+    for(int kernel_id = 0; kernel_id < kernel_count; ++kernel_id)
     {
         KernelInfo construction_parameters;
 
         construction_parameters.kernel_name = GetKernelName() + std::to_string(kernel_id);
         construction_parameters.kernel_file = construction_parameters.kernel_name + ".mlir";
         construction_parameters.comp_options =
-            mlir::PopulateHandle(ctx, GetOperation(), GetKernelName(), true, kernel_id);
+            mlir::ConstructBuildOptions(ctx, GetOperation(), GetKernelName(), true, kernel_id);
 
         size_t local_size  = 0;
         size_t global_size = 0;

--- a/src/solver/conv_mlir_igemm_bwd_xdlops.cpp
+++ b/src/solver/conv_mlir_igemm_bwd_xdlops.cpp
@@ -62,7 +62,7 @@ std::tuple<int, int, int> CalculateGemmSize(const ConvolutionContext& ctx)
 
 std::string GetKernelName()
 {
-    std::string version   = "_v1r1";
+    std::string version   = "_v4r1";
     std::string direction = "_bwd";
     return "mlir_gen_igemm_conv2d" + version + direction + "_xdlops";
 }
@@ -110,27 +110,32 @@ ConvSolution ConvMlirIgemmBwdXdlops::GetSolution(const ConvolutionContext& ctx) 
 {
 #if MIOPEN_USE_MLIR
     ConvSolution result;
-    KernelInfo construction_parameters;
+    int kernel_count =
+        MiirGetKernelCount(mlir::PopulateHandle(ctx, GetOperation(), GetKernelName(), true));
 
-    construction_parameters.kernel_name = GetKernelName();
-    construction_parameters.kernel_file = construction_parameters.kernel_name + ".mlir";
-    construction_parameters.comp_options =
-        mlir::PopulateHandle(ctx, GetOperation(), GetKernelName(), true);
+    for(std::size_t kernel_id = 0; kernel_id < kernel_count; ++kernel_id)
+    {
+        KernelInfo construction_parameters;
 
-    size_t local_size  = 0;
-    size_t global_size = 0;
-    MiirGenLaunchParams(construction_parameters.comp_options, local_size, global_size);
+        construction_parameters.kernel_name = GetKernelName() + std::to_string(kernel_id);
+        construction_parameters.kernel_file = construction_parameters.kernel_name + ".mlir";
+        construction_parameters.comp_options =
+            mlir::PopulateHandle(ctx, GetOperation(), GetKernelName(), true, kernel_id);
 
-    construction_parameters.l_wk.push_back(local_size);
-    construction_parameters.l_wk.push_back(1);
-    construction_parameters.l_wk.push_back(1);
+        size_t local_size  = 0;
+        size_t global_size = 0;
+        MiirGenLaunchParams(construction_parameters.comp_options, local_size, global_size);
+        construction_parameters.l_wk.push_back(local_size);
+        construction_parameters.l_wk.push_back(1);
+        construction_parameters.l_wk.push_back(1);
+        construction_parameters.g_wk.push_back(global_size);
+        construction_parameters.g_wk.push_back(1);
+        construction_parameters.g_wk.push_back(1);
 
-    construction_parameters.g_wk.push_back(global_size);
-    construction_parameters.g_wk.push_back(1);
-    construction_parameters.g_wk.push_back(1);
+        result.construction_params.push_back(construction_parameters);
+    }
 
     result.invoker_factory = conv::MakeMlirBwdInvokerFactory(ctx);
-    result.construction_params.push_back(construction_parameters);
     return result;
 #else
     std::ignore = ctx;

--- a/src/solver/conv_mlir_igemm_fwd.cpp
+++ b/src/solver/conv_mlir_igemm_fwd.cpp
@@ -96,7 +96,7 @@ bool ConvMlirIgemmFwd::IsApplicable(const ConvolutionContext& ctx) const
         return false;
 
     return MiirIsConfigApplicable(
-        mlir::PopulateHandle(ctx, GetOperation(), GetKernelName(), false));
+        mlir::ConstructBuildOptions(ctx, GetOperation(), GetKernelName(), false));
 #else
     std::ignore = ctx;
     return false;
@@ -112,7 +112,7 @@ ConvSolution ConvMlirIgemmFwd::GetSolution(const ConvolutionContext& ctx) const
     construction_parameters.kernel_name = GetKernelName();
     construction_parameters.kernel_file = construction_parameters.kernel_name + ".mlir";
     construction_parameters.comp_options =
-        mlir::PopulateHandle(ctx, GetOperation(), GetKernelName(), false);
+        mlir::ConstructBuildOptions(ctx, GetOperation(), GetKernelName(), false);
 
     size_t local_size  = 0;
     size_t global_size = 0;

--- a/src/solver/conv_mlir_igemm_fwd_xdlops.cpp
+++ b/src/solver/conv_mlir_igemm_fwd_xdlops.cpp
@@ -99,7 +99,8 @@ bool ConvMlirIgemmFwdXdlops::IsApplicable(const ConvolutionContext& ctx) const
     if(!IsValidGridGemmXdlops(gemm_m, gemm_n, gemm_k))
         return false;
 
-    return MiirIsConfigApplicable(mlir::PopulateHandle(ctx, GetOperation(), GetKernelName(), true));
+    return MiirIsConfigApplicable(
+        mlir::ConstructBuildOptions(ctx, GetOperation(), GetKernelName(), true));
 #else
     std::ignore = ctx;
     return false;
@@ -115,7 +116,7 @@ ConvSolution ConvMlirIgemmFwdXdlops::GetSolution(const ConvolutionContext& ctx) 
     construction_parameters.kernel_name = GetKernelName();
     construction_parameters.kernel_file = construction_parameters.kernel_name + ".mlir";
     construction_parameters.comp_options =
-        mlir::PopulateHandle(ctx, GetOperation(), GetKernelName(), true);
+        mlir::ConstructBuildOptions(ctx, GetOperation(), GetKernelName(), true);
 
     size_t local_size  = 0;
     size_t global_size = 0;

--- a/src/solver/conv_mlir_igemm_wrw.cpp
+++ b/src/solver/conv_mlir_igemm_wrw.cpp
@@ -99,7 +99,7 @@ bool ConvMlirIgemmWrW::IsApplicable(const ConvolutionContext& ctx) const
         return false;
 
     return MiirIsConfigApplicable(
-        mlir::PopulateHandle(ctx, GetOperation(), GetKernelName(), false));
+        mlir::ConstructBuildOptions(ctx, GetOperation(), GetKernelName(), false));
 #else
     std::ignore = ctx;
     return false;
@@ -115,7 +115,7 @@ ConvSolution ConvMlirIgemmWrW::GetSolution(const ConvolutionContext& ctx) const
     construction_parameters.kernel_name = GetKernelName();
     construction_parameters.kernel_file = construction_parameters.kernel_name + ".mlir";
     construction_parameters.comp_options =
-        mlir::PopulateHandle(ctx, GetOperation(), GetKernelName(), false);
+        mlir::ConstructBuildOptions(ctx, GetOperation(), GetKernelName(), false);
 
     size_t local_size  = 0;
     size_t global_size = 0;

--- a/src/solver/conv_mlir_igemm_wrw_xdlops.cpp
+++ b/src/solver/conv_mlir_igemm_wrw_xdlops.cpp
@@ -102,7 +102,8 @@ bool ConvMlirIgemmWrWXdlops::IsApplicable(const ConvolutionContext& ctx) const
     if(!IsValidGridGemmXdlops(gemm_m, gemm_n, gemm_k))
         return false;
 
-    return MiirIsConfigApplicable(mlir::PopulateHandle(ctx, GetOperation(), GetKernelName(), true));
+    return MiirIsConfigApplicable(
+        mlir::ConstructBuildOptions(ctx, GetOperation(), GetKernelName(), true));
 #else
     std::ignore = ctx;
     return false;
@@ -118,7 +119,7 @@ ConvSolution ConvMlirIgemmWrWXdlops::GetSolution(const ConvolutionContext& ctx) 
     construction_parameters.kernel_name = GetKernelName();
     construction_parameters.kernel_file = construction_parameters.kernel_name + ".mlir";
     construction_parameters.comp_options =
-        mlir::PopulateHandle(ctx, GetOperation(), GetKernelName(), true);
+        mlir::ConstructBuildOptions(ctx, GetOperation(), GetKernelName(), true);
 
     size_t local_size  = 0;
     size_t global_size = 0;

--- a/src/solver/mlir_common.cpp
+++ b/src/solver/mlir_common.cpp
@@ -44,7 +44,8 @@ std::string InsertGToLayout(const std::string& layout, char dim)
 std::string PopulateHandle(const ConvolutionContext& ctx,
                            const std::string& operation,
                            const std::string& kernel_name,
-                           bool isXdlops)
+                           bool is_xdlops,
+                           int kernel_id)
 {
     // Arguments for mlir-miopen-driver.
     // clang-format off
@@ -55,13 +56,14 @@ std::string PopulateHandle(const ConvolutionContext& ctx,
     std::string out_layout = InsertGToLayout(CI::GetOutputLayout(ctx), 'C');
 
     std::string mlir_handle;
-    if (isXdlops)
+    if (is_xdlops)
         mlir_handle += std::string(" --x2 ") + "1";
 
     std::string data_type = ctx.IsFp32() ? "fp32" : "fp16";
 
     mlir_handle +=
         std::string(" --operation ") + operation +
+        std::string(" --kernel_id ") + std::to_string(kernel_id) +
         std::string(" --num_cu ") + std::to_string(ctx.GetStream().GetMaxComputeUnits()) +
         std::string(" --arch ") + ctx.GetStream().GetDeviceName() +
         std::string(" --groupsize ") + std::to_string(CI::GetGroupCountG(ctx)) +

--- a/src/solver/mlir_common.cpp
+++ b/src/solver/mlir_common.cpp
@@ -41,11 +41,11 @@ std::string InsertGToLayout(const std::string& layout, char dim)
     return layout_with_g.insert(index, 1, 'G');
 }
 
-std::string PopulateHandle(const ConvolutionContext& ctx,
-                           const std::string& operation,
-                           const std::string& kernel_name,
-                           bool is_xdlops,
-                           int kernel_id)
+std::string ConstructBuildOptions(const ConvolutionContext& ctx,
+                                  const std::string& operation,
+                                  const std::string& kernel_name,
+                                  bool is_xdlops,
+                                  int kernel_id)
 {
     // Arguments for mlir-miopen-driver.
     // clang-format off


### PR DESCRIPTION
*Please note: this PR can not and should not be tested because MLIR support for it is not there yet. Since both bwd and bwd_xdlops solvers are also disabled, running CI through does not exercise those two solvers. I am pushing those changes hoping that this will simplify the final bring up process.*
  - *If things are working as expected when MLIR add support for both solvers, the only thing needs to be done in MIOpen side is to bump the MLIR commit id/ add bwd unit tests.*
  - *If anything else needs to be adjusted, further PR will be filed to update the MIOpen side of the implementation.*
 
----

This PR does the following:
 - Used the MiirGetKernelCount() API for kernel count in bwd solvers
 - Implement v4r1 bwd multi-kernel compilation in bwd solvers
    - This replaced the original v1r1 implementation which doesn't work in post ROCm 3.7 releases
 - Implement v4r1 bwd invoker that expect multi-kernel invokation

---

Previous PRs in the series:

https://github.com/ROCmSoftwarePlatform/MIOpen/pull/841
https://github.com/ROCmSoftwarePlatform/MIOpen/pull/889
https://github.com/ROCmSoftwarePlatform/MIOpen/pull/892
https://github.com/ROCmSoftwarePlatform/MIOpen/pull/902
https://github.com/ROCmSoftwarePlatform/MIOpen/pull/912
https://github.com/ROCmSoftwarePlatform/MIOpen/pull/927