### PR TITLE
[Solvers] ConvHipImplicitGemmV4R4WrW: split ConvolutionContext and ProblemDescription (stage 2)

### DIFF
--- a/src/include/miopen/solver.hpp
+++ b/src/include/miopen/solver.hpp
@@ -907,19 +907,23 @@ struct PerformanceImplicitGemmV4R4WrW : PerfConfigBase<PerformanceImplicitGemmV4
         f(self.GemmNPerThread, "GemmNPerThread");
     }
 
-    std::tuple<int, bool> CalculateGridSize(const ConvolutionContext& ctx) const;
+    std::tuple<int, bool> CalculateGridSize(const ProblemDescription&) const;
     std::tuple<int, int, int, int, bool>
-    CalculateBlockGemmPerformanceParameters(const ConvolutionContext& ctx) const;
+    CalculateBlockGemmPerformanceParameters() const;
     std::tuple<int, int, int, int, bool>
-    CalculateGemmABlockCopyPerformanceParameters(const ConvolutionContext& ctx) const;
+    CalculateGemmABlockCopyPerformanceParameters() const;
     std::tuple<int, int, int, int, bool>
-    CalculateGemmBBlockCopyPerformanceParameters(const ConvolutionContext& ctx) const;
+    CalculateGemmBBlockCopyPerformanceParameters(const ProblemDescription&) const;
     std::tuple<int, bool>
-    CalculateGemmCThreadCopyPerformanceParameters(const ConvolutionContext& ctx) const;
-    std::tuple<std::size_t, bool> CalculateLdsNumberOfByte(const ConvolutionContext& ctx) const;
+    CalculateGemmCThreadCopyPerformanceParameters(const ProblemDescription&) const;
+    std::tuple<std::size_t, bool> CalculateLdsNumberOfByte(const ProblemDescription&) const;
     bool IsValidValue() const;
-    bool IsValid(const ConvolutionContext& ctx) const;
-    void HeuristicInit(const ConvolutionContext& ctx);
+    bool IsValid(const ConvolutionContext& ctx) const
+    {
+        return IsValid(ctx.problem);
+    }
+    bool IsValid(const ProblemDescription&) const;
+    void HeuristicInit(const ConvolutionContext&, const ProblemDescription&);
     bool SetNextValue(const ConvolutionContext&);
 };
 
@@ -1412,23 +1416,57 @@ private:
 
 struct ConvHipImplicitGemmV4R4WrW final : ConvTunableSolver<PerformanceImplicitGemmV4R4WrW>
 {
+    // To suppress -Woverloaded-virtual
+    using ConvTunableSolver::IsApplicable;
+    using ConvTunableSolver::GetDefaultPerformanceConfig;
+    using ConvTunableSolver::IsValidPerformanceConfig;
+    using ConvTunableSolver::Search;
+    using ConvTunableSolver::GetSolution;
+
     const std::string& SolverDbId() const override
     {
         return GetSolverDbId<ConvHipImplicitGemmV4R4WrW>();
     }
 
-    bool IsApplicable(const ConvolutionContext& ctx) const override;
+    bool IsApplicable(const ConvolutionContext& ctx) const override
+    {
+        return IsApplicable(ctx, ctx.problem);
+    }
     PerformanceImplicitGemmV4R4WrW
-    GetDefaultPerformanceConfig(const ConvolutionContext& ctx) const override;
+    GetDefaultPerformanceConfig(const ConvolutionContext& ctx) const override
+    {
+        return GetDefaultPerformanceConfig(ctx, ctx.problem);
+    }
     bool IsValidPerformanceConfig(const ConvolutionContext& ctx,
-                                  const PerformanceImplicitGemmV4R4WrW& config) const override;
-    PerformanceImplicitGemmV4R4WrW Search(const ConvolutionContext&,
-                                          const AnyInvokeParams& invoke_ctx) const override;
+                                  const PerformanceImplicitGemmV4R4WrW& config) const override
+    {
+        return IsValidPerformanceConfig(ctx.problem, config);
+    }
+    PerformanceImplicitGemmV4R4WrW Search(const ConvolutionContext& ctx,
+                                          const AnyInvokeParams& invoke_ctx) const override
+    {
+        return Search(ctx, ctx.problem, invoke_ctx);
+    }
     ConvSolution GetSolution(const ConvolutionContext& ctx,
-                             const PerformanceImplicitGemmV4R4WrW& config) const override;
+                             const PerformanceImplicitGemmV4R4WrW& config) const override
+    {
+        return GetSolution(ctx, ctx.problem, config);
+    }
 
 private:
-    static std::tuple<int, int, int> CalculateGemmSize(const ConvolutionContext& ctx);
+    bool IsApplicable(const ConvolutionContext&, const ProblemDescription&) const;
+    PerformanceImplicitGemmV4R4WrW
+    GetDefaultPerformanceConfig(const ConvolutionContext&, const ProblemDescription&) const;
+    bool IsValidPerformanceConfig(const ProblemDescription&,
+                                  const PerformanceImplicitGemmV4R4WrW&) const;
+    PerformanceImplicitGemmV4R4WrW Search(const ConvolutionContext&,
+                                          const ProblemDescription&,
+                                          const AnyInvokeParams& invoke_ctx) const;
+    ConvSolution GetSolution(const ConvolutionContext&,
+                             const ProblemDescription&,
+                             const PerformanceImplicitGemmV4R4WrW&) const;
+
+    static std::tuple<int, int, int> CalculateGemmSize(const ProblemDescription&);
 
     friend struct PerformanceImplicitGemmV4R4WrW;
 };

--- a/src/include/miopen/solver.hpp
+++ b/src/include/miopen/solver.hpp
@@ -908,20 +908,15 @@ struct PerformanceImplicitGemmV4R4WrW : PerfConfigBase<PerformanceImplicitGemmV4
     }
 
     std::tuple<int, bool> CalculateGridSize(const ProblemDescription&) const;
-    std::tuple<int, int, int, int, bool>
-    CalculateBlockGemmPerformanceParameters() const;
-    std::tuple<int, int, int, int, bool>
-    CalculateGemmABlockCopyPerformanceParameters() const;
+    std::tuple<int, int, int, int, bool> CalculateBlockGemmPerformanceParameters() const;
+    std::tuple<int, int, int, int, bool> CalculateGemmABlockCopyPerformanceParameters() const;
     std::tuple<int, int, int, int, bool>
     CalculateGemmBBlockCopyPerformanceParameters(const ProblemDescription&) const;
     std::tuple<int, bool>
     CalculateGemmCThreadCopyPerformanceParameters(const ProblemDescription&) const;
     std::tuple<std::size_t, bool> CalculateLdsNumberOfByte(const ProblemDescription&) const;
     bool IsValidValue() const;
-    bool IsValid(const ConvolutionContext& ctx) const
-    {
-        return IsValid(ctx.problem);
-    }
+    bool IsValid(const ConvolutionContext& ctx) const { return IsValid(ctx.problem); }
     bool IsValid(const ProblemDescription&) const;
     void HeuristicInit(const ConvolutionContext&, const ProblemDescription&);
     bool SetNextValue(const ConvolutionContext&);
@@ -1417,11 +1412,11 @@ private:
 struct ConvHipImplicitGemmV4R4WrW final : ConvTunableSolver<PerformanceImplicitGemmV4R4WrW>
 {
     // To suppress -Woverloaded-virtual
-    using ConvTunableSolver::IsApplicable;
     using ConvTunableSolver::GetDefaultPerformanceConfig;
+    using ConvTunableSolver::GetSolution;
+    using ConvTunableSolver::IsApplicable;
     using ConvTunableSolver::IsValidPerformanceConfig;
     using ConvTunableSolver::Search;
-    using ConvTunableSolver::GetSolution;
 
     const std::string& SolverDbId() const override
     {
@@ -1455,8 +1450,8 @@ struct ConvHipImplicitGemmV4R4WrW final : ConvTunableSolver<PerformanceImplicitG
 
 private:
     bool IsApplicable(const ConvolutionContext&, const ProblemDescription&) const;
-    PerformanceImplicitGemmV4R4WrW
-    GetDefaultPerformanceConfig(const ConvolutionContext&, const ProblemDescription&) const;
+    PerformanceImplicitGemmV4R4WrW GetDefaultPerformanceConfig(const ConvolutionContext&,
+                                                               const ProblemDescription&) const;
     bool IsValidPerformanceConfig(const ProblemDescription&,
                                   const PerformanceImplicitGemmV4R4WrW&) const;
     PerformanceImplicitGemmV4R4WrW Search(const ConvolutionContext&,

--- a/src/include/miopen/solver/implicitgemm_util.hpp
+++ b/src/include/miopen/solver/implicitgemm_util.hpp
@@ -360,7 +360,8 @@ IsValidGridGemmXdlops(const std::size_t GemmM, const std::size_t GemmN, const st
 }
 
 ///\todo remove
-static inline bool IsApplicableXdlops(const ExecutionContext& ctx, const ProblemDescription& problem)
+static inline bool IsApplicableXdlops(const ExecutionContext& ctx,
+                                      const ProblemDescription& problem)
 {
     if(!IsXdlopsSupport(ctx))
         return false;

--- a/src/include/miopen/solver/implicitgemm_util.hpp
+++ b/src/include/miopen/solver/implicitgemm_util.hpp
@@ -59,36 +59,36 @@ namespace solver {
 
 // these functions map the dimensions of a bwd-wrw problem into a fwd problem
 // they are not supposed to be called by backward-data
-static inline std::size_t KernelFilterStrideH(const ConvolutionContext& c)
+static inline std::size_t KernelFilterStrideH(const ProblemDescription& problem)
 {
-    if(c.problem.direction.IsBackwardWrW())
-        return c.problem.kernel_dilation_h;
+    if(problem.direction.IsBackwardWrW())
+        return problem.kernel_dilation_h;
     else
-        return c.problem.kernel_stride_h;
+        return problem.kernel_stride_h;
 }
 
-static inline std::size_t KernelFilterStrideW(const ConvolutionContext& c)
+static inline std::size_t KernelFilterStrideW(const ProblemDescription& problem)
 {
-    if(c.problem.direction.IsBackwardWrW())
-        return c.problem.kernel_dilation_w;
+    if(problem.direction.IsBackwardWrW())
+        return problem.kernel_dilation_w;
     else
-        return c.problem.kernel_stride_w;
+        return problem.kernel_stride_w;
 }
 
-static inline std::size_t KernelFilterDilationH(const ConvolutionContext& c)
+static inline std::size_t KernelFilterDilationH(const ProblemDescription& problem)
 {
-    if(c.problem.direction.IsBackwardWrW())
-        return c.problem.kernel_stride_h;
+    if(problem.direction.IsBackwardWrW())
+        return problem.kernel_stride_h;
     else
-        return c.problem.kernel_dilation_h;
+        return problem.kernel_dilation_h;
 }
 
-static inline std::size_t KernelFilterDilationW(const ConvolutionContext& c)
+static inline std::size_t KernelFilterDilationW(const ProblemDescription& problem)
 {
-    if(c.problem.direction.IsBackwardWrW())
-        return c.problem.kernel_stride_w;
+    if(problem.direction.IsBackwardWrW())
+        return problem.kernel_stride_w;
     else
-        return c.problem.kernel_dilation_w;
+        return problem.kernel_dilation_w;
 }
 
 static inline std::size_t KernelOutputChannelK(const ProblemDescription& problem)
@@ -360,39 +360,39 @@ IsValidGridGemmXdlops(const std::size_t GemmM, const std::size_t GemmN, const st
 }
 
 ///\todo remove
-static inline bool IsApplicableXdlops(const ConvolutionContext& ctx)
+static inline bool IsApplicableXdlops(const ExecutionContext& ctx, const ProblemDescription& problem)
 {
     if(!IsXdlopsSupport(ctx))
         return false;
 
-    std::size_t n  = ProblemInterpreter::GetBatchN(ctx.problem);
-    std::size_t k  = ProblemInterpreter::GetOutputChannelK(ctx.problem) / ctx.problem.group_counts;
-    std::size_t c  = ProblemInterpreter::GetInputChannelC(ctx.problem) / ctx.problem.group_counts;
-    std::size_t y  = ProblemInterpreter::GetFilterHeightY(ctx.problem);
-    std::size_t x  = ProblemInterpreter::GetFilterWidthX(ctx.problem);
-    std::size_t ho = ProblemInterpreter::GetOutputHeightHo(ctx.problem);
-    std::size_t wo = ProblemInterpreter::GetOutputWidthWo(ctx.problem);
+    std::size_t n  = ProblemInterpreter::GetBatchN(problem);
+    std::size_t k  = ProblemInterpreter::GetOutputChannelK(problem) / problem.group_counts;
+    std::size_t c  = ProblemInterpreter::GetInputChannelC(problem) / problem.group_counts;
+    std::size_t y  = ProblemInterpreter::GetFilterHeightY(problem);
+    std::size_t x  = ProblemInterpreter::GetFilterWidthX(problem);
+    std::size_t ho = ProblemInterpreter::GetOutputHeightHo(problem);
+    std::size_t wo = ProblemInterpreter::GetOutputWidthWo(problem);
 
     std::size_t GemmM, GemmN, GemmK;
     // forward
-    if(ctx.problem.direction.IsForward())
+    if(problem.direction.IsForward())
     {
         // TBD/ Since bfp16/fp16 fwd kernel extracts epack from c*y*x,
         //      one could relax the following restriction for bfp16/fp16,
         //      allowing c=1 when y*x=epack.
-        if(c % GetEPackLength(ctx, ctx.problem, true) != 0)
+        if(c % GetEPackLength(ctx, problem, true) != 0)
             return false;
-        const auto nonVectorizedC = c / GetEPackLength(ctx, ctx.problem, true);
+        const auto nonVectorizedC = c / GetEPackLength(ctx, problem, true);
         GemmM                     = k;
         GemmN                     = static_cast<std::size_t>(n) * ho * wo;
         GemmK                     = static_cast<std::size_t>(nonVectorizedC) * y * x;
     }
     // backwardData
-    else if(ctx.problem.direction.IsBackwardData())
+    else if(problem.direction.IsBackwardData())
     {
-        if(k % GetEPackLength(ctx, ctx.problem, true) != 0)
+        if(k % GetEPackLength(ctx, problem, true) != 0)
             return false;
-        const auto nonVectorizedK = k / GetEPackLength(ctx, ctx.problem, true);
+        const auto nonVectorizedK = k / GetEPackLength(ctx, problem, true);
         GemmM                     = static_cast<std::size_t>(c) * y * x;
         GemmN                     = static_cast<std::size_t>(n) * ho * wo;
         GemmK                     = nonVectorizedK;
@@ -400,25 +400,15 @@ static inline bool IsApplicableXdlops(const ConvolutionContext& ctx)
     // backwardWeights
     else
     {
-        if(n % GetEPackLength(ctx, ctx.problem, true) != 0)
+        if(n % GetEPackLength(ctx, problem, true) != 0)
             return false;
-        const auto nonVectorizedN = n / GetEPackLength(ctx, ctx.problem, true);
+        const auto nonVectorizedN = n / GetEPackLength(ctx, problem, true);
         GemmM                     = k;
         GemmN                     = static_cast<std::size_t>(c) * y * x;
         GemmK                     = static_cast<std::size_t>(nonVectorizedN) * ho * wo;
     }
 
     return IsValidGridGemmXdlops(GemmM, GemmN, GemmK);
-}
-
-///\todo remove
-template <class PerformanceImplicitGemm_t>
-inline static auto GetPerformanceConfigBase(const ConvolutionContext& ctx)
-{
-    PerformanceImplicitGemm_t pp;
-    pp.HeuristicInit(ctx);
-    MIOPEN_LOG_I(pp.ToString());
-    return pp;
 }
 
 ///\todo remove

--- a/src/solver/conv_hip_implicit_gemm_bwd_v4r1_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_bwd_v4r1_xdlops.cpp
@@ -837,7 +837,7 @@ bool ConvHipImplicitGemmBwdDataV4R1Xdlops::IsApplicable(const ConvolutionContext
         return false;
     if(!(problem.IsFp32() || problem.IsFp16() || problem.IsBfp16()))
         return false;
-    if(!IsApplicableXdlops(ctx))
+    if(!IsApplicableXdlops(ctx, problem))
         return false;
     if(!IsIndexRangeLargeEnough(problem))
         return false;

--- a/src/solver/conv_hip_implicit_gemm_wrw_v4r4.cpp
+++ b/src/solver/conv_hip_implicit_gemm_wrw_v4r4.cpp
@@ -90,7 +90,8 @@ PerformanceImplicitGemmV4R4WrW::CalculateGridSize(const ProblemDescription& prob
         int gemm_m = 0;
         int gemm_n = 0;
 
-        std::tie(gemm_m, gemm_n, std::ignore) = ConvHipImplicitGemmV4R4WrW::CalculateGemmSize(problem);
+        std::tie(gemm_m, gemm_n, std::ignore) =
+            ConvHipImplicitGemmV4R4WrW::CalculateGemmSize(problem);
 
         if(!(gemm_m % GemmMPerBlock == 0 && gemm_n % GemmNPerBlock == 0))
             MIOPEN_THROW("invalid performance parameter");
@@ -231,26 +232,24 @@ PerformanceImplicitGemmV4R4WrW::CalculateGemmBBlockCopyPerformanceParameters(
     {
         SrcDataPerRead_GemmK = gcd(SrcDataPerRead_GemmK, GemmKPerBlock);
 
-        const auto y             = ProblemInterpreter::GetFilterHeightY(problem);
-        const auto x             = ProblemInterpreter::GetFilterWidthX(problem);
-        const auto hi            = ProblemInterpreter::GetInputHeightHi(problem);
-        const auto wi            = ProblemInterpreter::GetInputWidthWi(problem);
-        const auto wo            = ProblemInterpreter::GetOutputWidthWo(problem);
-        const auto conv_stride_h = ProblemInterpreter::GetAdjustedConvolutionStrideH(problem);
-        const auto conv_stride_w = ProblemInterpreter::GetAdjustedConvolutionStrideW(problem);
-        const auto conv_dilation_w =
-            ProblemInterpreter::GetAdjustedConvolutionDilationW(problem);
-        const auto in_left_pad_h  = ProblemInterpreter::GetInputLeftPadH(problem);
-        const auto in_left_pad_w  = ProblemInterpreter::GetInputLeftPadW(problem);
-        const auto in_right_pad_h = ProblemInterpreter::GetAdjustedInputRightPadH(problem);
-        const auto in_right_pad_w = ProblemInterpreter::GetAdjustedInputRightPadW(problem);
+        const auto y               = ProblemInterpreter::GetFilterHeightY(problem);
+        const auto x               = ProblemInterpreter::GetFilterWidthX(problem);
+        const auto hi              = ProblemInterpreter::GetInputHeightHi(problem);
+        const auto wi              = ProblemInterpreter::GetInputWidthWi(problem);
+        const auto wo              = ProblemInterpreter::GetOutputWidthWo(problem);
+        const auto conv_stride_h   = ProblemInterpreter::GetAdjustedConvolutionStrideH(problem);
+        const auto conv_stride_w   = ProblemInterpreter::GetAdjustedConvolutionStrideW(problem);
+        const auto conv_dilation_w = ProblemInterpreter::GetAdjustedConvolutionDilationW(problem);
+        const auto in_left_pad_h   = ProblemInterpreter::GetInputLeftPadH(problem);
+        const auto in_left_pad_w   = ProblemInterpreter::GetInputLeftPadW(problem);
+        const auto in_right_pad_h  = ProblemInterpreter::GetAdjustedInputRightPadH(problem);
+        const auto in_right_pad_w  = ProblemInterpreter::GetAdjustedInputRightPadW(problem);
 
         if(problem.Is3d())
         {
-            const auto di = ProblemInterpreter::GetInputDepthDi(problem);
-            const auto z  = ProblemInterpreter::GetFilterDepthZ(problem);
-            const auto conv_stride_d =
-                ProblemInterpreter::GetAdjustedConvolutionStrideD(problem);
+            const auto di             = ProblemInterpreter::GetInputDepthDi(problem);
+            const auto z              = ProblemInterpreter::GetFilterDepthZ(problem);
+            const auto conv_stride_d  = ProblemInterpreter::GetAdjustedConvolutionStrideD(problem);
             const auto in_left_pad_d  = ProblemInterpreter::GetInputLeftPadD(problem);
             const auto in_right_pad_d = ProblemInterpreter::GetAdjustedInputRightPadD(problem);
 
@@ -351,8 +350,7 @@ std::tuple<int, bool> PerformanceImplicitGemmV4R4WrW::CalculateGemmCThreadCopyPe
         const auto x           = ProblemInterpreter::GetFilterWidthX(problem);
         DstDataPerWrite_GemmN1 =
             gcd(DstDataPerWrite_GemmN1,
-                c * y * x *
-                    (problem.Is3d() ? ProblemInterpreter::GetFilterDepthZ(problem) : 1));
+                c * y * x * (problem.Is3d() ? ProblemInterpreter::GetFilterDepthZ(problem) : 1));
     }
     catch(...)
     {
@@ -476,7 +474,8 @@ bool PerformanceImplicitGemmV4R4WrW::IsValid(const ProblemDescription& problem) 
     return (valid and lds_size <= get_lds_max_number_of_byte());
 }
 
-void PerformanceImplicitGemmV4R4WrW::HeuristicInit(const ConvolutionContext& ctx, const ProblemDescription& problem)
+void PerformanceImplicitGemmV4R4WrW::HeuristicInit(const ConvolutionContext& ctx,
+                                                   const ProblemDescription& problem)
 {
     std::ignore = ctx;
     PerformanceImplicitGemmV4R4WrW config;
@@ -576,7 +575,8 @@ ConvHipImplicitGemmV4R4WrW::CalculateGemmSize(const ProblemDescription& problem)
     return std::make_tuple(gemm_m, gemm_n, gemm_k);
 }
 
-bool ConvHipImplicitGemmV4R4WrW::IsApplicable(const ConvolutionContext& ctx, const ProblemDescription& problem) const
+bool ConvHipImplicitGemmV4R4WrW::IsApplicable(const ConvolutionContext& ctx,
+                                              const ProblemDescription& problem) const
 {
     if(miopen::IsDisabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_WRW_V4R4{}))
         return false;
@@ -606,7 +606,8 @@ bool ConvHipImplicitGemmV4R4WrW::IsApplicable(const ConvolutionContext& ctx, con
 }
 
 PerformanceImplicitGemmV4R4WrW
-ConvHipImplicitGemmV4R4WrW::GetDefaultPerformanceConfig(const ConvolutionContext& ctx, const ProblemDescription& problem) const
+ConvHipImplicitGemmV4R4WrW::GetDefaultPerformanceConfig(const ConvolutionContext& ctx,
+                                                        const ProblemDescription& problem) const
 {
     return GetPerformanceConfigBase<PerformanceImplicitGemmV4R4WrW>(ctx, problem);
 }

--- a/src/solver/conv_hip_implicit_gemm_wrw_v4r4.cpp
+++ b/src/solver/conv_hip_implicit_gemm_wrw_v4r4.cpp
@@ -81,7 +81,7 @@ bool PerformanceImplicitGemmV4R4WrW::operator==(const PerformanceImplicitGemmV4R
 }
 
 std::tuple<int, bool>
-PerformanceImplicitGemmV4R4WrW::CalculateGridSize(const ConvolutionContext& ctx) const
+PerformanceImplicitGemmV4R4WrW::CalculateGridSize(const ProblemDescription& problem) const
 {
     int GridSize = 0;
 
@@ -90,7 +90,7 @@ PerformanceImplicitGemmV4R4WrW::CalculateGridSize(const ConvolutionContext& ctx)
         int gemm_m = 0;
         int gemm_n = 0;
 
-        std::tie(gemm_m, gemm_n, std::ignore) = ConvHipImplicitGemmV4R4WrW::CalculateGemmSize(ctx);
+        std::tie(gemm_m, gemm_n, std::ignore) = ConvHipImplicitGemmV4R4WrW::CalculateGemmSize(problem);
 
         if(!(gemm_m % GemmMPerBlock == 0 && gemm_n % GemmNPerBlock == 0))
             MIOPEN_THROW("invalid performance parameter");
@@ -106,8 +106,7 @@ PerformanceImplicitGemmV4R4WrW::CalculateGridSize(const ConvolutionContext& ctx)
 }
 
 std::tuple<int, int, int, int, bool>
-PerformanceImplicitGemmV4R4WrW::CalculateBlockGemmPerformanceParameters(
-    const ConvolutionContext&) const
+PerformanceImplicitGemmV4R4WrW::CalculateBlockGemmPerformanceParameters() const
 {
     int GemmMLevel0Cluster = 0;
     int GemmNLevel0Cluster = 0;
@@ -173,8 +172,7 @@ PerformanceImplicitGemmV4R4WrW::CalculateBlockGemmPerformanceParameters(
 }
 
 std::tuple<int, int, int, int, bool>
-PerformanceImplicitGemmV4R4WrW::CalculateGemmABlockCopyPerformanceParameters(
-    const ConvolutionContext&) const
+PerformanceImplicitGemmV4R4WrW::CalculateGemmABlockCopyPerformanceParameters() const
 {
     int ClusterLengths_GemmK  = 0;
     int ClusterLengths_GemmM  = 0;
@@ -222,7 +220,7 @@ PerformanceImplicitGemmV4R4WrW::CalculateGemmABlockCopyPerformanceParameters(
 
 std::tuple<int, int, int, int, bool>
 PerformanceImplicitGemmV4R4WrW::CalculateGemmBBlockCopyPerformanceParameters(
-    const ConvolutionContext& ctx) const
+    const ProblemDescription& problem) const
 {
     int ClusterLengths_GemmK  = 0;
     int ClusterLengths_GemmN  = 0;
@@ -233,28 +231,28 @@ PerformanceImplicitGemmV4R4WrW::CalculateGemmBBlockCopyPerformanceParameters(
     {
         SrcDataPerRead_GemmK = gcd(SrcDataPerRead_GemmK, GemmKPerBlock);
 
-        const auto y             = ProblemInterpreter::GetFilterHeightY(ctx.problem);
-        const auto x             = ProblemInterpreter::GetFilterWidthX(ctx.problem);
-        const auto hi            = ProblemInterpreter::GetInputHeightHi(ctx.problem);
-        const auto wi            = ProblemInterpreter::GetInputWidthWi(ctx.problem);
-        const auto wo            = ProblemInterpreter::GetOutputWidthWo(ctx.problem);
-        const auto conv_stride_h = ProblemInterpreter::GetAdjustedConvolutionStrideH(ctx.problem);
-        const auto conv_stride_w = ProblemInterpreter::GetAdjustedConvolutionStrideW(ctx.problem);
+        const auto y             = ProblemInterpreter::GetFilterHeightY(problem);
+        const auto x             = ProblemInterpreter::GetFilterWidthX(problem);
+        const auto hi            = ProblemInterpreter::GetInputHeightHi(problem);
+        const auto wi            = ProblemInterpreter::GetInputWidthWi(problem);
+        const auto wo            = ProblemInterpreter::GetOutputWidthWo(problem);
+        const auto conv_stride_h = ProblemInterpreter::GetAdjustedConvolutionStrideH(problem);
+        const auto conv_stride_w = ProblemInterpreter::GetAdjustedConvolutionStrideW(problem);
         const auto conv_dilation_w =
-            ProblemInterpreter::GetAdjustedConvolutionDilationW(ctx.problem);
-        const auto in_left_pad_h  = ProblemInterpreter::GetInputLeftPadH(ctx.problem);
-        const auto in_left_pad_w  = ProblemInterpreter::GetInputLeftPadW(ctx.problem);
-        const auto in_right_pad_h = ProblemInterpreter::GetAdjustedInputRightPadH(ctx.problem);
-        const auto in_right_pad_w = ProblemInterpreter::GetAdjustedInputRightPadW(ctx.problem);
+            ProblemInterpreter::GetAdjustedConvolutionDilationW(problem);
+        const auto in_left_pad_h  = ProblemInterpreter::GetInputLeftPadH(problem);
+        const auto in_left_pad_w  = ProblemInterpreter::GetInputLeftPadW(problem);
+        const auto in_right_pad_h = ProblemInterpreter::GetAdjustedInputRightPadH(problem);
+        const auto in_right_pad_w = ProblemInterpreter::GetAdjustedInputRightPadW(problem);
 
-        if(ctx.problem.Is3d())
+        if(problem.Is3d())
         {
-            const auto di = ProblemInterpreter::GetInputDepthDi(ctx.problem);
-            const auto z  = ProblemInterpreter::GetFilterDepthZ(ctx.problem);
+            const auto di = ProblemInterpreter::GetInputDepthDi(problem);
+            const auto z  = ProblemInterpreter::GetFilterDepthZ(problem);
             const auto conv_stride_d =
-                ProblemInterpreter::GetAdjustedConvolutionStrideD(ctx.problem);
-            const auto in_left_pad_d  = ProblemInterpreter::GetInputLeftPadD(ctx.problem);
-            const auto in_right_pad_d = ProblemInterpreter::GetAdjustedInputRightPadD(ctx.problem);
+                ProblemInterpreter::GetAdjustedConvolutionStrideD(problem);
+            const auto in_left_pad_d  = ProblemInterpreter::GetInputLeftPadD(problem);
+            const auto in_right_pad_d = ProblemInterpreter::GetAdjustedInputRightPadD(problem);
 
             if(z == 1 && y == 1 && x == 1 && conv_stride_d == 1 && conv_stride_h == 1 &&
                conv_stride_w == 1 && in_left_pad_d == 0 && in_left_pad_h == 0 &&
@@ -341,20 +339,20 @@ PerformanceImplicitGemmV4R4WrW::CalculateGemmBBlockCopyPerformanceParameters(
 }
 
 std::tuple<int, bool> PerformanceImplicitGemmV4R4WrW::CalculateGemmCThreadCopyPerformanceParameters(
-    const ConvolutionContext& ctx) const
+    const ProblemDescription& problem) const
 {
     int DstDataPerWrite_GemmN1 = amd_buffer_store_max_length<float>();
     try
     {
         // GemmCThreadCopyDstDataPerWrite_GemmN1 bounded by size of threadwise GEMM
         DstDataPerWrite_GemmN1 = gcd(DstDataPerWrite_GemmN1, GemmNPerThread);
-        const auto c           = ProblemInterpreter::GetInputChannelC(ctx.problem);
-        const auto y           = ProblemInterpreter::GetFilterHeightY(ctx.problem);
-        const auto x           = ProblemInterpreter::GetFilterWidthX(ctx.problem);
+        const auto c           = ProblemInterpreter::GetInputChannelC(problem);
+        const auto y           = ProblemInterpreter::GetFilterHeightY(problem);
+        const auto x           = ProblemInterpreter::GetFilterWidthX(problem);
         DstDataPerWrite_GemmN1 =
             gcd(DstDataPerWrite_GemmN1,
                 c * y * x *
-                    (ctx.problem.Is3d() ? ProblemInterpreter::GetFilterDepthZ(ctx.problem) : 1));
+                    (problem.Is3d() ? ProblemInterpreter::GetFilterDepthZ(problem) : 1));
     }
     catch(...)
     {
@@ -365,7 +363,7 @@ std::tuple<int, bool> PerformanceImplicitGemmV4R4WrW::CalculateGemmCThreadCopyPe
 }
 
 std::tuple<std::size_t, bool>
-PerformanceImplicitGemmV4R4WrW::CalculateLdsNumberOfByte(const ConvolutionContext& ctx) const
+PerformanceImplicitGemmV4R4WrW::CalculateLdsNumberOfByte(const ProblemDescription& problem) const
 {
     std::size_t lds_size = 0;
 
@@ -376,7 +374,7 @@ PerformanceImplicitGemmV4R4WrW::CalculateLdsNumberOfByte(const ConvolutionContex
         int GemmABlockCopyDescDataPerWriteGemmM = 0;
         std::tie(
             std::ignore, std::ignore, std::ignore, GemmABlockCopyDescDataPerWriteGemmM, valid) =
-            CalculateGemmABlockCopyPerformanceParameters(ctx);
+            CalculateGemmABlockCopyPerformanceParameters();
 
         if(!valid)
             MIOPEN_THROW("invalid performance parameter");
@@ -384,7 +382,7 @@ PerformanceImplicitGemmV4R4WrW::CalculateLdsNumberOfByte(const ConvolutionContex
         int GemmBBlockCopyDescDataPerWriteGemmN = 0;
         std::tie(
             std::ignore, std::ignore, std::ignore, GemmBBlockCopyDescDataPerWriteGemmN, valid) =
-            CalculateGemmBBlockCopyPerformanceParameters(ctx);
+            CalculateGemmBBlockCopyPerformanceParameters(problem);
 
         if(!valid)
             MIOPEN_THROW("invalid performance parameter");
@@ -424,7 +422,7 @@ bool PerformanceImplicitGemmV4R4WrW::IsValidValue() const
     // clang-format on
 }
 
-bool PerformanceImplicitGemmV4R4WrW::IsValid(const ConvolutionContext& ctx) const
+bool PerformanceImplicitGemmV4R4WrW::IsValid(const ProblemDescription& problem) const
 {
     if(!IsValidValue())
         return false;
@@ -436,7 +434,7 @@ bool PerformanceImplicitGemmV4R4WrW::IsValid(const ConvolutionContext& ctx) cons
     int gemm_n = 0;
     int gemm_k = 0;
 
-    std::tie(gemm_m, gemm_n, gemm_k) = ConvHipImplicitGemmV4R4WrW::CalculateGemmSize(ctx);
+    std::tie(gemm_m, gemm_n, gemm_k) = ConvHipImplicitGemmV4R4WrW::CalculateGemmSize(problem);
 
     if(!(gemm_m % GemmMPerBlock == 0 && gemm_n % GemmNPerBlock == 0 && gemm_k % GemmKPerBlock == 0))
         return false;
@@ -446,84 +444,85 @@ bool PerformanceImplicitGemmV4R4WrW::IsValid(const ConvolutionContext& ctx) cons
 
     // check thread cluster in blockwise GEMM
     std::tie(std::ignore, std::ignore, std::ignore, std::ignore, valid) =
-        CalculateBlockGemmPerformanceParameters(ctx);
+        CalculateBlockGemmPerformanceParameters();
 
     if(!valid)
         return false;
 
     // check blockwise copy of A matrix
     std::tie(std::ignore, std::ignore, std::ignore, std::ignore, valid) =
-        CalculateGemmABlockCopyPerformanceParameters(ctx);
+        CalculateGemmABlockCopyPerformanceParameters();
 
     if(!valid)
         return false;
 
     // check blockwise copy of B matrix
     std::tie(std::ignore, std::ignore, std::ignore, std::ignore, valid) =
-        CalculateGemmBBlockCopyPerformanceParameters(ctx);
+        CalculateGemmBBlockCopyPerformanceParameters(problem);
 
     if(!valid)
         return false;
 
     // check threadwise copy of C matrix
-    std::tie(std::ignore, valid) = CalculateGemmCThreadCopyPerformanceParameters(ctx);
+    std::tie(std::ignore, valid) = CalculateGemmCThreadCopyPerformanceParameters(problem);
 
     if(!valid)
         return false;
 
     // check LDS allocation
     std::size_t lds_size      = 0;
-    std::tie(lds_size, valid) = CalculateLdsNumberOfByte(ctx);
+    std::tie(lds_size, valid) = CalculateLdsNumberOfByte(problem);
 
     return (valid and lds_size <= get_lds_max_number_of_byte());
 }
 
-void PerformanceImplicitGemmV4R4WrW::HeuristicInit(const ConvolutionContext& ctx)
+void PerformanceImplicitGemmV4R4WrW::HeuristicInit(const ConvolutionContext& ctx, const ProblemDescription& problem)
 {
+    std::ignore = ctx;
     PerformanceImplicitGemmV4R4WrW config;
 
     config = {256, 128, 128, 16, 4, 4};
-    if(!config.IsValid(ctx))
+    if(!config.IsValid(problem))
         config = {256, 128, 128, 8, 4, 4};
-    if(!config.IsValid(ctx))
+    if(!config.IsValid(problem))
         config = {256, 128, 128, 4, 4, 4};
-    if(!config.IsValid(ctx))
+    if(!config.IsValid(problem))
         config = {128, 128, 64, 16, 4, 4};
-    if(!config.IsValid(ctx))
+    if(!config.IsValid(problem))
         config = {128, 128, 64, 8, 4, 4};
-    if(!config.IsValid(ctx))
+    if(!config.IsValid(problem))
         config = {128, 128, 64, 4, 4, 4};
-    if(!config.IsValid(ctx))
+    if(!config.IsValid(problem))
         config = {128, 64, 128, 16, 4, 4};
-    if(!config.IsValid(ctx))
+    if(!config.IsValid(problem))
         config = {128, 64, 128, 8, 4, 4};
-    if(!config.IsValid(ctx))
+    if(!config.IsValid(problem))
         config = {128, 64, 128, 4, 4, 4};
-    if(!config.IsValid(ctx))
+    if(!config.IsValid(problem))
         config = {64, 64, 64, 16, 4, 4};
-    if(!config.IsValid(ctx))
+    if(!config.IsValid(problem))
         config = {64, 64, 64, 8, 4, 4};
-    if(!config.IsValid(ctx))
+    if(!config.IsValid(problem))
         config = {64, 64, 64, 4, 4, 4};
-    if(!config.IsValid(ctx))
+    if(!config.IsValid(problem))
         config = {64, 64, 32, 16, 4, 2};
-    if(!config.IsValid(ctx))
+    if(!config.IsValid(problem))
         config = {64, 64, 32, 8, 4, 2};
-    if(!config.IsValid(ctx))
+    if(!config.IsValid(problem))
         config = {64, 64, 32, 4, 4, 2};
-    if(!config.IsValid(ctx))
+    if(!config.IsValid(problem))
         config = {64, 32, 64, 16, 2, 4};
-    if(!config.IsValid(ctx))
+    if(!config.IsValid(problem))
         config = {64, 32, 64, 8, 2, 4};
-    if(!config.IsValid(ctx))
+    if(!config.IsValid(problem))
         config = {64, 32, 64, 4, 2, 4};
-    if(!config.IsValid(ctx))
+    if(!config.IsValid(problem))
         config = {64, 32, 32, 16, 2, 2};
-    if(!config.IsValid(ctx))
+    if(!config.IsValid(problem))
         config = {64, 32, 32, 8, 2, 2};
-    if(!config.IsValid(ctx))
+    if(!config.IsValid(problem))
         config = {64, 32, 32, 4, 2, 2};
-    if(!config.IsValid(ctx))
+    if(!config.IsValid(problem))
     {
         MIOPEN_LOG_E("All attempts failed: ");
         assert(false);
@@ -558,87 +557,89 @@ bool PerformanceImplicitGemmV4R4WrW::SetNextValue(const ConvolutionContext& /*ct
 }
 
 std::tuple<int, int, int>
-ConvHipImplicitGemmV4R4WrW::CalculateGemmSize(const ConvolutionContext& ctx)
+ConvHipImplicitGemmV4R4WrW::CalculateGemmSize(const ProblemDescription& problem)
 {
-    const auto n  = ProblemInterpreter::GetBatchN(ctx.problem);
-    const auto c  = ProblemInterpreter::GetInputChannelC(ctx.problem);
-    const auto k  = ProblemInterpreter::GetOutputChannelK(ctx.problem);
-    const auto ho = ProblemInterpreter::GetOutputHeightHo(ctx.problem);
-    const auto wo = ProblemInterpreter::GetOutputWidthWo(ctx.problem);
-    const auto y  = ProblemInterpreter::GetFilterHeightY(ctx.problem);
-    const auto x  = ProblemInterpreter::GetFilterWidthX(ctx.problem);
+    const auto n  = ProblemInterpreter::GetBatchN(problem);
+    const auto c  = ProblemInterpreter::GetInputChannelC(problem);
+    const auto k  = ProblemInterpreter::GetOutputChannelK(problem);
+    const auto ho = ProblemInterpreter::GetOutputHeightHo(problem);
+    const auto wo = ProblemInterpreter::GetOutputWidthWo(problem);
+    const auto y  = ProblemInterpreter::GetFilterHeightY(problem);
+    const auto x  = ProblemInterpreter::GetFilterWidthX(problem);
 
     const auto gemm_m = k;
     const auto gemm_n =
-        c * y * x * (ctx.problem.Is3d() ? ProblemInterpreter::GetFilterDepthZ(ctx.problem) : 1);
+        c * y * x * (problem.Is3d() ? ProblemInterpreter::GetFilterDepthZ(problem) : 1);
     const auto gemm_k =
-        n * ho * wo * (ctx.problem.Is3d() ? ProblemInterpreter::GetOutputDepthDo(ctx.problem) : 1);
+        n * ho * wo * (problem.Is3d() ? ProblemInterpreter::GetOutputDepthDo(problem) : 1);
 
     return std::make_tuple(gemm_m, gemm_n, gemm_k);
 }
 
-bool ConvHipImplicitGemmV4R4WrW::IsApplicable(const ConvolutionContext& ctx) const
+bool ConvHipImplicitGemmV4R4WrW::IsApplicable(const ConvolutionContext& ctx, const ProblemDescription& problem) const
 {
     if(miopen::IsDisabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_WRW_V4R4{}))
         return false;
-    if(ctx.problem.conv_problem.GetConv().attribute.deterministic)
+    if(problem.conv_problem.GetConv().attribute.deterministic)
         return false;
     if(!ctx.use_hip_kernels)
         return false;
-    if(!ctx.problem.IsLayoutDefault())
+    if(!problem.IsLayoutDefault())
         return false;
     if(!IsComposableKernelSupportedHardware(ctx))
         return false;
-    if(!ctx.problem.direction.IsBackwardWrW())
+    if(!problem.direction.IsBackwardWrW())
         return false;
-    if(!ctx.problem.Is2d() && !ctx.problem.Is3d())
+    if(!problem.Is2d() && !problem.Is3d())
         return false;
-    if(!ctx.problem.IsFp32())
+    if(!problem.IsFp32())
         return false;
-    if(ctx.problem.group_counts != 1)
+    if(problem.group_counts != 1)
         return false;
 
     int gemm_m = 0;
     int gemm_n = 0;
     int gemm_k = 0;
 
-    std::tie(gemm_m, gemm_n, gemm_k) = CalculateGemmSize(ctx);
+    std::tie(gemm_m, gemm_n, gemm_k) = CalculateGemmSize(problem);
     return gemm_m % 32 == 0 && gemm_n % 32 == 0 && gemm_k % 4 == 0;
 }
 
 PerformanceImplicitGemmV4R4WrW
-ConvHipImplicitGemmV4R4WrW::GetDefaultPerformanceConfig(const ConvolutionContext& ctx) const
+ConvHipImplicitGemmV4R4WrW::GetDefaultPerformanceConfig(const ConvolutionContext& ctx, const ProblemDescription& problem) const
 {
-    return GetPerformanceConfigBase<PerformanceImplicitGemmV4R4WrW>(ctx);
+    return GetPerformanceConfigBase<PerformanceImplicitGemmV4R4WrW>(ctx, problem);
 }
 
 bool ConvHipImplicitGemmV4R4WrW::IsValidPerformanceConfig(
-    const ConvolutionContext& ctx, const PerformanceImplicitGemmV4R4WrW& config) const
+    const ProblemDescription& problem, const PerformanceImplicitGemmV4R4WrW& config) const
 {
     MIOPEN_LOG_I("");
-    return config.IsValidValue() && config.IsValid(ctx);
+    return config.IsValidValue() && config.IsValid(problem);
 }
 
 PerformanceImplicitGemmV4R4WrW
 ConvHipImplicitGemmV4R4WrW::Search(const ConvolutionContext& ctx,
+                                   const ProblemDescription& problem,
                                    const AnyInvokeParams& invoke_ctx) const
 {
-    return GenericSearch(*this, ctx, ctx.problem, invoke_ctx);
+    return GenericSearch(*this, ctx, problem, invoke_ctx);
 }
 
 ConvSolution
 ConvHipImplicitGemmV4R4WrW::GetSolution(const ConvolutionContext& ctx,
+                                        const ProblemDescription& problem,
                                         const PerformanceImplicitGemmV4R4WrW& config) const
 {
 
     ConvSolution result;
     KernelInfo construction_parameters;
 
-    assert(config.IsValid(ctx));
+    assert(config.IsValid(problem));
 
     int grid_size = 0;
 
-    std::tie(grid_size, std::ignore) = config.CalculateGridSize(ctx);
+    std::tie(grid_size, std::ignore) = config.CalculateGridSize(problem);
 
     construction_parameters.l_wk.push_back(config.BlockSize);
     construction_parameters.l_wk.push_back(1);
@@ -648,7 +649,7 @@ ConvHipImplicitGemmV4R4WrW::GetSolution(const ConvolutionContext& ctx,
     construction_parameters.g_wk.push_back(1);
     construction_parameters.g_wk.push_back(1);
 
-    if(ctx.problem.Is3d())
+    if(problem.Is3d())
     {
         // clang-format off
         construction_parameters.kernel_file =
@@ -687,42 +688,42 @@ ConvHipImplicitGemmV4R4WrW::GetSolution(const ConvolutionContext& ctx,
              GemmNLevel0Cluster,
              GemmMLevel1Cluster,
              GemmNLevel1Cluster,
-             std::ignore) = config.CalculateBlockGemmPerformanceParameters(ctx);
+             std::ignore) = config.CalculateBlockGemmPerformanceParameters();
 
     std::tie(GemmABlockCopyClusterLengths_GemmK,
              GemmABlockCopyClusterLengths_GemmM,
              GemmABlockCopySrcDataPerRead_GemmK,
              GemmABlockCopyDstDataPerWrite_GemmM,
-             std::ignore) = config.CalculateGemmABlockCopyPerformanceParameters(ctx);
+             std::ignore) = config.CalculateGemmABlockCopyPerformanceParameters();
 
     std::tie(GemmBBlockCopyClusterLengths_GemmK,
              GemmBBlockCopyClusterLengths_GemmN,
              GemmBBlockCopySrcDataPerRead_GemmK,
              GemmBBlockCopyDstDataPerWrite_GemmN,
-             std::ignore) = config.CalculateGemmBBlockCopyPerformanceParameters(ctx);
+             std::ignore) = config.CalculateGemmBBlockCopyPerformanceParameters(problem);
 
     std::tie(GemmCThreadCopyDstDataPerWrite_GemmN1, std::ignore) =
-        config.CalculateGemmCThreadCopyPerformanceParameters(ctx);
+        config.CalculateGemmCThreadCopyPerformanceParameters(problem);
 
     // clang-format off
     construction_parameters.comp_options =
-        std::string(" -DCK_PARAM_PROBLEM_N=") + std::to_string(ProblemInterpreter::GetBatchN(ctx.problem)) +
-        std::string(" -DCK_PARAM_PROBLEM_C=") + std::to_string(ProblemInterpreter::GetInputChannelC(ctx.problem)) +
-        std::string(" -DCK_PARAM_PROBLEM_K=") + std::to_string(ProblemInterpreter::GetOutputChannelK(ctx.problem)) +
-        std::string(" -DCK_PARAM_PROBLEM_HO=") + std::to_string(ProblemInterpreter::GetOutputHeightHo(ctx.problem)) +
-        std::string(" -DCK_PARAM_PROBLEM_WO=") + std::to_string(ProblemInterpreter::GetOutputWidthWo(ctx.problem)) +
-        std::string(" -DCK_PARAM_PROBLEM_HI=") + std::to_string(ProblemInterpreter::GetInputHeightHi(ctx.problem)) +
-        std::string(" -DCK_PARAM_PROBLEM_WI=") + std::to_string(ProblemInterpreter::GetInputWidthWi(ctx.problem)) +
-        std::string(" -DCK_PARAM_PROBLEM_Y=") + std::to_string(ProblemInterpreter::GetFilterHeightY(ctx.problem)) +
-        std::string(" -DCK_PARAM_PROBLEM_X=") + std::to_string(ProblemInterpreter::GetFilterWidthX(ctx.problem)) +
-        std::string(" -DCK_PARAM_PROBLEM_CONV_STRIDE_H=") + std::to_string(ProblemInterpreter::GetAdjustedConvolutionStrideH(ctx.problem)) +
-        std::string(" -DCK_PARAM_PROBLEM_CONV_STRIDE_W=") + std::to_string(ProblemInterpreter::GetAdjustedConvolutionStrideW(ctx.problem)) +
-        std::string(" -DCK_PARAM_PROBLEM_CONV_DILATION_H=") + std::to_string(ProblemInterpreter::GetAdjustedConvolutionDilationH(ctx.problem)) +
-        std::string(" -DCK_PARAM_PROBLEM_CONV_DILATION_W=") + std::to_string(ProblemInterpreter::GetAdjustedConvolutionDilationW(ctx.problem)) +
-        std::string(" -DCK_PARAM_PROBLEM_IN_LEFT_PAD_H=") + std::to_string(ProblemInterpreter::GetInputLeftPadH(ctx.problem)) +
-        std::string(" -DCK_PARAM_PROBLEM_IN_LEFT_PAD_W=") + std::to_string(ProblemInterpreter::GetInputLeftPadW(ctx.problem)) +
-        std::string(" -DCK_PARAM_PROBLEM_IN_RIGHT_PAD_H=") + std::to_string(ProblemInterpreter::GetAdjustedInputRightPadH(ctx.problem)) +
-        std::string(" -DCK_PARAM_PROBLEM_IN_RIGHT_PAD_W=") + std::to_string(ProblemInterpreter::GetAdjustedInputRightPadW(ctx.problem)) +
+        std::string(" -DCK_PARAM_PROBLEM_N=") + std::to_string(ProblemInterpreter::GetBatchN(problem)) +
+        std::string(" -DCK_PARAM_PROBLEM_C=") + std::to_string(ProblemInterpreter::GetInputChannelC(problem)) +
+        std::string(" -DCK_PARAM_PROBLEM_K=") + std::to_string(ProblemInterpreter::GetOutputChannelK(problem)) +
+        std::string(" -DCK_PARAM_PROBLEM_HO=") + std::to_string(ProblemInterpreter::GetOutputHeightHo(problem)) +
+        std::string(" -DCK_PARAM_PROBLEM_WO=") + std::to_string(ProblemInterpreter::GetOutputWidthWo(problem)) +
+        std::string(" -DCK_PARAM_PROBLEM_HI=") + std::to_string(ProblemInterpreter::GetInputHeightHi(problem)) +
+        std::string(" -DCK_PARAM_PROBLEM_WI=") + std::to_string(ProblemInterpreter::GetInputWidthWi(problem)) +
+        std::string(" -DCK_PARAM_PROBLEM_Y=") + std::to_string(ProblemInterpreter::GetFilterHeightY(problem)) +
+        std::string(" -DCK_PARAM_PROBLEM_X=") + std::to_string(ProblemInterpreter::GetFilterWidthX(problem)) +
+        std::string(" -DCK_PARAM_PROBLEM_CONV_STRIDE_H=") + std::to_string(ProblemInterpreter::GetAdjustedConvolutionStrideH(problem)) +
+        std::string(" -DCK_PARAM_PROBLEM_CONV_STRIDE_W=") + std::to_string(ProblemInterpreter::GetAdjustedConvolutionStrideW(problem)) +
+        std::string(" -DCK_PARAM_PROBLEM_CONV_DILATION_H=") + std::to_string(ProblemInterpreter::GetAdjustedConvolutionDilationH(problem)) +
+        std::string(" -DCK_PARAM_PROBLEM_CONV_DILATION_W=") + std::to_string(ProblemInterpreter::GetAdjustedConvolutionDilationW(problem)) +
+        std::string(" -DCK_PARAM_PROBLEM_IN_LEFT_PAD_H=") + std::to_string(ProblemInterpreter::GetInputLeftPadH(problem)) +
+        std::string(" -DCK_PARAM_PROBLEM_IN_LEFT_PAD_W=") + std::to_string(ProblemInterpreter::GetInputLeftPadW(problem)) +
+        std::string(" -DCK_PARAM_PROBLEM_IN_RIGHT_PAD_H=") + std::to_string(ProblemInterpreter::GetAdjustedInputRightPadH(problem)) +
+        std::string(" -DCK_PARAM_PROBLEM_IN_RIGHT_PAD_W=") + std::to_string(ProblemInterpreter::GetAdjustedInputRightPadW(problem)) +
         std::string(" -DCK_PARAM_PROBLEM_CONV_DIRECTION_FORWARD=") + std::to_string(0) +
         std::string(" -DCK_PARAM_PROBLEM_CONV_DIRECTION_BACKWARD_DATA=") + std::to_string(0) +
         std::string(" -DCK_PARAM_PROBLEM_CONV_DIRECTION_BACKWARD_WEIGHT=") + std::to_string(1) +
@@ -746,20 +747,20 @@ ConvHipImplicitGemmV4R4WrW::GetSolution(const ConvolutionContext& ctx,
         std::string(" -DCK_PARAM_TUNABLE_GEMM_B_BLOCK_COPY_DST_DATA_PER_WRITE_GEMM_N=") + std::to_string(GemmBBlockCopyDstDataPerWrite_GemmN) +
         std::string(" -DCK_PARAM_TUNABLE_GEMM_C_THREAD_COPY_DST_DATA_PER_WRITE_GEMM_N1=") + std::to_string(GemmCThreadCopyDstDataPerWrite_GemmN1) +
         std::string(" -DCK_PARAM_DEPENDENT_GRID_SIZE=") + std::to_string(grid_size) +
-        std::string(" -DCK_THREADWISE_GEMM_USE_AMD_INLINE_ASM=") + (use_amd_inline_asm(ctx, ctx.problem) ? '1' : '0') +
-        std::string(" -DCK_USE_AMD_INLINE_ASM=") + (use_amd_inline_asm(ctx, ctx.problem) ? '1' : '0') +
+        std::string(" -DCK_THREADWISE_GEMM_USE_AMD_INLINE_ASM=") + (use_amd_inline_asm(ctx, problem) ? '1' : '0') +
+        std::string(" -DCK_USE_AMD_INLINE_ASM=") + (use_amd_inline_asm(ctx, problem) ? '1' : '0') +
         get_static_ck_common_compiler_flag(ctx) +
         ctx.general_compile_options;
 
-        if (ctx.problem.Is3d()){
+        if (problem.Is3d()){
             construction_parameters.comp_options +=
-                std::string(" -DCK_PARAM_PROBLEM_DI=") + std::to_string(ProblemInterpreter::GetInputDepthDi(ctx.problem)) +
-                std::string(" -DCK_PARAM_PROBLEM_DO=") + std::to_string(ProblemInterpreter::GetOutputDepthDo(ctx.problem)) +
-                std::string(" -DCK_PARAM_PROBLEM_Z=") + std::to_string(ProblemInterpreter::GetFilterDepthZ(ctx.problem)) +
-                std::string(" -DCK_PARAM_PROBLEM_CONV_STRIDE_D=") + std::to_string(ProblemInterpreter::GetAdjustedConvolutionStrideD(ctx.problem)) +
-                std::string(" -DCK_PARAM_PROBLEM_CONV_DILATION_D=") + std::to_string(ProblemInterpreter::GetAdjustedConvolutionDilationD(ctx.problem)) +
-                std::string(" -DCK_PARAM_PROBLEM_IN_LEFT_PAD_D=") + std::to_string(ProblemInterpreter::GetInputLeftPadD(ctx.problem)) +
-                std::string(" -DCK_PARAM_PROBLEM_IN_RIGHT_PAD_D=") + std::to_string(ProblemInterpreter::GetAdjustedInputRightPadD(ctx.problem)) ;
+                std::string(" -DCK_PARAM_PROBLEM_DI=") + std::to_string(ProblemInterpreter::GetInputDepthDi(problem)) +
+                std::string(" -DCK_PARAM_PROBLEM_DO=") + std::to_string(ProblemInterpreter::GetOutputDepthDo(problem)) +
+                std::string(" -DCK_PARAM_PROBLEM_Z=") + std::to_string(ProblemInterpreter::GetFilterDepthZ(problem)) +
+                std::string(" -DCK_PARAM_PROBLEM_CONV_STRIDE_D=") + std::to_string(ProblemInterpreter::GetAdjustedConvolutionStrideD(problem)) +
+                std::string(" -DCK_PARAM_PROBLEM_CONV_DILATION_D=") + std::to_string(ProblemInterpreter::GetAdjustedConvolutionDilationD(problem)) +
+                std::string(" -DCK_PARAM_PROBLEM_IN_LEFT_PAD_D=") + std::to_string(ProblemInterpreter::GetInputLeftPadD(problem)) +
+                std::string(" -DCK_PARAM_PROBLEM_IN_RIGHT_PAD_D=") + std::to_string(ProblemInterpreter::GetAdjustedInputRightPadD(problem)) ;
         }
 
     // clang-format on


### PR DESCRIPTION
PR splits `ConvolutionContext` and `ProblemDescription` inside `ConvHipImplicitGemmV4R4WrW`

Additional changes:
- `implicitgemm_util.hpp`: `ConvolutionContext` was replaced with `ProblemDescription`, temporary `GetPerformanceConfigBase()` was removed