### PR TITLE
[conv] Optimize performance of GWSS

### DIFF
--- a/src/include/miopen/any_solver.hpp
+++ b/src/include/miopen/any_solver.hpp
@@ -96,6 +96,12 @@ struct AnySolver
         return ptr_value->GetWorkspaceSize(ctx);
     }
 
+    bool MayNeedWorkspace() const
+    {
+        assert(ptr_value != nullptr);
+        return ptr_value->MayNeedWorkspace();
+    }
+
     // virtual base class
     struct AnySolver_base
     {
@@ -113,6 +119,7 @@ struct AnySolver
                                           Db& db,
                                           const miopen::AnyInvokeParams& invoke_ctx) const = 0;
         virtual size_t GetWorkspaceSize(const ConvolutionContext& ctx) const               = 0;
+        virtual bool MayNeedWorkspace() const                                              = 0;
     };
 
     // templated derived class
@@ -169,6 +176,7 @@ struct AnySolver
         {
             return value.GetWorkspaceSize(ctx);
         }
+        bool MayNeedWorkspace() const override { return value.MayNeedWorkspace(); }
         const std::type_info& Type() const override { return typeid(T); };
         std::string GetSolverDbId() const override { return ComputeSolverDbId(value); }
 

--- a/src/include/miopen/find_solution.hpp
+++ b/src/include/miopen/find_solution.hpp
@@ -248,10 +248,12 @@ struct SolverContainer
                     find_only->end()))
                 { // Do nothing (and keep silence for the sake of Tuna), just skip.
                 }
-                else if(!solver.IsApplicable(search_params))
-                    MIOPEN_LOG_I2(SolverDbId(solver) << ": Not applicable");
+                // For better performance, check IsDynamic() first, because
+                // it is much faster than IsApplicable().
                 else if(search_params.use_dynamic_solutions_only && !solver.IsDynamic())
                     MIOPEN_LOG_I2(SolverDbId(solver) << ": Skipped (non-dynamic)");
+                else if(!solver.IsApplicable(search_params))
+                    MIOPEN_LOG_I2(SolverDbId(solver) << ": Not applicable");
                 else
                 {
                     ++count;

--- a/src/include/miopen/find_solution.hpp
+++ b/src/include/miopen/find_solution.hpp
@@ -248,6 +248,8 @@ struct SolverContainer
                     find_only->end()))
                 { // Do nothing (and keep silence for the sake of Tuna), just skip.
                 }
+                else if(!solver.MayNeedWorkspace())
+                    MIOPEN_LOG_I2(SolverDbId(solver) << ": Skipped (no workspace required)");
                 // For better performance, check IsDynamic() first, because
                 // it is much faster than IsApplicable().
                 else if(search_params.use_dynamic_solutions_only && !solver.IsDynamic())

--- a/src/include/miopen/find_solution.hpp
+++ b/src/include/miopen/find_solution.hpp
@@ -232,7 +232,7 @@ struct SolverContainer
 
     template <class Context>
     std::vector<std::pair<std::string, size_t>>
-    GetWorkspaceSize(const Context& search_params,
+    GetWorkspaceSizes(const Context& search_params,
                      std::size_t limit = std::numeric_limits<std::size_t>::max()) const
     {
         std::vector<std::pair<std::string, size_t>> res;

--- a/src/include/miopen/solver.hpp
+++ b/src/include/miopen/solver.hpp
@@ -135,7 +135,10 @@ struct SolverBase
     float GetWti(const Context&) const { return -2.0; }
 
     // Returns the workspace size required by the solver for a given ConvolutionContext
-    size_t GetWorkspaceSize(const Context&) const { return 0; };
+    size_t GetWorkspaceSize(const Context&) const { return 0; }
+
+    // Must return true if a Solver has its own implementation of GetWorkspaceSize().
+    bool MayNeedWorkspace() const { return false; }
 
     /// Takes problem config, optimization parameters and other info
     /// and computes information required to build and run the kernel(s).
@@ -248,6 +251,7 @@ struct ConvAsm1x1U : SolverBase<ConvolutionContext>
                                         const AnyInvokeParams& invoke_ctx) const;
     bool IsApplicable(const ConvolutionContext& params) const;
     size_t GetWorkspaceSize(const ConvolutionContext& params) const;
+    bool MayNeedWorkspace() const { return true; }
     ConvSolution GetSolution(const ConvolutionContext& params,
                              const PerformanceConfigConvAsm1x1U& config,
                              bool disableConfigOverrideFromEnv = false) const;
@@ -1380,6 +1384,7 @@ struct ConvHipImplicitGemmBwdDataV1R1 : SolverBase<ConvolutionContext>
                              const PerformanceImplicitGemmBwdDataV1R1& config,
                              bool disableConfigOverrideFromEnv = false) const;
     size_t GetWorkspaceSize(const ConvolutionContext& ctx) const;
+    bool MayNeedWorkspace() const { return true; }
 };
 
 struct ConvMlirIgemmBwd : SolverBase<ConvolutionContext>
@@ -1448,6 +1453,7 @@ struct ConvHipImplicitGemmBwdDataV1R1Xdlops : SolverBase<ConvolutionContext>
                                   const PerformanceImplicitGemmBwdV1R1Xdlops& c) const;
     bool IsApplicable(const ConvolutionContext& ctx) const;
     size_t GetWorkspaceSize(const ConvolutionContext& ctx) const;
+    bool MayNeedWorkspace() const { return true; }
     ConvSolution GetSolution(const ConvolutionContext& ctx,
                              const PerformanceImplicitGemmBwdV1R1Xdlops& config,
                              bool disableConfigOverrideFromEnv = false) const;
@@ -1474,6 +1480,7 @@ struct ConvAsmImplicitGemmV4R1DynamicWrw : SolverBase<ConvolutionContext>
     bool IsApplicable(const ConvolutionContext& ctx) const;
     bool IsDynamic() const { return true; }
     size_t GetWorkspaceSize(const ConvolutionContext& ctx) const;
+    bool MayNeedWorkspace() const { return true; }
     ConvSolution GetSolution(const ConvolutionContext& ctx) const;
 };
 
@@ -1482,6 +1489,7 @@ struct ConvAsmImplicitGemmGTCDynamicWrwXdlops : SolverBase<ConvolutionContext>
     bool IsApplicable(const ConvolutionContext& ctx) const;
     bool IsDynamic() const { return true; }
     size_t GetWorkspaceSize(const ConvolutionContext& ctx) const;
+    bool MayNeedWorkspace() const { return true; }
     ConvSolution GetSolution(const ConvolutionContext& ctx) const;
 };
 
@@ -1675,6 +1683,7 @@ struct ConvMPBidirectWinograd : SolverBase<ConvolutionContext>
     bool IsApplicable(const ConvolutionContext& params) const;
     bool IsDynamic() const { return true; }
     size_t GetWorkspaceSize(const ConvolutionContext& params) const;
+    bool MayNeedWorkspace() const { return true; }
     ConvSolution GetSolution(const ConvolutionContext& params) const;
 
     // kernel_file_name for solver identification
@@ -1725,6 +1734,7 @@ struct ConvMPBidirectWinograd_xdlops : SolverBase<ConvolutionContext>
                ConvHipImplicitGemmForwardV4R4Xdlops{}.GetWorkspaceSize(
                    GetTransformedConvContext(ctx));
     }
+    bool MayNeedWorkspace() const { return true; }
 
     ConvSolution GetSolution(const ConvolutionContext& ctx,
                              const PerformanceImplicitGemmForwardV4R4Xdlops& config,
@@ -1783,6 +1793,7 @@ struct ConvWinograd3x3MultipassWrW : SolverBase<ConvolutionContext>
     bool IsApplicable(const ConvolutionContext& params) const;
     bool IsDynamic() const { return true; }
     size_t GetWorkspaceSize(const ConvolutionContext& params) const;
+    bool MayNeedWorkspace() const { return true; }
     ConvSolution GetSolution(const ConvolutionContext& params) const;
 
     // kernel_file_name for solver identification
@@ -1986,6 +1997,7 @@ struct ConvAsmBwdWrW1x1 : SolverBase<ConvolutionContext>
                                              const AnyInvokeParams& invoke_ctx) const;
     bool IsApplicable(const ConvolutionContext& params) const;
     size_t GetWorkspaceSize(const ConvolutionContext& params) const;
+    bool MayNeedWorkspace() const { return true; }
     ConvSolution GetSolution(const ConvolutionContext& params,
                              const PerformanceConfigConvAsmBwdWrW1x1& config,
                              bool disableConfigOverrideFromEnv = false) const;
@@ -2063,6 +2075,7 @@ struct ConvOclBwdWrW2 : SolverBase<ConvolutionContext>
                                                           const AnyInvokeParams& invoke_ctx) const;
     bool IsApplicable(const ConvolutionContext& params) const;
     size_t GetWorkspaceSize(const ConvolutionContext& params) const;
+    bool MayNeedWorkspace() const { return true; }
     ConvSolution GetSolution(const ConvolutionContext& params,
                              const PerformanceConfigConvOclBwdWrw2<N_BATCH_LOOPS>& config,
                              bool disableConfigOverrideFromEnv = false) const;
@@ -2099,6 +2112,7 @@ struct ConvOclBwdWrW53 : SolverBase<ConvolutionContext>
 {
     bool IsApplicable(const ConvolutionContext& params) const;
     size_t GetWorkspaceSize(const ConvolutionContext& params) const;
+    bool MayNeedWorkspace() const { return true; }
     ConvSolution GetSolution(const ConvolutionContext& params) const;
 };
 
@@ -2107,12 +2121,14 @@ struct ConvOclBwdWrW1x1 : SolverBase<ConvolutionContext>
     bool IsApplicable(const ConvolutionContext& params) const;
     ConvSolution GetSolution(const ConvolutionContext& params) const;
     size_t GetWorkspaceSize(const ConvolutionContext& params) const;
+    bool MayNeedWorkspace() const { return true; }
 };
 
 struct fft : SolverBase<ConvolutionContext>
 {
     bool IsApplicable(const ConvolutionContext& ctx) const;
     size_t GetWorkspaceSize(const ConvolutionContext& ctx) const;
+    bool MayNeedWorkspace() const { return true; }
     ConvSolution GetSolution(const ConvolutionContext& ctx) const;
 };
 
@@ -2174,6 +2190,7 @@ struct ConvHipImplicitGemmWrwV4R4Xdlops : SolverBase<ConvolutionContext>
 {
     PerformanceImplicitGemmWrwV4R4Xdlops GetPerformanceConfig(const ConvolutionContext& ctx) const;
     size_t GetWorkspaceSize(const ConvolutionContext& ctx) const;
+    bool MayNeedWorkspace() const { return true; }
     bool IsValidPerformanceConfig(const ConvolutionContext& ctx,
                                   const PerformanceImplicitGemmWrwV4R4Xdlops& c) const;
     bool IsApplicable(const ConvolutionContext& ctx) const;
@@ -2251,6 +2268,7 @@ struct ConvHipImplicitGemmWrwV4R4Xdlops_Padded_Gemm : SolverBase<ConvolutionCont
     PerformanceImplicitGemmWrwV4R4Xdlops_Padded_Gemm
     GetPerformanceConfig(const ConvolutionContext& ctx) const;
     size_t GetWorkspaceSize(const ConvolutionContext& ctx) const;
+    bool MayNeedWorkspace() const { return true; }
     bool IsValidPerformanceConfig(const ConvolutionContext& ctx,
                                   const PerformanceImplicitGemmWrwV4R4Xdlops_Padded_Gemm& c) const;
     bool IsApplicable(const ConvolutionContext& ctx) const;
@@ -2290,6 +2308,7 @@ struct ConvCkIgemmFwdV6r1DlopsNchw : SolverBase<ConvolutionContext>
 {
     bool IsApplicable(const ConvolutionContext&) const;
     std::size_t GetWorkspaceSize(const ConvolutionContext&) const;
+    bool MayNeedWorkspace() const { return true; }
     bool IsDynamic() const { return true; }
     PerformanceConvCkIgemmFwdV6r1DlopsNchw GetPerformanceConfig(const ConvolutionContext&) const;
     bool IsValidPerformanceConfig(const ConvolutionContext&,
@@ -2345,6 +2364,7 @@ struct GemmFwd1x1_0_2 : GemmFwdBase
     {
         return GetWorkspaceSize(ctx, ctx.conv_problem);
     }
+    bool MayNeedWorkspace() const { return true; }
 
     bool IsApplicable(const ConvolutionContext& ctx) const
     {
@@ -2367,6 +2387,7 @@ struct GemmFwd1x1_0_1_int8 : GemmFwdBase
     {
         return GetWorkspaceSize(ctx, ctx.conv_problem);
     }
+    bool MayNeedWorkspace() const { return true; }
 
     bool IsApplicable(const ConvolutionContext& ctx) const
     {
@@ -2389,6 +2410,7 @@ struct GemmFwd1x1_0_1 : GemmFwdBase
     {
         return GetWorkspaceSize(ctx, ctx.conv_problem);
     }
+    bool MayNeedWorkspace() const { return true; }
 
     bool IsApplicable(const ConvolutionContext& ctx) const
     {
@@ -2411,6 +2433,7 @@ struct GemmFwdRest : GemmFwdBase
     {
         return GetWorkspaceSize(ctx, ctx.conv_problem);
     }
+    bool MayNeedWorkspace() const { return true; }
 
     bool IsApplicable(const ConvolutionContext& ctx) const
     {
@@ -2441,6 +2464,7 @@ struct GemmBwd1x1_stride2 : GemmBwdBase
     {
         return GetWorkspaceSize(ctx, ctx.conv_problem);
     }
+    bool MayNeedWorkspace() const { return true; }
 
     bool IsApplicable(const ConvolutionContext& ctx) const
     {
@@ -2463,6 +2487,7 @@ struct GemmBwd1x1_stride1 : GemmBwdBase
     {
         return GetWorkspaceSize(ctx, ctx.conv_problem);
     }
+    bool MayNeedWorkspace() const { return true; }
 
     bool IsApplicable(const ConvolutionContext& ctx) const
     {
@@ -2485,6 +2510,7 @@ struct GemmBwdRest : GemmBwdBase
     {
         return GetWorkspaceSize(ctx, ctx.conv_problem);
     }
+    bool MayNeedWorkspace() const { return true; }
 
     bool IsApplicable(const ConvolutionContext& ctx) const
     {
@@ -2515,6 +2541,7 @@ struct GemmWrw1x1_stride1 : GemmWrwBase
     {
         return GetWorkspaceSize(ctx, ctx.conv_problem);
     }
+    bool MayNeedWorkspace() const { return true; }
 
     bool IsApplicable(const ConvolutionContext& ctx) const
     {
@@ -2537,6 +2564,7 @@ struct GemmWrwUniversal : GemmWrwBase
     {
         return GetWorkspaceSize(ctx, ctx.conv_problem);
     }
+    bool MayNeedWorkspace() const { return true; }
 
     bool IsApplicable(const ConvolutionContext& ctx) const
     {
@@ -2935,6 +2963,7 @@ struct ConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWC : SolverBase<ConvolutionContex
     Search(const ConvolutionContext&, const AnyInvokeParams& invoke_ctx) const;
 
     size_t GetWorkspaceSize(const ConvolutionContext& ctx) const;
+    bool MayNeedWorkspace() const { return true; }
 
     bool IsApplicable(const ConvolutionContext& ctx) const;
     bool IsDynamic() const { return true; }
@@ -3121,6 +3150,7 @@ struct ConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWC : SolverBase<ConvolutionContex
     Search(const ConvolutionContext&, const AnyInvokeParams& invoke_ctx) const;
 
     size_t GetWorkspaceSize(const ConvolutionContext& ctx) const;
+    bool MayNeedWorkspace() const { return true; }
 
     bool IsApplicable(const ConvolutionContext& ctx) const;
     bool IsDynamic() const { return true; }
@@ -3311,6 +3341,7 @@ struct ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC : SolverBase<ConvolutionContex
     Search(const ConvolutionContext&, const AnyInvokeParams& invoke_ctx) const;
 
     size_t GetWorkspaceSize(const ConvolutionContext& ctx) const;
+    bool MayNeedWorkspace() const { return true; }
 
     bool IsApplicable(const ConvolutionContext& ctx) const;
     bool IsDynamic() const { return true; }

--- a/src/mlo_dir_conv.cpp
+++ b/src/mlo_dir_conv.cpp
@@ -244,7 +244,7 @@ FindAllGemmSolutions(const miopen::ConvolutionContext& ctx,
 std::vector<std::pair<std::string, size_t>>
 AllGemmWorkspaceSize(const miopen::ConvolutionContext& ctx)
 {
-    return GetGemmSolvers().GetWorkspaceSize(ctx);
+    return GetGemmSolvers().GetWorkspaceSizes(ctx);
 }
 
 std::vector<miopen::solver::ConvSolution>
@@ -257,19 +257,19 @@ FindAllDirectSolutions(const miopen::ConvolutionContext& ctx,
 std::vector<std::pair<std::string, size_t>>
 AllDirectForwardBackwardDataWorkspaceSize(const miopen::ConvolutionContext& ctx)
 {
-    return GetDirectSolvers().GetWorkspaceSize(ctx);
+    return GetDirectSolvers().GetWorkspaceSizes(ctx);
 }
 
 std::vector<std::pair<std::string, size_t>>
 FindAllWinogradWorkspaceSizes(const miopen::ConvolutionContext& ctx)
 {
-    return GetWindogradSolvers().GetWorkspaceSize(ctx);
+    return GetWindogradSolvers().GetWorkspaceSizes(ctx);
 }
 
 std::vector<std::pair<std::string, size_t>>
 FindWinogradWrWWorkspaceSizes(const miopen::ConvolutionContext& ctx)
 {
-    return GetWindogradWrWSolvers().GetWorkspaceSize(ctx);
+    return GetWindogradWrWSolvers().GetWorkspaceSizes(ctx);
 }
 
 std::vector<std::pair<std::string, size_t>>
@@ -277,11 +277,11 @@ FindAllImplicitGemmWorkspaceSizes(const miopen::ConvolutionContext& ctx)
 {
 #if WORKAROUND_SWDEV_227826
     if(miopen::IsEnabled(MIOPEN_DEBUG_IMPLICIT_GEMM_FIND_ALL_SOLUTIONS{}))
-        return GetImplicitGemmSolvers().GetWorkspaceSize(ctx);
+        return GetImplicitGemmSolvers().GetWorkspaceSizes(ctx);
     else
-        return GetImplicitGemmSolvers().GetWorkspaceSize(ctx, 1);
+        return GetImplicitGemmSolvers().GetWorkspaceSizes(ctx, 1);
 #else
-    return GetImplicitGemmSolvers().GetWorkspaceSize(ctx);
+    return GetImplicitGemmSolvers().GetWorkspaceSizes(ctx);
 #endif
 }
 
@@ -316,7 +316,7 @@ FindWinogradWrWAllSolutions(const miopen::ConvolutionContext& ctx,
 std::vector<std::pair<std::string, size_t>>
 AllDirectBwdWrW2DWorkspaceSize(const miopen::ConvolutionContext& ctx)
 {
-    return GetBwdWrW2DSolvers().GetWorkspaceSize(ctx);
+    return GetBwdWrW2DSolvers().GetWorkspaceSizes(ctx);
 }
 
 std::vector<std::pair<std::string, size_t>>
@@ -324,11 +324,11 @@ FindImplicitGemmWrWWorkspaceSizes(const miopen::ConvolutionContext& ctx)
 {
 #if WORKAROUND_SWDEV_227826
     if(miopen::IsEnabled(MIOPEN_DEBUG_IMPLICIT_GEMM_FIND_ALL_SOLUTIONS{}))
-        return GetImplicitGemmWrWSolvers().GetWorkspaceSize(ctx);
+        return GetImplicitGemmWrWSolvers().GetWorkspaceSizes(ctx);
     else
-        return GetImplicitGemmWrWSolvers().GetWorkspaceSize(ctx, 1);
+        return GetImplicitGemmWrWSolvers().GetWorkspaceSizes(ctx, 1);
 #else
-    return GetImplicitGemmWrWSolvers().GetWorkspaceSize(ctx);
+    return GetImplicitGemmWrWSolvers().GetWorkspaceSizes(ctx);
 #endif
 }
 
@@ -363,7 +363,7 @@ FindAllFFTSolutions(const miopen::ConvolutionContext& ctx,
 std::vector<std::pair<std::string, size_t>>
 AllFFTForwardBackwardDataWorkspaceSize(const miopen::ConvolutionContext& ctx)
 {
-    return GetFFTSolvers().GetWorkspaceSize(ctx);
+    return GetFFTSolvers().GetWorkspaceSizes(ctx);
 }
 
 void miopen::ConvolutionContext::SetupFloats()

--- a/src/ocl/convolutionocl.cpp
+++ b/src/ocl/convolutionocl.cpp
@@ -913,6 +913,8 @@ std::size_t ConvolutionDescriptor::GetForwardSolutionWorkspaceSize(Handle& handl
     if(!solver_id.IsValid())
         MIOPEN_THROW(miopenStatusBadParm, "invalid solution id = " + solver_id.ToString());
     auto sol = solver_id.GetSolver();
+    if(!sol.MayNeedWorkspace())
+        return 0;
     auto ctx = ConvolutionContext{xDesc, wDesc, yDesc, *this, conv::Direction::Forward};
     ctx.SetStream(&handle);
     ctx.DetectRocm();
@@ -1373,6 +1375,8 @@ std::size_t ConvolutionDescriptor::GetBackwardSolutionWorkspaceSize(Handle& hand
         MIOPEN_THROW(miopenStatusBadParm, "invalid solution id = " + solver_id.ToString());
 
     auto sol = solver_id.GetSolver();
+    if(!sol.MayNeedWorkspace())
+        return 0;
     auto ctx = ConvolutionContext{dxDesc, wDesc, dyDesc, *this, conv::Direction::BackwardData};
     ctx.SetStream(&handle);
     ctx.DetectRocm();
@@ -1722,6 +1726,8 @@ std::size_t ConvolutionDescriptor::GetWrwSolutionWorkspaceSize(Handle& handle,
         MIOPEN_THROW(miopenStatusBadParm, "invalid solution id = " + solver_id.ToString());
 
     auto sol = solver_id.GetSolver();
+    if(!sol.MayNeedWorkspace())
+        return 0;
     auto problem =
         ProblemDescription{xDesc, dwDesc, dyDesc, *this, conv::Direction::BackwardWeights};
     auto ctx = ConvolutionContext{problem};


### PR DESCRIPTION
- Optimizes GWSS for DYNAMIC_HYBRID mode
- Optimize out `IsApplicable()` calls when workspace is not necessary for a Solver
  - `MayNeedWorkspace()` is introduced in the [Solver API](https://github.com/ROCmSoftwarePlatform/MIOpen/issues/866#issuecomment-822585406) for that.
- By-products
  - Refactor GetWorkspaceSize -> GetWorkspaceSizes for clarity

## Average acceleration of GWSS calls

- Immediate mode API (`miopenConvolutionForwardGetSolutionWorkspaceSize` etc): 15...115% 
- Find API (`miopenConvolutionForwardGetWorkSpaceSize` etc): 2...17%

However the overall effect on the total Aux Wall Time (that includes GWSS time) is relatively small and does not exceed 2%.

## Side effects

The total GWSS time for the use case described at #1297 is progressed from ~24 to ~7 ms.

:warning: This may camouflage the visibility of #1297 during GWSS calls. So engineers who work on #1297 may wish to revert this PR in their development trees.