### PR TITLE
[Workaround] bug in the llvm::msgpack when N is recognized as "false", a boolean type instead of string type.

### DIFF
--- a/src/kernels/Conv_Winograd_v13_3_12_epilogue.inc
+++ b/src/kernels/Conv_Winograd_v13_3_12_epilogue.inc
@@ -76,7 +76,7 @@ amdhsa.kernels:
     .max_flat_workgroup_size: \wg_x
     .wavefront_size: 64
     .args:
-    - { .size: 4, .offset: 0,   .value_kind: by_value,      .value_type: i32, .name: N }
+    - { .size: 4, .offset: 0,   .value_kind: by_value,      .value_type: i32, .name: BATCHSIZE }
     - { .size: 4, .offset: 4,   .value_kind: by_value,      .value_type: i32, .name: C }
     - { .size: 4, .offset: 8,   .value_kind: by_value,      .value_type: i32, .name: H }
     - { .size: 4, .offset: 12,  .value_kind: by_value,      .value_type: i32, .name: W }

--- a/src/kernels/Conv_Winograd_v16_5_0_epilogue.inc
+++ b/src/kernels/Conv_Winograd_v16_5_0_epilogue.inc
@@ -76,7 +76,7 @@ amdhsa.kernels:
     .max_flat_workgroup_size: \wg_x
     .wavefront_size: 64
     .args:
-    - { .size: 4, .offset: 0,   .value_kind: by_value,      .value_type: i32, .name: N }
+    - { .size: 4, .offset: 0,   .value_kind: by_value,      .value_type: i32, .name: BATCHSIZE }
     - { .size: 4, .offset: 4,   .value_kind: by_value,      .value_type: i32, .name: C }
     - { .size: 4, .offset: 8,   .value_kind: by_value,      .value_type: i32, .name: H }
     - { .size: 4, .offset: 12,  .value_kind: by_value,      .value_type: i32, .name: W }

--- a/src/kernels/Conv_Winograd_v21_1_3_metadata.inc
+++ b/src/kernels/Conv_Winograd_v21_1_3_metadata.inc
@@ -51,7 +51,7 @@ amdhsa.kernels:
     .max_flat_workgroup_size: \wg_x
     .wavefront_size: 64
     .args:
-    - { .size: 4, .offset:   0, .value_kind: by_value, .value_type: i32, .name: N }
+    - { .size: 4, .offset:   0, .value_kind: by_value, .value_type: i32, .name: BATCHSIZE }
     - { .size: 4, .offset:   4, .value_kind: by_value, .value_type: i32, .name: C }
     - { .size: 4, .offset:   8, .value_kind: by_value, .value_type: i32, .name: H }
     - { .size: 4, .offset:  12, .value_kind: by_value, .value_type: i32, .name: W }

--- a/src/kernels/conv1x1u.s
+++ b/src/kernels/conv1x1u.s
@@ -1076,7 +1076,7 @@ amdhsa.kernels:
     .max_flat_workgroup_size: \wg_x
     .wavefront_size: 64
     .args:
-    - { .size: 4, .offset:  0, .value_kind: by_value, .value_type: i32, .name: N }
+    - { .size: 4, .offset:  0, .value_kind: by_value, .value_type: i32, .name: BATCHSIZE }
     - { .size: 4, .offset:  4, .value_kind: by_value, .value_type: i32, .name: C }
     - { .size: 4, .offset:  8, .value_kind: by_value, .value_type: i32, .name: H }
     - { .size: 4, .offset: 12, .value_kind: by_value, .value_type: i32, .name: W }

--- a/src/kernels/conv1x1u_bias_activ.s
+++ b/src/kernels/conv1x1u_bias_activ.s
@@ -1230,7 +1230,7 @@ amdhsa.kernels:
     .max_flat_workgroup_size: \wg_x
     .wavefront_size: 64
     .args:
-    - { .size: 4, .offset:  0, .value_kind: by_value, .value_type: i32, .name: N }
+    - { .size: 4, .offset:  0, .value_kind: by_value, .value_type: i32, .name: BATCHSIZE }
     - { .size: 4, .offset:  4, .value_kind: by_value, .value_type: i32, .name: C }
     - { .size: 4, .offset:  8, .value_kind: by_value, .value_type: i32, .name: H }
     - { .size: 4, .offset: 12, .value_kind: by_value, .value_type: i32, .name: W }

--- a/src/kernels/conv1x1u_stride2.s
+++ b/src/kernels/conv1x1u_stride2.s
@@ -1162,7 +1162,7 @@ amdhsa.kernels:
     .max_flat_workgroup_size: \wg_x
     .wavefront_size: 64
     .args:
-    - { .size: 4, .offset:  0, .value_kind: by_value, .value_type: i32, .name: N }
+    - { .size: 4, .offset:  0, .value_kind: by_value, .value_type: i32, .name: BATCHSIZE }
     - { .size: 4, .offset:  4, .value_kind: by_value, .value_type: i32, .name: C }
     - { .size: 4, .offset:  8, .value_kind: by_value, .value_type: i32, .name: H }
     - { .size: 4, .offset: 12, .value_kind: by_value, .value_type: i32, .name: W }

--- a/src/kernels/conv1x1wrw.s
+++ b/src/kernels/conv1x1wrw.s
@@ -1243,7 +1243,7 @@ amdhsa.kernels:
     .max_flat_workgroup_size: \wg_x
     .wavefront_size: 64
     .args:
-    - { .size: 4, .offset:  0, .value_kind: by_value, .value_type: i32, .name: N }
+    - { .size: 4, .offset:  0, .value_kind: by_value, .value_type: i32, .name: BATCHSIZE }
     - { .size: 4, .offset:  4, .value_kind: by_value, .value_type: i32, .name: C }
     - { .size: 4, .offset:  8, .value_kind: by_value, .value_type: i32, .name: H }
     - { .size: 4, .offset: 12, .value_kind: by_value, .value_type: i32, .name: W }

--- a/src/kernels/conv3x3wrw.s
+++ b/src/kernels/conv3x3wrw.s
@@ -1033,7 +1033,7 @@ amdhsa.kernels:
     .max_flat_workgroup_size: \wg_x
     .wavefront_size: 64
     .args:
-    - { .size: 4, .offset:  0, .value_kind: by_value, .value_type: i32, .name: N }
+    - { .size: 4, .offset:  0, .value_kind: by_value, .value_type: i32, .name: BATCHSIZE }
     - { .size: 4, .offset:  4, .value_kind: by_value, .value_type: i32, .name: C }
     - { .size: 4, .offset:  8, .value_kind: by_value, .value_type: i32, .name: H }
     - { .size: 4, .offset: 12, .value_kind: by_value, .value_type: i32, .name: W }

--- a/src/kernels/conv_3x3_wheel_alpha_v3_0b_epilogue.inc
+++ b/src/kernels/conv_3x3_wheel_alpha_v3_0b_epilogue.inc
@@ -76,7 +76,7 @@ amdhsa.kernels:
     .max_flat_workgroup_size: \wg_x
     .wavefront_size: 64
     .args:
-    - { .size: 4, .offset: 0,   .value_kind: by_value,      .value_type: i32, .name: N }
+    - { .size: 4, .offset: 0,   .value_kind: by_value,      .value_type: i32, .name: BATCHSIZE }
     - { .size: 4, .offset: 4,   .value_kind: by_value,      .value_type: i32, .name: C }
     - { .size: 4, .offset: 8,   .value_kind: by_value,      .value_type: i32, .name: H }
     - { .size: 4, .offset: 12,  .value_kind: by_value,      .value_type: i32, .name: W }

--- a/src/kernels/conv_3x3_wheel_alpha_v7_0_3b_epilogue.inc
+++ b/src/kernels/conv_3x3_wheel_alpha_v7_0_3b_epilogue.inc
@@ -76,7 +76,7 @@ amdhsa.kernels:
     .max_flat_workgroup_size: \wg_x
     .wavefront_size: 64
     .args:
-    - { .size: 4, .offset: 0,   .value_kind: by_value,      .value_type: i32, .name: N }
+    - { .size: 4, .offset: 0,   .value_kind: by_value,      .value_type: i32, .name: BATCHSIZE }
     - { .size: 4, .offset: 4,   .value_kind: by_value,      .value_type: i32, .name: C }
     - { .size: 4, .offset: 8,   .value_kind: by_value,      .value_type: i32, .name: H }
     - { .size: 4, .offset: 12,  .value_kind: by_value,      .value_type: i32, .name: W }

--- a/src/kernels/conv_3x3_wheel_alpha_v9_0_15_epilogue.inc
+++ b/src/kernels/conv_3x3_wheel_alpha_v9_0_15_epilogue.inc
@@ -76,7 +76,7 @@ amdhsa.kernels:
     .max_flat_workgroup_size: \wg_x
     .wavefront_size: 64
     .args:
-    - { .size: 4, .offset: 0,   .value_kind: by_value,      .value_type: i32, .name: N }
+    - { .size: 4, .offset: 0,   .value_kind: by_value,      .value_type: i32, .name: BATCHSIZE }
     - { .size: 4, .offset: 4,   .value_kind: by_value,      .value_type: i32, .name: C }
     - { .size: 4, .offset: 8,   .value_kind: by_value,      .value_type: i32, .name: H }
     - { .size: 4, .offset: 12,  .value_kind: by_value,      .value_type: i32, .name: W }

--- a/src/kernels/conv_3x3_wheel_alpha_v9_2_7_epilogue.inc
+++ b/src/kernels/conv_3x3_wheel_alpha_v9_2_7_epilogue.inc
@@ -76,7 +76,7 @@ amdhsa.kernels:
     .max_flat_workgroup_size: \wg_x
     .wavefront_size: 64
     .args:
-    - { .size: 4, .offset: 0,   .value_kind: by_value,      .value_type: i32, .name: N }
+    - { .size: 4, .offset: 0,   .value_kind: by_value,      .value_type: i32, .name: BATCHSIZE }
     - { .size: 4, .offset: 4,   .value_kind: by_value,      .value_type: i32, .name: C }
     - { .size: 4, .offset: 8,   .value_kind: by_value,      .value_type: i32, .name: H }
     - { .size: 4, .offset: 12,  .value_kind: by_value,      .value_type: i32, .name: W }

--- a/src/kernels/xform_bidirect_winograd_code.inc
+++ b/src/kernels/xform_bidirect_winograd_code.inc
@@ -1566,7 +1566,7 @@ amdhsa.kernels:
     .max_flat_workgroup_size: \wg_x
     .wavefront_size: 64
     .args:
-    - { .size: 4, .offset:   0, .value_kind: by_value, .value_type: i32, .name: N }
+    - { .size: 4, .offset:   0, .value_kind: by_value, .value_type: i32, .name: BATCHSIZE }
     - { .size: 4, .offset:   4, .value_kind: by_value, .value_type: i32, .name: C }
     - { .size: 4, .offset:   8, .value_kind: by_value, .value_type: i32, .name: H }
     - { .size: 4, .offset:  12, .value_kind: by_value, .value_type: i32, .name: W }

--- a/src/kernels/xform_metadata.inc
+++ b/src/kernels/xform_metadata.inc
@@ -74,7 +74,7 @@ amdhsa.kernels:
     .max_flat_workgroup_size: \wg_x
     .wavefront_size: 64
     .args:
-    - { .size: 4, .offset:   0, .value_kind: by_value, .value_type: i32, .name: N }
+    - { .size: 4, .offset:   0, .value_kind: by_value, .value_type: i32, .name: BATCHSIZE }
     - { .size: 4, .offset:   4, .value_kind: by_value, .value_type: i32, .name: C }
     - { .size: 4, .offset:   8, .value_kind: by_value, .value_type: i32, .name: H }
     - { .size: 4, .offset:  12, .value_kind: by_value, .value_type: i32, .name: W }


### PR DESCRIPTION
Fixes #1731.

@junliume Please attribute this with:
- Reviewers: @littlewu2508, @Slimakanzer, @Kirpich30000
- `non-miopen-bug`, `urgency_high` (borrowed from #1731)