### PR TITLE
[NFC] Bump MLIR commit hash for ROCm 5.5 features

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 sqlite3@3.17 -DCMAKE_POSITION_INDEPENDENT_CODE=On
 boost@1.79 -DCMAKE_POSITION_INDEPENDENT_CODE=On --build -DCMAKE_CXX_FLAGS=" -Wno-enum-constexpr-conversion "
 half,https://github.com/pfultz2/half/archive/1.12.0.tar.gz -X header -H sha256:0a08660b68abb176ebc2a0cdf8de46e3182a7f46c66443bb80dbfaaec98cf969 --build
-ROCmSoftwarePlatform/rocMLIR@rocm-5.4.0 -H sha256:3823f455ee392118c3281e27d45fa0e5381f3c4070eb4e06ba13bc6b34a90a60 -DBUILD_FAT_LIBROCKCOMPILER=1
+ROCmSoftwarePlatform/rocMLIR@0e140c77232c1d3d25750648843717cd6aecd00c -DBUILD_FAT_LIBROCKCOMPILER=1
 nlohmann/json@v3.9.1 -DJSON_MultipleHeaders=ON -DJSON_BuildTests=Off
 ROCmSoftwarePlatform/composable_kernel@eef009d001b928db1bb377a105c93b75e0dccc7b -DGPU_TARGETS="gfx900;gfx906;gfx908;gfx90a;gfx1030"


### PR DESCRIPTION
This commit hash update include the fix for https://ontrack-internal.amd.com/browse/SWDEV-356492. After merging this PR, 
pytorch will be able to pull in latest MIOpen and be able to work with MLIR solvers.

CC: @jithunnair-amd Would you mind to use the branch and verify that the issue is gone after this bump?
