### PR TITLE
[MLIR] Implement tuning - step 3: bwd, nonxdlops + xdlops

### DIFF
--- a/src/include/miopen/solver.hpp
+++ b/src/include/miopen/solver.hpp
@@ -1387,13 +1387,27 @@ struct ConvHipImplicitGemmMlirCppBwd : SolverBase<ConvolutionContext>
 struct ConvMlirIgemmBwd : SolverBase<ConvolutionContext>
 {
     bool IsApplicable(const ConvolutionContext& ctx) const;
-    ConvSolution GetSolution(const ConvolutionContext& ctx) const;
+    PerformanceConvMlirIgemm GetPerformanceConfig(const ConvolutionContext& ctx) const;
+    bool IsValidPerformanceConfig(const ConvolutionContext& ctx,
+                                  const PerformanceConvMlirIgemm& config) const;
+    PerformanceConvMlirIgemm Search(const ConvolutionContext&,
+                                    const AnyInvokeParams& invoke_ctx) const;
+    ConvSolution GetSolution(const ConvolutionContext& ctx,
+                             const PerformanceConvMlirIgemm& config,
+                             bool disableConfigOverrideFromEnv = false) const;
 };
 
 struct ConvMlirIgemmBwdXdlops : SolverBase<ConvolutionContext>
 {
     bool IsApplicable(const ConvolutionContext& ctx) const;
-    ConvSolution GetSolution(const ConvolutionContext& ctx) const;
+    PerformanceConvMlirIgemmXdlops GetPerformanceConfig(const ConvolutionContext& ctx) const;
+    bool IsValidPerformanceConfig(const ConvolutionContext& ctx,
+                                  const PerformanceConvMlirIgemmXdlops& config) const;
+    PerformanceConvMlirIgemmXdlops Search(const ConvolutionContext&,
+                                          const AnyInvokeParams& invoke_ctx) const;
+    ConvSolution GetSolution(const ConvolutionContext& ctx,
+                             const PerformanceConvMlirIgemmXdlops& config,
+                             bool disableConfigOverrideFromEnv = false) const;
 };
 
 struct ConvHipImplicitGemmBwdDataV4R1 : SolverBase<ConvolutionContext>

--- a/src/include/miopen/solver/mlir_common.hpp
+++ b/src/include/miopen/solver/mlir_common.hpp
@@ -35,16 +35,13 @@ namespace miopen {
 namespace solver {
 namespace mlir {
 
-std::string InsertGToLayout(const std::string& layout, char dim);
+std::string GetKernelName(const ConvolutionContext& ctx, bool is_xdlops, int kernel_id = 0);
+
 std::string ConstructBuildOptions(const ConvolutionContext& ctx,
-                                  const std::string& operation,
-                                  const std::string& kernel_name,
                                   bool is_xdlops,
                                   int kernel_id = 0);
 
 std::string ConstructBuildOptions(const ConvolutionContext& ctx,
-                                  const std::string& operation,
-                                  const std::string& kernel_name,
                                   const std::string& config,
                                   bool is_xdlops,
                                   int kernel_id = 0);

--- a/src/solver/conv_mlir_igemm_bwd.cpp
+++ b/src/solver/conv_mlir_igemm_bwd.cpp
@@ -27,6 +27,7 @@
 #include <miopen/conv/invokers/mlir_impl_gemm.hpp>
 #include <miopen/config.h>
 #include <miopen/env.hpp>
+#include <miopen/generic_search.hpp>
 #include <miopen/solver.hpp>
 #include <miopen/solver/implicitgemm_util.hpp>
 #include <miopen/solver/mlir_common.hpp>
@@ -35,19 +36,6 @@ MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEBUG_CONV_MLIR_IGEMM_BWD)
 
 namespace miopen {
 namespace solver {
-
-namespace {
-#if MIOPEN_USE_MLIR
-std::string GetKernelName()
-{
-    std::string version   = "_v4r1";
-    std::string direction = "_bwd";
-    return "mlir_gen_igemm_conv2d" + version + direction;
-}
-
-std::string GetOperation() { return "conv2d_bwd_data"; }
-#endif
-} // Anonymous namespace
 
 bool ConvMlirIgemmBwd::IsApplicable(const ConvolutionContext& ctx) const
 {
@@ -59,29 +47,56 @@ bool ConvMlirIgemmBwd::IsApplicable(const ConvolutionContext& ctx) const
     if(!IsComposableKernelSupportedHardware(ctx))
         return false;
 
-    return MiirIsConfigApplicable(
-        mlir::ConstructBuildOptions(ctx, GetOperation(), GetKernelName(), false));
+    return MiirIsConfigApplicable(mlir::ConstructBuildOptions(ctx, false));
 #else
     std::ignore = ctx;
     return false;
 #endif
 }
 
-ConvSolution ConvMlirIgemmBwd::GetSolution(const ConvolutionContext& ctx) const
+PerformanceConvMlirIgemm ConvMlirIgemmBwd::GetPerformanceConfig(const ConvolutionContext& ctx) const
+{
+    std::ignore = ctx;
+    return {};
+}
+
+bool ConvMlirIgemmBwd::IsValidPerformanceConfig(const ConvolutionContext& ctx,
+                                                const PerformanceConvMlirIgemm& config) const
+{
+    MIOPEN_LOG_I("");
+    return config.IsValid(ctx);
+}
+
+PerformanceConvMlirIgemm ConvMlirIgemmBwd::Search(const ConvolutionContext& ctx,
+                                                  const AnyInvokeParams& invoke_ctx) const
+{
+    return GenericSearch(*this, ctx, invoke_ctx);
+}
+
+ConvSolution ConvMlirIgemmBwd::GetSolution(const ConvolutionContext& ctx,
+                                           const PerformanceConvMlirIgemm& config,
+                                           bool) const
 {
 #if MIOPEN_USE_MLIR
     ConvSolution result;
-    int kernel_count = MiirGetKernelCount(
-        mlir::ConstructBuildOptions(ctx, GetOperation(), GetKernelName(), false));
+    int kernel_count = MiirGetKernelCount(mlir::ConstructBuildOptions(ctx, false));
 
     for(int kernel_id = 0; kernel_id < kernel_count; ++kernel_id)
     {
         KernelInfo construction_parameters;
 
-        construction_parameters.kernel_name  = GetKernelName() + std::to_string(kernel_id);
+        construction_parameters.kernel_name  = mlir::GetKernelName(ctx, false, kernel_id);
         construction_parameters.kernel_file  = construction_parameters.kernel_name + ".mlir";
-        construction_parameters.comp_options = mlir::ConstructBuildOptions(
-            ctx, GetOperation(), construction_parameters.kernel_name, false, kernel_id);
+
+        if(config == PerformanceConvMlirIgemm())
+            // At this case, do not pass in the invalid perf config and instead make Miir library to
+            // do heuristic initialization
+            construction_parameters.comp_options =
+                mlir::ConstructBuildOptions(ctx, false, kernel_id);
+        else
+            // At this case, Make Miir library to use the valid perf config
+            construction_parameters.comp_options =
+                mlir::ConstructBuildOptions(ctx, config.ToString(), false, kernel_id);
 
         size_t local_size  = 0;
         size_t global_size = 0;
@@ -100,6 +115,7 @@ ConvSolution ConvMlirIgemmBwd::GetSolution(const ConvolutionContext& ctx) const
     return result;
 #else
     std::ignore = ctx;
+    std::ignore = config;
     return {};
 #endif
 }

--- a/src/solver/conv_mlir_igemm_bwd_xdlops.cpp
+++ b/src/solver/conv_mlir_igemm_bwd_xdlops.cpp
@@ -27,6 +27,7 @@
 #include <miopen/conv/invokers/mlir_impl_gemm.hpp>
 #include <miopen/config.h>
 #include <miopen/env.hpp>
+#include <miopen/generic_search.hpp>
 #include <miopen/mlir_build.hpp>
 #include <miopen/solver.hpp>
 #include <miopen/solver/implicitgemm_util.hpp>
@@ -36,19 +37,6 @@ MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEBUG_CONV_MLIR_IGEMM_BWD_XDLOPS)
 
 namespace miopen {
 namespace solver {
-
-namespace {
-#if MIOPEN_USE_MLIR
-std::string GetKernelName()
-{
-    std::string version   = "_v4r1";
-    std::string direction = "_bwd";
-    return "mlir_gen_igemm_conv2d" + version + direction + "_xdlops";
-}
-
-std::string GetOperation() { return "conv2d_bwd_data"; }
-#endif
-} // Anonymous namespace
 
 bool ConvMlirIgemmBwdXdlops::IsApplicable(const ConvolutionContext& ctx) const
 {
@@ -62,29 +50,58 @@ bool ConvMlirIgemmBwdXdlops::IsApplicable(const ConvolutionContext& ctx) const
     if(!IsComposableKernelSupportedHardware(ctx))
         return false;
 
-    return MiirIsConfigApplicable(
-        mlir::ConstructBuildOptions(ctx, GetOperation(), GetKernelName(), true));
+    return MiirIsConfigApplicable(mlir::ConstructBuildOptions(ctx, true));
 #else
     std::ignore = ctx;
     return false;
 #endif
 }
 
-ConvSolution ConvMlirIgemmBwdXdlops::GetSolution(const ConvolutionContext& ctx) const
+PerformanceConvMlirIgemmXdlops
+ConvMlirIgemmBwdXdlops::GetPerformanceConfig(const ConvolutionContext& ctx) const
+{
+    std::ignore = ctx;
+    return {};
+}
+
+bool ConvMlirIgemmBwdXdlops::IsValidPerformanceConfig(
+    const ConvolutionContext& ctx, const PerformanceConvMlirIgemmXdlops& config) const
+{
+    MIOPEN_LOG_I("");
+    return config.IsValid(ctx);
+}
+
+PerformanceConvMlirIgemmXdlops
+ConvMlirIgemmBwdXdlops::Search(const ConvolutionContext& ctx,
+                               const AnyInvokeParams& invoke_ctx) const
+{
+    return GenericSearch(*this, ctx, invoke_ctx);
+}
+
+ConvSolution ConvMlirIgemmBwdXdlops::GetSolution(const ConvolutionContext& ctx,
+                                                 const PerformanceConvMlirIgemmXdlops& config,
+                                                 bool) const
 {
 #if MIOPEN_USE_MLIR
     ConvSolution result;
-    int kernel_count =
-        MiirGetKernelCount(mlir::ConstructBuildOptions(ctx, GetOperation(), GetKernelName(), true));
+    int kernel_count = MiirGetKernelCount(mlir::ConstructBuildOptions(ctx, true));
 
     for(int kernel_id = 0; kernel_id < kernel_count; ++kernel_id)
     {
         KernelInfo construction_parameters;
 
-        construction_parameters.kernel_name  = GetKernelName() + std::to_string(kernel_id);
+        construction_parameters.kernel_name  = mlir::GetKernelName(ctx, true, kernel_id);
         construction_parameters.kernel_file  = construction_parameters.kernel_name + ".mlir";
-        construction_parameters.comp_options = mlir::ConstructBuildOptions(
-            ctx, GetOperation(), construction_parameters.kernel_name, true, kernel_id);
+
+        if(config == PerformanceConvMlirIgemmXdlops())
+            // At this case, do not pass in the invalid perf config and instead make Miir library to
+            // do heuristic initialization
+            construction_parameters.comp_options =
+                mlir::ConstructBuildOptions(ctx, true, kernel_id);
+        else
+            // At this case, Make Miir library to use the valid perf config
+            construction_parameters.comp_options =
+                mlir::ConstructBuildOptions(ctx, config.ToString(), true, kernel_id);
 
         size_t local_size  = 0;
         size_t global_size = 0;
@@ -103,6 +120,7 @@ ConvSolution ConvMlirIgemmBwdXdlops::GetSolution(const ConvolutionContext& ctx) 
     return result;
 #else
     std::ignore = ctx;
+    std::ignore = config;
     return {};
 #endif
 }

--- a/src/solver/conv_mlir_igemm_wrw.cpp
+++ b/src/solver/conv_mlir_igemm_wrw.cpp
@@ -37,21 +37,6 @@ MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEBUG_CONV_MLIR_IGEMM_WRW)
 namespace miopen {
 namespace solver {
 
-namespace {
-#if MIOPEN_USE_MLIR
-std::string GetKernelName()
-{
-    std::string version   = "_v4r4";
-    std::string direction = "_wrw";
-    std::string operation = "conv2d_bwd_weight";
-
-    return "mlir_gen_igemm_conv2d" + version + direction;
-}
-
-std::string GetOperation() { return "conv2d_bwd_weight"; }
-#endif
-} // Anonymous namespace
-
 bool ConvMlirIgemmWrW::IsApplicable(const ConvolutionContext& ctx) const
 {
 #if MIOPEN_USE_MLIR
@@ -62,8 +47,7 @@ bool ConvMlirIgemmWrW::IsApplicable(const ConvolutionContext& ctx) const
     if(!IsComposableKernelSupportedHardware(ctx))
         return false;
 
-    return MiirIsConfigApplicable(
-        mlir::ConstructBuildOptions(ctx, GetOperation(), GetKernelName(), false));
+    return MiirIsConfigApplicable(mlir::ConstructBuildOptions(ctx, false));
 #else
     std::ignore = ctx;
     return false;
@@ -76,10 +60,9 @@ ConvSolution ConvMlirIgemmWrW::GetSolution(const ConvolutionContext& ctx) const
     ConvSolution result;
     KernelInfo construction_parameters;
 
-    construction_parameters.kernel_name = GetKernelName();
+    construction_parameters.kernel_name  = mlir::GetKernelName(ctx, false);
     construction_parameters.kernel_file = construction_parameters.kernel_name + ".mlir";
-    construction_parameters.comp_options =
-        mlir::ConstructBuildOptions(ctx, GetOperation(), GetKernelName(), false);
+    construction_parameters.comp_options = mlir::ConstructBuildOptions(ctx, false);
 
     size_t local_size  = 0;
     size_t global_size = 0;

--- a/src/solver/conv_mlir_igemm_wrw_xdlops.cpp
+++ b/src/solver/conv_mlir_igemm_wrw_xdlops.cpp
@@ -38,21 +38,6 @@ MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEBUG_CONV_MLIR_IGEMM_WRW_XDLOPS)
 namespace miopen {
 namespace solver {
 
-namespace {
-#if MIOPEN_USE_MLIR
-std::string GetKernelName()
-{
-    std::string version   = "_v4r4";
-    std::string direction = "_wrw";
-    std::string operation = "conv2d_bwd_weight";
-
-    return "mlir_gen_igemm_conv2d" + version + direction + "_xdlops";
-}
-
-std::string GetOperation() { return "conv2d_bwd_weight"; }
-#endif
-} // Anonymous namespace
-
 bool ConvMlirIgemmWrWXdlops::IsApplicable(const ConvolutionContext& ctx) const
 {
 #if MIOPEN_USE_MLIR
@@ -65,8 +50,7 @@ bool ConvMlirIgemmWrWXdlops::IsApplicable(const ConvolutionContext& ctx) const
     if(!IsComposableKernelSupportedHardware(ctx))
         return false;
 
-    return MiirIsConfigApplicable(
-        mlir::ConstructBuildOptions(ctx, GetOperation(), GetKernelName(), true));
+    return MiirIsConfigApplicable(mlir::ConstructBuildOptions(ctx, true));
 #else
     std::ignore = ctx;
     return false;
@@ -79,10 +63,9 @@ ConvSolution ConvMlirIgemmWrWXdlops::GetSolution(const ConvolutionContext& ctx) 
     ConvSolution result;
     KernelInfo construction_parameters;
 
-    construction_parameters.kernel_name = GetKernelName();
+    construction_parameters.kernel_name  = mlir::GetKernelName(ctx, true);
     construction_parameters.kernel_file = construction_parameters.kernel_name + ".mlir";
-    construction_parameters.comp_options =
-        mlir::ConstructBuildOptions(ctx, GetOperation(), GetKernelName(), true);
+    construction_parameters.comp_options = mlir::ConstructBuildOptions(ctx, true);
 
     size_t local_size  = 0;
     size_t global_size = 0;

--- a/src/solver/mlir_common.cpp
+++ b/src/solver/mlir_common.cpp
@@ -38,7 +38,7 @@ namespace miopen {
 namespace solver {
 namespace mlir {
 
-std::string InsertGToLayout(const std::string& layout, char dim)
+static std::string InsertGToLayout(const std::string& layout, char dim)
 {
     std::string layout_with_g = layout;
     std::size_t index         = layout.find(dim);
@@ -47,7 +47,7 @@ std::string InsertGToLayout(const std::string& layout, char dim)
     return layout_with_g.insert(index, 1, 'G');
 }
 
-const char* DTypeName(miopenDataType_t ty)
+static const char* DTypeName(miopenDataType_t ty)
 {
     switch(ty)
     {
@@ -73,16 +73,61 @@ static std::string GetIsaName(const miopen::TargetProperties& target)
 #endif
 }
 
+std::string GetKernelName(const ConvolutionContext& ctx, bool is_xdlops, int kernel_id)
+{
+    std::string version;
+    std::string direction;
+    if(ctx.direction.IsForward())
+    {
+        version   = "_v4r4";
+        direction = "_fwd";
+    }
+    else if(ctx.direction.IsBackwardData())
+    {
+        version   = "_v4r1";
+        direction = "_bwd";
+    }
+    else
+    {
+        version   = "_v4r4";
+        direction = "_wrw";
+    }
+
+    std::string kernel_name = "mlir_gen_igemm_conv2d" + version + direction;
+
+    if(is_xdlops)
+        kernel_name += "_xdlops";
+
+    return kernel_name + std::to_string(kernel_id);
+}
+
+static std::string GetOperation(const ConvolutionContext& ctx)
+{
+    if(ctx.direction.IsForward())
+    {
+        return "conv2d";
+    }
+    else if(ctx.direction.IsBackwardData())
+    {
+        return "conv2d_bwd_data";
+    }
+    else
+    {
+        return "conv2d_bwd_weight";
+    }
+}
+
 /* Construct the options string passed to MLIR to cause it
 to generate a given convolution.*/
 std::string ConstructBuildOptions(const ConvolutionContext& ctx,
-                                  const std::string& operation,
-                                  const std::string& kernel_name,
                                   bool is_xdlops,
                                   int kernel_id)
 {
     // Arguments for mlir-miopen-driver.
     using CI = ConvolutionContextInterpreter;
+
+    std::string operation   = GetOperation(ctx);
+    std::string kernel_name = GetKernelName(ctx, is_xdlops, kernel_id);
 
     std::string in_layout  = InsertGToLayout(CI::GetInputLayout(ctx), 'C');
     std::string fil_layout = InsertGToLayout(CI::GetFilterLayout(ctx), 'N');
@@ -129,8 +174,6 @@ std::string ConstructBuildOptions(const ConvolutionContext& ctx,
 }
 
 std::string ConstructBuildOptions(const ConvolutionContext& ctx,
-                                  const std::string& operation,
-                                  const std::string& kernel_name,
                                   const std::string& config,
                                   bool is_xdlops,
                                   int kernel_id)
@@ -139,7 +182,7 @@ std::string ConstructBuildOptions(const ConvolutionContext& ctx,
 
     // clang-format off
     mlir_handle
-        << ConstructBuildOptions(ctx, operation, kernel_name, is_xdlops, kernel_id)
+        << ConstructBuildOptions(ctx, is_xdlops, kernel_id)
         << " --perf_config " << config;
     // clang-format on
 


### PR DESCRIPTION
#### Change description

- Enabled tuning for bwd, and bwd xdlops solver
  - Reused the previously available `PerformanceConvMlirIgemm` for bwd solver
  - Reused the previously available `PerformanceConvMlirIgemmXdlops` for bwd xdlops solver
- Refactored the solver infrastructures in `mlir_common.cpp`
  - Moved the `GetKernelName()` and `GetOperation()` into it to make it solver independent
  - Removed those two functions from all solvers
  - [TODO] Will consider about making it into a class in the future.

#### Test on `ConvMlirIgemmBwd`

Command:
>  MIOPEN_FIND_ENFORCE=4 MIOPEN_DRIVER_USE_GPU_REFERENCE=1 MIOPEN_LOG_LEVEL=6 MIOPEN_FIND_MODE=1 MIOPEN_DEBUG_FIND_ONLY_SOLVER=ConvMlirIgemmBwd ./bin/MIOpenDriver conv -F 2 -n 256 -c 64 -H 56 -W 56 -k 64 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -t 1 -V 1

Log:
> MIOpen(HIP): Warning [GenericSearch] Done: 24/0/24, best # 22 0.975909 64,64,64,8,4,4

#### Test on `ConvMlirIgemmBwdXdlops`

Command:
> MIOPEN_FIND_ENFORCE=4 MIOPEN_DRIVER_USE_GPU_REFERENCE=1 MIOPEN_LOG_LEVEL=6 MIOPEN_FIND_MODE=1 MIOPEN_DEBUG_FIND_ONLY_SOLVER=ConvMlirIgemmBwdXdlops ./bin/MIOpenDriver conv -F 2 -n 256 -c 64 -H 56 -W 56 -k 64 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -t 1 -V 1

Log:
> MIOpen(HIP): Warning [GenericSearch] Done: 118/0/118, best # 28 0.442594 64,128,8,64,32,4,1,1

---

Previous PR this series: 
 - #1075
 - #1139