### PR TITLE
Refine PR #1543 and more

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -268,7 +268,7 @@ if( MIOPEN_BACKEND STREQUAL "HIP" OR MIOPEN_BACKEND STREQUAL "HIPOC" OR MIOPEN_B
     set(MIOPEN_USE_ROCBLAS ON CACHE BOOL "")
     if(MIOPEN_USE_ROCBLAS)
         find_package(rocblas REQUIRED PATHS /opt/rocm)
-        message(STATUS "Build with rocblas")
+        message(STATUS "Build with rocblas ${rocblas_VERSION}")
     else()
         message(STATUS "Build without rocblas")
     endif()

--- a/include/miopen/config.h.in
+++ b/include/miopen/config.h.in
@@ -63,12 +63,6 @@
 #define MIOPEN_AMD_COMGR_VERSION_PATCH @amd_comgr_VERSION_PATCH@
 // clang-format on
 
-// clang-format off
-#define MIOPEN_ROCBLAS_VERSION_MAJOR @rocblas_VERSION_MAJOR@
-#define MIOPEN_ROCBLAS_VERSION_MINOR @rocblas_VERSION_MINOR@
-#define MIOPEN_ROCBLAS_VERSION_PATCH @rocblas_VERSION_PATCH@
-// clang-format on
-
 // Truncation rounding or (default) rounding to nearest even (RNE) is enabled.
 // This switch controls two related but different aspects of MIOpen behavior:
 // 1.  How host code performs conversions of float to bfloat16, important only
@@ -122,6 +116,31 @@
 #define HIP_PACKAGE_VERSION_FLAT                                                   \
     ((HIP_PACKAGE_VERSION_MAJOR * 1000ULL + HIP_PACKAGE_VERSION_MINOR) * 1000000 + \
      HIP_PACKAGE_VERSION_PATCH)
+
+#if MIOPEN_USE_ROCBLAS
+// clang-format off
+#define MIOPEN_ROCBLAS_VERSION_MAJOR @rocblas_VERSION_MAJOR@
+#define MIOPEN_ROCBLAS_VERSION_MINOR @rocblas_VERSION_MINOR@
+#define MIOPEN_ROCBLAS_VERSION_PATCH @rocblas_VERSION_PATCH@
+// clang-format on
+#ifndef MIOPEN_ROCBLAS_VERSION_MAJOR
+#define MIOPEN_ROCBLAS_VERSION_MAJOR 0
+#endif
+#ifndef MIOPEN_ROCBLAS_VERSION_MINOR
+#define MIOPEN_ROCBLAS_VERSION_MINOR 0
+#endif
+#ifndef MIOPEN_ROCBLAS_VERSION_PATCH
+#define MIOPEN_ROCBLAS_VERSION_PATCH 0
+#endif
+// 3 decimal digits for each number; max fits into 32 bits.
+#if MIOPEN_ROCBLAS_VERSION_MAJOR > 999 || MIOPEN_ROCBLAS_VERSION_MAJOR > 999 || \
+    MIOPEN_ROCBLAS_VERSION_PATCH > 999
+#error "Too big ROCBLAS version number(s)"
+#endif
+#define MIOPEN_ROCBLAS_VERSION_FLAT                                                   \
+    ((MIOPEN_ROCBLAS_VERSION_MAJOR * 1000 + MIOPEN_ROCBLAS_VERSION_MINOR) * 1000 + \
+     MIOPEN_ROCBLAS_VERSION_PATCH)
+#endif // MIOPEN_USE_ROCBLAS
 
 /// WORKAROUND_BOOST_ISSUE_392
 /// Workaround for https://github.com/boostorg/config/issues/392#issuecomment-1109889533

--- a/include/miopen/config.h.in
+++ b/include/miopen/config.h.in
@@ -123,8 +123,6 @@
     ((HIP_PACKAGE_VERSION_MAJOR * 1000ULL + HIP_PACKAGE_VERSION_MINOR) * 1000000 + \
      HIP_PACKAGE_VERSION_PATCH)
 
-#endif
-
 /// WORKAROUND_BOOST_ISSUE_392
 /// Workaround for https://github.com/boostorg/config/issues/392#issuecomment-1109889533
 /// See also https://github.com/ROCmSoftwarePlatform/MIOpen/pull/1490#issuecomment-1109928102,
@@ -133,3 +131,5 @@
 #if MIOPEN_BACKEND_HIP
 #include <hip/hip_version.h>
 #endif
+
+#endif // GUARD_CONFIG_H_IN

--- a/include/miopen/config.h.in
+++ b/include/miopen/config.h.in
@@ -63,6 +63,12 @@
 #define MIOPEN_AMD_COMGR_VERSION_PATCH @amd_comgr_VERSION_PATCH@
 // clang-format on
 
+// clang-format off
+#define MIOPEN_ROCBLAS_VERSION_MAJOR @rocblas_VERSION_MAJOR@
+#define MIOPEN_ROCBLAS_VERSION_MINOR @rocblas_VERSION_MINOR@
+#define MIOPEN_ROCBLAS_VERSION_PATCH @rocblas_VERSION_PATCH@
+// clang-format on
+
 // Truncation rounding or (default) rounding to nearest even (RNE) is enabled.
 // This switch controls two related but different aspects of MIOpen behavior:
 // 1.  How host code performs conversions of float to bfloat16, important only

--- a/include/miopen/config.h.in
+++ b/include/miopen/config.h.in
@@ -121,6 +121,8 @@
 
 /// WORKAROUND_BOOST_ISSUE_392
 /// Workaround for https://github.com/boostorg/config/issues/392#issuecomment-1109889533
+/// See also https://github.com/ROCmSoftwarePlatform/MIOpen/pull/1490#issuecomment-1109928102,
+/// https://github.com/ROCmSoftwarePlatform/MIOpen/pull/1543
 /// TODO: Remove the W/A as soon we switch to the properly fixed boost.
 #if MIOPEN_BACKEND_HIP
 #include <hip/hip_version.h>

--- a/include/miopen/config.h.in
+++ b/include/miopen/config.h.in
@@ -137,7 +137,7 @@
     MIOPEN_ROCBLAS_VERSION_PATCH > 999
 #error "Too big ROCBLAS version number(s)"
 #endif
-#define MIOPEN_ROCBLAS_VERSION_FLAT                                                   \
+#define MIOPEN_ROCBLAS_VERSION_FLAT                                                \
     ((MIOPEN_ROCBLAS_VERSION_MAJOR * 1000 + MIOPEN_ROCBLAS_VERSION_MINOR) * 1000 + \
      MIOPEN_ROCBLAS_VERSION_PATCH)
 #endif // MIOPEN_USE_ROCBLAS

--- a/include/miopen/config.h.in
+++ b/include/miopen/config.h.in
@@ -119,6 +119,7 @@
 
 #endif
 
+/// WORKAROUND_BOOST_ISSUE_392
 /// Workaround for https://github.com/boostorg/config/issues/392#issuecomment-1109889533
 /// TODO: Remove the W/A as soon we switch to the properly fixed boost.
 #if MIOPEN_BACKEND_HIP

--- a/speedtests/sequences.cpp
+++ b/speedtests/sequences.cpp
@@ -1,3 +1,4 @@
+#include <miopen/config.h> // WORKAROUND_BOOST_ISSUE_392
 #include <miopen/rank.hpp>
 #include <miopen/sequences.hpp>
 

--- a/src/gemm_v2.cpp
+++ b/src/gemm_v2.cpp
@@ -23,6 +23,7 @@
  * SOFTWARE.
  *
  *******************************************************************************/
+#include <miopen/config.h>
 #include <miopen/gemm_v2.hpp>
 #include <miopen/logger.hpp>
 #include <miopen/env.hpp>
@@ -57,21 +58,19 @@
 
 #if MIOPEN_USE_ROCBLAS
 
-#define MIOPEN_ROCBLAS_VERSION_DECIMAL (ROCBLAS_VERSION_MAJOR * 100 + ROCBLAS_VERSION_MINOR)
-
 /// Avoid warnings "The workspace_size and workspace arguments are obsolete" and
 /// "disabled expansion of recursive macro" injected by rocblas headers.
-#define AVOID_ROCBLAS_WRAPPERS_204 (MIOPEN_ROCBLAS_VERSION_DECIMAL >= 204)
+#define AVOID_ROCBLAS_WRAPPERS_204 (MIOPEN_ROCBLAS_VERSION_FLAT >= 2004000)
 
 /// Maintain API compatibility with various rocBLAS version
-#define USE_GEMM_FLAGS_PACK_INT8X4 (MIOPEN_ROCBLAS_VERSION_DECIMAL >= 238)
+#define USE_GEMM_FLAGS_PACK_INT8X4 (MIOPEN_ROCBLAS_VERSION_FLAT >= 2038000)
 
 /// Maintain API compatibility for versions not supporting FP16 alternate implementations
-#define USE_GEMM_FLAGS_FP16_ALT_IMPL (MIOPEN_ROCBLAS_VERSION_DECIMAL >= 243)
+#define USE_GEMM_FLAGS_FP16_ALT_IMPL (MIOPEN_ROCBLAS_VERSION_FLAT >= 2043000)
 /// Some 2.42 versions have rocblas_gemm_flags_fp16_alt_impl, but
 /// some do not, and that leads to build errors.
 /// Let's pass literal value as a workaround; there should be no harm.
-#define USE_GEMM_FLAGS_FP16_ALT_IMPL_242 (MIOPEN_ROCBLAS_VERSION_DECIMAL == 242)
+#define USE_GEMM_FLAGS_FP16_ALT_IMPL_242 (MIOPEN_ROCBLAS_VERSION_FLAT == 2042000)
 
 template <class... Ts>
 auto miopen_rocblas_gemm_ex(Ts... xs)

--- a/src/gemm_v2.cpp
+++ b/src/gemm_v2.cpp
@@ -41,7 +41,7 @@
 
 #if MIOPEN_USE_ROCBLAS
 #include <half.hpp>
-#if HIP_PACKAGE_VERSION_FLAT <= 5001999999ULL
+#if MIOPEN_ROCBLAS_VERSION_FLAT < 2045000
 #include <rocblas.h>
 #else
 #include <rocblas/rocblas.h>

--- a/src/include/miopen/find_db.hpp
+++ b/src/include/miopen/find_db.hpp
@@ -27,7 +27,7 @@
 #ifndef GUARD_MIOPEN_FIND_DB_HPP_
 #define GUARD_MIOPEN_FIND_DB_HPP_
 
-#include <miopen/config.h> // WORKAROUND_BOOST_ISSUE_392
+#include <miopen/config.h>
 #include <miopen/db.hpp>
 #include <miopen/db_path.hpp>
 #include <miopen/db_record.hpp>

--- a/src/include/miopen/find_db.hpp
+++ b/src/include/miopen/find_db.hpp
@@ -27,7 +27,7 @@
 #ifndef GUARD_MIOPEN_FIND_DB_HPP_
 #define GUARD_MIOPEN_FIND_DB_HPP_
 
-#include <miopen/config.h>
+#include <miopen/config.h> // WORKAROUND_BOOST_ISSUE_392
 #include <miopen/db.hpp>
 #include <miopen/db_path.hpp>
 #include <miopen/db_record.hpp>

--- a/src/include/miopen/handle.hpp
+++ b/src/include/miopen/handle.hpp
@@ -52,7 +52,7 @@
 
 #if MIOPEN_USE_ROCBLAS
 #include <miopen/manage_ptr.hpp>
-#if HIP_PACKAGE_VERSION_FLAT <= 5001999999ULL
+#if MIOPEN_ROCBLAS_VERSION_FLAT < 2045000
 #include <rocblas.h>
 #else
 #include <rocblas/rocblas.h>

--- a/src/include/miopen/op_kernel_args.hpp
+++ b/src/include/miopen/op_kernel_args.hpp
@@ -1,24 +1,10 @@
 #ifndef MIOPEN_GUARD_MLOPEN_OP_KERNEL_ARGS_HPP
 #define MIOPEN_GUARD_MLOPEN_OP_KERNEL_ARGS_HPP
 
-#include <miopen/config.h> /// WORKAROUND_BOOST_ISSUE_392
-
-/// The puzzling problem: WORKAROUND_BOOST_ISSUE_392 does not help
-/// with ROCm 5.1.x: even with config.h is included, build fails
-/// and complains the same thing about noinline.
-/// Therefore we avoid use of boost in this file for 5.1.x.
-/// NOTE: This W/A should be removed altogether with WORKAROUND_BOOST_ISSUE_392.
-#define WORKAROUND_BOOST_ISSUE_392_AVOID_BOOST (HIP_PACKAGE_VERSION_MAJOR == 5 && HIP_PACKAGE_VERSION_MINOR == 1)
-
 #include <type_traits>
 #include <cstdint>
 #include <half.hpp>
-
-#if WORKAROUND_BOOST_ISSUE_392_AVOID_BOOST
-#include <vector>
-#else
 #include <boost/container/small_vector.hpp>
-#endif
 
 struct OpKernelArg
 {
@@ -42,11 +28,7 @@ struct OpKernelArg
     }
 
     std::size_t size() const { return buffer.size(); };
-#if WORKAROUND_BOOST_ISSUE_392_AVOID_BOOST
-    std::vector<char> buffer;
-#else
     boost::container::small_vector<char, 8> buffer;
-#endif
     bool is_ptr = false;
 };
 

--- a/src/include/miopen/op_kernel_args.hpp
+++ b/src/include/miopen/op_kernel_args.hpp
@@ -1,11 +1,22 @@
 #ifndef MIOPEN_GUARD_MLOPEN_OP_KERNEL_ARGS_HPP
 #define MIOPEN_GUARD_MLOPEN_OP_KERNEL_ARGS_HPP
 
+#include <miopen/config.h> /// WORKAROUND_BOOST_ISSUE_392
+
+/// The puzzling problem: WORKAROUND_BOOST_ISSUE_392 does not help
+/// with ROCm 5.1.x: even with config.h is included, build fails
+/// and complains the same thing about noinline.
+/// Therefore we avoid use of boost in this file for 5.1.x.
+/// NOTE: This W/A should be removed altogether with WORKAROUND_BOOST_ISSUE_392.
+#define WORKAROUND_BOOST_ISSUE_392_AVOID_BOOST (HIP_PACKAGE_VERSION_MAJOR == 5 && HIP_PACKAGE_VERSION_MINOR == 1)
+
 #include <type_traits>
 #include <cstdint>
 #include <half.hpp>
-#if HIP_PACKAGE_VERSION_FLAT > 5001999999ULL
-#include <miopen/config.h>
+
+#if WORKAROUND_BOOST_ISSUE_392_AVOID_BOOST
+#include <vector>
+#else
 #include <boost/container/small_vector.hpp>
 #endif
 
@@ -31,7 +42,7 @@ struct OpKernelArg
     }
 
     std::size_t size() const { return buffer.size(); };
-#if HIP_PACKAGE_VERSION_FLAT <= 5001999999ULL
+#if WORKAROUND_BOOST_ISSUE_392_AVOID_BOOST
     std::vector<char> buffer;
 #else
     boost::container::small_vector<char, 8> buffer;


### PR DESCRIPTION
- `WORKAROUND_BOOST_ISSUE_392`
  - Note: For more info about issue, see #1489
  - Uniformly marked in comments (now easy to grep)
  - Fix: W/A moved under guard in config.h
    - Resolves https://github.com/ROCmSoftwarePlatform/MIOpen/pull/1543#discussion_r889131708
  - W/A added to speedtests/sequences.cpp instead of W/A + "puzzling W/A" in op_kernel_args.hpp
    - See https://github.com/ROCmSoftwarePlatform/MIOpen/pull/1543#discussion_r873109516
- rocBLAS version
  - Print from CMake
  - Uniformly provided in config.h as macros (`MIOPEN_ROCBLAS_VERSION_*`)
  - Refactor: Replaced old stuff with new version macros
- Tweak for inclusion of `rocblas.h` for ROCm 5.2
  - Fix: Use rocBLAS version (2.45) instead of HIP (5.2) version to detect
    - Why 2.45: https://github.com/ROCmSoftwarePlatform/rocBLAS/commit/99528dd09118e1990a27df1ca39ba30341c5f516
    - Resolves https://github.com/ROCmSoftwarePlatform/MIOpen/pull/1543#discussion_r886958057
    - Note: Now it is clear that can remove the tweak as soon support for rocBLAS < 2.45 is not required.

/cc @junliume @JP-Ellis 