### PR TITLE
[HOTFIX] Fix COMGR build error with ROCm 4.4.x...5.2.x due to an issue in #1943

### DIFF
--- a/src/comgr.cpp
+++ b/src/comgr.cpp
@@ -38,7 +38,7 @@
 #include <miopen/solver/implicitgemm_util.hpp>
 #include <miopen/stringutils.hpp>
 
-#if HIP_PACKAGE_VERSION_FLAT >= 4004000000ULL
+#if HIP_PACKAGE_VERSION_FLAT >= 5004000000ULL
 #include <amd_comgr/amd_comgr.h>
 #else
 #include <amd_comgr.h>


### PR DESCRIPTION
Resolves comment https://github.com/ROCmSoftwarePlatform/MIOpen/pull/1943#issuecomment-1407085552

@junliume @johnny-keker https://github.com/ROCmSoftwarePlatform/MIOpen/labels/urgency_blocker