### PR TITLE
Fix fusions asm1x1 supported arch

### DIFF
--- a/src/md_graph.cpp
+++ b/src/md_graph.cpp
@@ -733,22 +733,27 @@ void FusionMDGraph::InitConv(FusionMDGraph& g)
     { // Conv -> Bias -> Activ // Conv -> Activ
         // single precision
         {
+            const std::vector<std::string> supported_arch = {
+                "gfx803", "gfx900", "gfx906", "gfx908"};
             auto conv_v = std::make_shared<MDGraph_vertex>(miopenFusionOpConvForward,
                                                            "conv1x1u_bias_activ.s",
                                                            "miopenGcnAsmConv1x1U",
                                                            "miopenConvolutionDirectBiasActivAsm");
             conv_v->solver         = solver::ConvBiasActivAsm1x1U{};
-            conv_v->supported_arch = {"gfx803", "gfx900", "gfx906", "gfx908"};
+            conv_v->supported_arch = supported_arch;
 
             auto bias_v = std::make_shared<MDGraph_vertex>(miopenFusionOpBiasForward,
                                                            "conv1x1u_bias_activ.s",
                                                            "miopenGcnAsmConv1x1U",
                                                            "miopenConvolutionDirectBiasActivAsm");
+            bias_v->supported_arch = supported_arch;
+
             auto activ_v = std::make_shared<MDGraph_vertex>(miopenFusionOpActivForward,
                                                             "conv1x1u_bias_activ.s",
                                                             "miopenGcnAsmConv1x1U",
                                                             "miopenConvolutionDirectBiasActivAsm",
                                                             true);
+            activ_v->supported_arch = supported_arch;
             FusionMDGraph_Edge_Map map_asm_conv;
 
             map_asm_conv["constraints"] = {"group_count == 1",
@@ -780,22 +785,26 @@ void FusionMDGraph::InitConv(FusionMDGraph& g)
         }
         // half precision
         {
+            const std::vector<std::string> supported_arch = {"gfx900", "gfx906", "gfx908"};
             auto conv_v = std::make_shared<MDGraph_vertex>(miopenFusionOpConvForward,
                                                            "conv1x1u_bias_activ.s",
                                                            "miopenGcnAsmConv1x1U",
                                                            "miopenConvolutionDirectBiasActivAsm");
             conv_v->solver         = solver::ConvBiasActivAsm1x1U{};
-            conv_v->supported_arch = {"gfx900", "gfx906", "gfx908"};
+            conv_v->supported_arch = supported_arch;
 
             auto bias_v = std::make_shared<MDGraph_vertex>(miopenFusionOpBiasForward,
                                                            "conv1x1u_bias_activ.s",
                                                            "miopenGcnAsmConv1x1U",
                                                            "miopenConvolutionDirectBiasActivAsm");
+            bias_v->supported_arch = supported_arch;
+
             auto activ_v = std::make_shared<MDGraph_vertex>(miopenFusionOpActivForward,
                                                             "conv1x1u_bias_activ.s",
                                                             "miopenGcnAsmConv1x1U",
                                                             "miopenConvolutionDirectBiasActivAsm",
                                                             true);
+            activ_v->supported_arch = supported_arch;
             FusionMDGraph_Edge_Map map_asm_conv;
 
             map_asm_conv["constraints"] = {


### PR DESCRIPTION
This PR fixes missing fused asm1x1 _**supported arch**_ restrictions (see #706).
This bug could lead to failure while creating _Convolution+Bias+Activation_ Fusion Plan with unsupported arch:
```
MIOpen(HIP): Info2 [AmdgcnAssemble] ' -x assembler -target amdgcn--amdhsa  -Wa,-defsym,stride_h=1 -Wa,-defsym,stride_w=1 -Wa,-defsym,img_h=56 -Wa,-defsym,img_w=56 -Wa,-defsym,batch_size=1 -Wa,-defsym,input_channels=64 -Wa,-defsym,output_channels=64 -Wa,-defsym,wei_h=1 -Wa,-defsym,wei_w=1 -Wa,-defsym,pad_h=0 -Wa,-defsym,pad_w=0 -Wa,-defsym,weights_layout=0 -Wa,-defsym,vec_c_in=1 -Wa,-defsym,vec_k_out=1 -Wa,-defsym,vec_c_filter=1 -Wa,-defsym,acc_type=1 -Wa,-defsym,buf_type=1 -Wa,-defsym,input_n_stride=802816 -Wa,-defsym,input_c_stride=12544 -Wa,-defsym,input_h_stride=224 -Wa,-defsym,input_w_stride=4 -Wa,-defsym,output_n_stride=802816 -Wa,-defsym,output_k_stride=12544 -Wa,-defsym,output_h_stride=224 -Wa,-defsym,output_w_stride=4 -Wa,-defsym,filter_k_stride=256 -Wa,-defsym,filter_c_stride=4 -Wa,-defsym,filter_h_stride=4 -Wa,-defsym,filter_w_stride=4 -Wa,-defsym,input_buffer_size=802816 -Wa,-defsym,filter_buffer_size=16384 -Wa,-defsym,output_buffer_size=802816 -Wa,-defsym,ROCM_METADATA_VERSION=5 -Wa,-defsym,read_size=1 -Wa,-defsym,k_mult=4 -Wa,-defsym,chunks_per_wave=4 -Wa,-defsym,chunk_size=1 -Wa,-defsym,n_mult=1 -Wa,-defsym,c_mult=1 -Wa,-defsym,waves_c_in_group=1 -Wa,-defsym,waves_k_in_group=1 -Wa,-defsym,fusion_mode=1 -Wa,-defsym,bias_mode=1 -Wa,-defsym,enable_activ=1 -Wa,-defsym,activ_mode=3 -mcpu=gfx1030 - -o /tmp/miopen-tmp-91ca-bb5b-c106-5ce5/amdgcn-asm-out-XXXXXX'
<stdin>:757:5: error: Only Gfx8 and Gfx9 ISA is supported
    .error "Only Gfx8 and Gfx9 ISA is supported"
    ^
<stdin>:2587:1: error: unmatched .ifs or .elses

^
```

## Local verification
- gfx906
- gfx1030: https://github.com/ROCmSoftwarePlatform/MIOpen/issues/706#issuecomment-877355939