### PR TITLE
[NCHW][SWDEV-312112] fix local buffer alignment bug on transpose+nhwc kernel's solver

### DIFF
--- a/src/conv/invokers/impl_gemm_dynamic.cpp
+++ b/src/conv/invokers/impl_gemm_dynamic.cpp
@@ -579,7 +579,7 @@ InvokerFactory MakeImplGemmDynamicForwardXdlopsNHWCInvokerFactory(
             trans_output_idx = idx++;
     }
 
-    const size_t cast_offset = is_nchw ? (trans_output_offset + trans_output_size) : 0;
+    const size_t cast_offset = is_nchw ? (((trans_output_offset + trans_output_size + 3) >> 2) << 2) : 0;
     const size_t cast_size   = need_cast ? miopen::GetTypeSize(miopenFloat) * n * k * ho * wo : 0;
 
     const int kID_trans_start = isGfx90aFp16altSupport ? 2 : 1;
@@ -886,7 +886,7 @@ InvokerFactory MakeImplGemmDynamicBackwardDataXdlopsNHWCInvokerFactory(
             trans_output_idx = idx++;
     }
 
-    const size_t cast_offset = is_nchw ? (trans_output_offset + trans_output_size) : 0;
+    const size_t cast_offset = is_nchw ? (((trans_output_offset + trans_output_size + 3) >> 2) << 2) : 0;
     const size_t cast_size   = need_cast ? miopen::GetTypeSize(miopenFloat) * n * c * hi * wi : 0;
 
     const int kID_trans_start = isGfx90aFp16altSupport ? 2 : 1;

--- a/src/conv/invokers/impl_gemm_dynamic.cpp
+++ b/src/conv/invokers/impl_gemm_dynamic.cpp
@@ -579,6 +579,7 @@ InvokerFactory MakeImplGemmDynamicForwardXdlopsNHWCInvokerFactory(
             trans_output_idx = idx++;
     }
 
+    // 4 bytes alignment to do atomic add
     const size_t cast_offset = is_nchw ? (((trans_output_offset + trans_output_size + 3) >> 2) << 2) : 0;
     const size_t cast_size   = need_cast ? miopen::GetTypeSize(miopenFloat) * n * k * ho * wo : 0;
 
@@ -886,6 +887,7 @@ InvokerFactory MakeImplGemmDynamicBackwardDataXdlopsNHWCInvokerFactory(
             trans_output_idx = idx++;
     }
 
+    // 4 bytes alignment to do atomic add
     const size_t cast_offset = is_nchw ? (((trans_output_offset + trans_output_size + 3) >> 2) << 2) : 0;
     const size_t cast_size   = need_cast ? miopen::GetTypeSize(miopenFloat) * n * c * hi * wi : 0;
 

--- a/src/solver/conv_asm_implicit_gemm_gtc_bwd_nhwc.cpp
+++ b/src/solver/conv_asm_implicit_gemm_gtc_bwd_nhwc.cpp
@@ -927,6 +927,8 @@ ConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWC::GetWorkspaceSize(const ConvolutionCo
             workspace_size += trans_weight.GetSize();
         if(!trans_output.IsSkippable())
             workspace_size += trans_output.GetSize();
+
+        // 4 bytes alignment to do atomic add
         workspace_size = ((workspace_size + 3) >> 2) << 2;
     }
 

--- a/src/solver/conv_asm_implicit_gemm_gtc_bwd_nhwc.cpp
+++ b/src/solver/conv_asm_implicit_gemm_gtc_bwd_nhwc.cpp
@@ -927,6 +927,7 @@ ConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWC::GetWorkspaceSize(const ConvolutionCo
             workspace_size += trans_weight.GetSize();
         if(!trans_output.IsSkippable())
             workspace_size += trans_output.GetSize();
+        workspace_size = ((workspace_size + 3) >> 2) << 2;
     }
 
     if(!ctx.IsFp32())

--- a/src/solver/conv_asm_implicit_gemm_gtc_fwd_nhwc.cpp
+++ b/src/solver/conv_asm_implicit_gemm_gtc_fwd_nhwc.cpp
@@ -778,6 +778,7 @@ ConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWC::GetWorkspaceSize(const ConvolutionCo
         if(!trans_output.IsSkippable())
             workspace_size += trans_output.GetSize();
 
+        // 4 bytes alignment to do atomic add
         workspace_size = ((workspace_size + 3) >> 2) << 2;
     }
 

--- a/src/solver/conv_asm_implicit_gemm_gtc_fwd_nhwc.cpp
+++ b/src/solver/conv_asm_implicit_gemm_gtc_fwd_nhwc.cpp
@@ -777,6 +777,8 @@ ConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWC::GetWorkspaceSize(const ConvolutionCo
             workspace_size += trans_weight.GetSize();
         if(!trans_output.IsSkippable())
             workspace_size += trans_output.GetSize();
+
+        workspace_size = ((workspace_size + 3) >> 2) << 2;
     }
 
     if(!ctx.IsFp32())

--- a/src/solver/conv_asm_implicit_gemm_gtc_wrw_nhwc.cpp
+++ b/src/solver/conv_asm_implicit_gemm_gtc_wrw_nhwc.cpp
@@ -1142,7 +1142,7 @@ ConvSolution ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC::GetSolution(
                 ker(opArgs);
                 if(handle.IsProfilingEnabled())
                     elapsed += handle.GetKernelTime();
-
+#if 0
                 CastTensor(handle,
                            &lowp_quant,
                            cast_desc,
@@ -1151,7 +1151,8 @@ ConvSolution ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC::GetSolution(
                            (is_nchw && !trans_weight_skippable) ? trans_weight_buf.get() :  tensors.dw,
                            0,
                            0);
-
+#endif
+#if 0
                 if(is_nchw && !trans_weight_skippable)
                 {
                     auto& karg_weight = opArgsTrans[trans_weight_idx];
@@ -1161,7 +1162,7 @@ ConvSolution ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC::GetSolution(
                     if(handle.IsProfilingEnabled())
                         elapsed += handle.GetKernelTime();
                 }
-
+#endif
                 if(handle.IsProfilingEnabled())
                     elapsed += handle.GetKernelTime();
 

--- a/src/solver/conv_asm_implicit_gemm_gtc_wrw_nhwc.cpp
+++ b/src/solver/conv_asm_implicit_gemm_gtc_wrw_nhwc.cpp
@@ -903,6 +903,8 @@ ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC::GetWorkspaceSize(const ConvolutionCo
             workspace_size += trans_weight.GetSize();
         if(!trans_output.IsSkippable())
             workspace_size += trans_output.GetSize();
+
+        workspace_size = ((workspace_size + 3) >> 2) << 2;
     }
 
     if(!ctx.IsFp32())
@@ -1071,7 +1073,7 @@ ConvSolution ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC::GetSolution(
 
     MIOPEN_LOG_I2(SolverDbId(*this) << ": " << config.ToString() << msg.str());
 
-    const size_t cast_offset = is_nchw ? (trans_output_offset + trans_output_size) : 0;
+    const size_t cast_offset = is_nchw ? (((trans_output_offset + trans_output_size + 3) >> 2) << 2) : 0;
     const size_t cast_size = need_cast ?
         miopen::GetTypeSize(miopenFloat) * k * (c / group) * y * x  : 0;
 

--- a/src/solver/conv_asm_implicit_gemm_gtc_wrw_nhwc.cpp
+++ b/src/solver/conv_asm_implicit_gemm_gtc_wrw_nhwc.cpp
@@ -1076,7 +1076,7 @@ ConvSolution ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC::GetSolution(
 
     // 16 bytes alignment
     const size_t cast_offset = is_nchw ? (((trans_output_offset + trans_output_size + 1023) >> 10) << 10) : 0;
-    std::cout << "cast_offset:" << cast_offset << std::endl;
+    std::cout << __LINE__ << ": cast_offset:" << cast_offset << std::endl;
     const size_t cast_size = need_cast ?
         miopen::GetTypeSize(miopenFloat) * k * (c / group) * y * x  : 0;
 

--- a/src/solver/conv_asm_implicit_gemm_gtc_wrw_nhwc.cpp
+++ b/src/solver/conv_asm_implicit_gemm_gtc_wrw_nhwc.cpp
@@ -904,7 +904,7 @@ ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC::GetWorkspaceSize(const ConvolutionCo
         if(!trans_output.IsSkippable())
             workspace_size += trans_output.GetSize();
 
-        // need to do 4 bytes alignment to do atomic add
+        // 4 bytes alignment to do atomic add
         workspace_size = ((workspace_size + 3) >> 2) << 2;
     }
 

--- a/src/solver/conv_asm_implicit_gemm_gtc_wrw_nhwc.cpp
+++ b/src/solver/conv_asm_implicit_gemm_gtc_wrw_nhwc.cpp
@@ -905,7 +905,7 @@ ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC::GetWorkspaceSize(const ConvolutionCo
             workspace_size += trans_output.GetSize();
 
         // need to do alignment for atomic add kernels
-        workspace_size = ((workspace_size + 15) >> 4) << 4;
+        workspace_size = ((workspace_size + 1023) >> 10) << 10;
     }
 
     if(!ctx.IsFp32())
@@ -1075,7 +1075,7 @@ ConvSolution ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC::GetSolution(
     MIOPEN_LOG_I2(SolverDbId(*this) << ": " << config.ToString() << msg.str());
 
     // 16 bytes alignment
-    const size_t cast_offset = is_nchw ? (((trans_output_offset + trans_output_size + 15) >> 4) << 4) : 0;
+    const size_t cast_offset = is_nchw ? (((trans_output_offset + trans_output_size + 1023) >> 10) << 10) : 0;
     const size_t cast_size = need_cast ?
         miopen::GetTypeSize(miopenFloat) * k * (c / group) * y * x  : 0;
 

--- a/src/solver/conv_asm_implicit_gemm_gtc_wrw_nhwc.cpp
+++ b/src/solver/conv_asm_implicit_gemm_gtc_wrw_nhwc.cpp
@@ -1076,6 +1076,7 @@ ConvSolution ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC::GetSolution(
 
     // 16 bytes alignment
     const size_t cast_offset = is_nchw ? (((trans_output_offset + trans_output_size + 1023) >> 10) << 10) : 0;
+    std::cout << "cast_offset:" << cast_offset << std::endl;
     const size_t cast_size = need_cast ?
         miopen::GetTypeSize(miopenFloat) * k * (c / group) * y * x  : 0;
 

--- a/src/solver/conv_asm_implicit_gemm_gtc_wrw_nhwc.cpp
+++ b/src/solver/conv_asm_implicit_gemm_gtc_wrw_nhwc.cpp
@@ -904,7 +904,8 @@ ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC::GetWorkspaceSize(const ConvolutionCo
         if(!trans_output.IsSkippable())
             workspace_size += trans_output.GetSize();
 
-        workspace_size = ((workspace_size + 3) >> 2) << 2;
+        // need to do alignment for atomic add kernels
+        workspace_size = ((workspace_size + 15) >> 4) << 4;
     }
 
     if(!ctx.IsFp32())
@@ -1073,7 +1074,8 @@ ConvSolution ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC::GetSolution(
 
     MIOPEN_LOG_I2(SolverDbId(*this) << ": " << config.ToString() << msg.str());
 
-    const size_t cast_offset = is_nchw ? (((trans_output_offset + trans_output_size + 3) >> 2) << 2) : 0;
+    // 16 bytes alignment
+    const size_t cast_offset = is_nchw ? (((trans_output_offset + trans_output_size + 15) >> 4) << 4) : 0;
     const size_t cast_size = need_cast ?
         miopen::GetTypeSize(miopenFloat) * k * (c / group) * y * x  : 0;
 


### PR DESCRIPTION
root cause fix for swdev312112:
[nchw]fix local buffer alignment bug on transpose+nhwc kernel's solver.

_added by carlus:_

````
original buffer       workspace
inp NCHW fp16  --> 1# inp NHWC fp16 buffer
wei NCHW fp16  --> 2# wei NHWC fp16 buffer
out NCHW fp16  --> 3# out NHWC fp16 buffer
                   4# out NHWC fp32 buffer  <- bug here
````
Above is what we are implementing in fwd when input is NCHW but use NHWC kernel with transpose. Basically there should be 4 buffers in workspace, where the first 3 buffers are for transpose the original inp/wei/out buffer. the last one is for some kernel that need use atomic fp32 to accumulate the result, then cast back to fp16. We always allocate a single workspace, and keep an offset inside each of the buffer.
So the problem here is the offset for 4# may not be aligned to multiple of 4 byte, since the previous 3 buffers are fp16. If 4# buffer are not aligned to 4 byte, fp32 atomic will crash.
This PR tries to solve this problem by adding some extra byte to make sure 4# offset is aligned to multiple of 4.