### PR TITLE
[BugFix] MIOpenIm2d2Col.cl kernel: fix address calculation

### DIFF
--- a/src/kernels/MIOpenIm2d2Col.cl
+++ b/src/kernels/MIOpenIm2d2Col.cl
@@ -104,9 +104,9 @@ typedef float data_t;
  */
 
 #if USE_LARGE_BUFFER_INDEX
-#define index_t long
+typedef long index_t;
 #else
-#define index_t int
+typedef int index_t;
 #endif
 
 kernel void Im2d2Col(const int data_size_off,
@@ -138,7 +138,11 @@ kernel void Im2d2Col(const int data_size_off,
 
     global data_t* im_off = im + im_offset;
     int lid               = get_local_id(0);
-    int gid               = get_group_id(0);
+    /// tile_sz_x = {32,16,8,4,2,1}, tile_sz_y = {8,4,2,1}
+    /// NUM_IM_BLKS_X = out_w / tile_sz_x
+    /// NUM_IM_BLKS = NUM_IM_BLKS_X * out_h / tile_sz_y => out_w * out_h
+    /// c * NUM_IM_BLKS => c * out_w * out_h
+    index_t gid = get_group_id(0);
 
 #ifndef EXTREME_LARGE
 #if NUM_IM_BLKS == 1 && STRIDE_GT_1 == 0
@@ -155,8 +159,8 @@ kernel void Im2d2Col(const int data_size_off,
     int gid_stride = NUM_CH_PER_WG * h * w;
     while(im_lid < gid_stride)
     {
-        /// gid = 256 * max(1, (c_pack / NUM_CH_PER_WG)) => 256 * c
-        /// max (256 * c * LOCAL_MEM_SIZE) => 65536 * 256 * c
+        /// gid = max(1, (c_pack / NUM_CH_PER_WG)) => c
+        /// max (c * LOCAL_MEM_SIZE) => 65536 * c
         index_t im_off_id = index_t(gid) * gid_stride + im_lid;
         local_im[im_lid]  = IM_OFF_GUARD(im_off_id);
         im_lid += 256;
@@ -181,10 +185,10 @@ kernel void Im2d2Col(const int data_size_off,
         /// out_w < 32; out_y < 255; out_x < 255
         /// col_x < 2 080 800
         int col_x = out_y * out_w + out_x;
-        /// gid = 256 * c; NUM_CH_PER_WG{1,4}; out_hw_stride < 256;
+        /// gid = c = group_cnt-1; NUM_CH_PER_WG{1,4}; out_hw_stride < 256;
         /// EXTREME_LARGE==0
         /// => wei_h * wei_w * type_size * NUM_CH_PER_WG < max (LOCAL_MEM_SIZE)
-        /// gid * out_hw_stride * LOCAL_MEM_SIZE => 256 * c * 256 * 65536
+        /// gid * out_hw_stride * LOCAL_MEM_SIZE => c * 256 * 65536
         index_t col_y = (index_t(gid) * NUM_CH_PER_WG + witem_ch) * out_hw_stride * wei_h * wei_w;
 
         for(int y = 0; y < wei_h; y++)
@@ -211,27 +215,38 @@ kernel void Im2d2Col(const int data_size_off,
     local data_t local_im[LOCAL_MEM_SIZE];
 
     int wg_ch = gid / NUM_IM_BLKS;
+    /// TILE_SZ_X = 32, TILE_SZ_Y = 8;
+    /// gid = c * NUM_IM_BLKS => im_x = NUM_IM_BLKS*TILE_SZ_X = NUM_IM_BLKS*32
+    /// = NUM_IM_BLKS*32 = out_w * out_h / 8
+    int im_x = int((gid % NUM_IM_BLKS) % NUM_IM_BLKS_X) * TILE_SZ_X; /// < out_w
+    int im_y = int((gid % NUM_IM_BLKS) / NUM_IM_BLKS_X) * TILE_SZ_Y; /// < out_h
 
-    int im_x = ((gid % NUM_IM_BLKS) % NUM_IM_BLKS_X) * TILE_SZ_X;
-    int im_y = ((gid % NUM_IM_BLKS) / NUM_IM_BLKS_X) * TILE_SZ_Y;
-
-    int out_cols_wg = im_x + TILE_SZ_X <= out_w ? TILE_SZ_X : out_w - im_x;
-    int out_rows_wg = im_y + TILE_SZ_Y <= out_h ? TILE_SZ_Y : out_h - im_y;
+    int out_cols_wg = (im_x + TILE_SZ_X) <= out_w ? TILE_SZ_X : (out_w - im_x); /// < out_w
+    int out_rows_wg = (im_y + TILE_SZ_Y) <= out_h ? TILE_SZ_Y : (out_h - im_y); /// < out_h
 
     int im_cols_wg = (TILE_SZ_X - 1) * stride_w + (wei_w - 1) * dilation_w + 1;
-    int inner_lid  = lid;
+
+    int inner_lid = lid;
 
     while(inner_lid < LOCAL_MEM_SIZE)
     {
+        /// < 256
         int row_to_use = inner_lid / im_cols_wg;
         int col_to_use = inner_lid % im_cols_wg;
-        int lm_offset  = row_to_use * im_cols_wg + col_to_use;
-        if(im_y * stride_h + row_to_use >= pad_h && im_y * stride_h + row_to_use < h + pad_h &&
-           im_x * stride_w + col_to_use >= pad_w && im_x * stride_w + col_to_use < w + pad_w)
+        /// max = LOCAL_MEM_SIZE + im_cols_wg
+        int lm_offset = row_to_use * im_cols_wg + col_to_use;
+
+        /// out_h*stride_h+256
+        int im_y_off = im_y * stride_h + row_to_use;
+        /// out_w*stride_w+256
+        int im_x_off = im_x * stride_w + col_to_use;
+
+        if(im_y_off >= pad_h && im_y_off < h + pad_h && im_x_off >= pad_w && im_x_off < w + pad_w)
         {
-            int im_off_h        = im_y * stride_h + row_to_use - pad_h;
-            int im_off_w        = im_x * stride_w + col_to_use - pad_w;
-            local_im[lm_offset] = IM_OFF_GUARD(wg_ch * h * w + im_off_h * w + im_off_w);
+            int im_off_h        = im_y_off - pad_h;
+            int im_off_w        = im_x_off - pad_w;
+            index_t im_off_id   = index_t(wg_ch) * h * w + im_off_h * w + im_off_w;
+            local_im[lm_offset] = IM_OFF_GUARD(im_off_id);
         }
         else
             local_im[lm_offset] = 0;
@@ -243,20 +258,21 @@ kernel void Im2d2Col(const int data_size_off,
     inner_lid = lid;
     while(inner_lid < out_cols_wg * out_rows_wg)
     {
-        int out_x = inner_lid % out_cols_wg;
-        int out_y = inner_lid / out_cols_wg;
+        int out_x = inner_lid % out_cols_wg; /// < 256
+        int out_y = inner_lid / out_cols_wg; /// < 256
 
-        int col_x = (im_y + out_y) * out_w + im_x + out_x;
-        int col_y = (gid / NUM_IM_BLKS) * out_h * out_w * wei_h * wei_w;
+        index_t col_x = index_t(im_y + out_y) * out_w + im_x + out_x; /// out_h * out_w
+        /// c * out_h * out_w * wei_h * wei_w
+        index_t col_y = (gid / NUM_IM_BLKS) * out_h * out_w * wei_h * wei_w;
 
         for(int y = 0; y < wei_h; y++)
         {
             for(int x = 0; x < wei_w; x++)
             {
-                int im_off_h = out_y * stride_h + y * dilation_h;
-                int im_off_w = out_x * stride_w + x * dilation_w;
-                col[col_y + col_x + (y * wei_w + x) * out_h * out_w] =
-                    local_im[(im_off_h)*im_cols_wg + im_off_w];
+                int im_off_h    = out_y * stride_h + y * dilation_h;
+                int im_off_w    = out_x * stride_w + x * dilation_w;
+                index_t col_off = col_y + col_x + (index_t(y) * wei_w + x) * out_h * out_w;
+                col[col_off]    = local_im[(im_off_h)*im_cols_wg + im_off_w];
             }
         }
         inner_lid += 256;
@@ -264,32 +280,33 @@ kernel void Im2d2Col(const int data_size_off,
 #endif // NUM_IM_BLKS && STRIDE_GT_1
 #else
 
-    int tid = get_global_id(0);
-    while(tid < out_h * out_w * wei_w * wei_h * NUM_CH_TOTAL)
+    index_t tid = get_global_id(0);
+    while(tid < index_t(out_h) * out_w * wei_w * wei_h * NUM_CH_TOTAL)
     {
         // which row of the output to write to
-        int col_row = tid / (out_h * out_w);
+        index_t col_row = tid / (index_t(out_h) * out_w); // wei_w * wei_h * NUM_CH_TOTAL
 
         // which pixel from the image and which channel to read from
-        int im_x = col_row % wei_w;           // used to compute im_off_w
-        int im_y = (col_row / wei_w) % wei_h; // used to compute im_off_y
-        int im_c = col_row / (wei_w * wei_h); // im_c is the img channel
+        int im_x = int(col_row % wei_w);                    // used to compute im_off_w
+        int im_y = int((col_row / wei_w) % wei_h);          // used to compute im_off_y
+        int im_c = int(col_row / (index_t(wei_w) * wei_h)); // im_c is the img channel
 
-        int out_x = tid % out_w;
-        int out_y = (tid / out_w) % out_h;
+        int out_x = int(tid % out_w);
+        int out_y = int((tid / out_w) % out_h);
 
         // take the strides and padding into account while reading from the image
         int im_off_h = out_y * stride_h - pad_h + im_y * dilation_h;
         int im_off_w = out_x * stride_w - pad_w + im_x * dilation_w;
 
+        index_t col_off = col_row * out_h * out_w + index_t(out_y) * out_w + out_x;
+
         if(im_off_h >= 0 && im_off_h < h && im_off_w >= 0 && im_off_w < w)
         {
-            col[col_row * out_h * out_w + out_y * out_w + out_x] =
-                im_off[im_c * h * w + im_off_h * w + im_off_w];
+            col[col_off] = im_off[im_c * h * w + im_off_h * w + im_off_w];
         }
         else
         {
-            col[col_row * out_h * out_w + out_y * out_w + out_x] = 0.;
+            col[col_off] = 0.;
         }
         tid += get_global_size(0);
     }

--- a/src/kernels/MIOpenIm2d2Col.cl
+++ b/src/kernels/MIOpenIm2d2Col.cl
@@ -127,8 +127,8 @@ kernel void Im2d2Col(const int data_size_off,
                      global data_t* col)
 {
 #define THREADS_PER_CH (256 / NUM_CH_PER_WG)
-/// NUM_CH_PER_WG {1;4}
-/// THREADS_PER_CH {256; 64}
+    /// NUM_CH_PER_WG {1;4}
+    /// THREADS_PER_CH {256; 64}
 
 #if USE_IM_OFF_GUARD
 #define IM_OFF_GUARD(idx) (idx) < data_size_off ? im_off[(idx)] : 0
@@ -158,7 +158,7 @@ kernel void Im2d2Col(const int data_size_off,
         /// gid = 256 * max(1, (c_pack / NUM_CH_PER_WG)) => 256 * c
         /// max (256 * c * LOCAL_MEM_SIZE) => 65536 * 256 * c
         index_t im_off_id = index_t(gid) * gid_stride + im_lid;
-        local_im[im_lid] = IM_OFF_GUARD(im_off_id);
+        local_im[im_lid]  = IM_OFF_GUARD(im_off_id);
         im_lid += 256;
     }
     barrier(CLK_LOCAL_MEM_FENCE);
@@ -172,7 +172,7 @@ kernel void Im2d2Col(const int data_size_off,
     int out_hw_stride = out_h * out_w;
     if(lid % THREADS_PER_CH < out_hw_stride)
     {
-        /// lid[0, 255] % THREADS_PER_CH {256; 64} => 
+        /// lid[0, 255] % THREADS_PER_CH {256; 64} =>
         /// max(inner_lid)=255; max(out_x)=max(out_y)=255
         int inner_lid = lid % THREADS_PER_CH;
         int out_x     = inner_lid % out_w;
@@ -182,12 +182,10 @@ kernel void Im2d2Col(const int data_size_off,
         /// col_x < 2 080 800
         int col_x = out_y * out_w + out_x;
         /// gid = 256 * c; NUM_CH_PER_WG{1,4}; out_hw_stride < 256;
-        /// EXTREME_LARGE==0 
+        /// EXTREME_LARGE==0
         /// => wei_h * wei_w * type_size * NUM_CH_PER_WG < max (LOCAL_MEM_SIZE)
-        /// gid * out_hw_stride * LOCAL_MEM_SIZE => 256 * c * 256 * 65536 
-        index_t col_y = 
-            ( index_t(gid) * NUM_CH_PER_WG + witem_ch) 
-                * out_hw_stride * wei_h * wei_w;
+        /// gid * out_hw_stride * LOCAL_MEM_SIZE => 256 * c * 256 * 65536
+        index_t col_y = (index_t(gid) * NUM_CH_PER_WG + witem_ch) * out_hw_stride * wei_h * wei_w;
 
         for(int y = 0; y < wei_h; y++)
         {

--- a/src/kernels/MIOpenIm2d2Col.cl
+++ b/src/kernels/MIOpenIm2d2Col.cl
@@ -289,8 +289,8 @@ kernel void Im2d2Col(const int data_size_off,
         index_t col_row = tid / ((index_t)out_h * out_w); // wei_w * wei_h * NUM_CH_TOTAL
 
         // which pixel from the image and which channel to read from
-        int im_x = col_row % wei_w;                     // used to compute im_off_w
-        int im_y = (col_row / wei_w) % wei_h;           // used to compute im_off_y
+        int im_x = col_row % wei_w;                    // used to compute im_off_w
+        int im_y = (col_row / wei_w) % wei_h;          // used to compute im_off_y
         int im_c = col_row / ((index_t)wei_w * wei_h); // im_c is the img channel
 
         int out_x = tid % out_w;

--- a/src/kernels/MIOpenIm2d2Col.cl
+++ b/src/kernels/MIOpenIm2d2Col.cl
@@ -291,7 +291,7 @@ kernel void Im2d2Col(const int data_size_off,
         // which pixel from the image and which channel to read from
         int im_x = col_row % wei_w;                     // used to compute im_off_w
         int im_y = (col_row / wei_w) % wei_h;           // used to compute im_off_y
-        int im_c = (col_row / ((index_t)wei_w * wei_h); // im_c is the img channel
+        int im_c = col_row / ((index_t)wei_w * wei_h); // im_c is the img channel
 
         int out_x = tid % out_w;
         int out_y = (tid / out_w) % out_h;

--- a/src/ocl/utilocl.cpp
+++ b/src/ocl/utilocl.cpp
@@ -193,9 +193,66 @@ float Im2d2ColGPU(const Handle& handle,
 
         params += GetDataTypeKernelParams(type);
 
-        const std::vector<size_t> vld{256, 1, 1};
-        size_t global_threads = 256 * std::max(1, (c_pack / num_ch_per_wg)) * num_blks;
+        const int group_size_x = 256;
+        const std::vector<size_t> vld{group_size_x, 1, 1};
+        size_t group_cnt      = std::max(1, (c_pack / num_ch_per_wg)) * num_blks;
+        size_t global_threads = group_size_x * group_cnt;
         const std::vector<size_t> vgd{global_threads, 1, 1};
+
+        bool use_64bit_buffer_index = false;
+        use_64bit_buffer_index |= group_cnt > INT32_MAX
+
+                                  if(extreme_case > MAX_LOCAL_MEM)
+        {
+            // check get_global_id
+            use_64bit_buffer_index |= global_threads > INT32_MAX
+
+                                      const size_t out_hw =
+                                          1LL * out_h* out_w use_64bit_buffer_index |=
+                out_hw > INT32_MAX
+
+                const size_t col_row = 1LL * wei_w * wei_h * c_pack;
+
+            const size_t tid = col_row * out_hw;
+            use_64bit_buffer_index |= tid > INT32_MAX
+        }
+        else
+        {
+            if(num_blks == 1 && stride_h * stride_w == 1)
+            {
+                const size_t im_off_id = 1ll * group_cnt * num_ch_per_wg * in_h * in_w*;
+                use_64bit_buffer_index |= im_off_id > INT32_MAX;
+
+                const size_t col_y =
+                    (1LL * group_cnt * num_ch_per_wg) * out_h * out_w * wei_h * wei_w;
+                use_64bit_buffer_index |= col_y > INT32_MAX;
+
+                // col_x= out_y * out_w + out_x;
+                // out_y = group_size_x/out_w; out_x = group_size_x % out_w;
+                //  = 255 / out_w * out_w + 255 % out_w;
+                int col_x            = 255 + 255;
+                const size_t col_off = col_y + col_x + (1LL * wei_h * wei_w) * out_h * out_w;
+                use_64bit_buffer_index |= col_y > INT32_MAX;
+            }
+            else
+            {
+                const size_t im_off_id = 1ll * (group_cnt / num_blks) * in_h * in_w*;
+                use_64bit_buffer_index |= im_off_id > INT32_MAX;
+
+                const size_t col_x = 1ll * (out_h + 256) * out_w + 256;
+                use_64bit_buffer_index |= col_x > INT32_MAX;
+
+                const size_t col_y = 1ll * c * out_h * out_w * wei_h * wei_w;
+                use_64bit_buffer_index |= col_y > INT32_MAX;
+
+                const size_t col_off = col_y + col_x + (1LL * wei_h * wei_w) * out_h * out_w;
+                use_64bit_buffer_index |= col_off > INT32_MAX;
+            }
+        }
+
+        if(use_64bit_buffer_index)
+            params += " -DUSE_LARGE_BUFFER_INDEX";
+
         handle.AddKernel(
             "miopenIm2Col", network_config, program_name, kernel_name, vld, vgd, params)(
             data_size_bound_pack,

--- a/src/ocl/utilocl.cpp
+++ b/src/ocl/utilocl.cpp
@@ -207,7 +207,8 @@ float Im2d2ColGPU(const Handle& handle,
             // check get_global_id
             use_64bit_buffer_index |= global_threads > INT32_MAX;
 
-            const size_t out_hw = 1LL * out_h* out_w use_64bit_buffer_index |= out_hw > INT32_MAX;
+            const size_t out_hw = 1LL * out_h * out_w;
+            use_64bit_buffer_index |= out_hw > INT32_MAX;
 
             const size_t col_row = 1LL * wei_w * wei_h * c_pack;
 
@@ -218,7 +219,7 @@ float Im2d2ColGPU(const Handle& handle,
         {
             if(num_blks == 1 && stride_h * stride_w == 1)
             {
-                const size_t im_off_id = 1ll * group_cnt * num_ch_per_wg * in_h * in_w*;
+                const size_t im_off_id = 1ll * group_cnt * num_ch_per_wg * in_h * in_w;
                 use_64bit_buffer_index |= im_off_id > INT32_MAX;
 
                 const size_t col_y =
@@ -230,7 +231,7 @@ float Im2d2ColGPU(const Handle& handle,
                 //  = 255 / out_w * out_w + 255 % out_w;
                 int col_x            = 255 + 255;
                 const size_t col_off = col_y + col_x + (1LL * wei_h * wei_w) * out_h * out_w;
-                use_64bit_buffer_index |= col_y > INT32_MAX;
+                use_64bit_buffer_index |= col_off > INT32_MAX;
             }
             else
             {

--- a/src/ocl/utilocl.cpp
+++ b/src/ocl/utilocl.cpp
@@ -207,6 +207,9 @@ float Im2d2ColGPU(const Handle& handle,
             // check get_global_id
             use_64bit_buffer_index |= global_threads > INT32_MAX;
 
+            const size_t in_chw = 1LL * in_h * in_w * c_pack;
+            use_64bit_buffer_index |= in_chw > INT32_MAX;
+
             const size_t out_hw = 1LL * out_h * out_w;
             use_64bit_buffer_index |= out_hw > INT32_MAX;
 
@@ -219,7 +222,7 @@ float Im2d2ColGPU(const Handle& handle,
         {
             if(num_blks == 1 && stride_h * stride_w == 1)
             {
-                const size_t im_off_id = 1ll * group_cnt * num_ch_per_wg * in_h * in_w;
+                const size_t im_off_id = 1LL * group_cnt * num_ch_per_wg * in_h * in_w;
                 use_64bit_buffer_index |= im_off_id > INT32_MAX;
 
                 const size_t col_y =
@@ -235,13 +238,13 @@ float Im2d2ColGPU(const Handle& handle,
             }
             else
             {
-                const size_t im_off_id = 1ll * (group_cnt / num_blks) * in_h * in_w;
+                const size_t im_off_id = 1LL * (group_cnt / num_blks) * in_h * in_w;
                 use_64bit_buffer_index |= im_off_id > INT32_MAX;
 
-                const size_t col_x = 1ll * (out_h + 256) * out_w + 256;
+                const size_t col_x = 1LL * (out_h + 256) * out_w + 256;
                 use_64bit_buffer_index |= col_x > INT32_MAX;
 
-                const size_t col_y = 1ll * c * out_h * out_w * wei_h * wei_w;
+                const size_t col_y = 1LL * c * out_h * out_w * wei_h * wei_w;
                 use_64bit_buffer_index |= col_y > INT32_MAX;
 
                 const size_t col_off = col_y + col_x + (1LL * wei_h * wei_w) * out_h * out_w;

--- a/src/ocl/utilocl.cpp
+++ b/src/ocl/utilocl.cpp
@@ -200,21 +200,19 @@ float Im2d2ColGPU(const Handle& handle,
         const std::vector<size_t> vgd{global_threads, 1, 1};
 
         bool use_64bit_buffer_index = false;
-        use_64bit_buffer_index |= group_cnt > INT32_MAX
+        use_64bit_buffer_index |= group_cnt > INT32_MAX;
 
-                                  if(extreme_case > MAX_LOCAL_MEM)
+        if(extreme_case > MAX_LOCAL_MEM)
         {
             // check get_global_id
-            use_64bit_buffer_index |= global_threads > INT32_MAX
+            use_64bit_buffer_index |= global_threads > INT32_MAX;
 
-                                      const size_t out_hw =
-                                          1LL * out_h* out_w use_64bit_buffer_index |=
-                out_hw > INT32_MAX
+            const size_t out_hw = 1LL * out_h* out_w use_64bit_buffer_index |= out_hw > INT32_MAX;
 
-                const size_t col_row = 1LL * wei_w * wei_h * c_pack;
+            const size_t col_row = 1LL * wei_w * wei_h * c_pack;
 
             const size_t tid = col_row * out_hw;
-            use_64bit_buffer_index |= tid > INT32_MAX
+            use_64bit_buffer_index |= tid > INT32_MAX;
         }
         else
         {
@@ -236,7 +234,7 @@ float Im2d2ColGPU(const Handle& handle,
             }
             else
             {
-                const size_t im_off_id = 1ll * (group_cnt / num_blks) * in_h * in_w*;
+                const size_t im_off_id = 1ll * (group_cnt / num_blks) * in_h * in_w;
                 use_64bit_buffer_index |= im_off_id > INT32_MAX;
 
                 const size_t col_x = 1ll * (out_h + 256) * out_w + 256;


### PR DESCRIPTION
FIX for #1621 

Fixed bug with buffer index bigger than int32.
Fixed last part of kernel code, EXTREME_LARGE==1.

Tested configs:
```
export MIOPEN_FIND_MODE=1
export MIOPEN_DEBUG_FIND_ONLY_SOLVER=GemmFwdRest
./bin/MIOpenDriver convfp16 -W 300 -H 100 -c 1024 -n 1 -k 4 -x 256 -y 256 -p 0 -q 0 -u 1 -v 1 -F 1 -t 1 -V 1 -l 2

./bin/MIOpenDriver convfp16 -W 63 -H 135 -c 2040 -n 1 -k 16 -x 32 -y 128 -p 0 -q 0 -u 1 -v 1 -F 1 -t 1 -V 1
./bin/MIOpenDriver convfp16 -W 63 -H 135 -c 2050 -n 1 -k 16 -x 32 -y 128 -p 0 -q 0 -u 1 -v 1 -F 1 -t 1 -V 1

./bin/MIOpenDriver convfp16 -W 1760 -H 1760 -c 80 -n 1 -k 16 -x 3 -y 3 -p 0 -q 0 -u 1 -v 1 -F 1 -t 1 -V 1
./bin/MIOpenDriver convfp16 -W 1760 -H 1760 -c 75 -n 1 -k 16 -x 3 -y 3 -p 0 -q 0 -u 1 -v 1 -F 1 -t 1 -V 1

```