### PR TITLE
[HOTFIX][gfx90a][FP16] Disable ConvCkIgemmFwdV6r1DlopsNchw when "ALT FP16" kernel is required

### DIFF
--- a/src/solver/conv_ck_igemm_fwd_v6r1_dlops_nchw.cpp
+++ b/src/solver/conv_ck_igemm_fwd_v6r1_dlops_nchw.cpp
@@ -97,6 +97,8 @@ bool ConvCkIgemmFwdV6r1DlopsNchw::IsApplicable(const ConvolutionContext& ctx) co
         return false;
     if(ctx.group_counts != 1)
         return false;
+    if(name == "gfx90a" && ctx.conv_problem.IsGfx90aFp16altRequired())
+        return false;
 
     {
         // this kernel use int32_t for memory offset, which covers 2GB of memory maximum

--- a/src/solver/conv_ck_igemm_fwd_v6r1_dlops_nchw.cpp
+++ b/src/solver/conv_ck_igemm_fwd_v6r1_dlops_nchw.cpp
@@ -97,7 +97,8 @@ bool ConvCkIgemmFwdV6r1DlopsNchw::IsApplicable(const ConvolutionContext& ctx) co
         return false;
     if(ctx.group_counts != 1)
         return false;
-    if(name == "gfx90a" && ctx.conv_problem.IsGfx90aFp16altRequired())
+    if(ctx.GetStream().GetTargetProperties().Name() == "gfx90a" &&
+       ctx.conv_problem.IsGfx90aFp16altRequired())
         return false;
 
     {


### PR DESCRIPTION
This is leftover from #1258. Resolves https://github.com/ROCmSoftwarePlatform/MIOpen/pull/1258#issuecomment-984860960