### PR TITLE
[WORKAROUND][COMGR] W/A for issue 1359: Use hipModuleLoad with interim file instead of hipModuleLoadData. By-product: Better names for tempfiles.

### DIFF
--- a/src/include/miopen/temp_file.hpp
+++ b/src/include/miopen/temp_file.hpp
@@ -38,21 +38,24 @@ class TempFile
     public:
     TempFile(const std::string& path_infix);
 
-    TempFile(TempFile&& other) noexcept : name(std::move(other.name)), dir(std::move(other.dir)) {}
+    TempFile(TempFile&& other) noexcept
+        : path_infix(std::move(other.path_infix)), dir(std::move(other.dir))
+    {
+    }
 
     TempFile& operator=(TempFile&& other) noexcept
     {
-        name = std::move(other.name);
-        dir  = std::move(other.dir);
+        path_infix = std::move(other.path_infix);
+        dir        = std::move(other.dir);
         return *this;
     }
 
-    const std::string& Name() const { return name; }
-    std::string Path() const { return (dir.path / name).string(); }
+    const std::string& GetPathInfix() const { return path_infix; }
+    std::string Path() const { return (dir.path / "file").string(); }
     operator std::string() const { return Path(); }
 
     private:
-    std::string name;
+    std::string path_infix;
     TmpDir dir;
 };
 } // namespace miopen

--- a/src/include/miopen/temp_file.hpp
+++ b/src/include/miopen/temp_file.hpp
@@ -37,18 +37,8 @@ class TempFile
 {
     public:
     TempFile(const std::string& path_infix);
-
-    TempFile(TempFile&& other) noexcept
-        : path_infix(std::move(other.path_infix)), dir(std::move(other.dir))
-    {
-    }
-
-    TempFile& operator=(TempFile&& other) noexcept
-    {
-        path_infix = std::move(other.path_infix);
-        dir        = std::move(other.dir);
-        return *this;
-    }
+    TempFile(TempFile&& other) noexcept = default;
+    TempFile& operator=(TempFile&& other) noexcept = default;
 
     const std::string& GetPathInfix() const { return path_infix; }
     std::string Path() const { return (dir.path / "file").string(); }

--- a/src/include/miopen/temp_file.hpp
+++ b/src/include/miopen/temp_file.hpp
@@ -36,7 +36,7 @@ namespace miopen {
 class TempFile
 {
     public:
-    TempFile(const std::string& path_template);
+    TempFile(const std::string& path_infix);
 
     TempFile(TempFile&& other) noexcept : name(std::move(other.name)), dir(std::move(other.dir)) {}
 

--- a/src/ocl/gcn_asm_utils.cpp
+++ b/src/ocl/gcn_asm_utils.cpp
@@ -184,7 +184,7 @@ std::string AmdgcnAssemble(const std::string& source,
                            const miopen::TargetProperties& target)
 {
 #ifdef __linux__
-    miopen::TempFile outfile("amdgcn-asm-out-XXXXXX");
+    miopen::TempFile outfile("assembly");
 
     std::ostringstream options;
     options << " -x assembler -target amdgcn--amdhsa";

--- a/src/temp_file.cpp
+++ b/src/temp_file.cpp
@@ -4,7 +4,7 @@
 #include <boost/filesystem.hpp>
 
 namespace miopen {
-TempFile::TempFile(const std::string& path_template) : name(path_template), dir("tmp")
+TempFile::TempFile(const std::string& path_infix) : name("file"), dir(path_infix)
 {
     if(!std::ofstream{this->Path(), std::ios_base::out | std::ios_base::in | std::ios_base::trunc}
             .good())

--- a/src/temp_file.cpp
+++ b/src/temp_file.cpp
@@ -4,7 +4,7 @@
 #include <boost/filesystem.hpp>
 
 namespace miopen {
-TempFile::TempFile(const std::string& path_infix) : name("file"), dir(path_infix)
+TempFile::TempFile(const std::string& path_infix_) : path_infix(path_infix_), dir(path_infix)
 {
     if(!std::ofstream{this->Path(), std::ios_base::out | std::ios_base::in | std::ios_base::trunc}
             .good())

--- a/test/perfdb.cpp
+++ b/test/perfdb.cpp
@@ -227,7 +227,7 @@ class DbTest
         return data;
     }
 
-    static void ResetDbFile(TempFile& tmp_file) { tmp_file = TempFile{tmp_file.Name()}; }
+    static void ResetDbFile(TempFile& tmp_file) { tmp_file = TempFile{tmp_file.GetPathInfix()}; }
 
     void ResetDb() { ResetDbFile(temp_file); }
 


### PR DESCRIPTION
Quick W/A for issue #1359, almost identical to https://github.com/AMDComputeLibraries/MLOpen/pull/2501.