### PR TITLE
Add OpenCL deprecation Message

### DIFF
--- a/src/ocl/handleocl.cpp
+++ b/src/ocl/handleocl.cpp
@@ -189,7 +189,7 @@ Handle::Handle(miopenAcceleratorQueue_t stream) : impl(new HandleImpl())
     MIOPEN_LOG_NQI(*this);
 }
 
-static bool OpenCLDeprecateMsg()
+static bool PrintOpenCLDeprecateMsg()
 {
     MIOPEN_LOG_W("Please note that the OpenCL backend to MIOpen is being deprecated, ");
     MIOPEN_LOG_W(
@@ -204,9 +204,9 @@ Handle::Handle() : impl(new HandleImpl())
     /////////////////////////////////////////////////////////////////
     // Create an OpenCL context
     /////////////////////////////////////////////////////////////////
-    static const auto log_msg = OpenCLDeprecateMsg();
-    std::ignore               = log_msg;
-    impl->context             = impl->create_context();
+    static const auto run_once = PrintOpenCLDeprecateMsg();
+    std::ignore                = run_once;
+    impl->context              = impl->create_context();
     /* First, get the size of device list data */
     cl_uint deviceListSize;
     if(clGetContextInfo(impl->context.get(),

--- a/src/ocl/handleocl.cpp
+++ b/src/ocl/handleocl.cpp
@@ -189,13 +189,24 @@ Handle::Handle(miopenAcceleratorQueue_t stream) : impl(new HandleImpl())
     MIOPEN_LOG_NQI(*this);
 }
 
+static bool OpenCLDeprecateMsg()
+{
+    MIOPEN_LOG_W("Please note that the OpenCL backend to MIOpen is being deprecated, ");
+    MIOPEN_LOG_W(
+        "please port your application to the better supported and functional HIP backend. ");
+    MIOPEN_LOG_W("If you have any questions, please reach out to the MIOpen developers at ");
+    MIOPEN_LOG_W("https://github.com/ROCmSoftwarePlatform/MIOpen");
+    return true;
+}
+
 Handle::Handle() : impl(new HandleImpl())
 {
     /////////////////////////////////////////////////////////////////
     // Create an OpenCL context
     /////////////////////////////////////////////////////////////////
-
-    impl->context = impl->create_context();
+    static const auto log_msg = OpenCLDeprecateMsg();
+    std::ignore               = log_msg;
+    impl->context             = impl->create_context();
     /* First, get the size of device list data */
     cl_uint deviceListSize;
     if(clGetContextInfo(impl->context.get(),


### PR DESCRIPTION
Since most of our known clients use the AMD HIP based backend for managing code  objects and launching kernels, the MIOpen team has decided to deprecate the OpenCL backend. 

This PR adds a deprecation message to the OpenCL backend to inform users and gather input. 