### PR TITLE
[noGPU] Updated CMakeLists to exclude GPU dependent tests on NO GPU platform

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -213,7 +213,7 @@ else()
 endif()
 
 if (MIOPEN_NO_GPU)
-    set(SKIP_ALL_EXCEPT_TESTS test_include_inliner test_kernel_build_params test_lstm test_lstm_dropout
+    set(SKIP_ALL_EXCEPT_TESTS test_include_inliner test_kernel_build_params
             test_test_errors test_type_name test_tensor_test test_sqlite_perfdb test_sequences
             test_pooling3d test_perfdb)
 endif()


### PR DESCRIPTION
Updated test/CMakeLists.txt to exclude two GPU dependent tests on non-GPU platform.