### PR TITLE
Some cppcheck fixes

### DIFF
--- a/src/ocl/convolutionocl.cpp
+++ b/src/ocl/convolutionocl.cpp
@@ -118,8 +118,7 @@ static inline void ValidateGroupCount(const TensorDescriptor& xDesc,
     {
         if(xDesc.GetLengths()[1] % conv.group_count != 0 ||
            wDesc.GetLengths()[0] % conv.group_count != 0 ||
-           conv.group_count > xDesc.GetLengths()[1] || conv.group_count > wDesc.GetLengths()[0] ||
-           conv.group_count < 1)
+           conv.group_count > xDesc.GetLengths()[1] || conv.group_count > wDesc.GetLengths()[0])
             MIOPEN_THROW(miopenStatusBadParm, "Invalid group number");
         if(xDesc.GetLengths()[1] / conv.group_count != wDesc.GetLengths()[1])
             MIOPEN_THROW(miopenStatusBadParm, "Invalid filter channel number");

--- a/src/reducetensor.cpp
+++ b/src/reducetensor.cpp
@@ -246,7 +246,7 @@ inline int GetDataTypeId(miopenDataType_t t)
     case miopenInt8:
     case miopenInt8x4:
     case miopenInt32: return (static_cast<int>('O'));
-    default: MIOPEN_THROW("Only float, half, bfloat16 data type is supported."); break;
+    default: MIOPEN_THROW("Only float, half, bfloat16 data type is supported.");
     };
 };
 
@@ -263,7 +263,7 @@ inline int GetReduceTensorOpId(miopenReduceTensorOp_t t)
     case MIOPEN_REDUCE_TENSOR_NORM1: return (788201); // 'N' * 10000 + 'R' * 100 + '1'
     case MIOPEN_REDUCE_TENSOR_NORM2: return (788202); // 'N' * 10000 + 'R' * 100 + '2'
 
-    default: MIOPEN_THROW("Operation is not supported"); break;
+    default: MIOPEN_THROW("Operation is not supported");
     };
 };
 

--- a/src/solver/activ/bwd_0.cpp
+++ b/src/solver/activ/bwd_0.cpp
@@ -46,9 +46,9 @@ bool ActivBwdSolver0::IsApplicable(const ExecutionContext&,
         return false;
 
     const auto& xDesc  = problem.GetXDesc();
-    const auto& yDesc  = problem.GetXDesc();
+    const auto& yDesc  = problem.GetYDesc();
     const auto& dxDesc = problem.GetDXDesc();
-    const auto& dyDesc = problem.GetDXDesc();
+    const auto& dyDesc = problem.GetDYDesc();
 
     const auto x_elem_sz  = xDesc.GetElementSize();
     const auto y_elem_sz  = yDesc.GetElementSize();
@@ -107,9 +107,9 @@ ConvSolution ActivBwdSolver0::GetSolution(const ExecutionContext&,
     auto result = ConvSolution{miopenStatusSuccess};
 
     const auto& xDesc  = problem.GetXDesc();
-    const auto& yDesc  = problem.GetXDesc();
+    const auto& yDesc  = problem.GetYDesc();
     const auto& dxDesc = problem.GetDXDesc();
-    const auto& dyDesc = problem.GetDXDesc();
+    const auto& dyDesc = problem.GetDYDesc();
 
     const auto& x_lens  = xDesc.GetLengths();
     const auto& dx_lens = dxDesc.GetLengths();

--- a/src/solver/conv_ocl_dir2D_bwdWrW_2.cpp
+++ b/src/solver/conv_ocl_dir2D_bwdWrW_2.cpp
@@ -281,23 +281,6 @@ bool PerformanceConfigConvOclBwdWrw2<N_BATCH_LOOPS>::IsValid(const ConvolutionCo
         return false;
     }
 
-    // For group config, reducing search space
-    bool met = (n_output_channels_per_group % 4 == 0 && n_out_channels_per_tile % 4 == 0);
-    if(!met)
-    {
-        met = (n_output_channels_per_group % 3 == 0 && n_out_channels_per_tile % 3 == 0);
-        if(!met)
-        {
-            met = (n_output_channels_per_group % 2 == 0 && n_out_channels_per_tile % 2 == 0);
-            if(!met)
-            {
-                met = (n_output_channels_per_group % 1 == 0 && n_out_channels_per_tile % 1 == 0);
-                if(!met)
-                    return false;
-            }
-        }
-    }
-
     // group config requires n_out_channels_tiles to be 1 or else
     // kernel doesn't work.
     if(params.group_counts > 1 && n_out_channels_tiles != 1)

--- a/test/conv_common.hpp
+++ b/test/conv_common.hpp
@@ -1800,7 +1800,7 @@ struct conv_driver : test_driver
         // by default, this member is constructed when conv2d/3d is constructed (see
         // test_driver::add())
         // but this requires the dimensions come from commandline, which is hard for non-NCHW layout
-        if(in_layout != "NCHW" || in_layout != "NCDHW")
+        if(in_layout != "NCHW" && in_layout != "NCDHW")
         {
             const std::vector<std::size_t> dim_lens = input.desc.GetLengths();
             std::vector<std::size_t> dim_strides;
@@ -1811,7 +1811,7 @@ struct conv_driver : test_driver
                 dim_strides);
             input.desc = miopen::TensorDescriptor(miopen_type<T>{}, dim_lens, dim_strides);
         }
-        if(fil_layout != "NCHW" || fil_layout != "NCDHW")
+        if(fil_layout != "NCHW" && fil_layout != "NCDHW")
         {
             const std::vector<std::size_t> dim_lens = weights.desc.GetLengths();
             std::vector<std::size_t> dim_strides;

--- a/test/tensor_transform.cpp
+++ b/test/tensor_transform.cpp
@@ -409,7 +409,7 @@ struct tensor_transform_driver : test_driver
             srcSuper_depad = tensor<T>{srcLens}.generate(tensor_elem_gen_integer{max_value});
             dstDesc        = miopen::TensorDescriptor(this->type, srcLens.data(), srcLens.size());
 
-            if(srcDesc.GetLengths().size() == dstDesc.GetLengths().size() && !skip_layout)
+            if(srcDesc.GetLengths().size() == dstDesc.GetLengths().size())
             {
                 verify_equals(verify_tensor_transform_layout<T>{
                     srcSuper_pad, dstSuper_pad, srcDesc, dstDesc, alpha, beta});


### PR DESCRIPTION
This fixes some issues found with a newer version of cppcheck, but not all(as such the cppcheck version is not updated in this PR). This does find some serious bugs, like using the x desc instead of y desc and incorrect check for `NCDHW` layout, so we should probably merge these fixes in. 

----
@atamazov 
- :red_circle: Fixes a bug in activation
- :yellow_circle: Fixes a bug in _convolution_ ___tests___