### PR TITLE
[tests][Navi21] Disable WORKAROUND_ISSUE_1053 as issue is not reproducible.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -49,7 +49,7 @@ set_var_to_condition(MIOPEN_TEST_WITH_MIOPENDRIVER_DEFAULT MIOPEN_BUILD_DRIVER)
 option( MIOPEN_TEST_WITH_MIOPENDRIVER "Use MIOpenDriver in tests" ${MIOPEN_TEST_WITH_MIOPENDRIVER_DEFAULT})
 
 option( WORKAROUND_ISSUE_936 "" ON)
-option( WORKAROUND_ISSUE_1053 "" ON)
+option( WORKAROUND_ISSUE_1053 "" OFF) # TODO: Remove this W/A after ~6 months (in January 2023)
 
 # Run the test suite to a depth limit
 #limit greater than 2 leads to prolonged testing more than 5hrs per stage.


### PR DESCRIPTION
Closes #1053 as not reproducible.
- Tested with 5.0, HIP and OCL backends.
- `WORKAROUND_ISSUE_1053` to be removed during routine cleanup after some time.

@junliume @xinlipn Please review.