### PR TITLE
Fix the "deterministic" attribute in ConvHipImplicitGemmFwd/BwdXdlops

### DIFF
--- a/src/solver/conv_hip_implicit_gemm_bwd_data_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_bwd_data_xdlops.cpp
@@ -347,7 +347,7 @@ bool ConvHipImplicitGemmBwdXdlops::IsApplicable(const ConvolutionContext& ctx,
 #else
     if(miopen::IsDisabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_BWD_XDLOPS{}))
         return false;
-    if(miopen::IsEnabled(MIOPEN_DEBUG_CONVOLUTION_DETERMINISTIC{}))
+    if(problem.conv_problem.GetConv().attribute.deterministic)
         return false;
     if(problem.conv_problem.GetInDataType() != problem.conv_problem.GetWeightsDataType() ||
        problem.conv_problem.GetWeightsDataType() != problem.conv_problem.GetOutDataType() ||

--- a/src/solver/conv_hip_implicit_gemm_fwd_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_fwd_xdlops.cpp
@@ -329,7 +329,7 @@ bool ConvHipImplicitGemmFwdXdlops::IsApplicable(const ConvolutionContext& ctx,
 #else
     if(miopen::IsDisabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_FWD_XDLOPS{}))
         return false;
-    if(miopen::IsEnabled(MIOPEN_DEBUG_CONVOLUTION_DETERMINISTIC{}))
+    if(problem.conv_problem.GetConv().attribute.deterministic)
         return false;
     if(problem.conv_problem.GetInDataType() != problem.conv_problem.GetWeightsDataType() ||
        problem.conv_problem.GetWeightsDataType() != problem.conv_problem.GetOutDataType() ||


### PR DESCRIPTION
Fixed issue: ConvHipImplicitGemmFwdXdlops and ConvHipImplicitGemmBwdXdlops do not obey the `MIOPEN_CONVOLUTION_ATTRIB_DETERMINISTIC` attribute from `miopenConvolutionAttrib_t`. The root reason is that the developer of #1692 missed the introduction of the `MIOPEN_CONVOLUTION_ATTRIB_DETERMINISTIC` attribute that was added in #1551.

@junliume @JehandadKhan Can you please set the labels https://github.com/ROCmSoftwarePlatform/MIOpen/labels/urgency_normal https://github.com/ROCmSoftwarePlatform/MIOpen/labels/bug https://github.com/ROCmSoftwarePlatform/MIOpen/labels/correctness and review this, thanks!