### PR TITLE
[host code]fix a host static for loop bug

### DIFF
--- a/test/ford.hpp
+++ b/test/ford.hpp
@@ -140,7 +140,7 @@ struct par_ford_impl
         strides.fill(1);
         std::partial_sum(
             lens.rbegin(), lens.rend() - 1, strides.rbegin() + 1, std::multiplies<std::size_t>());
-        auto size = std::accumulate(lens.begin(), lens.end(), 1, std::multiplies<std::size_t>());
+        auto size = std::accumulate(lens.begin(), lens.end(), static_cast<std::size_t>(1), std::multiplies<std::size_t>());
         par_for(size, [&](std::size_t i) {
             array_type indices;
             std::transform(strides.begin(),


### PR DESCRIPTION
We currently use ```std::accumulate(lens.begin(), lens.end(), 1, std::multiplies<std::size_t>())``` to determine a ```for``` loop's max size. As per https://en.cppreference.com/w/cpp/algorithm/accumulate, std::accumulate will use type of init as a return data type. When we use immed num ```1``` as init, the return var will be deduced as ```int``` type. However, ```lens``` is a vector of ```std::size_t```, when multiply of each item in ```lens``` is larger than max value of ```int```, a ```for``` loop will get a weird num like ```-2147483648```, which will cause a dead loop.
When we run:
```
./bin/MIOpenDriver conv -n 4096 -c 1 -H 512 -W 1024 -k 1 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -g 1 -F 1 -t 1 -w 1 --in_layout NHWC --fil_layout NHWC --out_layout NHWC
```
host code will run a endless loop.
So the immed num ```1``` should be cast to ```std::size_t```.