### PR TITLE
[HotFix] Fix MIOpen dependencies build issues and sync CK version

### DIFF
--- a/install_deps.cmake
+++ b/install_deps.cmake
@@ -110,6 +110,7 @@ if(DEFINED CMAKE_TOOLCHAIN_FILE)
 endif()
 # Initialize directory
 cget(init ${TOOLCHAIN_FLAG} -DCMAKE_INSTALL_RPATH=${PREFIX}/lib ${PARSE_UNPARSED_ARGUMENTS})
+cget(ignore pcre)
 
 # Install dependencies
 cget(install -U pfultz2/rocm-recipes)

--- a/rbuild.ini
+++ b/rbuild.ini
@@ -1,6 +1,7 @@
 [main]
 cxx = ${rocm_path}/llvm/bin/clang++
 cc = ${rocm_path}/llvm/bin/clang
+ignore = pcre
 deps =
     ROCmSoftwarePlatform/rocm-recipes
     -f requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ boost@1.79 -DCMAKE_POSITION_INDEPENDENT_CODE=On --build
 half,https://github.com/pfultz2/half/archive/1.12.0.tar.gz -X header -H sha256:0a08660b68abb176ebc2a0cdf8de46e3182a7f46c66443bb80dbfaaec98cf969 --build
 ROCmSoftwarePlatform/llvm-project-mlir@rocm-5.3.0 -H sha256:ee5093aad5459773c350205ef937a186a20994b42798106f8126b9914ad099a5 -DBUILD_FAT_LIBMLIRMIOPEN=1
 nlohmann/json@v3.9.1 -DJSON_MultipleHeaders=ON -DJSON_BuildTests=Off
-ROCmSoftwarePlatform/composable_kernel@7589116121f80189f47cfd8692f300ee8c6377ad -D CMAKE_CXX_FLAGS=" --offload-arch=gfx900 --offload-arch=gfx906 --offload-arch=gfx908 --offload-arch=gfx90a --offload-arch=gfx1030 -O3 " 
+ROCmSoftwarePlatform/composable_kernel@91d8b7d67ae9dbf8a6e691ea3e17c0b9705c6ba7 -D CMAKE_CXX_FLAGS=" --offload-arch=gfx900 --offload-arch=gfx906 --offload-arch=gfx908 --offload-arch=gfx90a --offload-arch=gfx1030 -O3 " 


### PR DESCRIPTION
@JehandadKhan Thanks for the branch, this PR is needed to let `develop` passing builds on the docker images provided by CQE
1. Fix `pcre` dependency issue: the `cppcheck` version in Composable Kernel depends on an outdated URL of it, so we are ignoring it here; (BTW~ CK should be removing that dependency?)
2. Fix CK sync issue, when enabled, CK should provide the APIs expected from MIOpen.