### PR TITLE
[Enhancement] Use recipe instead of raw url to install sqlite3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-sqlite3,https://sqlite.org/2017/sqlite-autoconf-3170000.tar.gz -H sha256:a4e485ad3a16e054765baf6371826b5000beed07e626510896069c0bf013874c -X autotools -DCMAKE_POSITION_INDEPENDENT_CODE=On
+sqlite3@3.17 -DCMAKE_POSITION_INDEPENDENT_CODE=On
 boost@1.72 -DCMAKE_POSITION_INDEPENDENT_CODE=On --build
 half,https://github.com/pfultz2/half/archive/1.12.0.tar.gz -X header -H sha256:0a08660b68abb176ebc2a0cdf8de46e3182a7f46c66443bb80dbfaaec98cf969 --build


### PR DESCRIPTION
The enhancement is to use recipe instead of raw url to install sqlite3

sqlite3 is required dependency of MIOpen, as listed in requirements.txt