### PR TITLE
[SWDEV-321331] Fix ONNX runtime unit tests for reductions

### DIFF
--- a/src/composable_kernel/composable_kernel/src/kernel_wrapper/gridwise_generic_reduction_second_call_threadwise_reduce_all_dims.cpp
+++ b/src/composable_kernel/composable_kernel/src/kernel_wrapper/gridwise_generic_reduction_second_call_threadwise_reduce_all_dims.cpp
@@ -42,9 +42,6 @@ using compType =
 
 constexpr index_t BlockSize = CK_PARAM_BLOCKSIZE; // tunable
 
-using toReduceDims  = Sequence<CK_PARAM_TOREDUCE_DIMS>;
-using invariantDims = Sequence<CK_PARAM_INVARIANT_DIMS>; // this could be empty
-
 constexpr ReduceTensorOp_t op          = static_cast<ReduceTensorOp_t>(CK_PARAM_REDUCE_OP);
 constexpr NanPropagation_t nanPropaOpt = CK_PARAM_NAN_PROPAGATE == 0
                                              ? NanPropagation_t::NOT_PROPAGATE_NAN

--- a/src/reducetensor.cpp
+++ b/src/reducetensor.cpp
@@ -669,10 +669,10 @@ void ReduceTensorDescriptor::ReduceTensor(const Handle& handle,
 
     for(int i = 0; i < inDescLengths.size(); i++)
     {
-        if(outDescLengths[i] == inDescLengths[i])
-            invariantDims.push_back(i);
-        else
+        if(outDescLengths[i] == 1)
             toReduceDims.push_back(i);
+        else
+            invariantDims.push_back(i);
     };
 
     if(toReduceDims.empty())

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1546,6 +1546,29 @@ COMMAND ${CONV_CK_IGEMM_FWD_V6R1_DLOPS_NCHW_ENV}     $<TARGET_FILE:test_conv2d> 
 COMMAND ${CONV_CK_IGEMM_FWD_V6R1_DLOPS_NCHW_ENV}     $<TARGET_FILE:test_conv2d> ${MIOPEN_TEST_FLOAT_ARG} --verbose --input 128   64 56 56  --weights   64   64 3 3 --pads_strides_dilations 1 1 1 1 1 1 --disable-backward-data --disable-backward-weights
 )
 
+add_custom_test(test_reduce_custom HALF_ENABLED GFX1030_ENABLED SKIP_UNLESS_ALL
+COMMAND $<TARGET_FILE:test_reduce_test> ${MIOPEN_TEST_FLOAT_ARG} --scales 1 0 --CompType 1 --D 8 2 1 --I 0 --N 1 ---ReduceOp 0 --R 0 1 2 ${MIOPEN_TEST_FLAGS_ARGS}
+COMMAND $<TARGET_FILE:test_reduce_test> ${MIOPEN_TEST_FLOAT_ARG} --scales 1 0 --CompType 1 --D 160 10 1 --I 0 --N 1 ---ReduceOp 0 --R 0 1 2 ${MIOPEN_TEST_FLAGS_ARGS}
+COMMAND $<TARGET_FILE:test_reduce_test> ${MIOPEN_TEST_FLOAT_ARG} --scales 1 0 --CompType 1 --D 7 1024 1 --I 0 --N 1 ---ReduceOp 0 --R 0 1 2 ${MIOPEN_TEST_FLAGS_ARGS}
+COMMAND $<TARGET_FILE:test_reduce_test> ${MIOPEN_TEST_FLOAT_ARG} --scales 1 0 --CompType 1 --D 3 1 1 --I 0 --N 1 ---ReduceOp 0 --R 0 1 2 ${MIOPEN_TEST_FLAGS_ARGS}
+COMMAND $<TARGET_FILE:test_reduce_test> ${MIOPEN_TEST_FLOAT_ARG} --scales 1 0 --CompType 1 --D 3 1 1 --I 0 --N 1 ---ReduceOp 1 --R 0 1 2 ${MIOPEN_TEST_FLAGS_ARGS}
+COMMAND $<TARGET_FILE:test_reduce_test> ${MIOPEN_TEST_FLOAT_ARG} --scales 1 0 --CompType 1 --D 3 1 1 --I 1 --N 1 ---ReduceOp 3 --R 0 1 2 ${MIOPEN_TEST_FLAGS_ARGS}
+COMMAND $<TARGET_FILE:test_reduce_test> ${MIOPEN_TEST_FLOAT_ARG} --scales 1 0 --CompType 1 --D 3 2 1 --I 1 --N 1 ---ReduceOp 3 --R 1 2 ${MIOPEN_TEST_FLAGS_ARGS}
+COMMAND $<TARGET_FILE:test_reduce_test> ${MIOPEN_TEST_FLOAT_ARG} --scales 1 0 --CompType 1 --D 6 2 1 --I 0 --N 1 ---ReduceOp 3 --R 1 2 ${MIOPEN_TEST_FLAGS_ARGS}
+COMMAND $<TARGET_FILE:test_reduce_test> ${MIOPEN_TEST_FLOAT_ARG} --scales 1 0 --CompType 1 --D 6 2 1 --I 0 --N 1 ---ReduceOp 2 --R 1 2 ${MIOPEN_TEST_FLAGS_ARGS}
+COMMAND $<TARGET_FILE:test_reduce_test> ${MIOPEN_TEST_FLOAT_ARG} --scales 1 0 --CompType 1 --D 2 2 1 --I 0 --N 1 ---ReduceOp 0 --R 1 2 ${MIOPEN_TEST_FLAGS_ARGS}
+COMMAND $<TARGET_FILE:test_reduce_test> ${MIOPEN_TEST_FLOAT_ARG} --scales 1 0 --CompType 1 --D 4 3 1 --I 0 --N 1 ---ReduceOp 3 --R 1 2 ${MIOPEN_TEST_FLAGS_ARGS}
+COMMAND $<TARGET_FILE:test_reduce_test> ${MIOPEN_TEST_FLOAT_ARG} --scales 1 0 --CompType 1 --D 3 4 1 --I 0 --N 1 ---ReduceOp 3 --R 1 2 ${MIOPEN_TEST_FLAGS_ARGS}
+COMMAND $<TARGET_FILE:test_reduce_test> ${MIOPEN_TEST_FLOAT_ARG} --scales 1 0 --CompType 1 --D 3 4 1 --I 0 --N 1 ---ReduceOp 3 --R 0 2 ${MIOPEN_TEST_FLAGS_ARGS}
+COMMAND $<TARGET_FILE:test_reduce_test> ${MIOPEN_TEST_FLOAT_ARG} --scales 1 0 --CompType 1 --D 2048 32 1 --I 0 --N 1 ---ReduceOp 3 --R 0 2 ${MIOPEN_TEST_FLAGS_ARGS}
+COMMAND $<TARGET_FILE:test_reduce_test> ${MIOPEN_TEST_FLOAT_ARG} --scales 1 0 --CompType 1 --D 4 3 1 --I 0 --N 1 ---ReduceOp 2 --R 1 2 ${MIOPEN_TEST_FLAGS_ARGS}
+COMMAND $<TARGET_FILE:test_reduce_test> ${MIOPEN_TEST_FLOAT_ARG} --scales 1 0 --CompType 1 --D 3 4 1 --I 0 --N 1 ---ReduceOp 2 --R 0 2 ${MIOPEN_TEST_FLAGS_ARGS}
+COMMAND $<TARGET_FILE:test_reduce_test> ${MIOPEN_TEST_FLOAT_ARG} --scales 1 0 --CompType 1 --D 2048 32 1 --I 0 --N 1 ---ReduceOp 2 --R 0 2 ${MIOPEN_TEST_FLAGS_ARGS}
+COMMAND $<TARGET_FILE:test_reduce_test> ${MIOPEN_TEST_FLOAT_ARG} --scales 1 0 --CompType 1 --D 3 4 1 --I 0 --N 1 ---ReduceOp 2 --R 0 2 ${MIOPEN_TEST_FLAGS_ARGS}
+COMMAND $<TARGET_FILE:test_reduce_test> ${MIOPEN_TEST_FLOAT_ARG} --scales 1 0 --CompType 1 --D 12 11 1 --I 0 --N 1 ---ReduceOp 0 --R 0 1 2 ${MIOPEN_TEST_FLAGS_ARGS}
+COMMAND $<TARGET_FILE:test_reduce_test> ${MIOPEN_TEST_FLOAT_ARG} --scales 1 0 --CompType 1 --D 13 4 7 7 --I 0 --N 1 ---ReduceOp 0 --R 0 1 2 3 ${MIOPEN_TEST_FLAGS_ARGS}
+)
+
 if(MIOPEN_TEST_DEEPBENCH)
     add_custom_test(test_deepbench_conv  MIOTENSILE_ENABLED GFX1030_ENABLED
     COMMAND	$<TARGET_FILE:test_conv2d>	--verbose	--input	4	1	161	700	--weights	32	1	5	20	--pads_strides_dilations	0	0	2	2	1	1


### PR DESCRIPTION
Quick fix for [SWDEV-321331](https://ontrack-internal.amd.com/browse/SWDEV-321331). 

The fix has been verified with the following script using MIOpenDriver. 
```bash
#!/bin/bash

./bin/MIOpenDriver reduce -A 1 -B 0 -C 1 -D 8,2,1 -I 0 -N 1 -O 0 -R 0,1,2
./bin/MIOpenDriver reduce -A 1 -B 0 -C 1 -D 160,10,1 -I 0 -N 1 -O 0 -R 0,1,2
./bin/MIOpenDriver reduce -A 1 -B 0 -C 1 -D 7,1024,1 -I 0 -N 1 -O 0 -R 0,1,2
./bin/MIOpenDriver reduce -A 1 -B 0 -C 1 -D 1024,30528,1 -I 0 -N 1 -O 0 -R 0,1,2
./bin/MIOpenDriver reduce -A 1 -B 0 -C 1 -D 3,1,1 -I 0 -N 1 -O 0 -R 0,1,2
./bin/MIOpenDriver reduce -A 1 -B 0 -C 1 -D 3,1,1 -I 0 -N 1 -O 1 -R 0,1,2
./bin/MIOpenDriver reduce -A 1 -B 0 -C 1 -D 3,1,1 -I 1 -N 1 -O 3 -R 0,1,2
./bin/MIOpenDriver reduce -A 1 -B 0 -C 1 -D 3,2,1 -I 1 -N 1 -O 3 -R 1,2
./bin/MIOpenDriver reduce -A 1 -B 0 -C 1 -D 6,2,1 -I 0 -N 1 -O 3 -R 1,2
./bin/MIOpenDriver reduce -A 1 -B 0 -C 1 -D 6,2,1 -I 0 -N 1 -O 2 -R 1,2
./bin/MIOpenDriver reduce -A 1 -B 0 -C 1 -D 2,2,1 -I 0 -N 1 -O 0 -R 1,2
./bin/MIOpenDriver reduce -A 1 -B 0 -C 1 -D 4,3,1 -I 0 -N 1 -O 3 -R 1,2
./bin/MIOpenDriver reduce -A 1 -B 0 -C 1 -D 3,4,1 -I 0 -N 1 -O 3 -R 1,2
./bin/MIOpenDriver reduce -A 1 -B 0 -C 1 -D 3,4,1 -I 0 -N 1 -O 3 -R 0,2
./bin/MIOpenDriver reduce -A 1 -B 0 -C 1 -D 2048,32,1 -I 0 -N 1 -O 3 -R 0,2
./bin/MIOpenDriver reduce -A 1 -B 0 -C 1 -D 4,3,1 -I 0 -N 1 -O 2 -R 1,2
./bin/MIOpenDriver reduce -A 1 -B 0 -C 1 -D 3,4,1 -I 0 -N 1 -O 2 -R 0,2
./bin/MIOpenDriver reduce -A 1 -B 0 -C 1 -D 2048,32,1 -I 0 -N 1 -O 2 -R 0,2
./bin/MIOpenDriver reduce -A 1 -B 0 -C 1 -D 3,4,1 -I 0 -N 1 -O 2 -R 0,2
./bin/MIOpenDriver reduce -A 1 -B 0 -C 1 -D 12,11,1 -I 0 -N 1 -O 0 -R 0,1,2
./bin/MIOpenDriver reduce -A 1 -B 0 -C 1 -D 13,4,7,7 -I 0 -N 1 -O 0 -R 0,1,2,3

```

The usual `bin/test_reduce_test --all`
The fix has also been verified with a script using /bin/test_reduce_all: 
```bash
#!/bin/bash

./bin/test_reduce_test --scales 1 0 --CompType 1 --D 8 2 1 --I 0 --N 1 ---ReduceOp 0 --R 0 1 2 -v
./bin/test_reduce_test --scales 1 0 --CompType 1 --D 160 10 1 --I 0 --N 1 ---ReduceOp 0 --R 0 1 2 -v
./bin/test_reduce_test --scales 1 0 --CompType 1 --D 7 1024 1 --I 0 --N 1 ---ReduceOp 0 --R 0 1 2 -v
## The case will fail due to big accumulative error, so not used with test_reduce_test
##./bin/test_reduce_test --scales 1 0 --CompType 1 --D 1024 30528 1 --I 0 --N 1 ---ReduceOp 0 --R 0 1 2 -v
./bin/test_reduce_test --scales 1 0 --CompType 1 --D 3 1 1 --I 0 --N 1 ---ReduceOp 0 --R 0 1 2 -v
./bin/test_reduce_test --scales 1 0 --CompType 1 --D 3 1 1 --I 0 --N 1 ---ReduceOp 1 --R 0 1 2 -v 
./bin/test_reduce_test --scales 1 0 --CompType 1 --D 3 1 1 --I 1 --N 1 ---ReduceOp 3 --R 0 1 2 -v
./bin/test_reduce_test --scales 1 0 --CompType 1 --D 3 2 1 --I 1 --N 1 ---ReduceOp 3 --R 1 2 -v
./bin/test_reduce_test --scales 1 0 --CompType 1 --D 6 2 1 --I 0 --N 1 ---ReduceOp 3 --R 1 2 -v
./bin/test_reduce_test --scales 1 0 --CompType 1 --D 6 2 1 --I 0 --N 1 ---ReduceOp 2 --R 1 2 -v
./bin/test_reduce_test --scales 1 0 --CompType 1 --D 2 2 1 --I 0 --N 1 ---ReduceOp 0 --R 1 2 -v
./bin/test_reduce_test --scales 1 0 --CompType 1 --D 4 3 1 --I 0 --N 1 ---ReduceOp 3 --R 1 2 -v
./bin/test_reduce_test --scales 1 0 --CompType 1 --D 3 4 1 --I 0 --N 1 ---ReduceOp 3 --R 1 2 -v
./bin/test_reduce_test --scales 1 0 --CompType 1 --D 3 4 1 --I 0 --N 1 ---ReduceOp 3 --R 0 2 -v
./bin/test_reduce_test --scales 1 0 --CompType 1 --D 2048 32 1 --I 0 --N 1 ---ReduceOp 3 --R 0 2 -v
./bin/test_reduce_test --scales 1 0 --CompType 1 --D 4 3 1 --I 0 --N 1 ---ReduceOp 2 --R 1 2 -v
./bin/test_reduce_test --scales 1 0 --CompType 1 --D 3 4 1 --I 0 --N 1 ---ReduceOp 2 --R 0 2 -v 
./bin/test_reduce_test --scales 1 0 --CompType 1 --D 2048 32 1 --I 0 --N 1 ---ReduceOp 2 --R 0 2 -v
./bin/test_reduce_test --scales 1 0 --CompType 1 --D 3 4 1 --I 0 --N 1 ---ReduceOp 2 --R 0 2 -v
./bin/test_reduce_test --scales 1 0 --CompType 1 --D 12 11 1 --I 0 --N 1 ---ReduceOp 0 --R 0 1 2 -v
./bin/test_reduce_test --scales 1 0 --CompType 1 --D 13 4 7 7 --I 0 --N 1 ---ReduceOp 0 --R 0 1 2 3 -v
```




