### PR TITLE
Fixed missing checkNumericsOutput in bnorm forward

### DIFF
--- a/src/ocl/batchnormocl.cpp
+++ b/src/ocl/batchnormocl.cpp
@@ -147,24 +147,26 @@ void BatchNormForwardTraining(Handle& handle,
     if(const auto invoker = handle.GetInvoker(network_config, boost::none, algo))
     {
         (*invoker)(handle, invoke_params);
-        return;
     }
+    else
+    {
+        const auto ctx = ExecutionContext{&handle};
+        const auto solvers =
+            solver::SolverContainer<solver::batchnorm::BnFwdTrainingSpatialSingle,
+                                    solver::batchnorm::BnFwdTrainingSpatialMultiple,
+                                    solver::batchnorm::BnFwdTrainingPerActivation>{};
+        const auto slns = solvers.SearchForSolutions(ctx, problem, 1);
 
-    const auto ctx     = ExecutionContext{&handle};
-    const auto solvers = solver::SolverContainer<solver::batchnorm::BnFwdTrainingSpatialSingle,
-                                                 solver::batchnorm::BnFwdTrainingSpatialMultiple,
-                                                 solver::batchnorm::BnFwdTrainingPerActivation>{};
-    const auto slns    = solvers.SearchForSolutions(ctx, problem, 1);
+        if(slns.empty())
+            MIOPEN_THROW(miopenStatusNotImplemented, "No solver found for activation forward.");
 
-    if(slns.empty())
-        MIOPEN_THROW(miopenStatusNotImplemented, "No solver found for activation forward.");
-
-    const auto& sln = slns.front();
-    if(!sln.invoker_factory)
-        MIOPEN_THROW(miopenStatusInternalError, "Invoker missing in solver " + sln.solver_id);
-    const auto invoker = handle.PrepareInvoker(*sln.invoker_factory, sln.construction_params);
-    handle.RegisterInvoker(invoker, network_config, sln.solver_id, algo);
-    invoker(handle, invoke_params);
+        const auto& sln = slns.front();
+        if(!sln.invoker_factory)
+            MIOPEN_THROW(miopenStatusInternalError, "Invoker missing in solver " + sln.solver_id);
+        const auto invoker = handle.PrepareInvoker(*sln.invoker_factory, sln.construction_params);
+        handle.RegisterInvoker(invoker, network_config, sln.solver_id, algo);
+        invoker(handle, invoke_params);
+    }
 
     if(miopen::CheckNumericsEnabled())
     {

--- a/src/ocl/batchnormocl.cpp
+++ b/src/ocl/batchnormocl.cpp
@@ -144,9 +144,9 @@ void BatchNormForwardTraining(Handle& handle,
         return tmp;
     }();
 
-    if(const auto invoker = handle.GetInvoker(network_config, boost::none, algo))
+    if(const auto existingInvoker = handle.GetInvoker(network_config, boost::none, algo))
     {
-        (*invoker)(handle, invoke_params);
+        (*existingInvoker)(handle, invoke_params);
     }
     else
     {


### PR DESCRIPTION
`checkNumericsOutput` calls have been skipped on the second and later invocations of the bnorm forward function.