### PR TITLE
Adding versioning to JSON req for FIN

### DIFF
--- a/fin/requirements.txt
+++ b/fin/requirements.txt
@@ -1,5 +1,5 @@
 RadeonOpenCompute/rocm-cmake@cdd0f632b3a65bd4411593bb827eb664e25c80bc --build
 # ROCmSoftwarePlatform/MIOpen@9b2d37f9f1e4b5492ef8256cf8168363ca5fd2da 
-nlohmann/json
+nlohmann/json@v3.10.4
 #ROCmSoftwarePlatform/rocBLAS@9790a8658341bc665c11c311129ad0dfc533d5c4
 


### PR DESCRIPTION
Fin build fails because JSON cmake fails with latest v3.10.5 bc of experimental::filesystems stdc++fs lib linker.
Using v3.10.4 works, to avoid linking specific libraries, we are going to use an older version until we are ready to update libs.