### PR TITLE
[SWDEV-306318][WORKAROUND][gfx908] Disable ConvAsmImplicitGemmGTCDynamicFwdXdlops

### DIFF
--- a/src/solver/conv_asm_implicit_gemm_gtc_fwd.cpp
+++ b/src/solver/conv_asm_implicit_gemm_gtc_fwd.cpp
@@ -31,6 +31,8 @@
 #include <miopen/solver/implicitgemm_util.hpp>
 #include <miopen/conv/asm_implicit_gemm.hpp>
 
+#define WORKAROUND_SWDEV_306318 1
+
 MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_ASM_FWD_GTC_XDLOPS)
 
 namespace miopen {
@@ -1501,6 +1503,11 @@ bool ConvAsmImplicitGemmGTCDynamicFwdXdlops::IsApplicable(const ConvolutionConte
 {
     if(miopen::IsDisabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_ASM_FWD_GTC_XDLOPS{}))
         return false;
+
+#if WORKAROUND_SWDEV_306318
+    if(!miopen::IsEnabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_ASM_FWD_GTC_XDLOPS{}))
+        return false;
+#endif
 
     const auto device_name = ctx.GetStream().GetDeviceName();
     if(device_name != "gfx908")


### PR DESCRIPTION
w/a swd306318:
kernel produce wrong result using:
```
MIOpenDriver conv -n 16 -c 76 -H 9 -W 9 -k 32 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 1 -t 1 -w 1
```
As kernel was developed about 2 years ago and I was not the developer, I need more time to identity the faulty code block. In order to move the test process forward, I give a w/a at this moment and I will continue checking the root cause.

As MIOpen has nhwc+transpose kernel as backup, it will not broke anything by disabling this solver.