### PR TITLE
Fix: Remove 1x1 applicable from OclDirectFused

### DIFF
--- a/src/md_graph.cpp
+++ b/src/md_graph.cpp
@@ -850,7 +850,7 @@ void FusionMDGraph::InitConv(FusionMDGraph& g)
 
         conv_v->solver = solver::ConvOclDirectFwdFused{};
 
-        std::vector<size_t> lens = {1, 3, 5, 7, 9, 11};
+        std::vector<size_t> lens = {3, 5, 7, 9, 11};
         for(auto len : lens)
         {
             FusionMDGraph_Edge_Map map_conv_bias;


### PR DESCRIPTION
This PR resolves #1028 ([details here](https://github.com/ROCmSoftwarePlatform/MIOpen/issues/1028#issuecomment-877467684))

The ConvOclDirectFwdFused solver does not support 1x1 convolutions whereas the metadata graph encodes it as applicable which causes issues. 