### PR TITLE
Make int8 convolution default output type to be int32

### DIFF
--- a/driver/conv_driver.hpp
+++ b/driver/conv_driver.hpp
@@ -320,7 +320,7 @@ private:
 
     std::vector<Tgpu> din;
     std::vector<Tgpu> dwei;
-    std::vector<float> out_int8;
+    std::vector<int32_t> out_int8;
     std::vector<Tgpu> db;
     std::vector<float> b_int8;
 
@@ -596,7 +596,7 @@ int ConvDriver<Tgpu, Tref>::GetandSetData()
     std::vector<int> out_len = GetOutputTensorLengths();
 
     miopenDataType_t y_type =
-        (data_type == miopenInt8 || data_type == miopenInt8x4) ? miopenFloat : data_type;
+        (data_type == miopenInt8 || data_type == miopenInt8x4) ? miopenInt32 : data_type;
     SetTensorNd(outputTensor, out_len, inflags.GetValueStr("out_layout"), y_type);
 
     if(inflags.GetValueInt("bias") != 0)
@@ -1220,7 +1220,7 @@ int ConvDriver<Tgpu, Tref>::AllocateBuffersAndCopy()
     if(is_wrw)
         dwei = std::vector<Tgpu>(wei_sz, static_cast<Tgpu>(0));
     if(is_int8)
-        out_int8 = std::vector<float>(out_sz, static_cast<float>(0));
+        out_int8 = std::vector<int32_t>(out_sz, 0);
     if(is_transform)
     {
         in_vect4_dev = std::unique_ptr<GPUMem>(
@@ -1753,7 +1753,7 @@ int ConvDriver<Tgpu, Tref>::RunForwardGPU()
     if(inflags.GetValueInt("dump_output"))
     {
         if(is_int8)
-            dumpBufferToFile<float>("dump_fwd_out_gpu.bin", out_int8.data(), out_int8.size());
+            dumpBufferToFile<int32_t>("dump_fwd_out_gpu.bin", out_int8.data(), out_int8.size());
         else
             dumpBufferToFile<Tgpu>("dump_fwd_out_gpu.bin", out.data.data(), out.data.size());
     }

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -77,7 +77,7 @@ int main(int argc, char* argv[])
     }
     else if(base_arg == "convint8")
     {
-        drv = new ConvDriver<int8_t, float>();
+        drv = new ConvDriver<int8_t, int32_t>();
     }
     else if(base_arg == "CBAInfer")
     {


### PR DESCRIPTION
This PR makes MIOpenDriver's int8 convolution output native type to be int32, based on:

 - MIOpen's gemm is based on rocblas, whose int8 output type is int32
   - There's an unnecessary `CastTensor` operation forced in every int8 validation
 - More fundamentally, AMD XDLOPS instructions output type for int8 calculation is int32
   - This implied high performance kernel will pick int32 as the native output type 
 - Numerical precision has been compromised by forcing conversion from int32 to fp32
   - Not all int32 can be precisely converted, see [here](https://stackoverflow.com/questions/12442685/can-a-ieee-754-real-number-cover-all-integers-within-its-range)
 - fp32 type incorrectly becomes the first class citizen for int8
   - If there's a solver who can support only int32 as the output, it will be marked as in-applicable

Locally I tested the change and make sure no regression appear on existing gemm kernel on int8 convolutions.

[TODO]: Make the same change for `conv2d_test`