### PR TITLE
[MLIR] Bumping release tag to rocm-5.4.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 sqlite3@3.17 -DCMAKE_POSITION_INDEPENDENT_CODE=On
 boost@1.79 -DCMAKE_POSITION_INDEPENDENT_CODE=On --build
 half,https://github.com/pfultz2/half/archive/1.12.0.tar.gz -X header -H sha256:0a08660b68abb176ebc2a0cdf8de46e3182a7f46c66443bb80dbfaaec98cf969 --build
-ROCmSoftwarePlatform/rocMLIR@11f2e26f193d398cc67f00d9b8e5a58504a14092  -DBUILD_FAT_LIBROCKCOMPILER=1
+ROCmSoftwarePlatform/rocMLIR@rocm-5.4.0 -H sha256:3823f455ee392118c3281e27d45fa0e5381f3c4070eb4e06ba13bc6b34a90a60 -DBUILD_FAT_LIBROCKCOMPILER=1
 nlohmann/json@v3.9.1 -DJSON_MultipleHeaders=ON -DJSON_BuildTests=Off
 ROCmSoftwarePlatform/composable_kernel@2c6d63d0317d1a765b4e9f9b85177bb51a373b88 -DGPU_TARGETS="gfx900;gfx906;gfx908;gfx90a;gfx1030"


### PR DESCRIPTION
All regression tests have passed for the rocm-5.4.0 tag.