### PR TITLE
Fix for tidy failures when branch name contains 'hpp'

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -528,7 +528,7 @@ enable_clang_tidy(
         ${MIOPEN_TIDY_CHECKS}
     ${MIOPEN_TIDY_ERRORS}
     HEADER_FILTER
-        ".*hpp"
+        "\.hpp$"
     EXTRA_ARGS
         -DMIOPEN_USE_CLANG_TIDY
 


### PR DESCRIPTION
Header filter works wrong if path contains 'hpp' substring.

1 jenkins run shows this error.