### PR TITLE
[HOTFIX][SWDEV-326460] check MIOPEN_DEBUG_CONVOLUTION_DETERMINISTIC in IsApplicable()

### DIFF
--- a/include/miopen/miopen.h
+++ b/include/miopen/miopen.h
@@ -2436,8 +2436,8 @@ miopenBatchNormalizationForwardTraining(miopenHandle_t handle,
  *
  * If either estimatedMean, or estimatedVariance are null pointers then the values for the mean and
  * variance will be calculated from input data and this calculated mean and variance will be used
- * to update input values. 
- * If variance is zero and epsilon is also zero, this function outputs NAN values.  Input espilon 
+ * to update input values.
+ * If variance is zero and epsilon is also zero, this function outputs NAN values.  Input espilon
  * value should always be non zero positive value.
  *
  * @param handle                    MIOpen handle (input)

--- a/src/solver/conv_asm_implicit_gemm_gtc_bwd_nhwc.cpp
+++ b/src/solver/conv_asm_implicit_gemm_gtc_bwd_nhwc.cpp
@@ -782,13 +782,6 @@ bool PerformanceConfigAsmImplicitGemmGTCBwdXdlopsNHWC::IsValid(const Convolution
         if(ctx.IsFp16() && gemm_k_global_split != 0 && vector_store != 1)
             return false;
 
-    // An internal rule when we create the kernel_param_list. There always will be a config with
-    // gemm_k_global_split=0 in front of a almost the same config, with only gemm_k_global_split=1,
-    // so it will never choose the *=1 one. And indeed in the HeuristicInit() we never wish to find
-    // a config with gemm_k_global_split=1. So it is safe here to disable *=1 case
-    if(miopen::IsEnabled(MIOPEN_DEBUG_CONVOLUTION_DETERMINISTIC{}) && gemm_k_global_split != 0)
-        return false;
-
     const auto group      = ctx.group_counts;
     const auto k          = ctx.n_inputs;
     const auto c          = ctx.n_outputs;
@@ -891,6 +884,9 @@ ConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWC::Search(const ConvolutionContext& ctx
 bool ConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWC::IsApplicable(const ConvolutionContext& ctx) const
 {
     if(miopen::IsDisabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_ASM_BWD_GTC_XDLOPS_NHWC{}))
+        return false;
+
+    if(miopen::IsEnabled(MIOPEN_DEBUG_CONVOLUTION_DETERMINISTIC{}))
         return false;
 
     const auto device_name = ctx.GetStream().GetDeviceName();

--- a/src/solver/conv_asm_implicit_gemm_gtc_fwd_nhwc.cpp
+++ b/src/solver/conv_asm_implicit_gemm_gtc_fwd_nhwc.cpp
@@ -655,9 +655,6 @@ bool PerformanceConfigAsmImplicitGemmGTCFwdXdlopsNHWC::IsValid(const Convolution
         if(ctx.IsFp16() && gemm_k_global_split != 0 && vector_store != 1)
             return false;
 
-    if(miopen::IsEnabled(MIOPEN_DEBUG_CONVOLUTION_DETERMINISTIC{}) && gemm_k_global_split != 0)
-        return false;
-
     const auto& c         = ctx.n_inputs;
     const auto& k         = ctx.n_outputs;
     const auto& group     = ctx.group_counts;
@@ -824,6 +821,9 @@ ConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWC::GetWorkspaceSize(const ConvolutionCo
 bool ConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWC::IsApplicable(const ConvolutionContext& ctx) const
 {
     if(miopen::IsDisabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_ASM_FWD_GTC_XDLOPS_NHWC{}))
+        return false;
+
+    if(miopen::IsEnabled(MIOPEN_DEBUG_CONVOLUTION_DETERMINISTIC{}))
         return false;
 
     const auto device_name = ctx.GetStream().GetDeviceName();

--- a/src/solver/conv_asm_implicit_gemm_gtc_wrw_nhwc.cpp
+++ b/src/solver/conv_asm_implicit_gemm_gtc_wrw_nhwc.cpp
@@ -727,9 +727,6 @@ bool PerformanceConfigAsmImplicitGemmGTCWrwXdlopsNHWC::IsValid(const Convolution
         if(ctx.IsFp16() && tensor_b_thread_lengths[3] != 1 && gemm_k_global_split != 0 && vector_store != 1)
             return false;
 
-    if(miopen::IsEnabled(MIOPEN_DEBUG_CONVOLUTION_DETERMINISTIC{}) && gemm_k_global_split != 0)
-        return false;
-
     const auto& k         = ctx.n_inputs;
     const auto& c         = ctx.n_outputs;
     const auto& y         = ctx.kernel_size_h;
@@ -799,6 +796,9 @@ ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC::Search(const ConvolutionContext& ctx
 bool ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC::IsApplicable(const ConvolutionContext& ctx) const
 {
     if(miopen::IsDisabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_ASM_WRW_GTC_XDLOPS_NHWC{}))
+        return false;
+
+    if(miopen::IsEnabled(MIOPEN_DEBUG_CONVOLUTION_DETERMINISTIC{}))
         return false;
 
     const auto device_name = ctx.GetStream().GetDeviceName();

--- a/src/solver/conv_asm_implicit_gemm_wrw_gtc_dynamic_xdlops.cpp
+++ b/src/solver/conv_asm_implicit_gemm_wrw_gtc_dynamic_xdlops.cpp
@@ -810,6 +810,9 @@ bool ConvAsmImplicitGemmGTCDynamicWrwXdlops::IsApplicable(const ConvolutionConte
     if(miopen::IsDisabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_ASM_WRW_GTC_XDLOPS{}))
         return false;
 
+    if(miopen::IsEnabled(MIOPEN_DEBUG_CONVOLUTION_DETERMINISTIC{}))
+        return false;
+
     const auto device_name = ctx.GetStream().GetDeviceName();
     if(device_name != "gfx908")
         return false;

--- a/src/solver/conv_hip_implicit_gemm_bwd_v1r1.cpp
+++ b/src/solver/conv_hip_implicit_gemm_bwd_v1r1.cpp
@@ -638,6 +638,8 @@ bool ConvHipImplicitGemmBwdDataV1R1::IsApplicable(const ConvolutionContext& ctx)
 {
     if(miopen::IsDisabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_BWD_V1R1{}))
         return false;
+    if(miopen::IsEnabled(MIOPEN_DEBUG_CONVOLUTION_DETERMINISTIC{}))
+        return false;
     if(!ctx.use_hip_kernels)
         return false;
     if(!ctx.IsLayoutDefault())

--- a/src/solver/conv_hip_implicit_gemm_bwd_v1r1_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_bwd_v1r1_xdlops.cpp
@@ -751,6 +751,8 @@ bool ConvHipImplicitGemmBwdDataV1R1Xdlops::IsApplicable(const ConvolutionContext
 #endif
     if(miopen::IsDisabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_BWD_V1R1_XDLOPS{}))
         return false;
+    if(miopen::IsEnabled(MIOPEN_DEBUG_CONVOLUTION_DETERMINISTIC{}))
+        return false;
 
     if(!IsComposableKernelSupportedHardware(ctx))
         return false;

--- a/src/solver/conv_hip_implicit_gemm_bwd_v4r1.cpp
+++ b/src/solver/conv_hip_implicit_gemm_bwd_v4r1.cpp
@@ -749,6 +749,8 @@ bool ConvHipImplicitGemmBwdDataV4R1::IsApplicable(const ConvolutionContext& ctx)
 
     if(miopen::IsDisabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_BWD_V4R1{}))
         return false;
+    if(miopen::IsEnabled(MIOPEN_DEBUG_CONVOLUTION_DETERMINISTIC{}))
+        return false;
 
     if(!IsComposableKernelSupportedHardware(ctx))
         return false;

--- a/src/solver/conv_hip_implicit_gemm_bwd_v4r1_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_bwd_v4r1_xdlops.cpp
@@ -824,6 +824,8 @@ bool ConvHipImplicitGemmBwdDataV4R1Xdlops::IsApplicable(const ConvolutionContext
     if(miopen::IsDisabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_BWD_V4R1_XDLOPS{}))
         return false;
 #endif
+    if(miopen::IsEnabled(MIOPEN_DEBUG_CONVOLUTION_DETERMINISTIC{}))
+        return false;
     if(!IsComposableKernelSupportedHardware(ctx))
         return false;
     if(!ctx.direction.IsBackwardData())

--- a/src/solver/conv_hip_implicit_gemm_fwd_v4r1.cpp
+++ b/src/solver/conv_hip_implicit_gemm_fwd_v4r1.cpp
@@ -46,6 +46,8 @@ bool ConvHipImplicitGemmV4R1Fwd::IsApplicable(const ConvolutionContext& ctx) con
         return false;
     if(!IsComposableKernelSupportedHardware(ctx))
         return false;
+    if(miopen::IsEnabled(MIOPEN_DEBUG_CONVOLUTION_DETERMINISTIC{}))
+        return false;
     if(!ctx.direction.IsForward())
         return false;
     if(!ctx.use_hip_kernels)

--- a/src/solver/conv_hip_implicit_gemm_fwd_v4r4.cpp
+++ b/src/solver/conv_hip_implicit_gemm_fwd_v4r4.cpp
@@ -586,6 +586,8 @@ bool ConvHipImplicitGemmV4R4Fwd::IsApplicable(const ConvolutionContext& ctx) con
 {
     if(miopen::IsDisabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_FWD_V4R4{}))
         return false;
+    if(miopen::IsEnabled(MIOPEN_DEBUG_CONVOLUTION_DETERMINISTIC{}))
+        return false;
     if(!ctx.use_hip_kernels)
         return false;
     if(!ctx.IsLayoutDefault())

--- a/src/solver/conv_hip_implicit_gemm_fwd_v4r4_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_fwd_v4r4_xdlops.cpp
@@ -967,6 +967,9 @@ bool ConvHipImplicitGemmForwardV4R4Xdlops::IsApplicable(const ConvolutionContext
     if(miopen::IsDisabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_FWD_V4R4_XDLOPS{}))
         return false;
 
+    if(miopen::IsEnabled(MIOPEN_DEBUG_CONVOLUTION_DETERMINISTIC{}))
+        return false;
+
     if(!ctx.use_hip_kernels)
         return false;
 

--- a/src/solver/conv_hip_implicit_gemm_fwd_v4r4_xdlops_padded_gemm.cpp
+++ b/src/solver/conv_hip_implicit_gemm_fwd_v4r4_xdlops_padded_gemm.cpp
@@ -1042,6 +1042,9 @@ bool ConvHipImplicitGemmForwardV4R4Xdlops_Padded_Gemm::IsApplicable(
     if(miopen::IsDisabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_FWD_V4R4_PADDED_GEMM_XDLOPS{}))
         return false;
 
+    if(miopen::IsEnabled(MIOPEN_DEBUG_CONVOLUTION_DETERMINISTIC{}))
+        return false;
+
     if(!ctx.use_hip_kernels)
         return false;
 

--- a/src/solver/conv_hip_implicit_gemm_fwd_v4r5_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_fwd_v4r5_xdlops.cpp
@@ -997,6 +997,9 @@ bool ConvHipImplicitGemmForwardV4R5Xdlops::IsApplicable(const ConvolutionContext
     if(miopen::IsDisabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_FWD_V4R5_XDLOPS{}))
         return false;
 
+    if(miopen::IsEnabled(MIOPEN_DEBUG_CONVOLUTION_DETERMINISTIC{}))
+        return false;
+
     if(!ctx.use_hip_kernels)
         return false;
 

--- a/src/solver/conv_hip_implicit_gemm_wrw_v4r4.cpp
+++ b/src/solver/conv_hip_implicit_gemm_wrw_v4r4.cpp
@@ -590,6 +590,8 @@ bool ConvHipImplicitGemmV4R4WrW::IsApplicable(const ConvolutionContext& ctx) con
 {
     if(miopen::IsDisabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_WRW_V4R4{}))
         return false;
+    if(miopen::IsEnabled(MIOPEN_DEBUG_CONVOLUTION_DETERMINISTIC{}))
+        return false;
     if(!ctx.use_hip_kernels)
         return false;
     if(!ctx.IsLayoutDefault())

--- a/src/solver/conv_hip_implicit_gemm_wrw_v4r4_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_wrw_v4r4_xdlops.cpp
@@ -1036,6 +1036,9 @@ bool ConvHipImplicitGemmWrwV4R4Xdlops::IsApplicable(const ConvolutionContext& ct
     if(miopen::IsDisabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_WRW_V4R4_XDLOPS{}))
         return false;
 
+    if(miopen::IsEnabled(MIOPEN_DEBUG_CONVOLUTION_DETERMINISTIC{}))
+        return false;
+
     if(!ctx.use_hip_kernels)
         return false;
 

--- a/src/solver/conv_hip_implicit_gemm_wrw_v4r4_xdlops_padded_gemm.cpp
+++ b/src/solver/conv_hip_implicit_gemm_wrw_v4r4_xdlops_padded_gemm.cpp
@@ -1110,6 +1110,9 @@ bool ConvHipImplicitGemmWrwV4R4Xdlops_Padded_Gemm::IsApplicable(const Convolutio
     if(!IsComposableKernelSupportedHardware(ctx))
         return false;
 
+    if(miopen::IsEnabled(MIOPEN_DEBUG_CONVOLUTION_DETERMINISTIC{}))
+        return false;
+
     if(!IsXdlopsSupport(ctx))
         return false;
 

--- a/src/solver/conv_mlir_igemm_bwd.cpp
+++ b/src/solver/conv_mlir_igemm_bwd.cpp
@@ -42,6 +42,8 @@ bool ConvMlirIgemmBwd::IsApplicable(const ConvolutionContext& ctx) const
 #if MIOPEN_USE_MLIR
     if(miopen::IsDisabled(MIOPEN_DEBUG_CONV_MLIR_IGEMM_BWD{}))
         return false;
+    if(miopen::IsEnabled(MIOPEN_DEBUG_CONVOLUTION_DETERMINISTIC{}))
+        return false;
     if(!ctx.direction.IsBackwardData())
         return false;
     if(!IsComposableKernelSupportedHardware(ctx))

--- a/src/solver/conv_mlir_igemm_bwd_xdlops.cpp
+++ b/src/solver/conv_mlir_igemm_bwd_xdlops.cpp
@@ -43,6 +43,8 @@ bool ConvMlirIgemmBwdXdlops::IsApplicable(const ConvolutionContext& ctx) const
 #if MIOPEN_USE_MLIR
     if(miopen::IsDisabled(MIOPEN_DEBUG_CONV_MLIR_IGEMM_BWD_XDLOPS{}))
         return false;
+    if(miopen::IsEnabled(MIOPEN_DEBUG_CONVOLUTION_DETERMINISTIC{}))
+        return false;
     if(!IsXdlopsSupport(ctx))
         return false;
     if(!ctx.direction.IsBackwardData())

--- a/src/solver/conv_mlir_igemm_fwd.cpp
+++ b/src/solver/conv_mlir_igemm_fwd.cpp
@@ -160,6 +160,8 @@ bool ConvMlirIgemmFwd::IsApplicable(const ConvolutionContext& ctx) const
 #if MIOPEN_USE_MLIR
     if(miopen::IsDisabled(MIOPEN_DEBUG_CONV_MLIR_IGEMM_FWD{}))
         return false;
+    if(miopen::IsEnabled(MIOPEN_DEBUG_CONVOLUTION_DETERMINISTIC{}))
+        return false;
     if(!ctx.direction.IsForward())
         return false;
     if(!IsComposableKernelSupportedHardware(ctx))

--- a/src/solver/conv_mlir_igemm_fwd_xdlops.cpp
+++ b/src/solver/conv_mlir_igemm_fwd_xdlops.cpp
@@ -50,6 +50,8 @@ bool ConvMlirIgemmFwdXdlops::IsApplicable(const ConvolutionContext& ctx) const
 #if MIOPEN_USE_MLIR
     if(miopen::IsDisabled(MIOPEN_DEBUG_CONV_MLIR_IGEMM_FWD_XDLOPS{}))
         return false;
+    if(miopen::IsEnabled(MIOPEN_DEBUG_CONVOLUTION_DETERMINISTIC{}))
+        return false;
     if(!IsXdlopsSupport(ctx))
         return false;
     if(!ctx.direction.IsForward())

--- a/src/solver/conv_mlir_igemm_wrw.cpp
+++ b/src/solver/conv_mlir_igemm_wrw.cpp
@@ -43,6 +43,8 @@ bool ConvMlirIgemmWrW::IsApplicable(const ConvolutionContext& ctx) const
 #if MIOPEN_USE_MLIR
     if(miopen::IsDisabled(MIOPEN_DEBUG_CONV_MLIR_IGEMM_WRW{}))
         return false;
+    if(miopen::IsEnabled(MIOPEN_DEBUG_CONVOLUTION_DETERMINISTIC{}))
+        return false;
     if(!ctx.direction.IsBackwardWrW())
         return false;
     if(!IsComposableKernelSupportedHardware(ctx))

--- a/src/solver/conv_mlir_igemm_wrw_xdlops.cpp
+++ b/src/solver/conv_mlir_igemm_wrw_xdlops.cpp
@@ -44,6 +44,8 @@ bool ConvMlirIgemmWrWXdlops::IsApplicable(const ConvolutionContext& ctx) const
 #if MIOPEN_USE_MLIR
     if(miopen::IsDisabled(MIOPEN_DEBUG_CONV_MLIR_IGEMM_WRW_XDLOPS{}))
         return false;
+    if(miopen::IsEnabled(MIOPEN_DEBUG_CONVOLUTION_DETERMINISTIC{}))
+        return false;
     if(!IsXdlopsSupport(ctx))
         return false;
     if(!ctx.direction.IsBackwardWrW())


### PR DESCRIPTION
This is an hot fix for [SWDEV-316705](https://ontrack-internal.amd.com/browse/SWDEV-316705)
Due to our current design, if a solver has multiple configs, and some of the config support deterministic(e.g. non-deterministic), some are not, we can not disable a single config in `IsValid()` function. But We need disable it in `IsApplicable()`, which means will disable this solver entirely if `MIOPEN_DEBUG_CONVOLUTION_DETERMINISTIC` env var is set.
This may have a performance impact, but since currently this env var is for test purpose (in this case performance impact is OK per our customer), so this approach is simple and fine.
If in future has performance requirement under `MIOPEN_DEBUG_CONVOLUTION_DETERMINISTIC`, need to seek for other approach and implementation.