### PR TITLE
[MLIR] Enable COMGR when building with shared library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -316,8 +316,12 @@ endif()
 
 
 if(MIOPEN_USE_MLIR)
-    find_library(LIBMLIRMIOPEN MLIRMIOpen REQUIRED)
     # REQUIRED is not supported before cmake 3.18
+    find_library(LIBMLIRMIOPEN MLIRMIOpen REQUIRED)
+    if(NOT BUILD_SHARED_LIBS AND MIOPEN_USE_COMGR)
+        message(FATAL_ERROR "Potential symbol conflict between mlir and comgr in static build")
+    endif()
+
     if(NOT LIBMLIRMIOPEN)
         message(FATAL_ERROR "libMLIRMIOpen not found")
     else()

--- a/src/hipoc/hipoc_program.cpp
+++ b/src/hipoc/hipoc_program.cpp
@@ -269,8 +269,10 @@ void HIPOCProgramImpl::BuildCodeObjectInMemory(const std::string& params,
             comgr::BuildHip(filename, src, params, target, binary);
         else if(miopen::EndsWith(filename, ".s"))
             comgr::BuildAsm(filename, src, params, target, binary);
+#if MIOPEN_USE_MLIR
         else if(miopen::EndsWith(filename, ".mlir"))
-            MIOPEN_THROW(miopenStatusNotImplemented, "MLIR builds are not supported with COMgr");
+            MiirGenBin(params, binary);
+#endif
         else
             comgr::BuildOcl(filename, src, params, target, binary);
     }


### PR DESCRIPTION
I make it such that MLIR solvers can be used in when COMGR is enabled. This is so that MLIR is automatically available when COMGR becomes the default build option.
 - Added fatal error in cmake to not allow user to link with MLIR when the user is to build a static library of MIOpen
 - Amended the Jenkinsfile such that in the fp32 data type, it validate use COMGR
   - I didn't add additional stage because I believe we have other 3 stages that test non-COMGR, hip backend, which should have enough functional coverage
 -  Enabled MLIR build in `hipoc_program`

Tested locally and verified that PR work as expected.