### PR TITLE
[Solvers] ConvHipImplicitGemmForwardV4R5Xdlops: split ConvolutionContext and ProblemDescription (stage 2)

### DIFF
--- a/src/include/miopen/solver.hpp
+++ b/src/include/miopen/solver.hpp
@@ -1605,20 +1605,24 @@ struct PerformanceImplicitGemmForwardV4R5Xdlops
 
     bool operator==(const PerformanceImplicitGemmForwardV4R5Xdlops& other) const;
 
-    void HeuristicInit(const ConvolutionContext& ctx);
+    void HeuristicInit(const ConvolutionContext&, const ProblemDescription&);
     bool SetNextValue(const ConvolutionContext&);
     bool IsValidValue() const;
-    bool IsValid(const ConvolutionContext& ctx) const;
-    bool IsReallyValid(const ConvolutionContext& ctx) const;
-    bool IsFastToBeUsedForTuning(const ConvolutionContext& ctx) const;
+    bool IsValid(const ConvolutionContext& ctx) const
+    {
+        return IsValid(ctx, ctx.problem);
+    }
+    bool IsValid(const ConvolutionContext&, const ProblemDescription&) const;
+    bool IsReallyValid(const ProblemDescription&) const;
+    bool IsFastToBeUsedForTuning(const ConvolutionContext&, const ProblemDescription&) const;
 
     std::tuple<int, bool> CalculateBlockSize() const;
-    std::tuple<int, bool> CalculateGridSize(const ConvolutionContext& ctx) const;
+    std::tuple<int, bool> CalculateGridSize(const ProblemDescription&) const;
     std::tuple<int, int, int, int, int, bool>
-    CalculateGemmABlockCopyPerformanceParameters(const ConvolutionContext& ctx) const;
+    CalculateGemmABlockCopyPerformanceParameters(const ProblemDescription&) const;
     std::tuple<int, int, int, int, int, bool>
-    CalculateGemmBBlockCopyPerformanceParameters(const ConvolutionContext& ctx) const;
-    std::tuple<std::size_t, bool> CalculateLdsNumberOfByte(const ConvolutionContext& ctx) const;
+    CalculateGemmBBlockCopyPerformanceParameters(const ProblemDescription&) const;
+    std::tuple<std::size_t, bool> CalculateLdsNumberOfByte(const ProblemDescription&) const;
 };
 
 struct PerformanceImplicitGemmForwardV4R4Xdlops_Padded_Gemm
@@ -1781,20 +1785,54 @@ private:
 struct ConvHipImplicitGemmForwardV4R5Xdlops final
     : ConvTunableSolver<PerformanceImplicitGemmForwardV4R5Xdlops>
 {
+    // To suppress -Woverloaded-virtual
+    using ConvTunableSolver::IsApplicable;
+    using ConvTunableSolver::GetDefaultPerformanceConfig;
+    using ConvTunableSolver::IsValidPerformanceConfig;
+    using ConvTunableSolver::Search;
+    using ConvTunableSolver::GetSolution;
+
     const std::string& SolverDbId() const override
     {
         return GetSolverDbId<ConvHipImplicitGemmForwardV4R5Xdlops>();
     }
 
     PerformanceImplicitGemmForwardV4R5Xdlops
-    GetDefaultPerformanceConfig(const ConvolutionContext& ctx) const override;
+    GetDefaultPerformanceConfig(const ConvolutionContext& ctx) const override
+    {
+        return GetDefaultPerformanceConfig(ctx, ctx.problem);
+    }
     bool IsValidPerformanceConfig(const ConvolutionContext& ctx,
-                                  const PerformanceImplicitGemmForwardV4R5Xdlops& c) const override;
-    bool IsApplicable(const ConvolutionContext& ctx) const override;
+                                  const PerformanceImplicitGemmForwardV4R5Xdlops& config) const override
+    {
+        return IsValidPerformanceConfig(ctx.problem, config);
+    }
+    bool IsApplicable(const ConvolutionContext& ctx) const override
+    {
+        return IsApplicable(ctx, ctx.problem);
+    }
     ConvSolution GetSolution(const ConvolutionContext& ctx,
-                             const PerformanceImplicitGemmForwardV4R5Xdlops& config) const override;
+                             const PerformanceImplicitGemmForwardV4R5Xdlops& config) const override
+    {
+        return GetSolution(ctx, ctx.problem, config);
+    }
     PerformanceImplicitGemmForwardV4R5Xdlops
-    Search(const ConvolutionContext&, const AnyInvokeParams& invoke_ctx) const override;
+    Search(const ConvolutionContext& ctx, const AnyInvokeParams& invoke_ctx) const override
+    {
+        return Search(ctx, ctx.problem, invoke_ctx);
+    }
+
+private:
+    bool IsApplicable(const ConvolutionContext&, const ProblemDescription&) const;
+    PerformanceImplicitGemmForwardV4R5Xdlops
+    GetDefaultPerformanceConfig(const ConvolutionContext&, const ProblemDescription&) const;
+    bool IsValidPerformanceConfig(const ProblemDescription&,
+                                  const PerformanceImplicitGemmForwardV4R5Xdlops&) const;
+    PerformanceImplicitGemmForwardV4R5Xdlops
+    Search(const ConvolutionContext&, const ProblemDescription&, const AnyInvokeParams& invoke_ctx) const;
+    ConvSolution GetSolution(const ConvolutionContext&,
+                             const ProblemDescription&,
+                             const PerformanceImplicitGemmForwardV4R5Xdlops&) const;
 };
 
 struct ConvHipImplicitGemmV4R1WrW final : ConvTunableSolver<PerformanceImplicitGemmV4R1>

--- a/src/include/miopen/solver.hpp
+++ b/src/include/miopen/solver.hpp
@@ -1608,10 +1608,7 @@ struct PerformanceImplicitGemmForwardV4R5Xdlops
     void HeuristicInit(const ConvolutionContext&, const ProblemDescription&);
     bool SetNextValue(const ConvolutionContext&);
     bool IsValidValue() const;
-    bool IsValid(const ConvolutionContext& ctx) const
-    {
-        return IsValid(ctx, ctx.problem);
-    }
+    bool IsValid(const ConvolutionContext& ctx) const { return IsValid(ctx, ctx.problem); }
     bool IsValid(const ConvolutionContext&, const ProblemDescription&) const;
     bool IsReallyValid(const ProblemDescription&) const;
     bool IsFastToBeUsedForTuning(const ConvolutionContext&, const ProblemDescription&) const;
@@ -1786,11 +1783,11 @@ struct ConvHipImplicitGemmForwardV4R5Xdlops final
     : ConvTunableSolver<PerformanceImplicitGemmForwardV4R5Xdlops>
 {
     // To suppress -Woverloaded-virtual
-    using ConvTunableSolver::IsApplicable;
     using ConvTunableSolver::GetDefaultPerformanceConfig;
+    using ConvTunableSolver::GetSolution;
+    using ConvTunableSolver::IsApplicable;
     using ConvTunableSolver::IsValidPerformanceConfig;
     using ConvTunableSolver::Search;
-    using ConvTunableSolver::GetSolution;
 
     const std::string& SolverDbId() const override
     {
@@ -1802,8 +1799,9 @@ struct ConvHipImplicitGemmForwardV4R5Xdlops final
     {
         return GetDefaultPerformanceConfig(ctx, ctx.problem);
     }
-    bool IsValidPerformanceConfig(const ConvolutionContext& ctx,
-                                  const PerformanceImplicitGemmForwardV4R5Xdlops& config) const override
+    bool
+    IsValidPerformanceConfig(const ConvolutionContext& ctx,
+                             const PerformanceImplicitGemmForwardV4R5Xdlops& config) const override
     {
         return IsValidPerformanceConfig(ctx.problem, config);
     }
@@ -1828,8 +1826,9 @@ private:
     GetDefaultPerformanceConfig(const ConvolutionContext&, const ProblemDescription&) const;
     bool IsValidPerformanceConfig(const ProblemDescription&,
                                   const PerformanceImplicitGemmForwardV4R5Xdlops&) const;
-    PerformanceImplicitGemmForwardV4R5Xdlops
-    Search(const ConvolutionContext&, const ProblemDescription&, const AnyInvokeParams& invoke_ctx) const;
+    PerformanceImplicitGemmForwardV4R5Xdlops Search(const ConvolutionContext&,
+                                                    const ProblemDescription&,
+                                                    const AnyInvokeParams& invoke_ctx) const;
     ConvSolution GetSolution(const ConvolutionContext&,
                              const ProblemDescription&,
                              const PerformanceImplicitGemmForwardV4R5Xdlops&) const;

--- a/src/solver/conv_hip_implicit_gemm_fwd_v4r5_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_fwd_v4r5_xdlops.cpp
@@ -44,16 +44,16 @@ MIOPEN_DECLARE_ENV_VAR(
 namespace miopen {
 namespace solver {
 
-static std::tuple<int, int, int, int> CalculateGemmSize(const ConvolutionContext& ctx)
+static std::tuple<int, int, int, int> CalculateGemmSize(const ProblemDescription& problem)
 {
-    const std::size_t g  = ProblemInterpreter::GetGroupCountG(ctx.problem);
-    const std::size_t n  = ProblemInterpreter::GetBatchN(ctx.problem);
-    const std::size_t k  = ProblemInterpreter::GetOutputChannelK(ctx.problem);
-    const std::size_t c  = ProblemInterpreter::GetInputChannelC(ctx.problem);
-    const std::size_t ho = ProblemInterpreter::GetOutputHeightHo(ctx.problem);
-    const std::size_t wo = ProblemInterpreter::GetOutputWidthWo(ctx.problem);
-    const std::size_t y  = ProblemInterpreter::GetFilterHeightY(ctx.problem);
-    const std::size_t x  = ProblemInterpreter::GetFilterWidthX(ctx.problem);
+    const std::size_t g  = ProblemInterpreter::GetGroupCountG(problem);
+    const std::size_t n  = ProblemInterpreter::GetBatchN(problem);
+    const std::size_t k  = ProblemInterpreter::GetOutputChannelK(problem);
+    const std::size_t c  = ProblemInterpreter::GetInputChannelC(problem);
+    const std::size_t ho = ProblemInterpreter::GetOutputHeightHo(problem);
+    const std::size_t wo = ProblemInterpreter::GetOutputWidthWo(problem);
+    const std::size_t y  = ProblemInterpreter::GetFilterHeightY(problem);
+    const std::size_t x  = ProblemInterpreter::GetFilterWidthX(problem);
 
     const std::size_t k_per_group = k / g;
     const std::size_t c_per_group = c / g;
@@ -154,13 +154,13 @@ bool PerformanceImplicitGemmForwardV4R5Xdlops::SetNextValue(const ConvolutionCon
     return true;
 }
 
-void PerformanceImplicitGemmForwardV4R5Xdlops::HeuristicInit(const ConvolutionContext& ctx)
+void PerformanceImplicitGemmForwardV4R5Xdlops::HeuristicInit(const ConvolutionContext& ctx, const ProblemDescription& problem)
 {
     PerformanceImplicitGemmForwardV4R5Xdlops tmp;
 
     // loop over certain ranges of tuning parameter
     auto get_euristic_config = [&](auto is_valid_func) {
-        if(ctx.problem.IsFp32())
+        if(problem.IsFp32())
         {
             tmp = {256, 256, 8, 128, 128, 4, false, true, 1};
 
@@ -189,11 +189,11 @@ void PerformanceImplicitGemmForwardV4R5Xdlops::HeuristicInit(const ConvolutionCo
                     all_visited = true;
                 } while(false);
 
-                if(is_valid_func(tmp, ctx))
+                if(is_valid_func(tmp))
                     break;
             } while(!all_visited);
         }
-        else if(ctx.problem.IsFp16())
+        else if(problem.IsFp16())
         {
             tmp              = {256, 256, 8, 128, 128, 8, false, true, 1};
             bool all_visited = false;
@@ -221,11 +221,11 @@ void PerformanceImplicitGemmForwardV4R5Xdlops::HeuristicInit(const ConvolutionCo
                     all_visited = true;
                 } while(false);
 
-                if(is_valid_func(tmp, ctx))
+                if(is_valid_func(tmp))
                     break;
             } while(!all_visited);
         }
-        else if(ctx.problem.IsBfp16())
+        else if(problem.IsBfp16())
         {
             tmp = {256, 256, 8, 128, 128, 8, false, true, 1};
 
@@ -254,7 +254,7 @@ void PerformanceImplicitGemmForwardV4R5Xdlops::HeuristicInit(const ConvolutionCo
                     all_visited = true;
                 } while(false);
 
-                if(is_valid_func(tmp, ctx))
+                if(is_valid_func(tmp))
                     break;
             } while(!all_visited);
         }
@@ -266,19 +266,19 @@ void PerformanceImplicitGemmForwardV4R5Xdlops::HeuristicInit(const ConvolutionCo
     };
 
     // first round: really valid and fast
-    get_euristic_config([](auto config, auto conv_context) {
-        return config.IsReallyValid(conv_context) && config.IsFastToBeUsedForTuning(conv_context);
+    get_euristic_config([&ctx, &problem](const auto& config) {
+        return config.IsReallyValid(problem) && config.IsFastToBeUsedForTuning(ctx, problem);
     });
 
     // second round: really valid
-    if(!tmp.IsReallyValid(ctx))
+    if(!tmp.IsReallyValid(problem))
     {
         get_euristic_config(
-            [](auto config, auto conv_context) { return config.IsReallyValid(conv_context); });
+            [&ctx, &problem](const auto& config) { std::ignore = ctx; return config.IsReallyValid(problem); });
     }
 
     // final check
-    if(!tmp.IsReallyValid(ctx))
+    if(!tmp.IsReallyValid(problem))
     {
         MIOPEN_LOG_I("All attempts unsuccessful");
     }
@@ -307,7 +307,7 @@ std::tuple<int, bool> PerformanceImplicitGemmForwardV4R5Xdlops::CalculateBlockSi
 }
 
 std::tuple<int, bool>
-PerformanceImplicitGemmForwardV4R5Xdlops::CalculateGridSize(const ConvolutionContext& ctx) const
+PerformanceImplicitGemmForwardV4R5Xdlops::CalculateGridSize(const ProblemDescription& problem) const
 {
     int GridSize = 0;
 
@@ -317,7 +317,7 @@ PerformanceImplicitGemmForwardV4R5Xdlops::CalculateGridSize(const ConvolutionCon
         int gemm_m = -1;
         int gemm_n = -1;
 
-        std::tie(gemm_g, gemm_m, gemm_n, std::ignore) = CalculateGemmSize(ctx);
+        std::tie(gemm_g, gemm_m, gemm_n, std::ignore) = CalculateGemmSize(problem);
 
         if(!(gemm_m % GemmMPerBlock == 0 && gemm_n % GemmNPerBlock == 0))
             MIOPEN_THROW("invalid performance parameter");
@@ -334,17 +334,17 @@ PerformanceImplicitGemmForwardV4R5Xdlops::CalculateGridSize(const ConvolutionCon
 
 std::tuple<int, int, int, int, int, bool>
 PerformanceImplicitGemmForwardV4R5Xdlops::CalculateGemmABlockCopyPerformanceParameters(
-    const ConvolutionContext& ctx) const
+    const ProblemDescription& problem) const
 {
     // A tensor shape [GemmG, GemmK, GemmM, GemmKPack]
 
     int ClusterLengths_GemmK      = -1;
     int ClusterLengths_GemmM      = -1;
     int ClusterLengths_GemmKPack  = -1;
-    int SrcDataPerRead_GemmKPack  = ctx.problem.IsFp32()
+    int SrcDataPerRead_GemmKPack  = problem.IsFp32()
                                         ? amd_buffer_load_max_length<float>()
                                         : amd_buffer_load_max_length<half_float::half>();
-    int DstDataPerWrite_GemmKPack = ctx.problem.IsFp32()
+    int DstDataPerWrite_GemmKPack = problem.IsFp32()
                                         ? amd_lds_write_max_length<float>()
                                         : amd_lds_write_max_length<half_float::half>();
 
@@ -422,16 +422,16 @@ PerformanceImplicitGemmForwardV4R5Xdlops::CalculateGemmABlockCopyPerformancePara
 
 std::tuple<int, int, int, int, int, bool>
 PerformanceImplicitGemmForwardV4R5Xdlops::CalculateGemmBBlockCopyPerformanceParameters(
-    const ConvolutionContext& ctx) const
+    const ProblemDescription& problem) const
 {
     // B tensor shape [GemmG, GemmK, GemmN, GemmKPack]
 
     int ClusterLengths_GemmK      = -1;
     int ClusterLengths_B          = -1;
     int ClusterLengths_GemmKPack  = -1;
-    int SrcDataPerRead_B          = ctx.problem.IsFp32() ? amd_buffer_load_max_length<float>()
+    int SrcDataPerRead_B          = problem.IsFp32() ? amd_buffer_load_max_length<float>()
                                                          : amd_buffer_load_max_length<half_float::half>();
-    int DstDataPerWrite_GemmKPack = ctx.problem.IsFp32()
+    int DstDataPerWrite_GemmKPack = problem.IsFp32()
                                         ? amd_lds_write_max_length<float>()
                                         : amd_lds_write_max_length<half_float::half>();
 
@@ -448,18 +448,18 @@ PerformanceImplicitGemmForwardV4R5Xdlops::CalculateGemmBBlockCopyPerformancePara
 
         // GemmN is src vector read dimension
         // calculate vector length on gemmn dimension based on global tensor layout
-        const auto y             = ProblemInterpreter::GetFilterHeightY(ctx.problem);
-        const auto x             = ProblemInterpreter::GetFilterWidthX(ctx.problem);
-        const auto ho            = ProblemInterpreter::GetOutputHeightHo(ctx.problem);
-        const auto wo            = ProblemInterpreter::GetOutputWidthWo(ctx.problem);
-        const auto conv_stride_h = ProblemInterpreter::GetAdjustedConvolutionStrideH(ctx.problem);
-        const auto conv_stride_w = ProblemInterpreter::GetAdjustedConvolutionStrideW(ctx.problem);
+        const auto y             = ProblemInterpreter::GetFilterHeightY(problem);
+        const auto x             = ProblemInterpreter::GetFilterWidthX(problem);
+        const auto ho            = ProblemInterpreter::GetOutputHeightHo(problem);
+        const auto wo            = ProblemInterpreter::GetOutputWidthWo(problem);
+        const auto conv_stride_h = ProblemInterpreter::GetAdjustedConvolutionStrideH(problem);
+        const auto conv_stride_w = ProblemInterpreter::GetAdjustedConvolutionStrideW(problem);
         const auto conv_dilation_w =
-            ProblemInterpreter::GetAdjustedConvolutionDilationW(ctx.problem);
-        const auto in_left_pad_h  = ProblemInterpreter::GetInputLeftPadH(ctx.problem);
-        const auto in_left_pad_w  = ProblemInterpreter::GetInputLeftPadW(ctx.problem);
-        const auto in_right_pad_h = ProblemInterpreter::GetAdjustedInputRightPadH(ctx.problem);
-        const auto in_right_pad_w = ProblemInterpreter::GetAdjustedInputRightPadW(ctx.problem);
+            ProblemInterpreter::GetAdjustedConvolutionDilationW(problem);
+        const auto in_left_pad_h  = ProblemInterpreter::GetInputLeftPadH(problem);
+        const auto in_left_pad_w  = ProblemInterpreter::GetInputLeftPadW(problem);
+        const auto in_right_pad_h = ProblemInterpreter::GetAdjustedInputRightPadH(problem);
+        const auto in_right_pad_w = ProblemInterpreter::GetAdjustedInputRightPadW(problem);
 
         const auto NWaves    = GemmNPerBlock / GemmNPerWave;
         const auto BPerBlock = GemmNPerBlock / NWaves;
@@ -494,7 +494,7 @@ PerformanceImplicitGemmForwardV4R5Xdlops::CalculateGemmBBlockCopyPerformancePara
         if(miopen::IsEnabled(
                MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_FWD_V4R5_XDLOPS_ADD_VECTOR_LOAD_GEMMN_TUNE_PARAM{}))
         {
-            if(ctx.problem.IsFp16())
+            if(problem.IsFp16())
             {
                 if(SrcDataPerRead_B >= GemmBThreadDataPerRead_GemmN)
                 {
@@ -575,13 +575,13 @@ PerformanceImplicitGemmForwardV4R5Xdlops::CalculateGemmBBlockCopyPerformancePara
 }
 
 std::tuple<std::size_t, bool> PerformanceImplicitGemmForwardV4R5Xdlops::CalculateLdsNumberOfByte(
-    const ConvolutionContext& ctx) const
+    const ProblemDescription& problem) const
 {
     const auto a_block_space = GemmKPerBlock * GemmMPerBlock * GemmKPack;
     const auto b_block_space = GemmKPerBlock * GemmNPerBlock * GemmKPack;
 
     std::size_t lds_size = (a_block_space + b_block_space) *
-                           (ctx.problem.IsFp32() ? sizeof(float) : sizeof(half_float::half));
+                           (problem.IsFp32() ? sizeof(float) : sizeof(half_float::half));
 
     return std::make_tuple(lds_size, true);
 }
@@ -602,12 +602,12 @@ bool PerformanceImplicitGemmForwardV4R5Xdlops::IsValidValue() const
 
 // Used by HeuristicInit() and GenericSearch
 // Only return false if a performance config will violate requirements given by kernel algorithm
-bool PerformanceImplicitGemmForwardV4R5Xdlops::IsReallyValid(const ConvolutionContext& ctx) const
+bool PerformanceImplicitGemmForwardV4R5Xdlops::IsReallyValid(const ProblemDescription& problem) const
 {
     if(!IsValidValue())
         return false;
 
-    if(!IsValidBlockwiseGemmXdlops(ctx.problem,
+    if(!IsValidBlockwiseGemmXdlops(problem,
                                    GemmMPerBlock,
                                    GemmNPerBlock,
                                    GemmKPerBlock,
@@ -620,7 +620,7 @@ bool PerformanceImplicitGemmForwardV4R5Xdlops::IsReallyValid(const ConvolutionCo
 
     // check tensor contraction
     {
-        const std::size_t n = ProblemInterpreter::GetBatchN(ctx.problem);
+        const std::size_t n = ProblemInterpreter::GetBatchN(problem);
         const auto NWaves   = GemmNPerBlock / GemmNPerWave;
         // check if N can be divided by NWaves, as N will be unmerged into N1
         // and NWaves for tensor contraction
@@ -634,7 +634,7 @@ bool PerformanceImplicitGemmForwardV4R5Xdlops::IsReallyValid(const ConvolutionCo
         int gemm_n       = -1;
         int gemm_k_total = -1;
 
-        std::tie(std::ignore, gemm_m, gemm_n, gemm_k_total) = CalculateGemmSize(ctx);
+        std::tie(std::ignore, gemm_m, gemm_n, gemm_k_total) = CalculateGemmSize(problem);
 
         if(gemm_k_total % GemmKPack != 0)
             return false;
@@ -649,7 +649,7 @@ bool PerformanceImplicitGemmForwardV4R5Xdlops::IsReallyValid(const ConvolutionCo
     // check blockwise copy of A matrix
     {
         std::tie(std::ignore, std::ignore, std::ignore, std::ignore, std::ignore, valid) =
-            CalculateGemmABlockCopyPerformanceParameters(ctx);
+            CalculateGemmABlockCopyPerformanceParameters(problem);
 
         if(!valid)
             return false;
@@ -658,7 +658,7 @@ bool PerformanceImplicitGemmForwardV4R5Xdlops::IsReallyValid(const ConvolutionCo
     // check blockwise copy of B matrix
     {
         std::tie(std::ignore, std::ignore, std::ignore, std::ignore, std::ignore, valid) =
-            CalculateGemmBBlockCopyPerformanceParameters(ctx);
+            CalculateGemmBBlockCopyPerformanceParameters(problem);
 
         if(!valid)
             return false;
@@ -666,7 +666,7 @@ bool PerformanceImplicitGemmForwardV4R5Xdlops::IsReallyValid(const ConvolutionCo
 
     // check LDS allocation
     std::size_t lds_size      = 0;
-    std::tie(lds_size, valid) = CalculateLdsNumberOfByte(ctx);
+    std::tie(lds_size, valid) = CalculateLdsNumberOfByte(problem);
 
     return (valid and lds_size <= get_lds_max_number_of_byte());
 }
@@ -675,7 +675,7 @@ bool PerformanceImplicitGemmForwardV4R5Xdlops::IsReallyValid(const ConvolutionCo
 // Return false if a performance config is known to be sub-optimal, comparing to other performance
 // config inside tuning range
 bool PerformanceImplicitGemmForwardV4R5Xdlops::IsFastToBeUsedForTuning(
-    const ConvolutionContext& ctx) const
+    const ConvolutionContext& ctx, const ProblemDescription& problem) const
 {
     if(use_spare_set)
         return true;
@@ -692,7 +692,7 @@ bool PerformanceImplicitGemmForwardV4R5Xdlops::IsFastToBeUsedForTuning(
         int gemm_m = 0;
         int gemm_n = 0;
 
-        std::tie(std::ignore, gemm_m, gemm_n, std::ignore) = CalculateGemmSize(ctx);
+        std::tie(std::ignore, gemm_m, gemm_n, std::ignore) = CalculateGemmSize(problem);
 
         // this is grid size using current blockwise-GEMM
         const int grid_size = (gemm_m * gemm_n) / (GemmMPerBlock * GemmNPerBlock);
@@ -752,7 +752,7 @@ bool PerformanceImplicitGemmForwardV4R5Xdlops::IsFastToBeUsedForTuning(
         int gemm_m = 0;
         int gemm_n = 0;
 
-        std::tie(std::ignore, gemm_m, gemm_n, std::ignore) = CalculateGemmSize(ctx);
+        std::tie(std::ignore, gemm_m, gemm_n, std::ignore) = CalculateGemmSize(problem);
 
         if(GemmMPerBlock > 2 * GemmNPerBlock)
         {
@@ -789,12 +789,12 @@ bool PerformanceImplicitGemmForwardV4R5Xdlops::IsFastToBeUsedForTuning(
         const int a_data_per_thread_copy = (GemmKPerBlock * GemmMPerBlock * GemmKPack) / block_size;
         const int b_data_per_thread_copy = (GemmKPerBlock * GemmNPerBlock * GemmKPack) / block_size;
 
-        if(ctx.problem.IsFp32())
+        if(problem.IsFp32())
         {
             if(a_data_per_thread_copy > 16 || b_data_per_thread_copy > 16)
                 return false;
         }
-        else if(ctx.problem.IsFp16() || ctx.problem.IsBfp16())
+        else if(problem.IsFp16() || problem.IsBfp16())
         {
             if(a_data_per_thread_copy > 32 || b_data_per_thread_copy > 32)
                 return false;
@@ -804,7 +804,7 @@ bool PerformanceImplicitGemmForwardV4R5Xdlops::IsFastToBeUsedForTuning(
     // GemmKPerBlock*GemmKPack should not be too small, otherwise read performance of A matrix would
     // be bad
     {
-        if(ctx.problem.IsFp32())
+        if(problem.IsFp32())
         {
             if(GemmKPack > 4)
                 return false;
@@ -812,7 +812,7 @@ bool PerformanceImplicitGemmForwardV4R5Xdlops::IsFastToBeUsedForTuning(
             if(GemmKPerBlock * GemmKPack < 8)
                 return false;
         }
-        else if(ctx.problem.IsFp16() || ctx.problem.IsBfp16())
+        else if(problem.IsFp16() || problem.IsBfp16())
         {
             if(GemmKPerBlock * GemmKPack < 16)
                 return false;
@@ -825,7 +825,7 @@ bool PerformanceImplicitGemmForwardV4R5Xdlops::IsFastToBeUsedForTuning(
         if(miopen::IsEnabled(
                MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_FWD_V4R5_XDLOPS_ADD_VECTOR_LOAD_GEMMN_TUNE_PARAM{}))
         {
-            if(ctx.problem.IsFp16())
+            if(problem.IsFp16())
             {
                 int SrcDataPerRead_B          = 0;
                 int DstDataPerWrite_GemmKPack = 0;
@@ -835,7 +835,7 @@ bool PerformanceImplicitGemmForwardV4R5Xdlops::IsFastToBeUsedForTuning(
                          std::ignore,
                          SrcDataPerRead_B,
                          DstDataPerWrite_GemmKPack,
-                         valid)               = CalculateGemmBBlockCopyPerformanceParameters(ctx);
+                         valid)               = CalculateGemmBBlockCopyPerformanceParameters(problem);
                 if(valid)
                 {
                     if((SrcDataPerRead_B > 1) &&
@@ -854,34 +854,34 @@ bool PerformanceImplicitGemmForwardV4R5Xdlops::IsFastToBeUsedForTuning(
 // Return false, if you don't want to this to be included in tuning range used by generic search
 // A performance config may still be valid w.r.t algorithm correctness, even when IsValid() return
 // false
-bool PerformanceImplicitGemmForwardV4R5Xdlops::IsValid(const ConvolutionContext& ctx) const
+bool PerformanceImplicitGemmForwardV4R5Xdlops::IsValid(const ConvolutionContext& ctx, const ProblemDescription& problem) const
 {
-    return IsReallyValid(ctx) && IsFastToBeUsedForTuning(ctx);
+    return IsReallyValid(problem) && IsFastToBeUsedForTuning(ctx, problem);
 }
 
 // Used by GenericSearch, not used by HeuristicInit
 bool ConvHipImplicitGemmForwardV4R5Xdlops::IsValidPerformanceConfig(
-    const ConvolutionContext& ctx, const PerformanceImplicitGemmForwardV4R5Xdlops& c) const
+    const ProblemDescription& problem, const PerformanceImplicitGemmForwardV4R5Xdlops& config) const
 {
-    return c.IsReallyValid(ctx);
+    return config.IsReallyValid(problem);
 }
 
 PerformanceImplicitGemmForwardV4R5Xdlops
 ConvHipImplicitGemmForwardV4R5Xdlops::GetDefaultPerformanceConfig(
-    const ConvolutionContext& ctx) const
+    const ConvolutionContext& ctx, const ProblemDescription& problem) const
 {
     PerformanceImplicitGemmForwardV4R5Xdlops config;
-    config.HeuristicInit(ctx);
+    config.HeuristicInit(ctx, problem);
     MIOPEN_LOG_I(config.ToString());
     return config;
 }
 
 ConvSolution ConvHipImplicitGemmForwardV4R5Xdlops::GetSolution(
-    const ConvolutionContext& ctx, const PerformanceImplicitGemmForwardV4R5Xdlops& config) const
+    const ConvolutionContext& ctx, const ProblemDescription& problem, const PerformanceImplicitGemmForwardV4R5Xdlops& config) const
 {
     ConvSolution result;
 
-    if(!config.IsReallyValid(ctx))
+    if(!config.IsReallyValid(problem))
     {
         MIOPEN_LOG_E("invalid performance parameter");
         assert(false);
@@ -898,7 +898,7 @@ ConvSolution ConvHipImplicitGemmForwardV4R5Xdlops::GetSolution(
     int grid_size  = 0;
     int block_size = 0;
 
-    std::tie(grid_size, std::ignore)  = config.CalculateGridSize(ctx);
+    std::tie(grid_size, std::ignore)  = config.CalculateGridSize(problem);
     std::tie(block_size, std::ignore) = config.CalculateBlockSize();
 
     construction_parameters.l_wk.push_back(block_size);
@@ -926,14 +926,14 @@ ConvSolution ConvHipImplicitGemmForwardV4R5Xdlops::GetSolution(
              GemmABlockCopyClusterLengths_GemmKPack,
              GemmABlockCopySrcDataPerRead_GemmKPack,
              GemmABlockCopyDstDataPerWrite_GemmKPack,
-             std::ignore) = config.CalculateGemmABlockCopyPerformanceParameters(ctx);
+             std::ignore) = config.CalculateGemmABlockCopyPerformanceParameters(problem);
 
     std::tie(GemmBBlockCopyClusterLengths_GemmK,
              GemmBBlockCopyClusterLengths_B,
              GemmBBlockCopyClusterLengths_GemmKPack,
              GemmBBlockCopySrcDataPerRead_GemmN,
              GemmBBlockCopyDstDataPerWrite_GemmKPack,
-             std::ignore) = config.CalculateGemmBBlockCopyPerformanceParameters(ctx);
+             std::ignore) = config.CalculateGemmBBlockCopyPerformanceParameters(problem);
 
     const auto NWaves    = config.GemmNPerBlock / config.GemmNPerWave;
     const auto BPerBlock = config.GemmNPerBlock / NWaves;
@@ -941,24 +941,24 @@ ConvSolution ConvHipImplicitGemmForwardV4R5Xdlops::GetSolution(
 
     // clang-format off
     construction_parameters.comp_options =
-        std::string(" -DCK_PARAM_PROBLEM_G=") + std::to_string(ProblemInterpreter::GetGroupCountG(ctx.problem)) +
-        std::string(" -DCK_PARAM_PROBLEM_N=") + std::to_string(ProblemInterpreter::GetBatchN(ctx.problem)) +
-        std::string(" -DCK_PARAM_PROBLEM_K=") + std::to_string(ProblemInterpreter::GetOutputChannelK(ctx.problem)) +
-        std::string(" -DCK_PARAM_PROBLEM_C=") + std::to_string(ProblemInterpreter::GetInputChannelC(ctx.problem)) +
-        std::string(" -DCK_PARAM_PROBLEM_HI=") + std::to_string(ProblemInterpreter::GetInputHeightHi(ctx.problem)) +
-        std::string(" -DCK_PARAM_PROBLEM_WI=") + std::to_string(ProblemInterpreter::GetInputWidthWi(ctx.problem)) +
-        std::string(" -DCK_PARAM_PROBLEM_HO=") + std::to_string(ProblemInterpreter::GetOutputHeightHo(ctx.problem)) +
-        std::string(" -DCK_PARAM_PROBLEM_WO=") + std::to_string(ProblemInterpreter::GetOutputWidthWo(ctx.problem)) +
-        std::string(" -DCK_PARAM_PROBLEM_Y=") + std::to_string(ProblemInterpreter::GetFilterHeightY(ctx.problem)) +
-        std::string(" -DCK_PARAM_PROBLEM_X=") + std::to_string(ProblemInterpreter::GetFilterWidthX(ctx.problem)) +
-        std::string(" -DCK_PARAM_PROBLEM_CONV_STRIDE_H=") + std::to_string(ProblemInterpreter::GetAdjustedConvolutionStrideH(ctx.problem)) +
-        std::string(" -DCK_PARAM_PROBLEM_CONV_STRIDE_W=") + std::to_string(ProblemInterpreter::GetAdjustedConvolutionStrideW(ctx.problem)) +
-        std::string(" -DCK_PARAM_PROBLEM_CONV_DILATION_H=") + std::to_string(ProblemInterpreter::GetAdjustedConvolutionDilationH(ctx.problem)) +
-        std::string(" -DCK_PARAM_PROBLEM_CONV_DILATION_W=") + std::to_string(ProblemInterpreter::GetAdjustedConvolutionDilationW(ctx.problem)) +
-        std::string(" -DCK_PARAM_PROBLEM_IN_LEFT_PAD_H=") + std::to_string(ProblemInterpreter::GetInputLeftPadH(ctx.problem)) +
-        std::string(" -DCK_PARAM_PROBLEM_IN_LEFT_PAD_W=") + std::to_string(ProblemInterpreter::GetInputLeftPadW(ctx.problem)) +
-        std::string(" -DCK_PARAM_PROBLEM_IN_RIGHT_PAD_H=") + std::to_string(ProblemInterpreter::GetAdjustedInputRightPadH(ctx.problem)) +
-        std::string(" -DCK_PARAM_PROBLEM_IN_RIGHT_PAD_W=") + std::to_string(ProblemInterpreter::GetAdjustedInputRightPadW(ctx.problem)) +
+        std::string(" -DCK_PARAM_PROBLEM_G=") + std::to_string(ProblemInterpreter::GetGroupCountG(problem)) +
+        std::string(" -DCK_PARAM_PROBLEM_N=") + std::to_string(ProblemInterpreter::GetBatchN(problem)) +
+        std::string(" -DCK_PARAM_PROBLEM_K=") + std::to_string(ProblemInterpreter::GetOutputChannelK(problem)) +
+        std::string(" -DCK_PARAM_PROBLEM_C=") + std::to_string(ProblemInterpreter::GetInputChannelC(problem)) +
+        std::string(" -DCK_PARAM_PROBLEM_HI=") + std::to_string(ProblemInterpreter::GetInputHeightHi(problem)) +
+        std::string(" -DCK_PARAM_PROBLEM_WI=") + std::to_string(ProblemInterpreter::GetInputWidthWi(problem)) +
+        std::string(" -DCK_PARAM_PROBLEM_HO=") + std::to_string(ProblemInterpreter::GetOutputHeightHo(problem)) +
+        std::string(" -DCK_PARAM_PROBLEM_WO=") + std::to_string(ProblemInterpreter::GetOutputWidthWo(problem)) +
+        std::string(" -DCK_PARAM_PROBLEM_Y=") + std::to_string(ProblemInterpreter::GetFilterHeightY(problem)) +
+        std::string(" -DCK_PARAM_PROBLEM_X=") + std::to_string(ProblemInterpreter::GetFilterWidthX(problem)) +
+        std::string(" -DCK_PARAM_PROBLEM_CONV_STRIDE_H=") + std::to_string(ProblemInterpreter::GetAdjustedConvolutionStrideH(problem)) +
+        std::string(" -DCK_PARAM_PROBLEM_CONV_STRIDE_W=") + std::to_string(ProblemInterpreter::GetAdjustedConvolutionStrideW(problem)) +
+        std::string(" -DCK_PARAM_PROBLEM_CONV_DILATION_H=") + std::to_string(ProblemInterpreter::GetAdjustedConvolutionDilationH(problem)) +
+        std::string(" -DCK_PARAM_PROBLEM_CONV_DILATION_W=") + std::to_string(ProblemInterpreter::GetAdjustedConvolutionDilationW(problem)) +
+        std::string(" -DCK_PARAM_PROBLEM_IN_LEFT_PAD_H=") + std::to_string(ProblemInterpreter::GetInputLeftPadH(problem)) +
+        std::string(" -DCK_PARAM_PROBLEM_IN_LEFT_PAD_W=") + std::to_string(ProblemInterpreter::GetInputLeftPadW(problem)) +
+        std::string(" -DCK_PARAM_PROBLEM_IN_RIGHT_PAD_H=") + std::to_string(ProblemInterpreter::GetAdjustedInputRightPadH(problem)) +
+        std::string(" -DCK_PARAM_PROBLEM_IN_RIGHT_PAD_W=") + std::to_string(ProblemInterpreter::GetAdjustedInputRightPadW(problem)) +
         std::string(" -DCK_PARAM_TUNABLE_GEMM_M_PER_BLOCK=") + std::to_string(config.GemmMPerBlock) +
         std::string(" -DCK_PARAM_TUNABLE_GEMM_B_PER_BLOCK=") + std::to_string(BPerBlock) +
         std::string(" -DCK_PARAM_TUNABLE_GEMM_K_PER_BLOCK=") + std::to_string(config.GemmKPerBlock) +
@@ -985,17 +985,17 @@ ConvSolution ConvHipImplicitGemmForwardV4R5Xdlops::GetSolution(
         ctx.general_compile_options;
     // clang-format on
 
-    result.invoker_factory = conv::MakeImplGemmDataInvokerFactory(ctx.problem);
+    result.invoker_factory = conv::MakeImplGemmDataInvokerFactory(problem);
     result.construction_params.push_back(construction_parameters);
     return result;
 }
 
-bool ConvHipImplicitGemmForwardV4R5Xdlops::IsApplicable(const ConvolutionContext& ctx) const
+bool ConvHipImplicitGemmForwardV4R5Xdlops::IsApplicable(const ConvolutionContext& ctx, const ProblemDescription& problem) const
 {
     if(miopen::IsDisabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_FWD_V4R5_XDLOPS{}))
         return false;
 
-    if(ctx.problem.conv_problem.GetConv().attribute.deterministic)
+    if(problem.conv_problem.GetConv().attribute.deterministic)
         return false;
 
     if(!ctx.use_hip_kernels)
@@ -1007,30 +1007,30 @@ bool ConvHipImplicitGemmForwardV4R5Xdlops::IsApplicable(const ConvolutionContext
     if(!IsXdlopsSupport(ctx))
         return false;
 
-    if(!(ctx.problem.IsFp32() || ctx.problem.IsFp16() || ctx.problem.IsBfp16()))
+    if(!(problem.IsFp32() || problem.IsFp16() || problem.IsBfp16()))
         return false;
 
-    const auto y = ProblemInterpreter::GetFilterHeightY(ctx.problem);
-    const auto x = ProblemInterpreter::GetFilterWidthX(ctx.problem);
+    const auto y = ProblemInterpreter::GetFilterHeightY(problem);
+    const auto x = ProblemInterpreter::GetFilterWidthX(problem);
 
     // disable the solver for conv1x1 due to perf regression
     if(y == 1 && x == 1)
         return false;
 
-    if(!ctx.problem.direction.IsForward())
+    if(!problem.direction.IsForward())
         return false;
 
-    if(!ctx.problem.Is2d())
+    if(!problem.Is2d())
         return false;
 
     if(ctx.GetStream().GetDeviceName() == "gfx90a" &&
-       ctx.problem.conv_problem.IsGfx90aFp16altRequired())
+       problem.conv_problem.IsGfx90aFp16altRequired())
         return false;
 
-    if(!IsIndexRangeLargeEnough(ctx.problem))
+    if(!IsIndexRangeLargeEnough(problem))
         return false;
 
-    if(!ctx.problem.IsLayoutDefault())
+    if(!problem.IsLayoutDefault())
     {
         return false;
     }
@@ -1041,7 +1041,7 @@ bool ConvHipImplicitGemmForwardV4R5Xdlops::IsApplicable(const ConvolutionContext
         int gemm_n       = -1;
         int gemm_k_total = -1;
 
-        std::tie(gemm_g, gemm_m, gemm_n, gemm_k_total) = CalculateGemmSize(ctx);
+        std::tie(gemm_g, gemm_m, gemm_n, gemm_k_total) = CalculateGemmSize(problem);
 
         if(!IsValidGridGemmXdlops(gemm_m, gemm_n, gemm_k_total))
             return false;
@@ -1050,16 +1050,17 @@ bool ConvHipImplicitGemmForwardV4R5Xdlops::IsApplicable(const ConvolutionContext
     // this particular HeuristicInit is so comprehensive, that if it cannot predict a valid
     // performance config, the problem is probably not applicable
     PerformanceImplicitGemmForwardV4R5Xdlops config;
-    config.HeuristicInit(ctx);
+    config.HeuristicInit(ctx, problem);
 
-    return config.IsReallyValid(ctx);
+    return config.IsReallyValid(problem);
 }
 
 PerformanceImplicitGemmForwardV4R5Xdlops
 ConvHipImplicitGemmForwardV4R5Xdlops::Search(const ConvolutionContext& ctx,
+                                             const ProblemDescription& problem,
                                              const AnyInvokeParams& invoke_ctx) const
 {
-    return GenericSearch(*this, ctx, ctx.problem, invoke_ctx);
+    return GenericSearch(*this, ctx, problem, invoke_ctx);
 }
 
 } // namespace solver

--- a/src/solver/conv_hip_implicit_gemm_fwd_v4r5_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_fwd_v4r5_xdlops.cpp
@@ -154,7 +154,8 @@ bool PerformanceImplicitGemmForwardV4R5Xdlops::SetNextValue(const ConvolutionCon
     return true;
 }
 
-void PerformanceImplicitGemmForwardV4R5Xdlops::HeuristicInit(const ConvolutionContext& ctx, const ProblemDescription& problem)
+void PerformanceImplicitGemmForwardV4R5Xdlops::HeuristicInit(const ConvolutionContext& ctx,
+                                                             const ProblemDescription& problem)
 {
     PerformanceImplicitGemmForwardV4R5Xdlops tmp;
 
@@ -273,8 +274,10 @@ void PerformanceImplicitGemmForwardV4R5Xdlops::HeuristicInit(const ConvolutionCo
     // second round: really valid
     if(!tmp.IsReallyValid(problem))
     {
-        get_euristic_config(
-            [&ctx, &problem](const auto& config) { std::ignore = ctx; return config.IsReallyValid(problem); });
+        get_euristic_config([&ctx, &problem](const auto& config) {
+            std::ignore = ctx;
+            return config.IsReallyValid(problem);
+        });
     }
 
     // final check
@@ -344,9 +347,8 @@ PerformanceImplicitGemmForwardV4R5Xdlops::CalculateGemmABlockCopyPerformancePara
     int SrcDataPerRead_GemmKPack  = problem.IsFp32()
                                         ? amd_buffer_load_max_length<float>()
                                         : amd_buffer_load_max_length<half_float::half>();
-    int DstDataPerWrite_GemmKPack = problem.IsFp32()
-                                        ? amd_lds_write_max_length<float>()
-                                        : amd_lds_write_max_length<half_float::half>();
+    int DstDataPerWrite_GemmKPack = problem.IsFp32() ? amd_lds_write_max_length<float>()
+                                                     : amd_lds_write_max_length<half_float::half>();
 
     try
     {
@@ -430,10 +432,9 @@ PerformanceImplicitGemmForwardV4R5Xdlops::CalculateGemmBBlockCopyPerformancePara
     int ClusterLengths_B          = -1;
     int ClusterLengths_GemmKPack  = -1;
     int SrcDataPerRead_B          = problem.IsFp32() ? amd_buffer_load_max_length<float>()
-                                                         : amd_buffer_load_max_length<half_float::half>();
-    int DstDataPerWrite_GemmKPack = problem.IsFp32()
-                                        ? amd_lds_write_max_length<float>()
-                                        : amd_lds_write_max_length<half_float::half>();
+                                                     : amd_buffer_load_max_length<half_float::half>();
+    int DstDataPerWrite_GemmKPack = problem.IsFp32() ? amd_lds_write_max_length<float>()
+                                                     : amd_lds_write_max_length<half_float::half>();
 
     try
     {
@@ -448,18 +449,17 @@ PerformanceImplicitGemmForwardV4R5Xdlops::CalculateGemmBBlockCopyPerformancePara
 
         // GemmN is src vector read dimension
         // calculate vector length on gemmn dimension based on global tensor layout
-        const auto y             = ProblemInterpreter::GetFilterHeightY(problem);
-        const auto x             = ProblemInterpreter::GetFilterWidthX(problem);
-        const auto ho            = ProblemInterpreter::GetOutputHeightHo(problem);
-        const auto wo            = ProblemInterpreter::GetOutputWidthWo(problem);
-        const auto conv_stride_h = ProblemInterpreter::GetAdjustedConvolutionStrideH(problem);
-        const auto conv_stride_w = ProblemInterpreter::GetAdjustedConvolutionStrideW(problem);
-        const auto conv_dilation_w =
-            ProblemInterpreter::GetAdjustedConvolutionDilationW(problem);
-        const auto in_left_pad_h  = ProblemInterpreter::GetInputLeftPadH(problem);
-        const auto in_left_pad_w  = ProblemInterpreter::GetInputLeftPadW(problem);
-        const auto in_right_pad_h = ProblemInterpreter::GetAdjustedInputRightPadH(problem);
-        const auto in_right_pad_w = ProblemInterpreter::GetAdjustedInputRightPadW(problem);
+        const auto y               = ProblemInterpreter::GetFilterHeightY(problem);
+        const auto x               = ProblemInterpreter::GetFilterWidthX(problem);
+        const auto ho              = ProblemInterpreter::GetOutputHeightHo(problem);
+        const auto wo              = ProblemInterpreter::GetOutputWidthWo(problem);
+        const auto conv_stride_h   = ProblemInterpreter::GetAdjustedConvolutionStrideH(problem);
+        const auto conv_stride_w   = ProblemInterpreter::GetAdjustedConvolutionStrideW(problem);
+        const auto conv_dilation_w = ProblemInterpreter::GetAdjustedConvolutionDilationW(problem);
+        const auto in_left_pad_h   = ProblemInterpreter::GetInputLeftPadH(problem);
+        const auto in_left_pad_w   = ProblemInterpreter::GetInputLeftPadW(problem);
+        const auto in_right_pad_h  = ProblemInterpreter::GetAdjustedInputRightPadH(problem);
+        const auto in_right_pad_w  = ProblemInterpreter::GetAdjustedInputRightPadW(problem);
 
         const auto NWaves    = GemmNPerBlock / GemmNPerWave;
         const auto BPerBlock = GemmNPerBlock / NWaves;
@@ -602,7 +602,8 @@ bool PerformanceImplicitGemmForwardV4R5Xdlops::IsValidValue() const
 
 // Used by HeuristicInit() and GenericSearch
 // Only return false if a performance config will violate requirements given by kernel algorithm
-bool PerformanceImplicitGemmForwardV4R5Xdlops::IsReallyValid(const ProblemDescription& problem) const
+bool PerformanceImplicitGemmForwardV4R5Xdlops::IsReallyValid(
+    const ProblemDescription& problem) const
 {
     if(!IsValidValue())
         return false;
@@ -835,7 +836,7 @@ bool PerformanceImplicitGemmForwardV4R5Xdlops::IsFastToBeUsedForTuning(
                          std::ignore,
                          SrcDataPerRead_B,
                          DstDataPerWrite_GemmKPack,
-                         valid)               = CalculateGemmBBlockCopyPerformanceParameters(problem);
+                         valid) = CalculateGemmBBlockCopyPerformanceParameters(problem);
                 if(valid)
                 {
                     if((SrcDataPerRead_B > 1) &&
@@ -854,7 +855,8 @@ bool PerformanceImplicitGemmForwardV4R5Xdlops::IsFastToBeUsedForTuning(
 // Return false, if you don't want to this to be included in tuning range used by generic search
 // A performance config may still be valid w.r.t algorithm correctness, even when IsValid() return
 // false
-bool PerformanceImplicitGemmForwardV4R5Xdlops::IsValid(const ConvolutionContext& ctx, const ProblemDescription& problem) const
+bool PerformanceImplicitGemmForwardV4R5Xdlops::IsValid(const ConvolutionContext& ctx,
+                                                       const ProblemDescription& problem) const
 {
     return IsReallyValid(problem) && IsFastToBeUsedForTuning(ctx, problem);
 }
@@ -877,7 +879,9 @@ ConvHipImplicitGemmForwardV4R5Xdlops::GetDefaultPerformanceConfig(
 }
 
 ConvSolution ConvHipImplicitGemmForwardV4R5Xdlops::GetSolution(
-    const ConvolutionContext& ctx, const ProblemDescription& problem, const PerformanceImplicitGemmForwardV4R5Xdlops& config) const
+    const ConvolutionContext& ctx,
+    const ProblemDescription& problem,
+    const PerformanceImplicitGemmForwardV4R5Xdlops& config) const
 {
     ConvSolution result;
 
@@ -990,7 +994,8 @@ ConvSolution ConvHipImplicitGemmForwardV4R5Xdlops::GetSolution(
     return result;
 }
 
-bool ConvHipImplicitGemmForwardV4R5Xdlops::IsApplicable(const ConvolutionContext& ctx, const ProblemDescription& problem) const
+bool ConvHipImplicitGemmForwardV4R5Xdlops::IsApplicable(const ConvolutionContext& ctx,
+                                                        const ProblemDescription& problem) const
 {
     if(miopen::IsDisabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_FWD_V4R5_XDLOPS{}))
         return false;


### PR DESCRIPTION
PR splits ConvolutionContext and ProblemDescription inside ConvHipImplicitGemmForwardV4R5Xdlops

Additional changes:
- Parameters are passed to lambdas by reference (not by value) inside `HeuristicInit()`