### PR TITLE
[DEBUG] Fix incorrect assert

### DIFF
--- a/src/include/miopen/tensor.hpp
+++ b/src/include/miopen/tensor.hpp
@@ -47,7 +47,7 @@ namespace miopen {
 template <class T, std::size_t... Ns>
 auto tie_impl(T&& x, detail::seq<Ns...>) -> decltype(std::tie(x[Ns]...))
 {
-    assert(x.size() == sizeof...(Ns));
+    assert(x.size() >= sizeof...(Ns));
     return std::tie(x[Ns]...);
 }
 


### PR DESCRIPTION
The `miopen::tien()` function has legitimate uses with x.size() greater than Ns, so the assert() check was too strict. Relaxing assert() to accept any vector size not lower than Ns.