### PR TITLE
ConvBinWinoRxS GetSolverDbId naming fix

### DIFF
--- a/src/include/miopen/solver.hpp
+++ b/src/include/miopen/solver.hpp
@@ -1937,15 +1937,9 @@ struct PerformanceConfigConvBinWinogradRxS : PerfConfigBase<PerformanceConfigCon
 template <int Winodata, int Winofilter>
 struct ConvBinWinoRxS final : ConvTunableSolver<PerformanceConfigConvBinWinogradRxS>
 {
-    const std::string& SolverDbId() const override { return GetSolverDbId(); }
-
-    static const std::string& GetSolverDbId()
+    const std::string& SolverDbId() const override
     {
-        static const std::string dbId = std::string("ConvBinWinogradRxSf")
-                                            .append(std::to_string(Winodata))
-                                            .append("x")
-                                            .append(std::to_string(Winofilter));
-        return dbId;
+        return GetSolverDbId<ConvBinWinoRxS<Winodata, Winofilter>>();
     }
 
     PerformanceConfigConvBinWinogradRxS


### PR DESCRIPTION
Fixes the issue of getting the 
ConvBinWinoRxS solver DbId as:

- ConvBinWinoRxS<2, 3>
- ConvBinWinoRxS<3, 2> 

after rename in https://github.com/ROCmSoftwarePlatform/MIOpen/pull/1533