### PR TITLE
[MLIR] Adding misc optimizations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -334,7 +334,8 @@ if(MIOPEN_USE_MLIR)
     endif()
 
     if(NOT LIBMLIRMIOPEN)
-        message(FATAL_ERROR "libMLIRMIOpen not found")
+        message(FATAL_ERROR "libMLIRMIOpen not found, please reinstall dependencies. \
+        Refer to https://github.com/ROCmSoftwarePlatform/MIOpen#installing-the-dependencies")
     else()
         message(STATUS "Build with libMLIRMIOpen: " ${LIBMLIRMIOPEN})
     endif()

--- a/src/solver/conv_mlir_igemm_bwd.cpp
+++ b/src/solver/conv_mlir_igemm_bwd.cpp
@@ -46,6 +46,11 @@ bool ConvMlirIgemmBwd::IsApplicable(const ConvolutionContext& ctx) const
         return false;
     if(!IsComposableKernelSupportedHardware(ctx))
         return false;
+    // Note: ConvMlirIgemmBwd can run on a machine with xdlops support, however, it is
+    // guaranteed to be slower than its xdlops alternative, therefore disabling it to
+    // save compilation overhead
+    if(IsXdlopsSupport(ctx))
+        return false;
 
     return MiirIsConfigApplicable(mlir::ConstructBuildOptions(ctx, false));
 #else

--- a/src/solver/conv_mlir_igemm_fwd.cpp
+++ b/src/solver/conv_mlir_igemm_fwd.cpp
@@ -164,6 +164,11 @@ bool ConvMlirIgemmFwd::IsApplicable(const ConvolutionContext& ctx) const
         return false;
     if(!IsComposableKernelSupportedHardware(ctx))
         return false;
+    // Note: ConvMlirIgemmFwd can run on a machine with xdlops support, however, it is
+    // guaranteed to be slower than its xdlops alternative, therefore disabling it to
+    // save compilation overhead
+    if(IsXdlopsSupport(ctx))
+        return false;
 
     return MiirIsConfigApplicable(mlir::ConstructBuildOptions(ctx, false));
 #else

--- a/src/solver/conv_mlir_igemm_wrw.cpp
+++ b/src/solver/conv_mlir_igemm_wrw.cpp
@@ -47,6 +47,11 @@ bool ConvMlirIgemmWrW::IsApplicable(const ConvolutionContext& ctx) const
         return false;
     if(!IsComposableKernelSupportedHardware(ctx))
         return false;
+    // Note: ConvMlirIgemmWrW can run on a machine with xdlops support, however, it is
+    // guaranteed to be slower than its xdlops alternative, therefore disabling it to
+    // save compilation overhead
+    if(IsXdlopsSupport(ctx))
+        return false;
 
     return MiirIsConfigApplicable(mlir::ConstructBuildOptions(ctx, false));
 #else

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -653,14 +653,14 @@ set(IMPLICITGEMM_MLIR_ARGS_W ${IMPLICITGEMM_ARGS} --verbose --disable-forward --
 # Note: OpenCL Debug + Codecov test stage taking longer time than a smoke test should therefore disabling that scenario
 string(TOUPPER ${CMAKE_BUILD_TYPE} CMAKE_BUILD_TYPE)
 if ((NOT CMAKE_BUILD_TYPE MATCHES "DEBUG") OR (NOT ${CODECOV_TEST}))
-    add_custom_test(test_conv_igemm_mlir_small HALF_ENABLED SKIP_UNLESS_MLIR GFX90A_DISABLED
+    add_custom_test(test_conv_igemm_mlir_small HALF_ENABLED SKIP_UNLESS_MLIR GFX908_DISABLED GFX90A_DISABLED
         COMMAND ${IMPLICITGEMM_MLIR_ENV_F} $<TARGET_FILE:test_conv2d> ${IMPLICITGEMM_MLIR_ARGS_F} --input 64 128 14 14 --weights 128 128 1 1 --pads_strides_dilations 0 0 2 2 1 1 --in_layout NHWC --fil_layout NHWC --out_layout NHWC
         COMMAND ${IMPLICITGEMM_MLIR_ENV_B} $<TARGET_FILE:test_conv2d> ${IMPLICITGEMM_MLIR_ARGS_B} --input 64 256 28 28 --weights 64  64  1 1 --pads_strides_dilations 0 0 1 1 1 1 --group-count 4
         COMMAND ${IMPLICITGEMM_MLIR_ENV_W} $<TARGET_FILE:test_conv2d> ${IMPLICITGEMM_MLIR_ARGS_W} --input 64 64  28 28 --weights 64  64  1 1 --pads_strides_dilations 0 0 1 1 1 1
     )
 endif()
 
-add_custom_test(test_conv_igemm_mlir SKIP_UNLESS_ALL HALF_ENABLED SKIP_UNLESS_MLIR GFX90A_DISABLED
+add_custom_test(test_conv_igemm_mlir SKIP_UNLESS_ALL HALF_ENABLED SKIP_UNLESS_MLIR GFX908_DISABLED GFX90A_DISABLED
     COMMAND ${IMPLICITGEMM_MLIR_ENV_F} $<TARGET_FILE:test_conv2d> ${IMPLICITGEMM_MLIR_ARGS_F} --input 256 1024 14 14 --weights 2048 1024 1 1 --pads_strides_dilations 0 0 2 2 1 1
     COMMAND ${IMPLICITGEMM_MLIR_ENV_F} $<TARGET_FILE:test_conv2d> ${IMPLICITGEMM_MLIR_ARGS_F} --input 256 128  28 28 --weights 128  128  3 3 --pads_strides_dilations 1 1 1 1 1 1
     COMMAND ${IMPLICITGEMM_MLIR_ENV_F} $<TARGET_FILE:test_conv2d> ${IMPLICITGEMM_MLIR_ARGS_F} --input 256 128  28 28 --weights 128  128  3 3 --pads_strides_dilations 1 1 1 1 1 1 --in_layout NHWC --fil_layout NHWC --out_layout NHWC


### PR DESCRIPTION
This is to capture a few optimizations I talked with @atamazov offline:
 - Disable non-xdlops kernels from picking up on gfx908 (or gfx90a) to reduce compilation overhead
 - Add cmake error string to remind user to reinstall dependencies