### PR TITLE
[MLIR] Remove validations that have been moved into MLIR.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -117,7 +117,7 @@ RUN if [ "$USE_TARGETID" = "OFF" ] ; then echo "MIOpenTensile is not installed."
 
 RUN if [ "$USE_MLIR" = "ON" ]; \
     then cd ~ && \
-    export MLIR_COMMIT=44abc4783fe2f6b4415871f7c44aa52ab89bccab && \
+    export MLIR_COMMIT=cceb268dc6ca97a94f5bedc1fc316a2233769aaf && \
     wget https://github.com/ROCmSoftwarePlatform/llvm-project-mlir/archive/$MLIR_COMMIT.tar.gz && \
     tar -xvzf $MLIR_COMMIT.tar.gz && \
     rm -rf $MLIR_COMMIT.tar.gz && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -117,7 +117,7 @@ RUN if [ "$USE_TARGETID" = "OFF" ] ; then echo "MIOpenTensile is not installed."
 
 RUN if [ "$USE_MLIR" = "ON" ]; \
     then cd ~ && \
-    export MLIR_COMMIT=cceb268dc6ca97a94f5bedc1fc316a2233769aaf && \
+    export MLIR_COMMIT=950823986052e4750468e4e3a9641d0ce7be74a4 && \
     wget https://github.com/ROCmSoftwarePlatform/llvm-project-mlir/archive/$MLIR_COMMIT.tar.gz && \
     tar -xvzf $MLIR_COMMIT.tar.gz && \
     rm -rf $MLIR_COMMIT.tar.gz && \

--- a/src/include/miopen/solver/implicitgemm_util.hpp
+++ b/src/include/miopen/solver/implicitgemm_util.hpp
@@ -217,11 +217,13 @@ struct ConvolutionContextInterpreter
             return c.in_width;
     }
 
-    static auto GetOutputDataType(const ConvolutionContext& c) {
+    static auto GetOutputDataType(const ConvolutionContext& c)
+    {
         return c.direction.IsForward() ? c.out_data_type : c.in_data_type;
     }
 
-    static auto GetInputDataType(const ConvolutionContext& c) {
+    static auto GetInputDataType(const ConvolutionContext& c)
+    {
         return c.direction.IsForward() ? c.in_data_type : c.out_data_type;
     }
 

--- a/src/include/miopen/solver/implicitgemm_util.hpp
+++ b/src/include/miopen/solver/implicitgemm_util.hpp
@@ -217,6 +217,14 @@ struct ConvolutionContextInterpreter
             return c.in_width;
     }
 
+    static auto GetOutputDataType(const ConvolutionContext& c) {
+        return c.direction.IsForward() ? c.out_data_type : c.in_data_type;
+    }
+
+    static auto GetInputDataType(const ConvolutionContext& c) {
+        return c.direction.IsForward() ? c.in_data_type : c.out_data_type;
+    }
+
     static auto GetFilterDepthZ(const ConvolutionContext& c) { return c.kernel_size_d; }
 
     static auto GetFilterLayout(const ConvolutionContext& c) { return c.weights_layout; }

--- a/src/mlir_build.cpp
+++ b/src/mlir_build.cpp
@@ -150,9 +150,6 @@ void MiirGenLaunchParams(const std::string& params, size_t& local_size, size_t& 
 
 bool MiirIsConfigApplicable(const std::string& params)
 {
-    if (params.empty()) {
-        return false;
-    }
     AutoMiirHandle handle(params);
     return MIIR_SUCCESS == miirLowerTuningParams(handle());
 }

--- a/src/mlir_build.cpp
+++ b/src/mlir_build.cpp
@@ -150,6 +150,9 @@ void MiirGenLaunchParams(const std::string& params, size_t& local_size, size_t& 
 
 bool MiirIsConfigApplicable(const std::string& params)
 {
+    if (params.empty()) {
+        return false;
+    }
     AutoMiirHandle handle(params);
     return MIIR_SUCCESS == miirLowerTuningParams(handle());
 }

--- a/src/solver/conv_mlir_igemm_bwd.cpp
+++ b/src/solver/conv_mlir_igemm_bwd.cpp
@@ -75,16 +75,9 @@ bool ConvMlirIgemmBwd::IsApplicable(const ConvolutionContext& ctx) const
 #if MIOPEN_USE_MLIR
     if(miopen::IsDisabled(MIOPEN_DEBUG_CONV_MLIR_IGEMM_BWD{}))
         return false;
-    if(!ctx.IsLayoutDefault() && !ctx.IsLayoutNHWC())
-        return false;
-    // Future: MLIR will support 3d convolution
-    if(!ctx.Is2d())
-        return false;
-    if(!ctx.IsFp32() && !ctx.IsFp16())
+    if(!ctx.direction.IsBackwardData())
         return false;
     if(!IsComposableKernelSupportedHardware(ctx))
-        return false;
-    if(!ctx.direction.IsBackwardData())
         return false;
 
     const auto k = ConvolutionContextInterpreter::GetOutputChannelK(ctx);

--- a/src/solver/conv_mlir_igemm_bwd_xdlops.cpp
+++ b/src/solver/conv_mlir_igemm_bwd_xdlops.cpp
@@ -76,18 +76,11 @@ bool ConvMlirIgemmBwdXdlops::IsApplicable(const ConvolutionContext& ctx) const
 #if MIOPEN_USE_MLIR
     if(miopen::IsDisabled(MIOPEN_DEBUG_CONV_MLIR_IGEMM_BWD_XDLOPS{}))
         return false;
-    if(!ctx.IsLayoutDefault() && !ctx.IsLayoutNHWC())
-        return false;
     if(!IsXdlopsSupport(ctx))
-        return false;
-    // Future: MLIR will support 3d convolution
-    if(!ctx.Is2d())
-        return false;
-    if(!IsComposableKernelSupportedHardware(ctx))
         return false;
     if(!ctx.direction.IsBackwardData())
         return false;
-    if(!ctx.IsFp32() && !ctx.IsFp16())
+    if(!IsComposableKernelSupportedHardware(ctx))
         return false;
 
     int gemm_m = 0;

--- a/src/solver/conv_mlir_igemm_fwd.cpp
+++ b/src/solver/conv_mlir_igemm_fwd.cpp
@@ -54,16 +54,9 @@ bool ConvMlirIgemmFwd::IsApplicable(const ConvolutionContext& ctx) const
 #if MIOPEN_USE_MLIR
     if(miopen::IsDisabled(MIOPEN_DEBUG_CONV_MLIR_IGEMM_FWD{}))
         return false;
-    if(!ctx.IsLayoutDefault() && !ctx.IsLayoutNHWC())
-        return false;
-    // Future: MLIR will support 3d convolution
-    if(!ctx.Is2d())
-        return false;
-    if(!IsComposableKernelSupportedHardware(ctx))
-        return false;
     if(!ctx.direction.IsForward())
         return false;
-    if(!ctx.IsFp32() && !ctx.IsFp16())
+    if(!IsComposableKernelSupportedHardware(ctx))
         return false;
 
     return MiirIsConfigApplicable(

--- a/src/solver/conv_mlir_igemm_fwd_xdlops.cpp
+++ b/src/solver/conv_mlir_igemm_fwd_xdlops.cpp
@@ -55,20 +55,12 @@ bool ConvMlirIgemmFwdXdlops::IsApplicable(const ConvolutionContext& ctx) const
 #if MIOPEN_USE_MLIR
     if(miopen::IsDisabled(MIOPEN_DEBUG_CONV_MLIR_IGEMM_FWD_XDLOPS{}))
         return false;
-    if(!ctx.IsLayoutDefault() && !ctx.IsLayoutNHWC())
-        return false;
     if(!IsXdlopsSupport(ctx))
-        return false;
-    // Future: MLIR will support 3d convolution
-    if(!ctx.Is2d())
-        return false;
-    if(!IsComposableKernelSupportedHardware(ctx))
         return false;
     if(!ctx.direction.IsForward())
         return false;
-    if(!ctx.IsFp32() && !ctx.IsFp16())
+    if(!IsComposableKernelSupportedHardware(ctx))
         return false;
-
     return MiirIsConfigApplicable(
         mlir::ConstructBuildOptions(ctx, GetOperation(), GetKernelName(), true));
 #else

--- a/src/solver/conv_mlir_igemm_wrw.cpp
+++ b/src/solver/conv_mlir_igemm_wrw.cpp
@@ -57,16 +57,9 @@ bool ConvMlirIgemmWrW::IsApplicable(const ConvolutionContext& ctx) const
 #if MIOPEN_USE_MLIR
     if(miopen::IsDisabled(MIOPEN_DEBUG_CONV_MLIR_IGEMM_WRW{}))
         return false;
-    if(!ctx.IsLayoutDefault() && !ctx.IsLayoutNHWC())
-        return false;
-    // Future: MLIR will support 3d convolution
-    if(!ctx.Is2d())
-        return false;
-    if(!IsComposableKernelSupportedHardware(ctx))
-        return false;
     if(!ctx.direction.IsBackwardWrW())
         return false;
-    if(!ctx.IsFp32() && !ctx.IsFp16())
+    if(!IsComposableKernelSupportedHardware(ctx))
         return false;
 
     return MiirIsConfigApplicable(

--- a/src/solver/conv_mlir_igemm_wrw_xdlops.cpp
+++ b/src/solver/conv_mlir_igemm_wrw_xdlops.cpp
@@ -58,17 +58,11 @@ bool ConvMlirIgemmWrWXdlops::IsApplicable(const ConvolutionContext& ctx) const
 #if MIOPEN_USE_MLIR
     if(miopen::IsDisabled(MIOPEN_DEBUG_CONV_MLIR_IGEMM_WRW_XDLOPS{}))
         return false;
-    // Future: MLIR will support non-default layouts.
-    if(!ctx.IsLayoutDefault() && !ctx.IsLayoutNHWC())
-        return false;
-    // Future: MLIR will support 3d convolution
-    if(!ctx.Is2d())
-        return false;
-    if(!IsComposableKernelSupportedHardware(ctx))
+    if(!IsXdlopsSupport(ctx))
         return false;
     if(!ctx.direction.IsBackwardWrW())
         return false;
-    if(!ctx.IsFp32() && !ctx.IsFp16())
+    if(!IsComposableKernelSupportedHardware(ctx))
         return false;
 
     return MiirIsConfigApplicable(

--- a/src/solver/mlir_common.cpp
+++ b/src/solver/mlir_common.cpp
@@ -24,7 +24,7 @@
  *
  *******************************************************************************/
 
-#include "miopen/miopen.h"
+#include <miopen/miopen.h>
 #include <miopen/errors.hpp>
 #include <miopen/solver/implicitgemm_util.hpp>
 #include <miopen/solver/mlir_common.hpp>

--- a/src/solver/mlir_common.cpp
+++ b/src/solver/mlir_common.cpp
@@ -43,30 +43,23 @@ std::string InsertGToLayout(const std::string& layout, char dim)
     return layout_with_g.insert(index, 1, 'G');
 }
 
-const char* DTypeName(miopenDataType_t ty) {
-    switch (ty) {
-    case miopenHalf:
-        return "fp16";
-    case miopenFloat:
-        return "fp32";
-    case miopenDouble:
-        return "fp64";
-    case miopenBFloat16:
-        return "bf16";
-    case miopenInt32:
-        return "i32";
-    case miopenInt8:
-        return "i8";
-    case miopenInt8x4:
-        return "i8x4";
+const char* DTypeName(miopenDataType_t ty)
+{
+    switch(ty)
+    {
+    case miopenHalf: return "fp16";
+    case miopenFloat: return "fp32";
+    case miopenDouble: return "fp64";
+    case miopenBFloat16: return "bf16";
+    case miopenInt32: return "i32";
+    case miopenInt8: return "i8";
+    case miopenInt8x4: return "i8x4";
     }
     assert(false); // All cases should be covered before here
 }
 
 /* Construct the options string passed to MLIR to cause it
-to generate a given convolution.
-
-Returns an empty string on unsupported convolutions */
+to generate a given convolution.*/
 std::string ConstructBuildOptions(const ConvolutionContext& ctx,
                                   const std::string& operation,
                                   const std::string& kernel_name,
@@ -82,10 +75,6 @@ std::string ConstructBuildOptions(const ConvolutionContext& ctx,
     std::string out_layout = InsertGToLayout(CI::GetOutputLayout(ctx), 'C');
 
     std::string mlir_handle;
-    if (!ctx.Is2d()) {
-        // Future: Remove this once MLIr supports 3D convolutions
-        return mlir_handle;
-    }
 
     if (is_xdlops)
         mlir_handle += std::string(" --x2 1");

--- a/src/solver/mlir_common.cpp
+++ b/src/solver/mlir_common.cpp
@@ -57,7 +57,7 @@ const char* DTypeName(miopenDataType_t ty)
     case miopenInt8: return "i8";
     case miopenInt8x4: return "i8x4";
     }
-    MIOPEN_THROW("Internal error: value outside of datatype enum");
+    MIOPEN_THROW(miopenStatusInternalError, "Value outside of datatype enum");
 }
 
 /* Construct the options string passed to MLIR to cause it

--- a/src/solver/mlir_common.cpp
+++ b/src/solver/mlir_common.cpp
@@ -28,6 +28,8 @@
 #include <miopen/errors.hpp>
 #include <miopen/solver/implicitgemm_util.hpp>
 #include <miopen/solver/mlir_common.hpp>
+
+#include <sstream>
 #include <string>
 
 namespace miopen {
@@ -55,7 +57,7 @@ const char* DTypeName(miopenDataType_t ty)
     case miopenInt8: return "i8";
     case miopenInt8x4: return "i8x4";
     }
-    assert(false); // All cases should be covered before here
+    MIOPEN_THROW("Internal error: value outside of datatype enum");
 }
 
 /* Construct the options string passed to MLIR to cause it
@@ -67,48 +69,50 @@ std::string ConstructBuildOptions(const ConvolutionContext& ctx,
                                   int kernel_id)
 {
     // Arguments for mlir-miopen-driver.
-    // clang-format off
     using CI = ConvolutionContextInterpreter;
 
     std::string in_layout = InsertGToLayout(CI::GetInputLayout(ctx), 'C');
     std::string fil_layout = InsertGToLayout(CI::GetFilterLayout(ctx), 'N');
     std::string out_layout = InsertGToLayout(CI::GetOutputLayout(ctx), 'C');
 
-    std::string mlir_handle;
+    std::ostringstream mlir_handle;
 
-    if (is_xdlops)
-        mlir_handle += std::string(" --x2 1");
+    if(is_xdlops)
+    {
+        mlir_handle << " --x2 1";
+    }
 
-    mlir_handle +=
-        std::string(" --operation ") + operation +
-        std::string(" --kernel_id ") + std::to_string(kernel_id) +
-        std::string(" --num_cu ") + std::to_string(ctx.GetStream().GetMaxComputeUnits()) +
-        std::string(" --arch ") + ctx.GetStream().GetDeviceName() +
-        std::string(" --groupsize ") + std::to_string(CI::GetGroupCountG(ctx)) +
-        std::string(" --fil_layout ") + fil_layout +
-        std::string(" --fil_type ") + DTypeName(ctx.weights_data_type) +
-        std::string(" --in_layout ") + in_layout +
-        std::string(" --in_type ") + DTypeName(CI::GetInputDataType(ctx)) +
-        std::string(" --out_layout ") + out_layout +
-        std::string(" --out_type ") + DTypeName(CI::GetOutputDataType(ctx)) +
-        std::string(" --batchsize ") + std::to_string(CI::GetBatchN(ctx)) +
-        std::string(" --in_channels ") + std::to_string(CI::GetInputChannelC(ctx)) +
-        std::string(" --out_channels ") + std::to_string(CI::GetOutputChannelK(ctx)) +
-        std::string(" --in_h ") + std::to_string(CI::GetInputHeightHi(ctx)) +
-        std::string(" --in_w ") + std::to_string(CI::GetInputWidthWi(ctx)) +
-        std::string(" --out_h ") + std::to_string(CI::GetOutputHeightHo(ctx)) +
-        std::string(" --out_w ") + std::to_string(CI::GetOutputWidthWo(ctx)) +
-        std::string(" --fil_h ") + std::to_string(CI::GetFilterHeightY(ctx)) +
-        std::string(" --fil_w ") + std::to_string(CI::GetFilterWidthX(ctx)) +
-        std::string(" --dilation_h ") + std::to_string(CI::GetAdjustedConvolutionDilationH(ctx)) +
-        std::string(" --dilation_w ") + std::to_string(CI::GetAdjustedConvolutionDilationW(ctx)) +
-        std::string(" --conv_stride_h ") + std::to_string(CI::GetAdjustedConvolutionStrideH(ctx)) +
-        std::string(" --conv_stride_w ") + std::to_string(CI::GetAdjustedConvolutionStrideW(ctx)) +
-        std::string(" --padding_h ") + std::to_string(CI::GetInputLeftPadH(ctx)) +
-        std::string(" --padding_w ") + std::to_string(CI::GetInputLeftPadW(ctx)) +
-        std::string(" --kernel_name ") + kernel_name;
+    // clang-format off
+    mlir_handle
+        << " --operation " << operation
+        << " --kernel_id " << kernel_id
+        << " --num_cu " << ctx.GetStream().GetMaxComputeUnits()
+        << " --arch " << ctx.GetStream().GetDeviceName()
+        << " --groupsize " << CI::GetGroupCountG(ctx)
+        << " --fil_layout " << fil_layout
+        << " --fil_type " << DTypeName(ctx.weights_data_type)
+        << " --in_layout " << in_layout
+        << " --out_layout " << out_layout
+        << " --in_type " << DTypeName(CI::GetInputDataType(ctx))
+        << " --out_type " << DTypeName(CI::GetOutputDataType(ctx))
+        << " --batchsize " << CI::GetBatchN(ctx)
+        << " --in_channels " << CI::GetInputChannelC(ctx)
+        << " --out_channels " << CI::GetOutputChannelK(ctx)
+        << " --in_h " << CI::GetInputHeightHi(ctx)
+        << " --in_w " << CI::GetInputWidthWi(ctx)
+        << " --out_h " << CI::GetOutputHeightHo(ctx)
+        << " --out_w " << CI::GetOutputWidthWo(ctx)
+        << " --fil_h " << CI::GetFilterHeightY(ctx)
+        << " --fil_w " << CI::GetFilterWidthX(ctx)
+        << " --dilation_h " << CI::GetAdjustedConvolutionDilationH(ctx)
+        << " --dilation_w " << CI::GetAdjustedConvolutionDilationW(ctx)
+        << " --conv_stride_h " << CI::GetAdjustedConvolutionStrideH(ctx)
+        << " --conv_stride_w " << CI::GetAdjustedConvolutionStrideW(ctx)
+        << " --padding_h " << CI::GetInputLeftPadH(ctx)
+        << " --padding_w " << CI::GetInputLeftPadW(ctx)
+        << " --kernel_name " << kernel_name;
     // clang-format on
-    return mlir_handle;
+    return mlir_handle.str();
 }
 
 } // namespace mlir


### PR DESCRIPTION
Some of the checks that the MLIR solvers perform can be moved into
MLIR, allowing MLIR to enable support for more types of convolution
without needing to coordinate as many changes with MIOpen. This also
reduces redundancy in the solver applicability checks.