### PR TITLE
[Tuna] Updated solver id to include primitive.

### DIFF
--- a/src/include/miopen/solver_id.hpp
+++ b/src/include/miopen/solver_id.hpp
@@ -34,6 +34,11 @@
 #include <unordered_map>
 
 namespace miopen {
+
+struct ForceInit
+{
+};
+
 namespace solver {
 
 struct AnySolver;
@@ -50,6 +55,7 @@ struct Id
 
     Id() = default;
     Id(uint64_t value_);
+    Id(ForceInit, uint64_t value_);
     Id(const std::string& str);
     Id(const char* str);
 

--- a/src/include/miopen/solver_id.hpp
+++ b/src/include/miopen/solver_id.hpp
@@ -74,7 +74,7 @@ struct Id
     bool is_valid  = false;
 };
 
-const std::unordered_map<uint64_t, AnySolver>& GetMapValueToAnySolver();
+const std::vector<Id>& GetSolversByPrimitive(Primitive primitive);
 
 } // namespace solver
 } // namespace miopen

--- a/src/include/miopen/solver_id.hpp
+++ b/src/include/miopen/solver_id.hpp
@@ -38,6 +38,12 @@ namespace solver {
 
 struct AnySolver;
 
+enum class Primitive
+{
+    Convolution,
+    Activation,
+};
+
 struct Id
 {
     static constexpr uint64_t invalid_value = 0;
@@ -51,6 +57,7 @@ struct Id
     AnySolver GetSolver() const;
     std::string GetAlgo(conv::Direction dir) const;
     miopenConvAlgorithm_t GetAlgo() const;
+    Primitive GetPrimitive() const;
 
     bool IsValid() const { return is_valid; }
     uint64_t Value() const { return value; }

--- a/src/ocl/convolutionocl.cpp
+++ b/src/ocl/convolutionocl.cpp
@@ -778,6 +778,8 @@ void ConvolutionDescriptor::GetSolutionsFallback(Handle& handle,
         if(IsAlgorithmDisabled(algo)) // Algos can be disabled globally.
             continue;
         const auto& s = solver_id.GetSolver();
+        if(s.IsEmpty())
+            continue;
         if(!s.IsDynamic()) // Let's allow non-dynamic later, if necessary.
             continue;
         if(!s.IsApplicable(ctx))

--- a/src/ocl/convolutionocl.cpp
+++ b/src/ocl/convolutionocl.cpp
@@ -656,7 +656,7 @@ std::size_t ConvolutionDescriptor::GetSolutionCountFallback(Handle& handle,
                                                             const ProblemDescription& problem) const
 {
     size_t n                    = 0;
-    const auto maxSolutionCount = miopen::solver::GetMapValueToAnySolver()
+    const auto maxSolutionCount = solver::GetSolversByPrimitive(solver::Primitive::Convolution)
                                       .size(); // Simple and guarantees to provide enough space.
     GetSolutionsFallback(handle, problem, maxSolutionCount, &n, nullptr);
     if(n > 0)
@@ -770,16 +770,14 @@ void ConvolutionDescriptor::GetSolutionsFallback(Handle& handle,
         return 10.0f / wti; // Assume WTI == 1.0 (100%) is 10 ms.
     };
 
-    const auto& map = miopen::solver::GetMapValueToAnySolver();
-    for(const auto& item : map)
+    for(const auto& solver_id : solver::GetSolversByPrimitive(solver::Primitive::Convolution))
     {
-        const auto solver_id = solver::Id{item.first};
         // solver_id is always valid here, because taken from registry.
         // Validity check is not required.
         const auto algo = solver_id.GetAlgo();
         if(IsAlgorithmDisabled(algo)) // Algos can be disabled globally.
             continue;
-        const auto& s = item.second;
+        const auto& s = solver_id.GetSolver();
         if(!s.IsDynamic()) // Let's allow non-dynamic later, if necessary.
             continue;
         if(!s.IsApplicable(ctx))

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -106,12 +106,18 @@ std::ostream& operator<<(std::ostream& os, const ConvSolution& s)
     return os;
 }
 
+struct IdRegistryEntry
+{
+    std::string str_value;
+    Primitive primitive;
+    miopenConvAlgorithm_t convAlgo;
+};
+
 struct IdRegistryData
 {
-    std::unordered_map<uint64_t, std::string> value_to_str;
+    std::unordered_map<uint64_t, IdRegistryEntry> value_to_entry;
     std::unordered_map<std::string, uint64_t> str_to_value;
     std::unordered_map<uint64_t, AnySolver> value_to_solver;
-    std::unordered_map<uint64_t, miopenConvAlgorithm_t> value_to_algo;
 };
 
 struct SolverRegistrar
@@ -135,7 +141,7 @@ const std::unordered_map<uint64_t, AnySolver>& GetMapValueToAnySolver()
 
 Id::Id(uint64_t value_) : value(value_)
 {
-    is_valid = (IdRegistry().value_to_str.find(value) != IdRegistry().value_to_str.end());
+    is_valid = (IdRegistry().value_to_entry.find(value) != IdRegistry().value_to_entry.end());
 }
 
 Id::Id(const std::string& str) : Id(str.c_str()) {}
@@ -151,7 +157,7 @@ std::string Id::ToString() const
 {
     if(!IsValid())
         return "INVALID_SOLVER_ID_" + std::to_string(value);
-    return IdRegistry().value_to_str[value];
+    return IdRegistry().value_to_entry[value].str_value;
 }
 
 AnySolver Id::GetSolver() const
@@ -165,15 +171,24 @@ std::string Id::GetAlgo(conv::Direction dir) const
     return ConvolutionAlgoToDirectionalString(GetAlgo(), dir);
 }
 
-miopenConvAlgorithm_t Id::GetAlgo() const
+Primitive Id::GetPrimitive() const
 {
-    const auto it = IdRegistry().value_to_algo.find(value);
-    if(it == IdRegistry().value_to_algo.end())
+    const auto it = IdRegistry().value_to_entry.find(value);
+    if(it == IdRegistry().value_to_entry.end())
         MIOPEN_THROW(miopenStatusInternalError);
-    return it->second;
+    return it->second.primitive;
 }
 
-inline bool Register(IdRegistryData& registry, uint64_t value, const std::string& str)
+miopenConvAlgorithm_t Id::GetAlgo() const
+{
+    const auto it = IdRegistry().value_to_entry.find(value);
+    if(it == IdRegistry().value_to_entry.end())
+        MIOPEN_THROW(miopenStatusInternalError);
+    return it->second.convAlgo;
+}
+
+inline bool
+Register(IdRegistryData& registry, uint64_t value, Primitive primitive, const std::string& str)
 {
     if(value == Id::invalid_value)
     {
@@ -182,12 +197,13 @@ inline bool Register(IdRegistryData& registry, uint64_t value, const std::string
         return false;
     }
 
-    if(registry.value_to_str.find(value) != registry.value_to_str.end())
+    if(registry.value_to_entry.find(value) != registry.value_to_entry.end())
     {
-        MIOPEN_LOG_E("Registered duplicate ids: [" << value << "]" << str << " and ["
-                                                   << registry.value_to_str.find(value)->first
-                                                   << "]"
-                                                   << registry.value_to_str.find(value)->second);
+        MIOPEN_LOG_E(
+            "Registered duplicate ids: [" << value << "]" << str << " and ["
+                                          << registry.value_to_entry.find(value)->first
+                                          << "]"
+                                          << registry.value_to_entry.find(value)->second.str_value);
         return false;
     }
 
@@ -200,7 +216,11 @@ inline bool Register(IdRegistryData& registry, uint64_t value, const std::string
         return false;
     }
 
-    registry.value_to_str.emplace(value, str);
+    auto entry      = IdRegistryEntry{};
+    entry.str_value = str;
+    entry.primitive = primitive;
+
+    registry.value_to_entry.emplace(value, std::move(entry));
     registry.str_to_value.emplace(str, value);
     return true;
 }
@@ -210,9 +230,9 @@ inline bool Register(IdRegistryData& registry,
                      const std::string& str,
                      miopenConvAlgorithm_t algo)
 {
-    if(!Register(registry, value, str))
+    if(!Register(registry, value, Primitive::Convolution, str))
         return false;
-    registry.value_to_algo.emplace(value, algo);
+    registry.value_to_entry[value].convAlgo = algo;
     return true;
 }
 
@@ -426,7 +446,7 @@ inline SolverRegistrar::SolverRegistrar(IdRegistryData& registry)
     RegisterWithSolver(registry, ++id, ConvMlirIgemmBwdXdlops{}, miopenConvolutionAlgoImplicitGEMM);
     RegisterWithSolver(registry, ++id, ConvMlirIgemmWrWXdlops{}, miopenConvolutionAlgoImplicitGEMM);
 
-    Register(registry, ++id, SolverDbId(activ::ActivFwdSolver0{}));
+    Register(registry, ++id, Primitive::Activation, SolverDbId(activ::ActivFwdSolver0{}));
 
     RegisterWithSolver(registry,
                        ++id,

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -108,10 +108,10 @@ std::ostream& operator<<(std::ostream& os, const ConvSolution& s)
 
 struct IdRegistryEntry
 {
-    std::string str_value;
-    Primitive primitive;
-    miopenConvAlgorithm_t convAlgo;
-    AnySolver solver;
+    std::string str_value          = "";
+    Primitive primitive            = Primitive::Convolution;
+    miopenConvAlgorithm_t convAlgo = miopenConvolutionAlgoDirect;
+    AnySolver solver               = {};
 };
 
 struct IdRegistryData

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -145,6 +145,8 @@ Id::Id(uint64_t value_) : value(value_)
     is_valid = (IdRegistry().value_to_entry.find(value) != IdRegistry().value_to_entry.end());
 }
 
+Id::Id(ForceInit, uint64_t value_) : value(value_), is_valid(true) {}
+
 Id::Id(const std::string& str) : Id(str.c_str()) {}
 
 Id::Id(const char* str)
@@ -223,7 +225,7 @@ Register(IdRegistryData& registry, uint64_t value, Primitive primitive, const st
 
     registry.value_to_entry.emplace(value, std::move(entry));
     registry.str_to_value.emplace(str, value);
-    registry.primitive_to_ids[primitive].emplace_back(value);
+    registry.primitive_to_ids[primitive].emplace_back(ForceInit{}, value);
     return true;
 }
 


### PR DESCRIPTION
This allows one to fetch the primitive of a solver id or a vector of solver ids for the specified primitive.