### PR TITLE
Remove W/A for SWDEV-225285

### DIFF
--- a/src/binary_cache.cpp
+++ b/src/binary_cache.cpp
@@ -60,17 +60,15 @@ static boost::filesystem::path ComputeSysCachePath()
 static boost::filesystem::path ComputeUserCachePath()
 {
 #ifdef MIOPEN_CACHE_DIR
-    std::string cache_dir = MIOPEN_CACHE_DIR;
-    std::string version;
-
-    version = std::to_string(MIOPEN_VERSION_MAJOR) + "." + std::to_string(MIOPEN_VERSION_MINOR) +
-              "." + std::to_string(MIOPEN_VERSION_PATCH) + "." +
-              MIOPEN_STRINGIZE(MIOPEN_VERSION_TWEAK);
-    auto p = boost::filesystem::path{miopen::ExpandUser(cache_dir)} / version;
+    const std::string cache_dir = MIOPEN_CACHE_DIR;
+    const std::string version =
+        std::to_string(MIOPEN_VERSION_MAJOR) + "." + std::to_string(MIOPEN_VERSION_MINOR) + "." +
+        std::to_string(MIOPEN_VERSION_PATCH) + "." + MIOPEN_STRINGIZE(MIOPEN_VERSION_TWEAK);
 
     const char* const custom = miopen::GetStringEnv(MIOPEN_CUSTOM_CACHE_DIR{});
-    if(custom != nullptr && strlen(custom) > 0)
-        p = boost::filesystem::path{miopen::ExpandUser(custom)};
+    const auto p             = (custom != nullptr && strlen(custom) > 0)
+                       ? boost::filesystem::path{miopen::ExpandUser(custom)}
+                       : boost::filesystem::path{miopen::ExpandUser(cache_dir)} / version;
 
     if(!boost::filesystem::exists(p) && !MIOPEN_DISABLE_USERDB)
         boost::filesystem::create_directories(p);

--- a/src/expanduser.cpp
+++ b/src/expanduser.cpp
@@ -7,7 +7,7 @@ MIOPEN_DECLARE_ENV_VAR(HOME)
 
 namespace miopen {
 
-std::string ExpandUser(std::string p)
+std::string ExpandUser(const std::string& p)
 {
     const char* home_dir = GetStringEnv(HOME{});
     if(home_dir == nullptr || home_dir == std::string("/") || home_dir == std::string(""))

--- a/src/hip/handlehip.cpp
+++ b/src/hip/handlehip.cpp
@@ -503,12 +503,11 @@ std::size_t Handle::GetGlobalMemorySize() const
 
 std::size_t Handle::GetMaxComputeUnits() const
 {
+    const std::size_t num_cu = Value(MIOPEN_DEVICE_CU{});
+    if(num_cu > 0)
+        return num_cu;
+
     int result;
-    const char* const num_cu = miopen::GetStringEnv(MIOPEN_DEVICE_CU{});
-    if(num_cu != nullptr && strlen(num_cu) > 0)
-    {
-        return boost::lexical_cast<std::size_t>(num_cu);
-    }
     auto status =
         hipDeviceGetAttribute(&result, hipDeviceAttributeMultiprocessorCount, this->impl->device);
     if(status != hipSuccess)

--- a/src/hipoc/hipoc_program.cpp
+++ b/src/hipoc/hipoc_program.cpp
@@ -187,16 +187,12 @@ HIPOCProgramImpl::HIPOCProgramImpl(const std::string& program_name,
 }
 
 HIPOCProgramImpl::HIPOCProgramImpl(const std::string& program_name, const std::string& blob)
-    : program(program_name)
+    : program(program_name) ///, module(CreateModuleInMem(blob))
 {
-    TmpDir tmp_dir("miopen");
-    auto file_path = tmp_dir.path / boost::filesystem::unique_path("miopen-%%%%-%%%%-%%%%-%%%%");
-    WriteFile(blob, file_path);
-    const char* const arch = miopen::GetStringEnv(MIOPEN_DEVICE_ARCH{});
-    if(arch == nullptr)
-    {
-        this->module = CreateModule(file_path);
-    }
+    if(nullptr ==
+       miopen::GetStringEnv(MIOPEN_DEVICE_ARCH{})) /// \todo Finish off this spaghetti eventually.
+        return;
+    module = CreateModuleInMem(blob);
 }
 
 HIPOCProgramImpl::HIPOCProgramImpl(const std::string& program_name,

--- a/src/hipoc/hipoc_program.cpp
+++ b/src/hipoc/hipoc_program.cpp
@@ -180,7 +180,7 @@ HIPOCProgramImpl::HIPOCProgramImpl(const std::string& program_name,
 HIPOCProgramImpl::HIPOCProgramImpl(const std::string& program_name, const std::string& blob)
     : program(program_name) ///, module(CreateModuleInMem(blob))
 {
-    if(nullptr ==
+    if(nullptr !=
        miopen::GetStringEnv(MIOPEN_DEVICE_ARCH{})) /// \todo Finish off this spaghetti eventually.
         return;
     module = CreateModuleInMem(blob);

--- a/src/hipoc/hipoc_program.cpp
+++ b/src/hipoc/hipoc_program.cpp
@@ -58,8 +58,6 @@ MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEBUG_OPENCL_ENFORCE_CODE_OBJECT_OPTION)
 MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEBUG_OPENCL_ENFORCE_CODE_OBJECT_VERSION)
 MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEVICE_ARCH)
 
-#define MIOPEN_WORKAROUND_SWDEV_225285 1
-
 #if MIOPEN_USE_COMGR
 #define MIOPEN_WORKAROUND_ROCM_COMPILER_SUPPORT_ISSUE_27 1
 #endif
@@ -164,19 +162,12 @@ static hipModulePtr CreateModule(const boost::filesystem::path& hsaco_file)
 template <typename T> /// intended for std::string and std::vector<char>
 hipModulePtr CreateModuleInMem(const T& blob)
 {
-#if !MIOPEN_WORKAROUND_SWDEV_225285
     hipModule_t raw_m;
     auto status = hipModuleLoadData(&raw_m, reinterpret_cast<const void*>(blob.data()));
     hipModulePtr m{raw_m};
     if(status != hipSuccess)
         MIOPEN_THROW_HIP_STATUS(status, "Failed loading module");
     return m;
-#else
-    TmpDir tmp_dir("miopen");
-    auto file_path = tmp_dir.path / boost::filesystem::unique_path("miopen-%%%%-%%%%-%%%%-%%%%");
-    WriteFile(blob, file_path);
-    return CreateModule(file_path);
-#endif
 }
 
 HIPOCProgramImpl::HIPOCProgramImpl(const std::string& program_name,

--- a/src/include/miopen/expanduser.hpp
+++ b/src/include/miopen/expanduser.hpp
@@ -30,7 +30,7 @@
 
 namespace miopen {
 
-std::string ExpandUser(std::string p);
+std::string ExpandUser(const std::string& p);
 
 } // namespace miopen
 

--- a/src/include/miopen/stringutils.hpp
+++ b/src/include/miopen/stringutils.hpp
@@ -41,9 +41,10 @@
 namespace miopen {
 
 inline std::string
-ReplaceString(std::string subject, const std::string& search, const std::string& replace)
+ReplaceString(const std::string& in, const std::string& search, const std::string& replace)
 {
     size_t pos = 0;
+    std::string subject(in);
     while((pos = subject.find(search, pos)) != std::string::npos)
     {
         subject.replace(pos, search.length(), replace);


### PR DESCRIPTION
This is expected to resolve issue #962 by removing W/A for https://ontrack-internal.amd.com/browse/SWDEV-225285. That SWDEV is fixed in ROCm 3.4 which we do not support anymore. Some stale review comments from #307 resolved as well.

- [NFC] Allowed `ReplaceString()` to accept const reference on input.
- [NFC] Resolved https://github.com/ROCmSoftwarePlatform/MIOpen/pull/307#discussion_r513634922
- [NFC] Resolved https://github.com/ROCmSoftwarePlatform/MIOpen/pull/307#discussion_r513635358
- [NFC] Partially resolved https://github.com/ROCmSoftwarePlatform/MIOpen/pull/307#discussion_r513645212
- [NFC] Resolved https://github.com/ROCmSoftwarePlatform/MIOpen/pull/307#discussion_r513662388
- Removed `MIOPEN_WORKAROUND_SWDEV_225285`

/cc @zpwenjh 