### PR TITLE
[gfx90a] Direct conv3x3 wrw support

### DIFF
--- a/src/solver/conv_asm_dir_BwdWrW3x3.cpp
+++ b/src/solver/conv_asm_dir_BwdWrW3x3.cpp
@@ -38,7 +38,6 @@
 #include <miopen/generic_search.hpp>
 
 #define WORKAROUND_ISSUE_532 1 // ConvAsmBwdWrW3x3 has precision issues with some PerformanceConfigs
-#define WORKAROUND_ISSUE_1146 1 // check asm solver applicability for gfx90a
 #define MIOPEN_GCN_ASM_DIRECT_3X3WRW_SEARCH_LWC_FIXED 0
 
 MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEBUG_CONV_DIRECT_ASM_WRW3X3_PERF_VALS)
@@ -360,10 +359,6 @@ bool ConvAsmBwdWrW3x3::IsApplicable(const ConvolutionContext& params) const
     const std::string name = params.GetStream().GetDeviceName();
     if(!(StartsWith(name, "gfx8") || StartsWith(name, "gfx9")))
         return false;
-#if WORKAROUND_ISSUE_1146
-    if(name == "gfx90a")
-        return false;
-#endif
     if(!params.IsLayoutDefault())
     {
         return false;


### PR DESCRIPTION
This PR adds Direct conv3x3wrw support for gfx90a. Partially resolves issue ROCmSoftwarePlatform/MIOpen-internal#2.

## Local verification
- gfx90a, rocm 4.3.1

<details><summary>Test cases</summary>

type | -W | -H | -c | -n | -k | -x | -y | -p | -q | -u | -v | -F | -g
--   | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
fp16/fp32 | 7 | 7 | 160 | 32 | 224 | 3 | 3 | 1 | 1 | 1 | 1 | wrw | 1
fp16/fp32 | 7 | 7 | 160 | 32 | 224 | 3 | 3 | 1 | 1 | 1 | 1 | wrw | 4
fp16/fp32 | 7 | 7 | 160 | 32 | 320 | 3 | 3 | 1 | 1 | 1 | 1 | wrw | 1
fp16/fp32 | 7 | 7 | 160 | 32 | 320 | 3 | 3 | 1 | 1 | 1 | 1 | wrw | 4
fp16/fp32 | 7 | 7 | 160 | 128 | 320 | 3 | 3 | 1 | 1 | 1 | 1 | wrw | 1
fp16/fp32 | 7 | 7 | 160 | 128 | 320 | 3 | 3 | 1 | 1 | 1 | 1 | wrw | 4
fp16/fp32 | 7 | 7 | 192 | 32 | 224 | 3 | 3 | 1 | 1 | 1 | 1 | wrw | 1
fp16/fp32 | 7 | 7 | 192 | 32 | 224 | 3 | 3 | 1 | 1 | 1 | 1 | wrw | 4
fp16/fp32 | 7 | 7 | 192 | 32 | 320 | 3 | 3 | 1 | 1 | 1 | 1 | wrw | 1
fp16/fp32 | 7 | 7 | 192 | 32 | 320 | 3 | 3 | 1 | 1 | 1 | 1 | wrw | 4
fp16/fp32 | 13 | 13 | 192 | 50 | 384 | 3 | 3 | 1 | 1 | 1 | 1 | wrw | 1
fp16/fp32 | 13 | 13 | 192 | 50 | 384 | 3 | 3 | 1 | 1 | 1 | 1 | wrw | 4
fp16/fp32 | 13 | 13 | 192 | 64 | 384 | 3 | 3 | 1 | 1 | 1 | 1 | wrw | 1
fp16/fp32 | 13 | 13 | 192 | 64 | 384 | 3 | 3 | 1 | 1 | 1 | 1 | wrw | 4
fp16/fp32 | 14 | 14 | 96 | 32 | 128 | 3 | 3 | 1 | 1 | 1 | 1 | wrw | 1
fp16/fp32 | 14 | 14 | 96 | 32 | 128 | 3 | 3 | 1 | 1 | 1 | 1 | wrw | 4
fp16/fp32 | 14 | 14 | 96 | 32 | 208 | 3 | 3 | 1 | 1 | 1 | 1 | wrw | 1
fp16/fp32 | 14 | 14 | 96 | 32 | 208 | 3 | 3 | 1 | 1 | 1 | 1 | wrw | 4
fp16/fp32 | 14 | 14 | 160 | 32 | 192 | 3 | 3 | 1 | 1 | 1 | 1 | wrw | 1
fp16/fp32 | 14 | 14 | 160 | 32 | 192 | 3 | 3 | 1 | 1 | 1 | 1 | wrw | 4
fp16/fp32 | 14 | 14 | 160 | 32 | 320 | 3 | 3 | 1 | 1 | 1 | 1 | wrw | 1
fp16/fp32 | 14 | 14 | 160 | 32 | 320 | 3 | 3 | 1 | 1 | 1 | 1 | wrw | 4
fp16/fp32 | 27 | 27 | 128 | 1 | 128 | 3 | 3 | 1 | 1 | 1 | 1 | wrw | 1
fp16/fp32 | 27 | 27 | 128 | 1 | 128 | 3 | 3 | 1 | 1 | 1 | 1 | wrw | 4
fp16/fp32 | 27 | 27 | 128 | 8 | 128 | 3 | 3 | 1 | 1 | 1 | 1 | wrw | 1
fp16/fp32 | 27 | 27 | 128 | 8 | 128 | 3 | 3 | 1 | 1 | 1 | 1 | wrw | 4
fp16/fp32 | 28 | 28 | 256 | 8 | 512 | 3 | 3 | 1 | 1 | 1 | 1 | wrw | 1
fp16/fp32 | 28 | 28 | 256 | 8 | 512 | 3 | 3 | 1 | 1 | 1 | 1 | wrw | 4
fp16/fp32 | 28 | 28 | 256 | 16 | 512 | 3 | 3 | 1 | 1 | 1 | 1 | wrw | 1
fp16/fp32 | 28 | 28 | 256 | 16 | 512 | 3 | 3 | 1 | 1 | 1 | 1 | wrw | 4
fp16/fp32 | 56 | 56 | 64 | 8 | 64 | 3 | 3 | 1 | 1 | 1 | 1 | wrw | 1
fp16/fp32 | 56 | 56 | 64 | 8 | 64 | 3 | 3 | 1 | 1 | 1 | 1 | wrw | 4
fp16/fp32 | 56 | 56 | 64 | 32 | 192 | 3 | 3 | 1 | 1 | 1 | 1 | wrw | 1
fp16/fp32 | 56 | 56 | 64 | 32 | 192 | 3 | 3 | 1 | 1 | 1 | 1 | wrw | 4
fp16/fp32 | 56 | 56 | 64 | 128 | 192 | 3 | 3 | 1 | 1 | 1 | 1 | wrw | 1
fp16/fp32 | 56 | 56 | 64 | 128 | 192 | 3 | 3 | 1 | 1 | 1 | 1 | wrw | 4
fp16/fp32 | 56 | 56 | 128 | 1 | 256 | 3 | 3 | 1 | 1 | 1 | 1 | wrw | 1
fp16/fp32 | 56 | 56 | 128 | 1 | 256 | 3 | 3 | 1 | 1 | 1 | 1 | wrw | 4
fp16/fp32 | 56 | 56 | 128 | 2 | 256 | 3 | 3 | 1 | 1 | 1 | 1 | wrw | 1
fp16/fp32 | 56 | 56 | 128 | 2 | 256 | 3 | 3 | 1 | 1 | 1 | 1 | wrw | 4
fp16/fp32 | 56 | 56 | 128 | 8 | 256 | 3 | 3 | 1 | 1 | 1 | 1 | wrw | 1
fp16/fp32 | 56 | 56 | 128 | 8 | 256 | 3 | 3 | 1 | 1 | 1 | 1 | wrw | 4
fp16/fp32 | 120 | 12 | 32 | 1 | 64 | 3 | 3 | 1 | 1 | 1 | 1 | wrw | 1
fp16/fp32 | 120 | 12 | 32 | 1 | 64 | 3 | 3 | 1 | 1 | 1 | 1 | wrw | 4
fp16/fp32 | 350 | 80 | 64 | 1 | 64 | 3 | 3 | 1 | 1 | 1 | 1 | wrw | 1
fp16/fp32 | 350 | 80 | 64 | 1 | 64 | 3 | 3 | 1 | 1 | 1 | 1 | wrw | 4
fp16/fp32 | 350 | 80 | 64 | 2 | 64 | 3 | 3 | 1 | 1 | 1 | 1 | wrw | 1
fp16/fp32 | 350 | 80 | 64 | 2 | 64 | 3 | 3 | 1 | 1 | 1 | 1 | wrw | 4

</details>