### PR TITLE
Bump up the MIOpen version to 2.14 (after cutting the rocm-rel-4.4 branch)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,7 @@ if(NOT WIN32 AND NOT APPLE)
     set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -s")
 endif()
 
-rocm_setup_version(VERSION 2.13.0)
+rocm_setup_version(VERSION 2.14.0)
 
 list( APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake )
 include(TargetFlags)


### PR DESCRIPTION
Bump up the MIOpen version to 2.14 (after cutting the rocm-rel-4.4 branch)