### PR TITLE
[NFC] Bumping MLIR commit to 5.5.0 release tag

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,8 +23,6 @@ def cmake_build(Map conf=[:]){
     def build_envs = "CTEST_PARALLEL_LEVEL=4 MIOPEN_CONV_PRECISE_ROCBLAS_TIMING=0 " + conf.get("build_env","")
     def prefixpath = conf.get("prefixpath","/opt/rocm")
     def mlir_args = " -DMIOPEN_USE_MLIR=" + conf.get("mlir_build", "ON")
-    // WORKAROUND_ISSUE_1913:
-    mlir_args = mlir_args + " -DMIOPEN_LIBMLIR_SUPPORTS_GFX103X=ON"
     def setup_args = mlir_args + " -DMIOPEN_GPU_SYNC=Off " + conf.get("setup_flags","")
 
     setup_args = setup_args + " -DCMAKE_PREFIX_PATH=${prefixpath} "

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 sqlite3@3.17 -DCMAKE_POSITION_INDEPENDENT_CODE=On
 boost@1.79 -DCMAKE_POSITION_INDEPENDENT_CODE=On --build -DCMAKE_CXX_FLAGS=" -std=c++14 -Wno-enum-constexpr-conversion "
 half,https://github.com/pfultz2/half/archive/1.12.0.tar.gz -X header -H sha256:0a08660b68abb176ebc2a0cdf8de46e3182a7f46c66443bb80dbfaaec98cf969 --build
-ROCmSoftwarePlatform/rocMLIR@56a820ee3a50c83189348559181a673e1101846a -DBUILD_FAT_LIBROCKCOMPILER=1
+ROCmSoftwarePlatform/rocMLIR@rocm-5.5.0 -H sha256:a5f62769d28a73e60bc8d61022820f050e97c977c8f6f6275488db31512e1f42 -DBUILD_FAT_LIBROCKCOMPILER=1
 nlohmann/json@v3.9.1 -DJSON_MultipleHeaders=ON -DJSON_BuildTests=Off
 ROCmSoftwarePlatform/composable_kernel@eef009d001b928db1bb377a105c93b75e0dccc7b -DGPU_TARGETS="gfx900;gfx906;gfx908;gfx90a;gfx1030"


### PR DESCRIPTION
!!CI overriden with image: `rocm/miopen:ci_mlir_tag_rocm-5.5.0`

This pull request is the follow up to https://github.com/ROCmSoftwarePlatform/MIOpen/pull/1914. The only change from MLIR side is to bump the MLIR cmake version up on the minor version as https://github.com/ROCmSoftwarePlatform/rocMLIR/pull/930.

In summary, this PR:
 - Used the ROCm-5.5.0 tag to replace the commit id
 - Get rid of `WORKAROUND_ISSUE_1913` as suggested from @atamazov 