### PR TITLE
[MLIR] Querying all sub-kernels applicability

### DIFF
--- a/src/solver/conv_mlir_igemm_fwd.cpp
+++ b/src/solver/conv_mlir_igemm_fwd.cpp
@@ -91,7 +91,15 @@ bool PerformanceConvMlirIgemm::IsValid(const ConvolutionContext& ctx) const
     if(*this == MlirHeuristicInitRequest())
         return true;
 
-    return MiirIsConfigApplicable(mlir::ConstructBuildOptions(ctx, *this, false));
+    int kernel_count = MiirGetKernelCount(mlir::ConstructBuildOptions(ctx, false));
+    bool isValid     = false;
+    for(int kernel_id = 0; kernel_id < kernel_count; ++kernel_id)
+    {
+        isValid = MiirIsConfigApplicable(mlir::ConstructBuildOptions(ctx, *this, false, kernel_id));
+        if(!isValid)
+            return false;
+    }
+    return isValid;
 #else
     std::ignore = ctx;
     return false;

--- a/src/solver/conv_mlir_igemm_fwd_xdlops.cpp
+++ b/src/solver/conv_mlir_igemm_fwd_xdlops.cpp
@@ -127,7 +127,15 @@ bool PerformanceConvMlirIgemmXdlops::IsValid(const ConvolutionContext& ctx) cons
     if(*this == MlirHeuristicInitRequest())
         return true;
 
-    return MiirIsConfigApplicable(mlir::ConstructBuildOptions(ctx, *this, true));
+    int kernel_count = MiirGetKernelCount(mlir::ConstructBuildOptions(ctx, true));
+    bool isValid     = false;
+    for(int kernel_id = 0; kernel_id < kernel_count; ++kernel_id)
+    {
+        isValid = MiirIsConfigApplicable(mlir::ConstructBuildOptions(ctx, *this, true, kernel_id));
+        if(!isValid)
+            return false;
+    }
+    return isValid;
 #else
     std::ignore = ctx;
     return false;


### PR DESCRIPTION
In MLIR solver, I discovered a bug where, applicability check and get solution ended to get different result. The reason ended up being we only query the first kernel's applicability in MLIR whereas second kernel is in-applicable.

In this PR, I fixed this issue by making performance config to mark as applicable only when all subsequent kernels are applicable.