### PR TITLE
Fix for identifying LegacySolver

### DIFF
--- a/src/include/miopen/any_solver.hpp
+++ b/src/include/miopen/any_solver.hpp
@@ -159,10 +159,9 @@ struct AnySolver
         {
             template <typename U>
             static constexpr auto Test(U*) ->
-                typename std::is_same<ConvSolution,
-                                      decltype(std::declval<U>().GetSolution(
-                                          std::declval<const ConvolutionContext&>(),
-                                          std::declval<const LegacyPerformanceConfig&>()))>::type;
+                typename std::is_same<LegacyPerformanceConfig,
+                                      decltype(std::declval<U>().GetDefaultPerformanceConfig(
+                                          std::declval<const ConvolutionContext&>()))>::type;
 
             template <typename U>
             static constexpr std::false_type Test(...);


### PR DESCRIPTION
Fix for identifying LegacySolver in any_solver.hpp
Previous template was returning true for non LegacySolver types