### PR TITLE
Enable ConvHipImplicitGemmFwdXdlops for MI200 and hotfix for fp16_alt issue

### DIFF
--- a/src/solver/conv_hip_implicit_gemm_fwd_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_fwd_xdlops.cpp
@@ -339,7 +339,10 @@ bool ConvHipImplicitGemmFwdXdlops::IsApplicable(const ConvolutionContext& ctx,
         return false;
     if(!problem.Is2d())
         return false;
-    if(ctx.GetStream().GetDeviceName() != "gfx908")
+    const std::string& arch = ctx.GetStream().GetDeviceName();
+    if(!(arch == "gfx908" || arch == "gfx90a"))
+        return false;
+    if(arch == "gfx90a" && problem.conv_problem.IsGfx90aFp16altRequired())
         return false;
     if(!problem.IsLayoutNHWC())
         return false;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -767,7 +767,7 @@ add_custom_test(test_conv_igemm_mlir_xdlops_fwd SKIP_UNLESS_ALL HALF_ENABLED INT
 )
 
 if(MIOPEN_USE_COMPOSABLEKERNEL)
-add_custom_test(test_conv_hip_igemm_xdlops SKIP_UNLESS_ALL OCL_DISABLED HALF_DISABLED FLOAT_DISABLED INT8_ENABLED GFX900_DISABLED GFX906_DISABLED GFX90A_DISABLED
+add_custom_test(test_conv_hip_igemm_xdlops SKIP_UNLESS_ALL OCL_DISABLED HALF_DISABLED FLOAT_DISABLED INT8_ENABLED GFX900_DISABLED GFX906_DISABLED
     COMMAND $<TARGET_FILE:test_conv2d> ${MIOPEN_TEST_FLOAT_ARG} --disable-backward-data --disable-backward-weights --verbose --input 256 128  28 28 --weights 128  128  3 3 --output_type int8 --in_layout NHWC --fil_layout NHWC --out_layout NHWC --pads_strides_dilations 1 1 1 1 1 1
     COMMAND $<TARGET_FILE:test_conv2d> ${MIOPEN_TEST_FLOAT_ARG} --disable-backward-data --disable-backward-weights --verbose --input 128 512  7  7  --weights 512  512  3 3 --output_type int8 --in_layout NHWC --fil_layout NHWC --out_layout NHWC --pads_strides_dilations 1 1 1 1 1 1
     COMMAND $<TARGET_FILE:test_conv2d> ${MIOPEN_TEST_FLOAT_ARG} --disable-backward-data --disable-backward-weights --verbose --input 128 64   56 56 --weights 64   64   1 1 --output_type int8 --in_layout NHWC --fil_layout NHWC --out_layout NHWC --pads_strides_dilations 0 0 1 1 1 1


### PR DESCRIPTION
Enable ConvHipImplicitGemmFwdXdlops for MI200.
We expected the similar issue might raise with datatype fp16_alt, therefore we applied the same hotfix as in #1933. The support of fp16_alt will be addressed in a separate PR after discussion with CK group.