### PR TITLE
[TensorDescriptor][BugFix] Change vectorLength datatype to std::size_t

### DIFF
--- a/driver/tensor_driver.hpp
+++ b/driver/tensor_driver.hpp
@@ -67,9 +67,9 @@ inline void LengthReorder(std::vector<int>& lens, const std::initializer_list<in
     lens = std::move(out_lens);
 }
 
-inline int GetTensorVectorLength(miopenTensorDescriptor_t& tensor)
+inline std::size_t GetTensorVectorLength(miopenTensorDescriptor_t& tensor)
 {
-    int vectorLength;
+    std::size_t vectorLength;
 
     int size = 0;
     miopenGetTensorDescriptorSize(tensor, &size);

--- a/src/include/miopen/tensor.hpp
+++ b/src/include/miopen/tensor.hpp
@@ -170,7 +170,7 @@ struct TensorDescriptor : miopenTensorDescriptor
     miopenTensorLayout_t GetLayout_t() const;
     std::string GetLayout_str() const;
 
-    int GetVectorLength() const;
+    std::size_t GetVectorLength() const;
 
     std::size_t GetElementSize() const;
 
@@ -247,7 +247,7 @@ private:
     std::vector<std::size_t> strides;
 
     bool packed;
-    int vector_length = 1;
+    std::size_t vector_length = 1;
 
     miopenDataType_t type             = miopenFloat;
     miopenTensorLayout_t tensorLayout = miopenTensorNCHW;

--- a/src/include/miopen/tensor_extra.hpp
+++ b/src/include/miopen/tensor_extra.hpp
@@ -31,8 +31,8 @@ MIOPEN_EXPORT int miopenGetTensorIndex(miopenTensorDescriptor_t tensorDesc,
 
 int miopenGetTensorDescriptorElementSize(miopenTensorDescriptor_t tensorDesc);
 
-MIOPEN_EXPORT miopenStatus_t
-miopenGetNdTensorDescriptorVectorLength(miopenTensorDescriptor_t tensorDesc, int* vectorLength);
+MIOPEN_EXPORT miopenStatus_t miopenGetNdTensorDescriptorVectorLength(
+    miopenTensorDescriptor_t tensorDesc, std::size_t* vectorLength);
 
 MIOPEN_EXPORT miopenStatus_t miopenGet4dTensorDescriptorLengths(
     miopenTensorDescriptor_t tensorDesc, int* n, int* c, int* h, int* w);

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -185,7 +185,7 @@ std::string TensorDescriptor::GetLayout_str() const
     }
     return "Unknown tensor layout";
 }
-int TensorDescriptor::GetVectorLength() const { return this->vector_length; }
+std::size_t TensorDescriptor::GetVectorLength() const { return this->vector_length; }
 
 std::size_t TensorDescriptor::GetIndex(std::initializer_list<int> l) const
 {

--- a/src/tensor_api.cpp
+++ b/src/tensor_api.cpp
@@ -105,8 +105,8 @@ extern "C" miopenStatus_t miopenGet4dTensorDescriptor(miopenTensorDescriptor_t t
 
 // Internal API
 // MD: This should not be required to be exported. Temporary hack
-MIOPEN_EXPORT miopenStatus_t
-miopenGetNdTensorDescriptorVectorLength(miopenTensorDescriptor_t tensorDesc, int* vectorLength)
+MIOPEN_EXPORT miopenStatus_t miopenGetNdTensorDescriptorVectorLength(
+    miopenTensorDescriptor_t tensorDesc, std::size_t* vectorLength)
 {
 
     MIOPEN_LOG_FUNCTION(tensorDesc, vectorLength);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -651,6 +651,11 @@ if(${MIOPEN_TEST_WITH_MIOPENDRIVER})
         COMMAND $<TARGET_FILE:MIOpenDriver> ${MIOPENDRIVER_MODE_BN} -n 256 -c 512 -H 18 -W 18 -m 1 --forw 0 -b 1 -r 1
         COMMAND $<TARGET_FILE:MIOpenDriver> ${MIOPENDRIVER_MODE_BN} -n 256 -c 512 -H 28 -W 28 -m 1 --forw 0 -b 1 -r 1
     )
+
+    add_custom_test(test_miopendriver_big_tensor SKIP_UNLESS_ALL GFX103X_ENABLED
+        # Regression test for https://github.com/ROCmSoftwarePlatform/MIOpen/issues/1661
+        COMMAND MIOPEN_DRIVER_USE_GPU_REFERENCE=1 $<TARGET_FILE:MIOpenDriver> ${MIOPENDRIVER_MODE_CONV} -W 5078 -H 4903 -c 24 -n 5 -k 1 --fil_w 3 --fil_h 3 --pad_w 6 --pad_h 4 -F 1
+    )
 endif()
 
 set(IMPLICITGEMM_ARGS ${MIOPEN_TEST_FLOAT_ARG})


### PR DESCRIPTION
#1661 Found that int type `vectorLength` in `TensorDescriptor` cause incorrect result of `TensorDescriptor::GetElementSize()` when construct big tensor size > 32bits, This PR simply change `vectorLength` and related "Get“ function return type to `std::size_t` to fix the overflow bug.

You can verify the fixing by using the same command in the issue ticket:

`./build/bin/MIOpenDriver conv -W 5078 -H 4903 -c 24 -n 5 -k 1 --fil_w 3 --fil_h 3 --pad_w 6 --pad_h 4 -F 1`

Or I strongly recommend you to add the MIOPEN_USE_GPU_REFERENCE=1 flag, since CPU verification takes long time on the big tensor convolution result.

`MIOPEN_DRIVER_USE_GPU_REFERENCE=1 ./bin/MIOpenDriver conv -W 5078 -H 4903 -c 24 -n 5 -k 1 --fil_w 3 --fil_h 3 --pad_w 6 --pad_h 4 -F 1`

cc: @atamazov 