### PR TITLE
[API] Implement miopenSet4dTensorDescriptorEx for cuDNN parity

### DIFF
--- a/include/miopen/miopen.h
+++ b/include/miopen/miopen.h
@@ -579,6 +579,33 @@ MIOPEN_EXPORT miopenStatus_t miopenCreateTensorDescriptor(miopenTensorDescriptor
 MIOPEN_EXPORT miopenStatus_t miopenSet4dTensorDescriptor(
     miopenTensorDescriptor_t tensorDesc, miopenDataType_t dataType, int n, int c, int h, int w);
 
+/*! @brief Set shape and stride of 4D tensor
+ *
+ * Interface for setting 4-D tensor shape and stride.
+ *
+ * @param tensorDesc Tensor descriptor type (output)
+ * @param dataType   MIOpen datatype (input)
+ * @param n          Mini-batch size (input)
+ * @param c          Number of channels (input)
+ * @param h          Data height dimension size (input)
+ * @param w          Data width dimension size (input)
+ * @param nStride    Mini-batch dimension stride (input)
+ * @param cStride    Channel dimension stride (input)
+ * @param hStride    Height dimension stride (input)
+ * @param wStride    Width dimension stride (input)
+ * @return           miopenStatus_t
+ */
+MIOPEN_EXPORT miopenStatus_t miopenSet4dTensorDescriptorEx(miopenTensorDescriptor_t tensorDesc,
+                                                           miopenDataType_t dataType,
+                                                           int n,
+                                                           int c,
+                                                           int h,
+                                                           int w,
+                                                           int nStride,
+                                                           int cStride,
+                                                           int hStride,
+                                                           int wStride);
+
 /*! @brief Get the details of the tensor descriptor
  *
  * Interface to query the 4-D tensor shape.

--- a/src/tensor_api.cpp
+++ b/src/tensor_api.cpp
@@ -48,6 +48,26 @@ extern "C" miopenStatus_t miopenSet4dTensorDescriptor(
     });
 }
 
+extern "C" miopenStatus_t miopenSet4dTensorDescriptorEx(miopenTensorDescriptor_t tensorDesc,
+                                                        miopenDataType_t dataType,
+                                                        int n,
+                                                        int c,
+                                                        int h,
+                                                        int w,
+                                                        int nStride,
+                                                        int cStride,
+                                                        int hStride,
+                                                        int wStride)
+{
+    MIOPEN_LOG_FUNCTION(tensorDesc, dataType, n, c, h, w, nStride, cStride, hStride, wStride);
+    return miopen::try_([&] {
+        std::initializer_list<int> lens    = {n, c, h, w};
+        std::initializer_list<int> strides = {nStride, cStride, hStride, wStride};
+        miopen::deref(tensorDesc) =
+            miopen::TensorDescriptor(dataType, lens.begin(), strides.begin(), 4);
+    });
+}
+
 extern "C" miopenStatus_t miopenGet4dTensorDescriptor(miopenTensorDescriptor_t tensorDesc,
                                                       miopenDataType_t* dataType,
                                                       int* n,

--- a/test/tensor_api.cpp
+++ b/test/tensor_api.cpp
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2018 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#include "test.hpp"
+
+#include <miopen/miopen.h>
+#include <miopen/tensor.hpp>
+
+int main(int argc, char* argv[])
+{
+    std::ignore        = argc;
+    std::ignore        = argv;
+    miopenStatus_t res = miopenStatusSuccess;
+    miopenTensorDescriptor_t desc;
+    res = miopenCreateTensorDescriptor(&desc);
+    CHECK(res == miopenStatusSuccess);
+    const int n       = 32;
+    const int c       = 16;
+    const int h       = 27;
+    const int w       = 24;
+    const int wStride = 1;
+    const int hStride = h;
+    const int cStride = h * w;
+    const int nStride = c * h * w;
+    res               = miopenSet4dTensorDescriptorEx(
+        desc, miopenFloat, n, c, h, w, nStride, cStride, hStride, wStride);
+    CHECK(res == miopenStatusSuccess);
+    int t_nStride = 0;
+    int t_cStride = 0;
+    int t_hStride = 0;
+    int t_wStride = 0;
+    int t_n       = 0;
+    int t_c       = 0;
+    int t_h       = 0;
+    int t_w       = 0;
+    miopenDataType_t t_type;
+    res = miopenGet4dTensorDescriptor(
+        desc, &t_type, &t_n, &t_c, &t_h, &t_w, &t_nStride, &t_cStride, &t_hStride, &t_wStride);
+    CHECK(res == miopenStatusSuccess);
+    CHECK(t_type == miopenFloat);
+    CHECK(t_n == n);
+    CHECK(t_c == c);
+    CHECK(t_h == h);
+    CHECK(t_w == w);
+    CHECK(t_nStride == nStride);
+    CHECK(t_cStride == cStride);
+    CHECK(t_hStride == hStride);
+    CHECK(t_wStride == wStride);
+    return 0;
+}


### PR DESCRIPTION
This PR adds the new `miopenSet4dTensorDescriptorEx ` API as required by issue #1430 .

