### PR TITLE
[TESTS][Navi21][WORKAROUND] Move Navi21 tests for release schedule

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -250,6 +250,10 @@ pipeline {
             defaultValue: true,
             description: "")
         booleanParam(
+            name: "MIOPENNAVI21",
+            defaultValue: false,
+            description: "")
+        booleanParam(
             name: "MIOPENTENSILE",
             defaultValue: false,
             description: "")
@@ -654,16 +658,6 @@ pipeline {
                         buildHipClangJobAndReboot( setup_flags: Full_test, build_env: WORKAROUND_iGemm_936)
                     }
                 }
-                stage('Fp32 OpenCL All gfx1030') {
-                    agent{ label rocmnode("navi21") }
-                    options {
-                        // timeout(time: 150, unit: 'MINUTES')
-                        retry(2)
-                    }
-                    steps{
-                        buildHipClangJobAndReboot(compiler: 'g++', setup_flags: Full_test, build_env: extra_log_env, gpu_arch: "gfx1030")
-                    }
-                }
                 stage('Fp16 Hip All Install gfx908') {
                     agent{ label rocmnode("gfx908") }
                     steps{
@@ -676,6 +670,27 @@ pipeline {
                         buildHipClangJobAndReboot(setup_flags: Full_test + Fp16_flags, build_env: WORKAROUND_iGemm_936, build_install: "true", gpu_arch: "gfx90a:xnack-")
                     }
                 }
+            }
+        }
+
+        stage("Full Tests gfx1030"){
+            when { expression { params.MIOPENNAVI21 && !params.DISABLE_ALL_STAGES } }
+            environment{
+                WORKAROUND_iGemm_936 = " MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_FWD_V4R1=0"
+            }
+            parallel{
+                stage('Fp32 OpenCL All gfx1030') {
+                        agent{ label rocmnode("navi21") }
+                        steps{
+                            buildHipClangJobAndReboot(compiler: 'g++', setup_flags: Full_test, build_env: extra_log_env, gpu_arch: "gfx1030")
+                        }
+                    }
+                stage('Fp32 Hip All Install gfx1030') {
+                        agent{ label rocmnode("navi21") }
+                        steps{
+                            buildHipClangJobAndReboot(setup_flags: Full_test, build_env: WORKAROUND_iGemm_936, build_install: "true", gpu_arch: "gfx1030")
+                        }
+                    }
             }
         }
 


### PR DESCRIPTION
[Purpose]
Move Navi21 tests to optional stages and run nightly only **temporarily**

[Trigger Condition to *Ready for Review*]
- [Completed] CI has passed
- [AND] [Still observed] gfx1030 still not stable for develop branch for at least 2 consecutive days
- [OR] [not a blocking issue] gfx1030 CI resource availability fall short

[Actions when the above triggers condition is met]
- [[comment]](https://github.com/ROCmSoftwarePlatform/MIOpen/pull/1135#issuecomment-916461804) The unit test failures should be documented clearly
- [Open for review] Merge this PR (convert to ready for review first)
- [TBD] Set up nightly gfx1030 check separately 