### PR TITLE
[Navi21] Remove W/A for SWDEV-292187

### DIFF
--- a/src/execution_context.cpp
+++ b/src/execution_context.cpp
@@ -32,10 +32,7 @@
 #include <miopen/ocldeviceinfo.hpp>
 #endif
 #include <miopen/stringutils.hpp>
-#include <miopen/target_properties.hpp>
 #include <miopen/version.h>
-
-#include <tuple> // std::ignore
 
 MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEBUG_OPENCL_CONVOLUTIONS)
 MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEBUG_GCN_ASM_KERNELS)
@@ -196,36 +193,21 @@ static bool IsAmdRocmOpencl(miopen::ExecutionContext& context)
     return ret_bool;
 }
 
-bool IsHipKernelsEnabled(const miopen::TargetProperties& target)
+bool IsHipKernelsEnabled()
 {
-    std::ignore = target;
 #if MIOPEN_USE_HIP_KERNELS
-#if WORKAROUND_SWDEV_292187
-    if(target.Name() == "gfx1030")
-        return miopen::IsEnabled(MIOPEN_DEBUG_HIP_KERNELS{});
-#endif // WORKAROUND_SWDEV_292187
     return !miopen::IsDisabled(MIOPEN_DEBUG_HIP_KERNELS{});
 #else
     return miopen::IsEnabled(MIOPEN_DEBUG_HIP_KERNELS{});
 #endif
 }
 
-static bool IsOpenclConvolutionsEnabled(const miopen::TargetProperties& target)
-{
-#if WORKAROUND_SWDEV_292187
-    if(target.Name() == "gfx1030")
-        return miopen::IsEnabled(MIOPEN_DEBUG_OPENCL_CONVOLUTIONS{});
-#endif // WORKAROUND_SWDEV_292187
-    std::ignore = target;
-    return !miopen::IsDisabled(MIOPEN_DEBUG_OPENCL_CONVOLUTIONS{});
-}
-
 void miopen::ExecutionContext::DetectRocm()
 {
     use_binaries            = false;
     use_asm_kernels         = false;
-    use_hip_kernels         = IsHipKernelsEnabled(GetStream().GetTargetProperties());
-    use_opencl_convolutions = IsOpenclConvolutionsEnabled(GetStream().GetTargetProperties());
+    use_hip_kernels         = IsHipKernelsEnabled();
+    use_opencl_convolutions = !miopen::IsDisabled(MIOPEN_DEBUG_OPENCL_CONVOLUTIONS{});
     rmv                     = rocm_meta_version::Default;
     if(IsAmdRocmOpencl(*this))
     {

--- a/src/include/miopen/execution_context.hpp
+++ b/src/include/miopen/execution_context.hpp
@@ -29,7 +29,6 @@
 #include <miopen/db_path.hpp>
 #include <miopen/handle.hpp>
 #include <miopen/sqlite_db.hpp>
-#include <miopen/target_properties.hpp>
 #if MIOPEN_EMBED_DB
 #include <miopen_data.hpp>
 #endif
@@ -288,6 +287,6 @@ class AutoUseFastDynamicSolutions
     ~AutoUseFastDynamicSolutions() { ctx->use_dynamic_solutions_only = prev_use_dynamic_; }
 };
 
-bool IsHipKernelsEnabled(const TargetProperties& target);
+bool IsHipKernelsEnabled();
 
 } // namespace miopen

--- a/src/include/miopen/target_properties.hpp
+++ b/src/include/miopen/target_properties.hpp
@@ -29,8 +29,6 @@
 #include <boost/optional.hpp>
 #include <string>
 
-#define WORKAROUND_SWDEV_292187 1
-
 namespace miopen {
 
 struct Handle;

--- a/src/solver/conv_ocl_dir2D11x11.cpp
+++ b/src/solver/conv_ocl_dir2D11x11.cpp
@@ -30,7 +30,6 @@
 #include <miopen/visit_float.hpp>
 #include <miopen/conv/invokers/gen_x_w_y_pad.hpp>
 #include <miopen/conv/data_invoke_params.hpp>
-#include <miopen/stringutils.hpp>
 
 MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEBUG_CONV_DIRECT_OCL_FWD11X11)
 
@@ -39,11 +38,6 @@ namespace solver {
 
 bool ConvOclDirectFwd11x11::IsApplicable(const ConvolutionContext& params) const
 {
-#if WORKAROUND_SWDEV_292187
-    if(StartsWith(params.GetStream().GetDeviceName(), "gfx10"))
-        if(!miopen::IsEnabled(MIOPEN_DEBUG_CONV_DIRECT_OCL_FWD11X11{}))
-            return false;
-#endif
     if(miopen::IsDisabled(MIOPEN_DEBUG_CONV_DIRECT_OCL_FWD11X11{}))
         return false;
     if(!params.use_opencl_convolutions)

--- a/src/solver/conv_ocl_dir2D_bwdWrW_1x1.cpp
+++ b/src/solver/conv_ocl_dir2D_bwdWrW_1x1.cpp
@@ -41,7 +41,7 @@ namespace solver {
 
 bool ConvOclBwdWrW1x1::IsApplicable(const ConvolutionContext& params) const
 {
-#if WORKAROUND_SWDEV_266868 || WORKAROUND_SWDEV_292187
+#if WORKAROUND_SWDEV_266868
     if(StartsWith(params.GetStream().GetDeviceName(), "gfx10"))
         if(!miopen::IsEnabled(MIOPEN_DEBUG_CONV_DIRECT_OCL_WRW1X1{}))
             return false;

--- a/src/solver/conv_ocl_dir2D_bwdWrW_2.cpp
+++ b/src/solver/conv_ocl_dir2D_bwdWrW_2.cpp
@@ -33,7 +33,6 @@
 #include <miopen/generic_search.hpp>
 #include <miopen/bfloat16.hpp>
 #include <miopen/mlo_utils.hpp>
-#include <miopen/stringutils.hpp>
 #include <miopen/visit_float.hpp>
 
 #include <algorithm>
@@ -451,11 +450,6 @@ bool ConvOclBwdWrW2<N_BATCH_LOOPS>::IsValidPerformanceConfig(
 template <int N_BATCH_LOOPS>
 bool ConvOclBwdWrW2<N_BATCH_LOOPS>::IsApplicableBase(const ConvolutionContext& params) const
 {
-#if WORKAROUND_SWDEV_292187
-    if(StartsWith(params.GetStream().GetDeviceName(), "gfx10"))
-        if(!miopen::IsEnabled(MIOPEN_DEBUG_CONV_DIRECT_OCL_WRW2{}))
-            return false;
-#endif
     if(miopen::IsDisabled(MIOPEN_DEBUG_CONV_DIRECT_OCL_WRW2{}))
         return false;
     if(!params.use_opencl_convolutions)

--- a/src/solver/conv_ocl_dir2D_bwdWrW_53.cpp
+++ b/src/solver/conv_ocl_dir2D_bwdWrW_53.cpp
@@ -42,11 +42,6 @@ static bool WorkaroundSwdev168168() { return true; }
 
 bool ConvOclBwdWrW53::IsApplicable(const ConvolutionContext& params) const
 {
-#if WORKAROUND_SWDEV_292187
-    if(StartsWith(params.GetStream().GetDeviceName(), "gfx10"))
-        if(!miopen::IsEnabled(MIOPEN_DEBUG_CONV_DIRECT_OCL_WRW53{}))
-            return false;
-#endif
     if(miopen::IsDisabled(MIOPEN_DEBUG_CONV_DIRECT_OCL_WRW53{}))
         return false;
     if(!params.use_opencl_convolutions)

--- a/src/solver/conv_ocl_dir2Dfwd.cpp
+++ b/src/solver/conv_ocl_dir2Dfwd.cpp
@@ -29,7 +29,6 @@
 #include <miopen/solver.hpp>
 #include <miopen/env.hpp>
 #include <miopen/conv/invokers/gen_x_w_y_pad.hpp>
-#include <miopen/stringutils.hpp>
 
 MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEBUG_CONV_DIRECT_OCL_FWD)
 
@@ -38,11 +37,6 @@ namespace solver {
 
 bool ConvOclDirectFwd::IsApplicable(const ConvolutionContext& params) const
 {
-#if WORKAROUND_SWDEV_292187
-    if(StartsWith(params.GetStream().GetDeviceName(), "gfx10"))
-        if(!miopen::IsEnabled(MIOPEN_DEBUG_CONV_DIRECT_OCL_FWD{}))
-            return false;
-#endif
     if(miopen::IsDisabled(MIOPEN_DEBUG_CONV_DIRECT_OCL_FWD{}))
         return false;
     if(!params.use_opencl_convolutions)

--- a/src/solver/conv_ocl_dir2Dfwd1x1.cpp
+++ b/src/solver/conv_ocl_dir2Dfwd1x1.cpp
@@ -40,7 +40,7 @@ namespace solver {
 
 bool ConvOclDirectFwd1x1::IsApplicable(const ConvolutionContext& params) const
 {
-#if WORKAROUND_SWDEV_271887 || WORKAROUND_SWDEV_292187
+#if WORKAROUND_SWDEV_271887
     if(StartsWith(params.GetStream().GetDeviceName(), "gfx10"))
         if(!miopen::IsEnabled(MIOPEN_DEBUG_CONV_DIRECT_OCL_FWD1X1{}))
             return false;

--- a/src/solver/conv_ocl_dir2Dfwdgen.cpp
+++ b/src/solver/conv_ocl_dir2Dfwdgen.cpp
@@ -28,7 +28,6 @@
 #include <miopen/handle.hpp>
 #include <miopen/env.hpp>
 #include <miopen/conv/invokers/gen_x_w_y_pad.hpp>
-#include <miopen/stringutils.hpp>
 
 MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEBUG_CONV_DIRECT_OCL_FWDGEN)
 
@@ -37,11 +36,6 @@ namespace solver {
 
 bool ConvOclDirectFwdGen::IsApplicable(const ConvolutionContext& params) const
 {
-#if WORKAROUND_SWDEV_292187
-    if(StartsWith(params.GetStream().GetDeviceName(), "gfx10"))
-        if(!miopen::IsEnabled(MIOPEN_DEBUG_CONV_DIRECT_OCL_FWDGEN{}))
-            return false;
-#endif
     if(miopen::IsDisabled(MIOPEN_DEBUG_CONV_DIRECT_OCL_FWDGEN{}))
         return false;
     if(!params.use_opencl_convolutions)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -174,9 +174,6 @@ option( WORKAROUND_ISSUE_1148 "" ${WORKAROUND_ISSUE_1148_DEFAULT})
 set_var_to_condition(WORKAROUND_ISSUE_1334_DEFAULT MIOPEN_TEST_GFX1030 AND MIOPEN_TEST_FLOAT)
 option( WORKAROUND_ISSUE_1334 "" ${WORKAROUND_ISSUE_1334_DEFAULT})
 
-set_var_to_condition(WORKAROUND_SWDEV_292187_DEFAULT MIOPEN_TEST_GFX1030)
-option( WORKAROUND_SWDEV_292187 "" ${WORKAROUND_SWDEV_292187_DEFAULT})
-
 if(NOT MIOPEN_TEST_MIOTENSILE)
 	if(MIOPEN_TEST_HALF)
 	    if(MIOPEN_BACKEND_OPENCL)
@@ -601,10 +598,6 @@ function(add_custom_test NAME)
 
     if(WORKAROUND_ISSUE_1187
         AND (${NAME} MATCHES "test_conv_for_implicit_gemm" ))
-        set_tests_properties(${NAME} PROPERTIES DISABLED On)
-    endif()
-    if(WORKAROUND_SWDEV_292187
-        AND (${NAME} MATCHES "test_conv_ck_igemm_fwd_v6r1_dlops_nchw" ))
         set_tests_properties(${NAME} PROPERTIES DISABLED On)
     endif()
 endfunction()

--- a/test/handle_test.cpp
+++ b/test/handle_test.cpp
@@ -243,7 +243,7 @@ void test_arch_name()
 int main()
 {
     auto&& h = get_handle();
-    if(h.GetDeviceName() != "gfx803" && miopen::IsHipKernelsEnabled(h.GetTargetProperties()))
+    if(h.GetDeviceName() != "gfx803" && miopen::IsHipKernelsEnabled())
     {
         test_multithreads(miopenHIPKernelType);
         test_errors(miopenHIPKernelType);


### PR DESCRIPTION
This is the clone of #1390 for develop.

**_This is alternative for #1353_** which removes W/A for SWDEV-292187 completely instead of narrowing it, thus restoring both FP16 and FP32 performance for Navi21.