### PR TITLE
[MLIR] Implement tuning - step 5 of 5: wrw, nonxdlops + xdlops

### DIFF
--- a/src/include/miopen/solver.hpp
+++ b/src/include/miopen/solver.hpp
@@ -982,13 +982,27 @@ struct ConvHipImplicitGemmMlirCppWrW : SolverBase<ConvolutionContext>
 struct ConvMlirIgemmWrW : SolverBase<ConvolutionContext>
 {
     bool IsApplicable(const ConvolutionContext& ctx) const;
-    ConvSolution GetSolution(const ConvolutionContext& ctx) const;
+    PerformanceConvMlirIgemm GetPerformanceConfig(const ConvolutionContext& ctx) const;
+    bool IsValidPerformanceConfig(const ConvolutionContext& ctx,
+                                  const PerformanceConvMlirIgemm& config) const;
+    PerformanceConvMlirIgemm Search(const ConvolutionContext&,
+                                    const AnyInvokeParams& invoke_ctx) const;
+    ConvSolution GetSolution(const ConvolutionContext& ctx,
+                             const PerformanceConvMlirIgemm& config,
+                             bool disableConfigOverrideFromEnv = false) const;
 };
 
 struct ConvMlirIgemmWrWXdlops : SolverBase<ConvolutionContext>
 {
     bool IsApplicable(const ConvolutionContext& ctx) const;
-    ConvSolution GetSolution(const ConvolutionContext& ctx) const;
+    PerformanceConvMlirIgemmXdlops GetPerformanceConfig(const ConvolutionContext& ctx) const;
+    bool IsValidPerformanceConfig(const ConvolutionContext& ctx,
+                                  const PerformanceConvMlirIgemmXdlops& config) const;
+    PerformanceConvMlirIgemmXdlops Search(const ConvolutionContext&,
+                                          const AnyInvokeParams& invoke_ctx) const;
+    ConvSolution GetSolution(const ConvolutionContext& ctx,
+                             const PerformanceConvMlirIgemmXdlops& config,
+                             bool disableConfigOverrideFromEnv = false) const;
 };
 
 struct PerformanceImplicitGemmXdlops : Serializable<PerformanceImplicitGemmXdlops>

--- a/src/solver/conv_mlir_igemm_wrw.cpp
+++ b/src/solver/conv_mlir_igemm_wrw.cpp
@@ -28,6 +28,7 @@
 #include <miopen/conv/wrw_invoke_params.hpp>
 #include <miopen/config.h>
 #include <miopen/env.hpp>
+#include <miopen/generic_search.hpp>
 #include <miopen/solver.hpp>
 #include <miopen/solver/implicitgemm_util.hpp>
 #include <miopen/solver/mlir_common.hpp>
@@ -54,7 +55,28 @@ bool ConvMlirIgemmWrW::IsApplicable(const ConvolutionContext& ctx) const
 #endif
 }
 
-ConvSolution ConvMlirIgemmWrW::GetSolution(const ConvolutionContext& ctx) const
+PerformanceConvMlirIgemm ConvMlirIgemmWrW::GetPerformanceConfig(const ConvolutionContext& ctx) const
+{
+    std::ignore = ctx;
+    return PerformanceConvMlirIgemm::MlirHeuristicInitRequest();
+}
+
+bool ConvMlirIgemmWrW::IsValidPerformanceConfig(const ConvolutionContext& ctx,
+                                                const PerformanceConvMlirIgemm& config) const
+{
+    MIOPEN_LOG_I("");
+    return config.IsValid(ctx);
+}
+
+PerformanceConvMlirIgemm ConvMlirIgemmWrW::Search(const ConvolutionContext& ctx,
+                                                  const AnyInvokeParams& invoke_ctx) const
+{
+    return GenericSearch(*this, ctx, invoke_ctx);
+}
+
+ConvSolution ConvMlirIgemmWrW::GetSolution(const ConvolutionContext& ctx,
+                                           const PerformanceConvMlirIgemm& config,
+                                           bool) const
 {
 #if MIOPEN_USE_MLIR
     ConvSolution result;
@@ -62,7 +84,7 @@ ConvSolution ConvMlirIgemmWrW::GetSolution(const ConvolutionContext& ctx) const
 
     construction_parameters.kernel_name  = mlir::GetKernelName(ctx, false);
     construction_parameters.kernel_file = construction_parameters.kernel_name + ".mlir";
-    construction_parameters.comp_options = mlir::ConstructBuildOptions(ctx, false);
+    construction_parameters.comp_options = mlir::ConstructBuildOptions(ctx, config, false);
 
     size_t local_size  = 0;
     size_t global_size = 0;
@@ -81,6 +103,7 @@ ConvSolution ConvMlirIgemmWrW::GetSolution(const ConvolutionContext& ctx) const
     return result;
 #else
     std::ignore = ctx;
+    std::ignore = config;
     return {};
 #endif
 }

--- a/src/solver/conv_mlir_igemm_wrw_xdlops.cpp
+++ b/src/solver/conv_mlir_igemm_wrw_xdlops.cpp
@@ -28,6 +28,7 @@
 #include <miopen/conv/wrw_invoke_params.hpp>
 #include <miopen/config.h>
 #include <miopen/env.hpp>
+#include <miopen/generic_search.hpp>
 #include <miopen/mlir_build.hpp>
 #include <miopen/solver.hpp>
 #include <miopen/solver/implicitgemm_util.hpp>
@@ -57,7 +58,30 @@ bool ConvMlirIgemmWrWXdlops::IsApplicable(const ConvolutionContext& ctx) const
 #endif
 }
 
-ConvSolution ConvMlirIgemmWrWXdlops::GetSolution(const ConvolutionContext& ctx) const
+PerformanceConvMlirIgemmXdlops
+ConvMlirIgemmWrWXdlops::GetPerformanceConfig(const ConvolutionContext& ctx) const
+{
+    std::ignore = ctx;
+    return PerformanceConvMlirIgemmXdlops::MlirHeuristicInitRequest();
+}
+
+bool ConvMlirIgemmWrWXdlops::IsValidPerformanceConfig(
+    const ConvolutionContext& ctx, const PerformanceConvMlirIgemmXdlops& config) const
+{
+    MIOPEN_LOG_I("");
+    return config.IsValid(ctx);
+}
+
+PerformanceConvMlirIgemmXdlops
+ConvMlirIgemmWrWXdlops::Search(const ConvolutionContext& ctx,
+                               const AnyInvokeParams& invoke_ctx) const
+{
+    return GenericSearch(*this, ctx, invoke_ctx);
+}
+
+ConvSolution ConvMlirIgemmWrWXdlops::GetSolution(const ConvolutionContext& ctx,
+                                                 const PerformanceConvMlirIgemmXdlops& config,
+                                                 bool) const
 {
 #if MIOPEN_USE_MLIR
     ConvSolution result;
@@ -65,7 +89,7 @@ ConvSolution ConvMlirIgemmWrWXdlops::GetSolution(const ConvolutionContext& ctx) 
 
     construction_parameters.kernel_name  = mlir::GetKernelName(ctx, true);
     construction_parameters.kernel_file = construction_parameters.kernel_name + ".mlir";
-    construction_parameters.comp_options = mlir::ConstructBuildOptions(ctx, true);
+    construction_parameters.comp_options = mlir::ConstructBuildOptions(ctx, config, true);
 
     size_t local_size  = 0;
     size_t global_size = 0;
@@ -84,6 +108,7 @@ ConvSolution ConvMlirIgemmWrWXdlops::GetSolution(const ConvolutionContext& ctx) 
     return result;
 #else
     std::ignore = ctx;
+    std::ignore = config;
     return {};
 #endif
 }


### PR DESCRIPTION
#### Change description

- Enabled tuning for wrw, and wrw xdlops solver
  - Reused the previously available `PerformanceConvMlirIgemm` for wrw solver
  - Reused the previously available `PerformanceConvMlirIgemmXdlops` for wrw xdlops solver

#### Test on `ConvMlirIgemmWrW`
```bash
MIOPEN_FIND_ENFORCE=4 MIOPEN_DRIVER_USE_GPU_REFERENCE=1 MIOPEN_LOG_LEVEL=6 MIOPEN_FIND_MODE=1 MIOPEN_DEBUG_FIND_ONLY_SOLVER=ConvMlirIgemmWrW ./bin/MIOpenDriver conv -F 4 -n 256 -c 64 -H 56 -W 56 -k 64 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -t 1 -V 1
```

> MIOpen(HIP): Warning [GenericSearch] Done: 21/0/21, best # 7 235.356 128,64,32,16,2,2

#### Test on `ConvMlirIgemmWrWXdlops`
```bash
MIOPEN_FIND_ENFORCE=4 MIOPEN_DRIVER_USE_GPU_REFERENCE=1 MIOPEN_LOG_LEVEL=6 MIOPEN_FIND_MODE=1 MIOPEN_DEBUG_FIND_ONLY_SOLVER=ConvMlirIgemmWrWXdlops ./bin/MIOpenDriver conv -F 4 -n 256 -c 64 -H 56 -W 56 -k 64 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -t 1 -V 1
```

> MIOpen(HIP): Warning [GenericSearch] Done: 88/0/88, best # 39 1.01337 64,64,8,32,64,4,1,1

----

Previous PR this series: 
 - #1075
 - #1139
 - #1152
 - #1159
