### PR TITLE
[CI] Add capability to select GPU type for testing.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -546,47 +546,42 @@ pipeline {
             }
         }
         stage("Smoke MIOpenTensile Latest"){
+            when { expression { params.SMOKE_MIOPENTENSILE_LATEST } }
             environment{
                 Tensile_version = "latest"
             }
             parallel{
                 stage('Fp16 Hip Tensile-Latest All Vega20') {
-                    when { expression { params.SMOKE_MIOPENTENSILE_LATEST } }
                     agent{ label rocmnode("vega20") }
                     steps{
                         buildHipClangJobAndReboot( setup_flags: Tensile_setup + Fp16_flags, build_env: Tensile_build_env, test_flags: ' --verbose ', gpu_arch:"gfx906:xnack-", miotensile_version: Tensile_version, target_id: "ON")
                     }
                 }
                 stage('Int8 Hip Tensile-Latest All Vega20') {
-                    when { expression { params.SMOKE_MIOPENTENSILE_LATEST } }
                     agent{ label rocmnode("vega20") }
                     steps{
                         buildHipClangJobAndReboot( setup_flags: Tensile_setup + extra_log_env + Int8_flags, build_env: Tensile_build_env, test_flags: ' --verbose ', gpu_arch:"gfx906:xnack-", miotensile_version: Tensile_version, target_id: "ON")
                     }
                 }
                 stage('Fp32 Hip Tensile-Latest All gfx908') {
-                    when { expression { params.SMOKE_MIOPENTENSILE_LATEST } }
                     agent{ label rocmnode("gfx908") }
                     steps{
                         buildHipClangJobAndReboot( setup_flags: Tensile_setup + extra_log_env, build_env: Tensile_build_env + extra_log_env, gpu_arch: "gfx908:xnack-", test_flags: ' --verbose ', miotensile_version: Tensile_version, target_id: "ON")
                     }
                 }
                 stage('Bf16 Hip Tensile-Latest All gfx908') {
-                    when { expression { params.SMOKE_MIOPENTENSILE_LATEST } }
                     agent{ label rocmnode("gfx908") }
                     steps{
                         buildHipClangJobAndReboot( setup_flags: Tensile_setup + extra_log_env + Bf16_flags, build_env: Tensile_build_env + extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx908:xnack-", miotensile_version: Tensile_version, target_id: "ON")
                     }
                 }
                 // stage('Fp32 Hip Tensile-Latest All gfx90a') {
-                //     when { expression { params.SMOKE_MIOPENTENSILE_LATEST } }
                 //     agent{ label rocmnode("gfx90a") }
                 //     steps{
                 //         buildHipClangJobAndReboot( setup_flags: Tensile_setup + extra_log_env, build_env: Tensile_build_env + extra_log_env, gpu_arch: "gfx90a:xnack-", test_flags: ' --verbose ', miotensile_version: Tensile_version, target_id: "ON")
                 //     }
                 // }
                 // stage('Bf16 Hip Tensile-Latest All gfx90a') {
-                //     when { expression { params.SMOKE_MIOPENTENSILE_LATEST } }
                 //     agent{ label rocmnode("gfx90a") }
                 //     steps{
                 //         buildHipClangJobAndReboot( setup_flags: Tensile_setup + extra_log_env + Bf16_flags, build_env: Tensile_build_env + extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx90a:xnack-", miotensile_version: Tensile_version, target_id: "ON")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -351,6 +351,7 @@ pipeline {
             }
             parallel{
                stage('Fp32 OpenCL Debug + Codecov') {
+                    when { expression { params.TARGET_VEGA20 || params.TARGET_VEGA10 } }
                     agent{ label rocmnode("vega") }
                     steps{
                         buildHipClangJobAndReboot(compiler: 'g++', build_type: 'debug', config_targets: Smoke_targets, codecov: true)
@@ -369,12 +370,14 @@ pipeline {
                     }
                 }
                 stage('Fp32 Hip /opt/rocm') {
+                    when { expression { params.TARGET_VEGA20 || params.TARGET_VEGA10 } }
                     agent{ label rocmnode("vega") }
                     steps{
                         buildHipClangJobAndReboot(prefixpath: '/opt/rocm', config_targets: Smoke_targets)
                     }
                 }
                 stage('Fp32 Hip Debug') {
+                    when { expression { params.TARGET_VEGA20 || params.TARGET_VEGA10 } }
                     agent{ label rocmnode("vega") }
                     steps{
                         buildHipClangJobAndReboot(build_type: 'debug', config_targets: Smoke_targets)
@@ -423,6 +426,7 @@ pipeline {
             when { expression { params.SMOKE_FP32_AUX1 } }
             parallel{
                 stage('Fp32 Hip Debug COMGR') {
+                    when { expression { params.TARGET_VEGA20 || params.TARGET_VEGA10 } }
                     agent{ label rocmnode("vega") }
                     environment{
                         // See SWDEV-290754 for why LLVM_PATH is required.
@@ -433,6 +437,7 @@ pipeline {
                     }
                 }
                 stage('Fp32 Hip Debug Embedded Vega20') {
+                    when { expression { params.TARGET_VEGA20 } }
                     agent{ label rocmnode("vega20") }
                     environment{
                         Embedded_flags = "-DMIOPEN_EMBED_DB='gfx906_60'"
@@ -442,12 +447,14 @@ pipeline {
                     }
                 }
                 stage('Fp32 Hip Static') {
+                    when { expression { params.TARGET_VEGA20 || params.TARGET_VEGA10 } }
                     agent{ label rocmnode("vega") }
                     steps{
                         buildHipClangJobAndReboot( setup_flags: "-DBUILD_SHARED_LIBS=Off")
                     }
                 }
                 stage('Fp32 Hip Normal-Find') {
+                    when { expression { params.TARGET_VEGA20 || params.TARGET_VEGA10 } }
                     agent{ label rocmnode("vega") }
                     environment{
                         config_targets = "test_conv2d"
@@ -458,6 +465,7 @@ pipeline {
                     }
                 }
                 stage('Fp32 Hip Fast-Find') {
+                    when { expression { params.TARGET_VEGA20 || params.TARGET_VEGA10 } }
                     agent{ label rocmnode("vega") }
                     environment{
                         config_targets =   "test_conv2d"
@@ -468,6 +476,7 @@ pipeline {
                     }
                 }
                 stage('Fp32 Hip') {
+                    when { expression { params.TARGET_VEGA20 || params.TARGET_VEGA10 } }
                     agent{ label rocmnode("vega") }
                     steps{
                         buildHipClangJobAndReboot()
@@ -480,12 +489,14 @@ pipeline {
             environment{ MLIR_flags = "-DMIOPEN_USE_MLIR=On" }
             parallel{
                 stage('Fp32 Hip MLIR') {
+                    when { expression { params.TARGET_VEGA20 || params.TARGET_VEGA10 } }
                     agent{ label rocmnode("vega") }
                     steps{
                         buildHipClangJobAndReboot(setup_flags: MLIR_flags, build_env: extra_log_env, test_flags: ' --verbose ', mlir_build: "ON")
                     }
                 }
                 stage('Fp16 Hip MLIR') {
+                    when { expression { params.TARGET_VEGA20 || params.TARGET_VEGA10 } }
                     agent{ label rocmnode("vega") }
                     steps{
                         buildHipClangJobAndReboot(setup_flags: MLIR_flags + Fp16_flags, build_env: extra_log_env, test_flags: ' --verbose ', mlir_build: "ON")
@@ -512,24 +523,28 @@ pipeline {
             }
             parallel{
                 stage('Fp16 OpenCL Vega20') {
+                    when { expression { params.TARGET_VEGA20 } }
                     agent{ label rocmnode("vega20") }
                     steps{
                         buildHipClangJobAndReboot(compiler: 'g++', setup_flags: Fp16_flags, config_targets: Smoke_targets)
                     }
                 }
                 stage('Int8 OpenCL Vega20') {
+                    when { expression { params.TARGET_VEGA20 } }
                     agent{ label rocmnode("vega20") }
                     steps{
                         buildHipClangJobAndReboot(compiler: 'g++', setup_flags: Int8_flags, config_targets: Smoke_targets)
                     }
                 }
                 stage('Fp16 Hip Vega20 /opt/rocm') {
+                    when { expression { params.TARGET_VEGA20 } }
                     agent{ label rocmnode("vega20") }
                     steps{
                         buildHipClangJobAndReboot( setup_flags: Fp16_flags, prefixpath: '/opt/rocm', config_targets: Smoke_targets)
                     }
                 }
                 stage('Bf16 Hip Vega20 /opt/rocm') {
+                    when { expression { params.TARGET_VEGA20 } }
                     agent{ label rocmnode("vega20") }
                     steps{
                         buildHipClangJobAndReboot(setup_flags: Bf16_flags, prefixpath: '/opt/rocm', config_targets: Smoke_targets)
@@ -568,12 +583,14 @@ pipeline {
             }
             parallel{
                 stage('Fp16 Hip Tensile-Latest All Vega20') {
+                    when { expression { params.TARGET_VEGA20 } }
                     agent{ label rocmnode("vega20") }
                     steps{
                         buildHipClangJobAndReboot( setup_flags: Tensile_setup + Fp16_flags, build_env: Tensile_build_env, test_flags: ' --verbose ', gpu_arch:"gfx906:xnack-", miotensile_version: Tensile_version, target_id: "ON")
                     }
                 }
                 stage('Int8 Hip Tensile-Latest All Vega20') {
+                    when { expression { params.TARGET_VEGA20 } }
                     agent{ label rocmnode("vega20") }
                     steps{
                         buildHipClangJobAndReboot( setup_flags: Tensile_setup + extra_log_env + Int8_flags, build_env: Tensile_build_env, test_flags: ' --verbose ', gpu_arch:"gfx906:xnack-", miotensile_version: Tensile_version, target_id: "ON")
@@ -609,12 +626,14 @@ pipeline {
             when { expression { params.FULL_TESTS } }
             parallel{
                 stage('Int8 HIP All Vega20 /opt/rocm') {
+                    when { expression { params.TARGET_VEGA20 } }
                     agent{ label rocmnode("vega20") }
                     steps{
                         buildHipClangJobAndReboot( setup_flags: Int8_flags + Full_test, prefixpath: '/opt/rocm')
                     }
                 }
                 stage('Fp32 OpenCL Install All') {
+                    when { expression { params.TARGET_VEGA20 || params.TARGET_VEGA10 } }
                     agent{ label rocmnode("vega") }
                     steps{
                         buildHipClangJobAndReboot(compiler: 'g++', setup_flags: Full_test, build_install: "true")
@@ -654,12 +673,14 @@ pipeline {
                     }
                 }
                 stage('Fp16 Hip Install All Vega20') {
+                    when { expression { params.TARGET_VEGA20 } }
                     agent{ label rocmnode("vega20") }
                     steps{
                         buildHipClangJobAndReboot( setup_flags: Full_test + Fp16_flags, build_env: WORKAROUND_iGemm_936, build_install: "true")
                     }
                 }
                 stage('Fp32 Hip All Vega20') {
+                    when { expression { params.TARGET_VEGA20 } }
                     agent{ label rocmnode("vega20") }
                     steps{
                         buildHipClangJobAndReboot( setup_flags: Full_test, build_env: WORKAROUND_iGemm_936)
@@ -697,24 +718,28 @@ pipeline {
             }
             parallel{
                 stage('Fp32 Hip Tensile All Vega20') {
+                    when { expression { params.TARGET_VEGA20 } }
                     agent{ label rocmnode("vega20") }
                     steps{
                         buildHipClangJobAndReboot( setup_flags: Tensile_setup + Full_test, build_env: Tensile_build_env, test_flags: ' --verbose ', gpu_arch:"gfx906:xnack-", miotensile_version: Tensile_version, target_id: "ON")
                     }
                 }
                 stage('Fp16 Hip Tensile All Vega20') {
+                    when { expression { params.TARGET_VEGA20 } }
                     agent{ label rocmnode("vega20") }
                     steps{
                         buildHipClangJobAndReboot( setup_flags: Tensile_setup + Full_test + Fp16_flags, build_env: Tensile_build_env, test_flags: ' --verbose ', gpu_arch:"gfx906:xnack-", miotensile_version: Tensile_version, target_id: "ON")
                     }
                 }
                 stage('Bf16 Hip Tensile All Vega20') {
+                    when { expression { params.TARGET_VEGA20 } }
                     agent{ label rocmnode("vega20") }
                     steps{
                         buildHipClangJobAndReboot( setup_flags: Tensile_setup + Full_test + extra_log_env + Bf16_flags, build_env: Tensile_build_env, test_flags: ' --verbose ', gpu_arch:"gfx906:xnack-", miotensile_version: Tensile_version, target_id: "ON")
                     }
                 }
                 stage('Int8 Hip Tensile All Vega20') {
+                    when { expression { params.TARGET_VEGA20 } }
                     agent{ label rocmnode("vega20") }
                     steps{
                         buildHipClangJobAndReboot( setup_flags: Tensile_setup + Full_test + extra_log_env + Int8_flags, build_env: Tensile_build_env, test_flags: ' --verbose ', gpu_arch:"gfx906:xnack-", miotensile_version: Tensile_version, target_id: "ON")
@@ -777,24 +802,28 @@ pipeline {
             }
             parallel{
                 stage('Fp32 Hip Tensile-Latest All Vega20') {
+                    when { expression { params.TARGET_VEGA20 } }
                     agent{ label rocmnode("vega20") }
                     steps{
                         buildHipClangJobAndReboot( setup_flags: Tensile_setup + Full_test, build_env: Tensile_build_env, test_flags: ' --verbose ', gpu_arch:"gfx906:xnack-", miotensile_version: Tensile_version, target_id: "ON")
                     }
                 }
                 stage('Fp16 Hip Tensile-Latest All Vega20') {
+                    when { expression { params.TARGET_VEGA20 } }
                     agent{ label rocmnode("vega20") }
                     steps{
                         buildHipClangJobAndReboot( setup_flags: Tensile_setup + Full_test + Fp16_flags, build_env: Tensile_build_env, test_flags: ' --verbose ', gpu_arch:"gfx906:xnack-", miotensile_version: Tensile_version, target_id: "ON")
                     }
                 }
                 stage('Bf16 Hip Tensile-Latest All Vega20') {
+                    when { expression { params.TARGET_VEGA20 } }
                     agent{ label rocmnode("vega20") }
                     steps{
                         buildHipClangJobAndReboot( setup_flags: Tensile_setup + Full_test + extra_log_env + Bf16_flags, build_env: Tensile_build_env, test_flags: ' --verbose ', gpu_arch:"gfx906:xnack-", miotensile_version: Tensile_version, target_id: "ON")
                     }
                 }
                 stage('Int8 Hip Tensile-Latest All Vega20') {
+                    when { expression { params.TARGET_VEGA20 } }
                     agent{ label rocmnode("vega20") }
                     steps{
                         buildHipClangJobAndReboot( setup_flags: Tensile_setup + Full_test + extra_log_env + Int8_flags, build_env: Tensile_build_env, test_flags: ' --verbose ', gpu_arch:"gfx906:xnack-", miotensile_version: Tensile_version, target_id: "ON")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -245,6 +245,10 @@ pipeline {
             defaultValue: true,
             description: "")
         booleanParam(
+            name: "FULL_TESTS_NAVI21_OPTIONAL",
+            defaultValue: false,
+            description: "")
+        booleanParam(
             name: "MIOPENTENSILE",
             defaultValue: false,
             description: "")
@@ -706,14 +710,17 @@ pipeline {
                     }
                 }
                 stage('Fp32 OpenCL All gfx1030') {
-                    when { expression { params.TARGET_NAVI21 } }
+                    when { expression { params.TARGET_NAVI21 && params.FULL_TESTS_NAVI21_OPTIONAL } }
                     agent{ label rocmnode("navi21") }
-                    options {
-                        // timeout(time: 150, unit: 'MINUTES')
-                        retry(2)
-                    }
                     steps{
                         buildHipClangJobAndReboot(compiler: 'g++', setup_flags: Full_test, build_env: extra_log_env, gpu_arch: "gfx1030")
+                    }
+                }
+                stage('Fp32 Hip All Install gfx1030') {
+                    when { expression { params.TARGET_NAVI21 && params.FULL_TESTS_NAVI21_OPTIONAL } }
+                    agent{ label rocmnode("navi21") }
+                    steps{
+                        buildHipClangJobAndReboot(setup_flags: Full_test, build_env: WORKAROUND_iGemm_936, build_install: "true", gpu_arch: "gfx1030")
                     }
                 }
                 stage('Fp16 Hip All Install gfx908') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -250,10 +250,6 @@ pipeline {
             defaultValue: true,
             description: "")
         booleanParam(
-            name: "MIOPENNAVI21",
-            defaultValue: false,
-            description: "")
-        booleanParam(
             name: "MIOPENTENSILE",
             defaultValue: false,
             description: "")
@@ -658,6 +654,16 @@ pipeline {
                         buildHipClangJobAndReboot( setup_flags: Full_test, build_env: WORKAROUND_iGemm_936)
                     }
                 }
+                stage('Fp32 OpenCL All gfx1030') {
+                    agent{ label rocmnode("navi21") }
+                    options {
+                        // timeout(time: 150, unit: 'MINUTES')
+                        retry(2)
+                    }
+                    steps{
+                        buildHipClangJobAndReboot(compiler: 'g++', setup_flags: Full_test, build_env: extra_log_env, gpu_arch: "gfx1030")
+                    }
+                }
                 stage('Fp16 Hip All Install gfx908') {
                     agent{ label rocmnode("gfx908") }
                     steps{
@@ -670,27 +676,6 @@ pipeline {
                         buildHipClangJobAndReboot(setup_flags: Full_test + Fp16_flags, build_env: WORKAROUND_iGemm_936, build_install: "true", gpu_arch: "gfx90a:xnack-")
                     }
                 }
-            }
-        }
-
-        stage("Full Tests gfx1030"){
-            when { expression { params.MIOPENNAVI21 && !params.DISABLE_ALL_STAGES } }
-            environment{
-                WORKAROUND_iGemm_936 = " MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_FWD_V4R1=0"
-            }
-            parallel{
-                stage('Fp32 OpenCL All gfx1030') {
-                        agent{ label rocmnode("navi21") }
-                        steps{
-                            buildHipClangJobAndReboot(compiler: 'g++', setup_flags: Full_test, build_env: extra_log_env, gpu_arch: "gfx1030")
-                        }
-                    }
-                stage('Fp32 Hip All Install gfx1030') {
-                        agent{ label rocmnode("navi21") }
-                        steps{
-                            buildHipClangJobAndReboot(setup_flags: Full_test, build_env: WORKAROUND_iGemm_936, build_install: "true", gpu_arch: "gfx1030")
-                        }
-                    }
             }
         }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -386,6 +386,7 @@ pipeline {
                     }
                 }
                 stage('Fp32 OpenCL Debug gfx1030') {
+                    when { expression { params.TARGET_NAVI21 } }
                     agent{ label rocmnode("navi21") }
                     steps{
                         buildHipClangJobAndReboot(compiler: 'g++', build_type: 'debug', config_targets: Smoke_targets, build_env: extra_log_env, gpu_arch: "gfx1030")
@@ -705,6 +706,7 @@ pipeline {
                     }
                 }
                 stage('Fp32 OpenCL All gfx1030') {
+                    when { expression { params.TARGET_NAVI21 } }
                     agent{ label rocmnode("navi21") }
                     options {
                         // timeout(time: 150, unit: 'MINUTES')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -256,6 +256,30 @@ pipeline {
             name: "PACKAGES",
             defaultValue: true,
             description: "")
+        booleanParam(
+            name: "TARGET_NOGPU",
+            defaultValue: true,
+            description: "")
+        booleanParam(
+            name: "TARGET_VEGA10",
+            defaultValue: true,
+            description: "")
+        booleanParam(
+            name: "TARGET_VEGA20",
+            defaultValue: true,
+            description: "")
+        booleanParam(
+            name: "TARGET_GFX908",
+            defaultValue: true,
+            description: "")
+        booleanParam(
+            name: "TARGET_GFX90A",
+            defaultValue: true,
+            description: "")
+        booleanParam(
+            name: "TARGET_NAVI21",
+            defaultValue: true,
+            description: "")
     }
 
     environment{
@@ -269,7 +293,7 @@ pipeline {
     }
     stages{
         stage("Static checks"){
-            when { expression { params.STATIC_CHECKS } }
+            when { expression { params.STATIC_CHECKS && params.TARGET_NOGPU } }
             parallel{
                 stage('Hip Tidy') {
                     agent{ label rocmnode("nogpu") }
@@ -383,6 +407,7 @@ pipeline {
                     }
                 }
                 stage('Fp32 HipNoGPU Debug') {
+                    when { expression { params.TARGET_NOGPU } }
                     agent{ label rocmnode("nogpu") }
                     environment{
                         HipNoGPU_flags = "-DMIOPEN_BACKEND=HIPNOGPU -DMIOPEN_INSTALL_CXX_HEADERS=On"
@@ -826,7 +851,7 @@ pipeline {
             }
         }
         stage("Packages"){
-            when { expression { params.PACKAGES } }
+            when { expression { params.PACKAGES && params.TARGET_NOGPU } }
             parallel {
                 stage('OpenCL Package') {
                     agent{ label rocmnode("nogpu") }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -365,6 +365,7 @@ pipeline {
                     }
                 }
                 stage('Fp32 OpenCL gfx90a') {
+                    when { expression { params.TARGET_GFX90A } }
                     agent{ label rocmnode("gfx90a") }
                     steps{
                         buildHipClangJobAndReboot(compiler: 'g++', config_targets: Smoke_targets, gpu_arch: "gfx90a:xnack-")
@@ -402,6 +403,7 @@ pipeline {
                     }
                 }
                 stage('Fp32 Hip Debug gfx90a /opt/rocm') {
+                    when { expression { params.TARGET_GFX90A } }
                     agent{ label rocmnode("gfx90a") }
                     environment{
                         gpu_arch = "gfx90a:xnack-"
@@ -569,12 +571,14 @@ pipeline {
                     }
                 }
                 stage('Fp16 Hip gfx90a /opt/rocm') {
+                    when { expression { params.TARGET_GFX90A } }
                     agent{ label rocmnode("gfx90a") }
                     steps{
                         buildHipClangJobAndReboot( setup_flags: Fp16_flags, prefixpath: '/opt/rocm', config_targets: Smoke_targets, gpu_arch: "gfx90a:xnack-")
                     }
                 }
                 stage('Bf16 Hip gfx90a /opt/rocm') {
+                    when { expression { params.TARGET_GFX90A } }
                     agent{ label rocmnode("gfx90a") }
                     steps{
                         buildHipClangJobAndReboot(setup_flags: Bf16_flags, prefixpath: '/opt/rocm', config_targets: Smoke_targets, gpu_arch: "gfx90a:xnack-")
@@ -617,12 +621,14 @@ pipeline {
                     }
                 }
                 // stage('Fp32 Hip Tensile-Latest All gfx90a') {
+                //     when { expression { params.TARGET_GFX90A } }
                 //     agent{ label rocmnode("gfx90a") }
                 //     steps{
                 //         buildHipClangJobAndReboot( setup_flags: Tensile_setup + extra_log_env, build_env: Tensile_build_env + extra_log_env, gpu_arch: "gfx90a:xnack-", test_flags: ' --verbose ', miotensile_version: Tensile_version, target_id: "ON")
                 //     }
                 // }
                 // stage('Bf16 Hip Tensile-Latest All gfx90a') {
+                //     when { expression { params.TARGET_GFX90A } }
                 //     agent{ label rocmnode("gfx90a") }
                 //     steps{
                 //         buildHipClangJobAndReboot( setup_flags: Tensile_setup + extra_log_env + Bf16_flags, build_env: Tensile_build_env + extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx90a:xnack-", miotensile_version: Tensile_version, target_id: "ON")
@@ -655,6 +661,7 @@ pipeline {
                     }
                 }
                 stage('Bf16 Hip Install All gfx90a') {
+                    when { expression { params.TARGET_GFX90A } }
                     agent{ label rocmnode("gfx90a") }
                     steps{
                         buildHipClangJobAndReboot(setup_flags: Bf16_flags + Full_test, build_install: "true", gpu_arch: "gfx90a:xnack-")
@@ -677,6 +684,7 @@ pipeline {
                     }
                 }
                 stage('Fp32 Hip All gfx90a') {
+                    when { expression { params.TARGET_GFX90A } }
                     agent{ label rocmnode("gfx90a") }
                     steps{
                         buildHipClangJobAndReboot(setup_flags: Full_test, build_env: WORKAROUND_iGemm_936, gpu_arch: "gfx90a:xnack-")
@@ -714,6 +722,7 @@ pipeline {
                     }
                 }
                 stage('Fp16 Hip All Install gfx90a') {
+                    when { expression { params.TARGET_GFX90A } }
                     agent{ label rocmnode("gfx90a") }
                     steps{
                         buildHipClangJobAndReboot(setup_flags: Full_test + Fp16_flags, build_env: WORKAROUND_iGemm_936, build_install: "true", gpu_arch: "gfx90a:xnack-")
@@ -785,24 +794,28 @@ pipeline {
                     }
                 }
                 // stage('Fp32 Hip Tensile All gfx90a') {
+                //     when { expression { params.TARGET_GFX90A } }
                 //     agent{ label rocmnode("gfx90a") }
                 //     steps{
                 //         buildHipClangJobAndReboot( setup_flags: Tensile_setup + Full_test + extra_log_env, build_env: Tensile_build_env + extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx90a:xnack-", miotensile_version: Tensile_version, target_id: "ON")
                 //     }
                 // }
                 // stage('Fp16 Hip Tensile All gfx90a') {
+                //     when { expression { params.TARGET_GFX90A } }
                 //     agent{ label rocmnode("gfx90a") }
                 //     steps{
                 //         buildHipClangJobAndReboot( setup_flags: Tensile_setup + Full_test + extra_log_env + Fp16_flags, build_env: Tensile_build_env + extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx90a:xnack-", miotensile_version: Tensile_version, target_id: "ON")
                 //     }
                 // }
                 // stage('Bf16 Hip Tensile All gfx90a') {
+                //     when { expression { params.TARGET_GFX90A } }
                 //     agent{ label rocmnode("gfx90a") }
                 //     steps{
                 //         buildHipClangJobAndReboot( setup_flags: Tensile_setup + Full_test + extra_log_env + Bf16_flags, build_env: Tensile_build_env + extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx90a:xnack-", miotensile_version: Tensile_version, target_id: "ON")
                 //     }
                 // }
                 // stage('Int8 Hip Tensile All gfx90a') {
+                //     when { expression { params.TARGET_GFX90A } }
                 //     agent{ label rocmnode("gfx90a") }
                 //     steps{
                 //         buildHipClangJobAndReboot( setup_flags: Tensile_setup + Full_test + extra_log_env + Int8_flags, build_env: Tensile_build_env + extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx90a:xnack-", miotensile_version: Tensile_version, target_id: "ON")
@@ -873,24 +886,28 @@ pipeline {
                     }
                 }
                 // stage('Fp32 Hip Tensile-Latest All gfx90a') {
+                //     when { expression { params.TARGET_GFX90A } }
                 //     agent{ label rocmnode("gfx90a") }
                 //     steps{
                 //         buildHipClangJobAndReboot( setup_flags: Tensile_setup + Full_test + extra_log_env, build_env: Tensile_build_env + extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx90a:xnack-", miotensile_version: Tensile_version, target_id: "ON")
                 //     }
                 // }
                 // stage('Fp16 Hip Tensile-Latest All gfx90a') {
+                //     when { expression { params.TARGET_GFX90A } }
                 //     agent{ label rocmnode("gfx90a") }
                 //     steps{
                 //         buildHipClangJobAndReboot( setup_flags: Tensile_setup + Full_test + extra_log_env + Fp16_flags, build_env: Tensile_build_env + extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx90a:xnack-", miotensile_version: Tensile_version, target_id: "ON")
                 //     }
                 // }
                 // stage('Bf16 Hip Tensile-Latest All gfx90a') {
+                //     when { expression { params.TARGET_GFX90A } }
                 //     agent{ label rocmnode("gfx90a") }
                 //     steps{
                 //         buildHipClangJobAndReboot( setup_flags: Tensile_setup + Full_test + extra_log_env + Bf16_flags, build_env: Tensile_build_env + extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx90a:xnack-", miotensile_version: Tensile_version, target_id: "ON")
                 //     }
                 // }
                 // stage('Int8 Hip Tensile-Latest All gfx90a') {
+                //     when { expression { params.TARGET_GFX90A } }
                 //     agent{ label rocmnode("gfx90a") }
                 //     steps{
                 //         buildHipClangJobAndReboot( setup_flags: Tensile_setup + Full_test + extra_log_env + Int8_flags, build_env: Tensile_build_env + extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx90a:xnack-", miotensile_version: Tensile_version, target_id: "ON")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -358,6 +358,7 @@ pipeline {
                     }
                 }
                 stage('Fp32 OpenCL gfx908') {
+                    when { expression { params.TARGET_GFX908 } }
                     agent{ label rocmnode("gfx908") }
                     steps{
                         buildHipClangJobAndReboot(compiler: 'g++', config_targets: Smoke_targets, gpu_arch: "gfx908")
@@ -390,6 +391,7 @@ pipeline {
                     }
                 }
                 stage('Fp32 Hip Debug gfx908 /opt/rocm') {
+                    when { expression { params.TARGET_GFX908 } }
                     agent{ label rocmnode("gfx908") }
                     environment{
                         gpu_arch = "gfx908"
@@ -503,12 +505,14 @@ pipeline {
                     }
                 }
                 stage('Fp16 Hip MLIR gfx908') {
+                    when { expression { params.TARGET_GFX908 } }
                     agent{ label rocmnode("gfx908") }
                     steps{
                         buildHipClangJobAndReboot(setup_flags: MLIR_flags + Fp16_flags, build_env: extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx908", mlir_build: "ON")
                     }
                 }
                 stage('Fp32 Hip MLIR gfx908') {
+                    when { expression { params.TARGET_GFX908 } }
                     agent{ label rocmnode("gfx908") }
                     steps{
                         buildHipClangJobAndReboot(setup_flags: MLIR_flags, build_env: extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx908", mlir_build: "ON")
@@ -551,12 +555,14 @@ pipeline {
                     }
                 }
                 stage('Fp16 Hip gfx908 /opt/rocm') {
+                    when { expression { params.TARGET_GFX908 } }
                     agent{ label rocmnode("gfx908") }
                     steps{
                         buildHipClangJobAndReboot( setup_flags: Fp16_flags, prefixpath: '/opt/rocm', config_targets: Smoke_targets, gpu_arch: "gfx908")
                     }
                 }
                 stage('Bf16 Hip gfx908 /opt/rocm') {
+                    when { expression { params.TARGET_GFX908 } }
                     agent{ label rocmnode("gfx908") }
                     steps{
                         buildHipClangJobAndReboot(setup_flags: Bf16_flags, prefixpath: '/opt/rocm', config_targets: Smoke_targets, gpu_arch: "gfx908")
@@ -597,12 +603,14 @@ pipeline {
                     }
                 }
                 stage('Fp32 Hip Tensile-Latest All gfx908') {
+                    when { expression { params.TARGET_GFX908 } }
                     agent{ label rocmnode("gfx908") }
                     steps{
                         buildHipClangJobAndReboot( setup_flags: Tensile_setup + extra_log_env, build_env: Tensile_build_env + extra_log_env, gpu_arch: "gfx908:xnack-", test_flags: ' --verbose ', miotensile_version: Tensile_version, target_id: "ON")
                     }
                 }
                 stage('Bf16 Hip Tensile-Latest All gfx908') {
+                    when { expression { params.TARGET_GFX908 } }
                     agent{ label rocmnode("gfx908") }
                     steps{
                         buildHipClangJobAndReboot( setup_flags: Tensile_setup + extra_log_env + Bf16_flags, build_env: Tensile_build_env + extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx908:xnack-", miotensile_version: Tensile_version, target_id: "ON")
@@ -640,6 +648,7 @@ pipeline {
                     }
                 }
                 stage('Bf16 Hip Install All gfx908') {
+                    when { expression { params.TARGET_GFX908 } }
                     agent{ label rocmnode("gfx908") }
                     steps{
                         buildHipClangJobAndReboot(setup_flags: Bf16_flags + Full_test, build_install: "true", gpu_arch: "gfx908")
@@ -661,6 +670,7 @@ pipeline {
             }
             parallel{
                 stage('Fp32 Hip All gfx908') {
+                    when { expression { params.TARGET_GFX908 } }
                     agent{ label rocmnode("gfx908") }
                     steps{
                         buildHipClangJobAndReboot(setup_flags: Full_test, build_env: WORKAROUND_iGemm_936, gpu_arch: "gfx908")
@@ -697,6 +707,7 @@ pipeline {
                     }
                 }
                 stage('Fp16 Hip All Install gfx908') {
+                    when { expression { params.TARGET_GFX908 } }
                     agent{ label rocmnode("gfx908") }
                     steps{
                         buildHipClangJobAndReboot(setup_flags: Full_test + Fp16_flags, build_env: WORKAROUND_iGemm_936, build_install: "true", gpu_arch: "gfx908")
@@ -746,24 +757,28 @@ pipeline {
                     }
                 }
                 stage('Fp32 Hip Tensile All gfx908') {
+                    when { expression { params.TARGET_GFX908 } }
                     agent{ label rocmnode("gfx908") }
                     steps{
                         buildHipClangJobAndReboot( setup_flags: Tensile_setup + Full_test + extra_log_env, build_env: Tensile_build_env + extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx908:xnack-", miotensile_version: Tensile_version, target_id: "ON")
                     }
                 }
                 stage('Fp16 Hip Tensile All gfx908') {
+                    when { expression { params.TARGET_GFX908 } }
                     agent{ label rocmnode("gfx908") }
                     steps{
                         buildHipClangJobAndReboot( setup_flags: Tensile_setup + Full_test + extra_log_env + Fp16_flags, build_env: Tensile_build_env + extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx908:xnack-", miotensile_version: Tensile_version, target_id: "ON")
                     }
                 }
                 stage('Bf16 Hip Tensile All gfx908') {
+                    when { expression { params.TARGET_GFX908 } }
                     agent{ label rocmnode("gfx908") }
                     steps{
                         buildHipClangJobAndReboot( setup_flags: Tensile_setup + Full_test + extra_log_env + Bf16_flags, build_env: Tensile_build_env + extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx908:xnack-", miotensile_version: Tensile_version, target_id: "ON")
                     }
                 }
                 stage('Int8 Hip Tensile All gfx908') {
+                    when { expression { params.TARGET_GFX908 } }
                     agent{ label rocmnode("gfx908") }
                     steps{
                         buildHipClangJobAndReboot( setup_flags: Tensile_setup + Full_test + extra_log_env + Int8_flags, build_env: Tensile_build_env + extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx908:xnack-", miotensile_version: Tensile_version, target_id: "ON")
@@ -830,24 +845,28 @@ pipeline {
                     }
                 }
                 stage('Fp32 Hip Tensile-Latest All gfx908') {
+                    when { expression { params.TARGET_GFX908 } }
                     agent{ label rocmnode("gfx908") }
                     steps{
                         buildHipClangJobAndReboot( setup_flags: Tensile_setup + Full_test + extra_log_env, build_env: Tensile_build_env + extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx908:xnack-", miotensile_version: Tensile_version, target_id: "ON")
                     }
                 }
                 stage('Fp16 Hip Tensile-Latest All gfx908') {
+                    when { expression { params.TARGET_GFX908 } }
                     agent{ label rocmnode("gfx908") }
                     steps{
                         buildHipClangJobAndReboot( setup_flags: Tensile_setup + Full_test + extra_log_env + Fp16_flags, build_env: Tensile_build_env + extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx908:xnack-", miotensile_version: Tensile_version, target_id: "ON")
                     }
                 }
                 stage('Bf16 Hip Tensile-Latest All gfx908') {
+                    when { expression { params.TARGET_GFX908 } }
                     agent{ label rocmnode("gfx908") }
                     steps{
                         buildHipClangJobAndReboot( setup_flags: Tensile_setup + Full_test + extra_log_env + Bf16_flags, build_env: Tensile_build_env + extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx908:xnack-", miotensile_version: Tensile_version, target_id: "ON")
                     }
                 }
                 stage('Int8 Hip Tensile-Latest All gfx908') {
+                    when { expression { params.TARGET_GFX908 } }
                     agent{ label rocmnode("gfx908") }
                     steps{
                         buildHipClangJobAndReboot( setup_flags: Tensile_setup + Full_test + extra_log_env + Int8_flags, build_env: Tensile_build_env + extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx908:xnack-", miotensile_version: Tensile_version, target_id: "ON")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -278,7 +278,7 @@ pipeline {
     }
     stages{
         stage("Static checks"){
-            when { expression { params.STATIC_CHECKS && !params.DISABLE_ALL_STAGES } }
+            when { expression { params.STATIC_CHECKS } }
             parallel{
                 stage('Hip Tidy') {
                     agent{  label rocmnode("nogpu") }
@@ -330,7 +330,7 @@ pipeline {
             }
         }
         stage("Smoke Fp32"){
-            when { expression { params.SMOKE_FP32_AUX1 && !params.DISABLE_ALL_STAGES } }
+            when { expression { params.SMOKE_FP32_AUX1 } }
             environment{
                 Smoke_targets = "check doc MIOpenDriver"
             }
@@ -404,7 +404,7 @@ pipeline {
             }
         }
         stage("Smoke Aux 1"){
-            when { expression { params.SMOKE_FP32_AUX1 && !params.DISABLE_ALL_STAGES } }
+            when { expression { params.SMOKE_FP32_AUX1 } }
             parallel{
                 stage('Fp32 Hip Debug COMGR') {
                     agent{ label rocmnode("vega") }
@@ -460,7 +460,7 @@ pipeline {
             }
         }
         stage("Smoke MLIR"){
-            when { expression { params.SMOKE_MLIR && !params.DISABLE_ALL_STAGES } }
+            when { expression { params.SMOKE_MLIR } }
             environment{ MLIR_flags = "-DMIOPEN_USE_MLIR=On" }
             parallel{
                 stage('Fp32 Hip MLIR') {
@@ -490,7 +490,7 @@ pipeline {
             }
         }
         stage("Smoke Fp16/Bf16/Int8"){
-            when { expression { params.SMOKE_FP16_BF16_INT8 && !params.DISABLE_ALL_STAGES } }
+            when { expression { params.SMOKE_FP16_BF16_INT8 } }
             environment{
                 Smoke_targets = "check doc MIOpenDriver"
             }
@@ -551,42 +551,42 @@ pipeline {
             }
             parallel{
                 stage('Fp16 Hip Tensile-Latest All Vega20') {
-                    when { expression { params.SMOKE_MIOPENTENSILE_LATEST && !params.DISABLE_ALL_STAGES } }
+                    when { expression { params.SMOKE_MIOPENTENSILE_LATEST } }
                     agent{ label rocmnode("vega20") }
                     steps{
                         buildHipClangJobAndReboot( setup_flags: Tensile_setup + Fp16_flags, build_env: Tensile_build_env, test_flags: ' --verbose ', gpu_arch:"gfx906:xnack-", miotensile_version: Tensile_version, target_id: "ON")
                     }
                 }
                 stage('Int8 Hip Tensile-Latest All Vega20') {
-                    when { expression { params.SMOKE_MIOPENTENSILE_LATEST && !params.DISABLE_ALL_STAGES } }
+                    when { expression { params.SMOKE_MIOPENTENSILE_LATEST } }
                     agent{ label rocmnode("vega20") }
                     steps{
                         buildHipClangJobAndReboot( setup_flags: Tensile_setup + extra_log_env + Int8_flags, build_env: Tensile_build_env, test_flags: ' --verbose ', gpu_arch:"gfx906:xnack-", miotensile_version: Tensile_version, target_id: "ON")
                     }
                 }
                 stage('Fp32 Hip Tensile-Latest All gfx908') {
-                    when { expression { params.SMOKE_MIOPENTENSILE_LATEST && !params.DISABLE_ALL_STAGES } }
+                    when { expression { params.SMOKE_MIOPENTENSILE_LATEST } }
                     agent{ label rocmnode("gfx908") }
                     steps{
                         buildHipClangJobAndReboot( setup_flags: Tensile_setup + extra_log_env, build_env: Tensile_build_env + extra_log_env, gpu_arch: "gfx908:xnack-", test_flags: ' --verbose ', miotensile_version: Tensile_version, target_id: "ON")
                     }
                 }
                 stage('Bf16 Hip Tensile-Latest All gfx908') {
-                    when { expression { params.SMOKE_MIOPENTENSILE_LATEST && !params.DISABLE_ALL_STAGES } }
+                    when { expression { params.SMOKE_MIOPENTENSILE_LATEST } }
                     agent{ label rocmnode("gfx908") }
                     steps{
                         buildHipClangJobAndReboot( setup_flags: Tensile_setup + extra_log_env + Bf16_flags, build_env: Tensile_build_env + extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx908:xnack-", miotensile_version: Tensile_version, target_id: "ON")
                     }
                 }
                 // stage('Fp32 Hip Tensile-Latest All gfx90a') {
-                //     when { expression { params.SMOKE_MIOPENTENSILE_LATEST && !params.DISABLE_ALL_STAGES } }
+                //     when { expression { params.SMOKE_MIOPENTENSILE_LATEST } }
                 //     agent{ label rocmnode("gfx90a") }
                 //     steps{
                 //         buildHipClangJobAndReboot( setup_flags: Tensile_setup + extra_log_env, build_env: Tensile_build_env + extra_log_env, gpu_arch: "gfx90a:xnack-", test_flags: ' --verbose ', miotensile_version: Tensile_version, target_id: "ON")
                 //     }
                 // }
                 // stage('Bf16 Hip Tensile-Latest All gfx90a') {
-                //     when { expression { params.SMOKE_MIOPENTENSILE_LATEST && !params.DISABLE_ALL_STAGES } }
+                //     when { expression { params.SMOKE_MIOPENTENSILE_LATEST } }
                 //     agent{ label rocmnode("gfx90a") }
                 //     steps{
                 //         buildHipClangJobAndReboot( setup_flags: Tensile_setup + extra_log_env + Bf16_flags, build_env: Tensile_build_env + extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx90a:xnack-", miotensile_version: Tensile_version, target_id: "ON")
@@ -595,7 +595,7 @@ pipeline {
             }
         }
         stage("Full Tests I"){
-            when { expression { params.FULL_TESTS && !params.DISABLE_ALL_STAGES } }
+            when { expression { params.FULL_TESTS } }
             parallel{
                 stage('Int8 HIP All Vega20 /opt/rocm') {
                     agent{ label rocmnode("vega20") }
@@ -625,7 +625,7 @@ pipeline {
         }
 
         stage("Full Tests II"){
-            when { expression { params.FULL_TESTS && !params.DISABLE_ALL_STAGES } }
+            when { expression { params.FULL_TESTS } }
             environment{
                 WORKAROUND_iGemm_936 = " MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_FWD_V4R1=0"
             }
@@ -680,7 +680,7 @@ pipeline {
         }
 
         stage("MIOpenTensile"){
-            when { expression { params.MIOPENTENSILE && !params.DISABLE_ALL_STAGES } }
+            when { expression { params.MIOPENTENSILE } }
             environment{
                 Tensile_version = "default"
             }
@@ -760,7 +760,7 @@ pipeline {
             }
         }
         stage("MIOpenTensile Latest"){
-            when { expression { params.MIOPENTENSILE_LATEST && !params.DISABLE_ALL_STAGES  } }
+            when { expression { params.MIOPENTENSILE_LATEST  } }
             environment{
                 Tensile_version = "latest"
             }
@@ -840,7 +840,7 @@ pipeline {
             }
         }
         stage("Packages"){
-            when { expression { params.PACKAGES && !params.DISABLE_ALL_STAGES } }
+            when { expression { params.PACKAGES } }
             parallel {
                 stage('OpenCL Package') {
                     agent{ label rocmnode("nogpu") }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -685,14 +685,14 @@ pipeline {
                     when { expression { params.TARGET_GFX908 } }
                     agent{ label rocmnode("gfx908") }
                     steps{
-                        buildHipClangJobAndReboot(setup_flags: Full_test, build_env: WORKAROUND_iGemm_936, gpu_arch: "gfx908")
+                        buildHipClangJobAndReboot(setup_flags: Full_test, gpu_arch: "gfx908")
                     }
                 }
                 stage('Fp32 Hip All gfx90a') {
                     when { expression { params.TARGET_GFX90A } }
                     agent{ label rocmnode("gfx90a") }
                     steps{
-                        buildHipClangJobAndReboot(setup_flags: Full_test, build_env: WORKAROUND_iGemm_936, gpu_arch: "gfx90a:xnack-")
+                        buildHipClangJobAndReboot(setup_flags: Full_test, gpu_arch: "gfx90a:xnack-")
                     }
                 }
                 stage('Fp16 Hip Install All Vega20') {
@@ -706,7 +706,7 @@ pipeline {
                     when { expression { params.TARGET_VEGA20 } }
                     agent{ label rocmnode("vega20") }
                     steps{
-                        buildHipClangJobAndReboot( setup_flags: Full_test, build_env: WORKAROUND_iGemm_936)
+                        buildHipClangJobAndReboot( setup_flags: Full_test)
                     }
                 }
                 stage('Fp32 OpenCL All gfx1030') {
@@ -720,7 +720,7 @@ pipeline {
                     when { expression { params.TARGET_NAVI21 && params.FULL_TESTS_NAVI21_OPTIONAL } }
                     agent{ label rocmnode("navi21") }
                     steps{
-                        buildHipClangJobAndReboot(setup_flags: Full_test, build_env: WORKAROUND_iGemm_936, build_install: "true", gpu_arch: "gfx1030")
+                        buildHipClangJobAndReboot(setup_flags: Full_test, build_install: "true", gpu_arch: "gfx1030")
                     }
                 }
                 stage('Fp16 Hip All Install gfx908') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -221,10 +221,6 @@ pipeline {
     }
     parameters {
         booleanParam(
-            name: "DISABLE_ALL_STAGES",
-            defaultValue: false,
-            description: "Disables each stage in the pipline")
-        booleanParam(
             name: "STATIC_CHECKS",
             defaultValue: true,
             description: "")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,6 @@ def rocmnode(name) {
     return 'rocmtest && miopen && ' + name
 }
 
-
 def show_node_info() {
     sh """
         echo "NODE_NAME = \$NODE_NAME"
@@ -281,7 +280,7 @@ pipeline {
             when { expression { params.STATIC_CHECKS } }
             parallel{
                 stage('Hip Tidy') {
-                    agent{  label rocmnode("nogpu") }
+                    agent{ label rocmnode("nogpu") }
                     environment{
                         setup_cmd = "CXX='/opt/rocm/llvm/bin/clang++' cmake -DMIOPEN_BACKEND=HIP -DBUILD_DEV=On .. "
                         build_cmd = "make -j\$(nproc) -k analyze"
@@ -291,7 +290,7 @@ pipeline {
                     }
                 }
                 stage('OpenCL Tidy') {
-                    agent{  label rocmnode("nogpu") }
+                    agent{ label rocmnode("nogpu") }
                     environment{
                         setup_cmd = "cmake -DMIOPEN_BACKEND=OpenCL -DBUILD_DEV=On .."
                         build_cmd = "make -j\$(nproc) -k analyze"
@@ -317,16 +316,16 @@ pipeline {
                         buildHipClangJobAndReboot(setup_cmd: "", build_cmd: "", execute_cmd: execute_cmd, no_reboot:true)
                     }
                 }
-              stage('Tuna Fin Build Test') {
-                  agent{ label rocmnode("nogpu") }
-                  environment{
+                stage('Tuna Fin Build Test') {
+                    agent{ label rocmnode("nogpu") }
+                    environment{
                       setup_cmd = "CXX='/opt/rocm/llvm/bin/clang++' cmake -DCMAKE_BUILD_TYPE=DEBUG -DMIOPEN_BACKEND=HIPNOGPU -DBUILD_SHARED_LIBS=Off -DMIOPEN_INSTALL_CXX_HEADERS=On -DMIOPEN_ENABLE_FIN=ON .. "
                       build_cmd = "make -j\$(nproc) "
-                  }
-                  steps{
+                    }
+                    steps{
                       buildHipClangJobAndReboot(setup_cmd: setup_cmd, execute_cmd: "", no_reboot:true, build_cmd: build_cmd, build_fin: "ON")
-                  }
-              }
+                    }
+                }
             }
         }
         stage("Smoke Fp32"){
@@ -392,7 +391,7 @@ pipeline {
                     }
                 }
                 stage('Fp32 HipNoGPU Debug') {
-                    agent{  label rocmnode("nogpu") }
+                    agent{ label rocmnode("nogpu") }
                     environment{
                         HipNoGPU_flags = "-DMIOPEN_BACKEND=HIPNOGPU -DMIOPEN_INSTALL_CXX_HEADERS=On"
                         build_cmd = "make -j\$(nproc)"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -256,10 +256,6 @@ pipeline {
             name: "PACKAGES",
             defaultValue: true,
             description: "")
-        booleanParam(
-                name: "BUILD_PACKAGES",
-                defaultValue: true,
-                description: "Run packages stage")
     }
 
     environment{


### PR DESCRIPTION
- New feature: Now you can select subset of GPU types for testing.
  - How: https://github.com/ROCmSoftwarePlatform/MIOpen/wiki/How-to-manually-run-CI-job-with-parameters.

By-products:
- Re-implements #1135
  - :warning: ___Quiet change: The [`MIOPENNAVI21`](https://github.com/ROCmSoftwarePlatform/MIOpen/issues/1148#issuecomment-916656557) parameter renamed to___ `FULL_TESTS_NAVI21_OPTIONAL`.
- Testing quality: Removed `WORKAROUND_iGemm_936` from FP32. This should resolve https://github.com/ROCmSoftwarePlatform/MIOpen/pull/147/files#r706276953
- Refactorings:
  - Removed redundant DISABLE_ALL_STAGES parameter
  - Refactored SMOKE_MIOPENTENSILE_LATEST
  - Removed unused BUILD_PACKAGES
  - Formatting fixes