### PR TITLE
[Navi21][HOTFIX] Fix kernel build issues introduced in PR #1037

### DIFF
--- a/src/kernels/batchnorm_functions.h
+++ b/src/kernels/batchnorm_functions.h
@@ -129,9 +129,16 @@
 #define MIO_BN_MAXN 65
 #endif
 
-#ifdef __AMDGCN__
+// TODO: Spaghetti code!!!
+// MIOPEN_USE_AMDGCN may be defined before this header.
+#ifndef MIOPEN_USE_AMDGCN
+#if defined(__AMDGCN__) && !(defined(MIO_BN_GFX1030) && MIO_BN_GFX1030 == 1)
 #define MIOPEN_USE_AMDGCN 1
+#else
+#define MIOPEN_USE_AMDGCN 0
 #endif
+#endif
+// MIOPEN_USE_AMDGCN is guaranteed to be defined at this point.
 
 #ifndef MIO_BN_NODPP
 #define MIO_BN_NODPP 0

--- a/src/kernels/reduction_functions.h
+++ b/src/kernels/reduction_functions.h
@@ -1,5 +1,5 @@
 
-#ifndef __AMDGCN__
+#if !MIOPEN_USE_AMDGCN
 static inline void lds_reduce2(_FLOAT_ACCUM* x,
                                _FLOAT_ACCUM* y,
                                _FLOAT_ACCUM scale,
@@ -57,7 +57,7 @@ regLDSreduce(_FLOAT_ACCUM* value, local _FLOAT_ACCUM* data, uint localID, _FLOAT
 
 #endif
 
-#ifdef __AMDGCN__
+#if MIOPEN_USE_AMDGCN
 static inline void dpp_reduction(_FLOAT_ACCUM* temp_sum)
 {
     __asm__ volatile("s_nop 4\n"


### PR DESCRIPTION
Also fixes potential bug because `MIOPEN_USE_AMDGCN` should not be defined for gfx1030.