### PR TITLE
[SWDEV-330460] Improve workaround for ConvAsmBwdWrw3x3

### DIFF
--- a/src/solver/conv_asm_dir_BwdWrW3x3.cpp
+++ b/src/solver/conv_asm_dir_BwdWrW3x3.cpp
@@ -373,7 +373,8 @@ bool ConvAsmBwdWrW3x3::IsApplicable(const ConvolutionContext& params) const
         return false;
 
 #if WORKAROUND_SWDEV_330460
-    if(name == "gfx90a" && params.IsFp32())
+    if(!miopen::IsEnabled(MIOPEN_DEBUG_CONV_DIRECT_ASM_WRW3X3{}) && name == "gfx90a" &&
+       params.IsFp32())
         return false;
 #endif
 


### PR DESCRIPTION
Improvement of W/A introduced in #1616: this allows to enable ConvAsmBwdWrw3x3 explicitly by means of `MIOPEN_DEBUG_CONV_DIRECT_ASM_WRW3X3`. Might be useful for experimentation when developing the full-blown fix.