### PR TITLE
[Solvers] Single performance config for ConvBiasActivAsm1x1U

### DIFF
--- a/src/include/miopen/solver.hpp
+++ b/src/include/miopen/solver.hpp
@@ -303,6 +303,7 @@ struct PerformanceConfigConvBiasActivAsm1x1U : PerformanceConfigConvAsm1x1U
     bool operator==(const PerformanceConfigConvBiasActivAsm1x1U& other) const;
 };
 
+// Fused solver
 struct ConvBiasActivAsm1x1U : ConvAsm1x1U
 {
     const std::string& SolverDbId() const override { return GetSolverDbId<ConvBiasActivAsm1x1U>(); }
@@ -312,7 +313,7 @@ struct ConvBiasActivAsm1x1U : ConvAsm1x1U
     PerformanceConfigConvBiasActivAsm1x1U Search(const ConvolutionContext&,
                                                  const AnyInvokeParams& invoke_ctx) const;
     ConvSolution GetSolution(const ConvolutionContext& params,
-                             const PerformanceConfigConvAsm1x1U& config,
+                             const PerformanceConfigConvBiasActivAsm1x1U& config,
                              bool disableConfigOverrideFromEnv = false) const;
 };
 

--- a/src/include/miopen/solver.hpp
+++ b/src/include/miopen/solver.hpp
@@ -304,12 +304,17 @@ struct PerformanceConfigConvBiasActivAsm1x1U : PerformanceConfigConvAsm1x1U
 };
 
 // Fused solver
-struct ConvBiasActivAsm1x1U : ConvAsm1x1U
+struct ConvBiasActivAsm1x1U : ConvSolver
 {
     const std::string& SolverDbId() const override { return GetSolverDbId<ConvBiasActivAsm1x1U>(); }
 
-    PerformanceConfigConvBiasActivAsm1x1U GetPerformanceConfig(const ConvolutionContext&) const;
+    bool IsApplicable(const ConvolutionContext& params) const override;
+    size_t GetWorkspaceSize(const ConvolutionContext& params) const override;
+    bool MayNeedWorkspace() const override { return true; }
 
+    PerformanceConfigConvBiasActivAsm1x1U GetPerformanceConfig(const ConvolutionContext&) const;
+    bool IsValidPerformanceConfig(const ConvolutionContext&,
+                                  const PerformanceConfigConvBiasActivAsm1x1U&) const;
     PerformanceConfigConvBiasActivAsm1x1U Search(const ConvolutionContext&,
                                                  const AnyInvokeParams& invoke_ctx) const;
     ConvSolution GetSolution(const ConvolutionContext& params,

--- a/src/solver/conv_asm_1x1u_bias_activ.cpp
+++ b/src/solver/conv_asm_1x1u_bias_activ.cpp
@@ -77,8 +77,8 @@ ConvBiasActivAsm1x1U::GetPerformanceConfig(const ConvolutionContext& params) con
     return pp;
 }
 
-bool ConvBiasActivAsm1x1U::IsValidPerformanceConfig(const ConvolutionContext& problem,
-                                                    const PerformanceConfigConvBiasActivAsm1x1U& c) const
+bool ConvBiasActivAsm1x1U::IsValidPerformanceConfig(
+    const ConvolutionContext& problem, const PerformanceConfigConvBiasActivAsm1x1U& c) const
 {
     return c.IsValidValue() && c.IsValid(problem);
 }

--- a/src/solver/conv_asm_1x1u_bias_activ.cpp
+++ b/src/solver/conv_asm_1x1u_bias_activ.cpp
@@ -77,6 +77,22 @@ ConvBiasActivAsm1x1U::GetPerformanceConfig(const ConvolutionContext& params) con
     return pp;
 }
 
+bool ConvBiasActivAsm1x1U::IsValidPerformanceConfig(const ConvolutionContext& problem,
+                                                    const PerformanceConfigConvBiasActivAsm1x1U& c) const
+{
+    return c.IsValidValue() && c.IsValid(problem);
+}
+
+bool ConvBiasActivAsm1x1U::IsApplicable(const ConvolutionContext& params) const
+{
+    return ConvAsm1x1U{}.IsApplicable(params);
+}
+
+size_t ConvBiasActivAsm1x1U::GetWorkspaceSize(const ConvolutionContext& params) const
+{
+    return ConvAsm1x1U{}.GetWorkspaceSize(params);
+}
+
 PerformanceConfigConvBiasActivAsm1x1U
 ConvBiasActivAsm1x1U::Search(const ConvolutionContext& context, const AnyInvokeParams&) const
 {
@@ -111,7 +127,7 @@ ConvSolution ConvBiasActivAsm1x1U::GetSolution(const ConvolutionContext& params,
                                                const PerformanceConfigConvBiasActivAsm1x1U& config,
                                                bool disableConfigOverrideFromEnv) const
 {
-    auto sol = ConvAsm1x1U::GetSolution(params, config, disableConfigOverrideFromEnv);
+    auto sol = ConvAsm1x1U{}.GetSolution(params, config, disableConfigOverrideFromEnv);
 
     if(sol.construction_params.size() != 1)
         MIOPEN_THROW("ConvBiasActivAsm1x1U expects only one kernel");

--- a/src/solver/conv_asm_1x1u_bias_activ.cpp
+++ b/src/solver/conv_asm_1x1u_bias_activ.cpp
@@ -108,7 +108,7 @@ ConvBiasActivAsm1x1U::Search(const ConvolutionContext& context, const AnyInvokeP
 }
 
 ConvSolution ConvBiasActivAsm1x1U::GetSolution(const ConvolutionContext& params,
-                                               const PerformanceConfigConvAsm1x1U& config,
+                                               const PerformanceConfigConvBiasActivAsm1x1U& config,
                                                bool disableConfigOverrideFromEnv) const
 {
     auto sol = ConvAsm1x1U::GetSolution(params, config, disableConfigOverrideFromEnv);


### PR DESCRIPTION
- `GetSolution()` uses `PerformanceConfigConvBiasActivAsm1x1U`
- Solver is inherited from `ConvSolver`

Fixes https://github.com/ROCmSoftwarePlatform/MIOpen/issues/1432