### PR TITLE
[NFC] Removed miopen::ConvolutionUserBuffers

### DIFF
--- a/fin/src/include/conv_fin.hpp
+++ b/fin/src/include/conv_fin.hpp
@@ -986,21 +986,6 @@ int ConvFin<Tgpu, Tref>::MIOpenFind()
     std::ostringstream ss;
     problem.Serialize(ss);
     output["db_key"] = ss.str();
-    miopen::ConvolutionUserBuffers bufs(workspace.gpuData.buf.get(), workspace.desc.GetNumBytes());
-    if(conv_dir == miopen::conv::Direction::Forward)
-        bufs.SetFwd(inputTensor.gpuData.buf.get(),
-                    weightTensor.gpuData.buf.get(),
-                    outputTensor.gpuData.buf.get());
-    else if(conv_dir == miopen::conv::Direction::BackwardData)
-        bufs.SetBwd(inputTensor.gpuData.buf.get(),
-                    weightTensor.gpuData.buf.get(),
-                    outputTensor.gpuData.buf.get());
-    else if(conv_dir == miopen::conv::Direction::BackwardWeights)
-        bufs.SetWrW(inputTensor.gpuData.buf.get(),
-                    weightTensor.gpuData.buf.get(),
-                    outputTensor.gpuData.buf.get());
-
-    ctx.SetBufs(bufs);
 
     auto db = GetDb(ctx);
     json find_result;

--- a/src/include/miopen/conv/context.hpp
+++ b/src/include/miopen/conv/context.hpp
@@ -38,57 +38,6 @@ struct ConvolutionDescriptor;
 struct Handle;
 struct TensorDescriptor;
 
-struct ConvolutionUserBuffers
-{
-    union
-    {
-        struct Fwd
-        {
-            ConstData_t x;
-            ConstData_t w;
-            Data_t y;
-        } fwd;
-        struct Bwd
-        {
-            Data_t dx;
-            ConstData_t w;
-            ConstData_t dy;
-        } bwd;
-        struct WrW
-        {
-            ConstData_t dx;
-            Data_t dw;
-            ConstData_t dy;
-        } wrw;
-    } io;
-    Data_t workSpace;
-    size_t workSpaceSize;
-    ConstData_t bias;
-    ConvolutionUserBuffers(Data_t w, size_t s, ConstData_t b = nullptr)
-        : io({{nullptr, nullptr, nullptr}}), workSpace(w), workSpaceSize(s), bias(b)
-    {
-    }
-    ConvolutionUserBuffers() : ConvolutionUserBuffers(nullptr, 0, nullptr) {}
-    void SetFwd(ConstData_t x, ConstData_t w, Data_t y)
-    {
-        io.fwd.x = x;
-        io.fwd.y = y;
-        io.fwd.w = w;
-    }
-    void SetBwd(Data_t dx, ConstData_t w, ConstData_t dy)
-    {
-        io.bwd.dx = dx;
-        io.bwd.dy = dy;
-        io.bwd.w  = w;
-    }
-    void SetWrW(ConstData_t dx, Data_t dw, ConstData_t dy)
-    {
-        io.wrw.dx = dx;
-        io.wrw.dy = dy;
-        io.wrw.dw = dw;
-    }
-};
-
 /// A leftover of the legacy design, houses problem config,
 /// environmental context (e.g. HW/SW platform) and solver-specific state.
 ///
@@ -116,13 +65,7 @@ struct ConvolutionContext : ExecutionContext
 public:
     bool is_for_generic_search = false;
 
-    inline void SetBufs(const ConvolutionUserBuffers& bufs) { _bufs = bufs; }
-    inline const ConvolutionUserBuffers& GetBufs() const { return _bufs; }
-
     ProblemDescription problem;
-
-private:
-    ConvolutionUserBuffers _bufs;
 };
 
 } // namespace miopen

--- a/src/include/miopen/convolution.hpp
+++ b/src/include/miopen/convolution.hpp
@@ -59,7 +59,6 @@ struct ExecutionContext;
 struct ConvolutionContext;
 struct Handle;
 struct TensorDescriptor;
-struct ConvolutionUserBuffers;
 struct ProblemDescription;
 
 using ExtraKernelArgs = std::tuple<int /*N*/,
@@ -204,7 +203,6 @@ struct ConvolutionDescriptor : miopenConvolutionDescriptor
                             const TensorDescriptor& yDesc,
                             bool exhaustiveSearch,
                             bool isForward,
-                            const ConvolutionUserBuffers& bufs,
                             const AnyInvokeParams& invoke_ctx) const;
 
     std::vector<miopen::solver::ConvSolution>
@@ -220,7 +218,6 @@ struct ConvolutionDescriptor : miopenConvolutionDescriptor
                                   const TensorDescriptor& yDesc,
                                   bool exhaustiveSearch,
                                   bool isForward,
-                                  const ConvolutionUserBuffers& bufs,
                                   const AnyInvokeParams& invoke_ctx) const;
 
     std::vector<miopen::solver::ConvSolution>

--- a/src/include/miopen/mlo_internal.hpp
+++ b/src/include/miopen/mlo_internal.hpp
@@ -394,10 +394,6 @@ struct mlo_construct_activ_lrn_pooling_common : mlo_construct_base
 
     void setupFloats();
 
-    inline void setBufs(const miopen::ConvolutionUserBuffers& bufs)
-    {
-        _search_params.SetBufs(bufs);
-    }
     /*
      * set top tensor
      */

--- a/src/include/miopen/solver.hpp
+++ b/src/include/miopen/solver.hpp
@@ -1687,7 +1687,8 @@ struct ConvOclDirectFwdLegacyExhaustiveSearch : ConvTunableSolver<LegacyPerforma
 
 private:
     template <typename Tgpu>
-    LegacyPerformanceConfig SearchImpl(const ConvolutionContext&) const;
+    LegacyPerformanceConfig SearchImpl(const ConvolutionContext&,
+                                       const AnyInvokeParams& invoke_ctx) const;
 };
 
 struct ConvOclDirectFwd : ConvOclDirectFwdLegacyExhaustiveSearch

--- a/src/ocl/convolutionocl.cpp
+++ b/src/ocl/convolutionocl.cpp
@@ -390,16 +390,14 @@ static void DirConvFindCore(Handle& handle,
     }();
     const auto gemm = !use_winograd_only ? conv.FindDataGemmSolutions(ctx, invoke_ctx)
                                          : std::vector<miopen::solver::ConvSolution>{};
-    const auto direct =
-        !use_winograd_only
-            ? conv.FindDataDirectSolutions(
-                  handle, xDesc, wDesc, yDesc, exhaustiveSearch, true, invoke_ctx)
-            : std::vector<miopen::solver::ConvSolution>{};
-    const auto igemm =
-        !use_winograd_only
-            ? conv.FindDataImplicitGemmSolutions(
-                  handle, xDesc, wDesc, yDesc, exhaustiveSearch, true, invoke_ctx)
-            : std::vector<miopen::solver::ConvSolution>{};
+    const auto direct = !use_winograd_only
+                            ? conv.FindDataDirectSolutions(
+                                  handle, xDesc, wDesc, yDesc, exhaustiveSearch, true, invoke_ctx)
+                            : std::vector<miopen::solver::ConvSolution>{};
+    const auto igemm = !use_winograd_only
+                           ? conv.FindDataImplicitGemmSolutions(
+                                 handle, xDesc, wDesc, yDesc, exhaustiveSearch, true, invoke_ctx)
+                           : std::vector<miopen::solver::ConvSolution>{};
     const auto fft = !use_winograd_only ? conv.FindFftSolutions(ctx, invoke_ctx)
                                         : std::vector<miopen::solver::ConvSolution>{};
 

--- a/src/ocl/convolutionocl.cpp
+++ b/src/ocl/convolutionocl.cpp
@@ -205,7 +205,6 @@ ConvolutionDescriptor::FindDataDirectSolutions(Handle& handle,
     ctx.save_srch_req              = true;
     ctx.general_compile_options    = "";
     ctx.SetStream(&handle);
-    ctx.SetBufs(bufs);
     ctx.DetectRocm();
     ctx.SetupFloats();
 
@@ -241,7 +240,6 @@ ConvolutionDescriptor::FindDataImplicitGemmSolutions(Handle& handle,
     ctx.save_srch_req              = true;
     ctx.general_compile_options    = "";
     ctx.SetStream(&handle);
-    ctx.SetBufs(bufs);
     ctx.DetectRocm();
     ctx.SetupFloats();
 

--- a/src/solver/conv_ocl_dir2Dfwd_exhaustive_search.cpp
+++ b/src/solver/conv_ocl_dir2Dfwd_exhaustive_search.cpp
@@ -298,7 +298,7 @@ ConvOclDirectFwdLegacyExhaustiveSearch::SearchImpl(const ConvolutionContext& par
     const auto wei_ocl_ptr    = invoke_params.tensors.w;
     // There was no place in the source, where it has been actual set to something other than
     // nullptr.
-    const auto bias_ocl_ptr = (Data_t) nullptr;
+    const auto bias_ocl_ptr = static_cast<Data_t>(nullptr);
 #endif
     AutoEnableProfiling enableProfiling{profile_h};
 

--- a/src/solver/conv_ocl_dir2Dfwd_exhaustive_search.cpp
+++ b/src/solver/conv_ocl_dir2Dfwd_exhaustive_search.cpp
@@ -296,7 +296,7 @@ ConvOclDirectFwdLegacyExhaustiveSearch::SearchImpl(const ConvolutionContext& par
     const auto bot_ocl_ptr    = invoke_params.tensors.in;
     const auto top_ocl_ptr    = invoke_params.tensors.out;
     const auto wei_ocl_ptr    = invoke_params.tensors.w;
-    // There was no place in the source, where it has been actual set to something other than
+    // There was no place in the source, where it has been actually set to something other than
     // nullptr.
     const auto bias_ocl_ptr = static_cast<Data_t>(nullptr);
 #endif

--- a/src/solver/conv_ocl_dir2Dfwd_exhaustive_search.cpp
+++ b/src/solver/conv_ocl_dir2Dfwd_exhaustive_search.cpp
@@ -24,11 +24,13 @@
  *
  *******************************************************************************/
 
+#include <miopen/solver.hpp>
+
 #include <miopen/allocator.hpp>
+#include <miopen/conv/data_invoke_params.hpp>
 #include <miopen/db_path.hpp>
 #include <miopen/handle.hpp>
 #include <miopen/legacy_exhaustive_search.hpp>
-#include <miopen/solver.hpp>
 #include <miopen/bfloat16.hpp>
 
 #include <half.hpp>
@@ -209,14 +211,14 @@ static int MeasurePerfConfig(const Handle& handle,
 
 LegacyPerformanceConfig
 ConvOclDirectFwdLegacyExhaustiveSearch::Search(const ConvolutionContext& params,
-                                               const AnyInvokeParams&) const
+                                               const AnyInvokeParams& invoke_ctx) const
 {
     if(params.problem.IsFp16())
-        return SearchImpl<half_float::half>(params);
+        return SearchImpl<half_float::half>(params, invoke_ctx);
     else if(params.problem.IsFp32())
-        return SearchImpl<float>(params);
+        return SearchImpl<float>(params, invoke_ctx);
     else if(params.problem.IsBfp16())
-        return SearchImpl<bfloat16>(params);
+        return SearchImpl<bfloat16>(params, invoke_ctx);
     else
     {
         MIOPEN_THROW("Unsupported float_size");
@@ -225,7 +227,8 @@ ConvOclDirectFwdLegacyExhaustiveSearch::Search(const ConvolutionContext& params,
 
 template <typename Tgpu>
 LegacyPerformanceConfig
-ConvOclDirectFwdLegacyExhaustiveSearch::SearchImpl(const ConvolutionContext& params) const
+ConvOclDirectFwdLegacyExhaustiveSearch::SearchImpl(const ConvolutionContext& params,
+                                                   const AnyInvokeParams& invoke_ctx) const
 {
     LegacyPerformanceConfig result;
     bool is_passed = false;
@@ -288,14 +291,14 @@ ConvOclDirectFwdLegacyExhaustiveSearch::SearchImpl(const ConvolutionContext& par
     }
     auto bias_ocl_ptr = bias_ocl_buf.get();
 #else
-    auto& profile_h  = params.GetStream();
-    auto bot_ocl_ptr = params.problem.direction.IsForward() ? params.GetBufs().io.fwd.x
-                                                            : params.GetBufs().io.bwd.dy;
-    auto top_ocl_ptr = params.problem.direction.IsForward() ? params.GetBufs().io.fwd.y
-                                                            : params.GetBufs().io.bwd.dx;
-    auto wei_ocl_ptr = params.problem.direction.IsForward() ? params.GetBufs().io.fwd.w
-                                                            : params.GetBufs().io.bwd.w;
-    auto bias_ocl_ptr = params.GetBufs().bias;
+    auto& profile_h           = params.GetStream();
+    const auto& invoke_params = invoke_ctx.CastTo<conv::DataInvokeParams>();
+    const auto bot_ocl_ptr    = invoke_params.tensors.in;
+    const auto top_ocl_ptr    = invoke_params.tensors.out;
+    const auto wei_ocl_ptr    = invoke_params.tensors.w;
+    // There was no place in the source, where it has been actual set to something other than
+    // nullptr.
+    const auto bias_ocl_ptr = (Data_t) nullptr;
 #endif
     AutoEnableProfiling enableProfiling{profile_h};
 


### PR DESCRIPTION
Dead code elimination.
`miopen::ConvolutionUserBuffers` was not used anywhere and only passed and initialized.
It has been spreading some confusion and even propagated around a bit.