### PR TITLE
[FP32] [miopengemm][Workaround] Disabled GemmBwd1x1_stride1

### DIFF
--- a/src/include/miopen/solver.hpp
+++ b/src/include/miopen/solver.hpp
@@ -2952,6 +2952,7 @@ struct GemmBwd1x1_stride1 final : GemmBwdBase
 
 private:
     size_t GetWorkspaceSize(const ExecutionContext&, const conv::ProblemDescription&) const;
+    bool IsApplicableBeforeWorkaround(const ExecutionContext&, const conv::ProblemDescription&) const;
     bool IsApplicable(const ExecutionContext&, const conv::ProblemDescription&) const;
     ConvSolution GetSolution(const ExecutionContext&, const conv::ProblemDescription&) const;
 

--- a/src/include/miopen/solver.hpp
+++ b/src/include/miopen/solver.hpp
@@ -2952,7 +2952,8 @@ struct GemmBwd1x1_stride1 final : GemmBwdBase
 
 private:
     size_t GetWorkspaceSize(const ExecutionContext&, const conv::ProblemDescription&) const;
-    bool IsApplicableBeforeWorkaround(const ExecutionContext&, const conv::ProblemDescription&) const;
+    bool IsApplicableBeforeWorkaround(const ExecutionContext&,
+                                      const conv::ProblemDescription&) const;
     bool IsApplicable(const ExecutionContext&, const conv::ProblemDescription&) const;
     ConvSolution GetSolution(const ExecutionContext&, const conv::ProblemDescription&) const;
 

--- a/src/solver/gemm_bwd.cpp
+++ b/src/solver/gemm_bwd.cpp
@@ -412,14 +412,10 @@ size_t GemmBwd1x1_stride1::GetWorkspaceSize(const ExecutionContext&,
     return 0;
 }
 
-bool GemmBwd1x1_stride1::IsApplicable(const ExecutionContext& context,
+bool GemmBwd1x1_stride1::IsApplicableBeforeWorkaround(const ExecutionContext& context,
                                       const conv::ProblemDescription& problem) const
 {
-#if MIOPEN_USE_MIOPENGEMM && WORKAROUND_MIOPENGEMM_ISSUE_59
-    std::ignore = context;
-    std::ignore = problem;
-    return false;
-#elif MIOPEN_USE_GEMM
+#if MIOPEN_USE_GEMM
     if(!GemmBwdBase::IsApplicable(context, problem))
         return false;
 
@@ -432,6 +428,18 @@ bool GemmBwd1x1_stride1::IsApplicable(const ExecutionContext& context,
     return miopen::all_of(wei_spatial, [](auto v) { return v == 1; }) &&
            miopen::all_of(conv.GetConvPads(), [](auto v) { return v == 0; }) &&
            miopen::all_of(conv.GetConvStrides(), [](auto v) { return v == 1; });
+#else
+    std::ignore = context;
+    std::ignore = problem;
+    return false;
+#endif
+}
+
+bool GemmBwd1x1_stride1::IsApplicable(const ExecutionContext& context,
+                                      const conv::ProblemDescription& problem) const
+{
+#if MIOPEN_USE_GEMM && (!MIOPEN_USE_MIOPENGEMM || !WORKAROUND_MIOPENGEMM_ISSUE_59)
+    return IsApplicableBeforeWorkaround(context, problem);
 #else
     std::ignore = context;
     std::ignore = problem;
@@ -634,7 +642,7 @@ bool GemmBwdRest::IsApplicable(const ExecutionContext& context,
         return false;
 
     return !GemmBwd1x1_stride2{}.IsApplicable(context, problem) &&
-           !GemmBwd1x1_stride1{}.IsApplicable(context, problem) &&
+           !GemmBwd1x1_stride1{}.IsApplicableBeforeWorkaround(context, problem) &&
            GetWorkspaceSize(context, problem) > 0;
 #else
     std::ignore = context;

--- a/src/solver/gemm_bwd.cpp
+++ b/src/solver/gemm_bwd.cpp
@@ -42,6 +42,8 @@
 
 MIOPEN_DECLARE_ENV_VAR(MIOPEN_CONV_PRECISE_ROCBLAS_TIMING)
 
+#define WORKAROUND_MIOPENGEMM_ISSUE_59 1
+
 // copy from convolution.cpp
 // Workaround for issue 1430.
 // Vega20 fails to access GPU memory larger than the return value of GetMaxMemoryAllocSize() of
@@ -413,7 +415,11 @@ size_t GemmBwd1x1_stride1::GetWorkspaceSize(const ExecutionContext&,
 bool GemmBwd1x1_stride1::IsApplicable(const ExecutionContext& context,
                                       const conv::ProblemDescription& problem) const
 {
-#if MIOPEN_USE_GEMM
+#if MIOPEN_USE_MIOPENGEMM && WORKAROUND_MIOPENGEMM_ISSUE_59
+    std::ignore = context;
+    std::ignore = problem;
+    return false;
+#elif MIOPEN_USE_GEMM
     if(!GemmBwdBase::IsApplicable(context, problem))
         return false;
 
@@ -437,38 +443,11 @@ ConvSolution GemmBwd1x1_stride1::GetSolution(const ExecutionContext&,
                                              const conv::ProblemDescription& problem) const
 {
 #if MIOPEN_USE_GEMM
-    const auto& dyDesc = problem.GetIn();
-    const auto& wDesc  = problem.GetWeights();
-    const auto& dxDesc = problem.GetOut();
-    const auto& conv   = problem.GetConv();
-
-    const auto group_count = conv.group_count;
-    const auto in_n        = dxDesc.GetLengths()[0];
+    const auto group_count = problem.GetConv().group_count;
+    const auto spatial_dim = problem.GetConv().GetSpatialDimension();
 
     auto solution         = ConvSolution{miopenStatusSuccess};
     solution.workspace_sz = 0;
-
-    // dx = transpose(w) * dy
-    const auto gemm_desc = [&]() {
-        auto tmp = group_count > 1
-                       ? CreateGemmDescriptorGroupConvBwdData(wDesc, dyDesc, dxDesc, group_count)
-                       : CreateGemmStridedBatchedDescriptorConv1x1BwdData(wDesc, dyDesc, dxDesc);
-        tmp.deterministic = problem.GetConv().attribute.deterministic;
-        return tmp;
-    }();
-    const auto in_c = dxDesc.GetLengths()[1];
-
-    const auto wei_k = wDesc.GetLengths()[0];
-
-    const auto spatial_dim = conv.GetSpatialDimension();
-    const auto in_spatial  = boost::adaptors::slice(dxDesc.GetLengths(), 2, 2 + spatial_dim);
-    const auto out_spatial = boost::adaptors::slice(dyDesc.GetLengths(), 2, 2 + spatial_dim);
-
-    std::size_t out_spatial_size = std::accumulate(
-        out_spatial.begin(), out_spatial.end(), std::size_t(1), std::multiplies<std::size_t>());
-
-    std::size_t in_spatial_size = std::accumulate(
-        in_spatial.begin(), in_spatial.end(), std::size_t(1), std::multiplies<std::size_t>());
 
     solution.invoker_factory = [=](const std::vector<Kernel>&) {
         const bool time_precision = (!IsDisabled(MIOPEN_CONV_PRECISE_ROCBLAS_TIMING{}));
@@ -478,6 +457,38 @@ ConvSolution GemmBwd1x1_stride1::GetSolution(const ExecutionContext&,
             const auto& dy          = conv_params.tensors.in;
             const auto& w           = conv_params.tensors.w;
             const auto& dx          = conv_params.tensors.out;
+            const auto& dyDesc      = conv_params.tensors.inDesc;
+            const auto& wDesc       = conv_params.tensors.wDesc;
+            const auto& dxDesc      = conv_params.tensors.outDesc;
+
+            const auto in_n = dxDesc.GetLengths()[0];
+
+            // dx = transpose(w) * dy
+            const auto gemm_desc = [&]() {
+                auto tmp =
+                    group_count > 1
+                        ? CreateGemmDescriptorGroupConvBwdData(wDesc, dyDesc, dxDesc, group_count)
+                        : CreateGemmStridedBatchedDescriptorConv1x1BwdData(wDesc, dyDesc, dxDesc);
+                tmp.deterministic = problem.GetConv().attribute.deterministic;
+                return tmp;
+            }();
+
+            const auto in_c  = dxDesc.GetLengths()[1];
+            const auto wei_k = wDesc.GetLengths()[0];
+
+            const auto in_spatial = boost::adaptors::slice(dxDesc.GetLengths(), 2, 2 + spatial_dim);
+            const auto out_spatial =
+                boost::adaptors::slice(dyDesc.GetLengths(), 2, 2 + spatial_dim);
+
+            std::size_t out_spatial_size = std::accumulate(out_spatial.begin(),
+                                                           out_spatial.end(),
+                                                           std::size_t(1),
+                                                           std::multiplies<std::size_t>());
+
+            std::size_t in_spatial_size = std::accumulate(in_spatial.begin(),
+                                                          in_spatial.end(),
+                                                          std::size_t(1),
+                                                          std::multiplies<std::size_t>());
 
             if(group_count > 1)
             {

--- a/src/solver/gemm_bwd.cpp
+++ b/src/solver/gemm_bwd.cpp
@@ -462,17 +462,6 @@ ConvSolution GemmBwd1x1_stride1::GetSolution(const ExecutionContext&,
     auto solution         = ConvSolution{miopenStatusSuccess};
     solution.workspace_sz = 0;
 
-    const auto& dyDesc = problem.GetIn();
-    const auto& wDesc  = problem.GetWeights();
-    const auto& dxDesc = problem.GetOut();
-    const auto& conv   = problem.GetConv();
-
-    const auto group_count = conv.group_count;
-    const auto in_n        = dxDesc.GetLengths()[0];
-
-    auto solution         = ConvSolution{miopenStatusSuccess};
-    solution.workspace_sz = 0;
-
     // dx = transpose(w) * dy
     const auto gemm_desc = [&]() {
         auto tmp = group_count > 1

--- a/src/solver/gemm_bwd.cpp
+++ b/src/solver/gemm_bwd.cpp
@@ -413,7 +413,7 @@ size_t GemmBwd1x1_stride1::GetWorkspaceSize(const ExecutionContext&,
 }
 
 bool GemmBwd1x1_stride1::IsApplicableBeforeWorkaround(const ExecutionContext& context,
-                                      const conv::ProblemDescription& problem) const
+                                                      const conv::ProblemDescription& problem) const
 {
 #if MIOPEN_USE_GEMM
     if(!GemmBwdBase::IsApplicable(context, problem))

--- a/src/solver/gemm_bwd.cpp
+++ b/src/solver/gemm_bwd.cpp
@@ -451,12 +451,49 @@ ConvSolution GemmBwd1x1_stride1::GetSolution(const ExecutionContext&,
                                              const conv::ProblemDescription& problem) const
 {
 #if MIOPEN_USE_GEMM
-    const auto group_count = problem.GetConv().group_count;
-    const auto spatial_dim = problem.GetConv().GetSpatialDimension();
+    const auto& dyDesc = problem.GetIn();
+    const auto& wDesc  = problem.GetWeights();
+    const auto& dxDesc = problem.GetOut();
+    const auto& conv   = problem.GetConv();
+
+    const auto group_count = conv.group_count;
+    const auto in_n        = dxDesc.GetLengths()[0];
 
     auto solution         = ConvSolution{miopenStatusSuccess};
     solution.workspace_sz = 0;
 
+    const auto& dyDesc = problem.GetIn();
+    const auto& wDesc  = problem.GetWeights();
+    const auto& dxDesc = problem.GetOut();
+    const auto& conv   = problem.GetConv();
+
+    const auto group_count = conv.group_count;
+    const auto in_n        = dxDesc.GetLengths()[0];
+
+    auto solution         = ConvSolution{miopenStatusSuccess};
+    solution.workspace_sz = 0;
+
+    // dx = transpose(w) * dy
+    const auto gemm_desc = [&]() {
+        auto tmp = group_count > 1
+                       ? CreateGemmDescriptorGroupConvBwdData(wDesc, dyDesc, dxDesc, group_count)
+                       : CreateGemmStridedBatchedDescriptorConv1x1BwdData(wDesc, dyDesc, dxDesc);
+        tmp.deterministic = problem.GetConv().attribute.deterministic;
+        return tmp;
+    }();
+    const auto in_c = dxDesc.GetLengths()[1];
+
+    const auto wei_k = wDesc.GetLengths()[0];
+
+    const auto spatial_dim = conv.GetSpatialDimension();
+    const auto in_spatial  = boost::adaptors::slice(dxDesc.GetLengths(), 2, 2 + spatial_dim);
+    const auto out_spatial = boost::adaptors::slice(dyDesc.GetLengths(), 2, 2 + spatial_dim);
+
+    std::size_t out_spatial_size = std::accumulate(
+        out_spatial.begin(), out_spatial.end(), std::size_t(1), std::multiplies<std::size_t>());
+
+    std::size_t in_spatial_size = std::accumulate(
+        in_spatial.begin(), in_spatial.end(), std::size_t(1), std::multiplies<std::size_t>());
     solution.invoker_factory = [=](const std::vector<Kernel>&) {
         const bool time_precision = (!IsDisabled(MIOPEN_CONV_PRECISE_ROCBLAS_TIMING{}));
 
@@ -465,38 +502,6 @@ ConvSolution GemmBwd1x1_stride1::GetSolution(const ExecutionContext&,
             const auto& dy          = conv_params.tensors.in;
             const auto& w           = conv_params.tensors.w;
             const auto& dx          = conv_params.tensors.out;
-            const auto& dyDesc      = conv_params.tensors.inDesc;
-            const auto& wDesc       = conv_params.tensors.wDesc;
-            const auto& dxDesc      = conv_params.tensors.outDesc;
-
-            const auto in_n = dxDesc.GetLengths()[0];
-
-            // dx = transpose(w) * dy
-            const auto gemm_desc = [&]() {
-                auto tmp =
-                    group_count > 1
-                        ? CreateGemmDescriptorGroupConvBwdData(wDesc, dyDesc, dxDesc, group_count)
-                        : CreateGemmStridedBatchedDescriptorConv1x1BwdData(wDesc, dyDesc, dxDesc);
-                tmp.deterministic = problem.GetConv().attribute.deterministic;
-                return tmp;
-            }();
-
-            const auto in_c  = dxDesc.GetLengths()[1];
-            const auto wei_k = wDesc.GetLengths()[0];
-
-            const auto in_spatial = boost::adaptors::slice(dxDesc.GetLengths(), 2, 2 + spatial_dim);
-            const auto out_spatial =
-                boost::adaptors::slice(dyDesc.GetLengths(), 2, 2 + spatial_dim);
-
-            std::size_t out_spatial_size = std::accumulate(out_spatial.begin(),
-                                                           out_spatial.end(),
-                                                           std::size_t(1),
-                                                           std::multiplies<std::size_t>());
-
-            std::size_t in_spatial_size = std::accumulate(in_spatial.begin(),
-                                                          in_spatial.end(),
-                                                          std::size_t(1),
-                                                          std::multiplies<std::size_t>());
 
             if(group_count > 1)
             {


### PR DESCRIPTION
Workaround for https://github.com/ROCmSoftwarePlatform/MIOpenGEMM/issues/59.
As in title, disables on backward gemm solver for MIOpenGEMM, which failes on CI.
This blocks #1503