### PR TITLE
[SWDEV-306318][WORKAROUND][gfx908] Limit WA PR:1619 by only ignore 1x1 conv where C is not 8x

### DIFF
--- a/src/solver/conv_asm_implicit_gemm_gtc_fwd.cpp
+++ b/src/solver/conv_asm_implicit_gemm_gtc_fwd.cpp
@@ -1504,11 +1504,6 @@ bool ConvAsmImplicitGemmGTCDynamicFwdXdlops::IsApplicable(const ConvolutionConte
     if(miopen::IsDisabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_ASM_FWD_GTC_XDLOPS{}))
         return false;
 
-#if WORKAROUND_SWDEV_306318
-    if(!miopen::IsEnabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_ASM_FWD_GTC_XDLOPS{}))
-        return false;
-#endif
-
     const auto device_name = ctx.GetStream().GetDeviceName();
     if(device_name != "gfx908")
         return false;
@@ -1535,6 +1530,11 @@ bool ConvAsmImplicitGemmGTCDynamicFwdXdlops::IsApplicable(const ConvolutionConte
     {
         return false;
     }
+
+#if WORKAROUND_SWDEV_306318
+    if((ctx.kernel_size_h == 1) && (ctx.kernel_size_w == 1) && (ctx.n_inputs % 8 != 0))
+        return false;
+#endif
 
     const auto target = ctx.GetStream().GetTargetProperties();
     if(target.Xnack() && *target.Xnack())


### PR DESCRIPTION
https://github.com/ROCmSoftwarePlatform/MIOpen/pull/1619 originally try to fix SWDEV-306318, but introduced large performance regression.
 This PR try to narrow down the non-applicable range, only when 1x1 conv, C is not multiple of 8, this solver is not applicable. This is true for both fp32 and fp16

cc @atamazov 