### PR TITLE
Allow setting the default FIND_MODE at CMake configuration phase

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -70,6 +70,12 @@ def cmake_build(Map conf=[:]){
        setup_args = "-DMIOPEN_TEST_FLAGS='${test_flags}'" + setup_args
     }
 
+    if(conf.containsKey("find_mode"))
+    {
+        def fmode = conf.get("find_mode", "")
+        setup_args = " -DMIOPEN_DEFAULT_FIND_MODE=${fmode} " + setup_args
+    }
+
     def pre_setup_cmd = """
             echo \$HSA_ENABLE_SDMA
             ulimit -c unlimited
@@ -555,10 +561,10 @@ pipeline {
                     agent{ label rocmnode("vega") }
                     environment{
                         config_targets = "test_conv2d"
-                        execute_cmd = "MIOPEN_FIND_MODE=1 MIOPEN_CONV_PRECISE_ROCBLAS_TIMING=0 bin/test_conv2d --disable-verification-cache"
+                        execute_cmd = "MIOPEN_CONV_PRECISE_ROCBLAS_TIMING=0 bin/test_conv2d --disable-verification-cache"
                     }
                     steps{
-                        buildHipClangJobAndReboot(config_targets: config_targets, execute_cmd: execute_cmd)
+                        buildHipClangJobAndReboot(config_targets: config_targets, execute_cmd: execute_cmd, find_mode: "Normal")
                     }
                 }
                 stage('Fp32 Hip Fast-Find') {

--- a/include/miopen/config.h.in
+++ b/include/miopen/config.h.in
@@ -73,6 +73,9 @@
 //     to BF16 results. This affects the main functionality of the library.
 #cmakedefine01 MIOPEN_USE_RNE_BFLOAT16
 
+// clang-format off
+#cmakedefine MIOPEN_DEFAULT_FIND_MODE @MIOPEN_DEFAULT_FIND_MODE@
+// clang-format on
 #cmakedefine MIOPEN_AMDGCN_ASSEMBLER "@MIOPEN_AMDGCN_ASSEMBLER@"
 #cmakedefine HIP_OC_COMPILER "@HIP_OC_COMPILER@"
 #cmakedefine MIOPEN_HIP_COMPILER "@MIOPEN_HIP_COMPILER@"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -37,6 +37,9 @@ add_subdirectory(sqlite)
 #     remain in the future)  perform final conversion (and rounding) of FP32
 #     to BF16 results. This affects the main functionality of the library.
 option( MIOPEN_USE_RNE_BFLOAT16 "Sets rounding scheme for bfloat16 type" ON )
+set ( MIOPEN_DEFAULT_FIND_MODE "DynamicHybrid" CACHE STRING "Sets the default find mode")
+set_property(CACHE MIOPEN_DEFAULT_FIND_MODE PROPERTY STRINGS 
+    Normal Fast Hybrid FastHybrid DynamicHybrid)
 
 configure_file("${PROJECT_SOURCE_DIR}/include/miopen/config.h.in" "${PROJECT_BINARY_DIR}/include/miopen/config.h")
 

--- a/src/find_controls.cpp
+++ b/src/find_controls.cpp
@@ -238,8 +238,5 @@ static_assert(miopenConvolutionFindModeFastHybrid ==
 static_assert(miopenConvolutionFindModeDynamicHybrid ==
                   static_cast<miopenConvolutionFindMode_t>(FindMode::Values::DynamicHybrid),
               "API is not in sync with the implementation.");
-static_assert(miopenConvolutionFindModeDefault ==
-                  static_cast<miopenConvolutionFindMode_t>(FindMode::Values::Default_),
-              "API is not in sync with the implementation.");
 
 } // namespace miopen

--- a/src/include/miopen/find_controls.hpp
+++ b/src/include/miopen/find_controls.hpp
@@ -117,7 +117,7 @@ class FindMode
         FastHybrid,
         DynamicHybrid,
         End_,
-        Default_ = DynamicHybrid,
+        Default_ = MIOPEN_DEFAULT_FIND_MODE,
     };
 
     private:

--- a/src/include/miopen/miopen_internal.h
+++ b/src/include/miopen/miopen_internal.h
@@ -67,6 +67,9 @@ extern "C" {
  * * Dynamic Hybrid: This mode is similar to Fast Hybrid, but in case of Find-db miss skips all
  * non-dynamic kernels, thus saving compilation time. Versus Fast Hybrid, we expect similar start-up
  * times but better GPU performance.
+ *
+ * * The default find mode may be queried by using the miopenGetConvolutionFindMode API described
+ * below
  */
 typedef enum
 {
@@ -75,8 +78,6 @@ typedef enum
     miopenConvolutionFindModeHybrid        = 3, /*!< Hybrid mode */
     miopenConvolutionFindModeFastHybrid    = 4, /*!< Fast Hybrid mode */
     miopenConvolutionFindModeDynamicHybrid = 5, /*!< Dynamic Hybrid mode */
-    miopenConvolutionFindModeDefault =
-        miopenConvolutionFindModeDynamicHybrid, /*!< Default setting */
 } miopenConvolutionFindMode_t;
 
 /*! @brief Sets the Find Mode attribute in the convolution descriptor.


### PR DESCRIPTION
MIOPEN_DEFAULT_FIND_MODE cmake variable maybe used to override the default MIOpen find mode. 

This is #1347 for `develop`.