### PR TITLE
[gfx90a][FP16] Disable Solvers that unable to comply the "ALT FP16" attribute

### DIFF
--- a/src/include/miopen/conv/problem_description.hpp
+++ b/src/include/miopen/conv/problem_description.hpp
@@ -304,6 +304,21 @@ struct ProblemDescription
                GetOutDataType() == miopenBFloat16;
     }
 
+    // To be used in Solvers that do not implement ALT FP16 kernels.
+    // Those Solvers must be non-applicable for gfx90a when this function returns true.
+    bool IsGfx90aFp16altRequired() const
+    {
+        if(!IsFp16())
+            return false;
+        if(direction == conv::Direction::Forward)
+            return conv.attribute.gfx90aFp16alt.GetFwd();
+        if(direction == conv::Direction::BackwardData)
+            return conv.attribute.gfx90aFp16alt.GetBwd();
+        if(direction == conv::Direction::BackwardWeights)
+            return conv.attribute.gfx90aFp16alt.GetWrW();
+        MIOPEN_THROW("Direction must be known!");
+    }
+
     bool IsLayoutDefault() const;
 
     void HeuristicUpdateLayouts();

--- a/src/solver/conv_asm_1x1u.cpp
+++ b/src/solver/conv_asm_1x1u.cpp
@@ -407,6 +407,9 @@ bool ConvAsm1x1U::IsApplicable(const ConvolutionContext& params) const
         return false;
     }
 
+    if(name == "gfx90a" && params.conv_problem.IsGfx90aFp16altRequired())
+        return false;
+
     const auto elements_in_dword = 4 / GetTypeSize(params.in_data_type);
     // clang-format off
     const int img_hw = params.out_height * params.out_width;

--- a/src/solver/conv_asm_1x1u_stride2.cpp
+++ b/src/solver/conv_asm_1x1u_stride2.cpp
@@ -503,6 +503,9 @@ bool ConvAsm1x1UV2::IsApplicable(const ConvolutionContext& params) const
         return false;
     }
 
+    if(name == "gfx90a" && params.conv_problem.IsGfx90aFp16altRequired())
+        return false;
+
     const auto elements_in_dword = 4 / GetTypeSize(params.in_data_type);
     // clang-format off
     const auto img_hw = params.out_height * params.out_width;

--- a/src/solver/conv_asm_dir_BwdWrW1x1.cpp
+++ b/src/solver/conv_asm_dir_BwdWrW1x1.cpp
@@ -493,6 +493,9 @@ bool ConvAsmBwdWrW1x1::IsApplicable(const ConvolutionContext& params) const
         return false;
     }
 
+    if(name == "gfx90a" && params.conv_problem.IsGfx90aFp16altRequired())
+        return false;
+
     // clang-format off
     bool ok = (params.pad_w == 0         // -q  pad_w
         && params.pad_h == 0             // -p  pad_h

--- a/src/solver/conv_asm_dir_BwdWrW3x3.cpp
+++ b/src/solver/conv_asm_dir_BwdWrW3x3.cpp
@@ -368,6 +368,9 @@ bool ConvAsmBwdWrW3x3::IsApplicable(const ConvolutionContext& params) const
         return false;
 #endif
 
+    if(name == "gfx90a" && params.conv_problem.IsGfx90aFp16altRequired())
+        return false;
+
     // clang-format off
     bool ok = params.pad_w == 1           // -q  pad_w
         && params.pad_h == 1              // -p  pad_h

--- a/src/solver/conv_bin_winoRxS.cpp
+++ b/src/solver/conv_bin_winoRxS.cpp
@@ -265,10 +265,6 @@ bool ConvBinWinogradRxS::IsApplicable(const ConvolutionContext& params) const
         }
     }
 
-    // Proactive change.
-    if(name == "gfx90a" && params.conv_problem.IsGfx90aFp16altRequired())
-        return false;
-
     // clang-format off
     if (! (params.kernel_stride_w <= 2 // -u inp_u 1 or 2
         && params.kernel_stride_w == params.kernel_stride_h

--- a/src/solver/conv_bin_winoRxS.cpp
+++ b/src/solver/conv_bin_winoRxS.cpp
@@ -265,6 +265,10 @@ bool ConvBinWinogradRxS::IsApplicable(const ConvolutionContext& params) const
         }
     }
 
+    // Proactive change.
+    if(name == "gfx90a" && params.conv_problem.IsGfx90aFp16altRequired())
+        return false;
+
     // clang-format off
     if (! (params.kernel_stride_w <= 2 // -u inp_u 1 or 2
         && params.kernel_stride_w == params.kernel_stride_h

--- a/src/solver/conv_hip_implicit_gemm_bwd_v1r1.cpp
+++ b/src/solver/conv_hip_implicit_gemm_bwd_v1r1.cpp
@@ -662,6 +662,8 @@ bool ConvHipImplicitGemmBwdDataV1R1::IsApplicable(const ConvolutionContext& ctx)
         if(ctx.IsBfp16())
             return false;
 #endif
+    if(ctx.GetStream().GetDeviceName() == "gfx90a" && ctx.conv_problem.IsGfx90aFp16altRequired())
+        return false;
 
     const auto k = ConvolutionContextInterpreter::GetOutputChannelK(ctx);
     if(k % GetEPackLength(ctx, false) != 0)

--- a/src/solver/conv_hip_implicit_gemm_bwd_v1r1_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_bwd_v1r1_xdlops.cpp
@@ -774,6 +774,9 @@ bool ConvHipImplicitGemmBwdDataV1R1Xdlops::IsApplicable(const ConvolutionContext
     if(!ctx.Is2d())
         return false;
 
+    if(ctx.GetStream().GetDeviceName() == "gfx90a" && ctx.conv_problem.IsGfx90aFp16altRequired())
+        return false;
+
     if(!IsIndexRangeLargeEnough(ctx))
         return false;
 

--- a/src/solver/conv_hip_implicit_gemm_bwd_v4r1_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_bwd_v4r1_xdlops.cpp
@@ -841,9 +841,9 @@ bool ConvHipImplicitGemmBwdDataV4R1Xdlops::IsApplicable(const ConvolutionContext
     if(!IsIndexRangeLargeEnough(ctx))
         return false;
     if(!ctx.IsLayoutDefault())
-    {
         return false;
-    }
+    if(ctx.GetStream().GetDeviceName() == "gfx90a" && ctx.conv_problem.IsGfx90aFp16altRequired())
+        return false;
 
     bool is_applicable = true;
     int gemm_g         = 0;

--- a/src/solver/conv_hip_implicit_gemm_fwd_v4r1.cpp
+++ b/src/solver/conv_hip_implicit_gemm_fwd_v4r1.cpp
@@ -57,9 +57,9 @@ bool ConvHipImplicitGemmV4R1Fwd::IsApplicable(const ConvolutionContext& ctx) con
     if(!ctx.IsFp32() && !ctx.IsFp16() && !ctx.IsBfp16())
         return false;
     if(!ctx.IsLayoutDefault())
-    {
         return false;
-    }
+    if(ctx.GetStream().GetDeviceName() == "gfx90a" && ctx.conv_problem.IsGfx90aFp16altRequired())
+        return false;
 
     std::size_t n         = ctx.batch_sz;
     std::size_t k         = ctx.n_outputs / ctx.group_counts;
@@ -95,9 +95,9 @@ bool ConvHipImplicitGemmV4R1WrW::IsApplicable(const ConvolutionContext& ctx) con
     if(!ctx.IsFp32() && !ctx.IsFp16() && !ctx.IsBfp16())
         return false;
     if(!ctx.IsLayoutDefault())
-    {
         return false;
-    }
+    if(ctx.GetStream().GetDeviceName() == "gfx90a" && ctx.conv_problem.IsGfx90aFp16altRequired())
+        return false;
 
     // retrieve dimension from ConvolutionContext
     // remember: ConvolutionContext has swapped some dimensions for you!

--- a/src/solver/conv_hip_implicit_gemm_fwd_v4r4_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_fwd_v4r4_xdlops.cpp
@@ -988,6 +988,9 @@ bool ConvHipImplicitGemmForwardV4R4Xdlops::IsApplicable(const ConvolutionContext
     if(!ctx.Is2d())
         return false;
 
+    if(ctx.GetStream().GetDeviceName() == "gfx90a" && ctx.conv_problem.IsGfx90aFp16altRequired())
+        return false;
+
     if(!IsIndexRangeLargeEnough(ctx))
         return false;
 

--- a/src/solver/conv_hip_implicit_gemm_fwd_v4r4_xdlops_padded_gemm.cpp
+++ b/src/solver/conv_hip_implicit_gemm_fwd_v4r4_xdlops_padded_gemm.cpp
@@ -1064,6 +1064,9 @@ bool ConvHipImplicitGemmForwardV4R4Xdlops_Padded_Gemm::IsApplicable(
     if(!ctx.Is2d())
         return false;
 
+    if(ctx.GetStream().GetDeviceName() == "gfx90a" && ctx.conv_problem.IsGfx90aFp16altRequired())
+        return false;
+
     if(!IsIndexRangeLargeEnough(ctx))
         return false;
 

--- a/src/solver/conv_hip_implicit_gemm_fwd_v4r5_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_fwd_v4r5_xdlops.cpp
@@ -1025,6 +1025,9 @@ bool ConvHipImplicitGemmForwardV4R5Xdlops::IsApplicable(const ConvolutionContext
     if(!ctx.Is2d())
         return false;
 
+    if(ctx.GetStream().GetDeviceName() == "gfx90a" && ctx.conv_problem.IsGfx90aFp16altRequired())
+        return false;
+
     if(!IsIndexRangeLargeEnough(ctx))
         return false;
 

--- a/src/solver/conv_hip_implicit_gemm_wrw_v4r4_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_wrw_v4r4_xdlops.cpp
@@ -1060,6 +1060,9 @@ bool ConvHipImplicitGemmWrwV4R4Xdlops::IsApplicable(const ConvolutionContext& ct
     if(!ctx.Is2d())
         return false;
 
+    if(ctx.GetStream().GetDeviceName() == "gfx90a" && ctx.conv_problem.IsGfx90aFp16altRequired())
+        return false;
+
     if(!IsIndexRangeLargeEnough(ctx))
         return false;
 

--- a/src/solver/conv_hip_implicit_gemm_wrw_v4r4_xdlops_padded_gemm.cpp
+++ b/src/solver/conv_hip_implicit_gemm_wrw_v4r4_xdlops_padded_gemm.cpp
@@ -1129,6 +1129,9 @@ bool ConvHipImplicitGemmWrwV4R4Xdlops_Padded_Gemm::IsApplicable(const Convolutio
     if(!ctx.Is2d())
         return false;
 
+    if(ctx.GetStream().GetDeviceName() == "gfx90a" && ctx.conv_problem.IsGfx90aFp16altRequired())
+        return false;
+
     if(!IsIndexRangeLargeEnough(ctx))
         return false;
 

--- a/src/solver/conv_winoRxS_f2x3.cpp
+++ b/src/solver/conv_winoRxS_f2x3.cpp
@@ -463,6 +463,9 @@ static bool IsApplicableBase(const ConvolutionContext& params)
          StartsWith(name, "gfx1011") || StartsWith(name, "gfx1012") || StartsWith(name, "gfx103")))
         return false;
 
+    if(name == "gfx90a" && params.conv_problem.IsGfx90aFp16altRequired())
+        return false;
+
     // clang-format off
     if (! ( (params.kernel_stride_w == 1 || params.kernel_stride_w == 2)
         && params.kernel_stride_w == params.kernel_stride_h

--- a/src/solver/conv_winoRxS_f3x2.cpp
+++ b/src/solver/conv_winoRxS_f3x2.cpp
@@ -331,6 +331,9 @@ bool ConvBinWinogradRxSf3x2::IsApplicable(const ConvolutionContext& params) cons
          StartsWith(name, "gfx1011") || StartsWith(name, "gfx1012") || StartsWith(name, "gfx103")))
         return false;
 
+    if(name == "gfx90a" && params.conv_problem.IsGfx90aFp16altRequired())
+        return false;
+
     // clang-format off
     if (! (params.kernel_stride_w == 1
         && params.kernel_stride_w == params.kernel_stride_h


### PR DESCRIPTION
- Simplify access to ALT attribute from ProblemDescription
- ConvBinWinogradRxSf2x3, ConvBinWinogradRxSf2x3g1
- ConvBinWinogradRxSf3x2
- ConvAsm1x1U, ConvAsm1x1UV2
- ConvAsmBwdWrW1x1, ConvAsmBwdWrW3x3
- ConvHipImplicitGemmBwdDataV1R1, ConvHipImplicitGemmBwdDataV1R1Xdlops
- ConvHipImplicitGemmBwdDataV4R1Xdlops
- ConvHipImplicitGemmForwardV4R4Xdlops, ConvHipImplicitGemmForwardV4R4Xdlops_Padded_Gemm
- ConvHipImplicitGemmForwardV4R5Xdlops
- ConvHipImplicitGemmV4R1Fwd, ConvHipImplicitGemmV4R1WrW
- ConvHipImplicitGemmWrwV4R4Xdlops, ConvHipImplicitGemmWrwV4R4Xdlops_Padded_Gemm
- Not necessary for:
  - ConvBinWinogradRxS due to [this reasoning](https://github.com/ROCmSoftwarePlatform/MIOpen-internal/issues/2#issuecomment-919021192).
  - ConvHipImplicitGemmBwdDataV4R1, ConvHipImplicitGemmV4R4Fwd, ConvHipImplicitGemmV4R4WrW as these support only FP32.

:warning: @JehandadKhan From now on, many Bwd and WrW Solvers are disabled for gfx90a by default. Therefore, ___perf-db tuning___ will skip them. In order to tune perf-configs for them, `MIOPEN_DEBUG_CONVOLUTION_ATTRIB_FP16_ALT_IMPL=0` can be set in the environment. This is just FYI. I do not think that tuning of disabled Solvers is really required.
