### PR TITLE
[LRN] fix incorrect sign in output

### DIFF
--- a/driver/lrn_driver.hpp
+++ b/driver/lrn_driver.hpp
@@ -265,7 +265,7 @@ int LRNDriver<Tgpu, Tref>::AllocateBuffersAndCopy()
 
     for(int i = 0; i < in_sz; i++)
     {
-        in[i] = RAN_GEN<Tgpu>(static_cast<Tgpu>(0.0), static_cast<Tgpu>(1.0));
+        in[i] = RAN_GEN<Tgpu>(static_cast<Tgpu>(-1.0), static_cast<Tgpu>(1.0));
     }
 
     Tgpu Data_scale = static_cast<Tgpu>(0.001);

--- a/src/kernels/MIOpenLRNFwd.cl
+++ b/src/kernels/MIOpenLRNFwd.cl
@@ -410,10 +410,12 @@ MIOpenLRNAcrossChannels4(const __global _FLOAT* bottom,
     int b               = get_global_id(2); // batch
     MLO_READ_TYPE accum = 0;
     MLO_READ_TYPE bot_in2[MLO_LRN_KERNEL_SZ];
+    MLO_READ_TYPE bot_in[MLO_LRN_KERNEL_SZ];
     int c_i = 0, c_o = 0;
     for(int i = 0; i < MLO_LRN_KERNEL_SZ; ++i)
     {
         bot_in2[i] = 0;
+        bot_in[i]  = 0;
     }
 
     int top_off = 0;
@@ -452,8 +454,9 @@ MIOpenLRNAcrossChannels4(const __global _FLOAT* bottom,
         }
 
         bot_in2[c_i] = prv_in * prv_in;
+        bot_in[c_i]  = prv_in;
         accum        = accum + bot_in2[c_i];
-        //				fma(bot_in[c_i + MLO_LRN_PAD], bot_in[c_i + MLO_LRN_PAD],
+        //				fma(bot_in2[c_i + MLO_LRN_PAD], bot_in2[c_i + MLO_LRN_PAD],
         // accum);
     }
 
@@ -489,6 +492,7 @@ MIOpenLRNAcrossChannels4(const __global _FLOAT* bottom,
         }
 
         bot_in2[c_i] = prv_in * prv_in;
+        bot_in[c_i]  = prv_in;
         accum        = accum + bot_in2[c_i];
 
         top_off = b * MLO_LRN_TOP_BATCH_STRIDE + c_o * MLO_LRN_TOP_CHANNEL_STRIDE +
@@ -504,8 +508,7 @@ MIOpenLRNAcrossChannels4(const __global _FLOAT* bottom,
         //				pow(prv_scale,-beta);
         // bug
         //	MLO_READ_TYPE prv_out = sqrt(bot_in2[c_o]);
-        MLO_READ_TYPE prv_out = bot_in2[c_o];
-        prv_out               = sqrt(prv_out);
+        MLO_READ_TYPE prv_out = bot_in[c_o];
         MLO_READ_TYPE out_val = prv_out * exp_scale;
 #if MLO_LOW_CHNL_COUNT == 1
         if(c_o < MLO_LRN_N_OUTPUTS)
@@ -577,14 +580,16 @@ MIOpenLRNAcrossChannels4(const __global _FLOAT* bottom,
         accum                     = accum + prv_bot_in2;
 
         accum = accum - bot_in2[0];
-        //				fma(-bot_in[0], bot_in[0], accum);
+        //				fma(-bot_in2[0], bot_in2[0], accum);
 
         for(int i = 0; i < MLO_LRN_KERNEL_SZ - 1; i++)
         {
             bot_in2[i] = bot_in2[i + 1];
+            bot_in[i]  = bot_in[i + 1];
         }
 
         bot_in2[MLO_LRN_KERNEL_SZ - 1] = prv_bot_in2;
+        bot_in[MLO_LRN_KERNEL_SZ - 1]  = prv_in;
 
         top_off = b * MLO_LRN_TOP_BATCH_STRIDE + c_o * MLO_LRN_TOP_CHANNEL_STRIDE +
                   (pix_id * MLO_READ_UNIT);
@@ -598,9 +603,8 @@ MIOpenLRNAcrossChannels4(const __global _FLOAT* bottom,
         MLO_READ_TYPE exp_scale = exp((MLO_READ_TYPE)-beta * log(prv_scale));
         //				pow(prv_scale,-beta);
         // bug
-        //			MLO_READ_TYPE prv_out = sqrt(bot_in2[MLO_LRN_PAD]);
-        MLO_READ_TYPE prv_out = bot_in2[MLO_LRN_PRE_PAD];
-        prv_out               = sqrt(prv_out);
+        //			MLO_READ_TYPE prv_out = sqrt(bot_in2[MLO_LRN_PRE_PAD]);
+        MLO_READ_TYPE prv_out = bot_in[MLO_LRN_PRE_PAD];
         MLO_READ_TYPE out_val = prv_out * exp_scale;
 
 #if MLO_LOW_CHNL_COUNT == 1
@@ -645,11 +649,12 @@ MIOpenLRNAcrossChannels4(const __global _FLOAT* bottom,
     {
 
         accum = accum - bot_in2[0];
-        //				fma(-bot_in[0], bot_in[0], accum);
+        //				fma(-bot_in2[0], bot_in2[0], accum);
 
         for(int i = 0; i < MLO_LRN_KERNEL_SZ - 1; i++)
         {
             bot_in2[i] = bot_in2[i + 1];
+            bot_in[i]  = bot_in[i + 1];
         }
 
         top_off = b * MLO_LRN_TOP_BATCH_STRIDE + c_o * MLO_LRN_TOP_CHANNEL_STRIDE +
@@ -664,9 +669,8 @@ MIOpenLRNAcrossChannels4(const __global _FLOAT* bottom,
         MLO_READ_TYPE exp_scale = exp((MLO_READ_TYPE)-beta * log(prv_scale));
         //				pow(prv_scale,-beta);
         // bug
-        //			MLO_READ_TYPE prv_out = sqrt(bot_in2[MLO_LRN_PAD]);
-        MLO_READ_TYPE prv_out = bot_in2[MLO_LRN_PRE_PAD];
-        prv_out               = sqrt(prv_out);
+        //			MLO_READ_TYPE prv_out = sqrt(bot_in2[MLO_LRN_PRE_PAD]);
+        MLO_READ_TYPE prv_out = bot_in[MLO_LRN_PRE_PAD];
 
         MLO_READ_TYPE out_val = prv_out * exp_scale;
 #if MLO_LOW_CHNL_COUNT == 1

--- a/test/lrn_test.cpp
+++ b/test/lrn_test.cpp
@@ -285,9 +285,12 @@ struct lrn_driver : test_driver
 
     lrn_driver()
     {
-        add(input,
-            "input",
-            get_input_tensor(tensor_elem_gen_integer{miopen_type<T>{} == miopenHalf ? 5 : 17}));
+        auto gen_value = [](auto... is) {
+            return tensor_elem_gen_integer{miopen_type<T>{} == miopenHalf ? 5 : 17}() *
+                   tensor_elem_gen_checkboard_sign{}(is...);
+        };
+
+        add(input, "input", get_input_tensor(gen_value));
         add(n, "N", generate_data({1, 4, 5}));
         add(alpha, "alpha", generate_data({double(1)}));
         add(beta, "beta", generate_data({double(1)}));


### PR DESCRIPTION
This PR fixes #1559 and adjusts initialization of the input data in `MIOpenDriver` for LRN and `test_lrn_test` to test the cases when input contains negative values.