### PR TITLE
Fixed MLIR kernel count retrieval

### DIFF
--- a/src/solver/conv_mlir_igemm_bwd.cpp
+++ b/src/solver/conv_mlir_igemm_bwd.cpp
@@ -90,7 +90,7 @@ ConvSolution ConvMlirIgemmBwd::GetSolution(const ConvolutionContext& ctx,
 {
 #if MIOPEN_USE_MLIR
     ConvSolution result;
-    int kernel_count = MiirGetKernelCount(mlir::ConstructBuildOptions(ctx, false));
+    int kernel_count = MiirGetKernelCount(mlir::ConstructBuildOptions(ctx, config, false));
 
     for(int kernel_id = 0; kernel_id < kernel_count; ++kernel_id)
     {

--- a/src/solver/conv_mlir_igemm_bwd_xdlops.cpp
+++ b/src/solver/conv_mlir_igemm_bwd_xdlops.cpp
@@ -85,7 +85,7 @@ ConvSolution ConvMlirIgemmBwdXdlops::GetSolution(const ConvolutionContext& ctx,
 {
 #if MIOPEN_USE_MLIR
     ConvSolution result;
-    int kernel_count = MiirGetKernelCount(mlir::ConstructBuildOptions(ctx, true));
+    int kernel_count = MiirGetKernelCount(mlir::ConstructBuildOptions(ctx, config, true));
 
     for(int kernel_id = 0; kernel_id < kernel_count; ++kernel_id)
     {

--- a/src/solver/conv_mlir_igemm_fwd.cpp
+++ b/src/solver/conv_mlir_igemm_fwd.cpp
@@ -91,7 +91,7 @@ bool PerformanceConvMlirIgemm::IsValid(const ConvolutionContext& ctx) const
     if(*this == MlirHeuristicInitRequest())
         return true;
 
-    int kernel_count = MiirGetKernelCount(mlir::ConstructBuildOptions(ctx, false));
+    int kernel_count = MiirGetKernelCount(mlir::ConstructBuildOptions(ctx, *this, false));
     bool isValid     = false;
     for(int kernel_id = 0; kernel_id < kernel_count; ++kernel_id)
     {

--- a/src/solver/conv_mlir_igemm_fwd_xdlops.cpp
+++ b/src/solver/conv_mlir_igemm_fwd_xdlops.cpp
@@ -127,7 +127,7 @@ bool PerformanceConvMlirIgemmXdlops::IsValid(const ConvolutionContext& ctx) cons
     if(*this == MlirHeuristicInitRequest())
         return true;
 
-    int kernel_count = MiirGetKernelCount(mlir::ConstructBuildOptions(ctx, true));
+    int kernel_count = MiirGetKernelCount(mlir::ConstructBuildOptions(ctx, *this, true));
     bool isValid     = false;
     for(int kernel_id = 0; kernel_id < kernel_count; ++kernel_id)
     {

--- a/src/solver/conv_mlir_igemm_wrw_xdlops.cpp
+++ b/src/solver/conv_mlir_igemm_wrw_xdlops.cpp
@@ -86,7 +86,7 @@ ConvSolution ConvMlirIgemmWrWXdlops::GetSolution(const ConvolutionContext& ctx,
 {
 #if MIOPEN_USE_MLIR
     ConvSolution result;
-    int kernel_count = MiirGetKernelCount(mlir::ConstructBuildOptions(ctx, true));
+    int kernel_count = MiirGetKernelCount(mlir::ConstructBuildOptions(ctx, config, true));
 
     for(int kernel_id = 0; kernel_id < kernel_count; ++kernel_id)
     {


### PR DESCRIPTION
This commit fixes the kernel count retrieval
to include perf_config used as part of the string
that is generated to pass to the Miir API.

Note this does not change the API per se but
includes extra information (additive) to passed
on to rocMLIR side.