### PR TITLE
[NFC] Comgr include header reorg

### DIFF
--- a/src/comgr.cpp
+++ b/src/comgr.cpp
@@ -38,7 +38,7 @@
 #include <miopen/solver/implicitgemm_util.hpp>
 #include <miopen/stringutils.hpp>
 
-#include <amd_comgr.h>
+#include <amd_comgr/amd_comgr.h>
 #include <hip/hip_runtime_api.h>
 #if MIOPEN_USE_HIPRTC
 #include <miopen/manage_ptr.hpp>

--- a/src/comgr.cpp
+++ b/src/comgr.cpp
@@ -38,7 +38,11 @@
 #include <miopen/solver/implicitgemm_util.hpp>
 #include <miopen/stringutils.hpp>
 
+#if HIP_PACKAGE_VERSION_FLAT >= 4004000000ULL
 #include <amd_comgr/amd_comgr.h>
+#else
+#include <amd_comgr.h>
+#endif
 #include <hip/hip_runtime_api.h>
 #if MIOPEN_USE_HIPRTC
 #include <miopen/manage_ptr.hpp>


### PR DESCRIPTION
some residue which causes warning messages like
```
In file included from /root/MIOpen/src/comgr.cpp:41:
/opt/rocm-5.5.0-11454/include/amd_comgr.h:27:2: warning: "This file is deprecated. Use file from include path /opt/rocm-ver/include/ and prefix with amd_comgr" [-W#warnings]
#warning "This file is deprecated. Use file from include path /opt/rocm-ver/include/ and prefix with amd_comgr"
 ^
1 warning generated when compiling for gfx1030.
```
This PR resolve issue mentioned in #1945 