### PR TITLE
[MLIR]Reuse one tuning parameters

### DIFF
--- a/src/solver/conv_mlir_igemm_fwd_xdlops.cpp
+++ b/src/solver/conv_mlir_igemm_fwd_xdlops.cpp
@@ -153,9 +153,10 @@ bool PerformanceConvMlirIgemmXdlops::SetNextValue(const ProblemDescription& prob
         return false;
 
     GemmBThreadCopyMoreGemmKPack = true;
-    GemmAThreadCopyMoreGemmK     = true;
     do
     {
+        if(!NextFlag<false, true>(GemmAThreadCopyMoreGemmK))
+            break;
         if(!NextTwoPower<4, 256>(GemmMPerBlock))
             break;
         if(!NextTwoPower<16, 256>(GemmNPerBlock))


### PR DESCRIPTION
This PR will pass a new tuning parameter to MLIR to help tuning MLIR kernels.

This patch affects solvers ConvMlirIgemmFwdXdlops, ConvMlirIgemmBwdXdlops and ConvMlirIgemmWrWXdlops. The tuning time for these solvers will double. The average improvement for Xdlops will be about 10%. There is no changes on the non-Xdlops side.

The MLIR library that uses this newly passed tuning parameter will be in the ROCm5.5 release. The MLIR library older than ROCm5.5 RC is not affected by this PR. That means there is no need to re-tune those solvers in MLIR library that is older than ROCm5.5 RC.