### PR TITLE
[Solvers] ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC: split ConvolutionContext and ProblemDescription (stage 2)

### DIFF
--- a/src/include/miopen/solver.hpp
+++ b/src/include/miopen/solver.hpp
@@ -4316,10 +4316,7 @@ struct PerformanceConfigAsmImplicitGemmGTCWrwXdlopsNHWC : PerformanceConfigAsmIm
     void HeuristicInit(const ConvolutionContext&, const ProblemDescription&);
     bool SetNextValue(const ConvolutionContext&);
     bool IsValidValue() const;
-    bool IsValid(const ConvolutionContext& ctx) const
-    {
-        return IsValid(ctx.problem);
-    }
+    bool IsValid(const ConvolutionContext& ctx) const { return IsValid(ctx.problem); }
     bool IsValid(const ProblemDescription&) const;
     size_t ComputeKernelOccupancy() const;
 
@@ -4331,12 +4328,12 @@ struct ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC final
     : ConvTunableSolver<PerformanceConfigAsmImplicitGemmGTCWrwXdlopsNHWC>
 {
     // To suppress -Woverloaded-virtual
-    using ConvTunableSolver::IsApplicable;
-    using ConvTunableSolver::GetWorkspaceSize;
     using ConvTunableSolver::GetDefaultPerformanceConfig;
+    using ConvTunableSolver::GetSolution;
+    using ConvTunableSolver::GetWorkspaceSize;
+    using ConvTunableSolver::IsApplicable;
     using ConvTunableSolver::IsValidPerformanceConfig;
     using ConvTunableSolver::Search;
-    using ConvTunableSolver::GetSolution;
 
     const std::string& SolverDbId() const override
     {
@@ -4381,15 +4378,15 @@ private:
     size_t GetWorkspaceSize(const ConvolutionContext&, const ProblemDescription&) const;
     PerformanceConfigAsmImplicitGemmGTCWrwXdlopsNHWC
     GetDefaultPerformanceConfig(const ConvolutionContext&, const ProblemDescription&) const;
-    bool IsValidPerformanceConfig(
-        const ProblemDescription&,
-        const PerformanceConfigAsmImplicitGemmGTCWrwXdlopsNHWC&) const;
+    bool IsValidPerformanceConfig(const ProblemDescription&,
+                                  const PerformanceConfigAsmImplicitGemmGTCWrwXdlopsNHWC&) const;
     PerformanceConfigAsmImplicitGemmGTCWrwXdlopsNHWC
-    Search(const ConvolutionContext&, const ProblemDescription&, const AnyInvokeParams& invoke_ctx) const;
-    ConvSolution
-    GetSolution(const ConvolutionContext&,
-                const ProblemDescription&,
-                const PerformanceConfigAsmImplicitGemmGTCWrwXdlopsNHWC&) const;
+    Search(const ConvolutionContext&,
+           const ProblemDescription&,
+           const AnyInvokeParams& invoke_ctx) const;
+    ConvSolution GetSolution(const ConvolutionContext&,
+                             const ProblemDescription&,
+                             const PerformanceConfigAsmImplicitGemmGTCWrwXdlopsNHWC&) const;
 };
 
 struct PerformanceConfigAsmImplicitGemmGTCvector

--- a/src/include/miopen/solver.hpp
+++ b/src/include/miopen/solver.hpp
@@ -4313,38 +4313,83 @@ struct PerformanceConfigAsmImplicitGemmGTCWrwXdlopsNHWC : PerformanceConfigAsmIm
     {
     }
 
-    void HeuristicInit(const ConvolutionContext& ctx);
-    bool SetNextValue(const ConvolutionContext& config);
+    void HeuristicInit(const ConvolutionContext&, const ProblemDescription&);
+    bool SetNextValue(const ConvolutionContext&);
     bool IsValidValue() const;
-    bool IsValid(const ConvolutionContext& ctx) const;
+    bool IsValid(const ConvolutionContext& ctx) const
+    {
+        return IsValid(ctx.problem);
+    }
+    bool IsValid(const ProblemDescription&) const;
     size_t ComputeKernelOccupancy() const;
 
 private:
-    void SetParamsForKSplit(const ConvolutionContext& ctx, const size_t& occupancy);
+    void SetParamsForKSplit(const ProblemDescription& problem, const size_t& occupancy);
 };
 
 struct ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC final
     : ConvTunableSolver<PerformanceConfigAsmImplicitGemmGTCWrwXdlopsNHWC>
 {
+    // To suppress -Woverloaded-virtual
+    using ConvTunableSolver::IsApplicable;
+    using ConvTunableSolver::GetWorkspaceSize;
+    using ConvTunableSolver::GetDefaultPerformanceConfig;
+    using ConvTunableSolver::IsValidPerformanceConfig;
+    using ConvTunableSolver::Search;
+    using ConvTunableSolver::GetSolution;
+
     const std::string& SolverDbId() const override
     {
         return GetSolverDbId<ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC>();
     }
 
     PerformanceConfigAsmImplicitGemmGTCWrwXdlopsNHWC
-    GetDefaultPerformanceConfig(const ConvolutionContext&) const override;
+    GetDefaultPerformanceConfig(const ConvolutionContext& ctx) const override
+    {
+        return GetDefaultPerformanceConfig(ctx, ctx.problem);
+    }
     bool IsValidPerformanceConfig(
-        const ConvolutionContext&,
-        const PerformanceConfigAsmImplicitGemmGTCWrwXdlopsNHWC&) const override;
+        const ConvolutionContext& ctx,
+        const PerformanceConfigAsmImplicitGemmGTCWrwXdlopsNHWC& config) const override
+    {
+        return IsValidPerformanceConfig(ctx.problem, config);
+    }
     PerformanceConfigAsmImplicitGemmGTCWrwXdlopsNHWC
-    Search(const ConvolutionContext&, const AnyInvokeParams& invoke_ctx) const override;
-    size_t GetWorkspaceSize(const ConvolutionContext& ctx) const override;
+    Search(const ConvolutionContext& ctx, const AnyInvokeParams& invoke_ctx) const override
+    {
+        return Search(ctx, ctx.problem, invoke_ctx);
+    }
+    size_t GetWorkspaceSize(const ConvolutionContext& ctx) const override
+    {
+        return GetWorkspaceSize(ctx, ctx.problem);
+    }
     bool MayNeedWorkspace() const override { return true; }
-    bool IsApplicable(const ConvolutionContext& ctx) const override;
+    bool IsApplicable(const ConvolutionContext& ctx) const override
+    {
+        return IsApplicable(ctx, ctx.problem);
+    }
     bool IsDynamic() const override { return true; }
     ConvSolution
     GetSolution(const ConvolutionContext& ctx,
-                const PerformanceConfigAsmImplicitGemmGTCWrwXdlopsNHWC& config) const override;
+                const PerformanceConfigAsmImplicitGemmGTCWrwXdlopsNHWC& config) const override
+    {
+        return GetSolution(ctx, ctx.problem, config);
+    }
+
+private:
+    bool IsApplicable(const ConvolutionContext&, const ProblemDescription&) const;
+    size_t GetWorkspaceSize(const ConvolutionContext&, const ProblemDescription&) const;
+    PerformanceConfigAsmImplicitGemmGTCWrwXdlopsNHWC
+    GetDefaultPerformanceConfig(const ConvolutionContext&, const ProblemDescription&) const;
+    bool IsValidPerformanceConfig(
+        const ProblemDescription&,
+        const PerformanceConfigAsmImplicitGemmGTCWrwXdlopsNHWC&) const;
+    PerformanceConfigAsmImplicitGemmGTCWrwXdlopsNHWC
+    Search(const ConvolutionContext&, const ProblemDescription&, const AnyInvokeParams& invoke_ctx) const;
+    ConvSolution
+    GetSolution(const ConvolutionContext&,
+                const ProblemDescription&,
+                const PerformanceConfigAsmImplicitGemmGTCWrwXdlopsNHWC&) const;
 };
 
 struct PerformanceConfigAsmImplicitGemmGTCvector
@@ -4663,10 +4708,6 @@ struct PerformanceConfigAsmImplicitGemmGTCFwdDlopsNCHWC : PerformanceConfigAsmIm
     bool IsValidValue() const;
     bool IsValid(const ConvolutionContext& ctx) const { return IsValid(ctx.problem); }
     bool IsValid(const ProblemDescription&) const;
-    size_t ComputeKernelOccupancy() const;
-
-private:
-    void SetParamsForKSplit(const ConvolutionContext& ctx, const size_t& occupancy);
 };
 
 struct ConvAsmImplicitGemmGTCDynamicFwdDlopsNCHWC final

--- a/src/solver/conv_asm_implicit_gemm_gtc_wrw_nhwc.cpp
+++ b/src/solver/conv_asm_implicit_gemm_gtc_wrw_nhwc.cpp
@@ -314,7 +314,9 @@ static std::tuple<std::string, // kernel_name
                   size_t,      // grid_size
                   size_t>      // occupancy
 GetImplicitGemmGtcDynamicWrwXdlopsNHWCKernel(
-    const ConvolutionContext& ctx, const ProblemDescription& problem, const PerformanceConfigAsmImplicitGemmGTCWrwXdlopsNHWC& config)
+    const ConvolutionContext& ctx,
+    const ProblemDescription& problem,
+    const PerformanceConfigAsmImplicitGemmGTCWrwXdlopsNHWC& config)
 {
     // const auto& n     = problem.batch_sz;
     const auto& k = problem.n_inputs;
@@ -415,7 +417,8 @@ size_t PerformanceConfigAsmImplicitGemmGTCWrwXdlopsNHWC::ComputeKernelOccupancy(
     return occupancy;
 }
 
-void PerformanceConfigAsmImplicitGemmGTCWrwXdlopsNHWC::SetParamsForKSplit(const ProblemDescription& problem, const size_t& occupancy)
+void PerformanceConfigAsmImplicitGemmGTCWrwXdlopsNHWC::SetParamsForKSplit(
+    const ProblemDescription& problem, const size_t& occupancy)
 {
     if(problem.IsFp16())
     {
@@ -430,7 +433,8 @@ void PerformanceConfigAsmImplicitGemmGTCWrwXdlopsNHWC::SetParamsForKSplit(const 
     gemm_k_global_split = occupancy;
 }
 
-void PerformanceConfigAsmImplicitGemmGTCWrwXdlopsNHWC::HeuristicInit(const ConvolutionContext& ctx, const ProblemDescription& problem)
+void PerformanceConfigAsmImplicitGemmGTCWrwXdlopsNHWC::HeuristicInit(
+    const ConvolutionContext& ctx, const ProblemDescription& problem)
 {
     static const std::vector<std::tuple<int, int, int>> tile_list_fp32 = {
         std::make_tuple(128, 128, 16),
@@ -557,13 +561,17 @@ void PerformanceConfigAsmImplicitGemmGTCWrwXdlopsNHWC::HeuristicInit(const Convo
 
     bool unit_conv = (x == 1) && (y == 1) && (stride_h == 1) && (stride_w == 1) &&
                      (dilation_h == 1) && (dilation_w == 1) && (pad_h == 0) && (pad_w == 0);
-    bool not_support_vector_store = (problem.IsFp16() || problem.IsBfp16()) && ((c / group) % 2 != 0);
+    bool not_support_vector_store =
+        (problem.IsFp16() || problem.IsBfp16()) && ((c / group) % 2 != 0);
     int m_per_block, n_per_block, k_per_block;
 
     std::tie(m_per_block, n_per_block, k_per_block) = HeuristicInitMacroTileNoPadGemmK(
-        gemm_m, gemm_n, 0, problem.IsFp32() ? tile_list_fp32 : (problem.IsFp16() ? tile_list_fp16 : tile_list_bfp16));
+        gemm_m,
+        gemm_n,
+        0,
+        problem.IsFp32() ? tile_list_fp32 : (problem.IsFp16() ? tile_list_fp16 : tile_list_bfp16));
 
-    auto find_with_gemm_k_pad = [&](){
+    auto find_with_gemm_k_pad = [&]() {
         // not found, let's try  gemm_k pad now.
         const auto& config_list = GetWrwXdlopsNHWCConfigList();
         size_t min_pad_pixel    = std::numeric_limits<std::size_t>::max();
@@ -718,16 +726,19 @@ bool PerformanceConfigAsmImplicitGemmGTCWrwXdlopsNHWC::IsValidValue() const
     return *this == config_list[index];
 }
 
-bool PerformanceConfigAsmImplicitGemmGTCWrwXdlopsNHWC::IsValid(const ProblemDescription& problem) const
+bool PerformanceConfigAsmImplicitGemmGTCWrwXdlopsNHWC::IsValid(
+    const ProblemDescription& problem) const
 {
     if(IsDefaultConstructed())
         return false;
 
-    if(!((problem.IsFp16() && precision == "fp16") || (problem.IsFp32() && precision == "fp32") || (problem.IsBfp16() && precision == "bf16")))
+    if(!((problem.IsFp16() && precision == "fp16") || (problem.IsFp32() && precision == "fp32") ||
+         (problem.IsBfp16() && precision == "bf16")))
         return false;
 
     if(miopen::IsDisabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_ASM_PK_ATOMIC_ADD_FP16{}))
-        if(problem.IsFp16() && tensor_b_thread_lengths[3] != 1 && gemm_k_global_split != 0 && vector_store != 1)
+        if(problem.IsFp16() && tensor_b_thread_lengths[3] != 1 && gemm_k_global_split != 0 &&
+           vector_store != 1)
             return false;
 
     const auto& k         = problem.n_inputs;
@@ -740,8 +751,9 @@ bool PerformanceConfigAsmImplicitGemmGTCWrwXdlopsNHWC::IsValid(const ProblemDesc
     const auto dilation_w = problem.kernel_size_w > 1 ? problem.kernel_dilation_w : 1;
     const auto& pad_h     = problem.pad_h;
     const auto& pad_w     = problem.pad_w;
-    const auto precision  = problem.IsFp16() ? miopenHalf : (problem.IsBfp16() ? miopenBFloat16 : miopenFloat);
-    const auto& group     = problem.group_counts;
+    const auto precision =
+        problem.IsFp16() ? miopenHalf : (problem.IsBfp16() ? miopenBFloat16 : miopenFloat);
+    const auto& group = problem.group_counts;
 
     bool unit_conv = (x == 1) && (y == 1) && (stride_h == 1) && (stride_w == 1) &&
                      (dilation_h == 1) && (dilation_w == 1) && (pad_h == 0) && (pad_w == 0);
@@ -797,7 +809,8 @@ ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC::Search(const ConvolutionContext& ctx
     return GenericSearch(*this, ctx, problem, invoke_ctx);
 }
 
-bool ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC::IsApplicable(const ConvolutionContext& ctx, const ProblemDescription& problem) const
+bool ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC::IsApplicable(
+    const ConvolutionContext& ctx, const ProblemDescription& problem) const
 {
     if(miopen::IsDisabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_ASM_WRW_GTC_XDLOPS_NHWC{}))
         return false;
@@ -827,13 +840,13 @@ bool ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC::IsApplicable(const ConvolutionC
     if(target.Xnack() && *target.Xnack())
         return false; // NOLINT (readability-simplify-boolean-expr)
 
-    if(0 == igemm_split_batch_size(problem.out_height, 
-                                   problem.out_width, 
-                                   problem.in_height, 
-                                   problem.in_width, 
-                                   problem.batch_sz, 
-                                   problem.n_inputs, 
-                                   problem.n_outputs, 
+    if(0 == igemm_split_batch_size(problem.out_height,
+                                   problem.out_width,
+                                   problem.in_height,
+                                   problem.in_width,
+                                   problem.batch_sz,
+                                   problem.n_inputs,
+                                   problem.n_outputs,
                                    miopen::GetTypeSize(problem.in_data_type)))
         return false;
 
@@ -889,54 +902,55 @@ ComputeDynamicIGemmWrwKernelArgsNHWC(const conv::ProblemDescription& conv_proble
     return opArgs;
 }
 
-size_t
-ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC::GetWorkspaceSize(const ConvolutionContext& ctx, const ProblemDescription& problem) const
+size_t ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC::GetWorkspaceSize(
+    const ConvolutionContext& ctx, const ProblemDescription& problem) const
 {
-    const auto& hi        = problem.out_height;
-    const auto& wi        = problem.out_width;
-    const auto& n         = problem.batch_sz;
-    const auto& k         = problem.n_inputs;
-    const auto& c         = problem.n_outputs;
-    const auto& ho        = problem.in_height;
-    const auto& wo        = problem.in_width;
-    const auto& y         = problem.kernel_size_h;
-    const auto& x         = problem.kernel_size_w;
-    const auto& group     = problem.group_counts;
-    const auto is_nchw     = problem.IsLayoutDefault();
+    const auto& hi     = problem.out_height;
+    const auto& wi     = problem.out_width;
+    const auto& n      = problem.batch_sz;
+    const auto& k      = problem.n_inputs;
+    const auto& c      = problem.n_outputs;
+    const auto& ho     = problem.in_height;
+    const auto& wo     = problem.in_width;
+    const auto& y      = problem.kernel_size_h;
+    const auto& x      = problem.kernel_size_w;
+    const auto& group  = problem.group_counts;
+    const auto is_nchw = problem.IsLayoutDefault();
 
     size_t size_trans_input  = 0;
     size_t size_trans_weight = 0;
     size_t size_trans_output = 0;
     size_t size_tensor_cast  = 0;
 
-    constexpr size_t buf_alignment     = 256;
+    constexpr size_t buf_alignment = 256;
 
     size_t workspace_size = 0;
     if(is_nchw)
     {
         TransposeSolutionDefault2Nhwc trans_input(ctx, problem.out_data_type, n, c, hi, wi);
         TransposeSolutionNhwc2Default trans_weight(ctx,
-                                                 problem.weights_data_type,
-                                                 k,
-                                                 c / group,
-                                                 y,
-                                                 x); // group * k_per_group as batch for weight
+                                                   problem.weights_data_type,
+                                                   k,
+                                                   c / group,
+                                                   y,
+                                                   x); // group * k_per_group as batch for weight
         TransposeSolutionDefault2Nhwc trans_output(ctx, problem.in_data_type, n, k, ho, wo);
         if(!trans_input.IsSkippable())
-            size_trans_input  = trans_input.GetOutputTensorSize();
+            size_trans_input = trans_input.GetOutputTensorSize();
         if(!trans_weight.IsSkippable())
             size_trans_weight = trans_weight.GetOutputTensorSize();
         if(!trans_output.IsSkippable())
             size_trans_output = trans_output.GetOutputTensorSize();
-
     }
 
     if(!problem.IsFp32())
-        size_tensor_cast = miopen::GetTypeSize(miopenFloat) // The intermediate output of the 1st
-                                                           // kernel is FP32, when using FP32 atomic
-                           * (k / group) * c * y * x;
+        size_tensor_cast =
+            miopen::GetTypeSize(miopenFloat) // The intermediate output of the 1st
+                                             // kernel is FP32, when using FP32 atomic
+            * (k / group) * c * y * x;
 
-    MultiBufferWorkspaceTraits wt({size_trans_input, size_trans_weight, size_trans_output, size_tensor_cast}, buf_alignment);
+    MultiBufferWorkspaceTraits wt(
+        {size_trans_input, size_trans_weight, size_trans_output, size_tensor_cast}, buf_alignment);
     workspace_size = wt.GetSize();
 
     return workspace_size;
@@ -957,18 +971,19 @@ ConvSolution ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC::GetSolution(
     std::tie(kernel_name, block_size, grid_size, std::ignore) =
         GetImplicitGemmGtcDynamicWrwXdlopsNHWCKernel(ctx, problem, config);
 
-    const auto& hi        = problem.out_height;
-    const auto& wi        = problem.out_width;
-    const auto& n         = problem.batch_sz;
-    const auto& k         = problem.n_inputs;
-    const auto& c         = problem.n_outputs;
-    const auto& ho        = problem.in_height;
-    const auto& wo        = problem.in_width;
-    const auto& y         = problem.kernel_size_h;
-    const auto& x         = problem.kernel_size_w;
-    const auto& group     = problem.group_counts;
+    const auto& hi    = problem.out_height;
+    const auto& wi    = problem.out_width;
+    const auto& n     = problem.batch_sz;
+    const auto& k     = problem.n_inputs;
+    const auto& c     = problem.n_outputs;
+    const auto& ho    = problem.in_height;
+    const auto& wo    = problem.in_width;
+    const auto& y     = problem.kernel_size_h;
+    const auto& x     = problem.kernel_size_w;
+    const auto& group = problem.group_counts;
 
-    auto splits_4G = igemm_split_batch_size(hi, wi, ho, wo, n, k, c, miopen::GetTypeSize(problem.in_data_type));
+    auto splits_4G =
+        igemm_split_batch_size(hi, wi, ho, wo, n, k, c, miopen::GetTypeSize(problem.in_data_type));
 
     size_t gemm_k_global_splits =
         config.gemm_k_global_split >= 1
@@ -983,15 +998,16 @@ ConvSolution ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC::GetSolution(
         gemm_k_global_splits = 1;
 
     // compute workload for 1 workgroup and update gemmk splits (remove the ones compute 0 data)
-    size_t gemmk = integer_divide_ceil(static_cast<size_t>(problem.batch_sz / splits_4G), min_n_per_block) *
-                   problem.in_height * problem.in_width;
+    size_t gemmk =
+        integer_divide_ceil(static_cast<size_t>(problem.batch_sz / splits_4G), min_n_per_block) *
+        problem.in_height * problem.in_width;
     size_t gemmk_per_wg = integer_divide_ceil(gemmk, gemm_k_global_splits);
 
     gemmk_per_wg         = (gemmk_per_wg + nb_per_block - 1) / nb_per_block * nb_per_block;
     gemm_k_global_splits = integer_divide_ceil(gemmk, gemmk_per_wg);
 
     const auto required_workspace_size = GetWorkspaceSize(ctx, problem);
-    result.workspace_sz                 = required_workspace_size;
+    result.workspace_sz                = required_workspace_size;
 
     kernel.kernel_file = kernel_name + ".s";
     kernel.kernel_name = kernel_name;
@@ -1007,9 +1023,11 @@ ConvSolution ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC::GetSolution(
     const auto& conv_problem          = problem.conv_problem;
     const auto isFp16                 = conv_problem.IsFp16();
     const auto isGfx90aFp16altSupport = (ctx.GetStream().GetDeviceName() == "gfx90a") && isFp16;
-    const bool need_cast = (conv_problem.IsBfp16() && gemm_k_global_splits >= 1) || (isFp16 && gemm_k_global_splits >= 1 && (config.tensor_b_thread_lengths[3] == 1 || config.vector_store == 1));
+    const bool need_cast              = (conv_problem.IsBfp16() && gemm_k_global_splits >= 1) ||
+                           (isFp16 && gemm_k_global_splits >= 1 &&
+                            (config.tensor_b_thread_lengths[3] == 1 || config.vector_store == 1));
 
-    const auto is_nchw     = problem.IsLayoutDefault();
+    const auto is_nchw = problem.IsLayoutDefault();
 
     result.construction_params.push_back(kernel); // Intentionally without options.
     std::ostringstream options;                   // Common options for both kernels.
@@ -1033,8 +1051,8 @@ ConvSolution ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC::GetSolution(
 
     const auto lowp_quant = conv_problem.GetConv().lowp_quant;
 
-    auto opArgs =
-        ComputeDynamicIGemmWrwKernelArgsNHWC(conv_problem, gemm_k_global_splits, gemmk_per_wg, splits_4G);
+    auto opArgs = ComputeDynamicIGemmWrwKernelArgsNHWC(
+        conv_problem, gemm_k_global_splits, gemmk_per_wg, splits_4G);
     std::vector<std::vector<OpKernelArg>> opArgsTrans;
     size_t trans_input_offset = 0;
     size_t trans_input_size   = 0;
@@ -1054,39 +1072,42 @@ ConvSolution ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC::GetSolution(
     int trans_output_idx = -1;
 
     constexpr size_t buf_alignment = 256;
-    
+
     if(is_nchw)
     {
         TransposeSolutionDefault2Nhwc trans_input(ctx, problem.out_data_type, n, c, hi, wi);
         TransposeSolutionNhwc2Default trans_weight(ctx,
-                                                 problem.weights_data_type,
-                                                 k,
-                                                 c / group,
-                                                 y,
-                                                 x); // group * k_per_group as batch for weight
+                                                   problem.weights_data_type,
+                                                   k,
+                                                   c / group,
+                                                   y,
+                                                   x); // group * k_per_group as batch for weight
         TransposeSolutionDefault2Nhwc trans_output(ctx, problem.in_data_type, n, k, ho, wo);
 
         trans_input_skippable  = trans_input.IsSkippable();
         trans_weight_skippable = trans_weight.IsSkippable();
         trans_output_skippable = trans_output.IsSkippable();
 
-        if(!trans_input_skippable){
+        if(!trans_input_skippable)
+        {
             result.construction_params.push_back(trans_input.GetKernelInfo());
             opArgsTrans.emplace_back(trans_input.GetKernelArg());
             if(miopen::IsLogging(LoggingLevel::Info2))
-                msg << ", inp trans:"<<trans_input.GetKernelName();
+                msg << ", inp trans:" << trans_input.GetKernelName();
         }
-        if(!trans_weight_skippable){
+        if(!trans_weight_skippable)
+        {
             result.construction_params.push_back(trans_weight.GetKernelInfo());
             opArgsTrans.emplace_back(trans_weight.GetKernelArg());
             if(miopen::IsLogging(LoggingLevel::Info2))
-                msg << ", wei trans:"<<trans_weight.GetKernelName();
+                msg << ", wei trans:" << trans_weight.GetKernelName();
         }
-        if(!trans_output_skippable){
+        if(!trans_output_skippable)
+        {
             result.construction_params.push_back(trans_output.GetKernelInfo());
             opArgsTrans.emplace_back(trans_output.GetKernelArg());
             if(miopen::IsLogging(LoggingLevel::Info2))
-                msg << ", out trans:"<<trans_output.GetKernelName();
+                msg << ", out trans:" << trans_output.GetKernelName();
         }
 
         trans_input_size  = trans_input_skippable ? 0 : trans_input.GetOutputTensorSize();
@@ -1104,10 +1125,11 @@ ConvSolution ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC::GetSolution(
 
     MIOPEN_LOG_I2(SolverDbId() << ": " << config.ToString() << msg.str());
 
-    const size_t cast_size = need_cast ?
-        miopen::GetTypeSize(miopenFloat) * k * (c / group) * y * x  : 0;
+    const size_t cast_size =
+        need_cast ? miopen::GetTypeSize(miopenFloat) * k * (c / group) * y * x : 0;
 
-    MultiBufferWorkspaceTraits wt({trans_input_size, trans_weight_size, trans_output_size, cast_size}, buf_alignment);
+    MultiBufferWorkspaceTraits wt(
+        {trans_input_size, trans_weight_size, trans_output_size, cast_size}, buf_alignment);
 
     trans_input_offset  = wt.GetOffset(0);
     trans_weight_offset = wt.GetOffset(1);
@@ -1117,8 +1139,10 @@ ConvSolution ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC::GetSolution(
 
     const int kID_trans_start = isGfx90aFp16altSupport ? 2 : 1;
 
-    const TensorDescriptor cast_desc(miopenFloat, problem.conv_problem.GetWeights().GetLengths(), problem.conv_problem.GetWeights().GetStrides());
-    auto null_buf = shared<Data_t> {};
+    const TensorDescriptor cast_desc(miopenFloat,
+                                     problem.conv_problem.GetWeights().GetLengths(),
+                                     problem.conv_problem.GetWeights().GetStrides());
+    auto null_buf = shared<Data_t>{};
 
     if(need_cast)
     {
@@ -1127,7 +1151,7 @@ ConvSolution ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC::GetSolution(
                 decltype(auto) wrw_invoke_params =
                     primitive_parameters.CastTo<conv::WrWInvokeParams>();
                 const auto& tensors = wrw_invoke_params.tensors;
-                const auto ker        = handle.Run(
+                const auto ker      = handle.Run(
                     kernels[(isGfx90aFp16altSupport && wrw_invoke_params.gfx90aFp16alt) ? 1 : 0]);
                 const auto& workSpace     = wrw_invoke_params.workSpace;
                 const auto& workSpaceSize = wrw_invoke_params.workSpaceSize;
@@ -1138,14 +1162,21 @@ ConvSolution ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC::GetSolution(
                     MIOPEN_THROW("Not enough workspace has been provided for "
                                  "ConvAsmImplicitGemmGTCDynamicWrwXdlops with fp16 and atomic "
                                  "add.");
-                auto trans_input_buf = trans_input_size== 0 ?null_buf : handle.CreateSubBuffer(
-                    workSpace, trans_input_offset, trans_input_size);
-                auto trans_weight_buf = trans_weight_size==0 ? null_buf : handle.CreateSubBuffer(
-                    workSpace, trans_weight_offset, trans_weight_size);
-                auto trans_output_buf = trans_output_size ==0 ? null_buf : handle.CreateSubBuffer(
-                    workSpace, trans_output_offset, trans_output_size);
-                auto cast_buf = cast_size == 0 ? null_buf : handle.CreateSubBuffer(
-                    workSpace, cast_offset, cast_size);
+                auto trans_input_buf =
+                    trans_input_size == 0
+                        ? null_buf
+                        : handle.CreateSubBuffer(workSpace, trans_input_offset, trans_input_size);
+                auto trans_weight_buf =
+                    trans_weight_size == 0
+                        ? null_buf
+                        : handle.CreateSubBuffer(workSpace, trans_weight_offset, trans_weight_size);
+                auto trans_output_buf =
+                    trans_output_size == 0
+                        ? null_buf
+                        : handle.CreateSubBuffer(workSpace, trans_output_offset, trans_output_size);
+                auto cast_buf = cast_size == 0
+                                    ? null_buf
+                                    : handle.CreateSubBuffer(workSpace, cast_offset, cast_size);
 
                 SetTensor(handle, cast_desc, cast_buf.get(), &zero);
                 if(handle.IsProfilingEnabled())
@@ -1153,27 +1184,32 @@ ConvSolution ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC::GetSolution(
 
                 if(is_nchw)
                 {
-                    if(!trans_input_skippable){
+                    if(!trans_input_skippable)
+                    {
                         auto& karg_input = opArgsTrans[trans_input_idx];
-                        karg_input[0] = OpKernelArg(trans_input_buf.get());
-                        karg_input[1] = OpKernelArg(tensors.x);
+                        karg_input[0]    = OpKernelArg(trans_input_buf.get());
+                        karg_input[1]    = OpKernelArg(tensors.x);
                         handle.Run(kernels[kID_trans_start + trans_input_idx])(karg_input);
                         if(handle.IsProfilingEnabled())
                             elapsed += handle.GetKernelTime();
                     }
-                    if(!trans_output_skippable){
+                    if(!trans_output_skippable)
+                    {
                         auto& karg_output = opArgsTrans[trans_output_idx];
-                        karg_output[0] = OpKernelArg(trans_output_buf.get());
-                        karg_output[1] = OpKernelArg(tensors.dy);
+                        karg_output[0]    = OpKernelArg(trans_output_buf.get());
+                        karg_output[1]    = OpKernelArg(tensors.dy);
                         handle.Run(kernels[kID_trans_start + trans_output_idx])(karg_output);
                         if(handle.IsProfilingEnabled())
                             elapsed += handle.GetKernelTime();
                     }
                 }
 
-                opArgs[0] = (is_nchw && !trans_input_skippable) ? OpKernelArg(trans_input_buf.get()) : OpKernelArg(tensors.x);
+                opArgs[0] = (is_nchw && !trans_input_skippable) ? OpKernelArg(trans_input_buf.get())
+                                                                : OpKernelArg(tensors.x);
                 opArgs[1] = OpKernelArg(cast_buf.get());
-                opArgs[2] = (is_nchw && !trans_output_skippable) ? OpKernelArg(trans_output_buf.get()) : OpKernelArg(tensors.dy);
+                opArgs[2] = (is_nchw && !trans_output_skippable)
+                                ? OpKernelArg(trans_output_buf.get())
+                                : OpKernelArg(tensors.dy);
 
                 ker(opArgs);
                 if(handle.IsProfilingEnabled())
@@ -1184,7 +1220,8 @@ ConvSolution ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC::GetSolution(
                            cast_desc,
                            cast_buf.get(),
                            tensors.dwDesc,
-                           (is_nchw && !trans_weight_skippable) ? trans_weight_buf.get() :  tensors.dw,
+                           (is_nchw && !trans_weight_skippable) ? trans_weight_buf.get()
+                                                                : tensors.dw,
                            0,
                            0);
 
@@ -1216,45 +1253,63 @@ ConvSolution ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC::GetSolution(
                 decltype(auto) wrw_invoke_params =
                     primitive_parameters.CastTo<conv::WrWInvokeParams>();
                 const auto& tensors = wrw_invoke_params.tensors;
-                const auto ker        = handle.Run(
+                const auto ker      = handle.Run(
                     kernels[(isGfx90aFp16altSupport && wrw_invoke_params.gfx90aFp16alt) ? 1 : 0]);
-                const auto& workSpace     = wrw_invoke_params.workSpace;
-                float elapsed = 0;
-                float zero    = 0.f;
+                const auto& workSpace = wrw_invoke_params.workSpace;
+                float elapsed         = 0;
+                float zero            = 0.f;
 
-                auto trans_input_buf = trans_input_size== 0 ?null_buf : handle.CreateSubBuffer(
-                    workSpace, trans_input_offset, trans_input_size);
-                auto trans_weight_buf = trans_weight_size==0 ? null_buf : handle.CreateSubBuffer(
-                    workSpace, trans_weight_offset, trans_weight_size);
-                auto trans_output_buf = trans_output_size ==0 ? null_buf : handle.CreateSubBuffer(
-                    workSpace, trans_output_offset, trans_output_size);
-                auto cast_buf = cast_size == 0 ? null_buf : handle.CreateSubBuffer(
-                    workSpace, cast_offset, cast_size);
+                auto trans_input_buf =
+                    trans_input_size == 0
+                        ? null_buf
+                        : handle.CreateSubBuffer(workSpace, trans_input_offset, trans_input_size);
+                auto trans_weight_buf =
+                    trans_weight_size == 0
+                        ? null_buf
+                        : handle.CreateSubBuffer(workSpace, trans_weight_offset, trans_weight_size);
+                auto trans_output_buf =
+                    trans_output_size == 0
+                        ? null_buf
+                        : handle.CreateSubBuffer(workSpace, trans_output_offset, trans_output_size);
+                auto cast_buf = cast_size == 0
+                                    ? null_buf
+                                    : handle.CreateSubBuffer(workSpace, cast_offset, cast_size);
 
-                opArgs[0] = (is_nchw && !trans_input_skippable) ? OpKernelArg(trans_input_buf.get()) : OpKernelArg(tensors.x);
-                opArgs[1] = (is_nchw && !trans_weight_skippable)? OpKernelArg(trans_weight_buf.get()) : OpKernelArg(tensors.dw);
-                opArgs[2] = (is_nchw && !trans_output_skippable) ? OpKernelArg(trans_output_buf.get()) : OpKernelArg(tensors.dy);
+                opArgs[0] = (is_nchw && !trans_input_skippable) ? OpKernelArg(trans_input_buf.get())
+                                                                : OpKernelArg(tensors.x);
+                opArgs[1] = (is_nchw && !trans_weight_skippable)
+                                ? OpKernelArg(trans_weight_buf.get())
+                                : OpKernelArg(tensors.dw);
+                opArgs[2] = (is_nchw && !trans_output_skippable)
+                                ? OpKernelArg(trans_output_buf.get())
+                                : OpKernelArg(tensors.dy);
 
-                SetTensor(handle, tensors.dwDesc, (is_nchw && !trans_weight_skippable) ? trans_weight_buf.get() : tensors.dw, &zero);
+                SetTensor(handle,
+                          tensors.dwDesc,
+                          (is_nchw && !trans_weight_skippable) ? trans_weight_buf.get()
+                                                               : tensors.dw,
+                          &zero);
                 if(handle.IsProfilingEnabled())
                     elapsed += handle.GetKernelTime();
 
                 if(is_nchw)
                 {
-                    if(!trans_input_skippable){
+                    if(!trans_input_skippable)
+                    {
 
                         auto& karg_input = opArgsTrans[trans_input_idx];
-                        karg_input[0] = OpKernelArg(trans_input_buf.get());
-                        karg_input[1] = OpKernelArg(tensors.x);
+                        karg_input[0]    = OpKernelArg(trans_input_buf.get());
+                        karg_input[1]    = OpKernelArg(tensors.x);
                         handle.Run(kernels[kID_trans_start + trans_input_idx])(karg_input);
                         if(handle.IsProfilingEnabled())
                             elapsed += handle.GetKernelTime();
                     }
-                    if(!trans_output_skippable){
+                    if(!trans_output_skippable)
+                    {
 
                         auto& karg_output = opArgsTrans[trans_output_idx];
-                        karg_output[0] = OpKernelArg(trans_output_buf.get());
-                        karg_output[1] = OpKernelArg(tensors.dy);
+                        karg_output[0]    = OpKernelArg(trans_output_buf.get());
+                        karg_output[1]    = OpKernelArg(tensors.dy);
                         handle.Run(kernels[kID_trans_start + trans_output_idx])(karg_output);
                         if(handle.IsProfilingEnabled())
                             elapsed += handle.GetKernelTime();


### PR DESCRIPTION
PR splits ConvolutionContext and ProblemDescription inside ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC

Additional changes:

- Missed `clang-format on` has been added, wrong code formatting has been fixed
- `inline` keyword has been replaced with `static` for `ComputeDynamicIGemmWrwKernelArgsNHWC()`
- `PerformanceConfigAsmImplicitGemmGTCFwdDlopsNCHWC:` unused function declarations have been removed