### PR TITLE
Fix HIP builds for the upcoming HIP compiler (SWDEV-310166)

### DIFF
--- a/src/comgr.cpp
+++ b/src/comgr.cpp
@@ -266,19 +266,25 @@ static bool IsLinkerOption(const std::string& option)
 
 static void RemoveCommonOptionsUnwanted(OptionList& list)
 {
-    list.erase(remove_if(list.begin(),
-                         list.end(),
-                         [&](const auto& option) { // clang-format off
+    list.erase(
+        remove_if(
+            list.begin(),
+            list.end(),
+            [&](const auto& option) { // clang-format off
                              return miopen::StartsWith(option, "-mcpu=")
                                 || (option == "-hc")
                                 || (option == "-x hip") || (option == "-xhip")
                                 || (option == "--hip-link")
-                                || (option.find("builtins-x86_64") != std::string::npos)
+                                // The following matches current "-lclang_rt.builtins-x86_64" (4.5) as weel as
+                                // upcoming ".../libclang_rt.builtins-x86_64.a" and even future things like
+                                // "...x86_64.../libclang_rt.builtins.a" etc.
+                                || ((option.find("clang_rt.builtins") != std::string::npos)
+                                 && (option.find("x86_64") != std::string::npos))
                                 || miopen::StartsWith(option, "-mllvm -amdgpu-early-inline-all")
                                 || miopen::StartsWith(option, "-mllvm -amdgpu-function-calls")
                                 || miopen::StartsWith(option, "--hip-device-lib-path="); // clang-format on
-                         }),
-               list.end());
+            }),
+        list.end());
 }
 
 static void RemoveCompilerOptionsUnwanted(OptionList& list)

--- a/src/comgr.cpp
+++ b/src/comgr.cpp
@@ -273,7 +273,7 @@ static void RemoveCommonOptionsUnwanted(OptionList& list)
                                 || (option == "-hc")
                                 || (option == "-x hip") || (option == "-xhip")
                                 || (option == "--hip-link")
-                                || (option == "-lclang_rt.builtins-x86_64")
+                                || (option.find("builtins-x86_64") != std::string::npos)
                                 || miopen::StartsWith(option, "-mllvm -amdgpu-early-inline-all")
                                 || miopen::StartsWith(option, "-mllvm -amdgpu-function-calls")
                                 || miopen::StartsWith(option, "--hip-device-lib-path="); // clang-format on

--- a/src/kernels/static_composable_kernel/include/utility/static_kernel_amd_buffer_addressing.hpp
+++ b/src/kernels/static_composable_kernel/include/utility/static_kernel_amd_buffer_addressing.hpp
@@ -15,6 +15,9 @@ union BufferAddressConfig
     int32_t range[4];
 };
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreserved-identifier"
+
 __device__ float __llvm_amdgcn_buffer_load_f32(int32x4_t rsrc,
                                                index_t vindex,
                                                index_t offset,
@@ -791,6 +794,8 @@ __device__ void amd_buffer_atomic_add<float, 4>(const float* p_src,
     }
 }
 #endif // CK_USE_AMD_BUFFER_ATOMIC_FADD
+
+#pragma clang diagnostic pop // "-Wreserved-identifier"
 
 } // namespace ck
 #endif


### PR DESCRIPTION
This is urgent PR that is expected to unblock hip promotion (https://ontrack-internal.amd.com/browse/SWDEV-310166).

- [HIP offline build] Remove x86 builtin lib from linking.
- [COMGR] Remove x86 builtin lib from linking more reliably.
- By-products
  - [Future ROCm] Disable `-Wreserved-identifier` for declarations of llvm intrinsics in HIP kernels. Otherwise DEV builds fail at runtime, during HIP compilation (due to -Werror).
