### PR TITLE
[Ubuntu 22.04] Add include file for libstdc++-12

### DIFF
--- a/src/include/miopen/sequences.hpp
+++ b/src/include/miopen/sequences.hpp
@@ -35,6 +35,7 @@
 #include <cassert>
 #include <tuple>
 #include <vector>
+#include <array>
 
 namespace miopen {
 namespace seq {


### PR DESCRIPTION
Resolve issue mentioned in https://github.com/ROCmSoftwarePlatform/MIOpen/issues/1921#issuecomment-1373269824