### PR TITLE
Fix missing padding of the transformed 2d-src and 1d-dst tensors in Generic-Tensor Reduction (SWDEV-284291)

### DIFF
--- a/src/kernels/composable_kernel/include/kernel_algorithm/reduction_kernel_simple_configurator.hpp
+++ b/src/kernels/composable_kernel/include/kernel_algorithm/reduction_kernel_simple_configurator.hpp
@@ -16,9 +16,9 @@ struct ReduceKernelSimpleConfigurator
     template <index_t invariantLength, index_t toReduceLength>
     __device__ static constexpr index_t GetGridSize(Number<invariantLength>, Number<toReduceLength>)
     {
-        if(toReduceLength < warpSize / 4) // let one thread to do each reduction
+        if(toReduceLength <= warpSize / 4) // let one thread to do each reduction
             return ((invariantLength + BlockSize - 1) / BlockSize);
-        else if(toReduceLength < BlockSize) // let one warp to do each reduction
+        else if(toReduceLength <= BlockSize) // let one warp to do each reduction
             return ((invariantLength + numWarpsPerBlock - 1) / numWarpsPerBlock);
         else
             return (invariantLength); // let one block to do each reduction
@@ -28,9 +28,9 @@ struct ReduceKernelSimpleConfigurator
     __device__ static constexpr ReductionMethod_t GetReductionMethod(Number<invariantLength>,
                                                                      Number<toReduceLength>)
     {
-        if(toReduceLength < warpSize / 4) // let one thread to do each reduction
+        if(toReduceLength <= warpSize / 4) // let one thread to do each reduction
             return (ReductionMethod_t::DirectThreadWise);
-        else if(toReduceLength < BlockSize) // let one warp to do each reduction
+        else if(toReduceLength <= BlockSize) // let one warp to do each reduction
             return (ReductionMethod_t::DirectWarpWise);
         else
             return (ReductionMethod_t::BlockWise);

--- a/src/kernels/composable_kernel/src/kernel_wrapper/gridwise_generic_reduction.cpp
+++ b/src/kernels/composable_kernel/src/kernel_wrapper/gridwise_generic_reduction.cpp
@@ -89,6 +89,8 @@ using srcDataType = typename get_type_from_type_id<static_cast<char>(CK_PARAM_SR
 using dstDataType = typename get_type_from_type_id<static_cast<char>(CK_PARAM_DST_DATATYPE)>::type;
 using compType = typename get_type_from_type_id<static_cast<char>(CK_PARAM_REDUCE_COMPTYPE)>::type;
 
+constexpr index_t gridSize =
+    CK_PARAM_GRIDSIZE; // determined by the invariant length and the reduction method
 constexpr index_t blockSize = CK_PARAM_BLOCKSIZE; // tunable
 constexpr index_t blkGroupSize =
     CK_PARAM_BLKGROUPSIZE; // determined by the problem and the selected BlockSize
@@ -133,6 +135,7 @@ extern "C" __global__ void gridwise_generic_reduce_1(float alpha,
     constexpr auto dstDesc = make_native_tensor_descriptor(dstLengths{}, dstStrides{});
 
     constexpr auto gridwise_reduce = GridwiseReduction<blkGroupSize,
+                                                       gridSize,
                                                        blockSize,
                                                        srcDataType,
                                                        dstDataType,
@@ -177,6 +180,7 @@ extern "C" __global__ void gridwise_generic_reduce_2(float alpha,
     constexpr auto dstDesc = make_native_tensor_descriptor(dstLengths{}, dstStrides{});
 
     constexpr auto gridwise_reduce = GridwiseReduction<blkGroupSize,
+                                                       gridSize,
                                                        blockSize,
                                                        srcDataType,
                                                        dstDataType,

--- a/src/reducetensor.cpp
+++ b/src/reducetensor.cpp
@@ -120,7 +120,7 @@ struct ReductionKernelConfigurator
 
         if(invariantLength == 1)
         {
-            if(toReduceLength <
+            if(toReduceLength <=
                GredBlockWiseUpperReductionLen) // let one block to do this only reduction
                 return (1);
             else
@@ -129,13 +129,13 @@ struct ReductionKernelConfigurator
         }
         else
         {
-            if(toReduceLength <
+            if(toReduceLength <=
                GredDirectThreadWiseUpperReductionLen) // let one thread to do each reduction
                 return ((invariantLength + blockSize_ - 1) / blockSize_);
-            else if(toReduceLength <
+            else if(toReduceLength <=
                     GredDirectWarpWiseUpperReductionLen) // let one warp to do each reduction
                 return ((invariantLength + numWarpsPerBlock - 1) / numWarpsPerBlock);
-            else if(toReduceLength <
+            else if(toReduceLength <=
                     GredBlockWiseUpperReductionLen) // let one block to do each reduction
                 return (invariantLength);
             else
@@ -159,7 +159,7 @@ struct ReductionKernelConfigurator
 
         if(invariantLength == 1)
         {
-            if(toReduceLength <
+            if(toReduceLength <=
                GredBlockWiseUpperReductionLen) // let one block to do this only reduction
                 return (Reduce_BlockWise);
             else // let multiple blocks to do this only reduction
@@ -167,13 +167,13 @@ struct ReductionKernelConfigurator
         }
         else
         {
-            if(toReduceLength <
+            if(toReduceLength <=
                GredDirectThreadWiseUpperReductionLen) // let one thread to do each reduction
                 return (Reduce_DirectThreadWise);
-            else if(toReduceLength <
+            else if(toReduceLength <=
                     GredDirectWarpWiseUpperReductionLen) // let one warp to do each reduction
                 return (Reduce_DirectWarpWise);
-            else if(toReduceLength <
+            else if(toReduceLength <=
                     GredBlockWiseUpperReductionLen) // let one block to do each reduction
                 return (Reduce_BlockWise);
             else
@@ -197,9 +197,9 @@ struct ReductionKernelConfigurator
 
     std::size_t getGridSize_2(std::size_t invariantLength, std::size_t toReduceLength) const
     {
-        if(toReduceLength < warpSize_ / 4) // let one thread to do each reduction
+        if(toReduceLength <= warpSize_ / 4) // let one thread to do each reduction
             return ((invariantLength + blockSize_ - 1) / blockSize_);
-        else if(toReduceLength < blockSize_) // let one warp to do each reduction
+        else if(toReduceLength <= blockSize_) // let one warp to do each reduction
             return ((invariantLength + numWarpsPerBlock - 1) / numWarpsPerBlock);
         else
             return (invariantLength); // let one block to do each reduction

--- a/test/reduce_test.cpp
+++ b/test/reduce_test.cpp
@@ -41,10 +41,6 @@
 
 #include "cpu_reduce_util.hpp"
 
-/// Not reproducible with ROCm 4.0 and 4.1.
-#define WORKAROUND_GPU_MEM_ACCESS_FAULT \
-    (HIP_PACKAGE_VERSION_MAJOR == 3 && HIP_PACKAGE_VERSION_MINOR == 7)
-
 template <class T, bool toVerifyData>
 struct verify_reduce_with_indices
 {
@@ -713,22 +709,6 @@ struct reduce_driver : test_driver
                 compTypeVal = static_cast<int>(miopenFloat);
         }
 
-#if WORKAROUND_GPU_MEM_ACCESS_FAULT
-        if(std::is_same<T, half_float::half>::value)
-        {
-            if(inLengths == std::vector<std::size_t>{4, 3, 60, 50} &&
-               toReduceDims == std::vector<int>{1, 2, 3} &&
-               ((reduceOp == 1 && compTypeVal == 1 && nanOpt == 1 && indicesOpt == 0) ||
-                (reduceOp == 4 && /*compTypeVal == X && nanOpt == X*/ indicesOpt == 0) ||
-                (reduceOp == 5 && compTypeVal == 1 && /*nanOpt == X &&*/ indicesOpt == 0) ||
-                (reduceOp == 6 && compTypeVal == 1 && /*nanOpt == X &&*/ indicesOpt == 0) ||
-                (reduceOp == 7 && compTypeVal == 1 && /*nanOpt == X &&*/ indicesOpt == 0)))
-            {
-                std::cout << "Workaround: Skipping the test." << std::endl;
-                return;
-            }
-        }
-#endif
         miopen::ReduceTensorDescriptor reduceDesc(
             static_cast<miopenReduceTensorOp_t>(reduceOp),
             static_cast<miopenDataType_t>(compTypeVal),


### PR DESCRIPTION
This is pushed in order to solve the issue raised by [SWDEV-284291](https://ontrack-internal.amd.com/browse/SWDEV-284291)

Regular testing has passed on (rocm-3.10,rocm-3.7,rocm-4.2)/MI00,  rocm-4.2/MI25, rocm-4.2/Navi21, rocm-3.10/MI60 

Method for regular testing
`#>bin/test_reduce_test --all`
`#>bin/test_reduce_test --half --all`

