### PR TITLE
[BugFix] CBAInfer verification

### DIFF
--- a/driver/CBAInferFusion_driver.hpp
+++ b/driver/CBAInferFusion_driver.hpp
@@ -1182,13 +1182,14 @@ int CBAInferFusionDriver<Tgpu, Tref>::VerifyForward()
 
     double allowedEps = std::numeric_limits<Tgpu>::epsilon() * 80;
 
-    int match = 1;
+    int match = miopenInferVerify(out.size(), out_host.data(), out.data(), allowedEps);
+    if(match == 0)
+    {
+        std::cout << "Forward Activation Failed" << std::endl;
+        return EC_VerifyFwd;
+    }
 
-    match &= miopenInferVerify(out.size(), out_host.data(), out.data(), allowedEps);
-
-    if(match)
-        MIOPEN_LOG_I("Forward Activation Verifies on CPU and GPU");
-
+    std::cout << "Forward Activation Verifies on CPU and GPU" << std::endl;
     return miopenStatusSuccess;
 }
 

--- a/driver/conv_driver.hpp
+++ b/driver/conv_driver.hpp
@@ -90,18 +90,6 @@ typedef cl_int status_t;
 typedef int status_t;
 #endif
 
-// Use values which are distinctively greater then miopenStatus_t,
-// so that these can be ORed with any miopen status code
-// without loss of information.
-typedef enum
-{
-    // These four codes could be returned together, ORed:
-    EC_VerifyFwd     = 0x100,
-    EC_VerifyBwd     = 0x200,
-    EC_VerifyWrw     = 0x400,
-    EC_VerifyBwdBias = 0x800,
-} errorCode_t;
-
 struct AutoMiopenWarmupMode
 {
     AutoMiopenWarmupMode()

--- a/driver/driver.hpp
+++ b/driver/driver.hpp
@@ -55,6 +55,18 @@ using float16 = half_float::half;
 
 #define UNPACK_VEC4(v) (v[0]), (v[1]), (v[2]), (v[3])
 
+// Use values which are distinctively greater then miopenStatus_t,
+// so that these can be ORed with any miopen status code
+// without loss of information.
+typedef enum
+{
+    // These four codes could be returned together, ORed:
+    EC_VerifyFwd     = 0x100,
+    EC_VerifyBwd     = 0x200,
+    EC_VerifyWrw     = 0x400,
+    EC_VerifyBwdBias = 0x800,
+} errorCode_t;
+
 struct GPUMem
 {
 

--- a/driver/miopen_ConvBatchNormActivHost.hpp
+++ b/driver/miopen_ConvBatchNormActivHost.hpp
@@ -223,7 +223,7 @@ int miopenInferVerify(size_t size, const Tref* c_res, const Tgpu* top_ptr, Tref 
             std::cout << "Difference in neuron layer: " << err << " too large at " << i
                       << " c_v = " << c_val << " vs g_val = " << g_val
                       << " tolerance = " << allowedEps << std::endl;
-            //   match = 0;
+            match = 0;
         }
     }
 


### PR DESCRIPTION
This PR fixes _CBAInfer_ driver bug.
`miopenInferVerify` always returns `1`. Due to this, the _CBAInfer_ verification was successful even if it was not.

https://github.com/ROCmSoftwarePlatform/MIOpen/blob/f02d9598fc02ad4fbf67d4f1cd88ed4e296f0961/driver/CBAInferFusion_driver.hpp#L1185-L1190