### PR TITLE
[HIP][COMGR] Re-enable PCH starting from 5.0 (SWDEV-308265 is fixed in ROCClr)

### DIFF
--- a/src/comgr.cpp
+++ b/src/comgr.cpp
@@ -106,9 +106,9 @@ MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEBUG_SRAM_EDC_DISABLED)
 #endif
 #endif
 
-// Temporary workaround for SWDEV-308265.
-// '__hipGetPCH' is not available since 4.4
-#if HIP_SUPPORTS_PCH && (HIP_PACKAGE_VERSION_FLAT > 4004000000)
+// '__hipGetPCH' is not available in [4.4, 5.0). See SWDEV-308265.
+#if HIP_SUPPORTS_PCH && (HIP_PACKAGE_VERSION_FLAT >= 4004000000) && \
+    (HIP_PACKAGE_VERSION_FLAT < 5000000000)
 #undef HIP_SUPPORTS_PCH
 #define HIP_SUPPORTS_PCH 0
 #endif


### PR DESCRIPTION
This switches off the W/A for [SWDEV-308265 "[COMGR] Precompiler headers are broken: __hipGetPCH() is not available.."](https://ontrack-internal.amd.com/browse/SWDEV-308265) introduced in #1243 starting from HIP version 5.0.0.

:warning: The fix in ROCClr present in Mainline since build 9292. However, the build reports HIP version 4.4.21493. In order to test PCH functionality in the Mainline, it is necessary to provide two additional options to MIOpen's CMake command line:
```
... -DMIOPEN_OVERRIDE_HIP_VERSION_MAJOR=5 -DMIOPEN_OVERRIDE_HIP_VERSION_MINOR=0 ...
```
Locally tested.

:warning: Similar PR needs to be prepared for 4.5.x (if 4.5.x with fix for missing `__hipGetPCH()` will be released).
