### PR TITLE
[NFC][SWDEV-257567] Update distribution list maintainer/contact

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -450,7 +450,7 @@ endif()
 rocm_create_package(
     NAME MIOpen-${MIOPEN_BACKEND}
     DESCRIPTION "AMD's DNN Library"
-    MAINTAINER "Paul Fultz II <paul.fultz@amd.com>"
+    MAINTAINER "MIOpen Maintainer <miopen-lib.support@amd.com>"
     LDCONFIG
     # DEPENDS rocm-opencl hip-rocclr tinygemm
 )


### PR DESCRIPTION
https://ontrack-internal.amd.com/browse/SWDEV-257567
created miopen-lib.support@amd.com for the MIOpen libraries: miopen-hip, miopen-opencl, and miopengemm