### PR TITLE
[Solvers] ConvWinograd3x3MultipassWrW: fix implicit conversion

### DIFF
--- a/src/include/miopen/conv/context.hpp
+++ b/src/include/miopen/conv/context.hpp
@@ -58,7 +58,7 @@ struct ConvolutionContext : ExecutionContext
         : problem(in, weights, out, conv, dir, bias_)
     {
     }
-    ConvolutionContext(const ProblemDescription& problem_) : problem(problem_) {}
+    explicit ConvolutionContext(const ProblemDescription& problem_) : problem(problem_) {}
     ConvolutionContext(const conv::ProblemDescription& problem_, const ExecutionContext& ctx)
         : ExecutionContext(ctx), problem(problem_)
     {

--- a/src/include/miopen/solver.hpp
+++ b/src/include/miopen/solver.hpp
@@ -2249,14 +2249,14 @@ struct ConvWinograd3x3MultipassWrW final : ConvSolver
 
     static int GetGroupCountMult() { return 4; }
 
-    static int GetSolverWinoXformHWSize(const miopen::ConvolutionContext& ctx, int id)
+    static int GetSolverWinoXformHWSize(const ProblemDescription& problem, int id)
     {
         if(id == 0)
             return WinoDataH +
-                   (WinoFilterH - 1) * (WinoDataH == 7 ? 2 : ctx.problem.kernel_stride_h);
+                   (WinoFilterH - 1) * (WinoDataH == 7 ? 2 : problem.kernel_stride_h);
         else
             return WinoDataW +
-                   (WinoFilterW - 1) * (WinoDataW == 7 ? 2 : ctx.problem.kernel_stride_w);
+                   (WinoFilterW - 1) * (WinoDataW == 7 ? 2 : problem.kernel_stride_w);
     }
 
 private:

--- a/src/include/miopen/solver.hpp
+++ b/src/include/miopen/solver.hpp
@@ -2252,11 +2252,9 @@ struct ConvWinograd3x3MultipassWrW final : ConvSolver
     static int GetSolverWinoXformHWSize(const ProblemDescription& problem, int id)
     {
         if(id == 0)
-            return WinoDataH +
-                   (WinoFilterH - 1) * (WinoDataH == 7 ? 2 : problem.kernel_stride_h);
+            return WinoDataH + (WinoFilterH - 1) * (WinoDataH == 7 ? 2 : problem.kernel_stride_h);
         else
-            return WinoDataW +
-                   (WinoFilterW - 1) * (WinoDataW == 7 ? 2 : problem.kernel_stride_w);
+            return WinoDataW + (WinoFilterW - 1) * (WinoDataW == 7 ? 2 : problem.kernel_stride_w);
     }
 
 private:

--- a/src/solver/conv_multipass_wino3x3WrW.cpp
+++ b/src/solver/conv_multipass_wino3x3WrW.cpp
@@ -596,8 +596,8 @@ ConvWinograd3x3MultipassWrW<WinoDataH, WinoFilterH, WinoDataW, WinoFilterW>::Pre
             K, C, R, S,
             GetTypeSize(params.problem.weights_data_type));
 
-    int wino_xform_h = GetSolverWinoXformHWSize(params,0),
-        wino_xform_w = GetSolverWinoXformHWSize(params,1);
+    int wino_xform_h = GetSolverWinoXformHWSize(params.problem, 0),
+        wino_xform_w = GetSolverWinoXformHWSize(params.problem, 1);
     WinogradBufferInfo <WinoDataH, WinoFilterH, WinoDataW, WinoFilterW>
         // cppcheck-suppress unreadVariable
         wino_in(N,K,C,out_H,out_W,R,S,


### PR DESCRIPTION
List of changes:

- Implicit conversion from `ProblemDescription` to `ConvolutionContext` has been fixed
- `ConvolutionContext` constructor taking `ProblemDescription` has been marked `explicit` to avoid similar cases in the future (see https://github.com/ROCmSoftwarePlatform/MIOpen/pull/1778#pullrequestreview-1122522467)