### PR TITLE
Fix: Use `use_hip_kernels` and `use_asm_kernels` in Naive convolution Solvers

### DIFF
--- a/src/include/miopen/solver/conv_direct_naive_conv.hpp
+++ b/src/include/miopen/solver/conv_direct_naive_conv.hpp
@@ -35,6 +35,7 @@ namespace solver {
 std::string ConvDirectNaiveConvKernelName(const ConvolutionContext& ctx);
 std::string ConvDirectNaiveConvKernelFile(const ConvolutionContext& ctx);
 std::string ConvDirectNaiveConvCompileOption(const ConvolutionContext& ctx);
+bool ConvDirectNaiveConvIsApplicableByKernelType(const ConvolutionContext& ctx);
 
 } // namespace solver
 } // namespace miopen

--- a/src/include/miopen/solver/conv_direct_naive_conv.hpp
+++ b/src/include/miopen/solver/conv_direct_naive_conv.hpp
@@ -32,6 +32,7 @@ namespace miopen {
 
 namespace solver {
 
+bool ConvDirectNaiveConvIsAssemblyKernel(const ConvolutionContext& ctx);
 std::string ConvDirectNaiveConvKernelName(const ConvolutionContext& ctx);
 std::string ConvDirectNaiveConvKernelFile(const ConvolutionContext& ctx);
 std::string ConvDirectNaiveConvCompileOption(const ConvolutionContext& ctx);

--- a/src/solver/conv_direct_naive_conv.cpp
+++ b/src/solver/conv_direct_naive_conv.cpp
@@ -44,13 +44,8 @@ namespace solver {
 bool ConvDirectNaiveConvIsAssemblyKernel(const ConvolutionContext& ctx)
 {
     const auto device_name = ctx.GetStream().GetDeviceName();
-    if((device_name == "gfx906" || device_name == "gfx908") && ctx.rmv.IsV3() &&
-       ctx.IsLayoutDefault())
-    {
-        return true;
-    }
-    else
-        return false;
+    return (device_name == "gfx906" || device_name == "gfx908") && ctx.rmv.IsV3() &&
+           ctx.IsLayoutDefault();
 }
 
 std::string ConvDirectNaiveConvKernelName(const ConvolutionContext& ctx)

--- a/src/solver/conv_direct_naive_conv.cpp
+++ b/src/solver/conv_direct_naive_conv.cpp
@@ -106,5 +106,22 @@ std::string ConvDirectNaiveConvCompileOption(const ConvolutionContext& ctx)
     return ctx.general_compile_options;
 }
 
+bool ConvDirectNaiveConvIsApplicableByKernelType(const ConvolutionContext& ctx)
+{
+    const auto device_name = ctx.GetStream().GetDeviceName();
+    if((device_name == "gfx906" || device_name == "gfx908") && ctx.rmv.IsV3() &&
+       ctx.IsLayoutDefault())
+    {
+        if(!ctx.use_asm_kernels)
+            return false;
+    }
+    else
+    {
+        if(!ctx.use_hip_kernels)
+            return false;
+    }
+    return true;
+}
+
 } // namespace solver
 } // namespace miopen

--- a/src/solver/conv_direct_naive_conv_bwd.cpp
+++ b/src/solver/conv_direct_naive_conv_bwd.cpp
@@ -40,18 +40,8 @@ bool ConvDirectNaiveConvBwd::IsApplicable(const ConvolutionContext& ctx) const
        miopen::IsDisabled(MIOPEN_DEBUG_CONV_DIRECT_NAIVE_CONV_BWD{}))
         return false;
 
-    const auto device_name = ctx.GetStream().GetDeviceName();
-    if((device_name == "gfx906" || device_name == "gfx908") && ctx.rmv.IsV3() &&
-       ctx.IsLayoutDefault())
-    {
-        if(!ctx.use_asm_kernels)
-            return false;
-    }
-    else
-    {
-        if(!ctx.use_hip_kernels)
-            return false;
-    }
+    if(!ConvDirectNaiveConvIsApplicableByKernelType(ctx))
+        return false;
 
     if(!ctx.IsLayoutDefault() && !ctx.IsLayoutNHWC())
         return false;

--- a/src/solver/conv_direct_naive_conv_bwd.cpp
+++ b/src/solver/conv_direct_naive_conv_bwd.cpp
@@ -40,6 +40,9 @@ bool ConvDirectNaiveConvBwd::IsApplicable(const ConvolutionContext& ctx) const
        miopen::IsDisabled(MIOPEN_DEBUG_CONV_DIRECT_NAIVE_CONV_BWD{}))
         return false;
 
+    if(!ctx.use_hip_kernels)
+        return false;
+
     if(!ctx.IsLayoutDefault() && !ctx.IsLayoutNHWC())
         return false;
 

--- a/src/solver/conv_direct_naive_conv_bwd.cpp
+++ b/src/solver/conv_direct_naive_conv_bwd.cpp
@@ -40,8 +40,18 @@ bool ConvDirectNaiveConvBwd::IsApplicable(const ConvolutionContext& ctx) const
        miopen::IsDisabled(MIOPEN_DEBUG_CONV_DIRECT_NAIVE_CONV_BWD{}))
         return false;
 
-    if(!ctx.use_hip_kernels)
-        return false;
+    const auto device_name = ctx.GetStream().GetDeviceName();
+    if((device_name == "gfx906" || device_name == "gfx908") && ctx.rmv.IsV3() &&
+       ctx.IsLayoutDefault())
+    {
+        if(!ctx.use_asm_kernels)
+            return false;
+    }
+    else
+    {
+        if(!ctx.use_hip_kernels)
+            return false;
+    }
 
     if(!ctx.IsLayoutDefault() && !ctx.IsLayoutNHWC())
         return false;

--- a/src/solver/conv_direct_naive_conv_fwd.cpp
+++ b/src/solver/conv_direct_naive_conv_fwd.cpp
@@ -40,18 +40,8 @@ bool ConvDirectNaiveConvFwd::IsApplicable(const ConvolutionContext& ctx) const
        miopen::IsDisabled(MIOPEN_DEBUG_CONV_DIRECT_NAIVE_CONV_FWD{}))
         return false;
 
-    const auto device_name = ctx.GetStream().GetDeviceName();
-    if((device_name == "gfx906" || device_name == "gfx908") && ctx.rmv.IsV3() &&
-       ctx.IsLayoutDefault())
-    {
-        if(!ctx.use_asm_kernels)
-            return false;
-    }
-    else
-    {
-        if(!ctx.use_hip_kernels)
-            return false;
-    }
+    if(!ConvDirectNaiveConvIsApplicableByKernelType(ctx))
+        return false;
 
     if(!ctx.IsLayoutDefault() && !ctx.IsLayoutNHWC())
         return false;

--- a/src/solver/conv_direct_naive_conv_fwd.cpp
+++ b/src/solver/conv_direct_naive_conv_fwd.cpp
@@ -40,6 +40,9 @@ bool ConvDirectNaiveConvFwd::IsApplicable(const ConvolutionContext& ctx) const
        miopen::IsDisabled(MIOPEN_DEBUG_CONV_DIRECT_NAIVE_CONV_FWD{}))
         return false;
 
+    if(!ctx.use_hip_kernels)
+        return false;
+
     if(!ctx.IsLayoutDefault() && !ctx.IsLayoutNHWC())
         return false;
 

--- a/src/solver/conv_direct_naive_conv_fwd.cpp
+++ b/src/solver/conv_direct_naive_conv_fwd.cpp
@@ -40,8 +40,18 @@ bool ConvDirectNaiveConvFwd::IsApplicable(const ConvolutionContext& ctx) const
        miopen::IsDisabled(MIOPEN_DEBUG_CONV_DIRECT_NAIVE_CONV_FWD{}))
         return false;
 
-    if(!ctx.use_hip_kernels)
-        return false;
+    const auto device_name = ctx.GetStream().GetDeviceName();
+    if((device_name == "gfx906" || device_name == "gfx908") && ctx.rmv.IsV3() &&
+       ctx.IsLayoutDefault())
+    {
+        if(!ctx.use_asm_kernels)
+            return false;
+    }
+    else
+    {
+        if(!ctx.use_hip_kernels)
+            return false;
+    }
 
     if(!ctx.IsLayoutDefault() && !ctx.IsLayoutNHWC())
         return false;

--- a/src/solver/conv_direct_naive_conv_wrw.cpp
+++ b/src/solver/conv_direct_naive_conv_wrw.cpp
@@ -40,6 +40,9 @@ bool ConvDirectNaiveConvWrw::IsApplicable(const ConvolutionContext& ctx) const
        miopen::IsDisabled(MIOPEN_DEBUG_CONV_DIRECT_NAIVE_CONV_WRW{}))
         return false;
 
+    if(!ctx.use_hip_kernels)
+        return false;
+
     if(!ctx.IsLayoutDefault() && !ctx.IsLayoutNHWC())
         return false;
 

--- a/src/solver/conv_direct_naive_conv_wrw.cpp
+++ b/src/solver/conv_direct_naive_conv_wrw.cpp
@@ -40,18 +40,8 @@ bool ConvDirectNaiveConvWrw::IsApplicable(const ConvolutionContext& ctx) const
        miopen::IsDisabled(MIOPEN_DEBUG_CONV_DIRECT_NAIVE_CONV_WRW{}))
         return false;
 
-    const auto device_name = ctx.GetStream().GetDeviceName();
-    if((device_name == "gfx906" || device_name == "gfx908") && ctx.rmv.IsV3() &&
-       ctx.IsLayoutDefault())
-    {
-        if(!ctx.use_asm_kernels)
-            return false;
-    }
-    else
-    {
-        if(!ctx.use_hip_kernels)
-            return false;
-    }
+    if(!ConvDirectNaiveConvIsApplicableByKernelType(ctx))
+        return false;
 
     if(!ctx.IsLayoutDefault() && !ctx.IsLayoutNHWC())
         return false;

--- a/src/solver/conv_direct_naive_conv_wrw.cpp
+++ b/src/solver/conv_direct_naive_conv_wrw.cpp
@@ -40,8 +40,18 @@ bool ConvDirectNaiveConvWrw::IsApplicable(const ConvolutionContext& ctx) const
        miopen::IsDisabled(MIOPEN_DEBUG_CONV_DIRECT_NAIVE_CONV_WRW{}))
         return false;
 
-    if(!ctx.use_hip_kernels)
-        return false;
+    const auto device_name = ctx.GetStream().GetDeviceName();
+    if((device_name == "gfx906" || device_name == "gfx908") && ctx.rmv.IsV3() &&
+       ctx.IsLayoutDefault())
+    {
+        if(!ctx.use_asm_kernels)
+            return false;
+    }
+    else
+    {
+        if(!ctx.use_hip_kernels)
+            return false;
+    }
 
     if(!ctx.IsLayoutDefault() && !ctx.IsLayoutNHWC())
         return false;

--- a/test/find_db.cpp
+++ b/test/find_db.cpp
@@ -33,7 +33,6 @@
 #include <miopen/logger.hpp>
 #include <miopen/temp_file.hpp>
 #include <miopen/hip_build_utils.hpp>
-#include <miopen/target_properties.hpp>
 
 #include <chrono>
 #include <cstdlib>
@@ -230,11 +229,5 @@ int main(int argc, const char* argv[])
 {
     setenv("MIOPEN_LOG_LEVEL", "6", 1);              // NOLINT (concurrency-mt-unsafe)
     setenv("MIOPEN_COMPILE_PARALLEL_LEVEL", "1", 1); // NOLINT (concurrency-mt-unsafe)
-
-#if WORKAROUND_SWDEV_292187
-    setenv("MIOPEN_DEBUG_HIP_KERNELS", "1", 1);
-    setenv("MIOPEN_DEBUG_OPENCL_CONVOLUTIONS", "1", 1);
-#endif
-
     test_drive<miopen::FindDbTest>(argc, argv);
 }

--- a/test/find_db.cpp
+++ b/test/find_db.cpp
@@ -232,8 +232,8 @@ int main(int argc, const char* argv[])
     setenv("MIOPEN_COMPILE_PARALLEL_LEVEL", "1", 1); // NOLINT (concurrency-mt-unsafe)
 
 #if WORKAROUND_SWDEV_292187
-    setenv("MIOPEN_DEBUG_HIP_KERNELS", "1", 1);         // NOLINT (concurrency-mt-unsafe)
-    setenv("MIOPEN_DEBUG_OPENCL_CONVOLUTIONS", "1", 1); // NOLINT (concurrency-mt-unsafe)
+    setenv("MIOPEN_DEBUG_HIP_KERNELS", "1", 1);
+    setenv("MIOPEN_DEBUG_OPENCL_CONVOLUTIONS", "1", 1);
 #endif
 
     test_drive<miopen::FindDbTest>(argc, argv);

--- a/test/find_db.cpp
+++ b/test/find_db.cpp
@@ -33,6 +33,7 @@
 #include <miopen/logger.hpp>
 #include <miopen/temp_file.hpp>
 #include <miopen/hip_build_utils.hpp>
+#include <miopen/target_properties.hpp>
 
 #include <chrono>
 #include <cstdlib>
@@ -229,5 +230,11 @@ int main(int argc, const char* argv[])
 {
     setenv("MIOPEN_LOG_LEVEL", "6", 1);              // NOLINT (concurrency-mt-unsafe)
     setenv("MIOPEN_COMPILE_PARALLEL_LEVEL", "1", 1); // NOLINT (concurrency-mt-unsafe)
+
+#if WORKAROUND_SWDEV_292187
+    setenv("MIOPEN_DEBUG_HIP_KERNELS", "1", 1);
+    setenv("MIOPEN_DEBUG_OPENCL_CONVOLUTIONS", "1", 1);
+#endif
+
     test_drive<miopen::FindDbTest>(argc, argv);
 }

--- a/test/find_db.cpp
+++ b/test/find_db.cpp
@@ -232,8 +232,8 @@ int main(int argc, const char* argv[])
     setenv("MIOPEN_COMPILE_PARALLEL_LEVEL", "1", 1); // NOLINT (concurrency-mt-unsafe)
 
 #if WORKAROUND_SWDEV_292187
-    setenv("MIOPEN_DEBUG_HIP_KERNELS", "1", 1);
-    setenv("MIOPEN_DEBUG_OPENCL_CONVOLUTIONS", "1", 1);
+    setenv("MIOPEN_DEBUG_HIP_KERNELS", "1", 1);         // NOLINT (concurrency-mt-unsafe)
+    setenv("MIOPEN_DEBUG_OPENCL_CONVOLUTIONS", "1", 1); // NOLINT (concurrency-mt-unsafe)
 #endif
 
     test_drive<miopen::FindDbTest>(argc, argv);


### PR DESCRIPTION
this fix https://github.com/ROCmSoftwarePlatform/MIOpen/issues/1319