### PR TITLE
[SWDEV-358170][Workaround] Specify -std=c++14 so boost builds using latest Clang and devtoolset-7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 sqlite3@3.17 -DCMAKE_POSITION_INDEPENDENT_CODE=On
-boost@1.79 -DCMAKE_POSITION_INDEPENDENT_CODE=On --build -DCMAKE_CXX_FLAGS=" -Wno-enum-constexpr-conversion "
+boost@1.79 -DCMAKE_POSITION_INDEPENDENT_CODE=On --build -DCMAKE_CXX_FLAGS=" -std=c++14 -Wno-enum-constexpr-conversion "
 half,https://github.com/pfultz2/half/archive/1.12.0.tar.gz -X header -H sha256:0a08660b68abb176ebc2a0cdf8de46e3182a7f46c66443bb80dbfaaec98cf969 --build
 ROCmSoftwarePlatform/rocMLIR@0e140c77232c1d3d25750648843717cd6aecd00c -DBUILD_FAT_LIBROCKCOMPILER=1
 nlohmann/json@v3.9.1 -DJSON_MultipleHeaders=ON -DJSON_BuildTests=Off


### PR DESCRIPTION
"It's probably a bug in devtoolset-7's C++ library support for C++17 that got exposed by clang's change of its default to C++17. "
**and updating devtoolset is not an option**

Error:
```
./boost/asio/detail/memory.hpp:89:15: error: no member named 'aligned_alloc' in namespace 'std'; did you mean simply 'aligned_alloc'?
  void* ptr = std::aligned_alloc(align, size);
              ^~~~~~~~~~~~~~~~~~
              aligned_alloc
/usr/include/stdlib.h:508:14: note: 'aligned_alloc' declared here extern void *aligned_alloc (size_t __alignment, size_t __size)
             ^
1 error generated.
```