### PR TITLE
[Test][CI] Fix #1064 #1095 remove work arounds for test_dropout

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -46,9 +46,7 @@ option( MIOPEN_TEST_MLIR "Add tests for MLIR -- EXPERIMENTAL" ${MIOPEN_USE_MLIR}
 option( WORKAROUND_ISSUE_898 "" ON)
 option( WORKAROUND_ISSUE_936 "" ON)
 option( WORKAROUND_ISSUE_1053 "" ON)
-option( WORKAROUND_ISSUE_1064 "" ON)
 option( WORKAROUND_ISSUE_1093 "" ON)
-option( WORKAROUND_ISSUE_1095 "" ON)
 
 # Run the test suite to a depth limit
 #limit greater than 2 leads to prolonged testing more than 5hrs per stage.
@@ -191,27 +189,15 @@ if (MIOPEN_NO_GPU)
             test_pooling3d test_perfdb)
 endif()
 
-if(MIOPEN_TEST_GFX908)
-    if(WORKAROUND_ISSUE_1064)
-        list(APPEND SKIP_TESTS test_dropout)
-    endif()
-endif()
-
 if (MIOPEN_TEST_GFX90a)
     if(WORKAROUND_ISSUE_1093)
         list(APPEND SKIP_TESTS test_find_db test_main test_immed_conv2d)
-    endif()
-    if(WORKAROUND_ISSUE_1095)
-        list(APPEND SKIP_TESTS test_dropout)
     endif()
 endif()
 
 if(MIOPEN_TEST_GFX1030)
     if(WORKAROUND_ISSUE_1053 AND MIOPEN_TEST_ALL)
         list(APPEND SKIP_TESTS test_lrn_test)
-    endif()
-    if(WORKAROUND_ISSUE_1095)
-        list(APPEND SKIP_TESTS test_dropout)
     endif()
 endif()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -46,7 +46,6 @@ option( MIOPEN_TEST_MLIR "Add tests for MLIR -- EXPERIMENTAL" ${MIOPEN_USE_MLIR}
 option( WORKAROUND_ISSUE_898 "" ON)
 option( WORKAROUND_ISSUE_936 "" ON)
 option( WORKAROUND_ISSUE_1053 "" ON)
-option( WORKAROUND_ISSUE_1093 "" ON)
 
 # Run the test suite to a depth limit
 #limit greater than 2 leads to prolonged testing more than 5hrs per stage.
@@ -187,12 +186,6 @@ if (MIOPEN_NO_GPU)
     set(SKIP_ALL_EXCEPT_TESTS test_include_inliner test_kernel_build_params test_lstm test_lstm_dropout 
             test_test_errors test_type_name test_tensor_test test_sqlite_perfdb test_sequences
             test_pooling3d test_perfdb)
-endif()
-
-if (MIOPEN_TEST_GFX90a)
-    if(WORKAROUND_ISSUE_1093)
-        list(APPEND SKIP_TESTS test_find_db test_main test_immed_conv2d)
-    endif()
 endif()
 
 if(MIOPEN_TEST_GFX1030)


### PR DESCRIPTION
**Updated description:**
After merging #1129, issues #1064 and #1095 are no longer observed, so no workaround is needed for them.


Fix #1064 #1095 remove work arounds for test_dropout
test_dropout only runs one iterations now and should not be very long
will monitor CI for progress