### PR TITLE
[HOTFIX] Remove duplicated group divide when calculation k per group (SWDEV-291574)

### DIFF
--- a/src/solver/conv_asm_implicit_gemm_gtc_bwd.cpp
+++ b/src/solver/conv_asm_implicit_gemm_gtc_bwd.cpp
@@ -872,7 +872,7 @@ static std::tuple<bool, // is suitable kernel found
             int i_x_tilda          = gemm_id % x_tilda;
             int y_dot_slice        = (i_y_tilda + 1) * y_dot <= y ? y_dot : y % y_dot;
             int x_dot_slice        = (i_x_tilda + 1) * x_dot <= x ? x_dot : x % x_dot;
-            int gemm_k             = k / group * y_dot_slice * x_dot_slice;
+            int gemm_k             = k * y_dot_slice * x_dot_slice;
             bool is_gemm_not_empty = gemm_k > 0;
             if(is_gemm_not_empty)
             {


### PR DESCRIPTION
This resolve [SWDEV-291574](https://ontrack-internal.amd.com/browse/SWDEV-291574) issue by removing the duplicated `group` divide while calculating k_per_block, since `k` already divided by `group` in above [L796](https://github.com/ROCmSoftwarePlatform/MIOpen/blob/develop/src/solver/conv_asm_implicit_gemm_gtc_bwd.cpp#L796).

After this fix, the original problematic config `./bin/MIOpenDriver convfp16 -n 64 -c 256 -H 56 -W 56 -k 256 -y 3 -x 3 -p 1 -q 1 -u 1 -v 1 -l 1 -j 1 -m conv -g 32 -F 2 -t 1` should not be valid for this asm solver, since `c_per_bloc = 256/32 = 8`, `k_per_bloc = 256/32 = 8`, this is too small for NCHW asm igemm to support (NCHW fp16 does not support pack c or k)

Beside, if reduce group size to like 2, 4, 8, 16, the solver can successfully calculate the result.
`./bin/MIOpenDriver convfp16 -n 64 -c 256 -H 56 -W 56 -k 256 -y 3 -x 3 -p 1 -q 1 -u 1 -v 1 -l 1 -j 1 -m conv -g 4 -F 2 -t 1`
`./bin/MIOpenDriver convfp16 -n 64 -c 256 -H 56 -W 56 -k 256 -y 3 -x 3 -p 1 -q 1 -u 1 -v 1 -l 1 -j 1 -m conv -g 8 -F 2 -t 1`
`./bin/MIOpenDriver convfp16 -n 64 -c 256 -H 56 -W 56 -k 256 -y 3 -x 3 -p 1 -q 1 -u 1 -v 1 -l 1 -j 1 -m conv -g 16 -F 2 -t 1`