### PR TITLE
[API] API call to query spatial dimension of ConvolutionDescriptor

### DIFF
--- a/include/miopen/miopen.h
+++ b/include/miopen/miopen.h
@@ -874,6 +874,15 @@ miopenInitConvolutionNdDescriptor(miopenConvolutionDescriptor_t convDesc,
                                   int* dilationA,
                                   miopenConvolutionMode_t c_mode);
 
+/*! @brief Retrieves the spatial dimension of a convolution layer descriptor
+ *
+ * @param convDesc              Convolution layer descriptor (input)
+ * @param spatialDim            Spatial dimension of convolution descriptor (output)
+ * @return                      miopenStatus_t
+ */
+MIOPEN_EXPORT miopenStatus_t miopenGetConvolutionSpatialDim(miopenConvolutionDescriptor_t convDesc,
+                                                            int* spatialDim);
+
 /*! @brief Retrieves a 2-D convolution layer descriptor's details
  *
  * For group/depthwise convolution dilation height and width, only a dilation value of 1 is

--- a/src/convolution_api.cpp
+++ b/src/convolution_api.cpp
@@ -219,6 +219,14 @@ extern "C" miopenStatus_t miopenGetConvolutionNdDescriptor(miopenConvolutionDesc
     });
 }
 
+extern "C" miopenStatus_t miopenGetConvolutionSpatialDim(miopenConvolutionDescriptor_t convDesc,
+                                                         int* spatialDim)
+{
+    MIOPEN_LOG_FUNCTION(convDesc, spatialDim);
+    return miopen::try_(
+        [&] { miopen::deref(spatialDim) = miopen::deref(convDesc).GetSpatialDimension(); });
+}
+
 extern "C" miopenStatus_t
 miopenGetConvolutionForwardOutputDim(miopenConvolutionDescriptor_t convDesc,
                                      const miopenTensorDescriptor_t inputTensorDesc,

--- a/test/gtest/conv_api.cpp
+++ b/test/gtest/conv_api.cpp
@@ -1,0 +1,24 @@
+#include <iostream>
+#include <miopen/miopen.h>
+#include <miopen/errors.hpp>
+#include <gtest/gtest.h>
+
+void testGetConvolutionSpatialDim(void)
+{
+    int spatial_dim = 0;
+    int pads[]      = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+    int strides[]   = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
+    int dilations[] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
+    for(size_t i = 0; i < 10; i++)
+    {
+        miopenConvolutionDescriptor_t conv_desc;
+        miopenCreateConvolutionDescriptor(&conv_desc);
+        miopenInitConvolutionNdDescriptor(
+            conv_desc, i, pads, strides, dilations, miopenConvolutionMode_t::miopenConvolution);
+        miopenGetConvolutionSpatialDim(conv_desc, &spatial_dim);
+        ASSERT_EQ(spatial_dim, i) << "Spatial Dimension does not match at index: " << i
+                                  << std::endl;
+    }
+}
+
+TEST(CONV_API_TEST, testGetConvolutionSpatialDim) { testGetConvolutionSpatialDim(); }


### PR DESCRIPTION
New interface for MIOpen convolutions to get the spatial dimension of a miopenConvolutionDescriptor_t object. Currently ONNX is having to perform a workaround when they want to obtain the spatial dimension of a miopenConvolutionDescriptor_t object (https://github.com/microsoft/onnxruntime/blob/bc353c7afea850164ecd9e2dab4a782c91dfc1a8/onnxruntime/contrib_ops/rocm/fused_conv.cc#L86-L115). Solves ticket: SWDEV-351568.