### PR TITLE
[Clang-16][D131307] suppress -Wenum-constexpr-conversion

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 sqlite3@3.17 -DCMAKE_POSITION_INDEPENDENT_CODE=On
-boost@1.79 -DCMAKE_POSITION_INDEPENDENT_CODE=On --build
+boost@1.79 -DCMAKE_POSITION_INDEPENDENT_CODE=On --build -DCMAKE_CXX_FLAGS=" -Wno-enum-constexpr-conversion "
 half,https://github.com/pfultz2/half/archive/1.12.0.tar.gz -X header -H sha256:0a08660b68abb176ebc2a0cdf8de46e3182a7f46c66443bb80dbfaaec98cf969 --build
 ROCmSoftwarePlatform/rocMLIR@rocm-5.4.0 -H sha256:3823f455ee392118c3281e27d45fa0e5381f3c4070eb4e06ba13bc6b34a90a60 -DBUILD_FAT_LIBROCKCOMPILER=1
 nlohmann/json@v3.9.1 -DJSON_MultipleHeaders=ON -DJSON_BuildTests=Off

--- a/src/comgr.cpp
+++ b/src/comgr.cpp
@@ -876,8 +876,12 @@ void BuildHip(const std::string& name,
             action.Do(AMD_COMGR_ACTION_LINK_RELOCATABLE_TO_EXECUTABLE, relocatable, exe);
         }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wenum-constexpr-conversion"
         constexpr auto INTENTIONALY_UNKNOWN = static_cast<amd_comgr_status_t>(0xffff);
-        if(exe.GetDataCount(AMD_COMGR_DATA_KIND_EXECUTABLE) < 1)
+#pragma clang diagnostic pop
+
+	if(exe.GetDataCount(AMD_COMGR_DATA_KIND_EXECUTABLE) < 1)
             throw ComgrError{INTENTIONALY_UNKNOWN, "Executable binary not found"};
         // Assume that the first exec data contains the binary we need.
         const auto data = exe.GetData(AMD_COMGR_DATA_KIND_EXECUTABLE, 0);
@@ -962,8 +966,11 @@ void BuildOcl(const std::string& name,
         const Dataset exe;
         action.Do(AMD_COMGR_ACTION_LINK_RELOCATABLE_TO_EXECUTABLE, relocatable, exe);
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wenum-constexpr-conversion"
         constexpr auto INTENTIONALY_UNKNOWN = static_cast<amd_comgr_status_t>(0xffff);
-        if(exe.GetDataCount(AMD_COMGR_DATA_KIND_EXECUTABLE) < 1)
+#pragma clang diagnostic pop
+	if(exe.GetDataCount(AMD_COMGR_DATA_KIND_EXECUTABLE) < 1)
             throw ComgrError{INTENTIONALY_UNKNOWN, "Executable binary not found"};
         // Assume that the first exec data contains the binary we need.
         const auto data = exe.GetData(AMD_COMGR_DATA_KIND_EXECUTABLE, 0);
@@ -1008,8 +1015,11 @@ void BuildAsm(const std::string& name,
         const Dataset exe;
         action.Do(AMD_COMGR_ACTION_LINK_RELOCATABLE_TO_EXECUTABLE, relocatable, exe);
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wenum-constexpr-conversion"
         constexpr auto INTENTIONALY_UNKNOWN = static_cast<amd_comgr_status_t>(0xffff);
-        if(exe.GetDataCount(AMD_COMGR_DATA_KIND_EXECUTABLE) < 1)
+#pragma clang diagnostic pop
+	if(exe.GetDataCount(AMD_COMGR_DATA_KIND_EXECUTABLE) < 1)
             throw ComgrError{INTENTIONALY_UNKNOWN, "Executable binary not found"};
         // Assume that the first exec data contains the binary we need.
         const auto data = exe.GetData(AMD_COMGR_DATA_KIND_EXECUTABLE, 0);

--- a/src/comgr.cpp
+++ b/src/comgr.cpp
@@ -876,11 +876,7 @@ void BuildHip(const std::string& name,
             action.Do(AMD_COMGR_ACTION_LINK_RELOCATABLE_TO_EXECUTABLE, relocatable, exe);
         }
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wenum-constexpr-conversion"
         constexpr auto INTENTIONALY_UNKNOWN = static_cast<amd_comgr_status_t>(0xffff);
-#pragma clang diagnostic pop
-
         if(exe.GetDataCount(AMD_COMGR_DATA_KIND_EXECUTABLE) < 1)
             throw ComgrError{INTENTIONALY_UNKNOWN, "Executable binary not found"};
         // Assume that the first exec data contains the binary we need.
@@ -966,10 +962,7 @@ void BuildOcl(const std::string& name,
         const Dataset exe;
         action.Do(AMD_COMGR_ACTION_LINK_RELOCATABLE_TO_EXECUTABLE, relocatable, exe);
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wenum-constexpr-conversion"
         constexpr auto INTENTIONALY_UNKNOWN = static_cast<amd_comgr_status_t>(0xffff);
-#pragma clang diagnostic pop
         if(exe.GetDataCount(AMD_COMGR_DATA_KIND_EXECUTABLE) < 1)
             throw ComgrError{INTENTIONALY_UNKNOWN, "Executable binary not found"};
         // Assume that the first exec data contains the binary we need.
@@ -1015,10 +1008,7 @@ void BuildAsm(const std::string& name,
         const Dataset exe;
         action.Do(AMD_COMGR_ACTION_LINK_RELOCATABLE_TO_EXECUTABLE, relocatable, exe);
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wenum-constexpr-conversion"
         constexpr auto INTENTIONALY_UNKNOWN = static_cast<amd_comgr_status_t>(0xffff);
-#pragma clang diagnostic pop
         if(exe.GetDataCount(AMD_COMGR_DATA_KIND_EXECUTABLE) < 1)
             throw ComgrError{INTENTIONALY_UNKNOWN, "Executable binary not found"};
         // Assume that the first exec data contains the binary we need.

--- a/src/comgr.cpp
+++ b/src/comgr.cpp
@@ -881,7 +881,7 @@ void BuildHip(const std::string& name,
         constexpr auto INTENTIONALY_UNKNOWN = static_cast<amd_comgr_status_t>(0xffff);
 #pragma clang diagnostic pop
 
-	if(exe.GetDataCount(AMD_COMGR_DATA_KIND_EXECUTABLE) < 1)
+        if(exe.GetDataCount(AMD_COMGR_DATA_KIND_EXECUTABLE) < 1)
             throw ComgrError{INTENTIONALY_UNKNOWN, "Executable binary not found"};
         // Assume that the first exec data contains the binary we need.
         const auto data = exe.GetData(AMD_COMGR_DATA_KIND_EXECUTABLE, 0);
@@ -970,7 +970,7 @@ void BuildOcl(const std::string& name,
 #pragma clang diagnostic ignored "-Wenum-constexpr-conversion"
         constexpr auto INTENTIONALY_UNKNOWN = static_cast<amd_comgr_status_t>(0xffff);
 #pragma clang diagnostic pop
-	if(exe.GetDataCount(AMD_COMGR_DATA_KIND_EXECUTABLE) < 1)
+        if(exe.GetDataCount(AMD_COMGR_DATA_KIND_EXECUTABLE) < 1)
             throw ComgrError{INTENTIONALY_UNKNOWN, "Executable binary not found"};
         // Assume that the first exec data contains the binary we need.
         const auto data = exe.GetData(AMD_COMGR_DATA_KIND_EXECUTABLE, 0);
@@ -1019,7 +1019,7 @@ void BuildAsm(const std::string& name,
 #pragma clang diagnostic ignored "-Wenum-constexpr-conversion"
         constexpr auto INTENTIONALY_UNKNOWN = static_cast<amd_comgr_status_t>(0xffff);
 #pragma clang diagnostic pop
-	if(exe.GetDataCount(AMD_COMGR_DATA_KIND_EXECUTABLE) < 1)
+        if(exe.GetDataCount(AMD_COMGR_DATA_KIND_EXECUTABLE) < 1)
             throw ComgrError{INTENTIONALY_UNKNOWN, "Executable binary not found"};
         // Assume that the first exec data contains the binary we need.
         const auto data = exe.GetData(AMD_COMGR_DATA_KIND_EXECUTABLE, 0);

--- a/src/comgr.cpp
+++ b/src/comgr.cpp
@@ -524,7 +524,10 @@ struct ComgrError : std::exception
     std::string text;
 
     ComgrError(const amd_comgr_status_t s, bool u) : status(s), unknown(u) {}
-    ComgrError(const amd_comgr_status_t s, bool u, const std::string& t) : status(s), unknown(u), text(t) {}
+    ComgrError(const amd_comgr_status_t s, bool u, const std::string& t)
+        : status(s), unknown(u), text(t)
+    {
+    }
     const char* what() const noexcept override { return text.c_str(); }
 };
 


### PR DESCRIPTION
https://reviews.llvm.org/D131307

It is also causing problems in MIOpen and MIOpen dependencies:
```
[2022-10-29T14:44:59.883Z] ./boost/mpl/aux_/integral_wrapper.hpp:73:31: error: integer value -1 is outside the valid range of values [0, 3] for this enumeration type [-Wenum-constexpr-conversion]
```