### PR TITLE
[Release][5.0] Revert incorrect change to ConvBiasActivAsm1x1U solver search method

### DIFF
--- a/src/solver/conv_asm_1x1u_bias_activ.cpp
+++ b/src/solver/conv_asm_1x1u_bias_activ.cpp
@@ -94,19 +94,17 @@ ConvBiasActivAsm1x1U::Search(const ConvolutionContext& context, const AnyInvokeP
     const auto wei_buf  = handle.Create(cba_context.weights_sz);
     const auto out_buf  = handle.Create(cba_context.top_sz);
 
-    auto tensors    = FusedConvDataTensors{};
-    tensors.in      = in_buf.get();
-    tensors.w       = wei_buf.get();
-    tensors.out     = out_buf.get();
-    tensors.inDesc  = context.conv_problem.GetIn();
-    tensors.wDesc   = context.conv_problem.GetWeights();
-    tensors.outDesc = context.conv_problem.GetOut();
-    tensors.bias    = bias_buf.get();
-
-    PerformanceConfigConvBiasActivAsm1x1U pp;
-    pp.HeuristicInit(context);
-    return pp;
-    // return GenericSearch(*this, cba_context, fused_invoke_ctx);
+    auto tensors                = FusedConvDataTensors{};
+    tensors.in                  = in_buf.get();
+    tensors.w                   = wei_buf.get();
+    tensors.out                 = out_buf.get();
+    tensors.inDesc              = context.conv_problem.GetIn();
+    tensors.wDesc               = context.conv_problem.GetWeights();
+    tensors.outDesc             = context.conv_problem.GetOut();
+    tensors.bias                = bias_buf.get();
+    const auto gfx90aaltimpl    = context.conv_problem.GetConv().attribute.gfx90aFp16alt.GetFwd();
+    const auto fused_invoke_ctx = conv::FusedDataInvokeParams(tensors, nullptr, 0, gfx90aaltimpl);
+    return GenericSearch(*this, cba_context, fused_invoke_ctx);
 }
 
 ConvSolution ConvBiasActivAsm1x1U::GetSolution(const ConvolutionContext& params,


### PR DESCRIPTION
Clone of #1395 for 5.0 release.

This PR reverts an incorrect code commit introduced in #1221 which disables search for the `ConvBiasActivAsm1x1U` solver