### PR TITLE
Fix NCHW bwd asm igemm solver. Remove WORKAROUND_SWDEV_286774.

### DIFF
--- a/src/solver/conv_asm_implicit_gemm_gtc_bwd.cpp
+++ b/src/solver/conv_asm_implicit_gemm_gtc_bwd.cpp
@@ -31,8 +31,6 @@
 #include <miopen/solver/implicitgemm_util.hpp>
 #include <miopen/conv/asm_implicit_gemm.hpp>
 
-#define WORKAROUND_SWDEV_286774 1
-
 MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_ASM_BWD_GTC_XDLOPS)
 
 namespace miopen {
@@ -860,6 +858,13 @@ static std::tuple<bool, // is suitable kernel found
         if(b % cfg.nxb != 0)
             continue;
 
+        // if thread length have multiple value in K direction, then must make sure K is multiply of
+        // gemm_k_per_block
+        if((cfg.tensor_a_thread_lengths[0] != 1 || cfg.tensor_a_thread_lengths[1] != 1 ||
+            cfg.tensor_b_thread_lengths[0] != 1 || cfg.tensor_b_thread_lengths[1] != 1) &&
+           (k % cfg.gemm_k_per_block != 0))
+            continue;
+
         bool gemm_k_valid = true;
         for(int gemm_id = 0; gemm_id < num_of_gemm; gemm_id++)
         {
@@ -931,6 +936,13 @@ static std::tuple<bool, // is suitable kernel found
             if(b % cfg.nxb != 0)
                 continue;
 
+            // if thread length have multiple value in K direction, then must make sure K is
+            // multiply of gemm_k_per_block
+            if((cfg.tensor_a_thread_lengths[0] != 1 || cfg.tensor_a_thread_lengths[1] != 1 ||
+                cfg.tensor_b_thread_lengths[0] != 1 || cfg.tensor_b_thread_lengths[1] != 1) &&
+               (k % cfg.gemm_k_per_block != 0))
+                continue;
+
             bool gemm_k_valid = true;
             for(int gemm_id = 0; gemm_id < num_of_gemm; gemm_id++)
             {
@@ -981,11 +993,6 @@ bool ConvAsmImplicitGemmGTCDynamicBwdXdlops::IsApplicable(const ConvolutionConte
 
     if(!ctx.IsFp32() && !ctx.IsFp16())
         return false;
-
-#if WORKAROUND_SWDEV_286774
-    if(ctx.IsFp16() && !miopen::IsEnabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_ASM_BWD_GTC_XDLOPS{}))
-        return false;
-#endif
 
     if(!ctx.rmv.IsV3())
         return false;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -783,7 +783,9 @@ COMMAND ${DYNAMIC_IMPLICITGEMM_BWD_ENVS_XDLOPS} $<TARGET_FILE:test_conv2d> --ver
 COMMAND ${DYNAMIC_IMPLICITGEMM_BWD_ENVS_XDLOPS} $<TARGET_FILE:test_conv2d> --verbose --input  4  512 128 128 --weights 12  512  1 1 --pads_strides_dilations 0 0 1 1 1 1 --disable-forward --disable-backward-weights
 COMMAND ${DYNAMIC_IMPLICITGEMM_BWD_ENVS_XDLOPS} $<TARGET_FILE:test_conv2d> --verbose --input  400  256 7 7 --weights 1024  256  7 7 --pads_strides_dilations 0 0 1 1 1 1 --disable-forward --disable-backward-weights
 COMMAND ${DYNAMIC_IMPLICITGEMM_BWD_ENVS_XDLOPS} $<TARGET_FILE:test_conv2d> --verbose --input  400  256 1 1 --weights 1024  256  1 1 --pads_strides_dilations 0 0 1 1 1 1 --disable-forward --disable-backward-weights
+COMMAND ${DYNAMIC_IMPLICITGEMM_BWD_ENVS_XDLOPS} $<TARGET_FILE:test_conv2d> --verbose --input  8  16 5 5 --weights 8  16  2 2 --pads_strides_dilations 0 0 1 1 1 1 --disable-forward --disable-backward-weights
 )
+
 add_custom_test(test_conv_igemm_dynamic_xdlops_fwd SKIP_UNLESS_ALL ALLOW_HALF
 COMMAND ${DYNAMIC_IMPLICITGEMM_FWD_GTC_DYNAMIC_XDLOPS_ENVS} $<TARGET_FILE:test_conv2d> --verbose --input 64 1024 14 14 --weights 1024 1024 1 1 --pads_strides_dilations 0 0 1 1 1 1 --disable-backward-data --disable-backward-weights
 COMMAND ${DYNAMIC_IMPLICITGEMM_FWD_GTC_DYNAMIC_XDLOPS_ENVS} $<TARGET_FILE:test_conv2d> --verbose --input 64 256 56 56 --weights 512 256 1 1 --pads_strides_dilations 0 0 2 2 1 1 --disable-backward-data --disable-backward-weights

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -770,7 +770,7 @@ COMMAND ${DYNAMIC_IMPLICITGEMM_BWD_ENVS} $<TARGET_FILE:test_conv2d> --verbose --
 COMMAND ${DYNAMIC_IMPLICITGEMM_BWD_ENVS} $<TARGET_FILE:test_conv2d> --verbose --input 128  256 56 56 --weights 64  256 1 1 --pads_strides_dilations 0 0 1 1 1 1 --disable-forward --disable-backward-weights
 )
 
-add_custom_test(test_conv_igemm_dynamic_xdlops_bwd SKIP_UNLESS_ALL
+add_custom_test(test_conv_igemm_dynamic_xdlops_bwd SKIP_UNLESS_ALL ALLOW_HALF
 COMMAND ${DYNAMIC_IMPLICITGEMM_BWD_ENVS_XDLOPS} $<TARGET_FILE:test_conv2d> --verbose --input  64  64 28 28 --weights 16  64 1 1 --pads_strides_dilations 0 0 1 1 1 1 --disable-forward --disable-backward-weights
 COMMAND ${DYNAMIC_IMPLICITGEMM_BWD_ENVS_XDLOPS} $<TARGET_FILE:test_conv2d> --verbose --input  16  128 36 36 --weights 32  128 1 1 --pads_strides_dilations 0 0 1 1 1 1 --disable-forward --disable-backward-weights
 COMMAND ${DYNAMIC_IMPLICITGEMM_BWD_ENVS_XDLOPS} $<TARGET_FILE:test_conv2d> --verbose --input  64   64 56 56 --weights 256  64  1 1 --pads_strides_dilations 0 0 1 1 1 1 --disable-forward --disable-backward-weights


### PR DESCRIPTION
Resolves #948. K need be multiple of gemm_k_per_block when thread_length have value not equal to 1.

test passed according to config from https://github.com/ROCmSoftwarePlatform/MIOpen/pull/945#issuecomment-846305287
```
# MIOPEN_DEBUG_FIND_ONLY_SOLVER=ConvAsmImplicitGemmGTCDynamicBwdXdlops  LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt//conda/lib/ MIOPEN_LOG_LEVEL=5 MIOPEN_FIND_MODE=1 ./bin/MIOpenDriver convfp16 -n 8 -c 16 -H 5 -W 5 -k 8 -y 2 -x 2 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 2 -t 1 -V 1 2>&1
MIOPEN_DEBUG_FIND_ONLY_SOLVER=ConvAsmImplicitGemmGTCDynamicBwdXdlops  LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt//conda/lib/ MIOPEN_LOG_LEVEL=5 MIOPEN_FIND_MODE=1 ./bin/MIOpenDriver convfp16 -n 8 -c 16 -H 5 -W 5 -k 8 -y 2 -x 2 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 2 -t 1 -V 1 2>&1 | tee log.txt
MIOpenDriver convfp16 -n 8 -c 16 -H 5 -W 5 -k 8 -y 2 -x 2 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 2 -t 1 -V 1
MIOpen(HIP): Info [get_device_name] Raw device name: gfx908:sramecc+:xnack-
MIOpen(HIP): Info [Handle] stream: 0x1ae3c30, device_id: 0
MIOpen(HIP): Info [GetFindModeValueImpl] MIOPEN_FIND_MODE = NORMAL(1)
MIOpen(HIP): Info [BackwardDataGetWorkSpaceSize]
MIOpen(HIP): Info [HipCompilerVersionImpl] 4.2.21185
MIOpen(HIP): Info [AmdRocmMetadataVersionDetect] ROCm MD version AMDHSA_COv3, MIOpen version 2.12.0.0b58280-dirty
MIOpen(HIP): Info [GetEnvFindOnlySolverImpl] 82
MIOpen(HIP): Info [FindConvBwdDataAlgorithm] requestAlgoCount = 2, workspace = 0
MIOpen(HIP): Info [TryLoad] Find-db regenerating.
MIOpen(HIP): Info [FindSolutionImpl] ConvAsmImplicitGemmGTCDynamicBwdXdlops (not searchable)
MIOpen(HIP): Info [EvaluateInvokers] ConvAsmImplicitGemmGTCDynamicBwdXdlops: igemm_bwd_gtcx_nchw_fp16_bx4_ex1_bt16x32x8_wt8x32x4_ws1x1_wr1x1_ta1x1x1x1_1x8x1x16_tb1x1x2x1_1x8x1x16: 0.01232 < 3.40282e+38
MIOpen(HIP): Info [EvaluateInvokers] Selected: ConvAsmImplicitGemmGTCDynamicBwdXdlops: igemm_bwd_gtcx_nchw_fp16_bx4_ex1_bt16x32x8_wt8x32x4_ws1x1_wr1x1_ta1x1x1x1_1x8x1x16_tb1x1x2x1_1x8x1x16: 0.01232, workspce_sz = 0
MIOpen(HIP): Info [FindConvBwdDataAlgorithm] miopenConvolutionBwdDataAlgoImplicitGEMM   0.01232 0
MIOpen(HIP): Info [FindConvBwdDataAlgorithm] BWD Chosen Algorithm: ConvAsmImplicitGemmGTCDynamicBwdXdlops , 0, 0.01232
MIOpen(HIP): Info [ConvolutionBackwardData] algo = 5, workspace = 0
MIOpen(HIP): Info [ConvolutionBackwardData] algo = 5, workspace = 0
MIOpen(HIP): Info [ConvolutionBackwardData] algo = 5, workspace = 0
MIOpen(HIP): Info [ConvolutionBackwardData] algo = 5, workspace = 0
MIOpen(HIP): Info [ConvolutionBackwardData] algo = 5, workspace = 0
MIOpen(HIP): Info [ConvolutionBackwardData] algo = 5, workspace = 0
MIOpen(HIP): Info [ConvolutionBackwardData] algo = 5, workspace = 0
MIOpen(HIP): Info [ConvolutionBackwardData] algo = 5, workspace = 0
MIOpen(HIP): Info [ConvolutionBackwardData] algo = 5, workspace = 0
MIOpen(HIP): Info [ConvolutionBackwardData] algo = 5, workspace = 0
MIOpen Backward Data Conv. Algorithm: 5, Solution: 82/ConvAsmImplicitGemmGTCDynamicBwdXdlops
GPU Kernel Time Backward Data Conv. Elapsed: 0.011769 ms (average)
stats: name, n, c, ho, wo, x, y, k, flopCnt, bytesRead, bytesWritten, GFLOPs, GB/s, timeMs
stats: bwdd-conv2x2u1, 8, 16, 2, 2, 8, 4, 4,  131072, 3072, 2048, 11, 0, 0.011769
Backward Convolution Data Verifies OK on CPU reference (6.74569e-05)
```

More info on testing: https://github.com/ROCmSoftwarePlatform/MIOpen/pull/952#issuecomment-847639019