### PR TITLE
[ROCm-cmake] Enable Origin header file dump option for wrapper

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 ROCmSoftwarePlatform/rocm-recipes
-RadeonOpenCompute/rocm-cmake@dbf523e5818ef2aa6db80ac58599023a2bf2f0f4 --build
+RadeonOpenCompute/rocm-cmake@839cf61c355f997283e3baaf245fa9acf2e3baa0 --build
 -f requirements.txt
 # 1.90+
 danmar/cppcheck@dd05839a7e63ef04afd34711cb3e1e0ef742882f

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 ROCmSoftwarePlatform/rocm-recipes
-RadeonOpenCompute/rocm-cmake@bd4e360c73fa366f817f5aa013433e799d8cd659 --build
+RadeonOpenCompute/rocm-cmake@dbf523e5818ef2aa6db80ac58599023a2bf2f0f4 --build
 -f requirements.txt
 # 1.90+
 danmar/cppcheck@dd05839a7e63ef04afd34711cb3e1e0ef742882f

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-RadeonOpenCompute/rocm-cmake@bd4e360c73fa366f817f5aa013433e799d8cd659 --build
+RadeonOpenCompute/rocm-cmake@dbf523e5818ef2aa6db80ac58599023a2bf2f0f4 --build
 sqlite3@3.17 -DCMAKE_POSITION_INDEPENDENT_CODE=On
 boost@1.72 -DCMAKE_POSITION_INDEPENDENT_CODE=On --build
 half,https://github.com/pfultz2/half/archive/1.12.0.tar.gz -X header -H sha256:0a08660b68abb176ebc2a0cdf8de46e3182a7f46c66443bb80dbfaaec98cf969 --build

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-RadeonOpenCompute/rocm-cmake@dbf523e5818ef2aa6db80ac58599023a2bf2f0f4 --build
+RadeonOpenCompute/rocm-cmake@839cf61c355f997283e3baaf245fa9acf2e3baa0 --build
 sqlite3@3.17 -DCMAKE_POSITION_INDEPENDENT_CODE=On
 boost@1.72 -DCMAKE_POSITION_INDEPENDENT_CODE=On --build
 half,https://github.com/pfultz2/half/archive/1.12.0.tar.gz -X header -H sha256:0a08660b68abb176ebc2a0cdf8de46e3182a7f46c66443bb80dbfaaec98cf969 --build

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -773,6 +773,7 @@ if(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY)
     HEADER_LOCATION include/miopen
     GUARDS WRAPPER
     WRAPPER_LOCATIONS miopen/include/miopen
+    ORIGINAL_FILES ${PROJECT_BINARY_DIR}/include/miopen/version.h ${PROJECT_BINARY_DIR}/include/miopen/config.h
   )
 
   #Installing Wrapper Headers


### PR DESCRIPTION
- Update ROCM-CMAKE Version
- Enable original file dump option for wrapper header to support backward compatibility  