### PR TITLE
Eliminate dependency to SetTensor/CastTensor in MLIR XDLOPS wrw solver.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 sqlite3@3.17 -DCMAKE_POSITION_INDEPENDENT_CODE=On
 boost@1.72 -DCMAKE_POSITION_INDEPENDENT_CODE=On --build
 half,https://github.com/pfultz2/half/archive/1.12.0.tar.gz -X header -H sha256:0a08660b68abb176ebc2a0cdf8de46e3182a7f46c66443bb80dbfaaec98cf969 --build
-ROCmSoftwarePlatform/llvm-project-mlir@85a4acddea54b51e52436463b6026d9193252747 -DBUILD_FAT_LIBMLIRMIOPEN=1
+ROCmSoftwarePlatform/llvm-project-mlir@4eb6f1febceb785b25e0dd2adc15dbea125c6b87 -DBUILD_FAT_LIBMLIRMIOPEN=1

--- a/src/conv/invokers/mlir_impl_gemm.cpp
+++ b/src/conv/invokers/mlir_impl_gemm.cpp
@@ -431,12 +431,12 @@ InvokerFactory MakeMlirWrWInvokerFactory(const ConvolutionContext& ctx, size_t w
                     elapsed += handle.GetKernelTime();
                 }
 #endif
+            }
 
-                if(handle.IsProfilingEnabled())
-                {
-                    handle.ResetKernelTime();
-                    handle.AccumKernelTime(elapsed);
-                }
+            if(handle.IsProfilingEnabled())
+            {
+                handle.ResetKernelTime();
+                handle.AccumKernelTime(elapsed);
             }
         };
     };

--- a/src/conv/invokers/mlir_impl_gemm.cpp
+++ b/src/conv/invokers/mlir_impl_gemm.cpp
@@ -300,7 +300,7 @@ InvokerFactory MakeMlirBwdInvokerFactory(const ConvolutionContext& ctx)
 
     return [=](const std::vector<Kernel>& kernels) mutable {
         return [=](const Handle& handle, const AnyInvokeParams& primitive_parameters) mutable {
-            float elapsed        = 0;
+            float elapsed        = 0.f;
             const auto& data_ctx = primitive_parameters.CastTo<conv::DataInvokeParams>();
             const auto& tensors  = data_ctx.tensors;
 
@@ -364,9 +364,9 @@ InvokerFactory MakeMlirWrWInvokerFactory(const ConvolutionContext& ctx, size_t w
 
     return [=](const std::vector<Kernel>& kernels) mutable {
         return [=](const Handle& handle, const AnyInvokeParams& primitive_parameters) mutable {
+            float elapsed                 = 0.f;
             const auto& wrw_invoke_params = primitive_parameters.CastTo<conv::WrWInvokeParams>();
             const auto& tensors           = wrw_invoke_params.tensors;
-            float zero                    = 0.f;
 
             if(workspace_req > 0)
             {
@@ -380,51 +380,63 @@ InvokerFactory MakeMlirWrWInvokerFactory(const ConvolutionContext& ctx, size_t w
 
                 TensorDescriptor workspaceDesc(
                     miopenFloat, tensors.dwDesc.GetLengths(), tensors.dwDesc.GetStrides());
-                SetTensor(handle, workspaceDesc, workspace, &zero);
 
 #if MIOPEN_BACKEND_OPENCL
-                handle.Run(kernels[0])(tensors.dw,
-                                       tensors.dw,
-                                       EXPAND_MLIR_CONV_ARGS(args.filter),
-                                       tensors.x,
-                                       tensors.x,
-                                       EXPAND_MLIR_CONV_ARGS(args.input),
-                                       tensors.dy,
-                                       tensors.dy,
-                                       EXPAND_MLIR_CONV_ARGS(args.output),
-                                       workspace,
-                                       workspace,
-                                       EXPAND_MLIR_CONV_ARGS(args.workspace));
+                for(const auto& k : kernels)
+                {
+                    handle.Run(k)(tensors.dw,
+                                  tensors.dw,
+                                  EXPAND_MLIR_CONV_ARGS(args.filter),
+                                  tensors.x,
+                                  tensors.x,
+                                  EXPAND_MLIR_CONV_ARGS(args.input),
+                                  tensors.dy,
+                                  tensors.dy,
+                                  EXPAND_MLIR_CONV_ARGS(args.output),
+                                  workspace,
+                                  workspace,
+                                  EXPAND_MLIR_CONV_ARGS(args.workspace));
+                    elapsed += handle.GetKernelTime();
+                }
 #elif MIOPEN_BACKEND_HIP
                 SetMlirConvArgsPtr(tensors.x, tensors.dy, tensors.dw, workspace, args);
-                handle.Run(kernels[0])(args);
+                for(const auto& k : kernels)
+                {
+                    handle.Run(k)(args);
+                    elapsed += handle.GetKernelTime();
+                }
 #endif
-                CastTensor(handle,
-                           &ctx.conv_problem.GetConv().lowp_quant,
-                           workspaceDesc,
-                           workspace,
-                           tensors.dwDesc,
-                           tensors.dw,
-                           0,
-                           0);
             }
             else
             {
-                SetTensor(handle, tensors.dwDesc, tensors.dw, &zero);
 #if MIOPEN_BACKEND_OPENCL
-                handle.Run(kernels[0])(tensors.dw,
-                                       tensors.dw,
-                                       EXPAND_MLIR_CONV_ARGS(args.filter),
-                                       tensors.x,
-                                       tensors.x,
-                                       EXPAND_MLIR_CONV_ARGS(args.input),
-                                       tensors.dy,
-                                       tensors.dy,
-                                       EXPAND_MLIR_CONV_ARGS(args.output));
+                for(const auto& k : kernels)
+                {
+                    handle.Run(k)(tensors.dw,
+                                  tensors.dw,
+                                  EXPAND_MLIR_CONV_ARGS(args.filter),
+                                  tensors.x,
+                                  tensors.x,
+                                  EXPAND_MLIR_CONV_ARGS(args.input),
+                                  tensors.dy,
+                                  tensors.dy,
+                                  EXPAND_MLIR_CONV_ARGS(args.output));
+                    elapsed += handle.GetKernelTime();
+                }
 #elif MIOPEN_BACKEND_HIP
                 SetMlirConvArgsPtr(tensors.x, tensors.dy, tensors.dw, args);
-                handle.Run(kernels[0])(args);
+                for(const auto& k : kernels)
+                {
+                    handle.Run(k)(args);
+                    elapsed += handle.GetKernelTime();
+                }
 #endif
+
+                if(handle.IsProfilingEnabled())
+                {
+                    handle.ResetKernelTime();
+                    handle.AccumKernelTime(elapsed);
+                }
             }
         };
     };

--- a/src/solver/conv_mlir_igemm_wrw_xdlops.cpp
+++ b/src/solver/conv_mlir_igemm_wrw_xdlops.cpp
@@ -113,7 +113,7 @@ ConvSolution ConvMlirIgemmWrWXdlops::GetSolution(const ConvolutionContext& ctx,
 
     size_t workspace_req   = GetWorkspaceSize(ctx);
     result.invoker_factory = conv::MakeMlirWrWInvokerFactory(ctx, workspace_req);
-    result.workspace_sz    = GetWorkspaceSize(ctx);
+    result.workspace_sz    = workspace_req;
     return result;
 #else
     std::ignore = ctx;

--- a/src/solver/conv_mlir_igemm_wrw_xdlops.cpp
+++ b/src/solver/conv_mlir_igemm_wrw_xdlops.cpp
@@ -87,28 +87,33 @@ ConvSolution ConvMlirIgemmWrWXdlops::GetSolution(const ConvolutionContext& ctx,
 {
 #if MIOPEN_USE_MLIR
     ConvSolution result;
-    KernelInfo construction_parameters;
+    int kernel_count = MiirGetKernelCount(mlir::ConstructBuildOptions(ctx, true));
 
-    construction_parameters.kernel_name  = mlir::GetKernelName(ctx, true);
-    construction_parameters.kernel_file  = construction_parameters.kernel_name + ".mlir";
-    construction_parameters.comp_options = mlir::ConstructBuildOptions(ctx, config, true);
+    for(int kernel_id = 0; kernel_id < kernel_count; ++kernel_id)
+    {
+        KernelInfo construction_parameters;
 
-    size_t local_size  = 0;
-    size_t global_size = 0;
-    MiirGenLaunchParams(construction_parameters.comp_options, local_size, global_size);
+        construction_parameters.kernel_name = mlir::GetKernelName(ctx, true, kernel_id);
+        construction_parameters.kernel_file = construction_parameters.kernel_name + ".mlir";
+        construction_parameters.comp_options =
+            mlir::ConstructBuildOptions(ctx, config, true, kernel_id);
 
-    construction_parameters.l_wk.push_back(local_size);
-    construction_parameters.l_wk.push_back(1);
-    construction_parameters.l_wk.push_back(1);
+        size_t local_size  = 0;
+        size_t global_size = 0;
+        MiirGenLaunchParams(construction_parameters.comp_options, local_size, global_size);
+        construction_parameters.l_wk.push_back(local_size);
+        construction_parameters.l_wk.push_back(1);
+        construction_parameters.l_wk.push_back(1);
+        construction_parameters.g_wk.push_back(global_size);
+        construction_parameters.g_wk.push_back(1);
+        construction_parameters.g_wk.push_back(1);
 
-    construction_parameters.g_wk.push_back(global_size);
-    construction_parameters.g_wk.push_back(1);
-    construction_parameters.g_wk.push_back(1);
+        result.construction_params.push_back(construction_parameters);
+    }
 
     size_t workspace_req   = GetWorkspaceSize(ctx);
     result.invoker_factory = conv::MakeMlirWrWInvokerFactory(ctx, workspace_req);
-    result.construction_params.push_back(construction_parameters);
-    result.workspace_sz = workspace_req;
+    result.workspace_sz    = GetWorkspaceSize(ctx);
     return result;
 #else
     std::ignore = ctx;


### PR DESCRIPTION
MLIR implementation is now capable of producing these utility kernels. Eliminate the dependency to OpenCL-based kernels in MIOpen.

This PR only address wrw. A subsequent PR will change the same for bwd kernel invocations.

This PR depend on #1443 be merged first.