### PR TITLE
[Tuning] Remove Solver ConvHipImplicitGemmBwdDataV4R1Xdlops FP32

### DIFF
--- a/src/solver/conv_hip_implicit_gemm_bwd_v4r1_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_bwd_v4r1_xdlops.cpp
@@ -30,10 +30,6 @@
 #include <miopen/solver/implicitgemm_util.hpp>
 #include <cstddef>
 
-/// Disable ConvHipImplicitGemmBwdDataV4R1Xdlops by default.
-/// \ref https://github.com/ROCmSoftwarePlatform/MIOpen/issues/1206.
-#define WORKAROUND_ISSUE_1206 1
-
 MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_BWD_V4R1_XDLOPS)
 
 namespace miopen {
@@ -808,11 +804,7 @@ ConvHipImplicitGemmBwdDataV4R1Xdlops::CalculateGemmSize(const ConvolutionContext
 
 bool ConvHipImplicitGemmBwdDataV4R1Xdlops::IsApplicable(const ConvolutionContext& ctx) const
 {
-#if WORKAROUND_ISSUE_1206
-    if(!miopen::IsEnabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_BWD_V4R1_XDLOPS{}))
-#else
     if(miopen::IsDisabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_BWD_V4R1_XDLOPS{}))
-#endif
         return false;
     if(ctx.skip_solutions_that_take_long_time_to_build_and_have_narrow_coverage)
         return false;


### PR DESCRIPTION
Removes FP32 ConvHipImplicitGemmBwdDataV4R1Xdlops from find_db replacing with second best Backward Data Implicit GEMM solver.