### PR TITLE
[Quality] Fix more verify error with NaNs and Inf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+build/
+.vscode/
+.history/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,0 @@
-build/
-.vscode/
-.history/

--- a/driver/bn_driver.hpp
+++ b/driver/bn_driver.hpp
@@ -1180,10 +1180,10 @@ int BatchNormDriver<Tgpu, Tref, Tmix>::VerifyForward()
             runningVariance_dev->FromGPU(GetStream(), runningVariance.data());
 
             auto errorRunMean = miopen::rms_range(runningMean_host, runningMean);
-            if(errorRunMean > maxrms || std::isnan(errorRunMean))
+            if(!std::isfinite(errorRunMean) || errorRunMean > maxrms)
             {
-                std::cout << "Forward train batch norm verification failed on running mean: "
-                          << errorRunMean << "\n";
+                std::cout << "Forward train batch norm verification FAILED on running mean: "
+                          << errorRunMean << std::endl;
                 anError = true;
 #if(MIO_BN_DEBUG == 1)
                 for(int i = 0; i < runningMean.size() && i < runningMean_host.size() &&
@@ -1191,7 +1191,7 @@ int BatchNormDriver<Tgpu, Tref, Tmix>::VerifyForward()
                     i++)
                 {
                     diff = fabs(Tmix(fabs(runningMean[i]) - fabs(runningMean_host[i])));
-                    if(!(diff < tolerance))
+                    if(!std::isfinite(diff) || diff > tolerance)
                     {
                         std::cout << "rm[" << i << "]: " << runningMean[i];
                         std::cout << ", rm_host[" << i << "]: " << runningMean_host[i];
@@ -1208,10 +1208,10 @@ int BatchNormDriver<Tgpu, Tref, Tmix>::VerifyForward()
             }
 
             auto errorRunVar = miopen::rms_range(runningVariance_host, runningVariance);
-            if(errorRunVar > maxrms || std::isnan(errorRunVar))
+            if(!std::isfinite(errorRunVar) || errorRunVar > maxrms)
             {
-                std::cout << "Forward train batch norm verification failed on running variance: "
-                          << errorRunVar << "\n";
+                std::cout << "Forward train batch norm verification FAILED on running variance: "
+                          << errorRunVar << std::endl;
                 anError = true;
 #if(MIO_BN_DEBUG == 1)
                 for(int i = 0; i < runningVariance.size() && i < runningVariance_host.size() &&
@@ -1219,7 +1219,7 @@ int BatchNormDriver<Tgpu, Tref, Tmix>::VerifyForward()
                     i++)
                 {
                     diff = fabs(Tmix(fabs(runningVariance[i]) - fabs(runningVariance_host[i])));
-                    if(!(diff < tolerance))
+                    if(!std::isfinite(diff) || diff > tolerance)
                     {
                         std::cout << "rv[" << i << "]: " << runningVariance[i];
                         std::cout << ", rv_host[" << i << "]: " << runningVariance_host[i];
@@ -1242,10 +1242,10 @@ int BatchNormDriver<Tgpu, Tref, Tmix>::VerifyForward()
             saveInvVariance_dev->FromGPU(GetStream(), saveInvVariance.data());
             maxval             = static_cast<Tref>(0.0);
             auto errorSaveMean = miopen::rms_range(saveMean_host, saveMean);
-            if(errorSaveMean > maxrms || std::isnan(errorSaveMean))
+            if(!std::isfinite(errorSaveMean) || errorSaveMean > maxrms)
             {
-                std::cout << "Forward train batch norm verification failed on saved mean: "
-                          << errorSaveMean << "\n";
+                std::cout << "Forward train batch norm verification FAILED on saved mean: "
+                          << errorSaveMean << std::endl;
                 anError = true;
 #if(MIO_BN_DEBUG == 1)
                 for(int i = 0;
@@ -1254,7 +1254,7 @@ int BatchNormDriver<Tgpu, Tref, Tmix>::VerifyForward()
                 {
                     diff   = fabs(Tmix(fabs(saveMean[i]) - fabs(saveMean_host[i])));
                     maxval = maxval < diff ? diff : maxval;
-                    if(!(diff < tolerance))
+                    if(!std::isfinite(diff) || diff > tolerance)
                     {
                         std::cout << "sm[" << i << "]: " << saveMean[i];
                         std::cout << ", sm_host[" << i << "]: " << saveMean_host[i];
@@ -1272,11 +1272,11 @@ int BatchNormDriver<Tgpu, Tref, Tmix>::VerifyForward()
             }
 
             auto errorSaveVar = miopen::rms_range(saveInvVariance_host, saveInvVariance);
-            if(errorSaveVar > maxrms || std::isnan(errorSaveVar))
+            if(!std::isfinite(errorSaveVar) || errorSaveVar > maxrms)
             {
                 std::cout
-                    << "Forward train batch norm verification failed on saved inverse variance: "
-                    << errorSaveVar << "\n";
+                    << "Forward train batch norm verification FAILED on saved inverse variance: "
+                    << errorSaveVar << std::endl;
                 anError = true;
 #if(MIO_BN_DEBUG == 1)
                 for(int i = 0; i < saveInvVariance.size() && i < saveInvVariance_host.size() &&
@@ -1284,7 +1284,7 @@ int BatchNormDriver<Tgpu, Tref, Tmix>::VerifyForward()
                     i++)
                 {
                     diff = fabs(Tmix(fabs(saveInvVariance[i]) - fabs(saveInvVariance_host[i])));
-                    if(!(diff < tolerance))
+                    if(!std::isfinite(diff) || diff > tolerance)
                     {
                         std::cout << "sv[" << i << "]: " << saveInvVariance[i];
                         std::cout << ", sv_host[" << i << "]: " << saveInvVariance_host[i];
@@ -1307,9 +1307,9 @@ int BatchNormDriver<Tgpu, Tref, Tmix>::VerifyForward()
     out_dev->FromGPU(GetStream(), out.data());
     maxval        = static_cast<Tref>(0.0);
     auto errorOut = miopen::rms_range(out_host, out);
-    if(errorOut > maxrms || std::isnan(errorOut))
+    if(!std::isfinite(errorOut) || errorOut > maxrms)
     {
-        std::cout << "Forward batch norm verification failed on output: " << errorOut << "\n";
+        std::cout << "Forward batch norm verification FAILED on output: " << errorOut << std::endl;
         anError = true;
 #if(MIO_BN_DEBUG == 1)
         unsigned int count = 0;
@@ -1325,7 +1325,7 @@ int BatchNormDriver<Tgpu, Tref, Tmix>::VerifyForward()
             }
             diff   = Tref(fabs(out[i]) - fabs(out_host[i]));
             maxval = maxval < diff ? diff : maxval;
-            if(!(diff < tolerance))
+            if(!std::isfinite(diff) || diff > tolerance)
             {
                 std::cout << "out[" << i << "]: " << out[i];
                 std::cout << ", out_host[" << i << "]: " << out_host[i];
@@ -1448,16 +1448,16 @@ int BatchNormDriver<Tgpu, Tref, Tmix>::VerifyBackward()
 #endif
     maxval          = static_cast<Tref>(0.0);
     auto errordxout = miopen::rms_range(dxout_host, dxout);
-    if(errordxout > maxrms || std::isnan(errordxout))
+    if(!std::isfinite(errordxout) || errordxout > maxrms)
     {
-        std::cout << "Backwards prop batch norm verification failed on dx: " << errordxout << "\n";
+        std::cout << "Backwards prop batch norm verification FAILED on dx: " << errordxout << std::endl;
         anError = true;
 #if(MIO_BN_DEBUG == 1)
         for(int i = 0; i < dxout.size() && i < MIO_BN_MAX_DEBUGLOOP; i++)
         {
             diff   = fabs(Tgpu(fabs(dxout[i]) - fabs(dxout_host[i])));
             maxval = maxval < diff ? diff : maxval;
-            if(!(diff < tolerance))
+            if(!std::isfinite(diff) || diff > tolerance)
             {
                 std::cout << "dxout[" << i << "]: " << dxout[i];
                 std::cout << "\tdxout_host[" << i << "]: " << dxout_host[i];
@@ -1477,17 +1477,17 @@ int BatchNormDriver<Tgpu, Tref, Tmix>::VerifyBackward()
 
     maxval           = static_cast<Tref>(0.0);
     auto errordscale = miopen::rms_range(dscale_host, dscale);
-    if(errordscale > maxrms || std::isnan(errordscale))
+    if(!std::isfinite(errordscale) || errordscale > maxrms)
     {
-        std::cout << "Backwards prop batch norm verification failed on dscale: " << errordscale
-                  << "\n";
+        std::cout << "Backwards prop batch norm verification FAILED on dscale: " << errordscale
+                  << std::endl;
         anError = true;
 #if(MIO_BN_DEBUG == 1)
         for(int i = 0; i < dscale.size() && i < MIO_BN_MAX_DEBUGLOOP; i++)
         {
             diff   = fabs(Tmix(fabs(dscale[i]) - fabs(dscale_host[i])));
             maxval = maxval < diff ? diff : maxval;
-            if(!(diff < tolerance))
+            if(!std::isfinite(diff) || diff > tolerance)
             {
                 std::cout << "dscale[" << i << "]: " << dscale[i];
                 std::cout << "\tdscale_host[" << i << "]: " << dscale_host[i];
@@ -1507,16 +1507,16 @@ int BatchNormDriver<Tgpu, Tref, Tmix>::VerifyBackward()
     }
 
     auto errordbias = miopen::rms_range(dbias_host, dbias);
-    if(errordbias > maxrms || std::isnan(errordbias))
+    if(!std::isfinite(errordbias) || errordbias > maxrms)
     {
-        std::cout << "Backwards prop batch norm verification failed on dbias: " << errordbias
-                  << "\n";
+        std::cout << "Backwards prop batch norm verification FAILED on dbias: " << errordbias
+                  << std::endl;
         anError = true;
 #if(MIO_BN_DEBUG == 1)
         for(int i = 0; i < dbias.size() && i < MIO_BN_MAX_DEBUGLOOP; i++)
         {
             diff = fabs(Tmix(fabs(dbias[i]) - fabs(dbias_host[i])));
-            if(!(diff < tolerance))
+            if(!std::isfinite(diff) || diff > tolerance)
             {
                 std::cout << "dbias[" << i << "]: " << dbias[i];
                 std::cout << "\tdbias_host[" << i << "]: " << dbias_host[i];

--- a/driver/bn_driver.hpp
+++ b/driver/bn_driver.hpp
@@ -1191,7 +1191,7 @@ int BatchNormDriver<Tgpu, Tref, Tmix>::VerifyForward()
                     i++)
                 {
                     diff = fabs(Tmix(fabs(runningMean[i]) - fabs(runningMean_host[i])));
-                    if(diff > tolerance)
+                    if(!(diff < tolerance))
                     {
                         std::cout << "rm[" << i << "]: " << runningMean[i];
                         std::cout << ", rm_host[" << i << "]: " << runningMean_host[i];
@@ -1219,7 +1219,7 @@ int BatchNormDriver<Tgpu, Tref, Tmix>::VerifyForward()
                     i++)
                 {
                     diff = fabs(Tmix(fabs(runningVariance[i]) - fabs(runningVariance_host[i])));
-                    if(diff > tolerance)
+                    if(!(diff < tolerance))
                     {
                         std::cout << "rv[" << i << "]: " << runningVariance[i];
                         std::cout << ", rv_host[" << i << "]: " << runningVariance_host[i];
@@ -1254,7 +1254,7 @@ int BatchNormDriver<Tgpu, Tref, Tmix>::VerifyForward()
                 {
                     diff   = fabs(Tmix(fabs(saveMean[i]) - fabs(saveMean_host[i])));
                     maxval = maxval < diff ? diff : maxval;
-                    if(diff > tolerance)
+                    if(!(diff < tolerance))
                     {
                         std::cout << "sm[" << i << "]: " << saveMean[i];
                         std::cout << ", sm_host[" << i << "]: " << saveMean_host[i];
@@ -1284,7 +1284,7 @@ int BatchNormDriver<Tgpu, Tref, Tmix>::VerifyForward()
                     i++)
                 {
                     diff = fabs(Tmix(fabs(saveInvVariance[i]) - fabs(saveInvVariance_host[i])));
-                    if(diff > tolerance)
+                    if(!(diff < tolerance))
                     {
                         std::cout << "sv[" << i << "]: " << saveInvVariance[i];
                         std::cout << ", sv_host[" << i << "]: " << saveInvVariance_host[i];
@@ -1325,7 +1325,7 @@ int BatchNormDriver<Tgpu, Tref, Tmix>::VerifyForward()
             }
             diff   = Tref(fabs(out[i]) - fabs(out_host[i]));
             maxval = maxval < diff ? diff : maxval;
-            if(diff > tolerance)
+            if(!(diff < tolerance))
             {
                 std::cout << "out[" << i << "]: " << out[i];
                 std::cout << ", out_host[" << i << "]: " << out_host[i];
@@ -1457,7 +1457,7 @@ int BatchNormDriver<Tgpu, Tref, Tmix>::VerifyBackward()
         {
             diff   = fabs(Tgpu(fabs(dxout[i]) - fabs(dxout_host[i])));
             maxval = maxval < diff ? diff : maxval;
-            if(diff > tolerance)
+            if(!(diff < tolerance))
             {
                 std::cout << "dxout[" << i << "]: " << dxout[i];
                 std::cout << "\tdxout_host[" << i << "]: " << dxout_host[i];
@@ -1487,7 +1487,7 @@ int BatchNormDriver<Tgpu, Tref, Tmix>::VerifyBackward()
         {
             diff   = fabs(Tmix(fabs(dscale[i]) - fabs(dscale_host[i])));
             maxval = maxval < diff ? diff : maxval;
-            if(diff > tolerance)
+            if(!(diff < tolerance))
             {
                 std::cout << "dscale[" << i << "]: " << dscale[i];
                 std::cout << "\tdscale_host[" << i << "]: " << dscale_host[i];
@@ -1516,7 +1516,7 @@ int BatchNormDriver<Tgpu, Tref, Tmix>::VerifyBackward()
         for(int i = 0; i < dbias.size() && i < MIO_BN_MAX_DEBUGLOOP; i++)
         {
             diff = fabs(Tmix(fabs(dbias[i]) - fabs(dbias_host[i])));
-            if(diff > tolerance)
+            if(!(diff < tolerance))
             {
                 std::cout << "dbias[" << i << "]: " << dbias[i];
                 std::cout << "\tdbias_host[" << i << "]: " << dbias_host[i];

--- a/driver/bn_driver.hpp
+++ b/driver/bn_driver.hpp
@@ -1450,7 +1450,8 @@ int BatchNormDriver<Tgpu, Tref, Tmix>::VerifyBackward()
     auto errordxout = miopen::rms_range(dxout_host, dxout);
     if(!std::isfinite(errordxout) || errordxout > maxrms)
     {
-        std::cout << "Backwards prop batch norm verification FAILED on dx: " << errordxout << std::endl;
+        std::cout << "Backwards prop batch norm verification FAILED on dx: " << errordxout
+                  << std::endl;
         anError = true;
 #if(MIO_BN_DEBUG == 1)
         for(int i = 0; i < dxout.size() && i < MIO_BN_MAX_DEBUGLOOP; i++)
@@ -1509,7 +1510,8 @@ int BatchNormDriver<Tgpu, Tref, Tmix>::VerifyBackward()
     auto errordbias = miopen::rms_range(dbias_host, dbias);
     if(!std::isfinite(errordbias) || errordbias > maxrms)
     {
-        std::cout << "Backwards prop batch norm verification FAILED on dbias: " << errordbias << std::endl;
+        std::cout << "Backwards prop batch norm verification FAILED on dbias: " << errordbias
+                  << std::endl;
         anError = true;
 #if(MIO_BN_DEBUG == 1)
         for(int i = 0; i < dbias.size() && i < MIO_BN_MAX_DEBUGLOOP; i++)

--- a/driver/bn_driver.hpp
+++ b/driver/bn_driver.hpp
@@ -1509,8 +1509,7 @@ int BatchNormDriver<Tgpu, Tref, Tmix>::VerifyBackward()
     auto errordbias = miopen::rms_range(dbias_host, dbias);
     if(!std::isfinite(errordbias) || errordbias > maxrms)
     {
-        std::cout << "Backwards prop batch norm verification FAILED on dbias: " << errordbias
-                  << std::endl;
+        std::cout << "Backwards prop batch norm verification FAILED on dbias: " << errordbias << std::endl;
         anError = true;
 #if(MIO_BN_DEBUG == 1)
         for(int i = 0; i < dbias.size() && i < MIO_BN_MAX_DEBUGLOOP; i++)

--- a/driver/conv_driver.hpp
+++ b/driver/conv_driver.hpp
@@ -3331,7 +3331,7 @@ int ConvDriver<Tgpu, Tref>::VerifyBackward()
         if(is_bwd_igemm)
             tolerance = tolerance * 10;
 
-        if(error_data > tolerance)
+        if(!(error_data < tolerance))
         {
             std::cout << "Backward Convolution Data Failed: " << error_data << " > " << tolerance
                       << std::endl;
@@ -3379,7 +3379,7 @@ int ConvDriver<Tgpu, Tref>::VerifyBackward()
         auto error_weights = is_wrw_run_failed ? std::numeric_limits<double>::max()
                                                : miopen::rms_range(dwei_host.data, dwei);
 
-        if(error_weights > tolerance)
+        if(!(error_weights < tolerance))
         {
             std::cout << "Backward Convolution Weights Failed: " << error_weights << " > "
                       << tolerance << std::endl;
@@ -3402,7 +3402,7 @@ int ConvDriver<Tgpu, Tref>::VerifyBackward()
 
         auto error_bias      = miopen::rms_range(db_host.data, db);
         const auto tolerance = GetDefaultTolerance();
-        if(error_bias > tolerance)
+        if(!(error_bias < tolerance))
         {
             std::cout << "Backward Convolution Bias Failed: " << error_bias << " > " << tolerance
                       << std::endl;

--- a/driver/conv_driver.hpp
+++ b/driver/conv_driver.hpp
@@ -3287,7 +3287,7 @@ int ConvDriver<Tgpu, Tref>::VerifyForward()
     if(is_fwd_igemm)
         tolerance = tolerance * 10;
 
-    if(error > tolerance)
+    if(!(error < tolerance))
     {
         std::cout << "Forward Convolution Failed: " << error << " > " << tolerance << std::endl;
         return EC_VerifyFwd;

--- a/driver/conv_driver.hpp
+++ b/driver/conv_driver.hpp
@@ -3287,9 +3287,9 @@ int ConvDriver<Tgpu, Tref>::VerifyForward()
     if(is_fwd_igemm)
         tolerance = tolerance * 10;
 
-    if(!(error < tolerance))
+    if(!std::isfinite(error) || error > tolerance)
     {
-        std::cout << "Forward Convolution Failed: " << error << " > " << tolerance << std::endl;
+        std::cout << "Forward Convolution FAILED: " << error << " > " << tolerance << std::endl;
         return EC_VerifyFwd;
     }
 
@@ -3331,9 +3331,9 @@ int ConvDriver<Tgpu, Tref>::VerifyBackward()
         if(is_bwd_igemm)
             tolerance = tolerance * 10;
 
-        if(!(error_data < tolerance))
+        if(!std::isfinite(error_data) || error_data > tolerance)
         {
-            std::cout << "Backward Convolution Data Failed: " << error_data << " > " << tolerance
+            std::cout << "Backward Convolution Data FAILED: " << error_data << " > " << tolerance
                       << std::endl;
             cumulative_rc |= EC_VerifyBwd;
         }
@@ -3379,9 +3379,9 @@ int ConvDriver<Tgpu, Tref>::VerifyBackward()
         auto error_weights = is_wrw_run_failed ? std::numeric_limits<double>::max()
                                                : miopen::rms_range(dwei_host.data, dwei);
 
-        if(!(error_weights < tolerance))
+        if(!std::isfinite(error_weights) || error_weights > tolerance)
         {
-            std::cout << "Backward Convolution Weights Failed: " << error_weights << " > "
+            std::cout << "Backward Convolution Weights FAILED: " << error_weights << " > "
                       << tolerance << std::endl;
             cumulative_rc |= EC_VerifyWrw;
         }
@@ -3402,9 +3402,9 @@ int ConvDriver<Tgpu, Tref>::VerifyBackward()
 
         auto error_bias      = miopen::rms_range(db_host.data, db);
         const auto tolerance = GetDefaultTolerance();
-        if(!(error_bias < tolerance))
+        if(!std::isfinite(error_bias) || error_bias > tolerance)
         {
-            std::cout << "Backward Convolution Bias Failed: " << error_bias << " > " << tolerance
+            std::cout << "Backward Convolution Bias FAILED: " << error_bias << " > " << tolerance
                       << std::endl;
             cumulative_rc |= EC_VerifyBwdBias;
         }

--- a/driver/ctc_driver.hpp
+++ b/driver/ctc_driver.hpp
@@ -440,17 +440,17 @@ int CTCDriver<Tgpu, Tref>::VerifyForward()
 
     const double tolerance1 = 1e-5;
     const double tolerance2 = 1e-3;
-    if(!(error1 < tolerance1))
+    if(!std::isfinite(error1) || error1 > tolerance1)
     {
-        std::cout << std::string("CTC loss Failed: ") << error1 << "\n";
+        std::cout << std::string("CTC loss FAILED: ") << error1 << std::endl;
     }
     else
     {
         printf("CTC loss Verifies on CPU and GPU\n");
     }
-    if(!(error2 < tolerance2))
+    if(!std::isfinite(error2) || error2 > tolerance2)
     {
-        std::cout << std::string("CTC gradient Failed: ") << error2 << "\n";
+        std::cout << std::string("CTC gradient FAILED: ") << error2 << std::endl;
     }
     else
     {

--- a/driver/dropout_driver.hpp
+++ b/driver/dropout_driver.hpp
@@ -451,9 +451,9 @@ int DropoutDriver<Tgpu, Tref>::VerifyForward()
     auto error = miopen::rms_range(outhost.data, out.data);
 
     const double tolerance = std::is_same<Tgpu, float16>{} ? 5e-4 : 1e-6;
-    if(!(error < tolerance))
+    if(!std::isfinite(error) || error > tolerance)
     {
-        std::cout << "Forward Dropout Failed: " << error << std::endl;
+        std::cout << "Forward Dropout FAILED: " << error << std::endl;
     }
     else
     {
@@ -471,9 +471,9 @@ int DropoutDriver<Tgpu, Tref>::VerifyBackward()
     auto error = miopen::rms_range(din_host.data, din.data);
 
     const double tolerance = std::is_same<Tgpu, float16>{} ? 5e-4 : 1e-6;
-    if(!(error < tolerance))
+    if(!std::isfinite(error) || error > tolerance)
     {
-        std::cout << "Backward Dropout Failed: " << error << std::endl;
+        std::cout << "Backward Dropout FAILED: " << error << std::endl;
     }
     else
     {

--- a/driver/gemm_driver.hpp
+++ b/driver/gemm_driver.hpp
@@ -395,9 +395,9 @@ int GemmDriver<T>::VerifyForward()
     auto error = miopen::rms_range(chost, c);
     const double tolerance =
         ((sizeof(T) == 4) ? static_cast<double>(1e-6) : static_cast<double>(7e-2));
-    if(!(error < tolerance))
+    if(!std::isfinite(error) || error > tolerance)
     {
-        std::cout << std::string("Forward GEMM Failed: ") << error << "\n";
+        std::cout << std::string("Forward GEMM FAILED: ") << error << std::endl;
     }
     else
     {

--- a/driver/lrn_driver.hpp
+++ b/driver/lrn_driver.hpp
@@ -474,7 +474,7 @@ int LRNDriver<Tgpu, Tref>::VerifyForward()
 
     auto error           = miopen::rms_range(outhost, out);
     const Tref tolerance = 1.5e-4; // 1e-6;
-    if(error > tolerance)
+    if(!(error < tolerance))
     {
         std::cout << "Forward LRN Failed: " << error << "\n";
     }
@@ -569,7 +569,7 @@ int LRNDriver<Tgpu, Tref>::VerifyBackward()
 
     auto error           = miopen::rms_range(dinhost, din);
     const Tref tolerance = 6.0e-5;
-    if(error > tolerance)
+    if(!(error < tolerance))
     {
         std::cout << "Backward LRN Failed: " << error << "\n";
     }

--- a/driver/lrn_driver.hpp
+++ b/driver/lrn_driver.hpp
@@ -474,9 +474,9 @@ int LRNDriver<Tgpu, Tref>::VerifyForward()
 
     auto error           = miopen::rms_range(outhost, out);
     const Tref tolerance = 1.5e-4; // 1e-6;
-    if(!(error < tolerance))
+    if(!std::isfinite(error) || error > tolerance)
     {
-        std::cout << "Forward LRN Failed: " << error << "\n";
+        std::cout << "Forward LRN FAILED: " << error << std::endl;
     }
     else
     {
@@ -569,9 +569,9 @@ int LRNDriver<Tgpu, Tref>::VerifyBackward()
 
     auto error           = miopen::rms_range(dinhost, din);
     const Tref tolerance = 6.0e-5;
-    if(!(error < tolerance))
+    if(!std::isfinite(error) || error > tolerance)
     {
-        std::cout << "Backward LRN Failed: " << error << "\n";
+        std::cout << "Backward LRN FAILED: " << error << std::endl;
     }
     else
     {

--- a/driver/pool_driver.hpp
+++ b/driver/pool_driver.hpp
@@ -595,7 +595,7 @@ int PoolDriver_impl<Tgpu, Tref, Index>::VerifyForward()
         spatial_dim == 3 ? 1 : inflags.GetValueInt("index_position"));
 
     printf(match ? "Forward Pooling Verifies on CPU and GPU\n"
-                 : "Forward Pooling Verification Failed !!\n");
+                 : "Forward Pooling verification FAILED !!\n");
 
     return 0;
 }

--- a/driver/reduce_driver.hpp
+++ b/driver/reduce_driver.hpp
@@ -493,7 +493,7 @@ int ReduceDriver<Tgpu, Tref>::VerifyForward()
     if(std::is_same<Tgpu, float>::value && reduceOp == MIOPEN_REDUCE_TENSOR_NORM2)
         tolerance *= 12.0;
 
-    if(error > tolerance)
+    if(!(error < tolerance))
     {
         std::cout << "ReduceTensor() Failed with error = " << error
                   << " , tolerance = " << tolerance << "\n";

--- a/driver/reduce_driver.hpp
+++ b/driver/reduce_driver.hpp
@@ -493,10 +493,10 @@ int ReduceDriver<Tgpu, Tref>::VerifyForward()
     if(std::is_same<Tgpu, float>::value && reduceOp == MIOPEN_REDUCE_TENSOR_NORM2)
         tolerance *= 12.0;
 
-    if(!(error < tolerance))
+    if(!std::isfinite(error) || error > tolerance)
     {
-        std::cout << "ReduceTensor() Failed with error = " << error
-                  << " , tolerance = " << tolerance << "\n";
+        std::cout << "ReduceTensor() FAILED with error = " << error
+                  << " , tolerance = " << tolerance << std::endl;
     }
     else
     {
@@ -504,9 +504,9 @@ int ReduceDriver<Tgpu, Tref>::VerifyForward()
         {
             auto error2 = miopen::rms_range(outhost_indices, out_indices);
 
-            if(static_cast<float>(error2) != 0.0f)
+            if(!std::isfinite(error2) || std::abs(static_cast<float>(error2)) > tolerance)
             {
-                std::cout << "ReduceTensor() with indices output Failed: " << error2 << "\n";
+                std::cout << "ReduceTensor() with indices output FAILED: " << error2 << std::endl;
             }
             else
             {

--- a/driver/reduce_driver.hpp
+++ b/driver/reduce_driver.hpp
@@ -504,7 +504,7 @@ int ReduceDriver<Tgpu, Tref>::VerifyForward()
         {
             auto error2 = miopen::rms_range(outhost_indices, out_indices);
 
-            if(!std::isfinite(error2) || std::abs(static_cast<float>(error2)) > tolerance)
+            if(!std::isfinite(error2) || std::abs(static_cast<float>(error2)) != 0.0f)
             {
                 std::cout << "ReduceTensor() with indices output FAILED: " << error2 << std::endl;
             }

--- a/driver/rnn_driver.hpp
+++ b/driver/rnn_driver.hpp
@@ -1576,9 +1576,9 @@ int RNNDriver<Tgpu, Tref>::VerifyForward()
 
     Tref tolerance = (sizeof(Tgpu) == 4 ? static_cast<Tref>(1e-6) : static_cast<Tref>(5e-2));
 
-    if(!(error < tolerance))
+    if(!std::isfinite(error) || error > tolerance)
     {
-        std::cout << std::string("Forward RNN Failed: ") << error << "\n";
+        std::cout << std::string("Forward RNN FAILED: ") << error << std::endl;
     }
     else
     {
@@ -1587,9 +1587,9 @@ int RNNDriver<Tgpu, Tref>::VerifyForward()
 
     auto error2 = miopen::rms_range(hy_host, hy);
 
-    if(!(error2 < tolerance))
+    if(!std::isfinite(error2) || error2 > tolerance)
     {
-        std::cout << std::string("final hidden state Failed: ") << error2 << "\n";
+        std::cout << std::string("final hidden state FAILED: ") << error2 << std::endl;
     }
     else
     {
@@ -1600,9 +1600,9 @@ int RNNDriver<Tgpu, Tref>::VerifyForward()
     {
         auto error3 = miopen::rms_range(cy_host, cy);
 
-        if(!(error3 < tolerance))
+        if(!std::isfinite(error3) || error3 > tolerance)
         {
-            std::cout << std::string("final cell state Failed: ") << error3 << "\n";
+            std::cout << std::string("final cell state FAILED: ") << error3 << std::endl;
         }
         else
         {
@@ -1673,10 +1673,10 @@ int RNNDriver<Tgpu, Tref>::VerifyBackward()
 
         auto error_data = miopen::rms_range(din_host, din);
 
-        if(!(error_data < tolerance))
+        if(!std::isfinite(error_data) || error_data > tolerance)
         {
-            std::cout << std::string("Backward RNN Data Failed: ") << error_data
-                      << std::string("\n");
+            std::cout << std::string("Backward RNN Data FAILED: ") << error_data
+                      << std::endl;
         }
         else
         {
@@ -1685,10 +1685,10 @@ int RNNDriver<Tgpu, Tref>::VerifyBackward()
 
         auto error_data2 = miopen::rms_range(dhx_host, dhx);
 
-        if(!(error_data2 < tolerance))
+        if(!std::isfinite(error_data2) || error_data2 > tolerance)
         {
-            std::cout << std::string("difference at inital hidden state Failed: ") << error_data2
-                      << "\n";
+            std::cout << std::string("difference at inital hidden state FAILED: ") << error_data2
+                      << std::endl;
         }
         else
         {
@@ -1699,10 +1699,10 @@ int RNNDriver<Tgpu, Tref>::VerifyBackward()
         {
             auto error_data3 = miopen::rms_range(dcx_host, dcx);
 
-            if(!(error_data3 < tolerance))
+            if(!std::isfinite(error_data3) || error_data3 > tolerance)
             {
-                std::cout << std::string("difference at inital cell state Failed: ") << error_data3
-                          << "\n";
+                std::cout << std::string("difference at inital cell state FAILED: ") << error_data3
+                          << std::endl;
             }
             else
             {
@@ -1719,10 +1719,10 @@ int RNNDriver<Tgpu, Tref>::VerifyBackward()
         }
 
         auto error_weights = miopen::rms_range(dwei_host, dwei);
-        if(!(error_weights < tolerance))
+        if(!std::isfinite(error_weights) || error_weights > tolerance)
         {
-            std::cout << std::string("Backward RNN Weights Failed: ") << error_weights
-                      << std::string("\n");
+            std::cout << std::string("Backward RNN Weights FAILED: ") << error_weights
+                      << std::endl;
         }
         else
         {

--- a/driver/rnn_driver.hpp
+++ b/driver/rnn_driver.hpp
@@ -1675,8 +1675,7 @@ int RNNDriver<Tgpu, Tref>::VerifyBackward()
 
         if(!std::isfinite(error_data) || error_data > tolerance)
         {
-            std::cout << std::string("Backward RNN Data FAILED: ") << error_data
-                      << std::endl;
+            std::cout << std::string("Backward RNN Data FAILED: ") << error_data << std::endl;
         }
         else
         {
@@ -1687,8 +1686,7 @@ int RNNDriver<Tgpu, Tref>::VerifyBackward()
 
         if(!std::isfinite(error_data2) || error_data2 > tolerance)
         {
-            std::cout << std::string("difference at inital hidden state FAILED: ") << error_data2
-                      << std::endl;
+            std::cout << std::string("difference at inital hidden state FAILED: ") << error_data2 << std::endl;
         }
         else
         {
@@ -1701,8 +1699,7 @@ int RNNDriver<Tgpu, Tref>::VerifyBackward()
 
             if(!std::isfinite(error_data3) || error_data3 > tolerance)
             {
-                std::cout << std::string("difference at inital cell state FAILED: ") << error_data3
-                          << std::endl;
+                std::cout << std::string("difference at inital cell state FAILED: ") << error_data3 << std::endl;
             }
             else
             {
@@ -1721,8 +1718,7 @@ int RNNDriver<Tgpu, Tref>::VerifyBackward()
         auto error_weights = miopen::rms_range(dwei_host, dwei);
         if(!std::isfinite(error_weights) || error_weights > tolerance)
         {
-            std::cout << std::string("Backward RNN Weights FAILED: ") << error_weights
-                      << std::endl;
+            std::cout << std::string("Backward RNN Weights FAILED: ") << error_weights << std::endl;
         }
         else
         {

--- a/driver/rnn_driver.hpp
+++ b/driver/rnn_driver.hpp
@@ -1686,7 +1686,8 @@ int RNNDriver<Tgpu, Tref>::VerifyBackward()
 
         if(!std::isfinite(error_data2) || error_data2 > tolerance)
         {
-            std::cout << std::string("difference at inital hidden state FAILED: ") << error_data2 << std::endl;
+            std::cout << std::string("difference at inital hidden state FAILED: ") << error_data2
+                      << std::endl;
         }
         else
         {
@@ -1699,7 +1700,8 @@ int RNNDriver<Tgpu, Tref>::VerifyBackward()
 
             if(!std::isfinite(error_data3) || error_data3 > tolerance)
             {
-                std::cout << std::string("difference at inital cell state FAILED: ") << error_data3 << std::endl;
+                std::cout << std::string("difference at inital cell state FAILED: ") << error_data3
+                          << std::endl;
             }
             else
             {

--- a/driver/softmax_driver.hpp
+++ b/driver/softmax_driver.hpp
@@ -341,7 +341,7 @@ int SoftmaxDriver<Tgpu, Tref>::VerifyForward()
 
     auto error           = miopen::rms_range(outhost, out);
     const Tref tolerance = data_type == miopenHalf ? 5e-2 : 1e-3; // 1e-6;
-    if(error > tolerance)
+    if(!(error < tolerance))
     {
         std::cout << "Forward Softmax Failed: " << error << "\n";
     }
@@ -375,7 +375,7 @@ int SoftmaxDriver<Tgpu, Tref>::VerifyBackward()
 
     auto error           = miopen::rms_range(dinhost, din);
     const Tref tolerance = data_type == miopenHalf ? 5e-2 : 1e-3; // 1e-6;
-    if(error > tolerance)
+    if(!(error < tolerance))
     {
         std::cout << "Backward Softmax Failed: " << error << "\n";
     }

--- a/driver/softmax_driver.hpp
+++ b/driver/softmax_driver.hpp
@@ -341,9 +341,9 @@ int SoftmaxDriver<Tgpu, Tref>::VerifyForward()
 
     auto error           = miopen::rms_range(outhost, out);
     const Tref tolerance = data_type == miopenHalf ? 5e-2 : 1e-3; // 1e-6;
-    if(!(error < tolerance))
+    if(!std::isfinite(error) || error > tolerance)
     {
-        std::cout << "Forward Softmax Failed: " << error << "\n";
+        std::cout << "Forward Softmax FAILED: " << error << std::endl;
     }
     else
     {
@@ -375,9 +375,9 @@ int SoftmaxDriver<Tgpu, Tref>::VerifyBackward()
 
     auto error           = miopen::rms_range(dinhost, din);
     const Tref tolerance = data_type == miopenHalf ? 5e-2 : 1e-3; // 1e-6;
-    if(!(error < tolerance))
+    if(!std::isfinite(error) || error > tolerance)
     {
-        std::cout << "Backward Softmax Failed: " << error << "\n";
+        std::cout << "Backward Softmax FAILED: " << error << std::endl;
     }
     else
     {


### PR DESCRIPTION
Update: fixed a few extra places where the comparison might have issues.

Original Comments about the root cause:

A lot of places:
```
    if(error > tolerance)
    {
        std::cout << "verification Failed ";
    }
```
will have issue if error contains NaN; per IEEE-754 the comparison will return FALSE.