### PR TITLE
[WORKAROUND] Enforce "no sramecc feature" for gfx900.

### DIFF
--- a/src/target_properties.cpp
+++ b/src/target_properties.cpp
@@ -30,6 +30,8 @@
 #include <map>
 #include <string>
 
+#define WORKAROUND_ISSUE_1204 1 // ROCm may incorrectly report "sramecc-" for gfx900.
+
 MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEBUG_ENFORCE_DEVICE)
 MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEVICE_ARCH)
 
@@ -85,6 +87,10 @@ void TargetProperties::Init(const Handle* const handle)
     // However we need to store the reported state, even if it is incorrect,
     // to use together with COMGR.
     sramecc_reported = [&]() -> boost::optional<bool> {
+#if WORKAROUND_ISSUE_1204
+        if(name == "gfx900")
+            return {};
+#endif
         if(rawName.find(":sramecc+") != std::string::npos)
             return true;
         if(rawName.find(":sramecc-") != std::string::npos)


### PR DESCRIPTION
This this is workaround for https://ontrack-internal.amd.com/browse/SWDEV-303062, resolves https://github.com/ROCmSoftwarePlatform/MIOpen/issues/1204#issuecomment-937746245.

@sunway513 @junliume The issue may manifest in 4.5 release. Shall we cherry-pick this to 4.5-staging? 