### PR TITLE
[MLIR] Bump ROCm version to 4.3.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN dpkg --add-architecture i386
 # unless MLIR library is incompatible with current ROCm.
 
 RUN if [ "$USE_MLIR" = "ON" ] ; \
-        then export ROCM_APT_VER=.apt_4.2;\
+        then export ROCM_APT_VER=.apt_4.3.1;\
     else export ROCM_APT_VER=.apt_4.3.1;  \
     fi && \
 echo $ROCM_APT_VER &&\


### PR DESCRIPTION
I get reminded by @JehandadKhan that MLIR used a different ROCm version then rest of stages. Bumping them to parallel version now.