### PR TITLE
[Enhancement] Simplify dependencies to build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -106,7 +106,7 @@ RUN pip3 install -r /doc-requirements.txt
 
 # Use parallel job to accelerate tensile build
 # Workaround for Tensile with TargetID feature
-RUN if [ "$USE_TARGETID" = "ON" ] ; then export HIPCC_LINK_FLAGS_APPEND='-O3 -parallel-jobs=4' && export HIPCC_COMPILE_FLAGS_APPEND='-O3 -Wno-format-nonliteral -parallel-jobs=4' && rm /usr/bin/hipcc; fi
+RUN if [ "$USE_TARGETID" = "ON" ] ; then export HIPCC_LINK_FLAGS_APPEND='-O3 -parallel-jobs=4' && export HIPCC_COMPILE_FLAGS_APPEND='-O3 -Wno-format-nonliteral -parallel-jobs=4' && rm -f /usr/bin/hipcc; fi
 
 # install last released miopentensile in default (master), install latest commits when MIOTENSILE_VER="latest" (develop)
 RUN if [ "$USE_TARGETID" = "OFF" ] ; then echo "MIOpenTensile is not installed."; elif [ "$MIOTENSILE_VER" = "latest" ] ; then cget -p $PREFIX install ROCmSoftwarePlatform/MIOpenTensile@94a9047741d16a8eccd290131b78fb1aa69cdcdf; else cget -p $PREFIX install ROCmSoftwarePlatform/MIOpenTensile@94a9047741d16a8eccd290131b78fb1aa69cdcdf; fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,10 +62,10 @@ apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --allow-unau
     rocm-device-libs \
     rocm-opencl \
     rocm-opencl-dev \
-    rocm-cmake \
     rocblas \
     zlib1g-dev \
     kmod && \
+    apt-get remove -y rocm-cmake && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -80,7 +80,7 @@ RUN wget https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.
 RUN dpkg -i dumb-init_*.deb && rm dumb-init_*.deb
 
 # Install rbuild
-RUN pip3 install https://github.com/RadeonOpenCompute/rbuild/archive/92f1c1d2bd1772dcd4b94cde19cd2355cf8fe478.tar.gz
+RUN pip3 install https://github.com/RadeonOpenCompute/rbuild/archive/6d78a0553babdaea8d2da5de15cbda7e869594b8.tar.gz
 
 # Add symlink to /opt/rocm
 RUN [ -d /opt/rocm ] || ln -sd $(realpath /opt/rocm-*) /opt/rocm

--- a/Dockerfile
+++ b/Dockerfile
@@ -79,8 +79,8 @@ ENV LANG=C.UTF-8
 RUN wget https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64.deb
 RUN dpkg -i dumb-init_*.deb && rm dumb-init_*.deb
 
-# Install cget
-RUN pip3 install cget
+# Install rbuild
+RUN pip3 install https://github.com/RadeonOpenCompute/rbuild/archive/92f1c1d2bd1772dcd4b94cde19cd2355cf8fe478.tar.gz
 
 # Add symlink to /opt/rocm
 RUN [ -d /opt/rocm ] || ln -sd $(realpath /opt/rocm-*) /opt/rocm
@@ -88,18 +88,17 @@ RUN [ -d /opt/rocm ] || ln -sd $(realpath /opt/rocm-*) /opt/rocm
 # Make sure /opt/rcom is in the paths
 ENV PATH="/opt/rocm:${PATH}"
 
-# Build using hip-clang
-RUN cget -p $PREFIX init --cxx /opt/rocm/llvm/bin/clang++ --std=c++14 -DAMDGPU_TARGETS=${GPU_ARCH}
-
+# Add requirements files
+ADD rbuild.ini /rbuild.ini
+ADD requirements.txt /requirements.txt
+ADD dev-requirements.txt /dev-requirements.txt
 # Install dependencies
-RUN cget -p $PREFIX install pfultz2/rocm-recipes
-# Install a newer version of cmake for libMLIRMIOpen
-RUN cget -p $PREFIX install kitware/cmake@v3.15.1
-
-ADD min-requirements.txt /min-requirements.txt
-RUN CXXFLAGS='-isystem $PREFIX/include' cget -p $PREFIX install -f /min-requirements.txt
-RUN if [ "$USE_FIN" = "ON" ]; then cget -p $PREFIX install nlohmann/json@350ff4f7ced7c4117eae2fb93df02823c8021fcb; fi
-RUN cget -p $PREFIX install danmar/cppcheck@dd05839a7e63ef04afd34711cb3e1e0ef742882f
+# TODO: Add --std=c++14
+RUN if [ "$USE_FIN" = "ON" ]; then \
+        rbuild prepare -s fin -d $PREFIX -DAMDGPU_TARGETS=${GPU_ARCH}; \
+    else \
+        rbuild prepare -s develop -d $PREFIX -DAMDGPU_TARGETS=${GPU_ARCH}; \
+    fi
 
 # Install doc requirements
 ADD doc/requirements.txt /doc-requirements.txt

--- a/README.md
+++ b/README.md
@@ -73,17 +73,6 @@ This prefix can used to specify the dependency path during the configuration pha
 MIOpen's HIP backend uses [rocBlas](https://github.com/ROCmSoftwarePlatform/rocBLAS) by default. Users can install rocBlas minimum release by using `apt-get install rocblas`. To disable using rocBlas set the configuration flag `-DMIOPEN_USE_ROCBLAS=Off`. rocBlas is *not* available for the OpenCL backend.
 
 
-## Installing minimum dependencies in ROCm environment
-
-Users who are working in a fully installed and up to date ROCm environment may not wish to additionally install rocm-cmake, clang-ocl, MIOpenGEMM, MIOpenTensile or rocBLAS. This can be done by simply inserting the command `--minimum` into the cmake command as shown below:
-
-```
-cmake -P install_deps.cmake --minimum --prefix /some/local/dir
-```
-
-This will build the Boost and half libraries.
-
-
 ## Building MIOpen from source
 
 ### Configuring with cmake
@@ -111,24 +100,6 @@ cmake -DMIOPEN_BACKEND=OpenCL -DMIOPEN_HIP_COMPILER=<hip-compiler-path> -DOPENCL
 And an example setting the dependency path for an envirnment in ROCm 3.5 and later:
 ```
 cmake -DMIOPEN_BACKEND=OpenCL -DMIOPEN_HIP_COMPILER=/opt/rocm/llvm/bin/clang++ -DCMAKE_PREFIX_PATH=/some/local/dir ..
-```
-
-For ROCm 3.3 and earlier:
-```
-cmake -DMIOPEN_BACKEND=OpenCL -DCMAKE_PREFIX_PATH=/some/local/dir ..
-```
-
-### For the HIP backend on ROCm 3.3 and earlier, run:
-
-Set the C++ compiler to `hcc`.
-```
-export CXX=<location-of-hcc-compiler>
-cmake -DMIOPEN_BACKEND=HIP -DCMAKE_PREFIX_PATH="<hip-installed-path>;<hcc-installed-path>;<clang-ocl-installed-path>;<miopen-dependency-path>" ..
-```
-
-An example cmake step can be:
-```
-CXX=/opt/rocm/hcc/bin/hcc cmake -DMIOPEN_BACKEND=HIP -DCMAKE_PREFIX_PATH="/opt/rocm/hcc;/opt/rocm/hip;/some/local/dir" ..
 ```
 
 ### For the HIP backend on ROCm 3.5 and later, run:

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
-pfultz2/rocm-recipes
+ROCmSoftwarePlatform/rocm-recipes
 RadeonOpenCompute/rocm-cmake@cdd0f632b3a65bd4411593bb827eb664e25c80bc --build
 -f requirements.txt
 # 1.90+

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 pfultz2/rocm-recipes
-ROCm-Developer-Tools/HIP@roc-3.0.0
+RadeonOpenCompute/rocm-cmake@cdd0f632b3a65bd4411593bb827eb664e25c80bc --build
 -f requirements.txt
 # 1.90+
 danmar/cppcheck@dd05839a7e63ef04afd34711cb3e1e0ef742882f

--- a/install_deps.cmake
+++ b/install_deps.cmake
@@ -113,8 +113,4 @@ cget(init ${TOOLCHAIN_FLAG} -DCMAKE_INSTALL_RPATH=${PREFIX}/lib ${PARSE_UNPARSED
 
 # Install dependencies
 cget(install -U pfultz2/rocm-recipes)
-if(PARSE_--minimum)
-    cget(install -U -f min-requirements.txt)
-else()
-    cget(install -U -f requirements.txt)
-endif()
+cget(install -U -f requirements.txt)

--- a/min-requirements.txt
+++ b/min-requirements.txt
@@ -1,3 +1,2 @@
-sqlite3,https://sqlite.org/2017/sqlite-autoconf-3170000.tar.gz -H sha256:a4e485ad3a16e054765baf6371826b5000beed07e626510896069c0bf013874c -X autotools -DCMAKE_POSITION_INDEPENDENT_CODE=On
-boost@1.72 -DCMAKE_POSITION_INDEPENDENT_CODE=On --build
-half,https://github.com/pfultz2/half/archive/1.12.0.tar.gz -X header -H sha256:0a08660b68abb176ebc2a0cdf8de46e3182a7f46c66443bb80dbfaaec98cf969 --build
+# This file should be removed in the future
+-f requirements.txt

--- a/mlir-requirements.txt
+++ b/mlir-requirements.txt
@@ -1,3 +1,2 @@
 # Install a newer version of cmake for libMLIRMIOpen
-kitware/cmake@v3.15.1
 ROCmSoftwarePlatform/llvm-project-mlir@15a5cacc38bb3dd29e9e88f382c27c958386928a -DBUILD_FAT_LIBMLIRMIOPEN=1

--- a/mlir-requirements.txt
+++ b/mlir-requirements.txt
@@ -1,1 +1,3 @@
+# Install a newer version of cmake for libMLIRMIOpen
+kitware/cmake@v3.15.1
 ROCmSoftwarePlatform/llvm-project-mlir@15a5cacc38bb3dd29e9e88f382c27c958386928a -DBUILD_FAT_LIBMLIRMIOPEN=1

--- a/rbuild.ini
+++ b/rbuild.ini
@@ -9,6 +9,7 @@ deps =
 cxx = ${rocm_path}/llvm/bin/clang++
 cc = ${rocm_path}/llvm/bin/clang
 deps =
+    kitware/cmake@v3.15.1
     -f dev-requirements.txt
 define =
     BUILD_DEV=On
@@ -18,6 +19,7 @@ cxx = ${rocm_path}/llvm/bin/clang++
 cc = ${rocm_path}/llvm/bin/clang
 deps =
     ROCmSoftwarePlatform/rocm-recipes
+    kitware/cmake@v3.15.1
     -f dev-requirements.txt
     nlohmann/json@350ff4f7ced7c4117eae2fb93df02823c8021fcb
 

--- a/rbuild.ini
+++ b/rbuild.ini
@@ -10,6 +10,8 @@ cxx = ${rocm_path}/llvm/bin/clang++
 cc = ${rocm_path}/llvm/bin/clang
 deps =
     -f dev-requirements.txt
+define =
+    BUILD_DEV=On
 
 [fin]
 cxx = ${rocm_path}/llvm/bin/clang++

--- a/rbuild.ini
+++ b/rbuild.ini
@@ -2,7 +2,7 @@
 cxx = ${rocm_path}/llvm/bin/clang++
 cc = ${rocm_path}/llvm/bin/clang
 deps =
-    pfultz2/rocm-recipes
+    ROCmSoftwarePlatform/rocm-recipes
     -f requirements.txt
 
 [develop]
@@ -17,7 +17,7 @@ define =
 cxx = ${rocm_path}/llvm/bin/clang++
 cc = ${rocm_path}/llvm/bin/clang
 deps =
-    pfultz2/rocm-recipes
+    ROCmSoftwarePlatform/rocm-recipes
     -f dev-requirements.txt
     nlohmann/json@350ff4f7ced7c4117eae2fb93df02823c8021fcb
 

--- a/rbuild.ini
+++ b/rbuild.ini
@@ -8,6 +8,7 @@ deps =
 [develop]
 cxx = ${rocm_path}/llvm/bin/clang++
 cc = ${rocm_path}/llvm/bin/clang
+ignore = pcre
 deps =
     kitware/cmake@v3.15.1
     -f dev-requirements.txt
@@ -17,6 +18,7 @@ define =
 [fin]
 cxx = ${rocm_path}/llvm/bin/clang++
 cc = ${rocm_path}/llvm/bin/clang
+ignore = pcre
 deps =
     ROCmSoftwarePlatform/rocm-recipes
     kitware/cmake@v3.15.1

--- a/rbuild.ini
+++ b/rbuild.ini
@@ -1,0 +1,21 @@
+[main]
+cxx = ${rocm_path}/llvm/bin/clang++
+cc = ${rocm_path}/llvm/bin/clang
+deps =
+    pfultz2/rocm-recipes
+    -f requirements.txt
+
+[develop]
+cxx = ${rocm_path}/llvm/bin/clang++
+cc = ${rocm_path}/llvm/bin/clang
+deps =
+    -f dev-requirements.txt
+
+[fin]
+cxx = ${rocm_path}/llvm/bin/clang++
+cc = ${rocm_path}/llvm/bin/clang
+deps =
+    pfultz2/rocm-recipes
+    -f dev-requirements.txt
+    nlohmann/json@350ff4f7ced7c4117eae2fb93df02823c8021fcb
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,3 @@
--f min-requirements.txt
-RadeonOpenCompute/rocm-cmake@cdd0f632b3a65bd4411593bb827eb664e25c80bc --build
-RadeonOpenCompute/clang-ocl@930015924b012c332d373535ff31a663b6ad2c64
-ROCmSoftwarePlatform/MIOpenGEMM@0eb1257cfaef83ea155aabd67af4437c0028db48
-ROCmSoftwarePlatform/rocBLAS@9790a8658341bc665c11c311129ad0dfc533d5c4
-# ROCmSoftwarePlatform/MIOpenTensile@master
+sqlite3,https://sqlite.org/2017/sqlite-autoconf-3170000.tar.gz -H sha256:a4e485ad3a16e054765baf6371826b5000beed07e626510896069c0bf013874c -X autotools -DCMAKE_POSITION_INDEPENDENT_CODE=On
+boost@1.72 -DCMAKE_POSITION_INDEPENDENT_CODE=On --build
+half,https://github.com/pfultz2/half/archive/1.12.0.tar.gz -X header -H sha256:0a08660b68abb176ebc2a0cdf8de46e3182a7f46c66443bb80dbfaaec98cf969 --build


### PR DESCRIPTION
This removes the old hcc dependencies in our requirements.txt files. Now min-requirements.txt and requirements.txt are the same(we could hopefully remove this file in the future).

I also moved the cmake installation to mlir-requirements.txt, since its purpose is for mlir. I am not sure why it installs to /opt/rocm instead of `$PREFIX` but I didnt change this just in case mlir has a broken cmake installation(we should be able to install mlir to any `$PREFIX` using cget and it should work without needing private env variables(ie ROCM_PATH, HIP_PATH, etc) but I havent tested this).

This also adds an rbuild.ini file which has different sessions to build dependencies and settings. It will set the clang compiler by default(for rocm releases), so users can build by just doing `rbuild build -d deps`.

There is also a session for `fin` so it can install the additional dependencies needed for fin. You can use this session with `rbuild prepare -s fin -d deps`.

Finally, it adds a `develop` session which installs the dev-requirements.txt dependencies which include requirements.txt, cppcheck, and rocm-cmake. So now you can setup MIOpen for development with `rbuild develop -d deps -B build`.