### PR TITLE
[HotFix][Issue 1576] Fix bwd conv gpu reference bug

### DIFF
--- a/driver/conv_driver.hpp
+++ b/driver/conv_driver.hpp
@@ -3151,7 +3151,7 @@ int ConvDriver<Tgpu, Tref>::RunBackwardDataGPUReference()
         din_dev->FromGPU(GetStream(), din_host.data.data());
     else
     {
-        auto din_tmp = tensor<Tgpu>(miopen::deref(inputTensor).GetType());
+        auto din_tmp = tensor<Tgpu>(miopen::deref(inputTensor));
         din_dev->FromGPU(GetStream(), din_tmp.data.data());
         for(int i = 0; i < din_tmp.data.size(); i++)
         {

--- a/driver/driver.hpp
+++ b/driver/driver.hpp
@@ -139,7 +139,7 @@ inline void PadBufferSize(size_t& sz, int datatype_sz)
 [[gnu::noreturn]] inline void Usage()
 {
     printf("Usage: ./driver *base_arg* *other_args*\n");
-    printf("Supported Base Arguments: conv[fp16|fp16x4|fp16x8|int8|bfp16], CBAInfer[fp16], "
+    printf("Supported Base Arguments: conv[fp16|int8|bfp16], CBAInfer[fp16], "
            "pool[fp16], lrn[fp16], "
            "activ[fp16], softmax[fp16], bnorm[fp16], rnn[fp16], gemm, ctc, dropout[fp16], "
            "tensorop[fp16], reduce[fp16,fp64]\n");


### PR DESCRIPTION
Problem and solution described in #1576 
Summary: caused by the way to construct the host tensor which used to hold the gpu reference data.
cc: @atamazov 