### PR TITLE
[Navi21] Fixed: Disabled enforcing of wavefrontsize=64 for OCL on COMGR path.

### DIFF
--- a/src/comgr.cpp
+++ b/src/comgr.cpp
@@ -73,6 +73,8 @@ MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEBUG_COMGR_HIP_BUILD_FATBIN)
 /// \todo see issue #1222, PR #1316
 MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEBUG_SRAM_EDC_DISABLED)
 
+MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEBUG_OPENCL_WAVE64_NOWGP)
+
 #ifndef MIOPEN_AMD_COMGR_VERSION_MAJOR
 #define MIOPEN_AMD_COMGR_VERSION_MAJOR 0
 #endif
@@ -210,8 +212,11 @@ static void AddCompilerOptions(OptionList& list, const miopen::TargetProperties&
 #endif
     list.push_back("-mllvm");
     list.push_back("-amdgpu-prelink");
-    list.push_back("-mwavefrontsize64"); // gfx1000+ WAVE32 mode: always disabled.
-    list.push_back("-mcumode");          // gfx1000+ WGP mode: always disabled.
+    if(miopen::IsEnabled(MIOPEN_DEBUG_OPENCL_WAVE64_NOWGP{}))
+    {
+        list.push_back("-mwavefrontsize64");
+        list.push_back("-mcumode");
+    }
     list.push_back("-O3");
 
 #if ROCM_FEATURE_TARGETID_OFF


### PR DESCRIPTION
Fixed issue: Enforcing of wavefrontsize=64 for OCL on COMGR build path may lead to correctness problems.

Added feature: support for MIOPEN_DEBUG_OPENCL_WAVE64_NOWGP env var on COMGR build path.