### PR TITLE
Fix Headers for Boost v1.78+

### DIFF
--- a/src/include/miopen/binary_cache.hpp
+++ b/src/include/miopen/binary_cache.hpp
@@ -28,6 +28,7 @@
 #define GUARD_MLOPEN_BINARY_CACHE_HPP
 
 #include <miopen/config.h>
+#include <miopen/kernel.hpp>
 #include <miopen/target_properties.hpp>
 #include <boost/filesystem/path.hpp>
 #include <string>

--- a/src/include/miopen/comgr.hpp
+++ b/src/include/miopen/comgr.hpp
@@ -27,6 +27,7 @@
 #define GUARD_COMGR_HPP
 
 #include <miopen/config.h>
+#include <miopen/kernel.hpp>
 #if MIOPEN_USE_COMGR
 
 #include <miopen/target_properties.hpp>

--- a/src/include/miopen/find_db.hpp
+++ b/src/include/miopen/find_db.hpp
@@ -27,6 +27,7 @@
 #ifndef GUARD_MIOPEN_FIND_DB_HPP_
 #define GUARD_MIOPEN_FIND_DB_HPP_
 
+#include <miopen/kernel.hpp>
 #include <miopen/db.hpp>
 #include <miopen/db_path.hpp>
 #include <miopen/db_record.hpp>

--- a/src/include/miopen/gcn_asm_utils.hpp
+++ b/src/include/miopen/gcn_asm_utils.hpp
@@ -27,6 +27,7 @@
 #define GCN_ASM_UTILS_H
 
 #include <miopen/config.h>
+#include <miopen/kernel.hpp>
 #include <miopen/target_properties.hpp>
 #include <sstream>
 #include <string>

--- a/src/include/miopen/hip_build_utils.hpp
+++ b/src/include/miopen/hip_build_utils.hpp
@@ -27,6 +27,7 @@
 #define MIOPEN_GUARD_MLOPEN_HIP_BUILD_UTILS_HPP
 
 #include <miopen/config.h>
+#include <miopen/kernel.hpp>
 #include <miopen/target_properties.hpp>
 #include <miopen/kernel.hpp>
 #include <miopen/tmp_dir.hpp>

--- a/src/include/miopen/mlir_build.hpp
+++ b/src/include/miopen/mlir_build.hpp
@@ -27,6 +27,7 @@
 #define MIOPEN_GUARD_MLIR_BUILD_HPP
 
 #include <miopen/config.h>
+#include <miopen/kernel.hpp>
 #if MIOPEN_USE_MLIR
 
 #include <miopen/target_properties.hpp>

--- a/src/include/miopen/mlo_internal.hpp
+++ b/src/include/miopen/mlo_internal.hpp
@@ -56,6 +56,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #endif
 
 #include <miopen/config.h>
+#include <miopen/kernel.hpp>
 
 #if MIOPEN_BACKEND_OPENCL
 #include <miopen/oclkernel.hpp>

--- a/src/include/miopen/sqlite_db.hpp
+++ b/src/include/miopen/sqlite_db.hpp
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <miopen/config.h>
+#include <miopen/kernel.hpp>
 
 #if MIOPEN_ENABLE_SQLITE
 


### PR DESCRIPTION
Boost's issues with `noinline` (see #658) have been fixed upstream in
boostorg/config#393 which was included in v1.78 of Boost; however, in order for
it to work properly Boost library headers must be included after we include
headers which define `HIP_VERSION` (which come through `kernel.hpp` and headers
therein).

Whilst most files worked fine, there were a small number which included a Boost
library before `HIP_VERSION` was defined causing a compilation error.

This will also allow MIOpen to be built against the system Boost instead of
requiring it to be compiled specifically for MIOpen.

Fixes #1489.