### PR TITLE
[SWDEV-366865] Add check for convolution API that all tensors are packed

### DIFF
--- a/src/ocl/convolutionocl.cpp
+++ b/src/ocl/convolutionocl.cpp
@@ -672,6 +672,12 @@ void ConvolutionDescriptor::ConvolutionForward(Handle& handle,
                                                size_t workSpaceSize) const
 {
     MIOPEN_LOG_I("algo = " << algo << ", workspace = " << workSpaceSize);
+
+    if(!(xDesc.IsPacked() && wDesc.IsPacked() && yDesc.IsPacked()))
+    {
+        MIOPEN_THROW(miopenStatusNotImplemented, "Only fully packed tensors are supported");
+    }
+
     const auto tensors = ConvFwdTensors{xDesc, x, wDesc, w, yDesc, y};
     ValidateConvTensors(tensors);
     ValidateAlphaBeta(alpha, beta);
@@ -1344,6 +1350,12 @@ void ConvolutionDescriptor::ConvolutionBackwardData(Handle& handle,
                                                     size_t workSpaceSize) const
 {
     MIOPEN_LOG_I("algo = " << algo << ", workspace = " << workSpaceSize);
+
+    if(!(dyDesc.IsPacked() && wDesc.IsPacked() && dxDesc.IsPacked()))
+    {
+        MIOPEN_THROW(miopenStatusNotImplemented, "Only fully packed tensors are supported");
+    }
+
     auto tensors = ConvBwdTensors{dyDesc, dy, wDesc, w, dxDesc, dx};
 
     ValidateConvTensors(tensors);


### PR DESCRIPTION
Only fully packed tensors are currently supported for convolutions. This check is needed to make sure that all tensors are packed and throw an error otherwise. 