### PR TITLE
[MLIR] Implement tuning - step 4: Use special value to represent default perf_config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -114,7 +114,7 @@ RUN if [ "$USE_TARGETID" = "OFF" ] ; then echo "MIOpenTensile is not installed."
 
 RUN if [ "$USE_MLIR" = "ON" ]; \
     then cd ~ && \
-    export MLIR_COMMIT=199d667b9d8caaf283436aaa8a48fd20e074f42c && \
+    export MLIR_COMMIT=31579e0c5cf6eb4d7b1db0d349407f8bab547d9b && \
     wget https://github.com/ROCmSoftwarePlatform/llvm-project-mlir/archive/$MLIR_COMMIT.tar.gz && \
     tar -xvzf $MLIR_COMMIT.tar.gz && \
     rm -rf $MLIR_COMMIT.tar.gz && \

--- a/src/include/miopen/solver.hpp
+++ b/src/include/miopen/solver.hpp
@@ -856,10 +856,8 @@ struct PerformanceConvMlirIgemmXdlops : Serializable<PerformanceConvMlirIgemmXdl
     int GemmMPerBlock; // 2^n[32..128]
     int GemmNPerBlock; // 2^n[8..16]
     int GemmKPerBlock; // 2^n[4..16]
-
     int GemmMPerWave;
     int GemmNPerWave;
-
     int GemmKPACKSize; // 2^[1..4]
 
     // GemmAThreadCopyMoreGemmK is currently a fix value, is untunable
@@ -867,6 +865,9 @@ struct PerformanceConvMlirIgemmXdlops : Serializable<PerformanceConvMlirIgemmXdl
     bool GemmBThreadCopyMoreGemmKPack;
 
     bool use_spare_set;
+
+    static const PerformanceConvMlirIgemmXdlops& GetHeuristicInitRequest();
+
     PerformanceConvMlirIgemmXdlops(int, int, int, int, int, int, bool, bool, bool);
 
     PerformanceConvMlirIgemmXdlops();

--- a/src/include/miopen/solver.hpp
+++ b/src/include/miopen/solver.hpp
@@ -807,7 +807,8 @@ struct PerformanceConvMlirIgemm : Serializable<PerformanceConvMlirIgemm>
     int GemmNPerThread;
     bool use_spare_set;
 
-    static const PerformanceConvMlirIgemm& GetHeuristicInitRequest();
+    /// \ref https://github.com/ROCmSoftwarePlatform/MIOpen/issues/1154
+    static const PerformanceConvMlirIgemm& MlirHeuristicInitRequest();
 
     PerformanceConvMlirIgemm(int, int, int, int, int, int, bool);
 
@@ -866,7 +867,8 @@ struct PerformanceConvMlirIgemmXdlops : Serializable<PerformanceConvMlirIgemmXdl
 
     bool use_spare_set;
 
-    static const PerformanceConvMlirIgemmXdlops& GetHeuristicInitRequest();
+    /// \ref https://github.com/ROCmSoftwarePlatform/MIOpen/issues/1154
+    static const PerformanceConvMlirIgemmXdlops& MlirHeuristicInitRequest();
 
     PerformanceConvMlirIgemmXdlops(int, int, int, int, int, int, bool, bool, bool);
 

--- a/src/include/miopen/solver.hpp
+++ b/src/include/miopen/solver.hpp
@@ -807,6 +807,8 @@ struct PerformanceConvMlirIgemm : Serializable<PerformanceConvMlirIgemm>
     int GemmNPerThread;
     bool use_spare_set;
 
+    static const PerformanceConvMlirIgemm& GetHeuristicInitRequest();
+
     PerformanceConvMlirIgemm(int, int, int, int, int, int, bool);
 
     PerformanceConvMlirIgemm(int a, int b, int c, int d, int e, int f)

--- a/src/include/miopen/solver/mlir_common.hpp
+++ b/src/include/miopen/solver/mlir_common.hpp
@@ -47,23 +47,14 @@ std::string ConstructBuildOptions(const ConvolutionContext& ctx,
                                   bool is_xdlops,
                                   int kernel_id = 0)
 {
-    std::ostringstream mlir_handle;
-
-    bool isHeuristicRequest = false;
-    if(perf_config == T::GetHeuristicInitRequest())
-    {
-        isHeuristicRequest = true;
-    }
+    std::ostringstream options{ConstructBuildOptions(ctx, is_xdlops, kernel_id), std::ios::ate};
 
     // Library does heuristic initialization when no perf_config
     // is specified
-    // clang-format off
-    mlir_handle
-        << ConstructBuildOptions(ctx, is_xdlops, kernel_id)
-        << (isHeuristicRequest? "" : " --perf_config " + perf_config.ToString());
-    // clang-format on
+    if(!(perf_config == T::MlirHeuristicInitRequest()))
+        options << " --perf_config " + perf_config.ToString();
 
-    return mlir_handle.str();
+    return options.str();
 }
 
 } // namespace mlir

--- a/src/include/miopen/solver/mlir_common.hpp
+++ b/src/include/miopen/solver/mlir_common.hpp
@@ -41,11 +41,6 @@ std::string ConstructBuildOptions(const ConvolutionContext& ctx,
                                   bool is_xdlops,
                                   int kernel_id = 0);
 
-std::string ConstructBuildOptions(const ConvolutionContext& ctx,
-                                  const std::string& config,
-                                  bool is_xdlops,
-                                  int kernel_id = 0);
-
 template <typename T>
 std::string ConstructBuildOptions(const ConvolutionContext& ctx,
                                   const T& perf_config,

--- a/src/include/miopen/solver/mlir_common.hpp
+++ b/src/include/miopen/solver/mlir_common.hpp
@@ -45,6 +45,32 @@ std::string ConstructBuildOptions(const ConvolutionContext& ctx,
                                   const std::string& config,
                                   bool is_xdlops,
                                   int kernel_id = 0);
+
+template <typename T>
+std::string ConstructBuildOptions(const ConvolutionContext& ctx,
+                                  const T& perf_config,
+                                  bool is_xdlops,
+                                  int kernel_id = 0)
+{
+    std::ostringstream mlir_handle;
+
+    bool isHeuristicRequest = false;
+    if(perf_config == T::GetHeuristicInitRequest())
+    {
+        isHeuristicRequest = true;
+    }
+
+    // Library does heuristic initialization when no perf_config
+    // is specified
+    // clang-format off
+    mlir_handle
+        << ConstructBuildOptions(ctx, is_xdlops, kernel_id)
+        << (isHeuristicRequest? "" : " --perf_config " + perf_config.ToString());
+    // clang-format on
+
+    return mlir_handle.str();
+}
+
 } // namespace mlir
 } // namespace solver
 } // namespace miopen

--- a/src/solver/conv_mlir_igemm_bwd.cpp
+++ b/src/solver/conv_mlir_igemm_bwd.cpp
@@ -57,7 +57,7 @@ bool ConvMlirIgemmBwd::IsApplicable(const ConvolutionContext& ctx) const
 PerformanceConvMlirIgemm ConvMlirIgemmBwd::GetPerformanceConfig(const ConvolutionContext& ctx) const
 {
     std::ignore = ctx;
-    return {};
+    return PerformanceConvMlirIgemm::GetHeuristicInitRequest();
 }
 
 bool ConvMlirIgemmBwd::IsValidPerformanceConfig(const ConvolutionContext& ctx,
@@ -87,16 +87,8 @@ ConvSolution ConvMlirIgemmBwd::GetSolution(const ConvolutionContext& ctx,
 
         construction_parameters.kernel_name  = mlir::GetKernelName(ctx, false, kernel_id);
         construction_parameters.kernel_file  = construction_parameters.kernel_name + ".mlir";
-
-        if(config == PerformanceConvMlirIgemm())
-            // At this case, do not pass in the invalid perf config and instead make Miir library to
-            // do heuristic initialization
-            construction_parameters.comp_options =
-                mlir::ConstructBuildOptions(ctx, false, kernel_id);
-        else
-            // At this case, Make Miir library to use the valid perf config
-            construction_parameters.comp_options =
-                mlir::ConstructBuildOptions(ctx, config.ToString(), false, kernel_id);
+        construction_parameters.comp_options =
+            mlir::ConstructBuildOptions(ctx, config, false, kernel_id);
 
         size_t local_size  = 0;
         size_t global_size = 0;

--- a/src/solver/conv_mlir_igemm_bwd.cpp
+++ b/src/solver/conv_mlir_igemm_bwd.cpp
@@ -57,7 +57,7 @@ bool ConvMlirIgemmBwd::IsApplicable(const ConvolutionContext& ctx) const
 PerformanceConvMlirIgemm ConvMlirIgemmBwd::GetPerformanceConfig(const ConvolutionContext& ctx) const
 {
     std::ignore = ctx;
-    return PerformanceConvMlirIgemm::GetHeuristicInitRequest();
+    return PerformanceConvMlirIgemm::MlirHeuristicInitRequest();
 }
 
 bool ConvMlirIgemmBwd::IsValidPerformanceConfig(const ConvolutionContext& ctx,

--- a/src/solver/conv_mlir_igemm_bwd_xdlops.cpp
+++ b/src/solver/conv_mlir_igemm_bwd_xdlops.cpp
@@ -61,7 +61,7 @@ PerformanceConvMlirIgemmXdlops
 ConvMlirIgemmBwdXdlops::GetPerformanceConfig(const ConvolutionContext& ctx) const
 {
     std::ignore = ctx;
-    return PerformanceConvMlirIgemmXdlops::GetHeuristicInitRequest();
+    return PerformanceConvMlirIgemmXdlops::MlirHeuristicInitRequest();
 }
 
 bool ConvMlirIgemmBwdXdlops::IsValidPerformanceConfig(

--- a/src/solver/conv_mlir_igemm_bwd_xdlops.cpp
+++ b/src/solver/conv_mlir_igemm_bwd_xdlops.cpp
@@ -61,7 +61,7 @@ PerformanceConvMlirIgemmXdlops
 ConvMlirIgemmBwdXdlops::GetPerformanceConfig(const ConvolutionContext& ctx) const
 {
     std::ignore = ctx;
-    return {};
+    return PerformanceConvMlirIgemmXdlops::GetHeuristicInitRequest();
 }
 
 bool ConvMlirIgemmBwdXdlops::IsValidPerformanceConfig(
@@ -92,16 +92,8 @@ ConvSolution ConvMlirIgemmBwdXdlops::GetSolution(const ConvolutionContext& ctx,
 
         construction_parameters.kernel_name  = mlir::GetKernelName(ctx, true, kernel_id);
         construction_parameters.kernel_file  = construction_parameters.kernel_name + ".mlir";
-
-        if(config == PerformanceConvMlirIgemmXdlops())
-            // At this case, do not pass in the invalid perf config and instead make Miir library to
-            // do heuristic initialization
-            construction_parameters.comp_options =
-                mlir::ConstructBuildOptions(ctx, true, kernel_id);
-        else
-            // At this case, Make Miir library to use the valid perf config
-            construction_parameters.comp_options =
-                mlir::ConstructBuildOptions(ctx, config.ToString(), true, kernel_id);
+        construction_parameters.comp_options =
+            mlir::ConstructBuildOptions(ctx, config, true, kernel_id);
 
         size_t local_size  = 0;
         size_t global_size = 0;

--- a/src/solver/conv_mlir_igemm_fwd.cpp
+++ b/src/solver/conv_mlir_igemm_fwd.cpp
@@ -37,9 +37,8 @@ MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEBUG_CONV_MLIR_IGEMM_FWD)
 namespace miopen {
 namespace solver {
 
-const PerformanceConvMlirIgemm& PerformanceConvMlirIgemm::GetHeuristicInitRequest()
+const PerformanceConvMlirIgemm& PerformanceConvMlirIgemm::MlirHeuristicInitRequest()
 {
-    // Special value to represent the heuristic initialized perf_config.
     static const PerformanceConvMlirIgemm p =
         PerformanceConvMlirIgemm(-2, -2, -2, -2, -2, -2, false);
     return p;
@@ -93,7 +92,7 @@ bool PerformanceConvMlirIgemm::operator==(const PerformanceConvMlirIgemm& other)
 bool PerformanceConvMlirIgemm::IsValid(const ConvolutionContext& ctx) const
 {
 #if MIOPEN_USE_MLIR
-    if(*this == GetHeuristicInitRequest())
+    if(*this == MlirHeuristicInitRequest())
         return true;
 
     return MiirIsConfigApplicable(mlir::ConstructBuildOptions(ctx, *this, false));
@@ -105,13 +104,8 @@ bool PerformanceConvMlirIgemm::IsValid(const ConvolutionContext& ctx) const
 
 bool PerformanceConvMlirIgemm::SetNextValue(const ConvolutionContext& /*config*/)
 {
-    if(*this == GetHeuristicInitRequest())
-    {
-        // If we ever attempt to iterate starting from the heuristic value,
-        // make its next iterator to be the minimal valid value.
-        *this = PerformanceConvMlirIgemm(use_spare_set);
-        return false;
-    }
+    if(*this == MlirHeuristicInitRequest())
+        MIOPEN_THROW("Should not iterate from the heuristic value");
 
     // always search full space, no matter if use_spare_set or not
     do
@@ -145,7 +139,7 @@ std::string PerformanceConvMlirIgemm::ToString() const
 PerformanceConvMlirIgemm ConvMlirIgemmFwd::GetPerformanceConfig(const ConvolutionContext& ctx) const
 {
     std::ignore = ctx;
-    return PerformanceConvMlirIgemm::GetHeuristicInitRequest();
+    return PerformanceConvMlirIgemm::MlirHeuristicInitRequest();
 }
 
 bool ConvMlirIgemmFwd::IsValidPerformanceConfig(const ConvolutionContext& ctx,

--- a/src/solver/conv_mlir_igemm_fwd.cpp
+++ b/src/solver/conv_mlir_igemm_fwd.cpp
@@ -37,6 +37,14 @@ MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEBUG_CONV_MLIR_IGEMM_FWD)
 namespace miopen {
 namespace solver {
 
+const PerformanceConvMlirIgemm& PerformanceConvMlirIgemm::GetHeuristicInitRequest()
+{
+    // Special value to represent the heuristic initialized perf_config.
+    static const PerformanceConvMlirIgemm p =
+        PerformanceConvMlirIgemm(-2, -2, -2, -2, -2, -2, false);
+    return p;
+}
+
 PerformanceConvMlirIgemm::PerformanceConvMlirIgemm(int BlockSize_,
                                                    int GemmMPerBlock_,
                                                    int GemmNPerBlock_,
@@ -85,7 +93,10 @@ bool PerformanceConvMlirIgemm::operator==(const PerformanceConvMlirIgemm& other)
 bool PerformanceConvMlirIgemm::IsValid(const ConvolutionContext& ctx) const
 {
 #if MIOPEN_USE_MLIR
-    return MiirIsConfigApplicable(mlir::ConstructBuildOptions(ctx, ToString(), false));
+    if(*this == GetHeuristicInitRequest())
+        return true;
+
+    return MiirIsConfigApplicable(mlir::ConstructBuildOptions(ctx, *this, false));
 #else
     std::ignore = ctx;
     return false;
@@ -94,6 +105,14 @@ bool PerformanceConvMlirIgemm::IsValid(const ConvolutionContext& ctx) const
 
 bool PerformanceConvMlirIgemm::SetNextValue(const ConvolutionContext& /*config*/)
 {
+    if(*this == GetHeuristicInitRequest())
+    {
+        // If we ever attempt to iterate starting from the heuristic value,
+        // make its next iterator to be the minimal valid value.
+        *this = PerformanceConvMlirIgemm(use_spare_set);
+        return false;
+    }
+
     // always search full space, no matter if use_spare_set or not
     do
     {
@@ -125,9 +144,8 @@ std::string PerformanceConvMlirIgemm::ToString() const
 
 PerformanceConvMlirIgemm ConvMlirIgemmFwd::GetPerformanceConfig(const ConvolutionContext& ctx) const
 {
-    // Return the invalid config as the default to signal MLIR do heuristic intialization
     std::ignore = ctx;
-    return {};
+    return PerformanceConvMlirIgemm::GetHeuristicInitRequest();
 }
 
 bool ConvMlirIgemmFwd::IsValidPerformanceConfig(const ConvolutionContext& ctx,
@@ -168,17 +186,9 @@ ConvSolution ConvMlirIgemmFwd::GetSolution(const ConvolutionContext& ctx,
     ConvSolution result;
     KernelInfo construction_parameters;
 
-    construction_parameters.kernel_name = mlir::GetKernelName(ctx, false);
-    construction_parameters.kernel_file = construction_parameters.kernel_name + ".mlir";
-
-    if(config == PerformanceConvMlirIgemm())
-        // At this case, do not pass in the invalid perf config and instead make Miir library to do
-        // heuristic initialization
-        construction_parameters.comp_options = mlir::ConstructBuildOptions(ctx, false);
-    else
-        // At this case, Make Miir library to use the valid perf config
-        construction_parameters.comp_options =
-            mlir::ConstructBuildOptions(ctx, config.ToString(), false);
+    construction_parameters.kernel_name  = mlir::GetKernelName(ctx, false);
+    construction_parameters.kernel_file  = construction_parameters.kernel_name + ".mlir";
+    construction_parameters.comp_options = mlir::ConstructBuildOptions(ctx, config, false);
 
     size_t local_size  = 0;
     size_t global_size = 0;

--- a/src/solver/conv_mlir_igemm_fwd_xdlops.cpp
+++ b/src/solver/conv_mlir_igemm_fwd_xdlops.cpp
@@ -38,6 +38,14 @@ MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEBUG_CONV_MLIR_IGEMM_FWD_XDLOPS)
 namespace miopen {
 namespace solver {
 
+const PerformanceConvMlirIgemmXdlops& PerformanceConvMlirIgemmXdlops::GetHeuristicInitRequest()
+{
+    // Special value to represent the heuristic initialized perf_config.
+    static const PerformanceConvMlirIgemmXdlops p =
+        PerformanceConvMlirIgemmXdlops(-2, -2, -2, -2, -2, -2, false, false, false);
+    return p;
+}
+
 bool ConvMlirIgemmFwdXdlops::IsApplicable(const ConvolutionContext& ctx) const
 {
 #if MIOPEN_USE_MLIR
@@ -107,8 +115,10 @@ bool PerformanceConvMlirIgemmXdlops::operator==(const PerformanceConvMlirIgemmXd
 bool PerformanceConvMlirIgemmXdlops::IsValid(const ConvolutionContext& ctx) const
 {
 #if MIOPEN_USE_MLIR
-    bool isValid = MiirIsConfigApplicable(mlir::ConstructBuildOptions(ctx, ToString(), true));
-    return isValid;
+    if(*this == GetHeuristicInitRequest())
+        return true;
+
+    return MiirIsConfigApplicable(mlir::ConstructBuildOptions(ctx, *this, true));
 #else
     std::ignore = ctx;
     return false;
@@ -117,6 +127,14 @@ bool PerformanceConvMlirIgemmXdlops::IsValid(const ConvolutionContext& ctx) cons
 
 bool PerformanceConvMlirIgemmXdlops::SetNextValue(const ConvolutionContext& /*config*/)
 {
+    if(*this == GetHeuristicInitRequest())
+    {
+        // If we ever attempt to iterate starting from the heuristic value,
+        // make its next iterator to be the minimal value.
+        *this = PerformanceConvMlirIgemmXdlops(use_spare_set);
+        return false;
+    }
+
     GemmBThreadCopyMoreGemmKPack = true;
     GemmAThreadCopyMoreGemmK     = true;
     do
@@ -151,7 +169,7 @@ PerformanceConvMlirIgemmXdlops
 ConvMlirIgemmFwdXdlops::GetPerformanceConfig(const ConvolutionContext& ctx) const
 {
     std::ignore = ctx;
-    return {};
+    return PerformanceConvMlirIgemmXdlops::GetHeuristicInitRequest();
 }
 
 bool ConvMlirIgemmFwdXdlops::IsValidPerformanceConfig(
@@ -176,17 +194,9 @@ ConvSolution ConvMlirIgemmFwdXdlops::GetSolution(const ConvolutionContext& ctx,
     ConvSolution result;
     KernelInfo construction_parameters;
 
-    construction_parameters.kernel_name = mlir::GetKernelName(ctx, true);
-    construction_parameters.kernel_file = construction_parameters.kernel_name + ".mlir";
-
-    if(config == PerformanceConvMlirIgemmXdlops())
-        // At this case, do not pass in the invalid perf config and instead make Miir library to do
-        // heuristic initialization
-        construction_parameters.comp_options = mlir::ConstructBuildOptions(ctx, true);
-    else
-        // At this case, Make Miir library to use the valid perf config
-        construction_parameters.comp_options =
-            mlir::ConstructBuildOptions(ctx, config.ToString(), true);
+    construction_parameters.kernel_name  = mlir::GetKernelName(ctx, true);
+    construction_parameters.kernel_file  = construction_parameters.kernel_name + ".mlir";
+    construction_parameters.comp_options = mlir::ConstructBuildOptions(ctx, config, true);
 
     size_t local_size  = 0;
     size_t global_size = 0;

--- a/src/solver/conv_mlir_igemm_fwd_xdlops.cpp
+++ b/src/solver/conv_mlir_igemm_fwd_xdlops.cpp
@@ -38,9 +38,8 @@ MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEBUG_CONV_MLIR_IGEMM_FWD_XDLOPS)
 namespace miopen {
 namespace solver {
 
-const PerformanceConvMlirIgemmXdlops& PerformanceConvMlirIgemmXdlops::GetHeuristicInitRequest()
+const PerformanceConvMlirIgemmXdlops& PerformanceConvMlirIgemmXdlops::MlirHeuristicInitRequest()
 {
-    // Special value to represent the heuristic initialized perf_config.
     static const PerformanceConvMlirIgemmXdlops p =
         PerformanceConvMlirIgemmXdlops(-2, -2, -2, -2, -2, -2, false, false, false);
     return p;
@@ -115,7 +114,7 @@ bool PerformanceConvMlirIgemmXdlops::operator==(const PerformanceConvMlirIgemmXd
 bool PerformanceConvMlirIgemmXdlops::IsValid(const ConvolutionContext& ctx) const
 {
 #if MIOPEN_USE_MLIR
-    if(*this == GetHeuristicInitRequest())
+    if(*this == MlirHeuristicInitRequest())
         return true;
 
     return MiirIsConfigApplicable(mlir::ConstructBuildOptions(ctx, *this, true));
@@ -127,13 +126,8 @@ bool PerformanceConvMlirIgemmXdlops::IsValid(const ConvolutionContext& ctx) cons
 
 bool PerformanceConvMlirIgemmXdlops::SetNextValue(const ConvolutionContext& /*config*/)
 {
-    if(*this == GetHeuristicInitRequest())
-    {
-        // If we ever attempt to iterate starting from the heuristic value,
-        // make its next iterator to be the minimal value.
-        *this = PerformanceConvMlirIgemmXdlops(use_spare_set);
-        return false;
-    }
+    if(*this == MlirHeuristicInitRequest())
+        MIOPEN_THROW("Should not iterate from the heuristic value");
 
     GemmBThreadCopyMoreGemmKPack = true;
     GemmAThreadCopyMoreGemmK     = true;
@@ -169,7 +163,7 @@ PerformanceConvMlirIgemmXdlops
 ConvMlirIgemmFwdXdlops::GetPerformanceConfig(const ConvolutionContext& ctx) const
 {
     std::ignore = ctx;
-    return PerformanceConvMlirIgemmXdlops::GetHeuristicInitRequest();
+    return PerformanceConvMlirIgemmXdlops::MlirHeuristicInitRequest();
 }
 
 bool ConvMlirIgemmFwdXdlops::IsValidPerformanceConfig(

--- a/src/solver/mlir_common.cpp
+++ b/src/solver/mlir_common.cpp
@@ -173,22 +173,6 @@ std::string ConstructBuildOptions(const ConvolutionContext& ctx,
     return mlir_handle.str();
 }
 
-std::string ConstructBuildOptions(const ConvolutionContext& ctx,
-                                  const std::string& config,
-                                  bool is_xdlops,
-                                  int kernel_id)
-{
-    std::ostringstream mlir_handle;
-
-    // clang-format off
-    mlir_handle
-        << ConstructBuildOptions(ctx, is_xdlops, kernel_id)
-        << " --perf_config " << config;
-    // clang-format on
-
-    return mlir_handle.str();
-}
-
 } // namespace mlir
 } // namespace solver
 } // namespace miopen


### PR DESCRIPTION
This address #1154 

Quote from @atamazov's proposal below:

- Modify GetPerformanceConfig() to return a special value (all -2) to ask MLIR to perform heuristic init
- PerformanceConvMlirIgemm::IsValid(HeuristicInitRequest) return true
- PerformanceConvMlirIgemm::SetNextValue(HeuristicInitRequest) return false
- Modify mlir::ConstructBuildOptions() treate HeuristicInitRequest as a special value.

Note: 
 - commit 055906b only address one solver
 - If you agree with my existing approach, I will apply the same fix to rest of xdlops/nonxdlops, fwd/bwd solvers in next commit

-----


Previous PR this series: 
 - #1075
 - #1139
 - #1152