### PR TITLE
Work-around Reduction issue due to inconsistent warpSize between different HIP kernel building methods

### DIFF
--- a/src/composable_kernel/composable_kernel/src/kernel_wrapper/gridwise_generic_reduction_first_call_warpwise_reduce_all_dims.cpp
+++ b/src/composable_kernel/composable_kernel/src/kernel_wrapper/gridwise_generic_reduction_first_call_warpwise_reduce_all_dims.cpp
@@ -59,6 +59,7 @@ constexpr bool indexable    = reduce_binary_operator<compType, op>::indexable;
 constexpr bool need_indices = indexable && (reduceIndicesOpt != ReduceTensorIndices_t::NO_INDICES);
 
 constexpr index_t GredAccessesPerThreadInWarp = CK_PARAM_ACCESSES_PER_THREAD_INWARP; // tunable
+constexpr index_t WavefrontSize               = CK_PARAM_WAVEFRONT_SIZE;
 
 // helper functions using variadic template arguments
 template <index_t... Ns>
@@ -130,11 +131,11 @@ extern "C" __global__ void gridwise_generic_reduce_1_prepare(int GridSize,
     constexpr int invariantLen = 1;
     const auto toReduceLen     = src2dDesc.GetLength(Number<1>{});
 
-    constexpr auto copySliceLen = warpSize * GredAccessesPerThreadInWarp;
+    constexpr auto copySliceLen = WavefrontSize * GredAccessesPerThreadInWarp;
 
     if constexpr(src2d_need_padding)
     {
-        const auto srcPad1 = GridSize * BlockSize / warpSize - invariantLen;
+        const auto srcPad1 = GridSize * BlockSize / WavefrontSize - invariantLen;
         const auto srcPad2 =
             ((toReduceLen + copySliceLen - 1) / copySliceLen) * copySliceLen - toReduceLen;
 
@@ -155,7 +156,7 @@ extern "C" __global__ void gridwise_generic_reduce_1_prepare(int GridSize,
 
     if constexpr(dst1d_need_padding)
     {
-        const auto dstPad = GridSize * BlockSize / warpSize - invariantLen;
+        const auto dstPad = GridSize * BlockSize / WavefrontSize - invariantLen;
         auto dst1dDesc_2 =
             transform_tensor_descriptor(dstDesc,
                                         make_tuple(make_pad_transform(invariantLen, 0, dstPad)),
@@ -259,6 +260,7 @@ extern "C" __global__ void gridwise_generic_reduce_1(int origReduceLen,
 
     using gridwise_2d_reduce =
         GridwiseReduction_xy_to_x_direct_warpwise<BlockSize,
+                                                  WavefrontSize,
                                                   srcDataType,
                                                   dstDataType,
                                                   compType,

--- a/src/composable_kernel/composable_kernel/src/kernel_wrapper/gridwise_generic_reduction_first_call_warpwise_reduce_partial_dims.cpp
+++ b/src/composable_kernel/composable_kernel/src/kernel_wrapper/gridwise_generic_reduction_first_call_warpwise_reduce_partial_dims.cpp
@@ -68,6 +68,7 @@ constexpr bool indexable    = reduce_binary_operator<compType, op>::indexable;
 constexpr bool need_indices = indexable && (reduceIndicesOpt != ReduceTensorIndices_t::NO_INDICES);
 
 constexpr index_t GredAccessesPerThreadInWarp = CK_PARAM_ACCESSES_PER_THREAD_INWARP; // tunable
+constexpr index_t WavefrontSize               = CK_PARAM_WAVEFRONT_SIZE;
 
 // helper functions using variadic template arguments
 template <index_t... Ns>
@@ -152,11 +153,11 @@ extern "C" __global__ void gridwise_generic_reduce_1_prepare(int GridSize,
     const auto invariantLen = src2dDesc.GetLength(Number<0>{});
     const auto toReduceLen  = src2dDesc.GetLength(Number<1>{});
 
-    constexpr auto copySliceLen = warpSize * GredAccessesPerThreadInWarp;
+    constexpr auto copySliceLen = WavefrontSize * GredAccessesPerThreadInWarp;
 
     if constexpr(src2d_need_padding)
     {
-        const auto srcPad1 = GridSize * BlockSize / warpSize - invariantLen;
+        const auto srcPad1 = GridSize * BlockSize / WavefrontSize - invariantLen;
         const auto srcPad2 =
             ((toReduceLen + copySliceLen - 1) / copySliceLen) * copySliceLen - toReduceLen;
 
@@ -177,7 +178,7 @@ extern "C" __global__ void gridwise_generic_reduce_1_prepare(int GridSize,
 
     if constexpr(dst1d_need_padding)
     {
-        const auto dstPad = GridSize * BlockSize / warpSize - invariantLen;
+        const auto dstPad = GridSize * BlockSize / WavefrontSize - invariantLen;
         auto dst1dDesc_2 =
             transform_tensor_descriptor(dst1dDesc,
                                         make_tuple(make_pad_transform(invariantLen, 0, dstPad)),
@@ -294,6 +295,7 @@ extern "C" __global__ void gridwise_generic_reduce_1(int origReduceLen,
 
     using gridwise_2d_reduce =
         GridwiseReduction_xy_to_x_direct_warpwise<BlockSize,
+                                                  WavefrontSize,
                                                   srcDataType,
                                                   dstDataType,
                                                   compType,

--- a/src/composable_kernel/composable_kernel/src/kernel_wrapper/gridwise_generic_reduction_second_call_warpwise_reduce_all_dims.cpp
+++ b/src/composable_kernel/composable_kernel/src/kernel_wrapper/gridwise_generic_reduction_second_call_warpwise_reduce_all_dims.cpp
@@ -57,6 +57,7 @@ constexpr bool indexable    = reduce_binary_operator<compType, op>::indexable;
 constexpr bool need_indices = indexable && (reduceIndicesOpt != ReduceTensorIndices_t::NO_INDICES);
 
 constexpr index_t GredAccessesPerThreadInWarp = CK_PARAM_ACCESSES_PER_THREAD_INWARP; // tunable
+constexpr index_t WavefrontSize               = CK_PARAM_WAVEFRONT_SIZE;
 
 extern "C" __global__ void
 gridwise_generic_reduce_2_prepare(int GridSize, int BlkGroupSize, void* __restrict__ ws_global)
@@ -76,11 +77,11 @@ gridwise_generic_reduce_2_prepare(int GridSize, int BlkGroupSize, void* __restri
 
     auto src2dDesc = make_naive_tensor_descriptor_packed(make_tuple(invariantLen, toReduceLen));
 
-    constexpr auto copySliceLen = warpSize * GredAccessesPerThreadInWarp;
+    constexpr auto copySliceLen = WavefrontSize * GredAccessesPerThreadInWarp;
 
     if constexpr(src2d_need_padding)
     {
-        const auto srcPad1 = GridSize * BlockSize / warpSize - invariantLen;
+        const auto srcPad1 = GridSize * BlockSize / WavefrontSize - invariantLen;
         const auto srcPad2 =
             ((toReduceLen + copySliceLen - 1) / copySliceLen) * copySliceLen - toReduceLen;
 
@@ -101,7 +102,7 @@ gridwise_generic_reduce_2_prepare(int GridSize, int BlkGroupSize, void* __restri
 
     if constexpr(dst1d_need_padding)
     {
-        const auto dstPad = GridSize * BlockSize / warpSize - invariantLen;
+        const auto dstPad = GridSize * BlockSize / WavefrontSize - invariantLen;
         auto dst1dDesc_2 =
             transform_tensor_descriptor(dstDesc,
                                         make_tuple(make_pad_transform(invariantLen, 0, dstPad)),
@@ -190,6 +191,7 @@ extern "C" __global__ void gridwise_generic_reduce_2(int origReduceLen,
 
     using gridwise_2d_reduce =
         GridwiseReduction_xy_to_x_direct_warpwise<BlockSize,
+                                                  WavefrontSize,
                                                   srcDataType,
                                                   dstDataType,
                                                   compType,

--- a/src/reducetensor.cpp
+++ b/src/reducetensor.cpp
@@ -950,7 +950,7 @@ void ReduceTensorDescriptor::ReduceTensor(const Handle& handle,
         param += " -DCK_PARAM_OUT_DIMS=";
         param += reduceAllDims ? "1" : std::to_string(invariantDims.size());
 
-        param += " -DCK_PARAM_WAVEFRONT_SIZE=" + std::to_string(handle.GetWavefrontWidth()); 
+        param += " -DCK_PARAM_WAVEFRONT_SIZE=" + std::to_string(handle.GetWavefrontWidth());
 
         float time_reduce = 0.0f;
 

--- a/src/reducetensor.cpp
+++ b/src/reducetensor.cpp
@@ -950,6 +950,8 @@ void ReduceTensorDescriptor::ReduceTensor(const Handle& handle,
         param += " -DCK_PARAM_OUT_DIMS=";
         param += reduceAllDims ? "1" : std::to_string(invariantDims.size());
 
+        param += " -DCK_PARAM_WAVEFRONT_SIZE=" + std::to_string(handle.GetWavefrontWidth()); 
+
         float time_reduce = 0.0f;
 
         network_config = detailDynamic::get_network_config_string_from_type_enums(


### PR DESCRIPTION
This P.R is a work-around for the Reduction test issue mentioned in [1431](https://github.com/ROCmSoftwarePlatform/MIOpen/issues/1431). 

It is found that when the HIP kernel is compiled using the `comgr` methd (with `MIOPEN_USE_COMGR` enabled), the the value of HIP kernel `warpSize` builtin variable will be 64 on Navi, rather than an expected value of 32.  The inconsistent value of `warpSize` will cause wrong result while calling the `DirectWarpWise`  kernel for Reduction.  This P.R provides the work-around by passing the miopen runtime detected wavefront size to the reduction kernel to avoid using the incorrect `warpSize`. 