### PR TITLE
[Tests] add test_reduce_test and follow up PR #1409

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1550,6 +1550,7 @@ add_custom_test(test_reduce_custom HALF_ENABLED GFX1030_ENABLED SKIP_UNLESS_ALL
 COMMAND $<TARGET_FILE:test_reduce_test> ${MIOPEN_TEST_FLOAT_ARG} --scales 1 0 --CompType 1 --D 8 2 1 --I 0 --N 1 ---ReduceOp 0 --R 0 1 2 ${MIOPEN_TEST_FLAGS_ARGS}
 COMMAND $<TARGET_FILE:test_reduce_test> ${MIOPEN_TEST_FLOAT_ARG} --scales 1 0 --CompType 1 --D 160 10 1 --I 0 --N 1 ---ReduceOp 0 --R 0 1 2 ${MIOPEN_TEST_FLAGS_ARGS}
 COMMAND $<TARGET_FILE:test_reduce_test> ${MIOPEN_TEST_FLOAT_ARG} --scales 1 0 --CompType 1 --D 7 1024 1 --I 0 --N 1 ---ReduceOp 0 --R 0 1 2 ${MIOPEN_TEST_FLAGS_ARGS}
+COMMAND $<TARGET_FILE:test_reduce_test> ${MIOPEN_TEST_FLOAT_ARG} --scales 1 0 --CompType 1 --D 1024 30528 1 --I 0 --N 1 ---ReduceOp 0 --R 0 1 2 ${MIOPEN_TEST_FLAGS_ARGS}
 COMMAND $<TARGET_FILE:test_reduce_test> ${MIOPEN_TEST_FLOAT_ARG} --scales 1 0 --CompType 1 --D 3 1 1 --I 0 --N 1 ---ReduceOp 0 --R 0 1 2 ${MIOPEN_TEST_FLAGS_ARGS}
 COMMAND $<TARGET_FILE:test_reduce_test> ${MIOPEN_TEST_FLOAT_ARG} --scales 1 0 --CompType 1 --D 3 1 1 --I 0 --N 1 ---ReduceOp 1 --R 0 1 2 ${MIOPEN_TEST_FLAGS_ARGS}
 COMMAND $<TARGET_FILE:test_reduce_test> ${MIOPEN_TEST_FLOAT_ARG} --scales 1 0 --CompType 1 --D 3 1 1 --I 1 --N 1 ---ReduceOp 3 --R 0 1 2 ${MIOPEN_TEST_FLAGS_ARGS}

--- a/test/reduce_test.cpp
+++ b/test/reduce_test.cpp
@@ -819,7 +819,7 @@ struct reduce_driver : test_driver
             max_value = 3;
         else
             max_value =
-                miopen_type<T>{} == miopenHalf ? 13 : miopen_type<T>{} == miopenInt8 ? 127 : 17;
+                miopen_type<T>{} == miopenHalf ? 13 : miopen_type<T>{} == miopenInt8 ? 127 : 999;
 
         // default data gneration (used by MIN/MAX)
         auto gen_value = [&](auto... is) {
@@ -833,7 +833,7 @@ struct reduce_driver : test_driver
             auto rand_value = tensor_elem_gen_integer{max_value}(is...);
             auto sign_value = tensor_elem_gen_checkboard_sign{}(is...);
 
-            return (sign_value * rand_value + 1.0);
+            return (sign_value * rand_value / max_value + 0.01);
         };
 
         // Special data generation for MUL, to avoid all-zero and large accumulative error in the
@@ -867,6 +867,8 @@ struct reduce_driver : test_driver
         // default tolerance (refer to driver.hpp)
         this->tolerance = 80;
 
+        if(reduceOp == MIOPEN_REDUCE_TENSOR_ADD || reduceOp == MIOPEN_REDUCE_TENSOR_AVG)
+            this->tolerance = 80 * 10;
         if(reduceOp == MIOPEN_REDUCE_TENSOR_MUL)
             this->tolerance = 80 * 300;
         else if(reduceOp == MIOPEN_REDUCE_TENSOR_NORM1 || reduceOp == MIOPEN_REDUCE_TENSOR_NORM2)


### PR DESCRIPTION
Resolves [Issue 1410](https://github.com/ROCmSoftwarePlatform/MIOpen/issues/1410)

Update in test/reduce_test.cpp to make the leaked testing case mentioned in [PR.1409 ](https://github.com/ROCmSoftwarePlatform/MIOpen/pull/1409) as well as [Issue 1410](https://github.com/ROCmSoftwarePlatform/MIOpen/issues/1410) pass.  The fix has passed all MIOpenDriver and test_reduce_test cases used in [PR.1409 ](https://github.com/ROCmSoftwarePlatform/MIOpen/pull/1409) as well as the case

`./bin/test_reduce_test --scales 1 0 --CompType 1 --D 1024 30528 1 --I 0 --N 1 ---ReduceOp 0 --R 0 1 2 -v`

Also, the following default test_reduce_test batch tests passed 
`./bin/test_reduce_test --all`
`./bin/test_reduce_test --all --half`
`./bin/test_reduce_test --all --double`
