### PR TITLE
[TESTS] Detection of GPU type (SWDEV-290980)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,9 +150,10 @@ if( MIOPEN_BACKEND STREQUAL "OpenCL")
     set(MIOPEN_BACKEND_OPENCL 1)
     find_package( OpenCL REQUIRED )
     find_program(MIOPEN_HIP_COMPILER hcc
-            PATH_SUFFIXES bin
-            PATHS 
-	        /opt/rocm
+        PATH_SUFFIXES bin
+        PATHS
+            ${ROCM_ROOT}
+            /opt/rocm
     )
     set(MIOPEN_USE_MIOPENGEMM ON CACHE BOOL "")
     if(MIOPEN_HIP_COMPILER)
@@ -160,9 +161,10 @@ if( MIOPEN_BACKEND STREQUAL "OpenCL")
     else()
         find_program(MIOPEN_HIP_COMPILER clang++
             PATH_SUFFIXES bin
-	        PATHS 
-		    /opt/rocm/llvm
-		    ${CMAKE_INSTALL_PREFIX}/llvm
+	        PATHS
+                ${ROCM_ROOT}/llvm
+    		    /opt/rocm/llvm
+	    	    ${CMAKE_INSTALL_PREFIX}/llvm
         )
         if(MIOPEN_HIP_COMPILER)
             message("hip compiler: ${MIOPEN_HIP_COMPILER}")
@@ -187,7 +189,7 @@ endif()
 
 
 # HIP is always required
-find_package(hip REQUIRED PATHS /opt/rocm)
+find_package(hip REQUIRED PATHS ${ROCM_ROOT} /opt/rocm)
 message(STATUS "Build with HIP ${hip_VERSION}")
 target_flags(HIP_COMPILER_FLAGS hip::device)
 # Remove cuda arch flags
@@ -233,10 +235,10 @@ if( MIOPEN_BACKEND STREQUAL "HIP" OR MIOPEN_BACKEND STREQUAL "HIPOC" OR MIOPEN_B
 
     find_program(HIP_OC_COMPILER clang-ocl
         PATH_SUFFIXES bin
-        PATHS 
-	    /opt/rocm
-	    ${CMAKE_INSTALL_PREFIX}
-
+        PATHS
+            ${ROCM_ROOT}
+    	    /opt/rocm
+    	    ${CMAKE_INSTALL_PREFIX}
     )
     if(HIP_OC_COMPILER)
         message(STATUS "hip compiler: ${HIP_OC_COMPILER}")
@@ -272,7 +274,7 @@ if( MIOPEN_BACKEND STREQUAL "HIP" OR MIOPEN_BACKEND STREQUAL "HIPOC" OR MIOPEN_B
     # rocblas
     set(MIOPEN_USE_ROCBLAS ON CACHE BOOL "")
     if(MIOPEN_USE_ROCBLAS)
-        find_package(rocblas REQUIRED PATHS /opt/rocm)
+        find_package(rocblas REQUIRED PATHS ${ROCM_ROOT} /opt/rocm)
         message(STATUS "Build with rocblas")
     else()
         message(STATUS "Build without rocblas")
@@ -284,9 +286,10 @@ message( STATUS "${MIOPEN_BACKEND} backend selected." )
 if(MIOPEN_HIP_COMPILER MATCHES ".*clang\\+\\+$")
     find_program(MIOPEN_OFFLOADBUNDLER_BIN clang-offload-bundler
         PATH_SUFFIXES bin
-        PATHS 
-	    /opt/rocm/llvm
-	    ${CMAKE_INSTALL_PREFIX}/llvm
+        PATHS
+            ${ROCM_ROOT}/llvm
+	        /opt/rocm/llvm
+	        ${CMAKE_INSTALL_PREFIX}/llvm
     )
 endif()
 if(MIOPEN_OFFLOADBUNDLER_BIN)
@@ -299,13 +302,15 @@ else()
     find_program(EXTRACTKERNEL_BIN extractkernel
         PATH_SUFFIXES bin
         PATHS
+            ${ROCM_ROOT}/hip
+            ${ROCM_ROOT}/hcc
+            ${ROCM_ROOT}
             /opt/rocm/hip
             /opt/rocm/hcc
             /opt/rocm
 	        ${CMAKE_INSTALL_PREFIX}/hip
             ${CMAKE_INSTALL_PREFIX}/hcc
             ${CMAKE_INSTALL_PREFIX}
-
     )
     if(EXTRACTKERNEL_BIN)
         message(STATUS "extractkernel found: ${EXTRACTKERNEL_BIN}")
@@ -332,6 +337,7 @@ find_program(MIOPEN_AMDGCN_ASSEMBLER
     NAMES clang
     PATHS
         ${MIOPEN_AMDGCN_ASSEMBLER_PATH}
+        ${ROCM_ROOT}
         /opt/rocm
         /opt/rocm/llvm
         /opt/rocm/hcc
@@ -356,7 +362,7 @@ endif()
 
 # miopengemm
 if(MIOPEN_USE_MIOPENGEMM)
-    find_package(miopengemm PATHS /opt/rocm)
+    find_package(miopengemm PATHS ${ROCM_ROOT} /opt/rocm)
     if(miopengemm_FOUND)
         message(STATUS "Build with miopengemm")
         set(MIOPEN_USE_MIOPENGEMM 1)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,9 +150,9 @@ if( MIOPEN_BACKEND STREQUAL "OpenCL")
     set(MIOPEN_BACKEND_OPENCL 1)
     find_package( OpenCL REQUIRED )
     find_program(MIOPEN_HIP_COMPILER hcc
-            PATH_SUFFIXES bin
-            PATHS 
-	        /opt/rocm
+        PATH_SUFFIXES bin
+        PATHS
+            /opt/rocm
     )
     set(MIOPEN_USE_MIOPENGEMM ON CACHE BOOL "")
     if(MIOPEN_HIP_COMPILER)
@@ -160,9 +160,9 @@ if( MIOPEN_BACKEND STREQUAL "OpenCL")
     else()
         find_program(MIOPEN_HIP_COMPILER clang++
             PATH_SUFFIXES bin
-	        PATHS 
-		    /opt/rocm/llvm
-		    ${CMAKE_INSTALL_PREFIX}/llvm
+            PATHS
+                /opt/rocm/llvm
+                ${CMAKE_INSTALL_PREFIX}/llvm
         )
         if(MIOPEN_HIP_COMPILER)
             message("hip compiler: ${MIOPEN_HIP_COMPILER}")
@@ -233,10 +233,9 @@ if( MIOPEN_BACKEND STREQUAL "HIP" OR MIOPEN_BACKEND STREQUAL "HIPOC" OR MIOPEN_B
 
     find_program(HIP_OC_COMPILER clang-ocl
         PATH_SUFFIXES bin
-        PATHS 
-	    /opt/rocm
-	    ${CMAKE_INSTALL_PREFIX}
-
+        PATHS
+            /opt/rocm
+            ${CMAKE_INSTALL_PREFIX}
     )
     if(HIP_OC_COMPILER)
         message(STATUS "hip compiler: ${HIP_OC_COMPILER}")
@@ -284,9 +283,9 @@ message( STATUS "${MIOPEN_BACKEND} backend selected." )
 if(MIOPEN_HIP_COMPILER MATCHES ".*clang\\+\\+$")
     find_program(MIOPEN_OFFLOADBUNDLER_BIN clang-offload-bundler
         PATH_SUFFIXES bin
-        PATHS 
-	    /opt/rocm/llvm
-	    ${CMAKE_INSTALL_PREFIX}/llvm
+        PATHS
+            /opt/rocm/llvm
+            ${CMAKE_INSTALL_PREFIX}/llvm
     )
 endif()
 if(MIOPEN_OFFLOADBUNDLER_BIN)
@@ -302,10 +301,9 @@ else()
             /opt/rocm/hip
             /opt/rocm/hcc
             /opt/rocm
-	        ${CMAKE_INSTALL_PREFIX}/hip
+            ${CMAKE_INSTALL_PREFIX}/hip
             ${CMAKE_INSTALL_PREFIX}/hcc
             ${CMAKE_INSTALL_PREFIX}
-
     )
     if(EXTRACTKERNEL_BIN)
         message(STATUS "extractkernel found: ${EXTRACTKERNEL_BIN}")
@@ -342,7 +340,6 @@ find_program(MIOPEN_AMDGCN_ASSEMBLER
         /opencl/bin/x86_64
         /opencl/bin
         /bin
-    NO_DEFAULT_PATH
 )
 message(STATUS "AMDGCN assembler: ${MIOPEN_AMDGCN_ASSEMBLER}")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,10 +150,9 @@ if( MIOPEN_BACKEND STREQUAL "OpenCL")
     set(MIOPEN_BACKEND_OPENCL 1)
     find_package( OpenCL REQUIRED )
     find_program(MIOPEN_HIP_COMPILER hcc
-        PATH_SUFFIXES bin
-        PATHS
-            ${ROCM_ROOT}
-            /opt/rocm
+            PATH_SUFFIXES bin
+            PATHS 
+	        /opt/rocm
     )
     set(MIOPEN_USE_MIOPENGEMM ON CACHE BOOL "")
     if(MIOPEN_HIP_COMPILER)
@@ -161,10 +160,9 @@ if( MIOPEN_BACKEND STREQUAL "OpenCL")
     else()
         find_program(MIOPEN_HIP_COMPILER clang++
             PATH_SUFFIXES bin
-	        PATHS
-                ${ROCM_ROOT}/llvm
-    		    /opt/rocm/llvm
-	    	    ${CMAKE_INSTALL_PREFIX}/llvm
+	        PATHS 
+		    /opt/rocm/llvm
+		    ${CMAKE_INSTALL_PREFIX}/llvm
         )
         if(MIOPEN_HIP_COMPILER)
             message("hip compiler: ${MIOPEN_HIP_COMPILER}")
@@ -189,7 +187,7 @@ endif()
 
 
 # HIP is always required
-find_package(hip REQUIRED PATHS ${ROCM_ROOT} /opt/rocm)
+find_package(hip REQUIRED PATHS /opt/rocm)
 message(STATUS "Build with HIP ${hip_VERSION}")
 target_flags(HIP_COMPILER_FLAGS hip::device)
 # Remove cuda arch flags
@@ -235,10 +233,10 @@ if( MIOPEN_BACKEND STREQUAL "HIP" OR MIOPEN_BACKEND STREQUAL "HIPOC" OR MIOPEN_B
 
     find_program(HIP_OC_COMPILER clang-ocl
         PATH_SUFFIXES bin
-        PATHS
-            ${ROCM_ROOT}
-    	    /opt/rocm
-    	    ${CMAKE_INSTALL_PREFIX}
+        PATHS 
+	    /opt/rocm
+	    ${CMAKE_INSTALL_PREFIX}
+
     )
     if(HIP_OC_COMPILER)
         message(STATUS "hip compiler: ${HIP_OC_COMPILER}")
@@ -274,7 +272,7 @@ if( MIOPEN_BACKEND STREQUAL "HIP" OR MIOPEN_BACKEND STREQUAL "HIPOC" OR MIOPEN_B
     # rocblas
     set(MIOPEN_USE_ROCBLAS ON CACHE BOOL "")
     if(MIOPEN_USE_ROCBLAS)
-        find_package(rocblas REQUIRED PATHS ${ROCM_ROOT} /opt/rocm)
+        find_package(rocblas REQUIRED PATHS /opt/rocm)
         message(STATUS "Build with rocblas")
     else()
         message(STATUS "Build without rocblas")
@@ -286,10 +284,9 @@ message( STATUS "${MIOPEN_BACKEND} backend selected." )
 if(MIOPEN_HIP_COMPILER MATCHES ".*clang\\+\\+$")
     find_program(MIOPEN_OFFLOADBUNDLER_BIN clang-offload-bundler
         PATH_SUFFIXES bin
-        PATHS
-            ${ROCM_ROOT}/llvm
-	        /opt/rocm/llvm
-	        ${CMAKE_INSTALL_PREFIX}/llvm
+        PATHS 
+	    /opt/rocm/llvm
+	    ${CMAKE_INSTALL_PREFIX}/llvm
     )
 endif()
 if(MIOPEN_OFFLOADBUNDLER_BIN)
@@ -302,15 +299,13 @@ else()
     find_program(EXTRACTKERNEL_BIN extractkernel
         PATH_SUFFIXES bin
         PATHS
-            ${ROCM_ROOT}/hip
-            ${ROCM_ROOT}/hcc
-            ${ROCM_ROOT}
             /opt/rocm/hip
             /opt/rocm/hcc
             /opt/rocm
 	        ${CMAKE_INSTALL_PREFIX}/hip
             ${CMAKE_INSTALL_PREFIX}/hcc
             ${CMAKE_INSTALL_PREFIX}
+
     )
     if(EXTRACTKERNEL_BIN)
         message(STATUS "extractkernel found: ${EXTRACTKERNEL_BIN}")
@@ -337,7 +332,6 @@ find_program(MIOPEN_AMDGCN_ASSEMBLER
     NAMES clang
     PATHS
         ${MIOPEN_AMDGCN_ASSEMBLER_PATH}
-        ${ROCM_ROOT}
         /opt/rocm
         /opt/rocm/llvm
         /opt/rocm/hcc
@@ -362,7 +356,7 @@ endif()
 
 # miopengemm
 if(MIOPEN_USE_MIOPENGEMM)
-    find_package(miopengemm PATHS ${ROCM_ROOT} /opt/rocm)
+    find_package(miopengemm PATHS /opt/rocm)
     if(miopengemm_FOUND)
         message(STATUS "Build with miopengemm")
         set(MIOPEN_USE_MIOPENGEMM 1)

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,7 +69,8 @@ apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-unau
     rocm-opencl-dev \
     rocm-cmake \
     rocblas \
-    zlib1g-dev && \
+    zlib1g-dev \
+    kmod && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -441,16 +441,16 @@ pipeline {
                         buildHipClangJobAndReboot(setup_flags: MLIR_flags + Fp16_flags, build_env: extra_log_env, test_flags: ' --verbose ', mlir_build: "ON")
                     }
                 }
-                stage('Fp16 Hip MLIR Xdlops') {
+                stage('Fp16 Hip MLIR gfx908') {
                     agent{ label rocmnode("gfx908") }
                     steps{
-                        buildHipClangJobAndReboot(setup_flags: MLIR_flags + Fp16_flags + gfx908_test, build_env: extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx908", mlir_build: "ON")
+                        buildHipClangJobAndReboot(setup_flags: MLIR_flags + Fp16_flags, build_env: extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx908", mlir_build: "ON")
                     }
                 }
-                stage('Fp32 Hip MLIR Xdlops') {
+                stage('Fp32 Hip MLIR gfx908') {
                     agent{ label rocmnode("gfx908") }
                     steps{
-                        buildHipClangJobAndReboot(setup_flags: MLIR_flags + gfx908_test, build_env: extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx908", mlir_build: "ON")
+                        buildHipClangJobAndReboot(setup_flags: MLIR_flags, build_env: extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx908", mlir_build: "ON")
                     }
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ def show_node_info() {
     """
 }
 
-//default 
+//default
 // CXX=/opt/rocm/llvm/bin/clang++ CXXFLAGS='-Werror' cmake -DMIOPEN_GPU_SYNC=Off -DCMAKE_PREFIX_PATH=/usr/local -DBUILD_DEV=On -DCMAKE_BUILD_TYPE=release ..
 //
 def cmake_build(Map conf=[:]){
@@ -24,14 +24,14 @@ def cmake_build(Map conf=[:]){
     def build_envs = "CTEST_PARALLEL_LEVEL=4 MIOPEN_CONV_PRECISE_ROCBLAS_TIMING=0 " + conf.get("build_env","")
     def prefixpath = conf.get("prefixpath","/usr/local")
     def setup_args = " -DMIOPEN_GPU_SYNC=Off " + conf.get("setup_flags","")
-    
+
     if (prefixpath != "/usr/local"){
         setup_args = setup_args + " -DCMAKE_PREFIX_PATH=${prefixpath} "
     }
 
     def build_type_debug = (conf.get("build_type",'release') == 'debug')
 
-    //cmake_env can overwrite default CXX variables. 
+    //cmake_env can overwrite default CXX variables.
     def cmake_envs = "CXX=${compiler} CXXFLAGS='-Werror' " + conf.get("cmake_ex_env","")
 
     def package_build = (conf.get("package_build","") == "true")
@@ -58,7 +58,7 @@ def cmake_build(Map conf=[:]){
         test_flags = " --disable-verification-cache " + test_flags
     }
 
-    if(conf.get("codecov", false)){ //Need 
+    if(conf.get("codecov", false)){ //Need
         setup_args = " -DCMAKE_BUILD_TYPE=debug -DCMAKE_CXX_FLAGS_DEBUG='${debug_flags} -fprofile-arcs -ftest-coverage' -DCODECOV_TEST=On " + setup_args
     }else if(build_type_debug){
         setup_args = " -DCMAKE_BUILD_TYPE=debug -DCMAKE_CXX_FLAGS_DEBUG='${debug_flags}'" + setup_args
@@ -121,7 +121,7 @@ def buildHipClangJob(Map conf=[:]){
         def variant = env.STAGE_NAME
 
         def codecov = conf.get("codecov", false)
-        
+
         def retimage
         gitStatusWrapper(credentialsId: '7126e5fe-eb51-4576-b52b-9aaf1de8f0fd', gitHubContext: "Jenkins - ${variant}", account: 'ROCmSoftwarePlatform', repo: 'MIOpen') {
             try {
@@ -263,10 +263,9 @@ pipeline {
                 defaultValue: true,
                 description: "Run packages stage")
     }
-    
+
     environment{
         extra_log_env   = " MIOPEN_LOG_LEVEL=5 "
-        gfx908_test     = " -DMIOPEN_TEST_GFX908=On"
         Fp16_flags      = " -DMIOPEN_TEST_HALF=On"
         Bf16_flags      = " -DMIOPEN_TEST_BFLOAT16=On"
         Int8_flags      = " -DMIOPEN_TEST_INT8=On"
@@ -334,7 +333,7 @@ pipeline {
                 stage('Fp32 OpenCL gfx908') {
                     agent{ label rocmnode("gfx908") }
                     steps{
-                        buildHipClangJobAndReboot(compiler: 'g++', config_targets: Smoke_targets, setup_flags: gfx908_test, gpu_arch: "gfx908")
+                        buildHipClangJobAndReboot(compiler: 'g++', config_targets: Smoke_targets, gpu_arch: "gfx908")
                     }
                 }
                 stage('Fp32 Hip /opt/rocm') {
@@ -356,7 +355,7 @@ pipeline {
                         prefixpath = "/opt/rocm"
                     }
                     steps{
-                        buildHipClangJobAndReboot(prefixpath: prefixpath, build_type: 'debug', setup_flags: gfx908_test, config_targets: Smoke_targets, gpu_arch: gpu_arch)
+                        buildHipClangJobAndReboot(prefixpath: prefixpath, build_type: 'debug', config_targets: Smoke_targets, gpu_arch: gpu_arch)
                     }
                 }
                 stage('Fp32 HipNoGPU Debug') {
@@ -489,13 +488,13 @@ pipeline {
                 stage('Fp16 Hip gfx908 /opt/rocm') {
                     agent{ label rocmnode("gfx908") }
                     steps{
-                        buildHipClangJobAndReboot( setup_flags: Fp16_flags + gfx908_test, prefixpath: '/opt/rocm', config_targets: Smoke_targets, gpu_arch: "gfx908")
+                        buildHipClangJobAndReboot( setup_flags: Fp16_flags, prefixpath: '/opt/rocm', config_targets: Smoke_targets, gpu_arch: "gfx908")
                     }
                 }
                 stage('Bf16 Hip gfx908 /opt/rocm') {
                     agent{ label rocmnode("gfx908") }
                     steps{
-                        buildHipClangJobAndReboot(setup_flags: Bf16_flags + gfx908_test, prefixpath: '/opt/rocm', config_targets: Smoke_targets, gpu_arch: "gfx908")
+                        buildHipClangJobAndReboot(setup_flags: Bf16_flags, prefixpath: '/opt/rocm', config_targets: Smoke_targets, gpu_arch: "gfx908")
                     }
                 }
             }
@@ -524,14 +523,14 @@ pipeline {
                     when { expression { params.SMOKE_MIOPENTENSILE_LATEST && !params.DISABLE_ALL_STAGES } }
                     agent{ label rocmnode("gfx908") }
                     steps{
-                        buildHipClangJobAndReboot( setup_flags: Tensile_setup + extra_log_env + gfx908_test , build_env: Tensile_build_env + extra_log_env, gpu_arch: "gfx908:xnack-", test_flags: ' --verbose ', miotensile_version: Tensile_version, target_id: "ON")
+                        buildHipClangJobAndReboot( setup_flags: Tensile_setup + extra_log_env, build_env: Tensile_build_env + extra_log_env, gpu_arch: "gfx908:xnack-", test_flags: ' --verbose ', miotensile_version: Tensile_version, target_id: "ON")
                     }
                 }
                 stage('Bf16 Hip Tensile-Latest All gfx908') {
                     when { expression { params.SMOKE_MIOPENTENSILE_LATEST && !params.DISABLE_ALL_STAGES } }
                     agent{ label rocmnode("gfx908") }
                     steps{
-                        buildHipClangJobAndReboot( setup_flags: Tensile_setup + extra_log_env + gfx908_test + Bf16_flags, build_env: Tensile_build_env + extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx908:xnack-", miotensile_version: Tensile_version, target_id: "ON")
+                        buildHipClangJobAndReboot( setup_flags: Tensile_setup + extra_log_env + Bf16_flags, build_env: Tensile_build_env + extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx908:xnack-", miotensile_version: Tensile_version, target_id: "ON")
                     }
                 }
             }
@@ -554,7 +553,7 @@ pipeline {
                 stage('Bf16 Hip Install All gfx908') {
                     agent{ label rocmnode("gfx908") }
                     steps{
-                        buildHipClangJobAndReboot(setup_flags: Bf16_flags + Full_test_limit + gfx908_test, build_install: "true", gpu_arch: "gfx908")
+                        buildHipClangJobAndReboot(setup_flags: Bf16_flags + Full_test_limit, build_install: "true", gpu_arch: "gfx908")
                     }
                 }
             }
@@ -569,7 +568,7 @@ pipeline {
                 stage('Fp32 Hip All gfx908') {
                     agent{ label rocmnode("gfx908") }
                     steps{
-                        buildHipClangJobAndReboot(setup_flags: Full_test_limit + gfx908_test, build_env: WORKAROUND_iGemm_936, gpu_arch: "gfx908")
+                        buildHipClangJobAndReboot(setup_flags: Full_test_limit, build_env: WORKAROUND_iGemm_936, gpu_arch: "gfx908")
                     }
                 }
                 stage('Fp16 Hip Install All Vega20') {
@@ -587,7 +586,7 @@ pipeline {
                 stage('Fp16 Hip All Install gfx908') {
                     agent{ label rocmnode("gfx908") }
                     steps{
-                        buildHipClangJobAndReboot(setup_flags: Full_test_limit + gfx908_test + Fp16_flags, build_env: WORKAROUND_iGemm_936, build_install: "true", gpu_arch: "gfx908")
+                        buildHipClangJobAndReboot(setup_flags: Full_test_limit + Fp16_flags, build_env: WORKAROUND_iGemm_936, build_install: "true", gpu_arch: "gfx908")
                     }
                 }
             }
@@ -626,25 +625,25 @@ pipeline {
                 stage('Fp32 Hip Tensile All gfx908') {
                     agent{ label rocmnode("gfx908") }
                     steps{
-                        buildHipClangJobAndReboot( setup_flags: Tensile_setup + Full_test_limit + extra_log_env + gfx908_test , build_env: Tensile_build_env + extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx908:xnack-", miotensile_version: Tensile_version, target_id: "ON")
+                        buildHipClangJobAndReboot( setup_flags: Tensile_setup + Full_test_limit + extra_log_env, build_env: Tensile_build_env + extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx908:xnack-", miotensile_version: Tensile_version, target_id: "ON")
                     }
                 }
                 stage('Fp16 Hip Tensile All gfx908') {
                     agent{ label rocmnode("gfx908") }
                     steps{
-                        buildHipClangJobAndReboot( setup_flags: Tensile_setup + Full_test_limit + extra_log_env + gfx908_test + Fp16_flags, build_env: Tensile_build_env + extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx908:xnack-", miotensile_version: Tensile_version, target_id: "ON")
+                        buildHipClangJobAndReboot( setup_flags: Tensile_setup + Full_test_limit + extra_log_env + Fp16_flags, build_env: Tensile_build_env + extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx908:xnack-", miotensile_version: Tensile_version, target_id: "ON")
                     }
                 }
                 stage('Bf16 Hip Tensile All gfx908') {
                     agent{ label rocmnode("gfx908") }
                     steps{
-                        buildHipClangJobAndReboot( setup_flags: Tensile_setup + Full_test_limit + extra_log_env + gfx908_test + Bf16_flags, build_env: Tensile_build_env + extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx908:xnack-", miotensile_version: Tensile_version, target_id: "ON")
+                        buildHipClangJobAndReboot( setup_flags: Tensile_setup + Full_test_limit + extra_log_env + Bf16_flags, build_env: Tensile_build_env + extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx908:xnack-", miotensile_version: Tensile_version, target_id: "ON")
                     }
                 }
                 stage('Int8 Hip Tensile All gfx908') {
                     agent{ label rocmnode("gfx908") }
                     steps{
-                        buildHipClangJobAndReboot( setup_flags: Tensile_setup + Full_test_limit + extra_log_env + gfx908_test + Int8_flags, build_env: Tensile_build_env + extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx908:xnack-", miotensile_version: Tensile_version, target_id: "ON")
+                        buildHipClangJobAndReboot( setup_flags: Tensile_setup + Full_test_limit + extra_log_env + Int8_flags, build_env: Tensile_build_env + extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx908:xnack-", miotensile_version: Tensile_version, target_id: "ON")
                     }
                 }
             }
@@ -682,25 +681,25 @@ pipeline {
                 stage('Fp32 Hip Tensile-Latest All gfx908') {
                     agent{ label rocmnode("gfx908") }
                     steps{
-                        buildHipClangJobAndReboot( setup_flags: Tensile_setup + Full_test_limit + extra_log_env + gfx908_test , build_env: Tensile_build_env + extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx908:xnack-", miotensile_version: Tensile_version, target_id: "ON")
+                        buildHipClangJobAndReboot( setup_flags: Tensile_setup + Full_test_limit + extra_log_env, build_env: Tensile_build_env + extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx908:xnack-", miotensile_version: Tensile_version, target_id: "ON")
                     }
                 }
                 stage('Fp16 Hip Tensile-Latest All gfx908') {
                     agent{ label rocmnode("gfx908") }
                     steps{
-                        buildHipClangJobAndReboot( setup_flags: Tensile_setup + Full_test_limit + extra_log_env + gfx908_test + Fp16_flags, build_env: Tensile_build_env + extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx908:xnack-", miotensile_version: Tensile_version, target_id: "ON")
+                        buildHipClangJobAndReboot( setup_flags: Tensile_setup + Full_test_limit + extra_log_env + Fp16_flags, build_env: Tensile_build_env + extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx908:xnack-", miotensile_version: Tensile_version, target_id: "ON")
                     }
                 }
                 stage('Bf16 Hip Tensile-Latest All gfx908') {
                     agent{ label rocmnode("gfx908") }
                     steps{
-                        buildHipClangJobAndReboot( setup_flags: Tensile_setup + Full_test_limit + extra_log_env + gfx908_test + Bf16_flags, build_env: Tensile_build_env + extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx908:xnack-", miotensile_version: Tensile_version, target_id: "ON")
+                        buildHipClangJobAndReboot( setup_flags: Tensile_setup + Full_test_limit + extra_log_env + Bf16_flags, build_env: Tensile_build_env + extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx908:xnack-", miotensile_version: Tensile_version, target_id: "ON")
                     }
                 }
                 stage('Int8 Hip Tensile-Latest All gfx908') {
                     agent{ label rocmnode("gfx908") }
                     steps{
-                        buildHipClangJobAndReboot( setup_flags: Tensile_setup + Full_test_limit + extra_log_env + gfx908_test + Int8_flags, build_env: Tensile_build_env + extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx908:xnack-", miotensile_version: Tensile_version, target_id: "ON")
+                        buildHipClangJobAndReboot( setup_flags: Tensile_setup + Full_test_limit + extra_log_env + Int8_flags, build_env: Tensile_build_env + extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx908:xnack-", miotensile_version: Tensile_version, target_id: "ON")
                     }
                 }
             }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -58,19 +58,11 @@ if(NOT (MIOPEN_TEST_VEGA OR MIOPEN_TEST_GFX908))
     if(ROCMINFO)
         execute_process (
             COMMAND ${ROCMINFO}
-            COMMAND grep -i -E "(gfx900)|(gfx906)"
-            RESULT_VARIABLE ROCMINFO_VEGA
-            OUTPUT_QUIET
+            OUTPUT_VARIABLE ROCMINFO_OUTPUT
         )
-        execute_process (
-            COMMAND ${ROCMINFO}
-            COMMAND grep -i gfx908
-            RESULT_VARIABLE ROCMINFO_GFX908
-            OUTPUT_QUIET
-        )
-        if(ROCMINFO_VEGA STREQUAL "0")
+        if(ROCMINFO_OUTPUT MATCHES "gfx900|gfx906")
             set(MIOPEN_TEST_VEGA ON)
-        elseif(ROCMINFO_GFX908 STREQUAL "0")
+        elseif(ROCMINFO_OUTPUT MATCHES "gfx908")
             set(MIOPEN_TEST_GFX908 ON)
         else()
             message(WARNING "TESTING IS NOT SUPPORTED FOR THE DETECTED GPU")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -49,11 +49,10 @@ if(NOT (MIOPEN_TEST_VEGA OR MIOPEN_TEST_GFX908))
     find_program(ROCMINFO
         NAMES rocminfo
         PATHS
-            ${ROCM_ROOT}
             /opt/rocm
+            ${CMAKE_INSTALL_PREFIX}
         PATH_SUFFIXES
             /bin
-        NO_DEFAULT_PATH
     )
     message(STATUS "rocminfo utility: ${ROCMINFO}")
     if(ROCMINFO)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -65,11 +65,7 @@ if(NOT (MIOPEN_TEST_VEGA OR MIOPEN_TEST_GFX908))
         )
         execute_process (
             COMMAND ${ROCMINFO}
-            #
-            # gfx90a bringup is not complete yet.
-            # Let's use gfx908 tests for gfx90a for now.
-            #
-            COMMAND grep -i -E "(gfx908)|(gfx90a)"
+            COMMAND grep -i gfx908
             RESULT_VARIABLE ROCMINFO_GFX908
             OUTPUT_QUIET
         )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -67,6 +67,7 @@ endif()
 # Detect GPU type for testing.
 # For HIP_NOGPU backend, GPU detection is not required and should be disabled.
 # Also we do not detect GPU when target GPU for testing is specified explicitly.
+set(MIOPEN_TEST_GPU_DETECTION_FAILED FALSE)
 if(NOT (MIOPEN_TEST_VEGA OR MIOPEN_TEST_GFX908 OR MIOPEN_TEST_HIP_NOGPU))
     find_program(ROCMINFO
         NAMES rocminfo
@@ -84,17 +85,19 @@ if(NOT (MIOPEN_TEST_VEGA OR MIOPEN_TEST_GFX908 OR MIOPEN_TEST_HIP_NOGPU))
             RESULT_VARIABLE ROCMINFO_EXIT_STATUS
         )
         if(NOT ROCMINFO_EXIT_STATUS EQUAL 0)
-            message(FATAL_ERROR "ROCMINFO FAILED, GPU TYPE UNKNOWN. Manually set respective MIOPEN_TEST_GFX* CMake variable to specify target GPU for testing.")
-        endif()
-        if(ROCMINFO_OUTPUT MATCHES "gfx900|gfx906")
+            message(WARNING "ROCMINFO FAILED, GPU TYPE UNKNOWN. Manually set respective MIOPEN_TEST_GFX* CMake variable to specify target GPU for testing.")
+            set(MIOPEN_TEST_GPU_DETECTION_FAILED TRUE)
+        elseif(ROCMINFO_OUTPUT MATCHES "gfx900|gfx906")
             set(MIOPEN_TEST_VEGA ON)
         elseif(ROCMINFO_OUTPUT MATCHES "gfx908")
             set(MIOPEN_TEST_GFX908 ON)
         else()
             message(WARNING "TESTING IS NOT SUPPORTED FOR THE DETECTED GPU")
+            set(MIOPEN_TEST_GPU_DETECTION_FAILED TRUE)
         endif()
     else()
-        message(FATAL_ERROR "ROCMINFO NOT FOUND, GPU TYPE UNKNOWN. Manually set respective MIOPEN_TEST_GFX* CMake variable to specify target GPU for testing.")
+        message(WARNING "ROCMINFO NOT FOUND, GPU TYPE UNKNOWN. Manually set respective MIOPEN_TEST_GFX* CMake variable to specify target GPU for testing.")
+        set(MIOPEN_TEST_GPU_DETECTION_FAILED TRUE)
     endif()
 endif()
 message(STATUS "MIOPEN_TEST_VEGA ${MIOPEN_TEST_VEGA}")
@@ -109,6 +112,11 @@ endif()
 find_package(Threads REQUIRED)
 add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure -C ${CMAKE_CFG_INTDIR})
 add_custom_target(tests)
+
+if(MIOPEN_TEST_GPU_DETECTION_FAILED)
+    add_custom_target(gpu_detection_check COMMAND echo "*** FATAL: GPU DETECTION FAILED DURING CMAKE PHASE, CHECK CMAKE WARNINGS ***" COMMAND exit 1)
+    add_dependencies(check gpu_detection_check)
+endif()
 
 set(MIOPEN_TEST_FLOAT_ARG)
 set(MIOPEN_TEST_FLOAT FALSE)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -79,7 +79,7 @@ if(NOT (MIOPEN_TEST_VEGA OR MIOPEN_TEST_GFX908 OR MIOPEN_TEST_HIP_NOGPU))
     message(STATUS "rocminfo utility: ${ROCMINFO}")
     if(ROCMINFO)
         execute_process (
-            COMMAND ${ROCMINFO}_
+            COMMAND ${ROCMINFO}
             OUTPUT_VARIABLE ROCMINFO_OUTPUT
             RESULT_VARIABLE ROCMINFO_EXIT_STATUS
         )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -33,6 +33,8 @@ option( MIOPEN_TEST_ALL "Run the full test suite" OFF )
 option( MIOPEN_TEST_HALF "Test in half mode" OFF )
 option( MIOPEN_TEST_INT8 "Test in int8 mode" OFF )
 option( MIOPEN_TEST_BFLOAT16 "Test in bfloat16 mode" OFF )
+option( MIOPEN_TEST_GFX908 "Test arch gfx908 mode" OFF )
+option( MIOPEN_TEST_VEGA "Test arch VEGA (gfx900, gfx906)" OFF )
 option( MIOPEN_TEST_CONV Off)
 option( MIOPEN_TEST_DEEPBENCH Off)
 option( MIOPEN_TEST_DRIVER_ITER_MODE Off)
@@ -43,47 +45,47 @@ option( WORKAROUND_ISSUE_898 "" ON)
 option( WORKAROUND_ISSUE_936 "" ON)
 
 # Detect GPU type for testing
-set(MIOPEN_TEST_GFX908_DEFAULT Off)
-set(MIOPEN_TEST_VEGA_DEFAULT Off)
-find_program(ROCMINFO
-    NAMES rocminfo
-    PATHS
-        ${ROCM_ROOT}
-        /opt/rocm
-    PATH_SUFFIXES
-        /bin
-    NO_DEFAULT_PATH
-)
-message(STATUS "rocminfo utility: ${ROCMINFO}")
-if(ROCMINFO)
-    execute_process (
-        COMMAND ${ROCMINFO}
-        COMMAND grep -i -E "(gfx900)|(gfx906)"
-        RESULT_VARIABLE ROCMINFO_VEGA
-        OUTPUT_QUIET
+if(NOT (MIOPEN_TEST_VEGA OR MIOPEN_TEST_GFX908))
+    find_program(ROCMINFO
+        NAMES rocminfo
+        PATHS
+            ${ROCM_ROOT}
+            /opt/rocm
+        PATH_SUFFIXES
+            /bin
+        NO_DEFAULT_PATH
     )
-    execute_process (
-        COMMAND ${ROCMINFO}
-        #
-        # gfx90a bringup is not complete yet.
-        # Let's use gfx908 tests for gfx90a for now.
-        #
-        COMMAND grep -i -E "(gfx908)|(gfx90a)"
-        RESULT_VARIABLE ROCMINFO_GFX908
-        OUTPUT_QUIET
-    )
-    if(ROCMINFO_VEGA STREQUAL "0")
-        set(MIOPEN_TEST_VEGA_DEFAULT On)
-    elseif(ROCMINFO_GFX908 STREQUAL "0")
-        set(MIOPEN_TEST_GFX908_DEFAULT On)
+    message(STATUS "rocminfo utility: ${ROCMINFO}")
+    if(ROCMINFO)
+        execute_process (
+            COMMAND ${ROCMINFO}
+            COMMAND grep -i -E "(gfx900)|(gfx906)"
+            RESULT_VARIABLE ROCMINFO_VEGA
+            OUTPUT_QUIET
+        )
+        execute_process (
+            COMMAND ${ROCMINFO}
+            #
+            # gfx90a bringup is not complete yet.
+            # Let's use gfx908 tests for gfx90a for now.
+            #
+            COMMAND grep -i -E "(gfx908)|(gfx90a)"
+            RESULT_VARIABLE ROCMINFO_GFX908
+            OUTPUT_QUIET
+        )
+        if(ROCMINFO_VEGA STREQUAL "0")
+            set(MIOPEN_TEST_VEGA ON)
+        elseif(ROCMINFO_GFX908 STREQUAL "0")
+            set(MIOPEN_TEST_GFX908 ON)
+        else()
+            message(WARNING "TESTING IS NOT SUPPORTED FOR THE DETECTED GPU")
+        endif()
     else()
-        message(WARNING "TESTING IS NOT SUPPORTED FOR THE DETECTED GPU")
+        message(WARNING "GPU DETECTION FAILED, SO AUTOMATIC TESTING MAY FAIL. Manually set respective MIOPEN_TEST_GFX* CMake variable to specify the target GPU for testing.")
     endif()
-else()
-    message(WARNING "GPU DETECTION FAILED, SO AUTOMATIC TESTING MAY FAIL. Manually set respective MIOPEN_TEST_GFX* CMake variable to specify the target GPU for testing.")
 endif()
-option( MIOPEN_TEST_GFX908 "Test arch gfx908 mode" ${MIOPEN_TEST_GFX908_DEFAULT} )
-option( MIOPEN_TEST_VEGA "Test arch VEGA (gfx900, gfx906)" ${MIOPEN_TEST_VEGA_DEFAULT} )
+message(STATUS "MIOPEN_TEST_VEGA ${MIOPEN_TEST_VEGA}")
+message(STATUS "MIOPEN_TEST_GFX908 ${MIOPEN_TEST_GFX908}")
 
 #Run the test suite to a depth limit
 set(MIOPEN_TEST_LIMIT "0" CACHE STRING "")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -33,8 +33,6 @@ option( MIOPEN_TEST_ALL "Run the full test suite" OFF )
 option( MIOPEN_TEST_HALF "Test in half mode" OFF )
 option( MIOPEN_TEST_INT8 "Test in int8 mode" OFF )
 option( MIOPEN_TEST_BFLOAT16 "Test in bfloat16 mode" OFF )
-option( MIOPEN_TEST_GFX908 "Test arch gfx908 mode" OFF )
-option( MIOPEN_TEST_VEGA "Test arch VEGA (gfx900, gfx906)" ON )
 option( MIOPEN_TEST_CONV Off)
 option( MIOPEN_TEST_DEEPBENCH Off)
 option( MIOPEN_TEST_DRIVER_ITER_MODE Off)
@@ -43,6 +41,49 @@ option( MIOPEN_TEST_MLIR "Add tests for MLIR -- EXPERIMENTAL" ${MIOPEN_USE_MLIR}
 
 option( WORKAROUND_ISSUE_898 "" ON)
 option( WORKAROUND_ISSUE_936 "" ON)
+
+# Detect GPU type for testing
+set(MIOPEN_TEST_GFX908_DEFAULT Off)
+set(MIOPEN_TEST_VEGA_DEFAULT Off)
+find_program(ROCMINFO
+    NAMES rocminfo
+    PATHS
+        ${ROCM_ROOT}
+        /opt/rocm
+    PATH_SUFFIXES
+        /bin
+    NO_DEFAULT_PATH
+)
+message(STATUS "rocminfo utility: ${ROCMINFO}")
+if(ROCMINFO)
+    execute_process (
+        COMMAND ${ROCMINFO}
+        COMMAND grep -i -E "(gfx900)|(gfx906)"
+        RESULT_VARIABLE ROCMINFO_VEGA
+        OUTPUT_QUIET
+    )
+    execute_process (
+        COMMAND ${ROCMINFO}
+        #
+        # gfx90a bringup is not complete yet.
+        # Let's use gfx908 tests for gfx90a for now.
+        #
+        COMMAND grep -i -E "(gfx908)|(gfx90a)"
+        RESULT_VARIABLE ROCMINFO_GFX908
+        OUTPUT_QUIET
+    )
+    if(ROCMINFO_VEGA STREQUAL "0")
+        set(MIOPEN_TEST_VEGA_DEFAULT On)
+    elseif(ROCMINFO_GFX908 STREQUAL "0")
+        set(MIOPEN_TEST_GFX908_DEFAULT On)
+    else()
+        message(WARNING "TESTING IS NOT SUPPORTED FOR THE DETECTED GPU")
+    endif()
+else()
+    message(WARNING "GPU DETECTION FAILED, SO AUTOMATIC TESTING MAY FAIL. Manually set respective MIOPEN_TEST_GFX* CMake variable to specify the target GPU for testing.")
+endif()
+option( MIOPEN_TEST_GFX908 "Test arch gfx908 mode" ${MIOPEN_TEST_GFX908_DEFAULT} )
+option( MIOPEN_TEST_VEGA "Test arch VEGA (gfx900, gfx906)" ${MIOPEN_TEST_VEGA_DEFAULT} )
 
 #Run the test suite to a depth limit
 set(MIOPEN_TEST_LIMIT "0" CACHE STRING "")
@@ -198,7 +239,7 @@ function(add_test_executable TEST_NAME)
     if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
         set_target_properties(${TEST_NAME} PROPERTIES COMPILE_FLAGS -pthread LINK_FLAGS -pthread)
     endif()
-    
+
     if(MIOPEN_TEST_ALL)
         set(TEST_COMMAND ${TEST_NAME} ${MIOPEN_TEST_FLOAT_ARG} --all ${MIOPEN_TEST_FLAGS_ARGS})
     else()
@@ -208,7 +249,7 @@ function(add_test_executable TEST_NAME)
     if(MIOPEN_TEST_LIMIT GREATER 0)
         set(TEST_COMMAND ${TEST_COMMAND} --limit ${MIOPEN_TEST_LIMIT})
     endif()
-    
+
     if(WORKAROUND_ISSUE_936 AND (${TEST_NAME} MATCHES "test_conv2d" OR ${TEST_NAME} MATCHES "test_immed_conv2d") )
         set(TEST_COMMAND ${TEST_COMMAND} --tolerance 130) #increased by 1.625 times
     endif()
@@ -488,7 +529,7 @@ if(${CODECOV_TEST})
     add_custom_test(test_pooling2d_codecov
         COMMAND $<TARGET_FILE:test_pooling2d> ${MIOPEN_TEST_FLOAT_ARG} --input 1, 192, 28, 28 --lens 2 2 --strides 2 2 --pads 0 0 ${MIOPEN_TEST_FLAGS_ARGS}
     )
-    
+
 endif()
 
 
@@ -1198,8 +1239,8 @@ set(DYNAMIC_IMPLICITGEMM_XDLOPS_NHWC_WRW_ENVS
 set(ARGS_NHWC_WRW
     --disable-forward
     --disable-backward-data
-    --in_layout NHWC 
-    --fil_layout NHWC 
+    --in_layout NHWC
+    --fil_layout NHWC
     --out_layout NHWC)
 
 add_custom_test(test_conv_igemm_dynamic_xdlops_nhwc_wrw SKIP_UNLESS_ALL HALF_ENABLED GFX908_ENABLED VEGA_DISABLED

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -44,37 +44,7 @@ option( MIOPEN_TEST_MLIR "Add tests for MLIR -- EXPERIMENTAL" ${MIOPEN_USE_MLIR}
 option( WORKAROUND_ISSUE_898 "" ON)
 option( WORKAROUND_ISSUE_936 "" ON)
 
-# Detect GPU type for testing
-if(NOT (MIOPEN_TEST_VEGA OR MIOPEN_TEST_GFX908))
-    find_program(ROCMINFO
-        NAMES rocminfo
-        PATHS
-            /opt/rocm
-            ${CMAKE_INSTALL_PREFIX}
-        PATH_SUFFIXES
-            /bin
-    )
-    message(STATUS "rocminfo utility: ${ROCMINFO}")
-    if(ROCMINFO)
-        execute_process (
-            COMMAND ${ROCMINFO}
-            OUTPUT_VARIABLE ROCMINFO_OUTPUT
-        )
-        if(ROCMINFO_OUTPUT MATCHES "gfx900|gfx906")
-            set(MIOPEN_TEST_VEGA ON)
-        elseif(ROCMINFO_OUTPUT MATCHES "gfx908")
-            set(MIOPEN_TEST_GFX908 ON)
-        else()
-            message(WARNING "TESTING IS NOT SUPPORTED FOR THE DETECTED GPU")
-        endif()
-    else()
-        message(WARNING "GPU DETECTION FAILED, SO AUTOMATIC TESTING MAY FAIL. Manually set respective MIOPEN_TEST_GFX* CMake variable to specify the target GPU for testing.")
-    endif()
-endif()
-message(STATUS "MIOPEN_TEST_VEGA ${MIOPEN_TEST_VEGA}")
-message(STATUS "MIOPEN_TEST_GFX908 ${MIOPEN_TEST_GFX908}")
-
-#Run the test suite to a depth limit
+# Run the test suite to a depth limit
 set(MIOPEN_TEST_LIMIT "0" CACHE STRING "")
 set(MIOPEN_TEST_FLAGS "" CACHE STRING "")
 set(MIOPEN_TEST_GDB On CACHE BOOL "")
@@ -94,6 +64,42 @@ if(MIOPEN_BACKEND_HIP AND NOT MIOPEN_TEST_HIP_NOGPU)
     set(MIOPEN_TEST_HIP TRUE)
 endif()
 
+# Detect GPU type for testing.
+# For HIP_NOGPU backend, GPU detection is not required and should be disabled.
+# Also we do not detect GPU when target GPU for testing is specified explicitly.
+if(NOT (MIOPEN_TEST_VEGA OR MIOPEN_TEST_GFX908 OR MIOPEN_TEST_HIP_NOGPU))
+    find_program(ROCMINFO
+        NAMES rocminfo
+        PATHS
+            /opt/rocm
+            ${CMAKE_INSTALL_PREFIX}
+        PATH_SUFFIXES
+            /bin
+    )
+    message(STATUS "rocminfo utility: ${ROCMINFO}")
+    if(ROCMINFO)
+        execute_process (
+            COMMAND ${ROCMINFO}_
+            OUTPUT_VARIABLE ROCMINFO_OUTPUT
+            RESULT_VARIABLE ROCMINFO_EXIT_STATUS
+        )
+        if(NOT ROCMINFO_EXIT_STATUS EQUAL 0)
+            message(FATAL_ERROR "ROCMINFO FAILED, GPU TYPE UNKNOWN. Manually set respective MIOPEN_TEST_GFX* CMake variable to specify target GPU for testing.")
+        endif()
+        if(ROCMINFO_OUTPUT MATCHES "gfx900|gfx906")
+            set(MIOPEN_TEST_VEGA ON)
+        elseif(ROCMINFO_OUTPUT MATCHES "gfx908")
+            set(MIOPEN_TEST_GFX908 ON)
+        else()
+            message(WARNING "TESTING IS NOT SUPPORTED FOR THE DETECTED GPU")
+        endif()
+    else()
+        message(FATAL_ERROR "ROCMINFO NOT FOUND, GPU TYPE UNKNOWN. Manually set respective MIOPEN_TEST_GFX* CMake variable to specify target GPU for testing.")
+    endif()
+endif()
+message(STATUS "MIOPEN_TEST_VEGA ${MIOPEN_TEST_VEGA}")
+message(STATUS "MIOPEN_TEST_GFX908 ${MIOPEN_TEST_GFX908}")
+
 if(MIOPEN_TEST_DRIVER_ITER_MODE)
     add_definitions(-DMIOPEN_TEST_DRIVER_MODE=2)
 else()
@@ -104,13 +110,7 @@ find_package(Threads REQUIRED)
 add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure -C ${CMAKE_CFG_INTDIR})
 add_custom_target(tests)
 
-if(MIOPEN_TEST_GFX908)
-    set(MIOPEN_TEST_VEGA FALSE)
-endif()
-
 set(MIOPEN_TEST_FLOAT_ARG)
-
-
 set(MIOPEN_TEST_FLOAT FALSE)
 if(MIOPEN_TEST_HALF)
     set(MIOPEN_TEST_FLOAT_ARG --half)
@@ -122,7 +122,6 @@ else()
     set(MIOPEN_TEST_FLOAT_ARG --float)
     set(MIOPEN_TEST_FLOAT TRUE)
 endif()
-
 
 if(NOT MIOPEN_TEST_MIOTENSILE)
 	if(MIOPEN_TEST_HALF)
@@ -175,8 +174,6 @@ if(SKIP_ALL_EXCEPT_TESTS)
 endif()
 message(STATUS "SKIP_TESTS: ${SKIP_TESTS}")
 message(STATUS "SKIP_ALL_EXCEPT_TESTS: ${SKIP_ALL_EXCEPT_TESTS}")
-
-
 
 
 function(add_test_command NAME EXE)


### PR DESCRIPTION
Implements #985 

* [TESTS] Added detection of GPU type for testing.
  * Explicit setting of `MIOPEN_TEST_GFX*` overrides it (for backward compatibility).
* [Jenkinsfile] Removed explicit setting of the MIOPEN_TEST_GFX908 flag because it is not required anymore.
* [Dockerfile] Installed `kmod` as it is required by `rocminfo` to work.

## :warning: QUIET CHANGES
- The default GPU for testing was gfx900/906 (Vega) before this PR. Now the default GPU for testing is identified by grepping the output of `rocminfo`.
- If `rocminfo` is not available or fails, then `make check` fails immediately. In this case the user need to explicitly specify `MIOPEN_TEST_GFX908=On` or `MIOPEN_TEST_VEGA=On` etc. _Before this PR_, Vega testing was enabled by default in this case.
- Ditto if detected GPU is not known to the test/CMakeLists.txt.
    :red_circle: Both Navi21 and gfx90a are NOT KNOWN to the tests yet!


