### PR TITLE
[HOTFIX][Navi21][SWDEV-292187] Do not enforce WAVE64 mode for all OpenCL kernels by default. Restored W/A for #1148.

### DIFF
--- a/src/hipoc/hipoc_program.cpp
+++ b/src/hipoc/hipoc_program.cpp
@@ -243,7 +243,7 @@ void HIPOCProgramImpl::BuildCodeObjectInFile(std::string& params,
     else
     {
         params += " " + GetCodeObjectVersionOption();
-        if(!miopen::IsDisabled(MIOPEN_DEBUG_OPENCL_WAVE64_NOWGP{}))
+        if(miopen::IsEnabled(MIOPEN_DEBUG_OPENCL_WAVE64_NOWGP{}))
             params += " -mwavefrontsize64 -mcumode";
         WriteFile(src, dir->path / filename);
         dir->Execute(HIP_OC_COMPILER, params + " " + filename + " -o " + hsaco_file.string());

--- a/src/ocl/clhelper.cpp
+++ b/src/ocl/clhelper.cpp
@@ -211,7 +211,7 @@ ClProgramPtr LoadProgram(cl_context ctx,
     else // OpenCL programs.
     {
         ClProgramPtr result{CreateProgram(ctx, source.data(), source.size())};
-        if(!miopen::IsDisabled(MIOPEN_DEBUG_OPENCL_WAVE64_NOWGP{}))
+        if(miopen::IsEnabled(MIOPEN_DEBUG_OPENCL_WAVE64_NOWGP{}))
             params += " -Wf,-mwavefrontsize64 -Wf,-mcumode";
 #if MIOPEN_BUILD_DEV
         params += " -Werror";

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -313,6 +313,7 @@ function(add_test_executable TEST_NAME)
     if(WORKAROUND_ISSUE_1148
         AND (${TEST_NAME} MATCHES "test_soft_max") )
         set_tests_properties(${TEST_NAME} PROPERTIES RUN_SERIAL On)
+    endif()
     if(WORKAROUND_ISSUE_1334
         AND (${TEST_NAME} MATCHES "test_activation") )
         set_tests_properties(${TEST_NAME} PROPERTIES RUN_SERIAL On)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -310,6 +310,9 @@ function(add_test_executable TEST_NAME)
     add_dependencies(tests ${TEST_NAME})
     add_dependencies(check ${TEST_NAME})
     set_tests_properties(${TEST_NAME} PROPERTIES FAIL_REGULAR_EXPRESSION "FAILED")
+    if(WORKAROUND_ISSUE_1148
+        AND (${TEST_NAME} MATCHES "test_soft_max") )
+        set_tests_properties(${TEST_NAME} PROPERTIES RUN_SERIAL On)
     if(WORKAROUND_ISSUE_1334
         AND (${TEST_NAME} MATCHES "test_activation") )
         set_tests_properties(${TEST_NAME} PROPERTIES RUN_SERIAL On)
@@ -563,7 +566,10 @@ function(add_custom_test NAME)
     endif()
 
     if(WORKAROUND_ISSUE_1148
-        AND (${NAME} MATCHES "test_conv_3d"))
+        AND (${NAME} MATCHES "test_conv_3d"
+          OR ${NAME} MATCHES "test_conv_group"
+          OR ${NAME} MATCHES "test_conv_extra"
+          OR ${NAME} MATCHES "test_conv_for_implicit_gemm" ))
         set_tests_properties(${NAME} PROPERTIES RUN_SERIAL On)
     endif()
 


### PR DESCRIPTION
Partially reverts #1336.

This should be merged only if necessary. i.e. if:
- SWDEV-292187 continues to reproduce with current Staging (amd-develop 8d400b378)
- Exporting `MIOPEN_DEBUG_OPENCL_WAVE64_NOWGP=0` resolves it with current Staging.