### PR TITLE
[CI][TESTS][Navi21] Basic support for Navi21

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 def rocmnode(name) {
-    return 'rocmtest-trial && miopen && ' + name
+    return 'rocmtest && miopen && ' + name
 }
 
 
@@ -276,294 +276,294 @@ pipeline {
         Tensile_setup = " -DMIOPEN_TEST_MIOTENSILE=ON -DMIOPEN_USE_MIOPENTENSILE=ON -DMIOPEN_USE_ROCBLAS=OFF"
     }
     stages{
-//        stage("Static checks"){
-//            when { expression { params.STATIC_CHECKS && !params.DISABLE_ALL_STAGES } }
-//            parallel{
-//                stage('Hip Tidy') {
-//                    agent{  label rocmnode("nogpu") }
-//                    environment{
-//                        setup_cmd = "CXX='/opt/rocm/llvm/bin/clang++' cmake -DMIOPEN_BACKEND=HIP -DBUILD_DEV=On .. "
-//                        build_cmd = "make -j\$(nproc) -k analyze"
-//                    }
-//                    steps{
-//                        buildHipClangJobAndReboot(setup_cmd: setup_cmd, build_cmd: build_cmd, no_reboot:true)
-//                    }
-//                }
-//                stage('OpenCL Tidy') {
-//                    agent{  label rocmnode("nogpu") }
-//                    environment{
-//                        setup_cmd = "cmake -DMIOPEN_BACKEND=OpenCL -DBUILD_DEV=On .."
-//                        build_cmd = "make -j\$(nproc) -k analyze"
-//                    }
-//                    steps{
-//                        buildHipClangJobAndReboot(setup_cmd: setup_cmd, build_cmd: build_cmd, no_reboot:true)
-//                    }
-//                }
-//                stage('Clang Format') {
-//                    agent{ label rocmnode("nogpu") }
-//                    environment{
-//                        execute_cmd = "find . -iname \'*.h\' \
-//                                -o -iname \'*.hpp\' \
-//                                -o -iname \'*.cpp\' \
-//                                -o -iname \'*.h.in\' \
-//                                -o -iname \'*.hpp.in\' \
-//                                -o -iname \'*.cpp.in\' \
-//                                -o -iname \'*.cl\' \
-//                                | grep -v 'build/' \
-//                                | xargs -n 1 -P 1 -I{} -t sh -c \'clang-format-3.8 -style=file {} | diff - {}\'"
-//                    }
-//                    steps{
-//                        buildHipClangJobAndReboot(setup_cmd: "", build_cmd: "", execute_cmd: execute_cmd, no_reboot:true)
-//                    }
-//                }
-//            }
-//        }
+        stage("Static checks"){
+            when { expression { params.STATIC_CHECKS && !params.DISABLE_ALL_STAGES } }
+            parallel{
+                stage('Hip Tidy') {
+                    agent{  label rocmnode("nogpu") }
+                    environment{
+                        setup_cmd = "CXX='/opt/rocm/llvm/bin/clang++' cmake -DMIOPEN_BACKEND=HIP -DBUILD_DEV=On .. "
+                        build_cmd = "make -j\$(nproc) -k analyze"
+                    }
+                    steps{
+                        buildHipClangJobAndReboot(setup_cmd: setup_cmd, build_cmd: build_cmd, no_reboot:true)
+                    }
+                }
+                stage('OpenCL Tidy') {
+                    agent{  label rocmnode("nogpu") }
+                    environment{
+                        setup_cmd = "cmake -DMIOPEN_BACKEND=OpenCL -DBUILD_DEV=On .."
+                        build_cmd = "make -j\$(nproc) -k analyze"
+                    }
+                    steps{
+                        buildHipClangJobAndReboot(setup_cmd: setup_cmd, build_cmd: build_cmd, no_reboot:true)
+                    }
+                }
+                stage('Clang Format') {
+                    agent{ label rocmnode("nogpu") }
+                    environment{
+                        execute_cmd = "find . -iname \'*.h\' \
+                                -o -iname \'*.hpp\' \
+                                -o -iname \'*.cpp\' \
+                                -o -iname \'*.h.in\' \
+                                -o -iname \'*.hpp.in\' \
+                                -o -iname \'*.cpp.in\' \
+                                -o -iname \'*.cl\' \
+                                | grep -v 'build/' \
+                                | xargs -n 1 -P 1 -I{} -t sh -c \'clang-format-3.8 -style=file {} | diff - {}\'"
+                    }
+                    steps{
+                        buildHipClangJobAndReboot(setup_cmd: "", build_cmd: "", execute_cmd: execute_cmd, no_reboot:true)
+                    }
+                }
+            }
+        }
         stage("Smoke Fp32"){
             when { expression { params.SMOKE_FP32_AUX1 && !params.DISABLE_ALL_STAGES } }
             environment{
                 Smoke_targets = "check doc MIOpenDriver"
             }
             parallel{
-//               stage('Fp32 OpenCL Debug + Codecov') {
-//                    agent{ label rocmnode("vega") }
-//                    steps{
-//                        buildHipClangJobAndReboot(compiler: 'g++', build_type: 'debug', config_targets: Smoke_targets, codecov: true)
-//                    }
-//                }
-//                stage('Fp32 OpenCL gfx908') {
-//                    agent{ label rocmnode("gfx908") }
-//                    steps{
-//                        buildHipClangJobAndReboot(compiler: 'g++', config_targets: Smoke_targets, gpu_arch: "gfx908")
-//                    }
-//                }
-//                stage('Fp32 Hip /opt/rocm') {
-//                    agent{ label rocmnode("vega") }
-//                    steps{
-//                        buildHipClangJobAndReboot(prefixpath: '/opt/rocm', config_targets: Smoke_targets)
-//                    }
-//                }
-//                stage('Fp32 Hip Debug') {
-//                    agent{ label rocmnode("vega") }
-//                    steps{
-//                        buildHipClangJobAndReboot(build_type: 'debug', config_targets: Smoke_targets)
-//                    }
-//                }
+               stage('Fp32 OpenCL Debug + Codecov') {
+                    agent{ label rocmnode("vega") }
+                    steps{
+                        buildHipClangJobAndReboot(compiler: 'g++', build_type: 'debug', config_targets: Smoke_targets, codecov: true)
+                    }
+                }
+                stage('Fp32 OpenCL gfx908') {
+                    agent{ label rocmnode("gfx908") }
+                    steps{
+                        buildHipClangJobAndReboot(compiler: 'g++', config_targets: Smoke_targets, gpu_arch: "gfx908")
+                    }
+                }
+                stage('Fp32 Hip /opt/rocm') {
+                    agent{ label rocmnode("vega") }
+                    steps{
+                        buildHipClangJobAndReboot(prefixpath: '/opt/rocm', config_targets: Smoke_targets)
+                    }
+                }
+                stage('Fp32 Hip Debug') {
+                    agent{ label rocmnode("vega") }
+                    steps{
+                        buildHipClangJobAndReboot(build_type: 'debug', config_targets: Smoke_targets)
+                    }
+                }
                 stage('Fp32 OpenCL Debug gfx1030') {
                     agent{ label rocmnode("navi21") }
                     steps{
                         buildHipClangJobAndReboot(compiler: 'g++', build_type: 'debug', config_targets: Smoke_targets, build_env: extra_log_env, gpu_arch: "gfx1030")
                     }
                 }
-//                stage('Fp32 Hip Debug gfx908 /opt/rocm') {
-//                    agent{ label rocmnode("gfx908") }
-//                    environment{
-//                        gpu_arch = "gfx908"
-//                        prefixpath = "/opt/rocm"
-//                    }
-//                    steps{
-//                        buildHipClangJobAndReboot(prefixpath: prefixpath, build_type: 'debug', config_targets: Smoke_targets, gpu_arch: gpu_arch)
-//                    }
-//                }
-//                stage('Fp32 HipNoGPU Debug') {
-//                    agent{  label rocmnode("nogpu") }
-//                    environment{
-//                        HipNoGPU_flags = "-DMIOPEN_BACKEND=HIPNOGPU -DMIOPEN_INSTALL_CXX_HEADERS=On"
-//                        build_cmd = "make -j\$(nproc)"
-//                    }
-//                    steps{
-//                        buildHipClangJob( build_type: 'debug', setup_flags: HipNoGPU_flags, build_cmd: build_cmd)
-//                    }
-//                }
+                stage('Fp32 Hip Debug gfx908 /opt/rocm') {
+                    agent{ label rocmnode("gfx908") }
+                    environment{
+                        gpu_arch = "gfx908"
+                        prefixpath = "/opt/rocm"
+                    }
+                    steps{
+                        buildHipClangJobAndReboot(prefixpath: prefixpath, build_type: 'debug', config_targets: Smoke_targets, gpu_arch: gpu_arch)
+                    }
+                }
+                stage('Fp32 HipNoGPU Debug') {
+                    agent{  label rocmnode("nogpu") }
+                    environment{
+                        HipNoGPU_flags = "-DMIOPEN_BACKEND=HIPNOGPU -DMIOPEN_INSTALL_CXX_HEADERS=On"
+                        build_cmd = "make -j\$(nproc)"
+                    }
+                    steps{
+                        buildHipClangJob( build_type: 'debug', setup_flags: HipNoGPU_flags, build_cmd: build_cmd)
+                    }
+                }
             }
         }
-//        stage("Smoke Aux 1"){
-//            when { expression { params.SMOKE_FP32_AUX1 && !params.DISABLE_ALL_STAGES } }
-//            parallel{
-//                stage('Fp32 Hip Debug COMGR') {
-//                    agent{ label rocmnode("vega") }
-//                    environment{
-//                        COMGR_build_cmd = "CTEST_PARALLEL_LEVEL=2 MIOPEN_CONV_PRECISE_ROCBLAS_TIMING=0 MIOPEN_LOG_LEVEL=5 make -j\$(nproc) check"
-//                    }
-//                    steps{
-//                        buildHipClangJobAndReboot( build_type: 'debug', setup_flags: "-DMIOPEN_USE_COMGR=On", build_cmd: COMGR_build_cmd, test_flags: ' --verbose ')
-//                    }
-//                }
-//                stage('Fp32 Hip Debug Embedded Vega20') {
-//                    agent{ label rocmnode("vega20") }
-//                    environment{
-//                        Embedded_flags = "-DMIOPEN_EMBED_DB='gfx906_60;gfx906_64'"
-//                    }
-//                    steps{
-//                        buildHipClangJobAndReboot( build_type: 'debug', setup_flags: Embedded_flags, build_env: extra_log_env, test_flags: ' --verbose ')
-//                    }
-//                }
-//                stage('Fp32 Hip Static') {
-//                    agent{ label rocmnode("vega") }
-//                    steps{
-//                        buildHipClangJobAndReboot( setup_flags: "-DBUILD_SHARED_LIBS=Off")
-//                    }
-//                }
-//                stage('Fp32 Hip Normal-Find') {
-//                    agent{ label rocmnode("vega") }
-//                    environment{
-//                        config_targets = "test_conv2d"
-//                        execute_cmd = "MIOPEN_FIND_MODE=1 MIOPEN_CONV_PRECISE_ROCBLAS_TIMING=0 bin/test_conv2d --disable-verification-cache"
-//                    }
-//                    steps{
-//                        buildHipClangJobAndReboot(config_targets: config_targets, execute_cmd: execute_cmd)
-//                    }
-//                }
-//                stage('Fp32 Hip Fast-Find') {
-//                    agent{ label rocmnode("vega") }
-//                    environment{
-//                        config_targets =   "test_conv2d"
-//                        execute_cmd = "MIOPEN_FIND_MODE=2 CTEST_PARALLEL_LEVEL=4  MIOPEN_CONV_PRECISE_ROCBLAS_TIMING=0 bin/test_conv2d --disable-verification-cache"
-//                    }
-//                    steps{
-//                        buildHipClangJobAndReboot( config_targets: config_targets, execute_cmd: execute_cmd)
-//                    }
-//                }
-//                stage('Fp32 Hip') {
-//                    agent{ label rocmnode("vega") }
-//                    steps{
-//                        buildHipClangJobAndReboot()
-//                    }
-//                }
-//            }
-//        }
-//        stage("Smoke MLIR"){
-//            when { expression { params.SMOKE_MLIR && !params.DISABLE_ALL_STAGES } }
-//            environment{ MLIR_flags = "-DMIOPEN_USE_MLIR=On" }
-//            parallel{
-//                stage('Fp32 Hip MLIR') {
-//                    agent{ label rocmnode("vega") }
-//                    steps{
-//                        buildHipClangJobAndReboot(setup_flags: MLIR_flags, build_env: extra_log_env, test_flags: ' --verbose ', mlir_build: "ON")
-//                    }
-//                }
-//                stage('Fp16 Hip MLIR') {
-//                    agent{ label rocmnode("vega") }
-//                    steps{
-//                        buildHipClangJobAndReboot(setup_flags: MLIR_flags + Fp16_flags, build_env: extra_log_env, test_flags: ' --verbose ', mlir_build: "ON")
-//                    }
-//                }
-//                stage('Fp16 Hip MLIR gfx908') {
-//                    agent{ label rocmnode("gfx908") }
-//                    steps{
-//                        buildHipClangJobAndReboot(setup_flags: MLIR_flags + Fp16_flags, build_env: extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx908", mlir_build: "ON")
-//                    }
-//                }
-//                stage('Fp32 Hip MLIR gfx908') {
-//                    agent{ label rocmnode("gfx908") }
-//                    steps{
-//                        buildHipClangJobAndReboot(setup_flags: MLIR_flags, build_env: extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx908", mlir_build: "ON")
-//                    }
-//                }
-//            }
-//        }
-//        stage("Smoke Fp16/Bf16/Int8"){
-//            when { expression { params.SMOKE_FP16_BF16_INT8 && !params.DISABLE_ALL_STAGES } }
-//            environment{
-//                Smoke_targets = "check doc MIOpenDriver"
-//            }
-//            parallel{
-//                stage('Fp16 OpenCL Vega20') {
-//                    agent{ label rocmnode("vega20") }
-//                    steps{
-//                        buildHipClangJobAndReboot(compiler: 'g++', setup_flags: Fp16_flags, config_targets: Smoke_targets)
-//                    }
-//                }
-//                stage('Int8 OpenCL Vega20') {
-//                    agent{ label rocmnode("vega20") }
-//                    steps{
-//                        buildHipClangJobAndReboot(compiler: 'g++', setup_flags: Int8_flags, config_targets: Smoke_targets)
-//                    }
-//                }
-//                stage('Fp16 Hip Vega20 /opt/rocm') {
-//                    agent{ label rocmnode("vega20") }
-//                    steps{
-//                        buildHipClangJobAndReboot( setup_flags: Fp16_flags, prefixpath: '/opt/rocm', config_targets: Smoke_targets)
-//                    }
-//                }
-//                stage('Bf16 Hip Vega20 /opt/rocm') {
-//                    agent{ label rocmnode("vega20") }
-//                    steps{
-//                        buildHipClangJobAndReboot(setup_flags: Bf16_flags, prefixpath: '/opt/rocm', config_targets: Smoke_targets)
-//                    }
-//                }
-//                stage('Fp16 Hip gfx908 /opt/rocm') {
-//                    agent{ label rocmnode("gfx908") }
-//                    steps{
-//                        buildHipClangJobAndReboot( setup_flags: Fp16_flags, prefixpath: '/opt/rocm', config_targets: Smoke_targets, gpu_arch: "gfx908")
-//                    }
-//                }
-//                stage('Bf16 Hip gfx908 /opt/rocm') {
-//                    agent{ label rocmnode("gfx908") }
-//                    steps{
-//                        buildHipClangJobAndReboot(setup_flags: Bf16_flags, prefixpath: '/opt/rocm', config_targets: Smoke_targets, gpu_arch: "gfx908")
-//                    }
-//                }
-//            }
-//        }
-//        stage("Smoke MIOpenTensile Latest"){
-//            environment{
-//                Tensile_version = "latest"
-//            }
-//            parallel{
-//                stage('Fp16 Hip Tensile-Latest All Vega20') {
-//                    when { expression { params.SMOKE_MIOPENTENSILE_LATEST && !params.DISABLE_ALL_STAGES } }
-//                    agent{ label rocmnode("vega20") }
-//                    steps{
-//                        buildHipClangJobAndReboot( setup_flags: Tensile_setup + Fp16_flags, build_env: Tensile_build_env, test_flags: ' --verbose ', gpu_arch:"gfx906:xnack-", miotensile_version: Tensile_version, target_id: "ON")
-//                    }
-//                }
-//                stage('Int8 Hip Tensile-Latest All Vega20') {
-//                    when { expression { params.SMOKE_MIOPENTENSILE_LATEST && !params.DISABLE_ALL_STAGES } }
-//                    agent{ label rocmnode("vega20") }
-//                    steps{
-//                        buildHipClangJobAndReboot( setup_flags: Tensile_setup + extra_log_env + Int8_flags, build_env: Tensile_build_env, test_flags: ' --verbose ', gpu_arch:"gfx906:xnack-", miotensile_version: Tensile_version, target_id: "ON")
-//                    }
-//                }
-//
-//                stage('Fp32 Hip Tensile-Latest All gfx908') {
-//                    when { expression { params.SMOKE_MIOPENTENSILE_LATEST && !params.DISABLE_ALL_STAGES } }
-//                    agent{ label rocmnode("gfx908") }
-//                    steps{
-//                        buildHipClangJobAndReboot( setup_flags: Tensile_setup + extra_log_env, build_env: Tensile_build_env + extra_log_env, gpu_arch: "gfx908:xnack-", test_flags: ' --verbose ', miotensile_version: Tensile_version, target_id: "ON")
-//                    }
-//                }
-//                stage('Bf16 Hip Tensile-Latest All gfx908') {
-//                    when { expression { params.SMOKE_MIOPENTENSILE_LATEST && !params.DISABLE_ALL_STAGES } }
-//                    agent{ label rocmnode("gfx908") }
-//                    steps{
-//                        buildHipClangJobAndReboot( setup_flags: Tensile_setup + extra_log_env + Bf16_flags, build_env: Tensile_build_env + extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx908:xnack-", miotensile_version: Tensile_version, target_id: "ON")
-//                    }
-//                }
-//            }
-//        }
-//        stage("Full Tests I"){
-//            when { expression { params.FULL_TESTS && !params.DISABLE_ALL_STAGES } }
-//            parallel{
-//                stage('Int8 HIP All Vega20 /opt/rocm') {
-//                    agent{ label rocmnode("vega20") }
-//                    steps{
-//                        buildHipClangJobAndReboot( setup_flags: Int8_flags + Full_test_limit, prefixpath: '/opt/rocm')
-//                    }
-//                }
-//                stage('Fp32 OpenCL Install All') {
-//                    agent{ label rocmnode("vega") }
-//                    steps{
-//                        buildHipClangJobAndReboot(compiler: 'g++', setup_flags: Full_test_limit, build_install: "true")
-//                    }
-//                }
-//                stage('Bf16 Hip Install All gfx908') {
-//                    agent{ label rocmnode("gfx908") }
-//                    steps{
-//                        buildHipClangJobAndReboot(setup_flags: Bf16_flags + Full_test_limit, build_install: "true", gpu_arch: "gfx908")
-//                    }
-//                }
-//            }
-//        }
+        stage("Smoke Aux 1"){
+            when { expression { params.SMOKE_FP32_AUX1 && !params.DISABLE_ALL_STAGES } }
+            parallel{
+                stage('Fp32 Hip Debug COMGR') {
+                    agent{ label rocmnode("vega") }
+                    environment{
+                        COMGR_build_cmd = "CTEST_PARALLEL_LEVEL=2 MIOPEN_CONV_PRECISE_ROCBLAS_TIMING=0 MIOPEN_LOG_LEVEL=5 make -j\$(nproc) check"
+                    }
+                    steps{
+                        buildHipClangJobAndReboot( build_type: 'debug', setup_flags: "-DMIOPEN_USE_COMGR=On", build_cmd: COMGR_build_cmd, test_flags: ' --verbose ')
+                    }
+                }
+                stage('Fp32 Hip Debug Embedded Vega20') {
+                    agent{ label rocmnode("vega20") }
+                    environment{
+                        Embedded_flags = "-DMIOPEN_EMBED_DB='gfx906_60;gfx906_64'"
+                    }
+                    steps{
+                        buildHipClangJobAndReboot( build_type: 'debug', setup_flags: Embedded_flags, build_env: extra_log_env, test_flags: ' --verbose ')
+                    }
+                }
+                stage('Fp32 Hip Static') {
+                    agent{ label rocmnode("vega") }
+                    steps{
+                        buildHipClangJobAndReboot( setup_flags: "-DBUILD_SHARED_LIBS=Off")
+                    }
+                }
+                stage('Fp32 Hip Normal-Find') {
+                    agent{ label rocmnode("vega") }
+                    environment{
+                        config_targets = "test_conv2d"
+                        execute_cmd = "MIOPEN_FIND_MODE=1 MIOPEN_CONV_PRECISE_ROCBLAS_TIMING=0 bin/test_conv2d --disable-verification-cache"
+                    }
+                    steps{
+                        buildHipClangJobAndReboot(config_targets: config_targets, execute_cmd: execute_cmd)
+                    }
+                }
+                stage('Fp32 Hip Fast-Find') {
+                    agent{ label rocmnode("vega") }
+                    environment{
+                        config_targets =   "test_conv2d"
+                        execute_cmd = "MIOPEN_FIND_MODE=2 CTEST_PARALLEL_LEVEL=4  MIOPEN_CONV_PRECISE_ROCBLAS_TIMING=0 bin/test_conv2d --disable-verification-cache"
+                    }
+                    steps{
+                        buildHipClangJobAndReboot( config_targets: config_targets, execute_cmd: execute_cmd)
+                    }
+                }
+                stage('Fp32 Hip') {
+                    agent{ label rocmnode("vega") }
+                    steps{
+                        buildHipClangJobAndReboot()
+                    }
+                }
+            }
+        }
+        stage("Smoke MLIR"){
+            when { expression { params.SMOKE_MLIR && !params.DISABLE_ALL_STAGES } }
+            environment{ MLIR_flags = "-DMIOPEN_USE_MLIR=On" }
+            parallel{
+                stage('Fp32 Hip MLIR') {
+                    agent{ label rocmnode("vega") }
+                    steps{
+                        buildHipClangJobAndReboot(setup_flags: MLIR_flags, build_env: extra_log_env, test_flags: ' --verbose ', mlir_build: "ON")
+                    }
+                }
+                stage('Fp16 Hip MLIR') {
+                    agent{ label rocmnode("vega") }
+                    steps{
+                        buildHipClangJobAndReboot(setup_flags: MLIR_flags + Fp16_flags, build_env: extra_log_env, test_flags: ' --verbose ', mlir_build: "ON")
+                    }
+                }
+                stage('Fp16 Hip MLIR gfx908') {
+                    agent{ label rocmnode("gfx908") }
+                    steps{
+                        buildHipClangJobAndReboot(setup_flags: MLIR_flags + Fp16_flags, build_env: extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx908", mlir_build: "ON")
+                    }
+                }
+                stage('Fp32 Hip MLIR gfx908') {
+                    agent{ label rocmnode("gfx908") }
+                    steps{
+                        buildHipClangJobAndReboot(setup_flags: MLIR_flags, build_env: extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx908", mlir_build: "ON")
+                    }
+                }
+            }
+        }
+        stage("Smoke Fp16/Bf16/Int8"){
+            when { expression { params.SMOKE_FP16_BF16_INT8 && !params.DISABLE_ALL_STAGES } }
+            environment{
+                Smoke_targets = "check doc MIOpenDriver"
+            }
+            parallel{
+                stage('Fp16 OpenCL Vega20') {
+                    agent{ label rocmnode("vega20") }
+                    steps{
+                        buildHipClangJobAndReboot(compiler: 'g++', setup_flags: Fp16_flags, config_targets: Smoke_targets)
+                    }
+                }
+                stage('Int8 OpenCL Vega20') {
+                    agent{ label rocmnode("vega20") }
+                    steps{
+                        buildHipClangJobAndReboot(compiler: 'g++', setup_flags: Int8_flags, config_targets: Smoke_targets)
+                    }
+                }
+                stage('Fp16 Hip Vega20 /opt/rocm') {
+                    agent{ label rocmnode("vega20") }
+                    steps{
+                        buildHipClangJobAndReboot( setup_flags: Fp16_flags, prefixpath: '/opt/rocm', config_targets: Smoke_targets)
+                    }
+                }
+                stage('Bf16 Hip Vega20 /opt/rocm') {
+                    agent{ label rocmnode("vega20") }
+                    steps{
+                        buildHipClangJobAndReboot(setup_flags: Bf16_flags, prefixpath: '/opt/rocm', config_targets: Smoke_targets)
+                    }
+                }
+                stage('Fp16 Hip gfx908 /opt/rocm') {
+                    agent{ label rocmnode("gfx908") }
+                    steps{
+                        buildHipClangJobAndReboot( setup_flags: Fp16_flags, prefixpath: '/opt/rocm', config_targets: Smoke_targets, gpu_arch: "gfx908")
+                    }
+                }
+                stage('Bf16 Hip gfx908 /opt/rocm') {
+                    agent{ label rocmnode("gfx908") }
+                    steps{
+                        buildHipClangJobAndReboot(setup_flags: Bf16_flags, prefixpath: '/opt/rocm', config_targets: Smoke_targets, gpu_arch: "gfx908")
+                    }
+                }
+            }
+        }
+        stage("Smoke MIOpenTensile Latest"){
+            environment{
+                Tensile_version = "latest"
+            }
+            parallel{
+                stage('Fp16 Hip Tensile-Latest All Vega20') {
+                    when { expression { params.SMOKE_MIOPENTENSILE_LATEST && !params.DISABLE_ALL_STAGES } }
+                    agent{ label rocmnode("vega20") }
+                    steps{
+                        buildHipClangJobAndReboot( setup_flags: Tensile_setup + Fp16_flags, build_env: Tensile_build_env, test_flags: ' --verbose ', gpu_arch:"gfx906:xnack-", miotensile_version: Tensile_version, target_id: "ON")
+                    }
+                }
+                stage('Int8 Hip Tensile-Latest All Vega20') {
+                    when { expression { params.SMOKE_MIOPENTENSILE_LATEST && !params.DISABLE_ALL_STAGES } }
+                    agent{ label rocmnode("vega20") }
+                    steps{
+                        buildHipClangJobAndReboot( setup_flags: Tensile_setup + extra_log_env + Int8_flags, build_env: Tensile_build_env, test_flags: ' --verbose ', gpu_arch:"gfx906:xnack-", miotensile_version: Tensile_version, target_id: "ON")
+                    }
+                }
+
+                stage('Fp32 Hip Tensile-Latest All gfx908') {
+                    when { expression { params.SMOKE_MIOPENTENSILE_LATEST && !params.DISABLE_ALL_STAGES } }
+                    agent{ label rocmnode("gfx908") }
+                    steps{
+                        buildHipClangJobAndReboot( setup_flags: Tensile_setup + extra_log_env, build_env: Tensile_build_env + extra_log_env, gpu_arch: "gfx908:xnack-", test_flags: ' --verbose ', miotensile_version: Tensile_version, target_id: "ON")
+                    }
+                }
+                stage('Bf16 Hip Tensile-Latest All gfx908') {
+                    when { expression { params.SMOKE_MIOPENTENSILE_LATEST && !params.DISABLE_ALL_STAGES } }
+                    agent{ label rocmnode("gfx908") }
+                    steps{
+                        buildHipClangJobAndReboot( setup_flags: Tensile_setup + extra_log_env + Bf16_flags, build_env: Tensile_build_env + extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx908:xnack-", miotensile_version: Tensile_version, target_id: "ON")
+                    }
+                }
+            }
+        }
+        stage("Full Tests I"){
+            when { expression { params.FULL_TESTS && !params.DISABLE_ALL_STAGES } }
+            parallel{
+                stage('Int8 HIP All Vega20 /opt/rocm') {
+                    agent{ label rocmnode("vega20") }
+                    steps{
+                        buildHipClangJobAndReboot( setup_flags: Int8_flags + Full_test_limit, prefixpath: '/opt/rocm')
+                    }
+                }
+                stage('Fp32 OpenCL Install All') {
+                    agent{ label rocmnode("vega") }
+                    steps{
+                        buildHipClangJobAndReboot(compiler: 'g++', setup_flags: Full_test_limit, build_install: "true")
+                    }
+                }
+                stage('Bf16 Hip Install All gfx908') {
+                    agent{ label rocmnode("gfx908") }
+                    steps{
+                        buildHipClangJobAndReboot(setup_flags: Bf16_flags + Full_test_limit, build_install: "true", gpu_arch: "gfx908")
+                    }
+                }
+            }
+        }
 
         stage("Full Tests II"){
             when { expression { params.FULL_TESTS && !params.DISABLE_ALL_STAGES } }
@@ -571,36 +571,36 @@ pipeline {
                 WORKAROUND_iGemm_936 = " MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_FWD_V4R1=0"
             }
             parallel{
-//                stage('Fp32 Hip All gfx908') {
-//                    agent{ label rocmnode("gfx908") }
-//                    steps{
-//                        buildHipClangJobAndReboot(setup_flags: Full_test_limit, build_env: WORKAROUND_iGemm_936, gpu_arch: "gfx908")
-//                    }
-//                }
-//                stage('Fp16 Hip Install All Vega20') {
-//                    agent{ label rocmnode("vega20") }
-//                    steps{
-//                        buildHipClangJobAndReboot( setup_flags: Full_test_limit + Fp16_flags, build_env: WORKAROUND_iGemm_936, build_install: "true")
-//                    }
-//                }
-//                stage('Fp32 Hip All Vega20') {
-//                    agent{ label rocmnode("vega20") }
-//                    steps{
-//                        buildHipClangJobAndReboot( setup_flags: Full_test_limit, build_env: WORKAROUND_iGemm_936)
-//                    }
-//                }
+                stage('Fp32 Hip All gfx908') {
+                    agent{ label rocmnode("gfx908") }
+                    steps{
+                        buildHipClangJobAndReboot(setup_flags: Full_test_limit, build_env: WORKAROUND_iGemm_936, gpu_arch: "gfx908")
+                    }
+                }
+                stage('Fp16 Hip Install All Vega20') {
+                    agent{ label rocmnode("vega20") }
+                    steps{
+                        buildHipClangJobAndReboot( setup_flags: Full_test_limit + Fp16_flags, build_env: WORKAROUND_iGemm_936, build_install: "true")
+                    }
+                }
+                stage('Fp32 Hip All Vega20') {
+                    agent{ label rocmnode("vega20") }
+                    steps{
+                        buildHipClangJobAndReboot( setup_flags: Full_test_limit, build_env: WORKAROUND_iGemm_936)
+                    }
+                }
                 stage('Fp32 OpenCL All gfx1030') {
                     agent{ label rocmnode("navi21") }
                     steps{
                         buildHipClangJobAndReboot(compiler: 'g++', setup_flags: Full_test_limit, build_env: extra_log_env, gpu_arch: "gfx1030")
                     }
                 }
-//                stage('Fp16 Hip All Install gfx908') {
-//                    agent{ label rocmnode("gfx908") }
-//                    steps{
-//                        buildHipClangJobAndReboot(setup_flags: Full_test_limit + Fp16_flags, build_env: WORKAROUND_iGemm_936, build_install: "true", gpu_arch: "gfx908")
-//                    }
-//                }
+                stage('Fp16 Hip All Install gfx908') {
+                    agent{ label rocmnode("gfx908") }
+                    steps{
+                        buildHipClangJobAndReboot(setup_flags: Full_test_limit + Fp16_flags, build_env: WORKAROUND_iGemm_936, build_install: "true", gpu_arch: "gfx908")
+                    }
+                }
             }
         }
 
@@ -716,23 +716,23 @@ pipeline {
                 }
             }
         }
-//        stage("Packages"){
-//            when { expression { params.PACKAGES && !params.DISABLE_ALL_STAGES } }
-//            parallel {
-//                stage('OpenCL Package') {
-//                    agent{ label rocmnode("nogpu") }
-//                    steps{
-//                        buildHipClangJobAndReboot(compiler: 'g++', package_build: "true", gpu_arch: "gfx900;gfx906;gfx908")
-//                    }
-//                }
-//                stage("HIP Package /opt/rocm"){
-//                    agent{ label rocmnode("nogpu") }
-//                    steps{
-//                        buildHipClangJobAndReboot( package_build: "true", prefixpath: '/opt/rocm', gpu_arch: "gfx900;gfx906;gfx908")
-//                    }
-//                }
-//            }
-//        }
+        stage("Packages"){
+            when { expression { params.PACKAGES && !params.DISABLE_ALL_STAGES } }
+            parallel {
+                stage('OpenCL Package') {
+                    agent{ label rocmnode("nogpu") }
+                    steps{
+                        buildHipClangJobAndReboot(compiler: 'g++', package_build: "true", gpu_arch: "gfx900;gfx906;gfx908")
+                    }
+                }
+                stage("HIP Package /opt/rocm"){
+                    agent{ label rocmnode("nogpu") }
+                    steps{
+                        buildHipClangJobAndReboot( package_build: "true", prefixpath: '/opt/rocm', gpu_arch: "gfx900;gfx906;gfx908")
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -590,7 +590,7 @@ pipeline {
                 stage('Fp32 OpenCL All gfx1030') {
                     agent{ label rocmnode("navi21") }
                     steps{
-                        buildHipClangJobAndReboot(compiler: 'g++', build_env: extra_log_env, gpu_arch: "gfx1030")
+                        buildHipClangJobAndReboot(compiler: 'g++', setup_flags: Full_test, build_env: extra_log_env, gpu_arch: "gfx1030")
                     }
                 }
                 stage('Fp16 Hip All Install gfx908') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -208,7 +208,7 @@ def buildHipClangJobAndReboot(Map conf=[:]){
 ///   * "All" corresponds to "cmake -DMIOPEN_TEST_ALL=On".
 ///   * "Smoke" (-DMIOPEN_TEST_ALL=Off) is the default and usually not specified.
 ///   * "Codecov" is optional code coverage analysis.
-/// Target := { gfx908 | Vega20 | Vega10 | Vega* }
+/// Target := { gfx908 | Vega20 | Vega10 | Vega* | gfx1030 }
 ///   * "Vega" (gfx906 or gfx900) is the default and usually not specified.
 
 
@@ -344,6 +344,12 @@ pipeline {
                 }
                 stage('Fp32 Hip Debug') {
                     agent{ label rocmnode("vega") }
+                    steps{
+                        buildHipClangJobAndReboot(build_type: 'debug', config_targets: Smoke_targets)
+                    }
+                }
+                stage('Fp32 Hip Debug gfx1030') {
+                    agent{ label rocmnode("navi21") }
                     steps{
                         buildHipClangJobAndReboot(build_type: 'debug', config_targets: Smoke_targets)
                     }
@@ -581,6 +587,12 @@ pipeline {
                     agent{ label rocmnode("vega20") }
                     steps{
                         buildHipClangJobAndReboot( setup_flags: Full_test_limit, build_env: WORKAROUND_iGemm_936)
+                    }
+                }
+                stage('Fp32 Hip All gfx1030') {
+                    agent{ label rocmnode("navi21") }
+                    steps{
+                        buildHipClangJobAndReboot( setup_flags: Full_test_limit)
                     }
                 }
                 stage('Fp16 Hip All Install gfx908') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -592,7 +592,7 @@ pipeline {
                 stage('Fp32 OpenCL All gfx1030') {
                     agent{ label rocmnode("navi21") }
                     steps{
-                        buildHipClangJobAndReboot(compiler: 'g++', setup_flags: Full_test_limit, gpu_arch: "gfx1030")
+                        buildHipClangJobAndReboot(compiler: 'g++', setup_flags: Full_test_limit, build_env: extra_log_env, gpu_arch: "gfx1030")
                     }
                 }
 //                stage('Fp16 Hip All Install gfx908') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -351,7 +351,7 @@ pipeline {
                 stage('Fp32 Hip Debug gfx1030') {
                     agent{ label rocmnode("navi21") }
                     steps{
-                        buildHipClangJobAndReboot(build_type: 'debug', config_targets: Smoke_targets)
+                        buildHipClangJobAndReboot(build_type: 'debug', config_targets: Smoke_targets, build_env: extra_log_env)
                     }
                 }
 //                stage('Fp32 Hip Debug gfx908 /opt/rocm') {
@@ -592,7 +592,7 @@ pipeline {
                 stage('Fp32 Hip All gfx1030') {
                     agent{ label rocmnode("navi21") }
                     steps{
-                        buildHipClangJobAndReboot( setup_flags: Full_test_limit)
+                        buildHipClangJobAndReboot( setup_flags: Full_test_limit, build_env: extra_log_env)
                     }
                 }
 //                stage('Fp16 Hip All Install gfx908') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 def rocmnode(name) {
-    return 'rocmtest && miopen && ' + name
+    return 'rocmtest-trial && miopen && ' + name
 }
 
 
@@ -276,294 +276,294 @@ pipeline {
         Tensile_setup = " -DMIOPEN_TEST_MIOTENSILE=ON -DMIOPEN_USE_MIOPENTENSILE=ON -DMIOPEN_USE_ROCBLAS=OFF"
     }
     stages{
-        stage("Static checks"){
-            when { expression { params.STATIC_CHECKS && !params.DISABLE_ALL_STAGES } }
-            parallel{
-                stage('Hip Tidy') {
-                    agent{  label rocmnode("nogpu") }
-                    environment{
-                        setup_cmd = "CXX='/opt/rocm/llvm/bin/clang++' cmake -DMIOPEN_BACKEND=HIP -DBUILD_DEV=On .. "
-                        build_cmd = "make -j\$(nproc) -k analyze"
-                    }
-                    steps{
-                        buildHipClangJobAndReboot(setup_cmd: setup_cmd, build_cmd: build_cmd, no_reboot:true)
-                    }
-                }
-                stage('OpenCL Tidy') {
-                    agent{  label rocmnode("nogpu") }
-                    environment{
-                        setup_cmd = "cmake -DMIOPEN_BACKEND=OpenCL -DBUILD_DEV=On .."
-                        build_cmd = "make -j\$(nproc) -k analyze"
-                    }
-                    steps{
-                        buildHipClangJobAndReboot(setup_cmd: setup_cmd, build_cmd: build_cmd, no_reboot:true)
-                    }
-                }
-                stage('Clang Format') {
-                    agent{ label rocmnode("nogpu") }
-                    environment{
-                        execute_cmd = "find . -iname \'*.h\' \
-                                -o -iname \'*.hpp\' \
-                                -o -iname \'*.cpp\' \
-                                -o -iname \'*.h.in\' \
-                                -o -iname \'*.hpp.in\' \
-                                -o -iname \'*.cpp.in\' \
-                                -o -iname \'*.cl\' \
-                                | grep -v 'build/' \
-                                | xargs -n 1 -P 1 -I{} -t sh -c \'clang-format-3.8 -style=file {} | diff - {}\'"
-                    }
-                    steps{
-                        buildHipClangJobAndReboot(setup_cmd: "", build_cmd: "", execute_cmd: execute_cmd, no_reboot:true)
-                    }
-                }
-            }
-        }
+//        stage("Static checks"){
+//            when { expression { params.STATIC_CHECKS && !params.DISABLE_ALL_STAGES } }
+//            parallel{
+//                stage('Hip Tidy') {
+//                    agent{  label rocmnode("nogpu") }
+//                    environment{
+//                        setup_cmd = "CXX='/opt/rocm/llvm/bin/clang++' cmake -DMIOPEN_BACKEND=HIP -DBUILD_DEV=On .. "
+//                        build_cmd = "make -j\$(nproc) -k analyze"
+//                    }
+//                    steps{
+//                        buildHipClangJobAndReboot(setup_cmd: setup_cmd, build_cmd: build_cmd, no_reboot:true)
+//                    }
+//                }
+//                stage('OpenCL Tidy') {
+//                    agent{  label rocmnode("nogpu") }
+//                    environment{
+//                        setup_cmd = "cmake -DMIOPEN_BACKEND=OpenCL -DBUILD_DEV=On .."
+//                        build_cmd = "make -j\$(nproc) -k analyze"
+//                    }
+//                    steps{
+//                        buildHipClangJobAndReboot(setup_cmd: setup_cmd, build_cmd: build_cmd, no_reboot:true)
+//                    }
+//                }
+//                stage('Clang Format') {
+//                    agent{ label rocmnode("nogpu") }
+//                    environment{
+//                        execute_cmd = "find . -iname \'*.h\' \
+//                                -o -iname \'*.hpp\' \
+//                                -o -iname \'*.cpp\' \
+//                                -o -iname \'*.h.in\' \
+//                                -o -iname \'*.hpp.in\' \
+//                                -o -iname \'*.cpp.in\' \
+//                                -o -iname \'*.cl\' \
+//                                | grep -v 'build/' \
+//                                | xargs -n 1 -P 1 -I{} -t sh -c \'clang-format-3.8 -style=file {} | diff - {}\'"
+//                    }
+//                    steps{
+//                        buildHipClangJobAndReboot(setup_cmd: "", build_cmd: "", execute_cmd: execute_cmd, no_reboot:true)
+//                    }
+//                }
+//            }
+//        }
         stage("Smoke Fp32"){
             when { expression { params.SMOKE_FP32_AUX1 && !params.DISABLE_ALL_STAGES } }
             environment{
                 Smoke_targets = "check doc MIOpenDriver"
             }
             parallel{
-               stage('Fp32 OpenCL Debug + Codecov') {
-                    agent{ label rocmnode("vega") }
-                    steps{
-                        buildHipClangJobAndReboot(compiler: 'g++', build_type: 'debug', config_targets: Smoke_targets, codecov: true)
-                    }
-                }
-                stage('Fp32 OpenCL gfx908') {
-                    agent{ label rocmnode("gfx908") }
-                    steps{
-                        buildHipClangJobAndReboot(compiler: 'g++', config_targets: Smoke_targets, gpu_arch: "gfx908")
-                    }
-                }
-                stage('Fp32 Hip /opt/rocm') {
-                    agent{ label rocmnode("vega") }
-                    steps{
-                        buildHipClangJobAndReboot(prefixpath: '/opt/rocm', config_targets: Smoke_targets)
-                    }
-                }
-                stage('Fp32 Hip Debug') {
-                    agent{ label rocmnode("vega") }
-                    steps{
-                        buildHipClangJobAndReboot(build_type: 'debug', config_targets: Smoke_targets)
-                    }
-                }
+//               stage('Fp32 OpenCL Debug + Codecov') {
+//                    agent{ label rocmnode("vega") }
+//                    steps{
+//                        buildHipClangJobAndReboot(compiler: 'g++', build_type: 'debug', config_targets: Smoke_targets, codecov: true)
+//                    }
+//                }
+//                stage('Fp32 OpenCL gfx908') {
+//                    agent{ label rocmnode("gfx908") }
+//                    steps{
+//                        buildHipClangJobAndReboot(compiler: 'g++', config_targets: Smoke_targets, gpu_arch: "gfx908")
+//                    }
+//                }
+//                stage('Fp32 Hip /opt/rocm') {
+//                    agent{ label rocmnode("vega") }
+//                    steps{
+//                        buildHipClangJobAndReboot(prefixpath: '/opt/rocm', config_targets: Smoke_targets)
+//                    }
+//                }
+//                stage('Fp32 Hip Debug') {
+//                    agent{ label rocmnode("vega") }
+//                    steps{
+//                        buildHipClangJobAndReboot(build_type: 'debug', config_targets: Smoke_targets)
+//                    }
+//                }
                 stage('Fp32 Hip Debug gfx1030') {
                     agent{ label rocmnode("navi21") }
                     steps{
                         buildHipClangJobAndReboot(build_type: 'debug', config_targets: Smoke_targets)
                     }
                 }
-                stage('Fp32 Hip Debug gfx908 /opt/rocm') {
-                    agent{ label rocmnode("gfx908") }
-                    environment{
-                        gpu_arch = "gfx908"
-                        prefixpath = "/opt/rocm"
-                    }
-                    steps{
-                        buildHipClangJobAndReboot(prefixpath: prefixpath, build_type: 'debug', config_targets: Smoke_targets, gpu_arch: gpu_arch)
-                    }
-                }
-                stage('Fp32 HipNoGPU Debug') {
-                    agent{  label rocmnode("nogpu") }
-                    environment{
-                        HipNoGPU_flags = "-DMIOPEN_BACKEND=HIPNOGPU -DMIOPEN_INSTALL_CXX_HEADERS=On"
-                        build_cmd = "make -j\$(nproc)"
-                    }
-                    steps{
-                        buildHipClangJob( build_type: 'debug', setup_flags: HipNoGPU_flags, build_cmd: build_cmd)
-                    }
-                }
+//                stage('Fp32 Hip Debug gfx908 /opt/rocm') {
+//                    agent{ label rocmnode("gfx908") }
+//                    environment{
+//                        gpu_arch = "gfx908"
+//                        prefixpath = "/opt/rocm"
+//                    }
+//                    steps{
+//                        buildHipClangJobAndReboot(prefixpath: prefixpath, build_type: 'debug', config_targets: Smoke_targets, gpu_arch: gpu_arch)
+//                    }
+//                }
+//                stage('Fp32 HipNoGPU Debug') {
+//                    agent{  label rocmnode("nogpu") }
+//                    environment{
+//                        HipNoGPU_flags = "-DMIOPEN_BACKEND=HIPNOGPU -DMIOPEN_INSTALL_CXX_HEADERS=On"
+//                        build_cmd = "make -j\$(nproc)"
+//                    }
+//                    steps{
+//                        buildHipClangJob( build_type: 'debug', setup_flags: HipNoGPU_flags, build_cmd: build_cmd)
+//                    }
+//                }
             }
         }
-        stage("Smoke Aux 1"){
-            when { expression { params.SMOKE_FP32_AUX1 && !params.DISABLE_ALL_STAGES } }
-            parallel{
-                stage('Fp32 Hip Debug COMGR') {
-                    agent{ label rocmnode("vega") }
-                    environment{
-                        COMGR_build_cmd = "CTEST_PARALLEL_LEVEL=2 MIOPEN_CONV_PRECISE_ROCBLAS_TIMING=0 MIOPEN_LOG_LEVEL=5 make -j\$(nproc) check"
-                    }
-                    steps{
-                        buildHipClangJobAndReboot( build_type: 'debug', setup_flags: "-DMIOPEN_USE_COMGR=On", build_cmd: COMGR_build_cmd, test_flags: ' --verbose ')
-                    }
-                }
-                stage('Fp32 Hip Debug Embedded Vega20') {
-                    agent{ label rocmnode("vega20") }
-                    environment{
-                        Embedded_flags = "-DMIOPEN_EMBED_DB='gfx906_60;gfx906_64'"
-                    }
-                    steps{
-                        buildHipClangJobAndReboot( build_type: 'debug', setup_flags: Embedded_flags, build_env: extra_log_env, test_flags: ' --verbose ')
-                    }
-                }
-                stage('Fp32 Hip Static') {
-                    agent{ label rocmnode("vega") }
-                    steps{
-                        buildHipClangJobAndReboot( setup_flags: "-DBUILD_SHARED_LIBS=Off")
-                    }
-                }
-                stage('Fp32 Hip Normal-Find') {
-                    agent{ label rocmnode("vega") }
-                    environment{
-                        config_targets = "test_conv2d"
-                        execute_cmd = "MIOPEN_FIND_MODE=1 MIOPEN_CONV_PRECISE_ROCBLAS_TIMING=0 bin/test_conv2d --disable-verification-cache"
-                    }
-                    steps{
-                        buildHipClangJobAndReboot(config_targets: config_targets, execute_cmd: execute_cmd)
-                    }
-                }
-                stage('Fp32 Hip Fast-Find') {
-                    agent{ label rocmnode("vega") }
-                    environment{
-                        config_targets =   "test_conv2d"
-                        execute_cmd = "MIOPEN_FIND_MODE=2 CTEST_PARALLEL_LEVEL=4  MIOPEN_CONV_PRECISE_ROCBLAS_TIMING=0 bin/test_conv2d --disable-verification-cache"
-                    }
-                    steps{
-                        buildHipClangJobAndReboot( config_targets: config_targets, execute_cmd: execute_cmd)
-                    }
-                }
-                stage('Fp32 Hip') {
-                    agent{ label rocmnode("vega") }
-                    steps{
-                        buildHipClangJobAndReboot()
-                    }
-                }
-            }
-        }
-        stage("Smoke MLIR"){
-            when { expression { params.SMOKE_MLIR && !params.DISABLE_ALL_STAGES } }
-            environment{ MLIR_flags = "-DMIOPEN_USE_MLIR=On" }
-            parallel{
-                stage('Fp32 Hip MLIR') {
-                    agent{ label rocmnode("vega") }
-                    steps{
-                        buildHipClangJobAndReboot(setup_flags: MLIR_flags, build_env: extra_log_env, test_flags: ' --verbose ', mlir_build: "ON")
-                    }
-                }
-                stage('Fp16 Hip MLIR') {
-                    agent{ label rocmnode("vega") }
-                    steps{
-                        buildHipClangJobAndReboot(setup_flags: MLIR_flags + Fp16_flags, build_env: extra_log_env, test_flags: ' --verbose ', mlir_build: "ON")
-                    }
-                }
-                stage('Fp16 Hip MLIR gfx908') {
-                    agent{ label rocmnode("gfx908") }
-                    steps{
-                        buildHipClangJobAndReboot(setup_flags: MLIR_flags + Fp16_flags, build_env: extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx908", mlir_build: "ON")
-                    }
-                }
-                stage('Fp32 Hip MLIR gfx908') {
-                    agent{ label rocmnode("gfx908") }
-                    steps{
-                        buildHipClangJobAndReboot(setup_flags: MLIR_flags, build_env: extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx908", mlir_build: "ON")
-                    }
-                }
-            }
-        }
-        stage("Smoke Fp16/Bf16/Int8"){
-            when { expression { params.SMOKE_FP16_BF16_INT8 && !params.DISABLE_ALL_STAGES } }
-            environment{
-                Smoke_targets = "check doc MIOpenDriver"
-            }
-            parallel{
-                stage('Fp16 OpenCL Vega20') {
-                    agent{ label rocmnode("vega20") }
-                    steps{
-                        buildHipClangJobAndReboot(compiler: 'g++', setup_flags: Fp16_flags, config_targets: Smoke_targets)
-                    }
-                }
-                stage('Int8 OpenCL Vega20') {
-                    agent{ label rocmnode("vega20") }
-                    steps{
-                        buildHipClangJobAndReboot(compiler: 'g++', setup_flags: Int8_flags, config_targets: Smoke_targets)
-                    }
-                }
-                stage('Fp16 Hip Vega20 /opt/rocm') {
-                    agent{ label rocmnode("vega20") }
-                    steps{
-                        buildHipClangJobAndReboot( setup_flags: Fp16_flags, prefixpath: '/opt/rocm', config_targets: Smoke_targets)
-                    }
-                }
-                stage('Bf16 Hip Vega20 /opt/rocm') {
-                    agent{ label rocmnode("vega20") }
-                    steps{
-                        buildHipClangJobAndReboot(setup_flags: Bf16_flags, prefixpath: '/opt/rocm', config_targets: Smoke_targets)
-                    }
-                }
-                stage('Fp16 Hip gfx908 /opt/rocm') {
-                    agent{ label rocmnode("gfx908") }
-                    steps{
-                        buildHipClangJobAndReboot( setup_flags: Fp16_flags, prefixpath: '/opt/rocm', config_targets: Smoke_targets, gpu_arch: "gfx908")
-                    }
-                }
-                stage('Bf16 Hip gfx908 /opt/rocm') {
-                    agent{ label rocmnode("gfx908") }
-                    steps{
-                        buildHipClangJobAndReboot(setup_flags: Bf16_flags, prefixpath: '/opt/rocm', config_targets: Smoke_targets, gpu_arch: "gfx908")
-                    }
-                }
-            }
-        }
-        stage("Smoke MIOpenTensile Latest"){
-            environment{
-                Tensile_version = "latest"
-            }
-            parallel{
-                stage('Fp16 Hip Tensile-Latest All Vega20') {
-                    when { expression { params.SMOKE_MIOPENTENSILE_LATEST && !params.DISABLE_ALL_STAGES } }
-                    agent{ label rocmnode("vega20") }
-                    steps{
-                        buildHipClangJobAndReboot( setup_flags: Tensile_setup + Fp16_flags, build_env: Tensile_build_env, test_flags: ' --verbose ', gpu_arch:"gfx906:xnack-", miotensile_version: Tensile_version, target_id: "ON")
-                    }
-                }
-                stage('Int8 Hip Tensile-Latest All Vega20') {
-                    when { expression { params.SMOKE_MIOPENTENSILE_LATEST && !params.DISABLE_ALL_STAGES } }
-                    agent{ label rocmnode("vega20") }
-                    steps{
-                        buildHipClangJobAndReboot( setup_flags: Tensile_setup + extra_log_env + Int8_flags, build_env: Tensile_build_env, test_flags: ' --verbose ', gpu_arch:"gfx906:xnack-", miotensile_version: Tensile_version, target_id: "ON")
-                    }
-                }
-
-                stage('Fp32 Hip Tensile-Latest All gfx908') {
-                    when { expression { params.SMOKE_MIOPENTENSILE_LATEST && !params.DISABLE_ALL_STAGES } }
-                    agent{ label rocmnode("gfx908") }
-                    steps{
-                        buildHipClangJobAndReboot( setup_flags: Tensile_setup + extra_log_env, build_env: Tensile_build_env + extra_log_env, gpu_arch: "gfx908:xnack-", test_flags: ' --verbose ', miotensile_version: Tensile_version, target_id: "ON")
-                    }
-                }
-                stage('Bf16 Hip Tensile-Latest All gfx908') {
-                    when { expression { params.SMOKE_MIOPENTENSILE_LATEST && !params.DISABLE_ALL_STAGES } }
-                    agent{ label rocmnode("gfx908") }
-                    steps{
-                        buildHipClangJobAndReboot( setup_flags: Tensile_setup + extra_log_env + Bf16_flags, build_env: Tensile_build_env + extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx908:xnack-", miotensile_version: Tensile_version, target_id: "ON")
-                    }
-                }
-            }
-        }
-        stage("Full Tests I"){
-            when { expression { params.FULL_TESTS && !params.DISABLE_ALL_STAGES } }
-            parallel{
-                stage('Int8 HIP All Vega20 /opt/rocm') {
-                    agent{ label rocmnode("vega20") }
-                    steps{
-                        buildHipClangJobAndReboot( setup_flags: Int8_flags + Full_test_limit, prefixpath: '/opt/rocm')
-                    }
-                }
-                stage('Fp32 OpenCL Install All') {
-                    agent{ label rocmnode("vega") }
-                    steps{
-                        buildHipClangJobAndReboot(compiler: 'g++', setup_flags: Full_test_limit, build_install: "true")
-                    }
-                }
-                stage('Bf16 Hip Install All gfx908') {
-                    agent{ label rocmnode("gfx908") }
-                    steps{
-                        buildHipClangJobAndReboot(setup_flags: Bf16_flags + Full_test_limit, build_install: "true", gpu_arch: "gfx908")
-                    }
-                }
-            }
-        }
+//        stage("Smoke Aux 1"){
+//            when { expression { params.SMOKE_FP32_AUX1 && !params.DISABLE_ALL_STAGES } }
+//            parallel{
+//                stage('Fp32 Hip Debug COMGR') {
+//                    agent{ label rocmnode("vega") }
+//                    environment{
+//                        COMGR_build_cmd = "CTEST_PARALLEL_LEVEL=2 MIOPEN_CONV_PRECISE_ROCBLAS_TIMING=0 MIOPEN_LOG_LEVEL=5 make -j\$(nproc) check"
+//                    }
+//                    steps{
+//                        buildHipClangJobAndReboot( build_type: 'debug', setup_flags: "-DMIOPEN_USE_COMGR=On", build_cmd: COMGR_build_cmd, test_flags: ' --verbose ')
+//                    }
+//                }
+//                stage('Fp32 Hip Debug Embedded Vega20') {
+//                    agent{ label rocmnode("vega20") }
+//                    environment{
+//                        Embedded_flags = "-DMIOPEN_EMBED_DB='gfx906_60;gfx906_64'"
+//                    }
+//                    steps{
+//                        buildHipClangJobAndReboot( build_type: 'debug', setup_flags: Embedded_flags, build_env: extra_log_env, test_flags: ' --verbose ')
+//                    }
+//                }
+//                stage('Fp32 Hip Static') {
+//                    agent{ label rocmnode("vega") }
+//                    steps{
+//                        buildHipClangJobAndReboot( setup_flags: "-DBUILD_SHARED_LIBS=Off")
+//                    }
+//                }
+//                stage('Fp32 Hip Normal-Find') {
+//                    agent{ label rocmnode("vega") }
+//                    environment{
+//                        config_targets = "test_conv2d"
+//                        execute_cmd = "MIOPEN_FIND_MODE=1 MIOPEN_CONV_PRECISE_ROCBLAS_TIMING=0 bin/test_conv2d --disable-verification-cache"
+//                    }
+//                    steps{
+//                        buildHipClangJobAndReboot(config_targets: config_targets, execute_cmd: execute_cmd)
+//                    }
+//                }
+//                stage('Fp32 Hip Fast-Find') {
+//                    agent{ label rocmnode("vega") }
+//                    environment{
+//                        config_targets =   "test_conv2d"
+//                        execute_cmd = "MIOPEN_FIND_MODE=2 CTEST_PARALLEL_LEVEL=4  MIOPEN_CONV_PRECISE_ROCBLAS_TIMING=0 bin/test_conv2d --disable-verification-cache"
+//                    }
+//                    steps{
+//                        buildHipClangJobAndReboot( config_targets: config_targets, execute_cmd: execute_cmd)
+//                    }
+//                }
+//                stage('Fp32 Hip') {
+//                    agent{ label rocmnode("vega") }
+//                    steps{
+//                        buildHipClangJobAndReboot()
+//                    }
+//                }
+//            }
+//        }
+//        stage("Smoke MLIR"){
+//            when { expression { params.SMOKE_MLIR && !params.DISABLE_ALL_STAGES } }
+//            environment{ MLIR_flags = "-DMIOPEN_USE_MLIR=On" }
+//            parallel{
+//                stage('Fp32 Hip MLIR') {
+//                    agent{ label rocmnode("vega") }
+//                    steps{
+//                        buildHipClangJobAndReboot(setup_flags: MLIR_flags, build_env: extra_log_env, test_flags: ' --verbose ', mlir_build: "ON")
+//                    }
+//                }
+//                stage('Fp16 Hip MLIR') {
+//                    agent{ label rocmnode("vega") }
+//                    steps{
+//                        buildHipClangJobAndReboot(setup_flags: MLIR_flags + Fp16_flags, build_env: extra_log_env, test_flags: ' --verbose ', mlir_build: "ON")
+//                    }
+//                }
+//                stage('Fp16 Hip MLIR gfx908') {
+//                    agent{ label rocmnode("gfx908") }
+//                    steps{
+//                        buildHipClangJobAndReboot(setup_flags: MLIR_flags + Fp16_flags, build_env: extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx908", mlir_build: "ON")
+//                    }
+//                }
+//                stage('Fp32 Hip MLIR gfx908') {
+//                    agent{ label rocmnode("gfx908") }
+//                    steps{
+//                        buildHipClangJobAndReboot(setup_flags: MLIR_flags, build_env: extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx908", mlir_build: "ON")
+//                    }
+//                }
+//            }
+//        }
+//        stage("Smoke Fp16/Bf16/Int8"){
+//            when { expression { params.SMOKE_FP16_BF16_INT8 && !params.DISABLE_ALL_STAGES } }
+//            environment{
+//                Smoke_targets = "check doc MIOpenDriver"
+//            }
+//            parallel{
+//                stage('Fp16 OpenCL Vega20') {
+//                    agent{ label rocmnode("vega20") }
+//                    steps{
+//                        buildHipClangJobAndReboot(compiler: 'g++', setup_flags: Fp16_flags, config_targets: Smoke_targets)
+//                    }
+//                }
+//                stage('Int8 OpenCL Vega20') {
+//                    agent{ label rocmnode("vega20") }
+//                    steps{
+//                        buildHipClangJobAndReboot(compiler: 'g++', setup_flags: Int8_flags, config_targets: Smoke_targets)
+//                    }
+//                }
+//                stage('Fp16 Hip Vega20 /opt/rocm') {
+//                    agent{ label rocmnode("vega20") }
+//                    steps{
+//                        buildHipClangJobAndReboot( setup_flags: Fp16_flags, prefixpath: '/opt/rocm', config_targets: Smoke_targets)
+//                    }
+//                }
+//                stage('Bf16 Hip Vega20 /opt/rocm') {
+//                    agent{ label rocmnode("vega20") }
+//                    steps{
+//                        buildHipClangJobAndReboot(setup_flags: Bf16_flags, prefixpath: '/opt/rocm', config_targets: Smoke_targets)
+//                    }
+//                }
+//                stage('Fp16 Hip gfx908 /opt/rocm') {
+//                    agent{ label rocmnode("gfx908") }
+//                    steps{
+//                        buildHipClangJobAndReboot( setup_flags: Fp16_flags, prefixpath: '/opt/rocm', config_targets: Smoke_targets, gpu_arch: "gfx908")
+//                    }
+//                }
+//                stage('Bf16 Hip gfx908 /opt/rocm') {
+//                    agent{ label rocmnode("gfx908") }
+//                    steps{
+//                        buildHipClangJobAndReboot(setup_flags: Bf16_flags, prefixpath: '/opt/rocm', config_targets: Smoke_targets, gpu_arch: "gfx908")
+//                    }
+//                }
+//            }
+//        }
+//        stage("Smoke MIOpenTensile Latest"){
+//            environment{
+//                Tensile_version = "latest"
+//            }
+//            parallel{
+//                stage('Fp16 Hip Tensile-Latest All Vega20') {
+//                    when { expression { params.SMOKE_MIOPENTENSILE_LATEST && !params.DISABLE_ALL_STAGES } }
+//                    agent{ label rocmnode("vega20") }
+//                    steps{
+//                        buildHipClangJobAndReboot( setup_flags: Tensile_setup + Fp16_flags, build_env: Tensile_build_env, test_flags: ' --verbose ', gpu_arch:"gfx906:xnack-", miotensile_version: Tensile_version, target_id: "ON")
+//                    }
+//                }
+//                stage('Int8 Hip Tensile-Latest All Vega20') {
+//                    when { expression { params.SMOKE_MIOPENTENSILE_LATEST && !params.DISABLE_ALL_STAGES } }
+//                    agent{ label rocmnode("vega20") }
+//                    steps{
+//                        buildHipClangJobAndReboot( setup_flags: Tensile_setup + extra_log_env + Int8_flags, build_env: Tensile_build_env, test_flags: ' --verbose ', gpu_arch:"gfx906:xnack-", miotensile_version: Tensile_version, target_id: "ON")
+//                    }
+//                }
+//
+//                stage('Fp32 Hip Tensile-Latest All gfx908') {
+//                    when { expression { params.SMOKE_MIOPENTENSILE_LATEST && !params.DISABLE_ALL_STAGES } }
+//                    agent{ label rocmnode("gfx908") }
+//                    steps{
+//                        buildHipClangJobAndReboot( setup_flags: Tensile_setup + extra_log_env, build_env: Tensile_build_env + extra_log_env, gpu_arch: "gfx908:xnack-", test_flags: ' --verbose ', miotensile_version: Tensile_version, target_id: "ON")
+//                    }
+//                }
+//                stage('Bf16 Hip Tensile-Latest All gfx908') {
+//                    when { expression { params.SMOKE_MIOPENTENSILE_LATEST && !params.DISABLE_ALL_STAGES } }
+//                    agent{ label rocmnode("gfx908") }
+//                    steps{
+//                        buildHipClangJobAndReboot( setup_flags: Tensile_setup + extra_log_env + Bf16_flags, build_env: Tensile_build_env + extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx908:xnack-", miotensile_version: Tensile_version, target_id: "ON")
+//                    }
+//                }
+//            }
+//        }
+//        stage("Full Tests I"){
+//            when { expression { params.FULL_TESTS && !params.DISABLE_ALL_STAGES } }
+//            parallel{
+//                stage('Int8 HIP All Vega20 /opt/rocm') {
+//                    agent{ label rocmnode("vega20") }
+//                    steps{
+//                        buildHipClangJobAndReboot( setup_flags: Int8_flags + Full_test_limit, prefixpath: '/opt/rocm')
+//                    }
+//                }
+//                stage('Fp32 OpenCL Install All') {
+//                    agent{ label rocmnode("vega") }
+//                    steps{
+//                        buildHipClangJobAndReboot(compiler: 'g++', setup_flags: Full_test_limit, build_install: "true")
+//                    }
+//                }
+//                stage('Bf16 Hip Install All gfx908') {
+//                    agent{ label rocmnode("gfx908") }
+//                    steps{
+//                        buildHipClangJobAndReboot(setup_flags: Bf16_flags + Full_test_limit, build_install: "true", gpu_arch: "gfx908")
+//                    }
+//                }
+//            }
+//        }
 
         stage("Full Tests II"){
             when { expression { params.FULL_TESTS && !params.DISABLE_ALL_STAGES } }
@@ -571,36 +571,36 @@ pipeline {
                 WORKAROUND_iGemm_936 = " MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_FWD_V4R1=0"
             }
             parallel{
-                stage('Fp32 Hip All gfx908') {
-                    agent{ label rocmnode("gfx908") }
-                    steps{
-                        buildHipClangJobAndReboot(setup_flags: Full_test_limit, build_env: WORKAROUND_iGemm_936, gpu_arch: "gfx908")
-                    }
-                }
-                stage('Fp16 Hip Install All Vega20') {
-                    agent{ label rocmnode("vega20") }
-                    steps{
-                        buildHipClangJobAndReboot( setup_flags: Full_test_limit + Fp16_flags, build_env: WORKAROUND_iGemm_936, build_install: "true")
-                    }
-                }
-                stage('Fp32 Hip All Vega20') {
-                    agent{ label rocmnode("vega20") }
-                    steps{
-                        buildHipClangJobAndReboot( setup_flags: Full_test_limit, build_env: WORKAROUND_iGemm_936)
-                    }
-                }
+//                stage('Fp32 Hip All gfx908') {
+//                    agent{ label rocmnode("gfx908") }
+//                    steps{
+//                        buildHipClangJobAndReboot(setup_flags: Full_test_limit, build_env: WORKAROUND_iGemm_936, gpu_arch: "gfx908")
+//                    }
+//                }
+//                stage('Fp16 Hip Install All Vega20') {
+//                    agent{ label rocmnode("vega20") }
+//                    steps{
+//                        buildHipClangJobAndReboot( setup_flags: Full_test_limit + Fp16_flags, build_env: WORKAROUND_iGemm_936, build_install: "true")
+//                    }
+//                }
+//                stage('Fp32 Hip All Vega20') {
+//                    agent{ label rocmnode("vega20") }
+//                    steps{
+//                        buildHipClangJobAndReboot( setup_flags: Full_test_limit, build_env: WORKAROUND_iGemm_936)
+//                    }
+//                }
                 stage('Fp32 Hip All gfx1030') {
                     agent{ label rocmnode("navi21") }
                     steps{
                         buildHipClangJobAndReboot( setup_flags: Full_test_limit)
                     }
                 }
-                stage('Fp16 Hip All Install gfx908') {
-                    agent{ label rocmnode("gfx908") }
-                    steps{
-                        buildHipClangJobAndReboot(setup_flags: Full_test_limit + Fp16_flags, build_env: WORKAROUND_iGemm_936, build_install: "true", gpu_arch: "gfx908")
-                    }
-                }
+//                stage('Fp16 Hip All Install gfx908') {
+//                    agent{ label rocmnode("gfx908") }
+//                    steps{
+//                        buildHipClangJobAndReboot(setup_flags: Full_test_limit + Fp16_flags, build_env: WORKAROUND_iGemm_936, build_install: "true", gpu_arch: "gfx908")
+//                    }
+//                }
             }
         }
 
@@ -716,23 +716,23 @@ pipeline {
                 }
             }
         }
-        stage("Packages"){
-            when { expression { params.PACKAGES && !params.DISABLE_ALL_STAGES } }
-            parallel {
-                stage('OpenCL Package') {
-                    agent{ label rocmnode("nogpu") }
-                    steps{
-                        buildHipClangJobAndReboot(compiler: 'g++', package_build: "true", gpu_arch: "gfx900;gfx906;gfx908")
-                    }
-                }
-                stage("HIP Package /opt/rocm"){
-                    agent{ label rocmnode("nogpu") }
-                    steps{
-                        buildHipClangJobAndReboot( package_build: "true", prefixpath: '/opt/rocm', gpu_arch: "gfx900;gfx906;gfx908")
-                    }
-                }
-            }
-        }
+//        stage("Packages"){
+//            when { expression { params.PACKAGES && !params.DISABLE_ALL_STAGES } }
+//            parallel {
+//                stage('OpenCL Package') {
+//                    agent{ label rocmnode("nogpu") }
+//                    steps{
+//                        buildHipClangJobAndReboot(compiler: 'g++', package_build: "true", gpu_arch: "gfx900;gfx906;gfx908")
+//                    }
+//                }
+//                stage("HIP Package /opt/rocm"){
+//                    agent{ label rocmnode("nogpu") }
+//                    steps{
+//                        buildHipClangJobAndReboot( package_build: "true", prefixpath: '/opt/rocm', gpu_arch: "gfx900;gfx906;gfx908")
+//                    }
+//                }
+//            }
+//        }
     }
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -590,7 +590,7 @@ pipeline {
                 stage('Fp32 OpenCL All gfx1030') {
                     agent{ label rocmnode("navi21") }
                     steps{
-                        buildHipClangJobAndReboot(compiler: 'g++', setup_flags: Full_test_limit, build_env: extra_log_env, gpu_arch: "gfx1030")
+                        buildHipClangJobAndReboot(compiler: 'g++', build_env: extra_log_env, gpu_arch: "gfx1030")
                     }
                 }
                 stage('Fp16 Hip All Install gfx908') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -351,7 +351,7 @@ pipeline {
                 stage('Fp32 Hip Debug gfx1030') {
                     agent{ label rocmnode("navi21") }
                     steps{
-                        buildHipClangJobAndReboot(build_type: 'debug', config_targets: Smoke_targets, build_env: extra_log_env)
+                        buildHipClangJobAndReboot(build_type: 'debug', config_targets: Smoke_targets, build_env: extra_log_env, gpu_arch: "gfx1030")
                     }
                 }
 //                stage('Fp32 Hip Debug gfx908 /opt/rocm') {
@@ -592,7 +592,7 @@ pipeline {
                 stage('Fp32 Hip All gfx1030') {
                     agent{ label rocmnode("navi21") }
                     steps{
-                        buildHipClangJobAndReboot( setup_flags: Full_test_limit, build_env: extra_log_env)
+                        buildHipClangJobAndReboot( setup_flags: Full_test_limit, build_env: extra_log_env, gpu_arch: "gfx1030")
                     }
                 }
 //                stage('Fp16 Hip All Install gfx908') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -348,10 +348,10 @@ pipeline {
 //                        buildHipClangJobAndReboot(build_type: 'debug', config_targets: Smoke_targets)
 //                    }
 //                }
-                stage('Fp32 Hip Debug gfx1030') {
+                stage('Fp32 OpenCL Debug gfx1030') {
                     agent{ label rocmnode("navi21") }
                     steps{
-                        buildHipClangJobAndReboot(build_type: 'debug', config_targets: Smoke_targets, build_env: extra_log_env, gpu_arch: "gfx1030")
+                        buildHipClangJobAndReboot(compiler: 'g++', build_type: 'debug', config_targets: Smoke_targets, build_env: extra_log_env, gpu_arch: "gfx1030")
                     }
                 }
 //                stage('Fp32 Hip Debug gfx908 /opt/rocm') {
@@ -589,10 +589,10 @@ pipeline {
 //                        buildHipClangJobAndReboot( setup_flags: Full_test_limit, build_env: WORKAROUND_iGemm_936)
 //                    }
 //                }
-                stage('Fp32 Hip All gfx1030') {
+                stage('Fp32 OpenCL All gfx1030') {
                     agent{ label rocmnode("navi21") }
                     steps{
-                        buildHipClangJobAndReboot( setup_flags: Full_test_limit, build_env: extra_log_env, gpu_arch: "gfx1030")
+                        buildHipClangJobAndReboot(compiler: 'g++', setup_flags: Full_test_limit, gpu_arch: "gfx1030")
                     }
                 }
 //                stage('Fp16 Hip All Install gfx908') {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -33,8 +33,9 @@ option( MIOPEN_TEST_ALL "Run the full test suite" OFF )
 option( MIOPEN_TEST_HALF "Test in half mode" OFF )
 option( MIOPEN_TEST_INT8 "Test in int8 mode" OFF )
 option( MIOPEN_TEST_BFLOAT16 "Test in bfloat16 mode" OFF )
-option( MIOPEN_TEST_GFX908 "Test arch gfx908 mode" OFF )
-option( MIOPEN_TEST_VEGA "Test arch VEGA (gfx900, gfx906)" OFF )
+option( MIOPEN_TEST_GFX908 "Test on MI100 (gfx908)" OFF )
+option( MIOPEN_TEST_VEGA "Test on Vega10/20 (gfx900, gfx906)" OFF )
+option( MIOPEN_TEST_GFX1030 "Test on Navi21 (gfx1030)" OFF )
 option( MIOPEN_TEST_CONV Off)
 option( MIOPEN_TEST_DEEPBENCH Off)
 option( MIOPEN_TEST_DRIVER_ITER_MODE Off)
@@ -68,7 +69,7 @@ endif()
 # For HIP_NOGPU backend, GPU detection is not required and should be disabled.
 # Also we do not detect GPU when target GPU for testing is specified explicitly.
 set(MIOPEN_TEST_GPU_DETECTION_FAILED FALSE)
-if(NOT (MIOPEN_TEST_VEGA OR MIOPEN_TEST_GFX908 OR MIOPEN_TEST_HIP_NOGPU))
+if(NOT (MIOPEN_TEST_VEGA OR MIOPEN_TEST_GFX908 OR MIOPEN_TEST_GFX1030 OR MIOPEN_TEST_HIP_NOGPU))
     find_program(ROCMINFO
         NAMES rocminfo
         PATHS
@@ -87,6 +88,8 @@ if(NOT (MIOPEN_TEST_VEGA OR MIOPEN_TEST_GFX908 OR MIOPEN_TEST_HIP_NOGPU))
         if(NOT ROCMINFO_EXIT_STATUS EQUAL 0)
             message(WARNING "ROCMINFO FAILED, GPU TYPE UNKNOWN. Manually set respective MIOPEN_TEST_GFX* CMake variable to specify target GPU for testing.")
             set(MIOPEN_TEST_GPU_DETECTION_FAILED TRUE)
+        elseif(ROCMINFO_OUTPUT MATCHES "gfx1030")
+            set(MIOPEN_TEST_GFX1030 ON)
         elseif(ROCMINFO_OUTPUT MATCHES "gfx900|gfx906")
             set(MIOPEN_TEST_VEGA ON)
         elseif(ROCMINFO_OUTPUT MATCHES "gfx908")
@@ -102,6 +105,7 @@ if(NOT (MIOPEN_TEST_VEGA OR MIOPEN_TEST_GFX908 OR MIOPEN_TEST_HIP_NOGPU))
 endif()
 message(STATUS "MIOPEN_TEST_VEGA ${MIOPEN_TEST_VEGA}")
 message(STATUS "MIOPEN_TEST_GFX908 ${MIOPEN_TEST_GFX908}")
+message(STATUS "MIOPEN_TEST_GFX1030 ${MIOPEN_TEST_GFX1030}")
 
 if(MIOPEN_TEST_DRIVER_ITER_MODE)
     add_definitions(-DMIOPEN_TEST_DRIVER_MODE=2)
@@ -173,6 +177,15 @@ if(MIOPEN_TEST_GFX908)
             test_conv3d_bias test_cba_inference test_cbna_inference test_pooling2d test_na_train
             test_na_inference test_bn_aux)
 endif()
+
+if(MIOPEN_TEST_GFX1030)
+#    list(APPEND SKIP_TESTS test_tensor_scale test_tensor_set test_tensor_transform
+#            test_tensor_vec test_w_supertensor test_dropout test_immed_conv3d test_conv3d
+#            test_soft_max test_fusion_aux test_activation test_lrn_test test_ctc test_conv2d_bias
+#            test_conv3d_bias test_cba_inference test_cbna_inference test_pooling2d test_na_train
+#            test_na_inference test_bn_aux)
+endif()
+
 # The usage is non-trivial, see function add_test_command.
 if(SKIP_TESTS)
     list(REMOVE_DUPLICATES SKIP_TESTS)
@@ -393,7 +406,7 @@ endfunction()
 # 2)Second options type describes support GPU types (gfx900, gfx906, gfx908 ...)
 #   The option can be enabled or disabled by using '_ENABLED' and '_DISABLED' suffix.
 #   If nothing is specified, the default value is taken.
-#       Default: VEGA=enabled, GFX908=disabled.
+#       Default: VEGA=enabled, all others disabled.
 # 3)Third type describes support for special internal components (MIOTENSILE MLIR ...)
 #   The option can be enabled or disabled by using '_ENABLED' and '_DISABLED' suffix.
 #   If nothing is specified, the default value is taken.
@@ -410,7 +423,7 @@ endfunction()
 function(add_custom_test NAME)
     set(options
         BF16_ENABLED BF16_DISABLED HALF_ENABLED HALF_DISABLED INT8_ENABLED INT8_DISABLED FLOAT_ENABLED FLOAT_DISABLED
-        VEGA_ENABLED VEGA_DISABLED GFX908_ENABLED GFX908_DISABLED
+        VEGA_ENABLED VEGA_DISABLED GFX908_ENABLED GFX908_DISABLED GFX1030_ENABLED GFX1030_DISABLED
         MIOTENSILE_ENABLED MIOTENSILE_DISABLED MLIR_ENABLED MLIR_DISABLED
         SKIP_UNLESS_ALL TEST_PERF_DB_RECORD_NOT_FOUND
         OCL_ENABLED OCL_DISABLED HIP_ENABLED HIP_DISABLED HIP_NOGPU_ENABLED HIP_NOGPU_DISABLED
@@ -483,6 +496,11 @@ function(add_custom_test NAME)
     option_support_check(${PARSE_GFX908_ENABLED} ${PARSE_GFX908_DISABLED} ${GFX908_TEST_DEFAULT} is_gfx908_check)
     bool_and_f(${MIOPEN_TEST_GFX908} ${is_gfx908_check} is_gfx908_check)
 
+    set(is_gfx1030_check)
+    set(GFX1030_TEST_DEFAULT FALSE)
+    option_support_check(${PARSE_GFX1030_ENABLED} ${PARSE_GFX1030_DISABLED} ${GFX1030_TEST_DEFAULT} is_gfx1030_check)
+    bool_and_f(${MIOPEN_TEST_GFX1030} ${is_gfx1030_check} is_gfx1030_check)
+
     set(is_full_check)
     bool_not_f(${PARSE_SKIP_UNLESS_ALL} is_full_check)
     bool_or_f(${is_full_check} ${MIOPEN_TEST_ALL} is_full_check)
@@ -493,7 +511,7 @@ function(add_custom_test NAME)
     if(WORKAROUND_ISSUE_898 AND MIOPEN_USE_COMGR)
         set_property(TEST ${NAME} PROPERTY ENVIRONMENT MIOPEN_DEBUG_COMGR_HIP_PCH_ENFORCE=0)
     endif()
-    if(  (is_vega_check OR is_gfx908_check)
+    if(  (is_vega_check OR is_gfx908_check OR is_gfx1030_check)
      AND is_full_check
      AND (is_miotensile_check AND is_mlir_check)
      AND ( is_half_check OR is_bfloat16_check OR is_int8_check OR is_float_check)
@@ -574,7 +592,7 @@ if(MIOPEN_TEST_MLIR)
     set(IMPLICITGEMM_MLIR_ARGS_B ${IMPLICITGEMM_ARGS} --verbose --disable-forward --disable-backward-weights)
     set(IMPLICITGEMM_MLIR_ARGS_W ${IMPLICITGEMM_ARGS} --verbose --disable-forward --disable-backward-data)
 
-    add_custom_test(test_conv_igemm_mlir  HALF_ENABLED MLIR_ENABLED
+    add_custom_test(test_conv_igemm_mlir  HALF_ENABLED MLIR_ENABLED GFX1030_ENABLED
         COMMAND ${IMPLICITGEMM_MLIR_ENV_F} $<TARGET_FILE:test_conv2d> ${IMPLICITGEMM_MLIR_ARGS_F} --input 256 1024 14 14 --weights 2048 1024 1 1 --pads_strides_dilations 0 0 2 2 1 1
         COMMAND ${IMPLICITGEMM_MLIR_ENV_F} $<TARGET_FILE:test_conv2d> ${IMPLICITGEMM_MLIR_ARGS_F} --input 256 1024 14 14 --weights 2048 1024 1 1 --pads_strides_dilations 0 0 2 2 1 1 --in_layout NHWC --fil_layout NHWC --out_layout NHWC
         COMMAND ${IMPLICITGEMM_MLIR_ENV_F} $<TARGET_FILE:test_conv2d> ${IMPLICITGEMM_MLIR_ARGS_F} --input 256 128  28 28 --weights 128  128  3 3 --pads_strides_dilations 1 1 1 1 1 1
@@ -662,7 +680,7 @@ if(WORKAROUND_ISSUE_936 AND MIOPEN_TEST_HALF)
     LIST(APPEND IMPLICITGEMM_ARGS --disable-forward --disable-backward-data)
     #Afther fix need to remove '| grep -v "cannot be executed due to incorrect params"'
 endif()
-add_custom_test(test_conv_for_implicit_gemm SKIP_UNLESS_ALL BF16_ENABLED HALF_ENABLED
+add_custom_test(test_conv_for_implicit_gemm SKIP_UNLESS_ALL BF16_ENABLED HALF_ENABLED GFX1030_ENABLED
 COMMAND ${IMPLICITGEMM_TESTING_ENV} $<TARGET_FILE:test_conv2d> ${IMPLICITGEMM_ARGS} --verbose   --input 64  16  28  28  --weights 192 16  3 3 --pads_strides_dilations 0 0 2 2 1 1 | grep -v "cannot be executed due to incorrect params"
 COMMAND ${IMPLICITGEMM_TESTING_ENV} $<TARGET_FILE:test_conv2d> ${IMPLICITGEMM_ARGS} --verbose   --input 64  16  14  14  --weights 160 16  3 3 --pads_strides_dilations 0 0 2 2 1 1 | grep -v "cannot be executed due to incorrect params"
 COMMAND ${IMPLICITGEMM_TESTING_ENV} $<TARGET_FILE:test_conv2d> ${IMPLICITGEMM_ARGS} --verbose   --input 64  16   7   7  --weights 128 16  3 3 --pads_strides_dilations 0 0 2 2 1 1 | grep -v "cannot be executed due to incorrect params"
@@ -746,7 +764,7 @@ COMMAND	${IMPLICITGEMM_TESTING_ENV} $<TARGET_FILE:test_conv2d> ${IMPLICITGEMM_AR
 COMMAND	${IMPLICITGEMM_TESTING_ENV} $<TARGET_FILE:test_conv2d> ${IMPLICITGEMM_ARGS} --verbose   --input 64	 32	7 7   --weights   192  32   3	3   --pads_strides_dilations	2   2	2   2	1   1         | grep -v "cannot be executed due to incorrect params"
 )
 
-add_custom_test(test_conv_group SKIP_UNLESS_ALL  MIOTENSILE_ENABLED
+add_custom_test(test_conv_group SKIP_UNLESS_ALL  MIOTENSILE_ENABLED GFX1030_ENABLED
 COMMAND	$<TARGET_FILE:test_conv2d>	--verbose	--input	16	128	56	56	--weights	256	4	3	3	--pads_strides_dilations	1	1	1	1	1	1	--group-count	32
 COMMAND	$<TARGET_FILE:test_conv2d>	--verbose	--input	16	256	56	56	--weights	512	8	3	3	--pads_strides_dilations	1	1	2	2	1	1	--group-count	32
 COMMAND	$<TARGET_FILE:test_conv2d>	--verbose	--input	16	256	28	28	--weights	512	8	3	3	--pads_strides_dilations	1	1	1	1	1	1	--group-count	32
@@ -806,7 +824,7 @@ COMMAND	$<TARGET_FILE:test_conv2d>	--verbose	--input	8	3	108	108	--weights	63	1	
 
 
 if(MIOPEN_TEST_DEEPBENCH)
-    add_custom_test(test_deepbench_rnn  MIOTENSILE_ENABLED
+    add_custom_test(test_deepbench_rnn  MIOTENSILE_ENABLED GFX1030_ENABLED
     COMMAND $<TARGET_FILE:test_rnn_vanilla> --verbose --batch-size 16 --seq-len 50 --vector-len 1760 --hidden-size 1760 --num-layers 1 --in-mode 1 --bias-mode 0 -dir-mode 0 --rnn-mode 0 --flat-batch-fill
     COMMAND $<TARGET_FILE:test_rnn_vanilla> --verbose --batch-size 32 --seq-len 50 --vector-len 1760 --hidden-size 1760 --num-layers 1 --in-mode 1 --bias-mode 0 -dir-mode 0 --rnn-mode 0 --flat-batch-fill
     COMMAND $<TARGET_FILE:test_rnn_vanilla> --verbose --batch-size 64 --seq-len 50 --vector-len 1760 --hidden-size 1760 --num-layers 1 --in-mode 1 --bias-mode 0 -dir-mode 0 --rnn-mode 0 --flat-batch-fill
@@ -864,7 +882,7 @@ if(MIOPEN_TEST_DEEPBENCH)
 endif()
 
 
-add_custom_test(test_rnn_extra SKIP_UNLESS_ALL  MIOTENSILE_ENABLED
+add_custom_test(test_rnn_extra SKIP_UNLESS_ALL  MIOTENSILE_ENABLED GFX1030_ENABLED
 COMMAND $<TARGET_FILE:test_rnn_vanilla> --verbose --batch-size 32 --seq-len 3 --batch-seq 32 32 32 --vector-len 128 --hidden-size 128 --num-layers 1 --in-mode 0 --bias-mode 0 -dir-mode 0 --rnn-mode 0 --no-hx
 COMMAND $<TARGET_FILE:test_rnn_vanilla> --verbose --batch-size 32 --seq-len 3 --batch-seq 32 32 32 --vector-len 128 --hidden-size 128 --num-layers 1 --in-mode 0 --bias-mode 0 -dir-mode 0 --rnn-mode 0 --no-dhy
 COMMAND $<TARGET_FILE:test_rnn_vanilla> --verbose --batch-size 32 --seq-len 3 --batch-seq 32 32 32 --vector-len 128 --hidden-size 128 --num-layers 1 --in-mode 0 --bias-mode 0 -dir-mode 0 --rnn-mode 0 --no-hx --no-dhy
@@ -895,7 +913,7 @@ COMMAND $<TARGET_FILE:test_rnn_vanilla> --verbose --batch-size 32 --seq-len 3 --
 COMMAND $<TARGET_FILE:test_rnn_vanilla> --verbose --batch-size 32 --seq-len 3 --batch-seq 32 32 32 --vector-len 128 --hidden-size 128 --num-layers 1 --in-mode 0 --bias-mode 0 -dir-mode 1 --rnn-mode 1 --no-hx --no-dhy --no-hy --no-dhx
 )
 
-add_custom_test(test_gru_extra SKIP_UNLESS_ALL  MIOTENSILE_ENABLED
+add_custom_test(test_gru_extra SKIP_UNLESS_ALL  MIOTENSILE_ENABLED GFX1030_ENABLED
 COMMAND $<TARGET_FILE:test_gru> --verbose --batch-size 32 --seq-len 3 --batch-seq 32 32 32 --vector-len 128 --hidden-size 128 --num-layers 1 --in-mode 0 --bias-mode 0 -dir-mode 0 --no-hx
 COMMAND $<TARGET_FILE:test_gru> --verbose --batch-size 32 --seq-len 3 --batch-seq 32 32 32 --vector-len 128 --hidden-size 128 --num-layers 1 --in-mode 0 --bias-mode 0 -dir-mode 0 --no-dhy
 COMMAND $<TARGET_FILE:test_gru> --verbose --batch-size 32 --seq-len 3 --batch-seq 32 32 32 --vector-len 128 --hidden-size 128 --num-layers 1 --in-mode 0 --bias-mode 0 -dir-mode 0 --no-hx --no-dhy
@@ -912,7 +930,7 @@ COMMAND $<TARGET_FILE:test_gru> --verbose --batch-size 32 --seq-len 3 --batch-se
 COMMAND $<TARGET_FILE:test_gru> --verbose --batch-size 32 --seq-len 3 --batch-seq 32 32 32 --vector-len 128 --hidden-size 128 --num-layers 1 --in-mode 0 --bias-mode 0 -dir-mode 1 --no-hx --no-dhy --no-hy --no-dhx
 )
 
-add_custom_test(test_lstm_extra SKIP_UNLESS_ALL  MIOTENSILE_ENABLED
+add_custom_test(test_lstm_extra SKIP_UNLESS_ALL  MIOTENSILE_ENABLED GFX1030_ENABLED
 COMMAND $<TARGET_FILE:test_lstm> --verbose --batch-size 32 --seq-len 3 --batch-seq 32 32 32 --vector-len 128 --hidden-size 128 --num-layers 1 --in-mode 0 --bias-mode 0 -dir-mode 0 --no-hx
 COMMAND $<TARGET_FILE:test_lstm> --verbose --batch-size 32 --seq-len 3 --batch-seq 32 32 32 --vector-len 128 --hidden-size 128 --num-layers 1 --in-mode 0 --bias-mode 0 -dir-mode 0 --no-dhy
 COMMAND $<TARGET_FILE:test_lstm> --verbose --batch-size 32 --seq-len 3 --batch-seq 32 32 32 --vector-len 128 --hidden-size 128 --num-layers 1 --in-mode 0 --bias-mode 0 -dir-mode 0 --no-hx --no-dhy
@@ -946,7 +964,7 @@ COMMAND $<TARGET_FILE:test_lstm> --verbose --batch-size 32 --seq-len 3 --batch-s
 )
 
 
-add_custom_test(test_conv_extra SKIP_UNLESS_ALL  MIOTENSILE_ENABLED
+add_custom_test(test_conv_extra SKIP_UNLESS_ALL  MIOTENSILE_ENABLED GFX1030_ENABLED
 # COMMAND	$<TARGET_FILE:test_conv2d>	--verbose	--input	1	1	1	1	--weights	1	1	2	2	--pads_strides_dilations	0	0	3	3	1	1
 COMMAND	$<TARGET_FILE:test_conv2d>	--verbose	--input	4	1	161	700	--weights	4	1	5	20	--pads_strides_dilations	0	0	2	2	1	1
 COMMAND	$<TARGET_FILE:test_conv2d>	--verbose	--input	4	1	161	700	--weights	4	1	5	20	--pads_strides_dilations	0	0	2	2	1	1
@@ -980,7 +998,7 @@ COMMAND $<TARGET_FILE:test_conv2d> ${MIOPEN_TEST_FLOAT_ARG} --input 352 16 7 1 -
 if (0) #disabled too many errors
 if(MIOPEN_TEST_LIMIT GREATER 0)
 if(${MIOPEN_USE_MIOPENGEMM} AND (${MIOPEN_hip_VERSION_MAJOR} EQUAL 3) AND (${MIOPEN_hip_VERSION_MINOR} EQUAL 7))
-    add_custom_test(test_conv3d_extra  SKIP_UNLESS_ALL
+    add_custom_test(test_conv3d_extra  SKIP_UNLESS_ALL GFX1030_ENABLED
     COMMAND MIOPEN_LOG_LEVEL=6 $<TARGET_FILE:test_conv3d> ${MIOPEN_TEST_FLOAT_ARG} --input 2 16 50 50 50 --weights 32 16 5 5 5 --pads_strides_dilations 0 0 0 1 1 1 1 1 1 ${MIOPEN_TEST_FLAGS_ARGS}
     COMMAND MIOPEN_LOG_LEVEL=6 $<TARGET_FILE:test_conv3d> ${MIOPEN_TEST_FLOAT_ARG} --input 2 16 50 50 50 --weights 32 16 5 5 5 --pads_strides_dilations 0 0 0 2 2 2 1 1 1 ${MIOPEN_TEST_FLAGS_ARGS}
     COMMAND MIOPEN_LOG_LEVEL=6 $<TARGET_FILE:test_conv3d> ${MIOPEN_TEST_FLOAT_ARG} --input 2 16 50 50 50 --weights 32 16 5 5 5 --pads_strides_dilations 2 2 2 1 1 1 1 1 1 ${MIOPEN_TEST_FLAGS_ARGS}
@@ -995,7 +1013,7 @@ if(${MIOPEN_USE_MIOPENGEMM} AND (${MIOPEN_hip_VERSION_MAJOR} EQUAL 3) AND (${MIO
     )
     message(STATUS "test_conv3d_extra reduced set")
 else()
-    add_custom_test(test_conv3d_extra  SKIP_UNLESS_ALL
+    add_custom_test(test_conv3d_extra  SKIP_UNLESS_ALL GFX1030_ENABLED
     COMMAND $<TARGET_FILE:test_conv3d> ${MIOPEN_TEST_FLOAT_ARG} --input 2 16 50 50 50 --weights 32 16 5 5 5 --pads_strides_dilations 0 0 0 1 1 1 1 1 1 ${MIOPEN_TEST_FLAGS_ARGS}
     COMMAND $<TARGET_FILE:test_conv3d> ${MIOPEN_TEST_FLOAT_ARG} --input 2 16 50  50 50 --weights 32 16 5 5 5 --pads_strides_dilations 0 0 0 2 2 2 1 1 1 ${MIOPEN_TEST_FLAGS_ARGS}
     COMMAND $<TARGET_FILE:test_conv3d> ${MIOPEN_TEST_FLOAT_ARG} --input 2 16 50 50 50 --weights 32 16 5 5 5 --pads_strides_dilations 2 2 2 1 1 1 1 1 1 ${MIOPEN_TEST_FLAGS_ARGS}
@@ -1011,7 +1029,7 @@ endif()
 endif()
 
 
-add_custom_test(test_conv_trans SKIP_UNLESS_ALL  MIOTENSILE_ENABLED
+add_custom_test(test_conv_trans SKIP_UNLESS_ALL  MIOTENSILE_ENABLED GFX1030_ENABLED
 COMMAND	$<TARGET_FILE:test_conv2d>	--verbose	--input	8	128	28	28	--weights	128	128	1	1	--pads_strides_dilations	0	0	1	1	1	1	--cmode	trans	--pmode	default
 COMMAND	$<TARGET_FILE:test_conv2d>	--verbose	--input	8	256	28	28	--weights	256	256	1	1	--pads_strides_dilations	0	0	1	1	1	1	--cmode	trans	--pmode	same
 COMMAND	$<TARGET_FILE:test_conv2d>	--verbose	--input	8	32	28	28	--weights	32	32	5	5	--pads_strides_dilations	0	0	2	2	1	1	--cmode	trans	--pmode	default
@@ -1031,7 +1049,7 @@ COMMAND	$<TARGET_FILE:test_conv2d>	--verbose	--input	100	6	4	4	--weights	6	4	1	1
 )
 
 
-add_custom_test(test_conv_3d SKIP_UNLESS_ALL  MIOTENSILE_ENABLED
+add_custom_test(test_conv_3d SKIP_UNLESS_ALL  MIOTENSILE_ENABLED GFX1030_ENABLED
 COMMAND $<TARGET_FILE:test_conv3d> --verbose --conv_dim_type conv3d --input 16    32   4    9     9  --weights    64    32   3  3    3  --pads_strides_dilations  0  0  0    2  2   2    1   1   1  --group-count   1   --cmode conv   --pmode   default
 COMMAND $<TARGET_FILE:test_conv3d> --verbose --conv_dim_type conv3d --input  4     3   4  227   227  --weights     4     3   3 11   11  --pads_strides_dilations  0  0  0    1  1   1    1   1   1  --group-count   1   --cmode conv   --pmode   default
 COMMAND $<TARGET_FILE:test_conv3d> --verbose --conv_dim_type conv3d --input 16   128   4   56    56  --weights   256     4   3  3    3  --pads_strides_dilations  1  1  1    1  1   1    1   1   1  --group-count   32  --cmode conv   --pmode   default
@@ -1103,7 +1121,7 @@ else()
     )
 endif() #if CODECOV_TEST
 
-add_custom_test(test_conv_igemm_dynamic SKIP_UNLESS_ALL
+add_custom_test(test_conv_igemm_dynamic SKIP_UNLESS_ALL GFX1030_ENABLED
 COMMAND ${DYNAMIC_IMPLICITGEMM_ENVS}     $<TARGET_FILE:test_conv2d> --verbose --input  64   64 56 56 --weights 256  64  1 1 --pads_strides_dilations 0 0 1 1 1 1 --disable-backward-data --disable-backward-weights
 COMMAND ${DYNAMIC_IMPLICITGEMM_ENVS}     $<TARGET_FILE:test_conv2d> --verbose --input  64  256 34 34 --weights 256  256 3 3 --pads_strides_dilations 0 0 1 1 1 1 --disable-backward-data --disable-backward-weights
 COMMAND ${DYNAMIC_IMPLICITGEMM_ENVS}     $<TARGET_FILE:test_conv2d> --verbose --input 128  128 35 35 --weights 128  128 3 3 --pads_strides_dilations 0 0 2 2 1 1 --disable-backward-data --disable-backward-weights
@@ -1270,7 +1288,7 @@ COMMAND MIOPEN_FIND_MODE=normal MIOPEN_DEBUG_FIND_ONLY_SOLVER=ConvHipImplicitGem
 )
 
 if(MIOPEN_TEST_DEEPBENCH)
-    add_custom_test(test_deepbench_conv  MIOTENSILE_ENABLED
+    add_custom_test(test_deepbench_conv  MIOTENSILE_ENABLED GFX1030_ENABLED
     COMMAND	$<TARGET_FILE:test_conv2d>	--verbose	--input	4	1	161	700	--weights	32	1	5	20	--pads_strides_dilations	0	0	2	2	1	1
     COMMAND	$<TARGET_FILE:test_conv2d>	--verbose	--input	8	1	161	700	--weights	32	1	5	20	--pads_strides_dilations	0	0	2	2	1	1
     COMMAND	$<TARGET_FILE:test_conv2d>	--verbose	--input	16	1	161	700	--weights	32	1	5	20	--pads_strides_dilations	0	0	2	2	1	1
@@ -1311,7 +1329,7 @@ if(MIOPEN_TEST_DEEPBENCH)
 endif()
 
 if(MIOPEN_TEST_CONV)
-    add_custom_test(test_miopen_conv  MIOTENSILE_ENABLED
+    add_custom_test(test_miopen_conv  MIOTENSILE_ENABLED GFX1030_ENABLED
     COMMAND	$<TARGET_FILE:test_conv2d>	--verbose	--input	1	3	32	32	--weights	1	3	7	7	--pads_strides_dilations	1	1	1	1	1	1
     COMMAND	$<TARGET_FILE:test_conv2d>	--verbose	--input	1	3	227	227	--weights	1	3	7	7	--pads_strides_dilations	1	1	1	1	1	1
     COMMAND	$<TARGET_FILE:test_conv2d>	--verbose	--input	1	64	56	56	--weights	1	64	1	1	--pads_strides_dilations	0	0	2	2	1	1
@@ -1356,7 +1374,7 @@ if(MIOPEN_TEST_CONV)
 endif()
 
 if(MIOPEN_TEST_FLOAT)
-    add_custom_test(test_reduce_double SKIP_UNLESS_ALL GFX908_ENABLED COMMAND  $<TARGET_FILE:test_reduce_test> --double --all --verbose)
+    add_custom_test(test_reduce_double SKIP_UNLESS_ALL GFX908_ENABLED GFX1030_ENABLED COMMAND  $<TARGET_FILE:test_reduce_test> --double --all --verbose)
 endif()
 
 # Add here regression tests that should be run only on Vega10/20 and only with FP16.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -45,7 +45,6 @@ option( MIOPEN_TEST_MLIR "Add tests for MLIR -- EXPERIMENTAL" ${MIOPEN_USE_MLIR}
 option( WORKAROUND_ISSUE_898 "" ON)
 option( WORKAROUND_ISSUE_936 "" ON)
 option( WORKAROUND_ISSUE_1053 "" ON)
-option( WORKAROUND_ISSUE_1054 "" ON)
 
 # Run the test suite to a depth limit
 #limit greater than 2 leads to prolonged testing more than 5hrs per stage.
@@ -182,9 +181,11 @@ if(MIOPEN_TEST_GFX908)
 endif()
 
 if(MIOPEN_TEST_GFX1030)
-    if(WORKAROUND_ISSUE_1053 AND MIOPEN_TEST_ALL)
-        list(APPEND SKIP_TESTS test_lrn_test)
-    endif()
+#    list(APPEND SKIP_TESTS test_tensor_scale test_tensor_set test_tensor_transform
+#            test_tensor_vec test_w_supertensor test_dropout test_immed_conv3d test_conv3d
+#            test_soft_max test_fusion_aux test_activation test_lrn_test test_ctc test_conv2d_bias
+#            test_conv3d_bias test_cba_inference test_cbna_inference test_pooling2d test_na_train
+#            test_na_inference test_bn_aux)
 endif()
 
 # The usage is non-trivial, see function add_test_command.
@@ -1122,7 +1123,6 @@ else()
     )
 endif() #if CODECOV_TEST
 
-if(NOT (MIOPEN_TEST_GFX1030 AND WORKAROUND_ISSUE_1054))
 add_custom_test(test_conv_igemm_dynamic SKIP_UNLESS_ALL GFX1030_ENABLED
 COMMAND ${DYNAMIC_IMPLICITGEMM_ENVS}     $<TARGET_FILE:test_conv2d> --verbose --input  64   64 56 56 --weights 256  64  1 1 --pads_strides_dilations 0 0 1 1 1 1 --disable-backward-data --disable-backward-weights
 COMMAND ${DYNAMIC_IMPLICITGEMM_ENVS}     $<TARGET_FILE:test_conv2d> --verbose --input  64  256 34 34 --weights 256  256 3 3 --pads_strides_dilations 0 0 1 1 1 1 --disable-backward-data --disable-backward-weights
@@ -1144,7 +1144,6 @@ COMMAND ${DYNAMIC_IMPLICITGEMM_BWD_ENVS} $<TARGET_FILE:test_conv2d> --verbose --
 COMMAND ${DYNAMIC_IMPLICITGEMM_BWD_ENVS} $<TARGET_FILE:test_conv2d> --verbose --input 128  128 35 35 --weights 128  128 3 3 --pads_strides_dilations 1 1 1 1 1 1 --disable-forward --disable-backward-weights
 COMMAND ${DYNAMIC_IMPLICITGEMM_BWD_ENVS} $<TARGET_FILE:test_conv2d> --verbose --input 128  256 56 56 --weights 64  256 1 1 --pads_strides_dilations 0 0 1 1 1 1 --disable-forward --disable-backward-weights
 )
-endif()
 
 add_custom_test(test_conv_igemm_dynamic_xdlops_bwd SKIP_UNLESS_ALL HALF_ENABLED GFX908_ENABLED VEGA_DISABLED
 COMMAND ${DYNAMIC_IMPLICITGEMM_BWD_ENVS_XDLOPS} $<TARGET_FILE:test_conv2d> ${MIOPEN_TEST_FLOAT_ARG} --verbose --input  64  64 28 28 --weights 16  64 1 1 --pads_strides_dilations 0 0 1 1 1 1 --disable-forward --disable-backward-weights

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -44,6 +44,8 @@ option( MIOPEN_TEST_MLIR "Add tests for MLIR -- EXPERIMENTAL" ${MIOPEN_USE_MLIR}
 
 option( WORKAROUND_ISSUE_898 "" ON)
 option( WORKAROUND_ISSUE_936 "" ON)
+option( WORKAROUND_ISSUE_1053 "" ON)
+option( WORKAROUND_ISSUE_1054 "" ON)
 
 # Run the test suite to a depth limit
 set(MIOPEN_TEST_LIMIT "0" CACHE STRING "")
@@ -179,11 +181,12 @@ if(MIOPEN_TEST_GFX908)
 endif()
 
 if(MIOPEN_TEST_GFX1030)
-#    list(APPEND SKIP_TESTS test_tensor_scale test_tensor_set test_tensor_transform
-#            test_tensor_vec test_w_supertensor test_dropout test_immed_conv3d test_conv3d
-#            test_soft_max test_fusion_aux test_activation test_lrn_test test_ctc test_conv2d_bias
-#            test_conv3d_bias test_cba_inference test_cbna_inference test_pooling2d test_na_train
-#            test_na_inference test_bn_aux)
+    if(WORKAROUND_ISSUE_1053 AND MIOPEN_TEST_ALL)
+        list(APPEND SKIP_TESTS test_lrn_test)
+    endif()
+    if(WORKAROUND_ISSUE_1054 AND MIOPEN_TEST_ALL)
+        list(APPEND SKIP_TESTS test_conv_igemm_dynamic)
+    endif()
 endif()
 
 # The usage is non-trivial, see function add_test_command.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -181,11 +181,9 @@ if(MIOPEN_TEST_GFX908)
 endif()
 
 if(MIOPEN_TEST_GFX1030)
-#    list(APPEND SKIP_TESTS test_tensor_scale test_tensor_set test_tensor_transform
-#            test_tensor_vec test_w_supertensor test_dropout test_immed_conv3d test_conv3d
-#            test_soft_max test_fusion_aux test_activation test_lrn_test test_ctc test_conv2d_bias
-#            test_conv3d_bias test_cba_inference test_cbna_inference test_pooling2d test_na_train
-#            test_na_inference test_bn_aux)
+    if(WORKAROUND_ISSUE_1053 AND MIOPEN_TEST_ALL)
+        list(APPEND SKIP_TESTS test_lrn_test)
+    endif()
 endif()
 
 # The usage is non-trivial, see function add_test_command.
@@ -1123,7 +1121,7 @@ else()
     )
 endif() #if CODECOV_TEST
 
-add_custom_test(test_conv_igemm_dynamic SKIP_UNLESS_ALL GFX1030_ENABLED
+add_custom_test(test_conv_igemm_dynamic SKIP_UNLESS_ALL
 COMMAND ${DYNAMIC_IMPLICITGEMM_ENVS}     $<TARGET_FILE:test_conv2d> --verbose --input  64   64 56 56 --weights 256  64  1 1 --pads_strides_dilations 0 0 1 1 1 1 --disable-backward-data --disable-backward-weights
 COMMAND ${DYNAMIC_IMPLICITGEMM_ENVS}     $<TARGET_FILE:test_conv2d> --verbose --input  64  256 34 34 --weights 256  256 3 3 --pads_strides_dilations 0 0 1 1 1 1 --disable-backward-data --disable-backward-weights
 COMMAND ${DYNAMIC_IMPLICITGEMM_ENVS}     $<TARGET_FILE:test_conv2d> --verbose --input 128  128 35 35 --weights 128  128 3 3 --pads_strides_dilations 0 0 2 2 1 1 --disable-backward-data --disable-backward-weights

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -185,9 +185,6 @@ if(MIOPEN_TEST_GFX1030)
     if(WORKAROUND_ISSUE_1053 AND MIOPEN_TEST_ALL)
         list(APPEND SKIP_TESTS test_lrn_test)
     endif()
-    if(WORKAROUND_ISSUE_1054 AND MIOPEN_TEST_ALL)
-        list(APPEND SKIP_TESTS test_conv_igemm_dynamic)
-    endif()
 endif()
 
 # The usage is non-trivial, see function add_test_command.
@@ -1125,6 +1122,7 @@ else()
     )
 endif() #if CODECOV_TEST
 
+if(NOT (MIOPEN_TEST_GFX1030 AND WORKAROUND_ISSUE_1054))
 add_custom_test(test_conv_igemm_dynamic SKIP_UNLESS_ALL GFX1030_ENABLED
 COMMAND ${DYNAMIC_IMPLICITGEMM_ENVS}     $<TARGET_FILE:test_conv2d> --verbose --input  64   64 56 56 --weights 256  64  1 1 --pads_strides_dilations 0 0 1 1 1 1 --disable-backward-data --disable-backward-weights
 COMMAND ${DYNAMIC_IMPLICITGEMM_ENVS}     $<TARGET_FILE:test_conv2d> --verbose --input  64  256 34 34 --weights 256  256 3 3 --pads_strides_dilations 0 0 1 1 1 1 --disable-backward-data --disable-backward-weights
@@ -1146,6 +1144,7 @@ COMMAND ${DYNAMIC_IMPLICITGEMM_BWD_ENVS} $<TARGET_FILE:test_conv2d> --verbose --
 COMMAND ${DYNAMIC_IMPLICITGEMM_BWD_ENVS} $<TARGET_FILE:test_conv2d> --verbose --input 128  128 35 35 --weights 128  128 3 3 --pads_strides_dilations 1 1 1 1 1 1 --disable-forward --disable-backward-weights
 COMMAND ${DYNAMIC_IMPLICITGEMM_BWD_ENVS} $<TARGET_FILE:test_conv2d> --verbose --input 128  256 56 56 --weights 64  256 1 1 --pads_strides_dilations 0 0 1 1 1 1 --disable-forward --disable-backward-weights
 )
+endif()
 
 add_custom_test(test_conv_igemm_dynamic_xdlops_bwd SKIP_UNLESS_ALL HALF_ENABLED GFX908_ENABLED VEGA_DISABLED
 COMMAND ${DYNAMIC_IMPLICITGEMM_BWD_ENVS_XDLOPS} $<TARGET_FILE:test_conv2d> ${MIOPEN_TEST_FLOAT_ARG} --verbose --input  64  64 28 28 --weights 16  64 1 1 --pads_strides_dilations 0 0 1 1 1 1 --disable-forward --disable-backward-weights


### PR DESCRIPTION
Partially (FP32 for OCL backend) implements issue #1022.

- Added Smoke and Full FP32 testing stages for Navi21 with **_OpenCL_** backend.
  - Why not HIP backend: HIP compiler as of 4.2 does not support gfx1030 by default, as well as rocBLAS etc. Therefore we need to wait for 4.3 release before enabling gfx1030 testing with HIP backend. Symptom: `"hipErrorNoBinaryForGpu: Unable to find code object for all current devices!"` More info about this problem is available [at this private link](http://gerrit-git.amd.com/c/compute/ec/hip/+/519434/5/docs/markdown/hip_faq.md). However, the most of the Navi21 functionality can be tested with OpenCL from 4.2.
- Added W/A for issue #1053.