### PR TITLE
[Navi21][COMGR][OpenCL] Disabled wavefrontsize=64 for OCL on COMGR path. [Quality] Fixed build warnings with ROCm mainline. [CK][NFC] Some simplification.

### DIFF
--- a/src/comgr.cpp
+++ b/src/comgr.cpp
@@ -73,6 +73,8 @@ MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEBUG_COMGR_HIP_BUILD_FATBIN)
 /// \todo see issue #1222, PR #1316
 MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEBUG_SRAM_EDC_DISABLED)
 
+MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEBUG_OPENCL_WAVE64_NOWGP)
+
 #ifndef MIOPEN_AMD_COMGR_VERSION_MAJOR
 #define MIOPEN_AMD_COMGR_VERSION_MAJOR 0
 #endif
@@ -105,7 +107,7 @@ MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEBUG_SRAM_EDC_DISABLED)
 #endif
 
 #if WORKAROUND_SWDEV_257056_PCH_INCORRECTLY_REPORTED
-#if(HIP_PACKAGE_VERSION_FLAT <= 3009999999ULL)
+#if HIP_SUPPORTS_PCH && (HIP_PACKAGE_VERSION_FLAT <= 3009999999ULL)
 #undef HIP_SUPPORTS_PCH
 #define HIP_SUPPORTS_PCH 0
 #endif
@@ -210,8 +212,11 @@ static void AddCompilerOptions(OptionList& list, const miopen::TargetProperties&
 #endif
     list.push_back("-mllvm");
     list.push_back("-amdgpu-prelink");
-    list.push_back("-mwavefrontsize64"); // gfx1000+ WAVE32 mode: always disabled.
-    list.push_back("-mcumode");          // gfx1000+ WGP mode: always disabled.
+    if(miopen::IsEnabled(MIOPEN_DEBUG_OPENCL_WAVE64_NOWGP{}))
+    {
+        list.push_back("-mwavefrontsize64");
+        list.push_back("-mcumode");
+    }
     list.push_back("-O3");
 
 #if ROCM_FEATURE_TARGETID_OFF

--- a/src/composable_kernel/composable_kernel/include/tensor_description/tensor_descriptor.hpp
+++ b/src/composable_kernel/composable_kernel/include/tensor_description/tensor_descriptor.hpp
@@ -278,7 +278,7 @@ struct TensorCoordinateStep
     MultiIndex<NTransform> do_transforms_;
 
     // HACK: control UpdateLowerIndex()
-    static constexpr UpdateLowerIndexHack update_lower_index_hack_;
+    typedef UpdateLowerIndexHack update_lower_index_hack_t;
 };
 
 // TODO: How to fix this? It uses an struct instead of lambda because lambda
@@ -526,7 +526,7 @@ __host__ __device__ constexpr void move_tensor_coordinate(const TensorDesc& tens
             MultiIndex<dims_low.Size()> idx_diff_low;
 
             // HACK: control UpdateLowerIndex for Merge using hack
-            constexpr index_t Hack = decltype(coord_step.update_lower_index_hack_)::At(itran);
+            constexpr index_t Hack = TensorCoordStep::update_lower_index_hack_t::At(itran);
 
             tran.UpdateLowerIndex(idx_diff_low, idx_diff_up, idx_low, idx_up_new, Number<Hack>{});
 

--- a/src/gemm_v2.cpp
+++ b/src/gemm_v2.cpp
@@ -435,7 +435,9 @@ static inline uint32_t FlagsForRocblasFp32Fp16Call(const bool gfx90aFp16Alt)
 #else
     std::ignore = gfx90aFp16Alt;
     return 0;
-#endif // !USE_GEMM_FLAGS_FP16_ALT_IMPL
+#endif
+#if USE_GEMM_FLAGS_FP16_ALT_IMPL_242 // -warning: macro is not used
+#endif
 }
 #endif // MIOPEN_USE_ROCBLAS
 

--- a/src/include/miopen/handle_lock.hpp
+++ b/src/include/miopen/handle_lock.hpp
@@ -32,8 +32,9 @@
 #include <boost/filesystem.hpp>
 #include <boost/filesystem/fstream.hpp>
 #include <mutex>
-#include <miopen/errors.hpp>
 #include <miopen/config.h>
+#include <miopen/errors.hpp>
+#include <miopen/logger.hpp>
 
 namespace miopen {
 
@@ -45,8 +46,9 @@ namespace miopen {
 
 #if MIOPEN_GPU_SYNC
 MIOPEN_DECLARE_HANDLE_MUTEX(gpu_handle_mutex)
-#define MIOPEN_HANDLE_LOCK \
-    auto miopen_handle_lock_guard_##__LINE__ = miopen::get_handle_lock(miopen::gpu_handle_mutex{});
+#define MIOPEN_HANDLE_LOCK                                    \
+    auto MIOPEN_PP_CAT(miopen_handle_lock_guard_, __LINE__) = \
+        miopen::get_handle_lock(miopen::gpu_handle_mutex{});
 #else
 #define MIOPEN_HANDLE_LOCK
 #endif

--- a/src/kernels/MIOpenConvDirBatchNormActiv.cl
+++ b/src/kernels/MIOpenConvDirBatchNormActiv.cl
@@ -164,7 +164,12 @@
 #define MLO_PADDING_FIX0 (MLO_FILTER_SIZE0 % MLO_OUT_TILE0)
 
 #if defined(__AMDGCN__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored \
+    "-Wunknown-warning-option" // clang in ROCm 4.3 does not support "reserved-identifier".
+#pragma clang diagnostic ignored "-Wreserved-identifier"
 extern uint __llvm_amdgcn_readfirstlane(uint) __asm("llvm.amdgcn.readfirstlane");
+#pragma clang diagnostic pop // "-Wreserved-identifier"
 #define uniform(x) __llvm_amdgcn_readfirstlane(x)
 #else
 #define uniform(x) (x)

--- a/src/kernels/MIOpenConvDirUni.cl
+++ b/src/kernels/MIOpenConvDirUni.cl
@@ -148,7 +148,12 @@
 #define MLO_PADDING_FIX0 (MLO_FILTER_SIZE0 % MLO_OUT_TILE0)
 
 #if defined(__AMDGCN__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored \
+    "-Wunknown-warning-option" // clang in ROCm 4.3 does not support "reserved-identifier".
+#pragma clang diagnostic ignored "-Wreserved-identifier"
 extern uint __llvm_amdgcn_readfirstlane(uint) __asm("llvm.amdgcn.readfirstlane");
+#pragma clang diagnostic pop // "-Wreserved-identifier"
 #define uniform(x) __llvm_amdgcn_readfirstlane(x)
 #else
 #define uniform(x) (x)

--- a/src/kernels/MIOpenConvDirUni_Vec2.cl
+++ b/src/kernels/MIOpenConvDirUni_Vec2.cl
@@ -163,7 +163,12 @@
 #define MLO_PADDING_FIX0 (MLO_FILTER_SIZE0 % MLO_OUT_TILE0)
 
 #if defined(__AMDGCN__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored \
+    "-Wunknown-warning-option" // clang in ROCm 4.3 does not support "reserved-identifier".
+#pragma clang diagnostic ignored "-Wreserved-identifier"
 extern uint __llvm_amdgcn_readfirstlane(uint) __asm("llvm.amdgcn.readfirstlane");
+#pragma clang diagnostic pop // "-Wreserved-identifier"
 #define uniform(x) __llvm_amdgcn_readfirstlane(x)
 #else
 #define uniform(x) (x)

--- a/src/kernels/MIOpenConvFwd_LxL_11.cl
+++ b/src/kernels/MIOpenConvFwd_LxL_11.cl
@@ -87,7 +87,12 @@
 #define MLO_HW_WAVE_ID_SETTING 1
 
 #if defined(__AMDGCN__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored \
+    "-Wunknown-warning-option" // clang in ROCm 4.3 does not support "reserved-identifier".
+#pragma clang diagnostic ignored "-Wreserved-identifier"
 extern uint __llvm_amdgcn_readfirstlane(uint) __asm("llvm.amdgcn.readfirstlane");
+#pragma clang diagnostic pop // "-Wreserved-identifier"
 #define uniform(x) __llvm_amdgcn_readfirstlane(x)
 #else
 #define uniform(x) (x)

--- a/src/kernels/MIOpenLRNFwd.cl
+++ b/src/kernels/MIOpenLRNFwd.cl
@@ -416,8 +416,10 @@ MIOpenLRNAcrossChannels4(const __global _FLOAT* bottom,
         bot_in2[i] = 0;
     }
 
-    int top_off   = 0;
-    int scale_off = 0;
+    int top_off = 0;
+#if MLO_LRN_DO_SCALE
+    int scale_off;
+#endif
 
     for(c_i = 0; c_i < MLO_LRN_PAD; c_i++)
     {
@@ -491,8 +493,10 @@ MIOpenLRNAcrossChannels4(const __global _FLOAT* bottom,
 
         top_off = b * MLO_LRN_TOP_BATCH_STRIDE + c_o * MLO_LRN_TOP_CHANNEL_STRIDE +
                   (pix_id * MLO_READ_UNIT);
+#if MLO_LRN_DO_SCALE
         scale_off = b * MLO_LRN_SCALE_BATCH_STRIDE + c_o * MLO_LRN_SCALE_CHANNEL_STRIDE +
                     (pix_id * MLO_READ_UNIT);
+#endif
         MLO_READ_TYPE prv_scale = ((MLO_READ_TYPE)K + accum * (MLO_READ_TYPE)alphaoverarea);
         //				fma(accum,alphaoverarea, (_FLOAT)1.f);
 
@@ -584,8 +588,10 @@ MIOpenLRNAcrossChannels4(const __global _FLOAT* bottom,
 
         top_off = b * MLO_LRN_TOP_BATCH_STRIDE + c_o * MLO_LRN_TOP_CHANNEL_STRIDE +
                   (pix_id * MLO_READ_UNIT);
+#if MLO_LRN_DO_SCALE
         scale_off = b * MLO_LRN_SCALE_BATCH_STRIDE + c_o * MLO_LRN_SCALE_CHANNEL_STRIDE +
                     (pix_id * MLO_READ_UNIT);
+#endif
         MLO_READ_TYPE prv_scale = ((MLO_READ_TYPE)K + accum * (MLO_READ_TYPE)alphaoverarea);
         //				fma(accum,alphaoverarea, (_FLOAT)1.f);
 
@@ -648,8 +654,10 @@ MIOpenLRNAcrossChannels4(const __global _FLOAT* bottom,
 
         top_off = b * MLO_LRN_TOP_BATCH_STRIDE + c_o * MLO_LRN_TOP_CHANNEL_STRIDE +
                   (pix_id * MLO_READ_UNIT);
+#if MLO_LRN_DO_SCALE
         scale_off = b * MLO_LRN_SCALE_BATCH_STRIDE + c_o * MLO_LRN_SCALE_CHANNEL_STRIDE +
                     (pix_id * MLO_READ_UNIT);
+#endif
         MLO_READ_TYPE prv_scale = ((MLO_READ_TYPE)K + accum * (MLO_READ_TYPE)alphaoverarea);
         //				fma(accum,alphaoverarea, (_FLOAT)1.f);
 

--- a/src/kernels/detect_llvm_amdgcn_buffer_atomic_fadd_f32_float.cpp
+++ b/src/kernels/detect_llvm_amdgcn_buffer_atomic_fadd_f32_float.cpp
@@ -26,6 +26,11 @@
 
 typedef int32_t int32x4_t __attribute__((ext_vector_type(4)));
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored \
+    "-Wunknown-warning-option" // clang in ROCm 4.3 does not support "reserved-identifier".
+#pragma clang diagnostic ignored "-Wreserved-identifier"
+
 __device__ float
 __llvm_amdgcn_buffer_atomic_add_f32(float vdata,
                                     int32x4_t rsrc,
@@ -38,3 +43,5 @@ extern "C" __global__ void test_llvm_amdgcn_buffer_atomic_fadd_f32_float(float* 
     int32x4_t buffer_resource{0};
     (void)__llvm_amdgcn_buffer_atomic_add_f32(*p_global, buffer_resource, 0, 0, false);
 }
+
+#pragma clang diagnostic pop // "-Wreserved-identifier"

--- a/test/args.hpp
+++ b/test/args.hpp
@@ -28,6 +28,7 @@
 #include <cassert>
 #include <functional>
 
+#include <miopen/logger.hpp>
 #include <miopen/each_args.hpp>
 #include <numeric>
 #include <sstream>
@@ -128,10 +129,13 @@ struct is_output_streamable : decltype(detail::is_output_streamable(
 #define ARGS_REQUIRES_BOOL(...) (__VA_ARGS__)
 #endif
 
-#define ARGS_REQUIRES(...)                                                                    \
-    bool RequiresBool##__LINE__             = true,                                           \
-         typename std::enable_if<ARGS_REQUIRES_BOOL(RequiresBool##__LINE__ && (__VA_ARGS__)), \
-                                 int>::type = 0
+#define ARGS_REQUIRES(...)                                                                  \
+    bool MIOPEN_PP_CAT(                                                                     \
+        RequiresBool,                                                                       \
+        __LINE__)                          = true,                                          \
+        typename std::enable_if<ARGS_REQUIRES_BOOL(MIOPEN_PP_CAT(RequiresBool, __LINE__) && \
+                                                   (__VA_ARGS__)),                          \
+                                int>::type = 0
 
 template <class T>
 struct value_parser

--- a/test/gpu_nchw_nhwc_transpose.cpp
+++ b/test/gpu_nchw_nhwc_transpose.cpp
@@ -36,6 +36,7 @@
 #include <vector>
 #include <cstdlib>
 #include <ctime>
+#include <tuple> // std::ignore
 #include "test.hpp"
 #include "driver.hpp"
 #include "random.hpp"
@@ -182,13 +183,11 @@ struct to_miopen_data_type<uint8_t>
 
 static int gen_rand_integer()
 {
-    // NOLINTNEXTLINE (cppcoreguidelines-avoid-non-const-global-variables)
-    static int inited = 0;
-    if(inited == 0)
-    {
+    static const int inited = []() -> int {
         std::srand(std::time(nullptr));
-        inited = 1;
-    }
+        return 1;
+    }();
+    std::ignore = inited;
     return GET_RAND();
 }
 


### PR DESCRIPTION
Some useful by-products of HIPRTC work.

- [Navi21][COMGR][OpenCL] Fixed: Disabled enforcing of wavefrontsize=64 for OCL on COMGR path
- Fixes some host code inaccuracies and build warnings with ROCm mainline
  - Resolves https://github.com/ROCmSoftwarePlatform/MIOpen/issues/1322#issuecomment-1030451028
- Fixes some kernel build warnings for DEV builds with ROCm mainline
- [NFC][composable_kernel] Rework: constexpr -> typedef as the former is not necessary
- Fixed initialization in test/gpu_nchw_nhwc_transpose.cpp, gen_rand_integer()
