### PR TITLE
[5.0][Navi21] Fixing Batchnorm backward precision issues by adjusting workgroup size (SWDEV-292187, SWDEV-319919)

### DIFF
--- a/src/solver/batchnorm/backward_spatial_single.cpp
+++ b/src/solver/batchnorm/backward_spatial_single.cpp
@@ -61,6 +61,7 @@ BnBwdTrainingSpatialSingle::GetSolution(const ExecutionContext& context,
                                         const miopen::batchnorm::ProblemDescription& problem) const
 {
     const auto& handle = context.GetStream();
+    const unsigned wavesize = (miopen::StartsWith(handle.GetDeviceName(), "gfx10") ? 32 : 64);
 
     bool bfpmixparm = false;
     bool bfp16parm  = false;
@@ -108,7 +109,7 @@ BnBwdTrainingSpatialSingle::GetSolution(const ExecutionContext& context,
         variant    = 1;
         xlocalsize = 1024;
         xgridsize  = c * xlocalsize;
-        ldsgcn     = xlocalsize / 64;
+            ldsgcn     = xlocalsize / wavesize;
         ldsnogcn   = xlocalsize;
     }
     //*************************************************************************************************
@@ -121,7 +122,7 @@ BnBwdTrainingSpatialSingle::GetSolution(const ExecutionContext& context,
         variant    = (n >= 32) ? 1 : 3;
             xlocalsize = 1024;
         xgridsize  = c * xlocalsize;
-        ldsgcn     = xlocalsize / 64;
+            ldsgcn     = xlocalsize / wavesize;
         ldsnogcn   = xlocalsize;
     }
     //*************************************************************************************************
@@ -135,14 +136,15 @@ BnBwdTrainingSpatialSingle::GetSolution(const ExecutionContext& context,
                 variant    = 3;
                 xlocalsize = 1024;
                 xgridsize  = c * xlocalsize;
-                ldsgcn     = xlocalsize / 64;
+                ldsgcn     = xlocalsize / wavesize;
                 ldsnogcn   = xlocalsize;
         }
         else
         {
                 variant    = 0;
                 xlocalsize = 1024;
-                ldsgcn     = xlocalsize / 64;
+                xgridsize  = 1024 * c;
+                ldsgcn     = xlocalsize / wavesize;
                 ldsnogcn   = xlocalsize;
         }
     }
@@ -157,7 +159,7 @@ BnBwdTrainingSpatialSingle::GetSolution(const ExecutionContext& context,
         auto segment = int(std::ceil(double(in_cstride) / double(ylocalsize)));
         xgridsize    = c;
         ygridsize    = segment * ylocalsize;
-        ldsgcn       = ylocalsize / 64;
+            ldsgcn       = ylocalsize / wavesize;
         ldsnogcn     = ylocalsize;
     }
     if((in_cstride < 200) && (in_cstride > 60) && bfpmixparm)
@@ -165,7 +167,7 @@ BnBwdTrainingSpatialSingle::GetSolution(const ExecutionContext& context,
         variant    = 1;
         xlocalsize = 1024;
         xgridsize  = c * xlocalsize;
-        ldsgcn     = xlocalsize / 64;
+            ldsgcn     = xlocalsize / wavesize;
         ldsnogcn   = xlocalsize;
     }
     }
@@ -192,6 +194,7 @@ BnBwdTrainingSpatialSingle::GetSolution(const ExecutionContext& context,
             {"MIO_BN_LDS_SIZE", ldsnogcn},
             {"MIO_BN_LDSGCN_SIZE", ldsgcn},
             {"MIO_BN_VARIANT", variant},
+            {"MIO_WAVESIZE", wavesize},
             {"MIO_BN_GRP0", xlocalsize},
             {"MIO_BN_GRP1", ylocalsize},
             {"MIO_BN_GRP2", zlocalsize},

--- a/src/solver/batchnorm/backward_spatial_single.cpp
+++ b/src/solver/batchnorm/backward_spatial_single.cpp
@@ -60,7 +60,7 @@ ConvSolution
 BnBwdTrainingSpatialSingle::GetSolution(const ExecutionContext& context,
                                         const miopen::batchnorm::ProblemDescription& problem) const
 {
-    const auto& handle = context.GetStream();
+    const auto& handle      = context.GetStream();
     const unsigned wavesize = (miopen::StartsWith(handle.GetDeviceName(), "gfx10") ? 32 : 64);
 
     bool bfpmixparm = false;
@@ -109,7 +109,7 @@ BnBwdTrainingSpatialSingle::GetSolution(const ExecutionContext& context,
         variant    = 1;
         xlocalsize = 1024;
         xgridsize  = c * xlocalsize;
-            ldsgcn     = xlocalsize / wavesize;
+        ldsgcn     = xlocalsize / wavesize;
         ldsnogcn   = xlocalsize;
     }
     //*************************************************************************************************
@@ -120,9 +120,9 @@ BnBwdTrainingSpatialSingle::GetSolution(const ExecutionContext& context,
     else if(in_nhw < (32 * 1024 * 1024) && in_cstride > 512)
     {
         variant    = (n >= 32) ? 1 : 3;
-            xlocalsize = 1024;
+        xlocalsize = 1024;
         xgridsize  = c * xlocalsize;
-            ldsgcn     = xlocalsize / wavesize;
+        ldsgcn     = xlocalsize / wavesize;
         ldsnogcn   = xlocalsize;
     }
     //*************************************************************************************************
@@ -133,19 +133,19 @@ BnBwdTrainingSpatialSingle::GetSolution(const ExecutionContext& context,
     {
         if((n > 64) && (in_cstride > 160))
         {
-                variant    = 3;
-                xlocalsize = 1024;
-                xgridsize  = c * xlocalsize;
-                ldsgcn     = xlocalsize / wavesize;
-                ldsnogcn   = xlocalsize;
+            variant    = 3;
+            xlocalsize = 1024;
+            xgridsize  = c * xlocalsize;
+            ldsgcn     = xlocalsize / wavesize;
+            ldsnogcn   = xlocalsize;
         }
         else
         {
-                variant    = 0;
-                xlocalsize = 1024;
-                xgridsize  = 1024 * c;
-                ldsgcn     = xlocalsize / wavesize;
-                ldsnogcn   = xlocalsize;
+            variant    = 0;
+            xlocalsize = 1024;
+            xgridsize  = 1024 * c;
+            ldsgcn     = xlocalsize / wavesize;
+            ldsnogcn   = xlocalsize;
         }
     }
     //*************************************************************************************************
@@ -159,7 +159,7 @@ BnBwdTrainingSpatialSingle::GetSolution(const ExecutionContext& context,
         auto segment = int(std::ceil(double(in_cstride) / double(ylocalsize)));
         xgridsize    = c;
         ygridsize    = segment * ylocalsize;
-            ldsgcn       = ylocalsize / wavesize;
+        ldsgcn       = ylocalsize / wavesize;
         ldsnogcn     = ylocalsize;
     }
     if((in_cstride < 200) && (in_cstride > 60) && bfpmixparm)
@@ -167,9 +167,8 @@ BnBwdTrainingSpatialSingle::GetSolution(const ExecutionContext& context,
         variant    = 1;
         xlocalsize = 1024;
         xgridsize  = c * xlocalsize;
-            ldsgcn     = xlocalsize / wavesize;
+        ldsgcn     = xlocalsize / wavesize;
         ldsnogcn   = xlocalsize;
-    }
     }
 
     auto result = ConvSolution{miopenStatusSuccess};

--- a/src/solver/batchnorm/backward_spatial_single.cpp
+++ b/src/solver/batchnorm/backward_spatial_single.cpp
@@ -119,7 +119,7 @@ BnBwdTrainingSpatialSingle::GetSolution(const ExecutionContext& context,
     else if(in_nhw < (32 * 1024 * 1024) && in_cstride > 512)
     {
         variant    = (n >= 32) ? 1 : 3;
-        xlocalsize = std::min(64 * ((in_cstride + 63) / 64), static_cast<unsigned int>(1024));
+            xlocalsize = 1024;
         xgridsize  = c * xlocalsize;
         ldsgcn     = xlocalsize / 64;
         ldsnogcn   = xlocalsize;
@@ -132,27 +132,18 @@ BnBwdTrainingSpatialSingle::GetSolution(const ExecutionContext& context,
     {
         if((n > 64) && (in_cstride > 160))
         {
-            variant    = 3;
-            xlocalsize = std::min(64 * ((in_cstride + 63) / 64), static_cast<unsigned int>(1024));
-            xgridsize  = c * xlocalsize;
-            ldsgcn     = xlocalsize / 64;
-            ldsnogcn   = xlocalsize;
+                variant    = 3;
+                xlocalsize = 1024;
+                xgridsize  = c * xlocalsize;
+                ldsgcn     = xlocalsize / 64;
+                ldsnogcn   = xlocalsize;
         }
         else
         {
-            variant = 0;
-            if(bfp32parm)
-            {
+                variant    = 0;
                 xlocalsize = 1024;
-                xgridsize  = 1024 * c;
-            }
-            else
-            {
-                xlocalsize = 256;
-                xgridsize  = 256 * c;
-            }
-            ldsgcn   = xlocalsize / 64;
-            ldsnogcn = xlocalsize;
+                ldsgcn     = xlocalsize / 64;
+                ldsnogcn   = xlocalsize;
         }
     }
     //*************************************************************************************************
@@ -176,6 +167,7 @@ BnBwdTrainingSpatialSingle::GetSolution(const ExecutionContext& context,
         xgridsize  = c * xlocalsize;
         ldsgcn     = xlocalsize / 64;
         ldsnogcn   = xlocalsize;
+    }
     }
 
     auto result = ConvSolution{miopenStatusSuccess};


### PR DESCRIPTION
This is #1386 ported to 5.0 release branch.

This fix addresses Batchnorm backward precision issues. Manually tested on gfx906 and gfx1030, including:
```
./bin/test_bn_3d_spatial_test --half --all
./bin/test_bn_spatial_test --half --all
./bin/MIOpenDriver bnormfp16 -n 256 -c 1024 -H 14 -W 14 -m 1 --forw 0 -b 1 -r 1
./bin/MIOpenDriver bnormfp16 -n 256 -c 1024 -H 14 -W 14 -m 1 --forw 1 -b 0 -s 1 -r 1
./bin/MIOpenDriver bnormfp16 -n 256 -c 2048 -H 7 -W 7 -m 1 --forw 0 -b 1 -r 1
./bin/MIOpenDriver bnormfp16 -n 256 -c 2048 -H 7 -W 7 -m 1 --forw 1 -b 0 -s 1 -r 1
./bin/MIOpenDriver bnormfp16 -n 256 -c 256 -H 56 -W 56 -m 1 --forw 0 -b 1 -r 1
./bin/MIOpenDriver bnormfp16 -n 256 -c 256 -H 56 -W 56 -m 1 --forw 1 -b 0 -s 1 -r 1
./bin/MIOpenDriver bnormfp16 -n 256 -c 512 -H 28 -W 28 -m 1 --forw 0 -b 1 -r 1
./bin/MIOpenDriver bnormfp16 -n 256 -c 512 -H 28 -W 28 -m 1 --forw 1 -b 0 -s 1 -r 1
```