### PR TITLE
[Dependency] Do not require clang-ocl when COMgr is enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -426,7 +426,7 @@ if(MIOPEN_USE_ROCBLAS)
 endif()
 
 if(MIOPEN_BACKEND STREQUAL "HIP")
-    # In HIP backend, there is a posibility of HIPRTC disabled.
+    # In HIP backend, there is a posibility of COMGR disabled.
     # In this case add the clang-ocl as dependency for runtime kernel compilation
     if(NOT MIOPEN_USE_COMGR)
         set(MIOPEN_PACKAGE_REQS "${MIOPEN_PACKAGE_REQS}, rocm-clang-ocl")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -428,7 +428,7 @@ endif()
 if(MIOPEN_BACKEND STREQUAL "HIP")
     # In HIP backend, there is a posibility of HIPRTC disabled.
     # In this case add the clang-ocl as dependency for runtime kernel compilation
-    if(NOT MIOPEN_USE_HIPRTC )
+    if(NOT MIOPEN_USE_COMGR)
         set(MIOPEN_PACKAGE_REQS "${MIOPEN_PACKAGE_REQS}, rocm-clang-ocl")
     endif()
     set(CPACK_DEBIAN_PACKAGE_DEPENDS "${MIOPEN_PACKAGE_REQS}")


### PR DESCRIPTION
We do not need clang-ocl when we have COMgr enabled. Details at https://github.com/ROCmSoftwarePlatform/MIOpen/pull/1492#pullrequestreview-989589625.

Enhancement, urgency: normal.