### PR TITLE
[HOTFIX][WORKAROUND] Revert #982 -- partial W/A for FP16 SSD issue (memory access fault in SWDEV-295434)

### DIFF
--- a/src/solver/conv_asm_implicit_gemm_wrw_gtc_dynamic_xdlops.cpp
+++ b/src/solver/conv_asm_implicit_gemm_wrw_gtc_dynamic_xdlops.cpp
@@ -732,17 +732,15 @@ static inline std::tuple<bool, // is valid
             if(cfg.tensor_b_thread_lengths[2] * cfg.tensor_b_cluster_lengths[2] > 1)
             {
 
-                if(c % gemm_n_per_block != 0 || gemm_m % gemm_m_per_block != 0)
+                if(c % gemm_n_per_block != 0)
                 {
                     continue;
                 }
             }
-            else
-            {
-                if(cfg.tensor_a_thread_lengths[2] * cfg.tensor_a_thread_lengths[3] > 1)
-                    if(gemm_m % gemm_m_per_block != 0)
-                        continue;
-            }
+
+            if(cfg.tensor_a_thread_lengths[2] * cfg.tensor_a_thread_lengths[3] > 1)
+                if(gemm_m % gemm_m_per_block != 0)
+                    continue;
 
             if(wo % cfg.tensor_b_thread_lengths[1] != 0)
             {


### PR DESCRIPTION
Reverts #982. Partial W/A for FP32 SSD issue (memory access fault in https://ontrack-internal.amd.com/browse/SWDEV-295434).

:warning: Merging this will cause #980 to appear again!