### PR TITLE
[BugFix] asm igemm heuristic init, for fwd/bwd/wrw

### DIFF
--- a/src/solver/conv_asm_implicit_gemm_gtc_bwd_nhwc.cpp
+++ b/src/solver/conv_asm_implicit_gemm_gtc_bwd_nhwc.cpp
@@ -623,9 +623,7 @@ void PerformanceConfigAsmImplicitGemmGTCBwdXdlopsNHWC::HeuristicInit(const Convo
     MIOPEN_LOG_I("m_per_block:" << m_per_block << ", n_per_block:" << n_per_block
                                 << ", k_per_block:" << k_per_block);
 
-    if((m_per_block == 0 && n_per_block == 0 && k_per_block == 0) || not_support_vector_store)
-    {
-        // not found, let's try  gemm_k pad now.
+    auto find_with_gemm_k_pad = [&]() {
         const auto& config_list = GetBwdXdlopsNHWCConfigList();
         size_t min_pad_pixel    = std::numeric_limits<std::size_t>::max();
         size_t selected_index   = 0;
@@ -638,7 +636,8 @@ void PerformanceConfigAsmImplicitGemmGTCBwdXdlopsNHWC::HeuristicInit(const Convo
                 continue;
             if(!(config.tensor_a_thread_lengths[1] == 1 && config.tensor_b_thread_lengths[1] == 1))
                 continue;
-
+            // If we go here, then this is our last hope.
+            // This kind of kernel support any configs
             size_t cur_pad_pixel =
                 ComputeMatrixPadSize(
                     gemm_m, config.gemm_m_per_block, gemm_k_even, config.gemm_k_per_block) +
@@ -653,6 +652,12 @@ void PerformanceConfigAsmImplicitGemmGTCBwdXdlopsNHWC::HeuristicInit(const Convo
             }
         }
         CopyParameters(config_list[selected_index]);
+    };
+
+    if((m_per_block == 0 && n_per_block == 0 && k_per_block == 0) || not_support_vector_store)
+    {
+        // not found, let's try  gemm_k pad now.
+        find_with_gemm_k_pad();
     }
     else
     {
@@ -693,6 +698,8 @@ void PerformanceConfigAsmImplicitGemmGTCBwdXdlopsNHWC::HeuristicInit(const Convo
                                                          << ", k_per_block:" << k_per_block);
                 if((unit_conv && config.nxe == 0) || (!unit_conv && config.nxe != 0))
                 {
+                    if(!config.IsValid(ctx)) // last check before assigning a heuristic value
+                        continue;
                     CopyParameters(config);
                     if(need_k_split)
                     {
@@ -700,7 +707,8 @@ void PerformanceConfigAsmImplicitGemmGTCBwdXdlopsNHWC::HeuristicInit(const Convo
                                MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_ASM_PK_ATOMIC_ADD_FP16{}))
                             if(ctx.IsFp16() && gks > 0)
                                 vector_store = 1;
-                        gemm_k_global_split = static_cast<int>(gks);
+                        if(gks > 0)
+                            gemm_k_global_split = static_cast<int>(gks);
                     }
                     return;
                 }
@@ -708,8 +716,8 @@ void PerformanceConfigAsmImplicitGemmGTCBwdXdlopsNHWC::HeuristicInit(const Convo
                     continue;
             }
         }
-        MIOPEN_LOG_E("can't find a suitable heuristic config");
-        MIOPEN_THROW(miopenStatusInternalError);
+        // last try
+        find_with_gemm_k_pad();
     }
 }
 bool PerformanceConfigAsmImplicitGemmGTCBwdXdlopsNHWC::IsValidValue() const

--- a/src/solver/conv_asm_implicit_gemm_gtc_fwd_nhwc.cpp
+++ b/src/solver/conv_asm_implicit_gemm_gtc_fwd_nhwc.cpp
@@ -494,9 +494,7 @@ void PerformanceConfigAsmImplicitGemmGTCFwdXdlopsNHWC::HeuristicInit(const Convo
         gemm_k,
         ctx.IsFp32() ? tile_list_fp32 : (ctx.IsFp16() ? tile_list_fp16 : tile_list_bfp16));
 
-    if((m_per_block == 0 && n_per_block == 0 && k_per_block == 0) || not_support_vector_store)
-    {
-        // not found, let's try  gemm_k pad now.
+    auto find_with_gemm_k_pad = [&]() {
         const auto& config_list = GetFwdXdlopsNHWCConfigList();
         size_t min_pad_pixel    = std::numeric_limits<std::size_t>::max();
         size_t selected_index   = 0;
@@ -509,7 +507,8 @@ void PerformanceConfigAsmImplicitGemmGTCFwdXdlopsNHWC::HeuristicInit(const Convo
                 continue;
             if(!(config.tensor_a_thread_lengths[1] == 1 && config.tensor_b_thread_lengths[1] == 1))
                 continue;
-
+            // If we go here, then this is our last hope.
+            // This kind of kernel support any configs
             size_t cur_pad_pixel =
                 ComputeMatrixPadSize(
                     gemm_m, config.gemm_m_per_block, gemm_k, config.gemm_k_per_block) +
@@ -524,6 +523,12 @@ void PerformanceConfigAsmImplicitGemmGTCFwdXdlopsNHWC::HeuristicInit(const Convo
             }
         }
         CopyParameters(config_list[selected_index]);
+    };
+
+    if((m_per_block == 0 && n_per_block == 0 && k_per_block == 0) || not_support_vector_store)
+    {
+        // not found, let's try  gemm_k pad now.
+        find_with_gemm_k_pad();
     }
     else
     {
@@ -562,6 +567,8 @@ void PerformanceConfigAsmImplicitGemmGTCFwdXdlopsNHWC::HeuristicInit(const Convo
 
                 if((unit_conv && config.nxe == 0) || (!unit_conv && config.nxe != 0))
                 {
+                    if(!config.IsValid(ctx)) // last check before assigning a heuristic value
+                        continue;
                     CopyParameters(config);
                     if(need_k_split)
                     {
@@ -569,7 +576,8 @@ void PerformanceConfigAsmImplicitGemmGTCFwdXdlopsNHWC::HeuristicInit(const Convo
                                MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_ASM_PK_ATOMIC_ADD_FP16{}))
                             if(ctx.IsFp16() && gks > 0)
                                 vector_store = 1;
-                        gemm_k_global_split = static_cast<int>(gks);
+                        if(gks > 0)
+                            gemm_k_global_split = static_cast<int>(gks);
                     }
                     return;
                 }
@@ -577,8 +585,8 @@ void PerformanceConfigAsmImplicitGemmGTCFwdXdlopsNHWC::HeuristicInit(const Convo
                     continue;
             }
         }
-        MIOPEN_LOG_E("can't find a suitable heuristic config");
-        MIOPEN_THROW(miopenStatusInternalError);
+        // last try
+        find_with_gemm_k_pad();
     }
 }
 

--- a/src/solver/conv_asm_implicit_gemm_gtc_wrw_nhwc.cpp
+++ b/src/solver/conv_asm_implicit_gemm_gtc_wrw_nhwc.cpp
@@ -537,8 +537,7 @@ void PerformanceConfigAsmImplicitGemmGTCWrwXdlopsNHWC::HeuristicInit(const Convo
     std::tie(m_per_block, n_per_block, k_per_block) = HeuristicInitMacroTileNoPadGemmK(
         gemm_m, gemm_n, 0, ctx.IsFp32() ? tile_list_fp32 : (ctx.IsFp16() ? tile_list_fp16 : tile_list_bfp16));
 
-    if((m_per_block == 0 && n_per_block == 0 && k_per_block == 0) || not_support_vector_store)
-    {
+    auto find_with_gemm_k_pad = [&](){
         // not found, let's try  gemm_k pad now.
         const auto& config_list = GetWrwXdlopsNHWCConfigList();
         size_t min_pad_pixel    = std::numeric_limits<std::size_t>::max();
@@ -607,6 +606,12 @@ void PerformanceConfigAsmImplicitGemmGTCWrwXdlopsNHWC::HeuristicInit(const Convo
             }
             gemm_k_global_split = occupancy;
         }
+    };
+
+    if((m_per_block == 0 && n_per_block == 0 && k_per_block == 0) || not_support_vector_store)
+    {
+        // not found, let's try gemm_k pad now.
+        find_with_gemm_k_pad();
     }
     else
     {
@@ -633,6 +638,8 @@ void PerformanceConfigAsmImplicitGemmGTCWrwXdlopsNHWC::HeuristicInit(const Convo
 
                 if((unit_conv && config.nxe == 0) || (!unit_conv && config.nxe != 0))
                 {
+                    if(!config.IsValid(ctx)) // last check before assigning a heuristic value
+                        continue;
                     CopyParameters(config);
                     if(need_k_split)
                     {
@@ -654,8 +661,8 @@ void PerformanceConfigAsmImplicitGemmGTCWrwXdlopsNHWC::HeuristicInit(const Convo
                     continue;
             }
         }
-        MIOPEN_LOG_E("can't find a suitable heuristic config");
-        MIOPEN_THROW(miopenStatusInternalError);
+        // last try
+        find_with_gemm_k_pad();
     }
 }
 

--- a/src/solver/conv_asm_implicit_gemm_gtc_wrw_nhwc.cpp
+++ b/src/solver/conv_asm_implicit_gemm_gtc_wrw_nhwc.cpp
@@ -537,7 +537,8 @@ void PerformanceConfigAsmImplicitGemmGTCWrwXdlopsNHWC::HeuristicInit(const Convo
     std::tie(m_per_block, n_per_block, k_per_block) = HeuristicInitMacroTileNoPadGemmK(
         gemm_m, gemm_n, 0, ctx.IsFp32() ? tile_list_fp32 : (ctx.IsFp16() ? tile_list_fp16 : tile_list_bfp16));
 
-    auto find_with_gemm_k_pad = [&](){
+    if((m_per_block == 0 && n_per_block == 0 && k_per_block == 0) || not_support_vector_store)
+    {
         // not found, let's try  gemm_k pad now.
         const auto& config_list = GetWrwXdlopsNHWCConfigList();
         size_t min_pad_pixel    = std::numeric_limits<std::size_t>::max();
@@ -606,12 +607,6 @@ void PerformanceConfigAsmImplicitGemmGTCWrwXdlopsNHWC::HeuristicInit(const Convo
             }
             gemm_k_global_split = occupancy;
         }
-    };
-
-    if((m_per_block == 0 && n_per_block == 0 && k_per_block == 0) || not_support_vector_store)
-    {
-        // not found, let's try gemm_k pad now.
-        find_with_gemm_k_pad();
     }
     else
     {
@@ -638,8 +633,6 @@ void PerformanceConfigAsmImplicitGemmGTCWrwXdlopsNHWC::HeuristicInit(const Convo
 
                 if((unit_conv && config.nxe == 0) || (!unit_conv && config.nxe != 0))
                 {
-                    if(!config.IsValid(ctx)) // last check before assigning a heuristic value
-                        continue;
                     CopyParameters(config);
                     if(need_k_split)
                     {
@@ -661,8 +654,8 @@ void PerformanceConfigAsmImplicitGemmGTCWrwXdlopsNHWC::HeuristicInit(const Convo
                     continue;
             }
         }
-        // last try
-        find_with_gemm_k_pad();
+        MIOPEN_LOG_E("can't find a suitable heuristic config");
+        MIOPEN_THROW(miopenStatusInternalError);
     }
 }
 


### PR DESCRIPTION
fix a bug in when heuristic init asm igemm fwd/bwd/wrw. Previously config like:

`./bin/test_conv2d --half --verbose --input 120 512 19 19 --weights 510 512 3 3  --pads_strides_dilations 1 1 1 1 1 1 --disable-backward-data --disable-backward-weights  --in_layout NHWC --fil_layout NHWC --out_layout NHWC `

will fail. This is due to a bug in heuristic init. If we run with `FIND_ENFORCE=4`, or tune the db, then everything is OK.

[informative] https://github.com/ROCmSoftwarePlatform/MIOpen/pull/1267/commits/27c8024374393e40d8ce9f904925406b00bf9bea message is not correct, actually wrw also have bug when heuristic init. bug is fixed and double checked SSD can converge