### PR TITLE
[API change] Removed automatic buffer allocation from find 2.0

### DIFF
--- a/include/miopen/miopen.h
+++ b/include/miopen/miopen.h
@@ -4877,10 +4877,10 @@ struct miopenTensorArgument_t
  * @param problem       Problem to solve
  * @param options       Find options. When null default values would be used
  * @param tensors       Buffers to use for kernel profiling. "descriptor" field is not used
- * @param workspace     Workspace to use for kernel profiling
+ * @param workspace     Workspace to use for kernel benchmarking
  * @param workspaceSize Workspace size
  * @param solutions     Pointer to the first result. Must not be null
- * @param numSolutions  Pointer to the amount of results. Ignored if null
+ * @param numSolutions  Pointer to the number of the returned results. Ignored if null
  * @param maxSolutions  Limits the amount of results
  * @return              miopenStatus_t
  */

--- a/include/miopen/miopen.h
+++ b/include/miopen/miopen.h
@@ -4852,24 +4852,6 @@ miopenStatus_t miopenSetFindOptionWorkspaceLimit(miopenFindOptions_t options, si
  */
 MIOPEN_DECLARE_OBJECT(miopenSolution);
 
-/*! @brief Finds solutions to a problem by running different applicable solutions. Memory is
- * automatically allocated.
- *
- * @param handle       Handle to execute the kernels
- * @param problem      Problem to solve
- * @param options      Find options. When null default values would be used
- * @param solutions    Pointer to the first result. Must not be null
- * @param numSolutions Pointer to the amount of results. Ignored if null
- * @param maxSolutions Limits the amount of results
- * @return             miopenStatus_t
- */
-miopenStatus_t miopenFindSolutions(miopenHandle_t handle,
-                                   miopenProblem_t problem,
-                                   miopenFindOptions_t options,
-                                   miopenSolution_t* solutions,
-                                   size_t* numSolutions,
-                                   size_t maxSolutions);
-
 /*! @brief Values of a tensor argument for the miopenRunSolution function.
  */
 struct miopenTensorArgument_t
@@ -4887,6 +4869,31 @@ struct miopenTensorArgument_t
      */
     void* buffer;
 };
+
+/*! @brief Finds solutions to a problem by running different applicable solutions. Memory is
+ * automatically allocated.
+ *
+ * @param handle        Handle to execute the kernels
+ * @param problem       Problem to solve
+ * @param options       Find options. When null default values would be used
+ * @param tensors       Buffers to use for kernel profiling. "descriptor" field is not used
+ * @param workspace     Workspace to use for kernel profiling
+ * @param workspaceSize Workspace size
+ * @param solutions     Pointer to the first result. Must not be null
+ * @param numSolutions  Pointer to the amount of results. Ignored if null
+ * @param maxSolutions  Limits the amount of results
+ * @return              miopenStatus_t
+ */
+miopenStatus_t miopenFindSolutions(miopenHandle_t handle,
+                                   miopenProblem_t problem,
+                                   miopenFindOptions_t options,
+                                   size_t nInputs,
+                                   const miopenTensorArgument_t* tensors,
+                                   void* workspace,
+                                   size_t workspaceSize,
+                                   miopenSolution_t* solutions,
+                                   size_t* numSolutions,
+                                   size_t maxSolutions);
 
 /*! @brief Runs the solution using the passed in buffers.
  *

--- a/src/include/miopen/problem.hpp
+++ b/src/include/miopen/problem.hpp
@@ -83,8 +83,8 @@ struct Problem : miopenProblem
     std::vector<Solution> FindSolutions(Handle& handle,
                                         const FindOptions& options,
                                         const Buffers& buffers,
-                                        const Data_t workspace,
-                                        const std::size_t workspace_size,
+                                        Data_t workspace,
+                                        std::size_t workspace_size,
                                         std::size_t max_solutions) const;
 
     conv::ProblemDescription AsConvolution() const;
@@ -110,8 +110,8 @@ private:
                                             const FindOptions& options,
                                             std::size_t max_solutions,
                                             const Buffers& buffers,
-                                            const Data_t workspace,
-                                            const std::size_t workspace_size,
+                                            Data_t workspace,
+                                            std::size_t workspace_size,
                                             const ConvolutionDescriptor& conv_desc) const;
 
     void TransposeImpl(const ConvolutionDescriptor& conv_desc);

--- a/src/include/miopen/problem.hpp
+++ b/src/include/miopen/problem.hpp
@@ -55,6 +55,8 @@ using OperatorDescriptor = boost::variant<ConvolutionDescriptor>;
 
 struct Problem : miopenProblem
 {
+    using Buffers = std::unordered_map<miopenTensorArgumentId_t, Data_t>;
+
     Problem() = default;
 
     const TensorDescriptor& GetTensorDescriptor(miopenTensorArgumentId_t name) const
@@ -78,8 +80,12 @@ struct Problem : miopenProblem
 
     const OperatorDescriptor& GetOperatorDescriptor() const { return operator_descriptor; }
 
-    std::vector<Solution>
-    FindSolutions(Handle& handle, const FindOptions& options, std::size_t max_solutions) const;
+    std::vector<Solution> FindSolutions(Handle& handle,
+                                        const FindOptions& options,
+                                        const Buffers& buffers,
+                                        const Data_t workspace,
+                                        const std::size_t workspace_size,
+                                        std::size_t max_solutions) const;
 
     conv::ProblemDescription AsConvolution() const;
 
@@ -100,12 +106,12 @@ private:
     std::unordered_map<miopenTensorArgumentId_t, TensorDescriptor> tensor_descriptors;
     OperatorDescriptor operator_descriptor;
 
-    using AllocatedBuffers = std::unordered_map<miopenTensorArgumentId_t, Allocator::ManageDataPtr>;
-
     std::vector<Solution> FindSolutionsImpl(Handle& handle,
                                             const FindOptions& options,
                                             std::size_t max_solutions,
-                                            const AllocatedBuffers& buffers,
+                                            const Buffers& buffers,
+                                            const Data_t workspace,
+                                            const std::size_t workspace_size,
                                             const ConvolutionDescriptor& conv_desc) const;
 
     void TransposeImpl(const ConvolutionDescriptor& conv_desc);

--- a/src/problem.cpp
+++ b/src/problem.cpp
@@ -96,8 +96,8 @@ void VisitType(int id, Args... args)
 std::vector<Solution> Problem::FindSolutions(Handle& handle,
                                              const FindOptions& options,
                                              const Buffers& buffers,
-                                             const Data_t workspace,
-                                             const std::size_t workspace_size,
+                                             Data_t workspace,
+                                             std::size_t workspace_size,
                                              std::size_t max_solutions) const
 {
     const auto find = boost::hof::match([&](const ConvolutionDescriptor& op_desc) {
@@ -191,8 +191,8 @@ std::vector<Solution> Problem::FindSolutionsImpl(Handle& handle,
                                                  const FindOptions& options,
                                                  std::size_t max_solutions,
                                                  const Buffers& buffers,
-                                                 const Data_t workspace,
-                                                 const std::size_t workspace_size,
+                                                 Data_t workspace,
+                                                 std::size_t workspace_size,
                                                  const ConvolutionDescriptor& conv_desc) const
 {
     const auto& actual = conv_desc.mode == miopenTranspose ? MakeTransposed() : *this;

--- a/test/conv_common.hpp
+++ b/test/conv_common.hpp
@@ -340,17 +340,9 @@ protected:
 
         for(const auto& solution : solutions)
         {
-            auto workspace_size = std::size_t{};
-            EXPECT_EQUAL(miopenStatusSuccess,
-                         miopenGetSolutionWorkspaceSize(solution, &workspace_size));
-
-            const auto workspace_dev = workspace_size != 0
-                                           ? get_handle().Write(std::vector<char>(workspace_size))
-                                           : nullptr;
-
-            EXPECT_EQUAL(miopenStatusSuccess,
-                         miopenRunSolution(
-                             handle, solution, 3, arguments, workspace_dev.get(), workspace_size));
+            EXPECT_EQUAL(
+                miopenStatusSuccess,
+                miopenRunSolution(handle, solution, 3, arguments, workspace, workspace_size));
         }
 
         const auto& solution_deref = miopen::deref(solutions.front());

--- a/test/conv_common.hpp
+++ b/test/conv_common.hpp
@@ -805,9 +805,9 @@ struct verify_forward_conv : conv_base<T, Tout>
             {
                 size_t workspace_size = filter.mode == miopenTranspose
                                             ? filter.BackwardDataGetWorkSpaceSize(
-                                                    handle, weights.desc, input.desc, rout.desc)
+                                                  handle, weights.desc, input.desc, rout.desc)
                                             : filter.ForwardGetWorkSpaceSize(
-                                                    handle, weights.desc, input.desc, rout.desc);
+                                                  handle, weights.desc, input.desc, rout.desc);
 
                 std::vector<char> workspace(workspace_size);
                 auto workspace_dev = workspace_size != 0 ? handle.Write(workspace) : nullptr;


### PR DESCRIPTION
Changes the signature of `miopenFindSolutions` to accept the buffers allocated by the user. This allows us not to allocate them inside the library.
This is a better way to implement #1839, solving #1800. It requires changing an existing API function in a breaking way. This should not affect many customers as find 2.0 is not widely used yet.