### PR TITLE
[CI] HOTFIX: Support Ubuntu 20.04. Fix: evaluate TARGET param in 'when' before entering agent. Syntax fixes/workarounds.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -124,3 +124,4 @@ RUN if [ "$USE_MLIR" = "ON" ]; \
     $PREFIX/bin/cmake --install . --component libMLIRMIOpen --prefix /opt/rocm && \
     cd ~ && rm -rf llvm-project-mlir-$MLIR_COMMIT; fi
     
+RUN groupadd -f render

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -115,7 +115,7 @@ def buildHipClangJob(Map conf=[:]){
         def target_id = conf.get("target_id", "OFF")
         def mlir_build = conf.get("mlir_build", "OFF")
         def build_fin = conf.get("build_fin", "OFF")
-        def dockerOpts="--device=/dev/kfd --device=/dev/dri --group-add video --cap-add=SYS_PTRACE --security-opt seccomp=unconfined"
+        def dockerOpts="--device=/dev/kfd --device=/dev/dri --group-add video --group-add render --cap-add=SYS_PTRACE --security-opt seccomp=unconfined"
         def dockerArgs = "--build-arg PREFIX=${prefixpath} --build-arg GPU_ARCH='${gpu_arch}' --build-arg MIOTENSILE_VER='${miotensile_version}' --build-arg USE_TARGETID='${target_id}' --build-arg USE_MLIR='${mlir_build}' --build-arg USE_FIN='${build_fin}' "
 
         def variant = env.STAGE_NAME

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -294,10 +294,14 @@ pipeline {
         Full_test       = " -DMIOPEN_TEST_ALL=On"
         Tensile_build_env = "MIOPEN_DEBUG_HIP_KERNELS=0 "
         Tensile_setup = " -DMIOPEN_TEST_MIOTENSILE=ON -DMIOPEN_USE_MIOPENTENSILE=ON -DMIOPEN_USE_ROCBLAS=OFF"
+        Smoke_targets = "check doc MIOpenDriver"
+        MLIR_flags    = "-DMIOPEN_USE_MLIR=On"
     }
     stages{
-        stage("Static checks"){
-            when { expression { params.STATIC_CHECKS && params.TARGET_NOGPU } }
+        stage("Static checks") {
+            when {
+                expression { params.STATIC_CHECKS && params.TARGET_NOGPU }
+            }
             parallel{
                 stage('Hip Tidy') {
                     agent{ label rocmnode("nogpu") }
@@ -348,56 +352,76 @@ pipeline {
                 }
             }
         }
-        stage("Smoke Fp32"){
-            when { expression { params.SMOKE_FP32_AUX1 } }
-            environment{
-                Smoke_targets = "check doc MIOpenDriver"
+        stage("Smoke Fp32") {
+            when {
+                expression { params.SMOKE_FP32_AUX1 }
             }
             parallel{
                stage('Fp32 OpenCL Debug + Codecov') {
-                    when { expression { params.TARGET_VEGA20 || params.TARGET_VEGA10 } }
+                    when {
+                        beforeAgent true
+                        expression { params.TARGET_VEGA20 || params.TARGET_VEGA10 }
+                    }
                     agent{ label rocmnode("vega") }
                     steps{
                         buildHipClangJobAndReboot(compiler: 'g++', build_type: 'debug', config_targets: Smoke_targets, codecov: true)
                     }
                 }
                 stage('Fp32 OpenCL gfx908') {
-                    when { expression { params.TARGET_GFX908 } }
+                    when {
+                        beforeAgent true
+                        expression { params.TARGET_GFX908 }
+                    }
                     agent{ label rocmnode("gfx908") }
                     steps{
                         buildHipClangJobAndReboot(compiler: 'g++', config_targets: Smoke_targets, gpu_arch: "gfx908")
                     }
                 }
                 stage('Fp32 OpenCL gfx90a') {
-                    when { expression { params.TARGET_GFX90A } }
+                    when {
+                        beforeAgent true
+                        expression { params.TARGET_GFX90A }
+                    }
                     agent{ label rocmnode("gfx90a") }
                     steps{
                         buildHipClangJobAndReboot(compiler: 'g++', config_targets: Smoke_targets, gpu_arch: "gfx90a:xnack-")
                     }
                 }
                 stage('Fp32 Hip /opt/rocm') {
-                    when { expression { params.TARGET_VEGA20 || params.TARGET_VEGA10 } }
+                    when {
+                        beforeAgent true
+                        expression { params.TARGET_VEGA20 || params.TARGET_VEGA10 }
+                    }
                     agent{ label rocmnode("vega") }
                     steps{
                         buildHipClangJobAndReboot(prefixpath: '/opt/rocm', config_targets: Smoke_targets)
                     }
                 }
                 stage('Fp32 Hip Debug') {
-                    when { expression { params.TARGET_VEGA20 || params.TARGET_VEGA10 } }
+                    when {
+                        beforeAgent true
+                        expression { params.TARGET_VEGA20 || params.TARGET_VEGA10 }
+                    }
                     agent{ label rocmnode("vega") }
                     steps{
                         buildHipClangJobAndReboot(build_type: 'debug', config_targets: Smoke_targets)
                     }
                 }
                 stage('Fp32 OpenCL Debug gfx1030') {
-                    when { expression { params.TARGET_NAVI21 } }
+                    when {
+                        beforeAgent true
+                        expression { params.TARGET_NAVI21 }
+                    }
                     agent{ label rocmnode("navi21") }
                     steps{
                         buildHipClangJobAndReboot(compiler: 'g++', build_type: 'debug', config_targets: Smoke_targets, build_env: extra_log_env, gpu_arch: "gfx1030")
                     }
                 }
                 stage('Fp32 Hip Debug gfx908 /opt/rocm') {
-                    when { expression { params.TARGET_GFX908 } }
+                    when {
+                        beforeAgent true
+                        expression { params.TARGET_GFX908 }
+                    }
                     agent{ label rocmnode("gfx908") }
                     environment{
                         gpu_arch = "gfx908"
@@ -408,7 +432,10 @@ pipeline {
                     }
                 }
                 stage('Fp32 Hip Debug gfx90a /opt/rocm') {
-                    when { expression { params.TARGET_GFX90A } }
+                    when {
+                        beforeAgent true
+                        expression { params.TARGET_GFX90A }
+                    }
                     agent{ label rocmnode("gfx90a") }
                     environment{
                         gpu_arch = "gfx90a:xnack-"
@@ -419,7 +446,10 @@ pipeline {
                     }
                 }
                 stage('Fp32 HipNoGPU Debug') {
-                    when { expression { params.TARGET_NOGPU } }
+                    when {
+                        beforeAgent true
+                        expression { params.TARGET_NOGPU }
+                    }
                     agent{ label rocmnode("nogpu") }
                     environment{
                         HipNoGPU_flags = "-DMIOPEN_BACKEND=HIPNOGPU -DMIOPEN_INSTALL_CXX_HEADERS=On"
@@ -431,11 +461,16 @@ pipeline {
                 }
             }
         }
-        stage("Smoke Aux 1"){
-            when { expression { params.SMOKE_FP32_AUX1 } }
+        stage("Smoke Aux 1") {
+            when {
+                expression { params.SMOKE_FP32_AUX1 }
+            }
             parallel{
                 stage('Fp32 Hip Debug COMGR') {
-                    when { expression { params.TARGET_VEGA20 || params.TARGET_VEGA10 } }
+                    when {
+                        beforeAgent true
+                        expression { params.TARGET_VEGA20 || params.TARGET_VEGA10 }
+                    }
                     agent{ label rocmnode("vega") }
                     environment{
                         // See SWDEV-290754 for why LLVM_PATH is required.
@@ -446,7 +481,10 @@ pipeline {
                     }
                 }
                 stage('Fp32 Hip Debug Embedded Vega20') {
-                    when { expression { params.TARGET_VEGA20 } }
+                    when {
+                        beforeAgent true
+                        expression { params.TARGET_VEGA20 }
+                    }
                     agent{ label rocmnode("vega20") }
                     environment{
                         Embedded_flags = "-DMIOPEN_EMBED_DB='gfx906_60'"
@@ -456,14 +494,20 @@ pipeline {
                     }
                 }
                 stage('Fp32 Hip Static') {
-                    when { expression { params.TARGET_VEGA20 || params.TARGET_VEGA10 } }
+                    when {
+                        beforeAgent true
+                        expression { params.TARGET_VEGA20 || params.TARGET_VEGA10 }
+                    }
                     agent{ label rocmnode("vega") }
                     steps{
                         buildHipClangJobAndReboot( setup_flags: "-DBUILD_SHARED_LIBS=Off")
                     }
                 }
                 stage('Fp32 Hip Normal-Find') {
-                    when { expression { params.TARGET_VEGA20 || params.TARGET_VEGA10 } }
+                    when {
+                        beforeAgent true
+                        expression { params.TARGET_VEGA20 || params.TARGET_VEGA10 }
+                    }
                     agent{ label rocmnode("vega") }
                     environment{
                         config_targets = "test_conv2d"
@@ -474,7 +518,10 @@ pipeline {
                     }
                 }
                 stage('Fp32 Hip Fast-Find') {
-                    when { expression { params.TARGET_VEGA20 || params.TARGET_VEGA10 } }
+                    when {
+                        beforeAgent true
+                        expression { params.TARGET_VEGA20 || params.TARGET_VEGA10 }
+                    }
                     agent{ label rocmnode("vega") }
                     environment{
                         config_targets =   "test_conv2d"
@@ -485,7 +532,10 @@ pipeline {
                     }
                 }
                 stage('Fp32 Hip') {
-                    when { expression { params.TARGET_VEGA20 || params.TARGET_VEGA10 } }
+                    when {
+                        beforeAgent true
+                        expression { params.TARGET_VEGA20 || params.TARGET_VEGA10 }
+                    }
                     agent{ label rocmnode("vega") }
                     steps{
                         buildHipClangJobAndReboot()
@@ -493,33 +543,46 @@ pipeline {
                 }
             }
         }
-        stage("Smoke MLIR"){
-            when { expression { params.SMOKE_MLIR } }
-            environment{ MLIR_flags = "-DMIOPEN_USE_MLIR=On" }
+        stage("Smoke MLIR") {
+            when {
+                expression { params.SMOKE_MLIR }
+            }
             parallel{
                 stage('Fp32 Hip MLIR') {
-                    when { expression { params.TARGET_VEGA20 || params.TARGET_VEGA10 } }
+                    when {
+                        beforeAgent true
+                        expression { params.TARGET_VEGA20 || params.TARGET_VEGA10 }
+                    }
                     agent{ label rocmnode("vega") }
                     steps{
                         buildHipClangJobAndReboot(setup_flags: MLIR_flags, build_env: extra_log_env, test_flags: ' --verbose ', mlir_build: "ON")
                     }
                 }
                 stage('Fp16 Hip MLIR') {
-                    when { expression { params.TARGET_VEGA20 || params.TARGET_VEGA10 } }
+                    when {
+                        beforeAgent true
+                        expression { params.TARGET_VEGA20 || params.TARGET_VEGA10 }
+                    }
                     agent{ label rocmnode("vega") }
                     steps{
                         buildHipClangJobAndReboot(setup_flags: MLIR_flags + Fp16_flags, build_env: extra_log_env, test_flags: ' --verbose ', mlir_build: "ON")
                     }
                 }
                 stage('Fp16 Hip MLIR gfx908') {
-                    when { expression { params.TARGET_GFX908 } }
+                    when {
+                        beforeAgent true
+                        expression { params.TARGET_GFX908 }
+                    }
                     agent{ label rocmnode("gfx908") }
                     steps{
                         buildHipClangJobAndReboot(setup_flags: MLIR_flags + Fp16_flags, build_env: extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx908", mlir_build: "ON")
                     }
                 }
                 stage('Fp32 Hip MLIR gfx908') {
-                    when { expression { params.TARGET_GFX908 } }
+                    when {
+                        beforeAgent true
+                        expression { params.TARGET_GFX908 }
+                    }
                     agent{ label rocmnode("gfx908") }
                     steps{
                         buildHipClangJobAndReboot(setup_flags: MLIR_flags, build_env: extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx908", mlir_build: "ON")
@@ -527,63 +590,86 @@ pipeline {
                 }
             }
         }
-        stage("Smoke Fp16/Bf16/Int8"){
-            when { expression { params.SMOKE_FP16_BF16_INT8 } }
-            environment{
-                Smoke_targets = "check doc MIOpenDriver"
+        stage("Smoke Fp16/Bf16/Int8") {
+            when {
+                expression { params.SMOKE_FP16_BF16_INT8 }
             }
             parallel{
                 stage('Fp16 OpenCL Vega20') {
-                    when { expression { params.TARGET_VEGA20 } }
+                    when {
+                        beforeAgent true
+                        expression { params.TARGET_VEGA20 }
+                    }
                     agent{ label rocmnode("vega20") }
                     steps{
                         buildHipClangJobAndReboot(compiler: 'g++', setup_flags: Fp16_flags, config_targets: Smoke_targets)
                     }
                 }
                 stage('Int8 OpenCL Vega20') {
-                    when { expression { params.TARGET_VEGA20 } }
+                    when {
+                        beforeAgent true
+                        expression { params.TARGET_VEGA20 }
+                    }
                     agent{ label rocmnode("vega20") }
                     steps{
                         buildHipClangJobAndReboot(compiler: 'g++', setup_flags: Int8_flags, config_targets: Smoke_targets)
                     }
                 }
                 stage('Fp16 Hip Vega20 /opt/rocm') {
-                    when { expression { params.TARGET_VEGA20 } }
+                    when {
+                        beforeAgent true
+                        expression { params.TARGET_VEGA20 }
+                    }
                     agent{ label rocmnode("vega20") }
                     steps{
                         buildHipClangJobAndReboot( setup_flags: Fp16_flags, prefixpath: '/opt/rocm', config_targets: Smoke_targets)
                     }
                 }
                 stage('Bf16 Hip Vega20 /opt/rocm') {
-                    when { expression { params.TARGET_VEGA20 } }
+                    when {
+                        beforeAgent true
+                        expression { params.TARGET_VEGA20 }
+                    }
                     agent{ label rocmnode("vega20") }
                     steps{
                         buildHipClangJobAndReboot(setup_flags: Bf16_flags, prefixpath: '/opt/rocm', config_targets: Smoke_targets)
                     }
                 }
                 stage('Fp16 Hip gfx908 /opt/rocm') {
-                    when { expression { params.TARGET_GFX908 } }
+                    when {
+                        beforeAgent true
+                        expression { params.TARGET_GFX908 }
+                    }
                     agent{ label rocmnode("gfx908") }
                     steps{
                         buildHipClangJobAndReboot( setup_flags: Fp16_flags, prefixpath: '/opt/rocm', config_targets: Smoke_targets, gpu_arch: "gfx908")
                     }
                 }
                 stage('Bf16 Hip gfx908 /opt/rocm') {
-                    when { expression { params.TARGET_GFX908 } }
+                    when {
+                        beforeAgent true
+                        expression { params.TARGET_GFX908 }
+                    }
                     agent{ label rocmnode("gfx908") }
                     steps{
                         buildHipClangJobAndReboot(setup_flags: Bf16_flags, prefixpath: '/opt/rocm', config_targets: Smoke_targets, gpu_arch: "gfx908")
                     }
                 }
                 stage('Fp16 Hip gfx90a /opt/rocm') {
-                    when { expression { params.TARGET_GFX90A } }
+                    when {
+                        beforeAgent true
+                        expression { params.TARGET_GFX90A }
+                    }
                     agent{ label rocmnode("gfx90a") }
                     steps{
                         buildHipClangJobAndReboot( setup_flags: Fp16_flags, prefixpath: '/opt/rocm', config_targets: Smoke_targets, gpu_arch: "gfx90a:xnack-")
                     }
                 }
                 stage('Bf16 Hip gfx90a /opt/rocm') {
-                    when { expression { params.TARGET_GFX90A } }
+                    when {
+                        beforeAgent true
+                        expression { params.TARGET_GFX90A }
+                    }
                     agent{ label rocmnode("gfx90a") }
                     steps{
                         buildHipClangJobAndReboot(setup_flags: Bf16_flags, prefixpath: '/opt/rocm', config_targets: Smoke_targets, gpu_arch: "gfx90a:xnack-")
@@ -591,49 +677,69 @@ pipeline {
                 }
             }
         }
-        stage("Smoke MIOpenTensile Latest"){
-            when { expression { params.SMOKE_MIOPENTENSILE_LATEST } }
+        stage("Smoke MIOpenTensile Latest") {
+            when {
+                expression { params.SMOKE_MIOPENTENSILE_LATEST }
+            }
             environment{
                 Tensile_version = "latest"
             }
             parallel{
                 stage('Fp16 Hip Tensile-Latest All Vega20') {
-                    when { expression { params.TARGET_VEGA20 } }
+                    when {
+                        beforeAgent true
+                        expression { params.TARGET_VEGA20 }
+                    }
                     agent{ label rocmnode("vega20") }
                     steps{
                         buildHipClangJobAndReboot( setup_flags: Tensile_setup + Fp16_flags, build_env: Tensile_build_env, test_flags: ' --verbose ', gpu_arch:"gfx906:xnack-", miotensile_version: Tensile_version, target_id: "ON")
                     }
                 }
                 stage('Int8 Hip Tensile-Latest All Vega20') {
-                    when { expression { params.TARGET_VEGA20 } }
+                    when {
+                        beforeAgent true
+                        expression { params.TARGET_VEGA20 }
+                    }
                     agent{ label rocmnode("vega20") }
                     steps{
                         buildHipClangJobAndReboot( setup_flags: Tensile_setup + extra_log_env + Int8_flags, build_env: Tensile_build_env, test_flags: ' --verbose ', gpu_arch:"gfx906:xnack-", miotensile_version: Tensile_version, target_id: "ON")
                     }
                 }
                 stage('Fp32 Hip Tensile-Latest All gfx908') {
-                    when { expression { params.TARGET_GFX908 } }
+                    when {
+                        beforeAgent true
+                        expression { params.TARGET_GFX908 }
+                    }
                     agent{ label rocmnode("gfx908") }
                     steps{
                         buildHipClangJobAndReboot( setup_flags: Tensile_setup + extra_log_env, build_env: Tensile_build_env + extra_log_env, gpu_arch: "gfx908:xnack-", test_flags: ' --verbose ', miotensile_version: Tensile_version, target_id: "ON")
                     }
                 }
                 stage('Bf16 Hip Tensile-Latest All gfx908') {
-                    when { expression { params.TARGET_GFX908 } }
+                    when {
+                        beforeAgent true
+                        expression { params.TARGET_GFX908 }
+                    }
                     agent{ label rocmnode("gfx908") }
                     steps{
                         buildHipClangJobAndReboot( setup_flags: Tensile_setup + extra_log_env + Bf16_flags, build_env: Tensile_build_env + extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx908:xnack-", miotensile_version: Tensile_version, target_id: "ON")
                     }
                 }
                 // stage('Fp32 Hip Tensile-Latest All gfx90a') {
-                //     when { expression { params.TARGET_GFX90A } }
+                //     when {
+                //         beforeAgent true
+                //         expression { params.TARGET_GFX90A }
+                //     }
                 //     agent{ label rocmnode("gfx90a") }
                 //     steps{
                 //         buildHipClangJobAndReboot( setup_flags: Tensile_setup + extra_log_env, build_env: Tensile_build_env + extra_log_env, gpu_arch: "gfx90a:xnack-", test_flags: ' --verbose ', miotensile_version: Tensile_version, target_id: "ON")
                 //     }
                 // }
                 // stage('Bf16 Hip Tensile-Latest All gfx90a') {
-                //     when { expression { params.TARGET_GFX90A } }
+                //     when {
+                //         beforeAgent true
+                //         expression { params.TARGET_GFX90A }
+                //     }
                 //     agent{ label rocmnode("gfx90a") }
                 //     steps{
                 //         buildHipClangJobAndReboot( setup_flags: Tensile_setup + extra_log_env + Bf16_flags, build_env: Tensile_build_env + extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx90a:xnack-", miotensile_version: Tensile_version, target_id: "ON")
@@ -641,32 +747,46 @@ pipeline {
                 // }
             }
         }
-        stage("Full Tests I"){
-            when { expression { params.FULL_TESTS } }
+        stage("Full Tests I") {
+            when {
+                expression { params.FULL_TESTS }
+            }
             parallel{
                 stage('Int8 HIP All Vega20 /opt/rocm') {
-                    when { expression { params.TARGET_VEGA20 } }
+                    when {
+                        beforeAgent true
+                        expression { params.TARGET_VEGA20 }
+                    }
                     agent{ label rocmnode("vega20") }
                     steps{
                         buildHipClangJobAndReboot( setup_flags: Int8_flags + Full_test, prefixpath: '/opt/rocm')
                     }
                 }
                 stage('Fp32 OpenCL Install All') {
-                    when { expression { params.TARGET_VEGA20 || params.TARGET_VEGA10 } }
+                    when {
+                        beforeAgent true
+                        expression { params.TARGET_VEGA20 || params.TARGET_VEGA10 }
+                    }
                     agent{ label rocmnode("vega") }
                     steps{
                         buildHipClangJobAndReboot(compiler: 'g++', setup_flags: Full_test, build_install: "true")
                     }
                 }
                 stage('Bf16 Hip Install All gfx908') {
-                    when { expression { params.TARGET_GFX908 } }
+                    when {
+                        beforeAgent true
+                        expression { params.TARGET_GFX908 }
+                    }
                     agent{ label rocmnode("gfx908") }
                     steps{
                         buildHipClangJobAndReboot(setup_flags: Bf16_flags + Full_test, build_install: "true", gpu_arch: "gfx908")
                     }
                 }
                 stage('Bf16 Hip Install All gfx90a') {
-                    when { expression { params.TARGET_GFX90A } }
+                    when {
+                        beforeAgent true
+                        expression { params.TARGET_GFX90A }
+                    }
                     agent{ label rocmnode("gfx90a") }
                     steps{
                         buildHipClangJobAndReboot(setup_flags: Bf16_flags + Full_test, build_install: "true", gpu_arch: "gfx90a:xnack-")
@@ -675,63 +795,89 @@ pipeline {
             }
         }
 
-        stage("Full Tests II"){
-            when { expression { params.FULL_TESTS } }
+        stage("Full Tests II") {
+            when {
+                expression { params.FULL_TESTS }
+            }
             environment{
                 WORKAROUND_iGemm_936 = " MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_FWD_V4R1=0"
             }
             parallel{
                 stage('Fp32 Hip All gfx908') {
-                    when { expression { params.TARGET_GFX908 } }
+                    when {
+                        beforeAgent true
+                        expression { params.TARGET_GFX908 }
+                    }
                     agent{ label rocmnode("gfx908") }
                     steps{
                         buildHipClangJobAndReboot(setup_flags: Full_test, gpu_arch: "gfx908")
                     }
                 }
                 stage('Fp32 Hip All gfx90a') {
-                    when { expression { params.TARGET_GFX90A } }
+                    when {
+                        beforeAgent true
+                        expression { params.TARGET_GFX90A }
+                    }
                     agent{ label rocmnode("gfx90a") }
                     steps{
                         buildHipClangJobAndReboot(setup_flags: Full_test, gpu_arch: "gfx90a:xnack-")
                     }
                 }
                 stage('Fp16 Hip Install All Vega20') {
-                    when { expression { params.TARGET_VEGA20 } }
+                    when {
+                        beforeAgent true
+                        expression { params.TARGET_VEGA20 }
+                    }
                     agent{ label rocmnode("vega20") }
                     steps{
                         buildHipClangJobAndReboot( setup_flags: Full_test + Fp16_flags, build_env: WORKAROUND_iGemm_936, build_install: "true")
                     }
                 }
                 stage('Fp32 Hip All Vega20') {
-                    when { expression { params.TARGET_VEGA20 } }
+                    when {
+                        beforeAgent true
+                        expression { params.TARGET_VEGA20 }
+                    }
                     agent{ label rocmnode("vega20") }
                     steps{
                         buildHipClangJobAndReboot( setup_flags: Full_test)
                     }
                 }
                 stage('Fp32 OpenCL All gfx1030') {
-                    when { expression { params.TARGET_NAVI21 && params.FULL_TESTS_NAVI21_OPTIONAL } }
+                    when {
+                        beforeAgent true
+                        expression { params.TARGET_NAVI21 && params.FULL_TESTS_NAVI21_OPTIONAL }
+                    }
                     agent{ label rocmnode("navi21") }
                     steps{
                         buildHipClangJobAndReboot(compiler: 'g++', setup_flags: Full_test, build_env: extra_log_env, gpu_arch: "gfx1030")
                     }
                 }
                 stage('Fp32 Hip All Install gfx1030') {
-                    when { expression { params.TARGET_NAVI21 && params.FULL_TESTS_NAVI21_OPTIONAL } }
+                    when {
+                        beforeAgent true
+                        expression { params.TARGET_NAVI21 && params.FULL_TESTS_NAVI21_OPTIONAL }
+                    }
                     agent{ label rocmnode("navi21") }
                     steps{
                         buildHipClangJobAndReboot(setup_flags: Full_test, build_install: "true", gpu_arch: "gfx1030")
                     }
                 }
                 stage('Fp16 Hip All Install gfx908') {
-                    when { expression { params.TARGET_GFX908 } }
+                    when {
+                        beforeAgent true
+                        expression { params.TARGET_GFX908 }
+                    }
                     agent{ label rocmnode("gfx908") }
                     steps{
                         buildHipClangJobAndReboot(setup_flags: Full_test + Fp16_flags, build_env: WORKAROUND_iGemm_936, build_install: "true", gpu_arch: "gfx908")
                     }
                 }
                 stage('Fp16 Hip All Install gfx90a') {
-                    when { expression { params.TARGET_GFX90A } }
+                    when {
+                        beforeAgent true
+                        expression { params.TARGET_GFX90A }
+                    }
                     agent{ label rocmnode("gfx90a") }
                     steps{
                         buildHipClangJobAndReboot(setup_flags: Full_test + Fp16_flags, build_env: WORKAROUND_iGemm_936, build_install: "true", gpu_arch: "gfx90a:xnack-")
@@ -740,91 +886,129 @@ pipeline {
             }
         }
 
-        stage("MIOpenTensile"){
-            when { expression { params.MIOPENTENSILE } }
+        stage("MIOpenTensile") {
+            when {
+                expression { params.MIOPENTENSILE }
+            }
             environment{
                 Tensile_version = "default"
             }
             parallel{
                 stage('Fp32 Hip Tensile All Vega20') {
-                    when { expression { params.TARGET_VEGA20 } }
+                    when {
+                        beforeAgent true
+                        expression { params.TARGET_VEGA20 }
+                    }
                     agent{ label rocmnode("vega20") }
                     steps{
                         buildHipClangJobAndReboot( setup_flags: Tensile_setup + Full_test, build_env: Tensile_build_env, test_flags: ' --verbose ', gpu_arch:"gfx906:xnack-", miotensile_version: Tensile_version, target_id: "ON")
                     }
                 }
                 stage('Fp16 Hip Tensile All Vega20') {
-                    when { expression { params.TARGET_VEGA20 } }
+                    when {
+                        beforeAgent true
+                        expression { params.TARGET_VEGA20 }
+                    }
                     agent{ label rocmnode("vega20") }
                     steps{
                         buildHipClangJobAndReboot( setup_flags: Tensile_setup + Full_test + Fp16_flags, build_env: Tensile_build_env, test_flags: ' --verbose ', gpu_arch:"gfx906:xnack-", miotensile_version: Tensile_version, target_id: "ON")
                     }
                 }
                 stage('Bf16 Hip Tensile All Vega20') {
-                    when { expression { params.TARGET_VEGA20 } }
+                    when {
+                        beforeAgent true
+                        expression { params.TARGET_VEGA20 }
+                    }
                     agent{ label rocmnode("vega20") }
                     steps{
                         buildHipClangJobAndReboot( setup_flags: Tensile_setup + Full_test + extra_log_env + Bf16_flags, build_env: Tensile_build_env, test_flags: ' --verbose ', gpu_arch:"gfx906:xnack-", miotensile_version: Tensile_version, target_id: "ON")
                     }
                 }
                 stage('Int8 Hip Tensile All Vega20') {
-                    when { expression { params.TARGET_VEGA20 } }
+                    when {
+                        beforeAgent true
+                        expression { params.TARGET_VEGA20 }
+                    }
                     agent{ label rocmnode("vega20") }
                     steps{
                         buildHipClangJobAndReboot( setup_flags: Tensile_setup + Full_test + extra_log_env + Int8_flags, build_env: Tensile_build_env, test_flags: ' --verbose ', gpu_arch:"gfx906:xnack-", miotensile_version: Tensile_version, target_id: "ON")
                     }
                 }
                 stage('Fp32 Hip Tensile All gfx908') {
-                    when { expression { params.TARGET_GFX908 } }
+                    when {
+                        beforeAgent true
+                        expression { params.TARGET_GFX908 }
+                    }
                     agent{ label rocmnode("gfx908") }
                     steps{
                         buildHipClangJobAndReboot( setup_flags: Tensile_setup + Full_test + extra_log_env, build_env: Tensile_build_env + extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx908:xnack-", miotensile_version: Tensile_version, target_id: "ON")
                     }
                 }
                 stage('Fp16 Hip Tensile All gfx908') {
-                    when { expression { params.TARGET_GFX908 } }
+                    when {
+                        beforeAgent true
+                        expression { params.TARGET_GFX908 }
+                    }
                     agent{ label rocmnode("gfx908") }
                     steps{
                         buildHipClangJobAndReboot( setup_flags: Tensile_setup + Full_test + extra_log_env + Fp16_flags, build_env: Tensile_build_env + extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx908:xnack-", miotensile_version: Tensile_version, target_id: "ON")
                     }
                 }
                 stage('Bf16 Hip Tensile All gfx908') {
-                    when { expression { params.TARGET_GFX908 } }
+                    when {
+                        beforeAgent true
+                        expression { params.TARGET_GFX908 }
+                    }
                     agent{ label rocmnode("gfx908") }
                     steps{
                         buildHipClangJobAndReboot( setup_flags: Tensile_setup + Full_test + extra_log_env + Bf16_flags, build_env: Tensile_build_env + extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx908:xnack-", miotensile_version: Tensile_version, target_id: "ON")
                     }
                 }
                 stage('Int8 Hip Tensile All gfx908') {
-                    when { expression { params.TARGET_GFX908 } }
+                    when {
+                        beforeAgent true
+                        expression { params.TARGET_GFX908 }
+                    }
                     agent{ label rocmnode("gfx908") }
                     steps{
                         buildHipClangJobAndReboot( setup_flags: Tensile_setup + Full_test + extra_log_env + Int8_flags, build_env: Tensile_build_env + extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx908:xnack-", miotensile_version: Tensile_version, target_id: "ON")
                     }
                 }
                 // stage('Fp32 Hip Tensile All gfx90a') {
-                //     when { expression { params.TARGET_GFX90A } }
+                //     when {
+                //         beforeAgent true
+                //         expression { params.TARGET_GFX90A }
+                //     }
                 //     agent{ label rocmnode("gfx90a") }
                 //     steps{
                 //         buildHipClangJobAndReboot( setup_flags: Tensile_setup + Full_test + extra_log_env, build_env: Tensile_build_env + extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx90a:xnack-", miotensile_version: Tensile_version, target_id: "ON")
                 //     }
                 // }
                 // stage('Fp16 Hip Tensile All gfx90a') {
-                //     when { expression { params.TARGET_GFX90A } }
+                //     when {
+                //         beforeAgent true
+                //         expression { params.TARGET_GFX90A }
+                //     }
                 //     agent{ label rocmnode("gfx90a") }
                 //     steps{
                 //         buildHipClangJobAndReboot( setup_flags: Tensile_setup + Full_test + extra_log_env + Fp16_flags, build_env: Tensile_build_env + extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx90a:xnack-", miotensile_version: Tensile_version, target_id: "ON")
                 //     }
                 // }
                 // stage('Bf16 Hip Tensile All gfx90a') {
-                //     when { expression { params.TARGET_GFX90A } }
+                //     when {
+                //         beforeAgent true
+                //         expression { params.TARGET_GFX90A }
+                //     }
                 //     agent{ label rocmnode("gfx90a") }
                 //     steps{
                 //         buildHipClangJobAndReboot( setup_flags: Tensile_setup + Full_test + extra_log_env + Bf16_flags, build_env: Tensile_build_env + extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx90a:xnack-", miotensile_version: Tensile_version, target_id: "ON")
                 //     }
                 // }
                 // stage('Int8 Hip Tensile All gfx90a') {
-                //     when { expression { params.TARGET_GFX90A } }
+                //     when {
+                //         beforeAgent true
+                //         expression { params.TARGET_GFX90A }
+                //     }
                 //     agent{ label rocmnode("gfx90a") }
                 //     steps{
                 //         buildHipClangJobAndReboot( setup_flags: Tensile_setup + Full_test + extra_log_env + Int8_flags, build_env: Tensile_build_env + extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx90a:xnack-", miotensile_version: Tensile_version, target_id: "ON")
@@ -832,91 +1016,129 @@ pipeline {
                 // }
             }
         }
-        stage("MIOpenTensile Latest"){
-            when { expression { params.MIOPENTENSILE_LATEST  } }
+        stage("MIOpenTensile Latest") {
+            when {
+                expression { params.MIOPENTENSILE_LATEST  }
+            }
             environment{
                 Tensile_version = "latest"
             }
             parallel{
                 stage('Fp32 Hip Tensile-Latest All Vega20') {
-                    when { expression { params.TARGET_VEGA20 } }
+                    when {
+                        beforeAgent true
+                        expression { params.TARGET_VEGA20 }
+                    }
                     agent{ label rocmnode("vega20") }
                     steps{
                         buildHipClangJobAndReboot( setup_flags: Tensile_setup + Full_test, build_env: Tensile_build_env, test_flags: ' --verbose ', gpu_arch:"gfx906:xnack-", miotensile_version: Tensile_version, target_id: "ON")
                     }
                 }
                 stage('Fp16 Hip Tensile-Latest All Vega20') {
-                    when { expression { params.TARGET_VEGA20 } }
+                    when {
+                        beforeAgent true
+                        expression { params.TARGET_VEGA20 }
+                    }
                     agent{ label rocmnode("vega20") }
                     steps{
                         buildHipClangJobAndReboot( setup_flags: Tensile_setup + Full_test + Fp16_flags, build_env: Tensile_build_env, test_flags: ' --verbose ', gpu_arch:"gfx906:xnack-", miotensile_version: Tensile_version, target_id: "ON")
                     }
                 }
                 stage('Bf16 Hip Tensile-Latest All Vega20') {
-                    when { expression { params.TARGET_VEGA20 } }
+                    when {
+                        beforeAgent true
+                        expression { params.TARGET_VEGA20 }
+                    }
                     agent{ label rocmnode("vega20") }
                     steps{
                         buildHipClangJobAndReboot( setup_flags: Tensile_setup + Full_test + extra_log_env + Bf16_flags, build_env: Tensile_build_env, test_flags: ' --verbose ', gpu_arch:"gfx906:xnack-", miotensile_version: Tensile_version, target_id: "ON")
                     }
                 }
                 stage('Int8 Hip Tensile-Latest All Vega20') {
-                    when { expression { params.TARGET_VEGA20 } }
+                    when {
+                        beforeAgent true
+                        expression { params.TARGET_VEGA20 }
+                    }
                     agent{ label rocmnode("vega20") }
                     steps{
                         buildHipClangJobAndReboot( setup_flags: Tensile_setup + Full_test + extra_log_env + Int8_flags, build_env: Tensile_build_env, test_flags: ' --verbose ', gpu_arch:"gfx906:xnack-", miotensile_version: Tensile_version, target_id: "ON")
                     }
                 }
                 stage('Fp32 Hip Tensile-Latest All gfx908') {
-                    when { expression { params.TARGET_GFX908 } }
+                    when {
+                        beforeAgent true
+                        expression { params.TARGET_GFX908 }
+                    }
                     agent{ label rocmnode("gfx908") }
                     steps{
                         buildHipClangJobAndReboot( setup_flags: Tensile_setup + Full_test + extra_log_env, build_env: Tensile_build_env + extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx908:xnack-", miotensile_version: Tensile_version, target_id: "ON")
                     }
                 }
                 stage('Fp16 Hip Tensile-Latest All gfx908') {
-                    when { expression { params.TARGET_GFX908 } }
+                    when {
+                        beforeAgent true
+                        expression { params.TARGET_GFX908 }
+                    }
                     agent{ label rocmnode("gfx908") }
                     steps{
                         buildHipClangJobAndReboot( setup_flags: Tensile_setup + Full_test + extra_log_env + Fp16_flags, build_env: Tensile_build_env + extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx908:xnack-", miotensile_version: Tensile_version, target_id: "ON")
                     }
                 }
                 stage('Bf16 Hip Tensile-Latest All gfx908') {
-                    when { expression { params.TARGET_GFX908 } }
+                    when {
+                        beforeAgent true
+                        expression { params.TARGET_GFX908 }
+                    }
                     agent{ label rocmnode("gfx908") }
                     steps{
                         buildHipClangJobAndReboot( setup_flags: Tensile_setup + Full_test + extra_log_env + Bf16_flags, build_env: Tensile_build_env + extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx908:xnack-", miotensile_version: Tensile_version, target_id: "ON")
                     }
                 }
                 stage('Int8 Hip Tensile-Latest All gfx908') {
-                    when { expression { params.TARGET_GFX908 } }
+                    when {
+                        beforeAgent true
+                        expression { params.TARGET_GFX908 }
+                    }
                     agent{ label rocmnode("gfx908") }
                     steps{
                         buildHipClangJobAndReboot( setup_flags: Tensile_setup + Full_test + extra_log_env + Int8_flags, build_env: Tensile_build_env + extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx908:xnack-", miotensile_version: Tensile_version, target_id: "ON")
                     }
                 }
                 // stage('Fp32 Hip Tensile-Latest All gfx90a') {
-                //     when { expression { params.TARGET_GFX90A } }
+                //     when {
+                //         beforeAgent true
+                //         expression { params.TARGET_GFX90A }
+                //     }
                 //     agent{ label rocmnode("gfx90a") }
                 //     steps{
                 //         buildHipClangJobAndReboot( setup_flags: Tensile_setup + Full_test + extra_log_env, build_env: Tensile_build_env + extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx90a:xnack-", miotensile_version: Tensile_version, target_id: "ON")
                 //     }
                 // }
                 // stage('Fp16 Hip Tensile-Latest All gfx90a') {
-                //     when { expression { params.TARGET_GFX90A } }
+                //     when {
+                //         beforeAgent true
+                //         expression { params.TARGET_GFX90A }
+                //     }
                 //     agent{ label rocmnode("gfx90a") }
                 //     steps{
                 //         buildHipClangJobAndReboot( setup_flags: Tensile_setup + Full_test + extra_log_env + Fp16_flags, build_env: Tensile_build_env + extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx90a:xnack-", miotensile_version: Tensile_version, target_id: "ON")
                 //     }
                 // }
                 // stage('Bf16 Hip Tensile-Latest All gfx90a') {
-                //     when { expression { params.TARGET_GFX90A } }
+                //     when {
+                //         beforeAgent true
+                //         expression { params.TARGET_GFX90A }
+                //     }
                 //     agent{ label rocmnode("gfx90a") }
                 //     steps{
                 //         buildHipClangJobAndReboot( setup_flags: Tensile_setup + Full_test + extra_log_env + Bf16_flags, build_env: Tensile_build_env + extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx90a:xnack-", miotensile_version: Tensile_version, target_id: "ON")
                 //     }
                 // }
                 // stage('Int8 Hip Tensile-Latest All gfx90a') {
-                //     when { expression { params.TARGET_GFX90A } }
+                //     when {
+                //         beforeAgent true
+                //         expression { params.TARGET_GFX90A }
+                //     }
                 //     agent{ label rocmnode("gfx90a") }
                 //     steps{
                 //         buildHipClangJobAndReboot( setup_flags: Tensile_setup + Full_test + extra_log_env + Int8_flags, build_env: Tensile_build_env + extra_log_env, test_flags: ' --verbose ', gpu_arch: "gfx90a:xnack-", miotensile_version: Tensile_version, target_id: "ON")
@@ -924,8 +1146,10 @@ pipeline {
                 // }
             }
         }
-        stage("Packages"){
-            when { expression { params.PACKAGES && params.TARGET_NOGPU } }
+        stage("Packages") {
+            when {
+                expression { params.PACKAGES && params.TARGET_NOGPU }
+            }
             parallel {
                 stage('OpenCL Package') {
                     agent{ label rocmnode("nogpu") }
@@ -933,7 +1157,7 @@ pipeline {
                         buildHipClangJobAndReboot(compiler: 'g++', package_build: "true", gpu_arch: "gfx900;gfx906;gfx908;gfx90a")
                     }
                 }
-                stage("HIP Package /opt/rocm"){
+                stage("HIP Package /opt/rocm") {
                     agent{ label rocmnode("nogpu") }
                     steps{
                         buildHipClangJobAndReboot( package_build: "true", prefixpath: '/opt/rocm', gpu_arch: "gfx900;gfx906;gfx908;gfx90a")


### PR DESCRIPTION
- [CI] HOTFIX: Create `render` group in the docker image. Add jenkins user to `render` group for Ubuntu 20.04. 
- [CI] Fix: evaluate TARGET param in 'when' before entering agent.
- [CI] Fix strange syntax errors

Resolves the following issues:
- :red_circle: CI fails on nodes with Ubuntu 20.04 (I see this on gfx90a nodes at least)
- :yellow_circle: CI tests takes too long time if subset of TARGETS is selected

### CI fails on nodes with Ubuntu 20.04

See https://rocmdocs.amd.com/en/latest/Installation_Guide/Installation-Guide.html#setting-permissions-for-groups.

### CI tests takes too long time if subset of TARGETS is selected

> @junliume ...observed here: jenkins / MLLibs/MIOpen / wip-rocmtest-trial-vega10 / #50 (amd.com).  It seem that several parallel stages are queued where they should not...
>
> Run `#50` timed out after 5 hours. Yes, the three “green” ones are needed and correct behavior. However, after these three are finished, it seems that the Smoke FP32 stage is “waiting” for the following stages to begin:
> - Fp32 Hip Debug gfx908 /opt/rocm
> - Fp32 OpenCL Debug gfx1030
> - Fp32 OpenCL gfx908
>
> These three stages are MI100 and should not run with Vega10 trial branch, right? I thought the correct behavior would be moving on to the next parallel stage, but the #50 pipeline stuck at Smoke FP32 till 5 hours time out.

For normal development/testing process, the issue only happens when you manually de-select one or more TARGET parameters for testing. ~However this seriously affects the `wip-rocmtest-trial-*` branches and therefore may hinder DevOps (which use the trial branches often).~

