### PR TITLE
[WORKAROUND] Generic-Reduction: Partially resolve SWDEV-291479. W/A for SWDEV-274384.

### DIFF
--- a/src/kernels/composable_kernel/include/kernel_algorithm/reduction_functions.hpp
+++ b/src/kernels/composable_kernel/include/kernel_algorithm/reduction_functions.hpp
@@ -50,10 +50,12 @@ struct binop_with_nan_check<NanPropagation_t::NOT_PROPAGATE_NAN, opReduce, compT
     };
 
     // The method is called when the opReduce is indexable and the user asked for indices
-    __device__ static inline void
-    calculate(const compType& accuVal, compType currVal, volatile int& accuIndex, int currIndex)
+    __device__ static inline void calculate(const compType& accuVal,
+                                            compType currVal,
+                                            VOLATILE_WA_274384 int& accuIndex,
+                                            int currIndex)
     {
-        volatile bool changed = false;
+        VOLATILE_WA_274384 bool changed = false;
 
         opReduce{}(const_cast<compType&>(accuVal), currVal, changed);
 
@@ -75,7 +77,7 @@ struct binop_with_nan_check<NanPropagation_t::PROPAGATE_NAN, opReduce, compType>
 
     // The method is called when the opReduce is indexable and the user asked for indices
     __device__ static inline void
-    calculate(compType& accuVal, compType currVal, volatile int& accuIndex, int currIndex)
+    calculate(compType& accuVal, compType currVal, VOLATILE_WA_274384 int& accuIndex, int currIndex)
     {
         if(isnan(currVal))
         {
@@ -84,7 +86,7 @@ struct binop_with_nan_check<NanPropagation_t::PROPAGATE_NAN, opReduce, compType>
         }
         else
         {
-            volatile bool changed = false;
+            VOLATILE_WA_274384 bool changed = false;
 
             opReduce{}(accuVal, currVal, changed);
 
@@ -527,9 +529,9 @@ struct BlockwiseReduction_2d_block_buffer
                                    compType& accuData,
                                    int& accuIndex)
     {
-        const index_t thread_local_id = get_thread_local_1d_id();
-        compType lAccuData            = opReduce::GetZeroVal();
-        volatile int lAccuIndex       = 0;
+        const index_t thread_local_id     = get_thread_local_1d_id();
+        compType lAccuData                = opReduce::GetZeroVal();
+        VOLATILE_WA_274384 int lAccuIndex = 0;
 
         static_if<blockIsOneRow>{}([&](auto) {
             for(index_t otherDimInd = 0; otherDimInd < toReduceBlocks; otherDimInd++)

--- a/src/kernels/composable_kernel/include/kernel_algorithm/reduction_functions.hpp
+++ b/src/kernels/composable_kernel/include/kernel_algorithm/reduction_functions.hpp
@@ -51,9 +51,9 @@ struct binop_with_nan_check<NanPropagation_t::NOT_PROPAGATE_NAN, opReduce, compT
 
     // The method is called when the opReduce is indexable and the user asked for indices
     __device__ static inline void
-    calculate(const compType& accuVal, compType currVal, int& accuIndex, int currIndex)
+    calculate(const compType& accuVal, compType currVal, volatile int& accuIndex, int currIndex)
     {
-        bool changed = false;
+        volatile bool changed = false;
 
         opReduce{}(const_cast<compType&>(accuVal), currVal, changed);
 
@@ -75,7 +75,7 @@ struct binop_with_nan_check<NanPropagation_t::PROPAGATE_NAN, opReduce, compType>
 
     // The method is called when the opReduce is indexable and the user asked for indices
     __device__ static inline void
-    calculate(compType& accuVal, compType currVal, int& accuIndex, int currIndex)
+    calculate(compType& accuVal, compType currVal, volatile int& accuIndex, int currIndex)
     {
         if(isnan(currVal))
         {
@@ -84,7 +84,7 @@ struct binop_with_nan_check<NanPropagation_t::PROPAGATE_NAN, opReduce, compType>
         }
         else
         {
-            bool changed = false;
+            volatile bool changed = false;
 
             opReduce{}(accuVal, currVal, changed);
 
@@ -529,7 +529,7 @@ struct BlockwiseReduction_2d_block_buffer
     {
         const index_t thread_local_id = get_thread_local_1d_id();
         compType lAccuData            = opReduce::GetZeroVal();
-        int lAccuIndex                = 0;
+        volatile int lAccuIndex       = 0;
 
         static_if<blockIsOneRow>{}([&](auto) {
             for(index_t otherDimInd = 0; otherDimInd < toReduceBlocks; otherDimInd++)

--- a/src/kernels/composable_kernel/include/utility/reduction_common.hpp
+++ b/src/kernels/composable_kernel/include/utility/reduction_common.hpp
@@ -28,6 +28,14 @@
 
 #include "float_type.hpp"
 
+#define WORKAROUND_SWDEV_274384 (HIP_PACKAGE_VERSION_FLAT >= 4002021203ULL)
+
+#if WORKAROUND_SWDEV_274384
+#define VOLATILE_WA_274384 volatile
+#else
+#define VOLATILE_WA_274384
+#endif
+
 // this enumerate should be synchronized with include/miopen/reduce_common.hpp
 namespace ck {
 enum class ReductionMethod_t

--- a/src/kernels/composable_kernel/include/utility/reduction_operator.hpp
+++ b/src/kernels/composable_kernel/include/utility/reduction_operator.hpp
@@ -93,15 +93,13 @@ struct Max
             a = b;
     }
 
-    __device__ inline constexpr void operator()(T& a, T b, bool& changed) const
+    __device__ inline constexpr void operator()(T& a, T b, volatile bool& changed) const
     {
         if(a < b)
         {
             a       = b;
             changed = true;
         }
-        else
-            changed = false;
     }
 
     static constexpr bool indexable = true;
@@ -120,15 +118,13 @@ struct Min
             a = b;
     }
 
-    __device__ inline constexpr void operator()(T& a, T b, bool& changed) const
+    __device__ inline constexpr void operator()(T& a, T b, volatile bool& changed) const
     {
         if(a > b)
         {
             a       = b;
             changed = true;
         }
-        else
-            changed = false;
     }
 
     static constexpr bool indexable = true;

--- a/src/kernels/composable_kernel/include/utility/reduction_operator.hpp
+++ b/src/kernels/composable_kernel/include/utility/reduction_operator.hpp
@@ -93,7 +93,7 @@ struct Max
             a = b;
     }
 
-    __device__ inline constexpr void operator()(T& a, T b, volatile bool& changed) const
+    __device__ inline constexpr void operator()(T& a, T b, VOLATILE_WA_274384 bool& changed) const
     {
         if(a < b)
         {
@@ -118,7 +118,7 @@ struct Min
             a = b;
     }
 
-    __device__ inline constexpr void operator()(T& a, T b, volatile bool& changed) const
+    __device__ inline constexpr void operator()(T& a, T b, VOLATILE_WA_274384 bool& changed) const
     {
         if(a > b)
         {

--- a/src/reducetensor.cpp
+++ b/src/reducetensor.cpp
@@ -593,9 +593,9 @@ void ReduceTensorDescriptor::ReduceTensor(const Handle& handle,
                      std::to_string(compType) + "IN";
     for(auto dimLen : inDescLengths)
         network_config += std::to_string(dimLen) + "_";
-    network_config += "OUT";
-    for(auto dimLen : outDescLengths)
-        network_config += std::to_string(dimLen) + "_";
+    network_config += "RED";
+    for(auto dim : toReduceDims)
+        network_config += std::to_string(dim) + "_";
     network_config += "BSIZE_" + std::to_string(blockSize);
 
     // kernel for the first call

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -294,13 +294,13 @@ function(option_support_check is_anabled is_disabled default_result result)
 endfunction()
 
 # The add_custom_test function contains options to describe the conditions,
-# under which new custom_tests should be run. Options are divided into several types. 
+# under which new custom_tests should be run. Options are divided into several types.
 # The option can be enabled or disabled, if nothing is specified, the default value is taken.
-# You can use any number of options, provided that options do not conflict 
+# You can use any number of options, provided that options do not conflict
 #   (e.g. "HALF_ENABLE HALF_DISABLE" is illegal)
 # 1)First describes supported data type. ( HALF BF16 INT8 FLOAT ...)
 #   The option can be enabled or disabled by using '_ENABLED' and '_DISABLED' suffix.
-#   If nothing is specified, the default value is taken. 
+#   If nothing is specified, the default value is taken.
 #       Default: HALF=disabled, BF16=disabled, INT8=disabled, FLOAT=enabled.
 # 2)Second options type describes support GPU types (gfx900, gfx906, gfx908 ...)
 #   The option can be enabled or disabled by using '_ENABLED' and '_DISABLED' suffix.
@@ -320,7 +320,7 @@ endfunction()
 #       Default: OCL=enabled, HIP=enabled, HIP_NOGPU=disabled.
 
 function(add_custom_test NAME)
-    set(options 
+    set(options
         BF16_ENABLED BF16_DISABLED HALF_ENABLED HALF_DISABLED INT8_ENABLED INT8_DISABLED FLOAT_ENABLED FLOAT_DISABLED
         VEGA_ENABLED VEGA_DISABLED GFX908_ENABLED GFX908_DISABLED
         MIOTENSILE_ENABLED MIOTENSILE_DISABLED MLIR_ENABLED MLIR_DISABLED
@@ -338,7 +338,7 @@ function(add_custom_test NAME)
     set(HALF_TEST_DEFAULT FALSE)
     option_support_check(${PARSE_HALF_ENABLED} ${PARSE_HALF_DISABLED} ${HALF_TEST_DEFAULT} is_half_check)
     bool_and_f(${MIOPEN_TEST_HALF} ${is_half_check} is_half_check)
-    
+
     set(is_bfloat16_check)
     set(BF16_TEST_DEFAULT FALSE)
     option_support_check(${PARSE_BF16_ENABLED} ${PARSE_BF16_DISABLED} ${BF16_TEST_DEFAULT} is_bfloat16_check)
@@ -353,7 +353,7 @@ function(add_custom_test NAME)
     set(FLOAT_TEST_DEFAULT TRUE)
     option_support_check(${PARSE_FLOAT_ENABLED} ${PARSE_FLOAT_DISABLED} ${FLOAT_TEST_DEFAULT} is_float_check)
     bool_and_f(${MIOPEN_TEST_FLOAT} ${is_float_check} is_float_check)
-    
+
     set(is_miotensile_check)
     set(MIOTENSILE_TEST_DEFAULT FALSE)
     option_support_check(${PARSE_MIOTENSILE_ENABLED} ${PARSE_MIOTENSILE_DISABLED} ${MIOTENSILE_TEST_DEFAULT} is_miotensile_check)
@@ -377,7 +377,7 @@ function(add_custom_test NAME)
     option_support_check(${PARSE_HIP_ENABLED} ${PARSE_HIP_DISABLED} ${HIP_TEST_DEFAULT} is_hip_check)
     bool_not_f(${MIOPEN_TEST_HIP} NOT_MIOPEN_TEST_HIP)
     bool_or_f(${NOT_MIOPEN_TEST_HIP} ${is_hip_check} is_hip_check)
-    
+
     set(is_hip_nogpu_check)
     set(HIP_NOGPU_TEST_DEFAULT FALSE)
     option_support_check(${PARSE_HIP_NOGPU_ENABLED} ${PARSE_HIP_NOGPU_DISABLED} ${HIP_NOGPU_TEST_DEFAULT} is_hip_nogpu_check)
@@ -403,7 +403,7 @@ function(add_custom_test NAME)
     add_custom_target(${NAME} ${PARSE_UNPARSED_ARGUMENTS})
     add_test(NAME ${NAME} COMMAND ${CMAKE_COMMAND} --build ${CMAKE_CURRENT_BINARY_DIR} --target ${NAME})
     if(  (is_vega_check OR is_gfx908_check)
-     AND is_full_check 
+     AND is_full_check
      AND (is_miotensile_check AND is_mlir_check)
      AND ( is_half_check OR is_bfloat16_check OR is_int8_check OR is_float_check)
      AND (is_ocl_check AND is_hip_check AND is_hip_nogpu_check)
@@ -429,7 +429,7 @@ if(MIOPEN_EMBED_DB)
     set(MIOPEN_WA_ISSUE_874_F  MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_FWD_V4R1=0)
     set(MIOPEN_WA_ISSUE_874_W  MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_WRW_V4R1=0)
     set(MIOPEN_WA_ISSUE_874_FW MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_FWD_V4R1=0 MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_WRW_V4R1=0)
-add_custom_test(test_conv_embed_db TEST_PERF_DB_RECORD_NOT_FOUND 
+add_custom_test(test_conv_embed_db TEST_PERF_DB_RECORD_NOT_FOUND
     COMMAND ${MIOPEN_WA_ISSUE_874_W}  $<TARGET_FILE:test_conv2d> ${MIOPEN_EMBED_TEST_ARG} --input 128 1024 14 14 --weights 2048 1024 1 1 --pads_strides_dilations 0 0 2 2 1 1
     COMMAND ${MIOPEN_WA_ISSUE_874_F}  $<TARGET_FILE:test_conv2d> ${MIOPEN_EMBED_TEST_ARG} --input 128 1024 14 14 --weights 256 1024 1 1 --pads_strides_dilations 0 0 1 1 1 1
     COMMAND ${MIOPEN_WA_ISSUE_874_W}  $<TARGET_FILE:test_conv2d> ${MIOPEN_EMBED_TEST_ARG} --input 128 1024 14 14 --weights 512 1024 1 1 --pads_strides_dilations 0 0 2 2 1 1
@@ -463,7 +463,7 @@ if(MIOPEN_TEST_MLIR)
     set(IMPLICITGEMM_MLIR_ARGS_F ${IMPLICITGEMM_ARGS} --verbose --disable-backward-data --disable-backward-weights)
     set(IMPLICITGEMM_MLIR_ARGS_B ${IMPLICITGEMM_ARGS} --verbose --disable-forward --disable-backward-weights)
     set(IMPLICITGEMM_MLIR_ARGS_W ${IMPLICITGEMM_ARGS} --verbose --disable-forward --disable-backward-data)
-    
+
     add_custom_test(test_conv_igemm_mlir  HALF_ENABLED MLIR_ENABLED
         COMMAND ${IMPLICITGEMM_MLIR_ENV_F} $<TARGET_FILE:test_conv2d> ${IMPLICITGEMM_MLIR_ARGS_F} --input 256 1024 14 14 --weights 2048 1024 1 1 --pads_strides_dilations 0 0 2 2 1 1
         COMMAND ${IMPLICITGEMM_MLIR_ENV_F} $<TARGET_FILE:test_conv2d> ${IMPLICITGEMM_MLIR_ARGS_F} --input 256 1024 14 14 --weights 2048 1024 1 1 --pads_strides_dilations 0 0 2 2 1 1 --in_layout NHWC --fil_layout NHWC --out_layout NHWC
@@ -911,7 +911,8 @@ COMMAND ${DYNAMIC_IMPLICITGEMM_WRW_ENVS} $<TARGET_FILE:test_conv2d> --verbose --
 COMMAND ${DYNAMIC_IMPLICITGEMM_BWD_ENVS} $<TARGET_FILE:test_conv2d> --verbose --input  64  64 28 28 --weights 16  64 1 1 --pads_strides_dilations 0 0 1 1 1 1 --disable-forward --disable-backward-weights
 COMMAND ${DYNAMIC_IMPLICITGEMM_BWD_ENVS} $<TARGET_FILE:test_conv2d> --verbose --input  16  128 36 36 --weights 32  128 1 1 --pads_strides_dilations 0 0 1 1 1 1 --disable-forward --disable-backward-weights
 )
-add_custom_test(test_conv_igemm_dynamic SKIP_UNLESS_ALL 
+
+add_custom_test(test_conv_igemm_dynamic SKIP_UNLESS_ALL
 COMMAND ${DYNAMIC_IMPLICITGEMM_ENVS}     $<TARGET_FILE:test_conv2d> --verbose --input  64   64 56 56 --weights 256  64  1 1 --pads_strides_dilations 0 0 1 1 1 1 --disable-backward-data --disable-backward-weights
 COMMAND ${DYNAMIC_IMPLICITGEMM_ENVS}     $<TARGET_FILE:test_conv2d> --verbose --input  64  256 34 34 --weights 256  256 3 3 --pads_strides_dilations 0 0 1 1 1 1 --disable-backward-data --disable-backward-weights
 COMMAND ${DYNAMIC_IMPLICITGEMM_ENVS}     $<TARGET_FILE:test_conv2d> --verbose --input 128  128 35 35 --weights 128  128 3 3 --pads_strides_dilations 0 0 2 2 1 1 --disable-backward-data --disable-backward-weights

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -294,13 +294,13 @@ function(option_support_check is_anabled is_disabled default_result result)
 endfunction()
 
 # The add_custom_test function contains options to describe the conditions,
-# under which new custom_tests should be run. Options are divided into several types.
+# under which new custom_tests should be run. Options are divided into several types. 
 # The option can be enabled or disabled, if nothing is specified, the default value is taken.
-# You can use any number of options, provided that options do not conflict
+# You can use any number of options, provided that options do not conflict 
 #   (e.g. "HALF_ENABLE HALF_DISABLE" is illegal)
 # 1)First describes supported data type. ( HALF BF16 INT8 FLOAT ...)
 #   The option can be enabled or disabled by using '_ENABLED' and '_DISABLED' suffix.
-#   If nothing is specified, the default value is taken.
+#   If nothing is specified, the default value is taken. 
 #       Default: HALF=disabled, BF16=disabled, INT8=disabled, FLOAT=enabled.
 # 2)Second options type describes support GPU types (gfx900, gfx906, gfx908 ...)
 #   The option can be enabled or disabled by using '_ENABLED' and '_DISABLED' suffix.
@@ -320,7 +320,7 @@ endfunction()
 #       Default: OCL=enabled, HIP=enabled, HIP_NOGPU=disabled.
 
 function(add_custom_test NAME)
-    set(options
+    set(options 
         BF16_ENABLED BF16_DISABLED HALF_ENABLED HALF_DISABLED INT8_ENABLED INT8_DISABLED FLOAT_ENABLED FLOAT_DISABLED
         VEGA_ENABLED VEGA_DISABLED GFX908_ENABLED GFX908_DISABLED
         MIOTENSILE_ENABLED MIOTENSILE_DISABLED MLIR_ENABLED MLIR_DISABLED
@@ -338,7 +338,7 @@ function(add_custom_test NAME)
     set(HALF_TEST_DEFAULT FALSE)
     option_support_check(${PARSE_HALF_ENABLED} ${PARSE_HALF_DISABLED} ${HALF_TEST_DEFAULT} is_half_check)
     bool_and_f(${MIOPEN_TEST_HALF} ${is_half_check} is_half_check)
-
+    
     set(is_bfloat16_check)
     set(BF16_TEST_DEFAULT FALSE)
     option_support_check(${PARSE_BF16_ENABLED} ${PARSE_BF16_DISABLED} ${BF16_TEST_DEFAULT} is_bfloat16_check)
@@ -353,7 +353,7 @@ function(add_custom_test NAME)
     set(FLOAT_TEST_DEFAULT TRUE)
     option_support_check(${PARSE_FLOAT_ENABLED} ${PARSE_FLOAT_DISABLED} ${FLOAT_TEST_DEFAULT} is_float_check)
     bool_and_f(${MIOPEN_TEST_FLOAT} ${is_float_check} is_float_check)
-
+    
     set(is_miotensile_check)
     set(MIOTENSILE_TEST_DEFAULT FALSE)
     option_support_check(${PARSE_MIOTENSILE_ENABLED} ${PARSE_MIOTENSILE_DISABLED} ${MIOTENSILE_TEST_DEFAULT} is_miotensile_check)
@@ -377,7 +377,7 @@ function(add_custom_test NAME)
     option_support_check(${PARSE_HIP_ENABLED} ${PARSE_HIP_DISABLED} ${HIP_TEST_DEFAULT} is_hip_check)
     bool_not_f(${MIOPEN_TEST_HIP} NOT_MIOPEN_TEST_HIP)
     bool_or_f(${NOT_MIOPEN_TEST_HIP} ${is_hip_check} is_hip_check)
-
+    
     set(is_hip_nogpu_check)
     set(HIP_NOGPU_TEST_DEFAULT FALSE)
     option_support_check(${PARSE_HIP_NOGPU_ENABLED} ${PARSE_HIP_NOGPU_DISABLED} ${HIP_NOGPU_TEST_DEFAULT} is_hip_nogpu_check)
@@ -403,7 +403,7 @@ function(add_custom_test NAME)
     add_custom_target(${NAME} ${PARSE_UNPARSED_ARGUMENTS})
     add_test(NAME ${NAME} COMMAND ${CMAKE_COMMAND} --build ${CMAKE_CURRENT_BINARY_DIR} --target ${NAME})
     if(  (is_vega_check OR is_gfx908_check)
-     AND is_full_check
+     AND is_full_check 
      AND (is_miotensile_check AND is_mlir_check)
      AND ( is_half_check OR is_bfloat16_check OR is_int8_check OR is_float_check)
      AND (is_ocl_check AND is_hip_check AND is_hip_nogpu_check)
@@ -429,7 +429,7 @@ if(MIOPEN_EMBED_DB)
     set(MIOPEN_WA_ISSUE_874_F  MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_FWD_V4R1=0)
     set(MIOPEN_WA_ISSUE_874_W  MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_WRW_V4R1=0)
     set(MIOPEN_WA_ISSUE_874_FW MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_FWD_V4R1=0 MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_WRW_V4R1=0)
-add_custom_test(test_conv_embed_db TEST_PERF_DB_RECORD_NOT_FOUND
+add_custom_test(test_conv_embed_db TEST_PERF_DB_RECORD_NOT_FOUND 
     COMMAND ${MIOPEN_WA_ISSUE_874_W}  $<TARGET_FILE:test_conv2d> ${MIOPEN_EMBED_TEST_ARG} --input 128 1024 14 14 --weights 2048 1024 1 1 --pads_strides_dilations 0 0 2 2 1 1
     COMMAND ${MIOPEN_WA_ISSUE_874_F}  $<TARGET_FILE:test_conv2d> ${MIOPEN_EMBED_TEST_ARG} --input 128 1024 14 14 --weights 256 1024 1 1 --pads_strides_dilations 0 0 1 1 1 1
     COMMAND ${MIOPEN_WA_ISSUE_874_W}  $<TARGET_FILE:test_conv2d> ${MIOPEN_EMBED_TEST_ARG} --input 128 1024 14 14 --weights 512 1024 1 1 --pads_strides_dilations 0 0 2 2 1 1
@@ -463,7 +463,7 @@ if(MIOPEN_TEST_MLIR)
     set(IMPLICITGEMM_MLIR_ARGS_F ${IMPLICITGEMM_ARGS} --verbose --disable-backward-data --disable-backward-weights)
     set(IMPLICITGEMM_MLIR_ARGS_B ${IMPLICITGEMM_ARGS} --verbose --disable-forward --disable-backward-weights)
     set(IMPLICITGEMM_MLIR_ARGS_W ${IMPLICITGEMM_ARGS} --verbose --disable-forward --disable-backward-data)
-
+    
     add_custom_test(test_conv_igemm_mlir  HALF_ENABLED MLIR_ENABLED
         COMMAND ${IMPLICITGEMM_MLIR_ENV_F} $<TARGET_FILE:test_conv2d> ${IMPLICITGEMM_MLIR_ARGS_F} --input 256 1024 14 14 --weights 2048 1024 1 1 --pads_strides_dilations 0 0 2 2 1 1
         COMMAND ${IMPLICITGEMM_MLIR_ENV_F} $<TARGET_FILE:test_conv2d> ${IMPLICITGEMM_MLIR_ARGS_F} --input 256 1024 14 14 --weights 2048 1024 1 1 --pads_strides_dilations 0 0 2 2 1 1 --in_layout NHWC --fil_layout NHWC --out_layout NHWC
@@ -911,8 +911,7 @@ COMMAND ${DYNAMIC_IMPLICITGEMM_WRW_ENVS} $<TARGET_FILE:test_conv2d> --verbose --
 COMMAND ${DYNAMIC_IMPLICITGEMM_BWD_ENVS} $<TARGET_FILE:test_conv2d> --verbose --input  64  64 28 28 --weights 16  64 1 1 --pads_strides_dilations 0 0 1 1 1 1 --disable-forward --disable-backward-weights
 COMMAND ${DYNAMIC_IMPLICITGEMM_BWD_ENVS} $<TARGET_FILE:test_conv2d> --verbose --input  16  128 36 36 --weights 32  128 1 1 --pads_strides_dilations 0 0 1 1 1 1 --disable-forward --disable-backward-weights
 )
-
-add_custom_test(test_conv_igemm_dynamic SKIP_UNLESS_ALL
+add_custom_test(test_conv_igemm_dynamic SKIP_UNLESS_ALL 
 COMMAND ${DYNAMIC_IMPLICITGEMM_ENVS}     $<TARGET_FILE:test_conv2d> --verbose --input  64   64 56 56 --weights 256  64  1 1 --pads_strides_dilations 0 0 1 1 1 1 --disable-backward-data --disable-backward-weights
 COMMAND ${DYNAMIC_IMPLICITGEMM_ENVS}     $<TARGET_FILE:test_conv2d> --verbose --input  64  256 34 34 --weights 256  256 3 3 --pads_strides_dilations 0 0 1 1 1 1 --disable-backward-data --disable-backward-weights
 COMMAND ${DYNAMIC_IMPLICITGEMM_ENVS}     $<TARGET_FILE:test_conv2d> --verbose --input 128  128 35 35 --weights 128  128 3 3 --pads_strides_dilations 0 0 2 2 1 1 --disable-backward-data --disable-backward-weights
@@ -1080,8 +1079,7 @@ if(MIOPEN_TEST_CONV)
 endif()
 
 if(MIOPEN_TEST_FLOAT)
-# WORKAROUND_SWDEV_291479
-#    add_custom_test(test_reduce_double SKIP_UNLESS_ALL GFX908_ENABLED COMMAND  $<TARGET_FILE:test_reduce_test> --double --all --verbose)
+    add_custom_test(test_reduce_double SKIP_UNLESS_ALL GFX908_ENABLED COMMAND  $<TARGET_FILE:test_reduce_test> --double --all --verbose)
 endif()
 
 # Add here regression tests that should be run only on Vega10/20 and only with FP16.


### PR DESCRIPTION
1)  The first commit is supposed to prevent the failure of lost index updates reported in [SWDEV-291479](https://ontrack-internal.amd.com/browse/SWDEV-291479) and [SWDEV-274384](https://ontrack-internal.amd.com/browse/SWDEV-274384)
2) The second commit is supposed to prevent the  failure of all-zero accumulated output (both cpu and gpu) for some reduce_test cases
3) The third commit is for fixing one potential issue. 

- The P.R has passed the following test 

```bash
bin/test_reduce_test --all  --double
bin/test_reduce_test --all
bin/test_reduce_test --all --half
```

- About the Performance 

No performance loss was seen when running `bin/test_reduce_test --all`  on cached binary kernels produced with or without this P.R


