### PR TITLE
[tests] Fix test_activation and remove W/A for issue 1334.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -179,9 +179,6 @@ option( WORKAROUND_ISSUE_1187 "" ${WORKAROUND_ISSUE_1187_DEFAULT})
 set_var_to_condition(WORKAROUND_ISSUE_1148_DEFAULT MIOPEN_TEST_GFX103X AND MIOPEN_TEST_FLOAT)
 option( WORKAROUND_ISSUE_1148 "" ${WORKAROUND_ISSUE_1148_DEFAULT})
 
-set_var_to_condition(WORKAROUND_ISSUE_1334_DEFAULT MIOPEN_TEST_GFX103X AND MIOPEN_TEST_FLOAT)
-option( WORKAROUND_ISSUE_1334 "" ${WORKAROUND_ISSUE_1334_DEFAULT})
-
 if(MIOPEN_TEST_HALF)
     if(MIOPEN_BACKEND_OPENCL)
 	    set(SKIP_TESTS test_gru test_rnn_vanilla test_lstm)
@@ -316,10 +313,6 @@ function(add_test_executable TEST_NAME)
     set_tests_properties(${TEST_NAME} PROPERTIES FAIL_REGULAR_EXPRESSION "FAILED")
     if(WORKAROUND_ISSUE_1148
         AND (${TEST_NAME} MATCHES "test_soft_max") )
-        set_tests_properties(${TEST_NAME} PROPERTIES RUN_SERIAL On)
-    endif()
-    if(WORKAROUND_ISSUE_1334
-        AND (${TEST_NAME} MATCHES "test_activation") )
         set_tests_properties(${TEST_NAME} PROPERTIES RUN_SERIAL On)
     endif()
     if(NOT MIOPEN_EMBED_DB STREQUAL "")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -364,6 +364,7 @@ set(LONG_TESTS
     test_pooling2d
     test_conv_igemm_mlir
     test_conv_igemm_mlir_xdlops
+    test_activation
     )
 
 function(rate_added_test NAME)


### PR DESCRIPTION
- Fixed: Missing initialization of input buffer in test_activation
  - Resolves https://github.com/ROCmSoftwarePlatform/MIOpen/pull/1765#issuecomment-1300868609. Testing of zeroed inputs is useless.
- Finally resolves #1334 by removing the W/A
- test_activation is a LONG test (improves CI performance)

@junliume https://github.com/ROCmSoftwarePlatform/MIOpen/labels/urgency_high https://github.com/ROCmSoftwarePlatform/MIOpen/labels/testing https://github.com/ROCmSoftwarePlatform/MIOpen/labels/bug

Proposed reviewers: @xinlipn @daniellowell 
