### PR TITLE
[Proactive][Fix][Performance] Winograd applicability for WrW direction

### DIFF
--- a/src/solver/conv_winoRxS.cpp
+++ b/src/solver/conv_winoRxS.cpp
@@ -531,7 +531,7 @@ bool ConvBinWinoRxS<Winodata, Winofilter>::IsApplicable(const ConvolutionContext
         if(miopen::IsDisabled(MIOPEN_DEBUG_AMD_WINOGRAD_RXS_F2X3{}))
             return false;
 #if !WORKAROUND_ISSUE_1681
-        if(params.problem.group_counts == 1)
+        if(params.problem.group_counts == 1 && !params.problem.direction.IsBackwardWrW())
             return false;
 #endif
     }
@@ -913,6 +913,10 @@ bool ConvBinWinogradRxSf2x3g1::IsApplicable(const ConvolutionContext& params) co
 {
     if(miopen::IsDisabled(MIOPEN_DEBUG_AMD_WINOGRAD_RXS_F2X3_G1{}))
         return false;
+#if !WORKAROUND_ISSUE_1681
+    if(params.problem.direction.IsBackwardWrW())
+        return false;
+#endif
     return IsApplicableBase(params) && params.problem.group_counts == 1;
 }
 


### PR DESCRIPTION
WrW direction is only supported by grouped Winograd kernels (`ConvBinWinogradRxSf2x3` solver) and must be disabled for `ConvBinWinogradRxSf2x3g1` solver.

Perf/Find DB are not affected, but they will be affected once the full blown fix for #1681 is implemented.