### PR TITLE
accept list of solvers in MIOPEN_DEBUG_FIND_ONLY_SOLVER

### DIFF
--- a/src/convolution.cpp
+++ b/src/convolution.cpp
@@ -287,7 +287,7 @@ bool ConvolutionDescriptor::IsWinograd3x3SupportedAndFast(miopen::ConvolutionCon
 
     // Disable this performance optimization when we want to run some specific Solver.
     // Other Solvers will be skipped anyway.
-    if(GetEnvFindOnlySolver().IsValid())
+    if(GetEnvFindOnlySolver())
         return false;
 
     // Filter out configs where 3x3 Winograd does not have high WTI.

--- a/src/find_controls.cpp
+++ b/src/find_controls.cpp
@@ -31,6 +31,9 @@
 #include <miopen/logger.hpp>
 #include <miopen/env.hpp>
 #include <miopen/solver_id.hpp>
+#include <miopen/stringutils.hpp>
+
+#include <boost/optional.hpp>
 
 #include <ostream>
 #include <cstdlib>
@@ -97,29 +100,45 @@ FindEnforceAction GetFindEnforceAction()
     return val;
 }
 
-solver::Id GetEnvFindOnlySolverImpl()
+boost::optional<std::vector<solver::Id>> GetEnvFindOnlySolverImpl()
 {
     static_assert(miopen::solver::Id::invalid_value == 0, "miopen::solver::Id::invalid_value == 0");
     const char* const p_asciz = miopen::GetStringEnv(MIOPEN_DEBUG_FIND_ONLY_SOLVER{});
+    std::vector<solver::Id> res;
     if(p_asciz != nullptr && strlen(p_asciz) > 0)
     {
-        auto numeric_id = std::strtoul(p_asciz, nullptr, 10);
-        if(errno == ERANGE || numeric_id == 0)
-        { // Assume string in the environment. Try to convert it to numeric id.
-            errno      = 0;
-            numeric_id = solver::Id{p_asciz}.Value();
+        const auto solver_list = miopen::SplitDelim(std::string(p_asciz), ';');
+        for(const auto& kinder : solver_list)
+        {
+            auto numeric_id = std::strtoul(kinder.c_str(), nullptr, 10);
+            if(errno == ERANGE || numeric_id == 0)
+            { // Assume string in the environment. Try to convert it to numeric id.
+                errno      = 0;
+                numeric_id = solver::Id{kinder}.Value();
+            }
+            else
+            { // Non-zero value, assume numeric id. Check if it denotes a solver.
+                numeric_id = solver::Id{solver::Id{numeric_id}.ToString()}.Value();
+            }
+            if(numeric_id != 0)
+                MIOPEN_LOG_NQI(numeric_id);
+            else
+                MIOPEN_THROW(miopenStatusBadParm,
+                             "Invalid value of MIOPEN_DEBUG_FIND_ONLY_SOLVER: " + kinder);
+            const auto id = solver::Id{numeric_id};
+            if(id.IsValid())
+                res.push_back(id);
+            else
+            {
+                MIOPEN_THROW(miopenStatusBadParm,
+                             "Invalid MIOPEN_DEBUG_FIND_ONLY_SOVER specified: " + kinder);
+            }
         }
-        else
-        { // Non-zero value, assume numeric id. Check if it denotes a solver.
-            numeric_id = solver::Id{solver::Id{numeric_id}.ToString()}.Value();
-        }
-        if(numeric_id != 0)
-            MIOPEN_LOG_NQI(numeric_id);
-        else
-            MIOPEN_THROW(miopenStatusBadParm, "Invalid value of MIOPEN_DEBUG_FIND_ONLY_SOLVER");
-        return {numeric_id};
     }
-    return {};
+    if(res.empty())
+        return boost::none;
+    else
+        return {res};
 }
 
 } // namespace
@@ -131,7 +150,7 @@ std::ostream& operator<<(std::ostream& os, const FindEnforce& val)
     return os << ToCString(val.action) << '(' << static_cast<int>(val.action) << ')';
 }
 
-solver::Id GetEnvFindOnlySolver()
+boost::optional<std::vector<solver::Id>> GetEnvFindOnlySolver()
 {
     static const auto once = GetEnvFindOnlySolverImpl();
     return once;

--- a/src/include/miopen/find_controls.hpp
+++ b/src/include/miopen/find_controls.hpp
@@ -29,6 +29,9 @@
 
 #include <miopen/logger.hpp>
 #include <miopen/solver_id.hpp>
+
+#include <boost/optional.hpp>
+
 #include <ostream>
 
 namespace miopen {
@@ -100,7 +103,7 @@ class FindEnforce
     friend std::ostream& operator<<(std::ostream&, const FindEnforce&);
 };
 
-solver::Id GetEnvFindOnlySolver();
+boost::optional<std::vector<solver::Id>> GetEnvFindOnlySolver();
 
 class FindMode
 {

--- a/src/include/miopen/find_solution.hpp
+++ b/src/include/miopen/find_solution.hpp
@@ -147,7 +147,9 @@ struct SolverContainer
             [&](auto solver) {
                 if(count >= limit)
                     return;
-                if(find_only.IsValid() && find_only != Id{SolverDbId(solver)})
+                if(find_only &&
+                   (std::find(find_only->begin(), find_only->end(), Id{SolverDbId(solver)}) ==
+                    find_only->end()))
                 { // Do nothing (and keep silence for the sake of Tuna), just skip.
                 }
                 // For better performance, check IsDynamic() first, because
@@ -195,7 +197,9 @@ struct SolverContainer
             [&](auto solver) {
                 if(count >= limit)
                     return;
-                if(find_only.IsValid() && find_only != Id{SolverDbId(solver)})
+                if(find_only &&
+                   (std::find(find_only->begin(), find_only->end(), Id{SolverDbId(solver)}) ==
+                    find_only->end()))
                 { // Do nothing (and keep silence for the sake of Tuna), just skip.
                 }
                 // For better performance, check IsDynamic() first, because
@@ -237,7 +241,9 @@ struct SolverContainer
                 if(count >= limit)
                     return;
 
-                if(find_only.IsValid() && find_only != Id{SolverDbId(solver)})
+                if(find_only &&
+                   (std::find(find_only->begin(), find_only->end(), Id{SolverDbId(solver)}) ==
+                    find_only->end()))
                 { // Do nothing (and keep silence for the sake of Tuna), just skip.
                 }
                 else if(!solver.IsApplicable(search_params))
@@ -265,7 +271,9 @@ struct SolverContainer
 
         miopen::each_args(
             [&](auto solver) {
-                if(found || (find_only.IsValid() && find_only != Id{SolverDbId(solver)}))
+                if(found || (find_only && (std::find(find_only->begin(),
+                                                     find_only->end(),
+                                                     Id{SolverDbId(solver)}) == find_only->end())))
                     return;
 
                 // For better performance, check IsDynamic() first, because

--- a/src/include/miopen/stringutils.hpp
+++ b/src/include/miopen/stringutils.hpp
@@ -129,6 +129,19 @@ inline std::vector<std::string> SplitSpaceSeparated(const std::string& in,
     return rv;
 }
 
+inline std::vector<std::string> SplitDelim(const std::string& in, const char delim)
+{
+    std::vector<std::string> rv;
+    std::string token;
+    std::istringstream ss(in);
+
+    while(std::getline(ss, token, delim))
+    {
+        rv.push_back(token);
+    }
+    return rv;
+}
+
 } // namespace miopen
 
 #endif // GUARD_MIOPEN_STRINGUTILS_HPP


### PR DESCRIPTION
This PR allows MIOPEN_DEBUG_FIND_ONLY_SOLVER to comprise of multiple solvers separated by semicolon. For example, when debugging issues in frameworks, one needs multiple solvers (different directions). This PR enables such a functionality.