### PR TITLE
[Hotfix] Issue 1653, Inappropriate Host API usage 

### DIFF
--- a/driver/conv_driver.hpp
+++ b/driver/conv_driver.hpp
@@ -1275,9 +1275,18 @@ int ConvDriver<Tgpu, Tref>::AllocateBuffersAndCopy()
             new GPUMem(ctx, GetTensorSize(weightTensor_vect4), sizeof(Tgpu)));
     }
 
-    outhost   = tensor<Tref>(miopen::deref(outputTensor));
-    din_host  = tensor<Tref>(miopen::deref(inputTensor));
-    dwei_host = tensor<Tref>(miopen::deref(weightTensor));
+    outhost   = tensor<Tref>(miopen::deref(outputTensor).GetType(),
+                           miopen::deref(outputTensor).GetLayout_t(),
+                           miopen::deref(outputTensor).GetLengths(),
+                           miopen::deref(outputTensor).GetStrides());
+    din_host  = tensor<Tref>(miopen::deref(inputTensor).GetType(),
+                            miopen::deref(inputTensor).GetLayout_t(),
+                            miopen::deref(inputTensor).GetLengths(),
+                            miopen::deref(inputTensor).GetStrides());
+    dwei_host = tensor<Tref>(miopen::deref(weightTensor).GetType(),
+                             miopen::deref(weightTensor).GetLayout_t(),
+                             miopen::deref(weightTensor).GetLengths(),
+                             miopen::deref(weightTensor).GetStrides());
 
     std::string inFileName   = inflags.GetValueStr("in_data");
     std::string weiFileName  = inflags.GetValueStr("weights");

--- a/driver/conv_driver.hpp
+++ b/driver/conv_driver.hpp
@@ -1275,15 +1275,15 @@ int ConvDriver<Tgpu, Tref>::AllocateBuffersAndCopy()
             new GPUMem(ctx, GetTensorSize(weightTensor_vect4), sizeof(Tgpu)));
     }
 
-    outhost   = tensor<Tref>(miopen::deref(outputTensor).GetType(),
+    outhost   = tensor<Tref>(miopen_type<Tref>{},
                            miopen::deref(outputTensor).GetLayout_t(),
                            miopen::deref(outputTensor).GetLengths(),
                            miopen::deref(outputTensor).GetStrides());
-    din_host  = tensor<Tref>(miopen::deref(inputTensor).GetType(),
+    din_host  = tensor<Tref>(miopen_type<Tref>{},
                             miopen::deref(inputTensor).GetLayout_t(),
                             miopen::deref(inputTensor).GetLengths(),
                             miopen::deref(inputTensor).GetStrides());
-    dwei_host = tensor<Tref>(miopen::deref(weightTensor).GetType(),
+    dwei_host = tensor<Tref>(miopen_type<Tref>{},
                              miopen::deref(weightTensor).GetLayout_t(),
                              miopen::deref(weightTensor).GetLengths(),
                              miopen::deref(weightTensor).GetStrides());


### PR DESCRIPTION
Fix for #1653 
Change the tensor constructor to avoid datatype not match error when construct the destination host tensor.
