### PR TITLE
[Hotfix][Issue 1564] Fix Conv Driver Failure with default vector_length parameter

### DIFF
--- a/driver/conv_driver.hpp
+++ b/driver/conv_driver.hpp
@@ -575,14 +575,15 @@ template <typename Tgpu, typename Tref>
 void ConvDriver<Tgpu, Tref>::ValidateVectorizedParameters(int vector_dim, int vector_length)
 {
     if(((vector_length == 4 || vector_length == 8) && vector_dim == 1) ||
-       (vector_length == 0 && vector_dim == 0))
+       (vector_length == 1 && vector_dim == 0))
     {
         // do nothing,Values are matching as defined in Lib.
     }
     else
     {
         std::cerr << "Invalid Tensor Vectorization Parameter Value - "
-                  << "vector_dim:" << vector_dim << "vector_length:" << vector_length << std::endl;
+                  << "vector_dim:" << vector_dim << ", vector_length:" << vector_length
+                  << std::endl;
         exit(EXIT_FAILURE);
     }
 }


### PR DESCRIPTION
hot fix issue #1564 

Without this PR, our `MIOpenDriver` will fail every time you launch the driver

cc @aska-0096 @atamazov @Slimakanzer 