### PR TITLE
[Find2.0] Fix support for INT8

### DIFF
--- a/src/kernels/MIOpenSubTensorOpWithScalarKernel.cl
+++ b/src/kernels/MIOpenSubTensorOpWithScalarKernel.cl
@@ -50,24 +50,18 @@
 #define MIOPEN_USE_INT8x4 0
 #endif
 
+#ifndef MIOPEN_USE_INT32
+#define MIOPEN_USE_INT32 0
+#endif
+
 #include "float_types.h"
 
 #if MIOPEN_USE_INT8 == 1 || MIOPEN_USE_INT8x4 == 1
 #define _FLOAT char
-#ifndef FLT_MAX
-#define MAX_VAL 127 /* max value */
-#else
-#define MAX_VAL FLT_MAX
-#endif
 #endif
 
 #if MIOPEN_USE_INT32 == 1
 #define _FLOAT unsigned
-#ifndef FLT_MAX
-#define MAX_VAL 4294967295 /* max value */
-#else
-#define MAX_VAL FLT_MAX
-#endif
 #endif
 
 #ifndef WORK_LENGTH_0

--- a/src/kernels/MIOpenSubTensorOpWithScalarKernel.cl
+++ b/src/kernels/MIOpenSubTensorOpWithScalarKernel.cl
@@ -61,7 +61,7 @@
 #endif
 
 #if MIOPEN_USE_INT32 == 1
-#define _FLOAT unsigned
+#define _FLOAT int
 #endif
 
 #ifndef WORK_LENGTH_0

--- a/src/kernels/MIOpenSubTensorOpWithScalarKernel.cl
+++ b/src/kernels/MIOpenSubTensorOpWithScalarKernel.cl
@@ -61,6 +61,15 @@
 #endif
 #endif
 
+#if MIOPEN_USE_INT32 == 1
+#define _FLOAT unsigned
+#ifndef FLT_MAX
+#define MAX_VAL 4294967295 /* max value */
+#else
+#define MAX_VAL FLT_MAX
+#endif
+#endif
+
 #ifndef WORK_LENGTH_0
 #define WORK_LENGTH_0 1
 #endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -191,7 +191,7 @@ if(NOT MIOPEN_TEST_MIOTENSILE)
 	elseif(MIOPEN_TEST_INT8)
 	    set(SKIP_ALL_EXCEPT_TESTS
                 test_tensor_vec test_tensor_cast test_tensor_trans test_tensor_copy test_tensor_set
-                test_tensor_transform test_conv2d)
+                test_tensor_transform test_conv2d test_conv2d_find2)
 	elseif(MIOPEN_TEST_BFLOAT16)
 	    set(SKIP_ALL_EXCEPT_TESTS
                 test_conv2d test_tensor_copy test_tensor_set test_tensor_vec test_immed_conv2d

--- a/test/conv2d_find2.cpp
+++ b/test/conv2d_find2.cpp
@@ -56,6 +56,12 @@ struct conv2d_find2_driver : conv_driver<T, ConvApi::Find_2_0>
         this->add(this->in_layout, "in_layout", this->generate_data({"NCHW"}));
         this->add(this->fil_layout, "fil_layout", this->generate_data({"NCHW"}));
         this->add(this->out_layout, "out_layout", this->generate_data({"NCHW"}));
+        this->add(this->deterministic, "deterministic", this->generate_data({false}));
+        this->add(this->tensor_vect, "tensor_vect", this->generate_data({0}));
+        this->add(this->vector_length, "vector_length", this->generate_data({1}));
+        // Only valid for int8 input and weights
+        this->add(this->output_type, "output_type", this->generate_data({"int32"}));
+        this->add(this->int8_vectorize, "int8_vectorize", this->generate_data({false}));
     }
 };
 


### PR DESCRIPTION
This resolves issue #1800.

- SetTensor: Added support for INT32 type in the kernel
  - It is necessary for Find 2.0 here: https://github.com/ROCmSoftwarePlatform/MIOpen/pull/1503/files#r996216187
- [tests] Fixed support for int8 in `test_conv2d_find2`
- [tests] `test_conv2d_find2` engaged in INT8 test stages. This works as a regression test for #1800.

@junliume I think this is https://github.com/ROCmSoftwarePlatform/MIOpen/labels/bug https://github.com/ROCmSoftwarePlatform/MIOpen/labels/urgency_high.