### PR TITLE
[Vega20] Workaround for 25% winograd performance drop

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -288,6 +288,15 @@ if( MIOPEN_BACKEND MATCHES "OpenCL" OR MIOPEN_BACKEND STREQUAL "HIPOC" OR MIOPEN
         kernels/conv_3x3_wheel_alpha_v9_0_15_gfx9_stride_2_dil.inc
         kernels/conv_3x3_wheel_alpha_v9_0_15_gfx9_stride_2_dec.inc
         kernels/conv_3x3_wheel_alpha_v9_0_15_gfx9.inc
+        kernels/Conv_Winograd_v21_1_3_gfx9_fp16_dot2_edc_f2x3_dilation2.inc
+        kernels/Conv_Winograd_v21_1_3_gfx9_fp16_dot2_edc_f2x3_stride1.inc
+        kernels/Conv_Winograd_v21_1_3_gfx9_fp16_dot2_edc_f2x3_stride2.inc
+        kernels/Conv_Winograd_v21_1_3_gfx9_fp16_dot2_edc_f3x2_stride1.inc
+        kernels/Conv_Winograd_v21_1_3_gfx9_fp32_f2x3_dilation2.inc
+        kernels/Conv_Winograd_v21_1_3_gfx9_fp32_f2x3_stride1.inc
+        kernels/Conv_Winograd_v21_1_3_gfx9_fp32_f2x3_stride2.inc
+        kernels/Conv_Winograd_v21_1_3_gfx9_fp32_f3x2_stride1.inc
+        kernels/Conv_Winograd_v21_1_3_metadata.inc
         kernels/Conv_Winograd_v30_2_6_gfx9_fp16_dot2_edc_f2x3_dilation2.inc
         kernels/Conv_Winograd_v30_2_6_gfx9_fp16_dot2_edc_f2x3_stride1.inc
         kernels/Conv_Winograd_v30_2_6_gfx9_fp16_dot2_edc_f2x3_stride2.inc
@@ -424,6 +433,14 @@ if( MIOPEN_BACKEND MATCHES "OpenCL" OR MIOPEN_BACKEND STREQUAL "HIPOC" OR MIOPEN
         kernels/conv_3x3_wheel_alpha_v3_0b.s
         kernels/conv_3x3_wheel_alpha_v9_2_7.s
         kernels/conv_3x3_wheel_alpha_v9_2_7_stride_2_dec.s
+        kernels/Conv_Winograd_v21_1_3_fp16_dot2_f2x3_dilation2.s
+        kernels/Conv_Winograd_v21_1_3_fp16_dot2_f2x3_stride1.s
+        kernels/Conv_Winograd_v21_1_3_fp16_dot2_f2x3_stride2.s
+        kernels/Conv_Winograd_v21_1_3_fp16_dot2_f3x2_stride1.s
+        kernels/Conv_Winograd_v21_1_3_fp32_f2x3_dilation2.s
+        kernels/Conv_Winograd_v21_1_3_fp32_f2x3_stride1.s
+        kernels/Conv_Winograd_v21_1_3_fp32_f2x3_stride2.s
+        kernels/Conv_Winograd_v21_1_3_fp32_f3x2_stride1.s
         kernels/Conv_Winograd_v30_2_6_fp16_dot2_f2x3_dilation2.s
         kernels/Conv_Winograd_v30_2_6_fp16_dot2_f2x3_stride1.s
         kernels/Conv_Winograd_v30_2_6_fp16_dot2_f2x3_stride2.s

--- a/src/kernels/Conv_Winograd_v21_1_3_fp16_dot2_f2x3_dilation2.s
+++ b/src/kernels/Conv_Winograd_v21_1_3_fp16_dot2_f2x3_dilation2.s
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2023 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+.include "Conv_Winograd_v21_1_3_metadata.inc"
+
+KERNEL_PROLOG fp16_dot2_edc_f2x3_dilation2
+
+.include "Conv_Winograd_v21_1_3_gfx9_fp16_dot2_edc_f2x3_dilation2.inc"
+
+KERNEL_EPILOG fp16_dot2_edc_f2x3_dilation2

--- a/src/kernels/Conv_Winograd_v21_1_3_fp16_dot2_f2x3_stride1.s
+++ b/src/kernels/Conv_Winograd_v21_1_3_fp16_dot2_f2x3_stride1.s
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2023 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+.include "Conv_Winograd_v21_1_3_metadata.inc"
+
+KERNEL_PROLOG fp16_dot2_edc_f2x3_stride1
+
+.include "Conv_Winograd_v21_1_3_gfx9_fp16_dot2_edc_f2x3_stride1.inc"
+
+KERNEL_EPILOG fp16_dot2_edc_f2x3_stride1

--- a/src/kernels/Conv_Winograd_v21_1_3_fp16_dot2_f2x3_stride2.s
+++ b/src/kernels/Conv_Winograd_v21_1_3_fp16_dot2_f2x3_stride2.s
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2023 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+.include "Conv_Winograd_v21_1_3_metadata.inc"
+
+KERNEL_PROLOG fp16_dot2_edc_f2x3_stride2
+
+.include "Conv_Winograd_v21_1_3_gfx9_fp16_dot2_edc_f2x3_stride2.inc"
+
+KERNEL_EPILOG fp16_dot2_edc_f2x3_stride2

--- a/src/kernels/Conv_Winograd_v21_1_3_fp16_dot2_f3x2_stride1.s
+++ b/src/kernels/Conv_Winograd_v21_1_3_fp16_dot2_f3x2_stride1.s
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2023 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+.include "Conv_Winograd_v21_1_3_metadata.inc"
+
+KERNEL_PROLOG fp16_dot2_edc_f3x2_stride1
+
+.include "Conv_Winograd_v21_1_3_gfx9_fp16_dot2_edc_f3x2_stride1.inc"
+
+KERNEL_EPILOG fp16_dot2_edc_f3x2_stride1

--- a/src/kernels/Conv_Winograd_v21_1_3_fp32_f2x3_dilation2.s
+++ b/src/kernels/Conv_Winograd_v21_1_3_fp32_f2x3_dilation2.s
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2023 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+.include "Conv_Winograd_v21_1_3_metadata.inc"
+
+KERNEL_PROLOG fp32_f2x3_dilation2
+
+.include "Conv_Winograd_v21_1_3_gfx9_fp32_f2x3_dilation2.inc"
+
+KERNEL_EPILOG fp32_f2x3_dilation2

--- a/src/kernels/Conv_Winograd_v21_1_3_fp32_f2x3_stride1.s
+++ b/src/kernels/Conv_Winograd_v21_1_3_fp32_f2x3_stride1.s
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2023 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+.include "Conv_Winograd_v21_1_3_metadata.inc"
+
+KERNEL_PROLOG fp32_f2x3_stride1
+
+.include "Conv_Winograd_v21_1_3_gfx9_fp32_f2x3_stride1.inc"
+
+KERNEL_EPILOG fp32_f2x3_stride1

--- a/src/kernels/Conv_Winograd_v21_1_3_fp32_f2x3_stride2.s
+++ b/src/kernels/Conv_Winograd_v21_1_3_fp32_f2x3_stride2.s
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2023 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+.include "Conv_Winograd_v21_1_3_metadata.inc"
+
+KERNEL_PROLOG fp32_f2x3_stride2
+
+.include "Conv_Winograd_v21_1_3_gfx9_fp32_f2x3_stride2.inc"
+
+KERNEL_EPILOG fp32_f2x3_stride2

--- a/src/kernels/Conv_Winograd_v21_1_3_fp32_f3x2_stride1.s
+++ b/src/kernels/Conv_Winograd_v21_1_3_fp32_f3x2_stride1.s
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2023 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+.include "Conv_Winograd_v21_1_3_metadata.inc"
+
+KERNEL_PROLOG fp32_f3x2_stride1
+
+.include "Conv_Winograd_v21_1_3_gfx9_fp32_f3x2_stride1.inc"
+
+KERNEL_EPILOG fp32_f3x2_stride1

--- a/src/kernels/Conv_Winograd_v21_1_3_gfx9_fp16_dot2_edc_f2x3_dilation2.inc
+++ b/src/kernels/Conv_Winograd_v21_1_3_gfx9_fp16_dot2_edc_f2x3_dilation2.inc
@@ -1,0 +1,3136 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2023 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+v_mov_b32_e32 v0, v0
+s_mov_b32 s0, 0
+s_mov_b32 s1, 0
+s_mov_b32 s2, 0
+s_mov_b32 s3, 0
+v_mov_b32_e32 v116, 0
+s_mov_b32 m0, 0x1ffff
+s_mov_b32 s97, 0xc1e0
+s_mov_b32 s96, 0xc1e0
+s_mov_b32 s91, 0
+v_lshlrev_b32_e32 v119, 2, v0
+v_add_co_u32_e32 v119, vcc, 0xffc0, v119
+v_cmp_ge_u32_e32 vcc, 12, v0
+s_cbranch_vccz 5
+v_mov_b32_e32 v118, 0
+v_cndmask_b32_e32 v119, -1, v119, vcc
+ds_write_b32 v119, v118
+s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+s_barrier
+v_readfirstlane_b32 s52, v0
+s_lshr_b32 s52, s52, 5
+s_add_u32 s52, s52, 8
+s_and_b32 s92, s52, 20
+s_mov_b64 s[40:41], s[6:7]
+s_load_dwordx16 s[12:27], s[40:41], 0x0
+s_load_dwordx4 s[28:31], s[40:41], 0x40
+s_load_dwordx2 s[32:33], s[40:41], 0x50
+s_waitcnt lgkmcnt(0)
+s_and_b32 s18, s18, 0xffff
+s_bitcmp1_b32 s18, 6
+s_cbranch_scc0 16
+s_and_b32 s21, s21, 0xffff
+s_and_b32 s23, s23, 0xffff
+s_and_b32 s25, s25, 0xffff
+s_and_b32 s27, s27, 0xffff
+s_load_dwordx2 s[20:21], s[20:21], 0x0
+s_load_dwordx2 s[22:23], s[22:23], 0x0
+s_load_dwordx2 s[24:25], s[24:25], 0x0
+s_load_dwordx2 s[26:27], s[26:27], 0x0
+s_bitcmp1_b32 s18, 7
+s_cbranch_scc0 2
+s_load_dwordx2 s[34:35], s[40:41], 0x58
+s_mov_b32 s36, 1.0
+s_bitcmp1_b32 s18, 8
+s_cbranch_scc0 2
+s_load_dword s36, s[40:41], 0x60
+s_bitcmp1_b32 s18, 7
+s_cbranch_scc0 7
+s_bitcmp1_b32 s18, 6
+s_cbranch_scc0 5
+s_waitcnt lgkmcnt(0)
+s_and_b32 s35, s35, 0xffff
+s_load_dwordx2 s[34:35], s[34:35], 0x0
+s_bitcmp1_b32 s18, 9
+s_cbranch_scc0 72
+s_mov_b32 s42, 0x8c
+s_mov_b32 s43, 0x9c
+v_cmp_le_u32_e32 vcc, 0x100, v0
+s_cmp_eq_u32 1, src_vccz
+s_cselect_b32 s42, s43, s42
+s_load_dword s65, s[40:41], 0x88
+s_load_dword s90, s[40:41], 0x98
+s_load_dword s68, s[40:41], s42
+s_load_dwordx2 s[66:67], s[40:41], 0xa8
+s_bitcmp1_b32 s18, 10
+s_cbranch_scc0 103
+s_load_dwordx4 s[44:47], s[40:41], 0xb8
+v_ffbh_u32_e32 v4, s17
+v_lshlrev_b32_e64 v5, v4, s17
+v_and_b32_e32 v6, 0xffffff00, v5
+v_cmp_eq_u32_e32 vcc, 0x80000000, v5
+v_cvt_f32_u32_e32 v6, v6
+v_rcp_f32_e32 v2, v6
+v_subb_co_u32_e32 v3, vcc, 32, v4, vcc
+v_cvt_f32_ubyte0_e32 v4, v5
+v_fma_f32 v6, v6, v2, -1.0
+v_fma_f32 v6, v4, v2, v6
+v_madak_f32 v6, v6, v2, 0x9f000000
+v_mul_f32_e32 v6, 0x5f800000, v6
+v_mov_b32_e32 v4, 0
+v_cvt_flr_i32_f32_e64 v6, -v6
+v_lshl_add_u32 v2, v2, 9, v6
+v_mad_u64_u32 v[4:5], vcc, v5, v2, v[4:5]
+v_subb_co_u32_e64 v2, vcc, v2, -1, vcc
+v_mul_hi_u32 v4, s8, v2
+v_add_co_u32_e64 v2, vcc, v4, s8
+v_addc_co_u32_e64 v4, vcc, 0, 0, vcc
+v_cmp_eq_u32_e32 vcc, 32, v3
+v_cndmask_b32_e32 v2, v2, v4, vcc
+v_alignbit_b32 v2, v4, v2, v3
+s_waitcnt lgkmcnt(0)
+v_readfirstlane_b32 s48, v2
+s_mul_i32 s49, s48, s17
+s_sub_u32 s8, s8, s49
+s_mul_i32 s49, s45, s48
+s_add_u32 s20, s20, s49
+s_addc_u32 s21, s21, 0
+s_mul_i32 s49, s46, s48
+s_add_u32 s22, s22, s49
+s_addc_u32 s23, s23, 0
+s_mul_i32 s49, s47, s48
+s_add_u32 s24, s24, s49
+s_addc_u32 s25, s25, 0
+s_branch 49
+s_mul_i32 s42, s14, s15
+s_lshr_b32 s46, -1, 16
+s_and_b32 s46, s46, s42
+s_lshr_b32 s47, s42, 16
+s_mul_i32 s47, s47, s13
+s_mul_i32 s44, s46, s13
+s_lshl_b32 s46, s47, 16
+s_lshr_b32 s47, s47, 16
+s_add_u32 s44, s46, s44
+s_addc_u32 s45, s47, 0
+s_lshl_b32 s65, s44, 1
+s_lshl_b32 s68, s42, 1
+s_mul_i32 s43, s32, s33
+s_lshr_b32 s46, -1, 16
+s_and_b32 s46, s46, s43
+s_lshr_b32 s47, s43, 16
+s_mul_i32 s47, s47, s16
+s_mul_i32 s44, s46, s16
+s_lshl_b32 s46, s47, 16
+s_lshr_b32 s47, s47, 16
+s_add_u32 s44, s46, s44
+s_addc_u32 s45, s47, 0
+s_lshl_b32 s66, s44, 1
+s_lshl_b32 s67, s43, 1
+s_bitcmp1_b32 s18, 13
+s_cbranch_scc0 2
+s_load_dwordx8 s[48:55], s[40:41], 0x68
+s_mul_i32 s42, s28, s29
+s_lshl_b32 s42, s42, 1
+s_bitcmp1_b32 s18, 2
+s_cselect_b32 s43, s16, s13
+s_lshr_b32 s44, -1, 16
+s_and_b32 s44, s44, s42
+s_lshr_b32 s45, s42, 16
+s_mul_i32 s45, s45, s43
+s_mul_i32 s56, s44, s43
+s_lshl_b32 s44, s45, 16
+s_lshr_b32 s45, s45, 16
+s_add_u32 s56, s44, s56
+s_addc_u32 s57, s45, 0
+s_mov_b32 s43, s56
+s_bitcmp1_b32 s18, 2
+s_cselect_b32 s44, s43, s42
+s_cselect_b32 s90, s42, s43
+v_cmp_le_u32_e32 vcc, 0x100, v0
+s_cmp_eq_u32 1, src_vccz
+s_cselect_b32 s68, s44, s68
+s_waitcnt lgkmcnt(0)
+s_and_b32 s21, s21, 0xffff
+s_and_b32 s23, s23, 0xffff
+s_and_b32 s25, s25, 0xffff
+s_and_b32 s27, s27, 0xffff
+s_and_b32 s35, s35, 0xffff
+s_bitcmp1_b32 s18, 13
+s_cbranch_scc0 8
+s_add_u32 s20, s20, s48
+s_addc_u32 s21, s21, s49
+s_add_u32 s22, s22, s50
+s_addc_u32 s23, s23, s51
+s_add_u32 s24, s24, s52
+s_addc_u32 s25, s25, s53
+s_add_u32 s34, s34, s54
+s_addc_u32 s35, s35, s55
+v_cvt_f16_f32_e32 v2, s36
+v_readfirstlane_b32 s36, v2
+s_and_b32 s44, 1, s30
+s_addc_u32 s44, s32, 1
+s_ashr_i32 s44, s44, 1
+s_add_u32 s42, s44, 1
+v_mov_b32_e32 v2, 0x80000000
+v_mul_hi_u32 v2, v2, s42
+v_readfirstlane_b32 s42, v2
+s_andn2_b32 s44, 1, s31
+s_addc_u32 s44, s33, 1
+s_ashr_i32 s44, s44, 1
+s_add_u32 s43, s44, 1
+v_mov_b32_e32 v2, 0x80000000
+v_mul_hi_u32 v2, v2, s43
+v_readfirstlane_b32 s43, v2
+s_sub_u32 s75, 0, s43
+s_sub_u32 s74, 0, s42
+s_add_u32 s60, s28, 2
+v_mov_b32_e32 v2, 0x55555556
+v_mul_hi_u32 v2, v2, s60
+v_readfirstlane_b32 s60, v2
+s_add_u32 s61, s29, 2
+v_mov_b32_e32 v2, 0x55555556
+v_mul_hi_u32 v2, v2, s61
+v_readfirstlane_b32 s61, v2
+v_mad_i32_i24 v2, 3, s60, -2
+v_sub_co_u32_e64 v2, vcc, v2, s28
+v_addc_co_u32_e64 v2, vcc, 0, 0, vcc
+v_readfirstlane_b32 s44, v2
+s_and_b32 s44, s44, 1
+s_and_b32 s44, s44, s60
+s_add_u32 s60, s60, s44
+v_readfirstlane_b32 s45, v0
+s_and_b32 s48, s45, 64
+s_cselect_b32 s48, 0x80000, 0
+s_or_b32 s18, s18, s48
+s_lshl_b32 s69, s68, 1
+s_sub_u32 s70, 0, s69
+s_subb_u32 s71, 0, 0
+s_bitset1_b32 s18, 23
+s_mov_b32 s69, s68
+s_mov_b32 s70, s68
+s_mov_b32 s71, 0
+s_add_u32 s61, s61, 1
+s_and_b32 s61, s61, -2
+s_branch 16
+s_and_b32 s48, s13, 3
+s_cselect_b32 s48, 0, 0x1000000
+s_bitcmp1_b32 s18, 2
+s_cselect_b32 s48, 0, s48
+s_or_b32 s18, s18, s48
+s_cmp_eq_u32 s48, 0
+s_cselect_b32 s69, s68, s69
+s_cselect_b32 s70, s68, s70
+s_cselect_b32 s71, 0, s71
+s_bitcmp0_b32 s45, 8
+s_cselect_b32 s48, s48, 0
+s_cmp_eq_u32 s48, 0
+s_cselect_b32 s48, 0, 0x80000
+s_andn2_b32 s18, s18, s48
+s_add_u32 s70, s70, s69
+s_addc_u32 s71, s71, 0
+s_add_u32 s70, s70, s69
+s_addc_u32 s71, s71, 0
+v_bfe_u32 v3, v0, 2, 6
+v_lshrrev_b32_e32 v111, 1, v3
+s_bitcmp0_b32 s45, 8
+s_cselect_b32 s48, 0x1000000, 0
+s_or_b32 s48, s48, 0x100000
+s_and_b32 s48, s18, s48
+s_cselect_b32 s48, 0, 15
+v_bfi_b32 v111, s48, v3, v111
+v_bfe_u32 v3, s45, 8, 1
+v_xor_b32_e64 v3, v3, 1
+v_lshrrev_b32_e32 v111, v3, v111
+s_mul_i32 s88, s12, s42
+s_sub_u32 s88, s88, 1
+s_lshr_b32 s88, s88, 0
+s_add_u32 s88, s88, 1
+s_lshr_b32 s46, -1, 16
+s_and_b32 s46, s46, s88
+s_lshr_b32 s47, s88, 16
+s_mul_i32 s47, s47, s43
+s_mul_i32 s88, s46, s43
+s_lshl_b32 s46, s47, 16
+s_lshr_b32 s47, s47, 16
+s_add_u32 s88, s46, s88
+s_addc_u32 s89, s47, 0
+s_sub_u32 s88, s88, 1
+s_subb_u32 s89, s89, 0
+s_lshr_b64 s[88:89], s[88:89], 5
+s_add_u32 s88, s88, 1
+s_addc_u32 s89, s89, 0
+v_mov_b32_e32 v4, s8
+v_mov_b32_e32 v5, s17
+v_and_b32_e32 v6, 3, v0
+v_cmp_eq_u32_e32 vcc, 2, v6
+v_cndmask_b32_e32 v4, v4, v5, vcc
+v_cmp_eq_u32_e32 vcc, 1, v6
+v_cndmask_b32_e32 v7, 0, v111, vcc
+s_bitcmp1_b32 s18, 20
+s_cbranch_scc0 4
+v_add_co_u32_e64 v5, vcc, v111, 8
+v_cmp_eq_u32_e32 vcc, 0, v6
+v_cndmask_b32_e32 v7, v7, v5, vcc
+v_cmp_eq_u32_e64 s[46:47], 3, v6
+v_bfe_u32 v109, v7, 0, 5
+v_mad_u32_u24 v109, v4, 32, v109
+v_ffbh_u32_e32 v9, s43
+v_lshlrev_b32_e64 v10, v9, s43
+v_and_b32_e32 v11, 0xffffff00, v10
+v_cmp_eq_u32_e32 vcc, 0x80000000, v10
+v_cvt_f32_u32_e32 v11, v11
+v_rcp_f32_e32 v110, v11
+v_subb_co_u32_e32 v8, vcc, 32, v9, vcc
+v_cvt_f32_ubyte0_e32 v9, v10
+v_fma_f32 v11, v11, v110, -1.0
+v_fma_f32 v11, v9, v110, v11
+v_madak_f32 v11, v11, v110, 0x9f000000
+v_mul_f32_e32 v11, 0x5f800000, v11
+v_mov_b32_e32 v9, 0
+v_cvt_flr_i32_f32_e64 v11, -v11
+v_lshl_add_u32 v110, v110, 9, v11
+v_mad_u64_u32 v[9:10], vcc, v10, v110, v[9:10]
+v_subb_co_u32_e64 v110, vcc, v110, -1, vcc
+v_mul_hi_u32 v9, v109, v110
+v_add_co_u32_e32 v110, vcc, v9, v109
+v_addc_co_u32_e64 v9, vcc, 0, 0, vcc
+v_cmp_eq_u32_e32 vcc, 32, v8
+v_cndmask_b32_e32 v110, v110, v9, vcc
+v_alignbit_b32 v110, v9, v110, v8
+v_mad_i32_i24 v108, v110, s75, v109
+v_lshrrev_b32_e32 v109, 5, v7
+v_mad_u32_u24 v109, v110, 1, v109
+v_cndmask_b32_e64 v109, v109, 1, s[46:47]
+v_ffbh_u32_e32 v9, s42
+v_lshlrev_b32_e64 v10, v9, s42
+v_and_b32_e32 v11, 0xffffff00, v10
+v_cmp_eq_u32_e32 vcc, 0x80000000, v10
+v_cvt_f32_u32_e32 v11, v11
+v_rcp_f32_e32 v110, v11
+v_subb_co_u32_e32 v8, vcc, 32, v9, vcc
+v_cvt_f32_ubyte0_e32 v9, v10
+v_fma_f32 v11, v11, v110, -1.0
+v_fma_f32 v11, v9, v110, v11
+v_madak_f32 v11, v11, v110, 0x9f000000
+v_mul_f32_e32 v11, 0x5f800000, v11
+v_mov_b32_e32 v9, 0
+v_cvt_flr_i32_f32_e64 v11, -v11
+v_lshl_add_u32 v110, v110, 9, v11
+v_mad_u64_u32 v[9:10], vcc, v10, v110, v[9:10]
+v_subb_co_u32_e64 v110, vcc, v110, -1, vcc
+v_mul_hi_u32 v9, v109, v110
+v_add_co_u32_e32 v110, vcc, v9, v109
+v_addc_co_u32_e64 v9, vcc, 0, 0, vcc
+v_cmp_eq_u32_e32 vcc, 32, v8
+v_cndmask_b32_e32 v110, v110, v9, vcc
+v_alignbit_b32 v110, v9, v110, v8
+v_mad_i32_i24 v109, v110, s74, v109
+v_readlane_b32 s76, v108, 2
+v_readlane_b32 s77, v109, 2
+v_readlane_b32 s78, v110, 2
+v_readlane_b32 s79, v109, 3
+v_readlane_b32 s80, v110, 3
+v_add_co_u32_e64 v108, vcc, v108, s75
+v_add_co_u32_e64 v109, vcc, v109, s74
+v_mov_b32_dpp v110, v110  quad_perm:[1,1,0,0] row_mask:0xf bank_mask:0xf
+v_mov_b32_dpp v108, v108  quad_perm:[1,1,0,0] row_mask:0xf bank_mask:0xf
+v_mov_b32_dpp v109, v109  quad_perm:[1,1,0,0] row_mask:0xf bank_mask:0xf
+s_mov_b32 s42, 0x80000000
+s_mov_b32 s43, 0x20000
+s_mov_b32 s46, 0x80000000
+s_mov_b32 s47, 0x20000
+v_cmp_le_u32_e32 vcc, 0x100, v0
+s_cbranch_vccnz 7
+v_xor_b32_dpp v112, v0, v0  quad_perm:[1,3,2,2] row_mask:0xf bank_mask:0xf
+v_subrev_co_u32_e32 v112, vcc, 1, v112
+v_cvt_f16_i16_e32 v112, v112
+v_pk_add_f16 v112, v112, 0 op_sel_hi:[0,0]
+s_branch 6
+v_xor_b32_dpp v112, v0, v0  quad_perm:[2,1,0,1] row_mask:0xf bank_mask:0xf
+v_sub_co_u32_e32 v112, vcc, 1, v112
+v_cvt_f16_i16_e32 v112, v112
+v_pk_add_f16 v112, v112, 0 op_sel_hi:[0,0]
+v_mov_b32_e32 v113, 1
+v_xor_b32_dpp v113, v0, v0  quad_perm:[2,3,2,3] row_mask:0xf bank_mask:0x4
+v_xor_b32_dpp v113, v0, v0  quad_perm:[0,1,0,1] row_mask:0xf bank_mask:0x8
+v_subrev_co_u32_e32 v113, vcc, 1, v113
+v_mov_b32_e32 v114, 1
+v_xor_b32_dpp v114, v0, v0  quad_perm:[0,3,2,1] row_mask:0xf bank_mask:0x2
+v_xor_b32_dpp v114, v0, v0  quad_perm:[2,1,0,3] row_mask:0xf bank_mask:0x4
+v_subrev_co_u32_e32 v114, vcc, 1, v114
+v_cvt_f32_i32_e32 v113, v113
+v_cvt_f32_i32_e32 v114, v114
+v_lshrrev_b32_e64 v118, 2, s92
+v_and_b32_e32 v119, 3, v0
+v_bfe_u32 v120, v0, 4, 3
+v_mad_u32_u24 v107, v120, 4, v119
+v_lshlrev_b32_e32 v107, 4, v107
+v_mad_u32_u24 v102, v118, 4, v119
+v_lshlrev_b32_e32 v102, 4, v102
+v_bfe_u32 v118, v0, 2, 2
+v_and_b32_e32 v119, 1, v118
+v_mad_u32_u24 v121, v118, 16, v119
+v_lshlrev_b32_e32 v121, 6, v121
+v_xor_b32_e32 v102, v102, v121
+v_mul_u32_u24_e32 v121, 0x400, v118
+v_xor_b32_e32 v107, v107, v121
+s_lshr_b32 s92, s92, 1
+v_cmp_le_u32_e32 vcc, 0x100, v0
+s_cbranch_vccnz 50
+s_and_b32 s53, s18, 0x1100000
+s_addc_u32 s53, 0, 0
+v_lshrrev_b32_e32 v121, 1, v0
+s_mul_i32 s52, 60, s53
+s_sub_u32 s52, 63, s52
+v_bfi_b32 v121, s52, v0, v121
+v_and_b32_e32 v118, 1, v121
+v_bfe_u32 v119, v121, 1, 1
+v_xor_b32_e32 v118, v118, v119
+v_bfe_u32 v120, v121, 3, 1
+v_mad_u32_u24 v119, v119, 2, v120
+v_mul_u32_u24_e32 v118, 0x118, v118
+v_bfe_u32 v120, v121, 2, 1
+v_mad_u32_u24 v119, v119, 2, v118
+v_xor_b32_e32 v119, v119, v120
+v_and_b32_e32 v120, 0xf0, v121
+v_xor_b32_e32 v119, v119, v120
+s_mul_i32 s52, 4, s53
+s_sub_u32 s52, 6, s52
+v_bfe_u32 v121, v0, s52, 1
+v_mul_u32_u24_e32 v121, 0x1040, v121
+v_xor_b32_e32 v104, 0x314, v119
+v_xor_b32_e32 v105, 0x31c, v119
+v_xor_b32_e32 v106, 8, v119
+s_bitcmp1_b32 s18, 0
+s_cselect_b64 vcc, -1, 0
+v_cndmask_b32_e32 v103, v119, v106, vcc
+v_cndmask_b32_e32 v106, v106, v119, vcc
+v_mad_u32_u24 v103, 4, v103, v121
+v_mad_u32_u24 v104, 4, v104, v121
+v_mad_u32_u24 v105, 4, v105, v121
+v_mad_u32_u24 v106, 4, v106, v121
+s_branch 44
+s_bfe_u32 s53, s18, 0x10014
+v_lshrrev_b32_e32 v121, 1, v0
+s_mul_i32 s52, 60, s53
+s_sub_u32 s52, 63, s52
+v_bfi_b32 v121, s52, v0, v121
+v_and_b32_e32 v118, 1, v121
+v_bfe_u32 v119, v121, 1, 1
+v_bfe_u32 v120, v121, 3, 1
+v_xor_b32_e32 v118, v118, v119
+v_mad_u32_u24 v119, v119, 2, v120
+v_mul_u32_u24_e32 v118, 0x109, v118
+v_bfe_u32 v120, v121, 2, 1
+v_mad_u32_u24 v119, v119, 2, v118
+v_xor_b32_e32 v119, v119, v120
+v_and_b32_e32 v120, 0xf0, v121
+v_or_b32_e32 v119, v119, v120
+s_mul_i32 s52, 4, s53
+s_sub_u32 s52, 6, s52
+v_bfe_u32 v121, v0, s52, 1
+v_mul_u32_u24_e32 v121, 0x1040, v121
+v_mad_u32_u24 v103, 4, v119, v121
+v_xor_b32_e32 v104, 0x307, v119
+v_mad_u32_u24 v104, 4, v104, v121
+v_xor_b32_e32 v105, 0x30f, v119
+v_mad_u32_u24 v105, 4, v105, v121
+v_xor_b32_e32 v106, 8, v119
+v_mad_u32_u24 v106, 4, v106, v121
+v_subrev_co_u32_e32 v108, vcc, s76, v108
+v_mov_b32_e32 v119, s75
+v_cmp_lt_i32_e32 vcc, v108, v119
+v_subb_co_u32_e64 v118, vcc, 0, 0, vcc
+v_mad_i32_i24 v108, v118, s75, v108
+v_mad_i32_i24 v110, v118, s80, v110
+v_mad_i32_i24 v109, v118, s79, v109
+v_mov_b32_e32 v119, s74
+v_cmp_lt_i32_e32 vcc, v109, v119
+v_subb_co_u32_e64 v118, vcc, 0, 0, vcc
+v_add_co_u32_e32 v110, vcc, v110, v118
+v_mad_i32_i24 v109, v118, v119, v109
+v_subrev_co_u32_e32 v109, vcc, s77, v109
+v_cmp_lt_i32_e32 vcc, v109, v119
+v_subb_co_u32_e64 v118, vcc, 0, 0, vcc
+v_add_co_u32_e32 v110, vcc, v110, v118
+v_mad_i32_i24 v109, v118, s74, v109
+v_subrev_co_u32_e32 v110, vcc, s78, v110
+s_mov_b32 s62, 0
+s_mov_b32 s63, s28
+s_mov_b32 s64, 1
+s_mov_b32 s84, 0
+s_mov_b32 s85, s16
+s_mov_b32 s83, s85
+s_sub_u32 s93, -1, s92
+s_sub_u32 s93, s93, 16
+s_bitset1_b32 s18, 21
+s_mov_b32 s47, 0
+s_mov_b32 s51, 0
+v_add_co_u32_e32 v118, vcc, 2, v0
+v_bfe_u32 v118, v118, 2, 1
+v_cmp_ne_u32_e64 vcc, v118, 1
+s_mov_b64 s[10:11], vcc
+s_mov_b32 s94, 34
+s_mov_b32 s82, 0
+s_bitset1_b32 s18, 26
+s_call_b64 s[38:39], 3038
+v_cmp_le_u32_e32 vcc, 0x100, v0
+s_cbranch_vccnz 65
+s_branch 1507
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_dot2_f32_f16 v2, v34, v42, v2
+v_dot2_f32_f16 v3, v35, v42, v3
+v_dot2_f32_f16 v4, v36, v42, v4
+v_dot2_f32_f16 v5, v37, v42, v5
+v_dot2_f32_f16 v6, v34, v43, v6
+v_dot2_f32_f16 v7, v35, v43, v7
+v_dot2_f32_f16 v8, v36, v43, v8
+v_dot2_f32_f16 v9, v37, v43, v9
+v_dot2_f32_f16 v10, v34, v44, v10
+v_dot2_f32_f16 v11, v35, v44, v11
+v_dot2_f32_f16 v12, v36, v44, v12
+v_dot2_f32_f16 v13, v37, v44, v13
+v_dot2_f32_f16 v14, v34, v45, v14
+v_dot2_f32_f16 v15, v35, v45, v15
+v_dot2_f32_f16 v16, v36, v45, v16
+v_dot2_f32_f16 v17, v37, v45, v17
+v_dot2_f32_f16 v18, v34, v46, v18
+v_dot2_f32_f16 v19, v35, v46, v19
+v_dot2_f32_f16 v20, v36, v46, v20
+v_dot2_f32_f16 v21, v37, v46, v21
+v_dot2_f32_f16 v22, v34, v47, v22
+v_dot2_f32_f16 v23, v35, v47, v23
+v_dot2_f32_f16 v24, v36, v47, v24
+v_dot2_f32_f16 v25, v37, v47, v25
+v_dot2_f32_f16 v26, v34, v48, v26
+v_dot2_f32_f16 v27, v35, v48, v27
+v_dot2_f32_f16 v28, v36, v48, v28
+v_dot2_f32_f16 v29, v37, v48, v29
+v_dot2_f32_f16 v30, v34, v49, v30
+v_dot2_f32_f16 v31, v35, v49, v31
+v_pack_b32_f16 v70, v82, v70
+v_pack_b32_f16 v71, v83, v71
+v_pack_b32_f16 v72, v84, v72
+v_pack_b32_f16 v73, v85, v73
+v_pk_fma_f16 v70, v72, -1.0, v70 op_sel_hi:[1,0,1]
+v_pk_mul_f16 v70, v70, 0.5 op_sel_hi:[1,0]
+v_pk_fma_f16 v73, v71, -1.0, v73 op_sel_hi:[1,0,1]
+v_pk_mul_f16 v73, v73, 0.5 op_sel_hi:[1,0]
+v_pk_add_f16 v71, v72, v71
+v_pk_mul_f16 v71, v71, 0.5 op_sel_hi:[1,0]
+s_setprio 0
+s_nop 0
+v_dot2_f32_f16 v32, v36, v49, v32
+v_dot2_f32_f16 v33, v37, v49, v33
+s_nop 0
+ds_read_b128 v[34:37], v107 offset:29440
+ds_read_b128 v[42:45], v102 offset:28928
+ds_read_b128 v[46:49], v102 offset:29056
+ds_write_b32 v103, v62
+ds_write_b32 v104, v63
+s_setprio 1
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v58, v94, s[40:43], 0 offen
+buffer_load_short_d16 v60, v96, s[40:43], 0 offen
+buffer_load_short_d16 v59, v95, s[40:43], 0 offen
+buffer_load_short_d16 v61, v97, s[40:43], 0 offen
+s_add_u32 s91, s91, 0x200
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 2
+s_call_b64 s[38:39], 2849
+s_nop 0
+v_dot2_f32_f16 v2, v38, v50, v2
+v_dot2_f32_f16 v3, v39, v50, v3
+v_dot2_f32_f16 v4, v40, v50, v4
+v_dot2_f32_f16 v5, v41, v50, v5
+v_dot2_f32_f16 v6, v38, v51, v6
+v_dot2_f32_f16 v7, v39, v51, v7
+v_dot2_f32_f16 v8, v40, v51, v8
+v_dot2_f32_f16 v9, v41, v51, v9
+v_dot2_f32_f16 v10, v38, v52, v10
+v_dot2_f32_f16 v11, v39, v52, v11
+v_dot2_f32_f16 v12, v40, v52, v12
+v_dot2_f32_f16 v13, v41, v52, v13
+v_dot2_f32_f16 v14, v38, v53, v14
+v_dot2_f32_f16 v15, v39, v53, v15
+v_dot2_f32_f16 v16, v40, v53, v16
+v_dot2_f32_f16 v17, v41, v53, v17
+v_dot2_f32_f16 v18, v38, v54, v18
+v_dot2_f32_f16 v19, v39, v54, v19
+v_dot2_f32_f16 v20, v40, v54, v20
+v_dot2_f32_f16 v21, v41, v54, v21
+v_dot2_f32_f16 v22, v38, v55, v22
+v_dot2_f32_f16 v23, v39, v55, v23
+v_dot2_f32_f16 v24, v40, v55, v24
+v_dot2_f32_f16 v25, v41, v55, v25
+v_dot2_f32_f16 v26, v38, v56, v26
+v_dot2_f32_f16 v27, v39, v56, v27
+v_dot2_f32_f16 v28, v40, v56, v28
+v_dot2_f32_f16 v29, v41, v56, v29
+v_dot2_f32_f16 v30, v38, v57, v30
+v_dot2_f32_f16 v31, v39, v57, v31
+v_pk_fma_f16 v72, v71, -1.0, v72 op_sel_hi:[1,0,1]
+v_mov_b32_dpp v115, v70  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v70, v115, v112, v70
+v_mov_b32_dpp v115, v71  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v71, v115, v112, v71
+v_mov_b32_dpp v115, v72  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v72, v115, v112, v72
+v_mov_b32_dpp v115, v73  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v73, v115, v112, v73
+s_setprio 0
+s_nop 0
+v_dot2_f32_f16 v32, v40, v57, v32
+v_dot2_f32_f16 v33, v41, v57, v33
+s_nop 0
+ds_read_b128 v[38:41], v107 offset:33536
+ds_read_b128 v[50:53], v102 offset:33024
+ds_read_b128 v[54:57], v102 offset:33152
+ds_write_b32 v105, v68 offset:8256
+ds_write_b32 v106, v69 offset:8256
+s_setprio 1
+s_add_u32 s40, s40, s69
+s_addc_u32 s41, s41, 0
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v82, v94, s[40:43], 0 offen
+buffer_load_short_d16 v84, v96, s[40:43], 0 offen
+buffer_load_short_d16 v83, v95, s[40:43], 0 offen
+buffer_load_short_d16 v85, v97, s[40:43], 0 offen
+s_nop 0
+s_waitcnt vmcnt(16) lgkmcnt(5)
+ds_append v117 offset:65472
+s_bitset1_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 4
+s_call_b64 s[38:39], 2731
+s_nop 0
+s_nop 0
+s_nop 0
+v_dot2_f32_f16 v2, v34, v42, v2
+v_dot2_f32_f16 v3, v35, v42, v3
+v_dot2_f32_f16 v4, v36, v42, v4
+v_dot2_f32_f16 v5, v37, v42, v5
+v_dot2_f32_f16 v6, v34, v43, v6
+v_dot2_f32_f16 v7, v35, v43, v7
+v_dot2_f32_f16 v8, v36, v43, v8
+v_dot2_f32_f16 v9, v37, v43, v9
+v_dot2_f32_f16 v10, v34, v44, v10
+v_dot2_f32_f16 v11, v35, v44, v11
+v_dot2_f32_f16 v12, v36, v44, v12
+v_dot2_f32_f16 v13, v37, v44, v13
+v_dot2_f32_f16 v14, v34, v45, v14
+v_dot2_f32_f16 v15, v35, v45, v15
+v_dot2_f32_f16 v16, v36, v45, v16
+v_dot2_f32_f16 v17, v37, v45, v17
+v_dot2_f32_f16 v18, v34, v46, v18
+v_dot2_f32_f16 v19, v35, v46, v19
+v_dot2_f32_f16 v20, v36, v46, v20
+v_dot2_f32_f16 v21, v37, v46, v21
+v_dot2_f32_f16 v22, v34, v47, v22
+v_dot2_f32_f16 v23, v35, v47, v23
+v_dot2_f32_f16 v24, v36, v47, v24
+v_dot2_f32_f16 v25, v37, v47, v25
+v_dot2_f32_f16 v26, v34, v48, v26
+v_dot2_f32_f16 v27, v35, v48, v27
+v_dot2_f32_f16 v28, v36, v48, v28
+v_dot2_f32_f16 v29, v37, v48, v29
+v_dot2_f32_f16 v30, v34, v49, v30
+v_dot2_f32_f16 v31, v35, v49, v31
+v_pack_b32_f16 v74, v86, v74
+v_pack_b32_f16 v75, v87, v75
+v_pack_b32_f16 v76, v88, v76
+v_pack_b32_f16 v77, v89, v77
+v_pk_fma_f16 v74, v76, -1.0, v74 op_sel_hi:[1,0,1]
+v_pk_mul_f16 v74, v74, 0.5 op_sel_hi:[1,0]
+v_pk_fma_f16 v77, v75, -1.0, v77 op_sel_hi:[1,0,1]
+v_pk_mul_f16 v77, v77, 0.5 op_sel_hi:[1,0]
+v_pk_add_f16 v75, v76, v75
+v_pk_mul_f16 v75, v75, 0.5 op_sel_hi:[1,0]
+s_setprio 0
+s_nop 0
+v_dot2_f32_f16 v32, v36, v49, v32
+v_dot2_f32_f16 v33, v37, v49, v33
+s_nop 0
+ds_read_b128 v[34:37], v107 offset:37696
+ds_read_b128 v[42:45], v102 offset:37184
+ds_read_b128 v[46:49], v102 offset:37312
+ds_write_b32 v103, v66 offset:8256
+ds_write_b32 v104, v67 offset:8256
+s_setprio 1
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v62, v94, s[40:43], 0 offen
+buffer_load_short_d16 v64, v96, s[40:43], 0 offen
+buffer_load_short_d16 v63, v95, s[40:43], 0 offen
+buffer_load_short_d16 v65, v97, s[40:43], 0 offen
+s_mov_b32 m0, 0x2ffc0
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 2
+s_call_b64 s[38:39], 2609
+s_nop 0
+v_dot2_f32_f16 v2, v38, v50, v2
+v_dot2_f32_f16 v3, v39, v50, v3
+v_dot2_f32_f16 v4, v40, v50, v4
+v_dot2_f32_f16 v5, v41, v50, v5
+v_dot2_f32_f16 v6, v38, v51, v6
+v_dot2_f32_f16 v7, v39, v51, v7
+v_dot2_f32_f16 v8, v40, v51, v8
+v_dot2_f32_f16 v9, v41, v51, v9
+v_dot2_f32_f16 v10, v38, v52, v10
+v_dot2_f32_f16 v11, v39, v52, v11
+v_dot2_f32_f16 v12, v40, v52, v12
+v_dot2_f32_f16 v13, v41, v52, v13
+v_dot2_f32_f16 v14, v38, v53, v14
+v_dot2_f32_f16 v15, v39, v53, v15
+v_dot2_f32_f16 v16, v40, v53, v16
+v_dot2_f32_f16 v17, v41, v53, v17
+v_dot2_f32_f16 v18, v38, v54, v18
+v_dot2_f32_f16 v19, v39, v54, v19
+v_dot2_f32_f16 v20, v40, v54, v20
+v_dot2_f32_f16 v21, v41, v54, v21
+v_dot2_f32_f16 v22, v38, v55, v22
+v_dot2_f32_f16 v23, v39, v55, v23
+v_dot2_f32_f16 v24, v40, v55, v24
+v_dot2_f32_f16 v25, v41, v55, v25
+v_dot2_f32_f16 v26, v38, v56, v26
+v_dot2_f32_f16 v27, v39, v56, v27
+v_dot2_f32_f16 v28, v40, v56, v28
+v_dot2_f32_f16 v29, v41, v56, v29
+v_dot2_f32_f16 v30, v38, v57, v30
+v_dot2_f32_f16 v31, v39, v57, v31
+v_dot2_f32_f16 v32, v40, v57, v32
+v_pk_fma_f16 v76, v75, -1.0, v76 op_sel_hi:[1,0,1]
+v_mov_b32_dpp v115, v74  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v74, v115, v112, v74
+v_mov_b32_dpp v115, v75  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v75, v115, v112, v75
+v_mov_b32_dpp v115, v76  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v76, v115, v112, v76
+v_mov_b32_dpp v115, v77  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v77, v115, v112, v77
+s_setprio 0
+s_nop 0
+v_dot2_f32_f16 v33, v41, v57, v33
+v_cmp_eq_u32_e64 vcc, src_lds_direct, s91
+s_nop 0
+s_nop 0
+s_cbranch_vccz 65531
+s_nop 0
+ds_read_b128 v[38:41], v107 offset:41792
+ds_read_b128 v[50:53], v102 offset:41280
+ds_read_b128 v[54:57], v102 offset:41408
+ds_write_b32 v105, v72 offset:16512
+ds_write_b32 v106, v73 offset:16512
+s_setprio 1
+s_add_u32 s40, s40, s69
+s_addc_u32 s41, s41, 0
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v86, v94, s[40:43], 0 offen
+buffer_load_short_d16 v88, v96, s[40:43], 0 offen
+buffer_load_short_d16 v87, v95, s[40:43], 0 offen
+buffer_load_short_d16 v89, v97, s[40:43], 0 offen
+s_nop 0
+s_waitcnt vmcnt(16) lgkmcnt(5)
+s_bitset1_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 1
+s_call_b64 s[38:39], 2488
+v_dot2_f32_f16 v2, v34, v42, v2
+v_dot2_f32_f16 v3, v35, v42, v3
+v_dot2_f32_f16 v4, v36, v42, v4
+v_dot2_f32_f16 v5, v37, v42, v5
+v_dot2_f32_f16 v6, v34, v43, v6
+v_dot2_f32_f16 v7, v35, v43, v7
+v_dot2_f32_f16 v8, v36, v43, v8
+v_dot2_f32_f16 v9, v37, v43, v9
+v_dot2_f32_f16 v10, v34, v44, v10
+v_dot2_f32_f16 v11, v35, v44, v11
+v_dot2_f32_f16 v12, v36, v44, v12
+v_dot2_f32_f16 v13, v37, v44, v13
+v_dot2_f32_f16 v14, v34, v45, v14
+v_dot2_f32_f16 v15, v35, v45, v15
+v_dot2_f32_f16 v16, v36, v45, v16
+v_dot2_f32_f16 v17, v37, v45, v17
+v_dot2_f32_f16 v18, v34, v46, v18
+v_dot2_f32_f16 v19, v35, v46, v19
+v_dot2_f32_f16 v20, v36, v46, v20
+v_dot2_f32_f16 v21, v37, v46, v21
+v_dot2_f32_f16 v22, v34, v47, v22
+v_dot2_f32_f16 v23, v35, v47, v23
+v_dot2_f32_f16 v24, v36, v47, v24
+v_dot2_f32_f16 v25, v37, v47, v25
+v_dot2_f32_f16 v26, v34, v48, v26
+v_dot2_f32_f16 v27, v35, v48, v27
+v_dot2_f32_f16 v28, v36, v48, v28
+v_dot2_f32_f16 v29, v37, v48, v29
+v_dot2_f32_f16 v30, v34, v49, v30
+v_dot2_f32_f16 v31, v35, v49, v31
+v_pack_b32_f16 v78, v90, v78
+v_pack_b32_f16 v79, v91, v79
+v_pack_b32_f16 v80, v92, v80
+v_pack_b32_f16 v81, v93, v81
+v_pk_fma_f16 v78, v80, -1.0, v78 op_sel_hi:[1,0,1]
+v_pk_mul_f16 v78, v78, 0.5 op_sel_hi:[1,0]
+v_pk_fma_f16 v81, v79, -1.0, v81 op_sel_hi:[1,0,1]
+v_pk_mul_f16 v81, v81, 0.5 op_sel_hi:[1,0]
+v_pk_add_f16 v79, v80, v79
+v_pk_mul_f16 v79, v79, 0.5 op_sel_hi:[1,0]
+s_setprio 0
+s_nop 0
+v_dot2_f32_f16 v32, v36, v49, v32
+v_dot2_f32_f16 v33, v37, v49, v33
+s_nop 0
+ds_read_b128 v[34:37], v107 offset:45952
+ds_read_b128 v[42:45], v102 offset:45440
+ds_read_b128 v[46:49], v102 offset:45568
+ds_write_b32 v103, v70 offset:16512
+ds_write_b32 v104, v71 offset:16512
+s_setprio 1
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v66, v94, s[40:43], 0 offen
+buffer_load_short_d16 v68, v96, s[40:43], 0 offen
+buffer_load_short_d16 v67, v95, s[40:43], 0 offen
+buffer_load_short_d16 v69, v97, s[40:43], 0 offen
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 4
+s_call_b64 s[38:39], 2371
+s_nop 0
+s_nop 0
+s_nop 0
+v_dot2_f32_f16 v2, v38, v50, v2
+v_dot2_f32_f16 v3, v39, v50, v3
+v_dot2_f32_f16 v4, v40, v50, v4
+v_dot2_f32_f16 v5, v41, v50, v5
+v_dot2_f32_f16 v6, v38, v51, v6
+v_dot2_f32_f16 v7, v39, v51, v7
+v_dot2_f32_f16 v8, v40, v51, v8
+v_dot2_f32_f16 v9, v41, v51, v9
+v_dot2_f32_f16 v10, v38, v52, v10
+v_dot2_f32_f16 v11, v39, v52, v11
+v_dot2_f32_f16 v12, v40, v52, v12
+v_dot2_f32_f16 v13, v41, v52, v13
+v_dot2_f32_f16 v14, v38, v53, v14
+v_dot2_f32_f16 v15, v39, v53, v15
+v_dot2_f32_f16 v16, v40, v53, v16
+v_dot2_f32_f16 v17, v41, v53, v17
+v_dot2_f32_f16 v18, v38, v54, v18
+v_dot2_f32_f16 v19, v39, v54, v19
+v_dot2_f32_f16 v20, v40, v54, v20
+v_dot2_f32_f16 v21, v41, v54, v21
+v_dot2_f32_f16 v22, v38, v55, v22
+v_dot2_f32_f16 v23, v39, v55, v23
+v_dot2_f32_f16 v24, v40, v55, v24
+v_dot2_f32_f16 v25, v41, v55, v25
+v_dot2_f32_f16 v26, v38, v56, v26
+v_dot2_f32_f16 v27, v39, v56, v27
+v_dot2_f32_f16 v28, v40, v56, v28
+v_dot2_f32_f16 v29, v41, v56, v29
+v_dot2_f32_f16 v30, v38, v57, v30
+v_dot2_f32_f16 v31, v39, v57, v31
+v_pk_fma_f16 v80, v79, -1.0, v80 op_sel_hi:[1,0,1]
+v_mov_b32_dpp v115, v78  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v78, v115, v112, v78
+v_mov_b32_dpp v115, v79  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v79, v115, v112, v79
+v_mov_b32_dpp v115, v80  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v80, v115, v112, v80
+v_mov_b32_dpp v115, v81  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v81, v115, v112, v81
+s_setprio 0
+s_nop 0
+v_dot2_f32_f16 v32, v40, v57, v32
+v_dot2_f32_f16 v33, v41, v57, v33
+s_nop 0
+ds_read_b128 v[38:41], v107 offset:512
+ds_read_b128 v[50:53], v102
+ds_read_b128 v[54:57], v102 offset:128
+ds_write_b32 v105, v76 offset:24768
+ds_write_b32 v106, v77 offset:24768
+s_setprio 1
+s_add_u32 s40, s40, s69
+s_addc_u32 s41, s41, 0
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v90, v94, s[40:43], 0 offen
+buffer_load_short_d16 v92, v96, s[40:43], 0 offen
+buffer_load_short_d16 v91, v95, s[40:43], 0 offen
+buffer_load_short_d16 v93, v97, s[40:43], 0 offen
+s_nop 0
+s_waitcnt vmcnt(16) lgkmcnt(5)
+ds_append v117 offset:65476
+s_bitset1_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 4
+s_call_b64 s[38:39], 2251
+s_nop 0
+s_nop 0
+s_nop 0
+v_dot2_f32_f16 v2, v34, v42, v2
+v_dot2_f32_f16 v3, v35, v42, v3
+v_dot2_f32_f16 v4, v36, v42, v4
+v_dot2_f32_f16 v5, v37, v42, v5
+v_dot2_f32_f16 v6, v34, v43, v6
+v_dot2_f32_f16 v7, v35, v43, v7
+v_dot2_f32_f16 v8, v36, v43, v8
+v_dot2_f32_f16 v9, v37, v43, v9
+v_dot2_f32_f16 v10, v34, v44, v10
+v_dot2_f32_f16 v11, v35, v44, v11
+v_dot2_f32_f16 v12, v36, v44, v12
+v_dot2_f32_f16 v13, v37, v44, v13
+v_dot2_f32_f16 v14, v34, v45, v14
+v_dot2_f32_f16 v15, v35, v45, v15
+v_dot2_f32_f16 v16, v36, v45, v16
+v_dot2_f32_f16 v17, v37, v45, v17
+v_dot2_f32_f16 v18, v34, v46, v18
+v_dot2_f32_f16 v19, v35, v46, v19
+v_dot2_f32_f16 v20, v36, v46, v20
+v_dot2_f32_f16 v21, v37, v46, v21
+v_dot2_f32_f16 v22, v34, v47, v22
+v_dot2_f32_f16 v23, v35, v47, v23
+v_dot2_f32_f16 v24, v36, v47, v24
+v_dot2_f32_f16 v25, v37, v47, v25
+v_dot2_f32_f16 v26, v34, v48, v26
+v_dot2_f32_f16 v27, v35, v48, v27
+v_dot2_f32_f16 v28, v36, v48, v28
+v_dot2_f32_f16 v29, v37, v48, v29
+v_dot2_f32_f16 v30, v34, v49, v30
+v_dot2_f32_f16 v31, v35, v49, v31
+v_pack_b32_f16 v58, v82, v58
+v_pack_b32_f16 v59, v83, v59
+v_pack_b32_f16 v60, v84, v60
+v_pack_b32_f16 v61, v85, v61
+v_pk_fma_f16 v58, v60, -1.0, v58 op_sel_hi:[1,0,1]
+v_pk_mul_f16 v58, v58, 0.5 op_sel_hi:[1,0]
+v_pk_fma_f16 v61, v59, -1.0, v61 op_sel_hi:[1,0,1]
+v_pk_mul_f16 v61, v61, 0.5 op_sel_hi:[1,0]
+v_pk_add_f16 v59, v60, v59
+v_pk_mul_f16 v59, v59, 0.5 op_sel_hi:[1,0]
+s_setprio 0
+s_nop 0
+v_dot2_f32_f16 v32, v36, v49, v32
+v_dot2_f32_f16 v33, v37, v49, v33
+s_nop 0
+ds_read_b128 v[34:37], v107 offset:4672
+ds_read_b128 v[42:45], v102 offset:4160
+ds_read_b128 v[46:49], v102 offset:4288
+ds_write_b32 v103, v74 offset:24768
+ds_write_b32 v104, v75 offset:24768
+s_setprio 1
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v70, v94, s[40:43], 0 offen
+buffer_load_short_d16 v72, v96, s[40:43], 0 offen
+buffer_load_short_d16 v71, v95, s[40:43], 0 offen
+buffer_load_short_d16 v73, v97, s[40:43], 0 offen
+s_mov_b32 m0, 0x2ffc4
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 2
+s_call_b64 s[38:39], 2129
+s_nop 0
+v_dot2_f32_f16 v2, v38, v50, v2
+v_dot2_f32_f16 v3, v39, v50, v3
+v_dot2_f32_f16 v4, v40, v50, v4
+v_dot2_f32_f16 v5, v41, v50, v5
+v_dot2_f32_f16 v6, v38, v51, v6
+v_dot2_f32_f16 v7, v39, v51, v7
+v_dot2_f32_f16 v8, v40, v51, v8
+v_dot2_f32_f16 v9, v41, v51, v9
+v_dot2_f32_f16 v10, v38, v52, v10
+v_dot2_f32_f16 v11, v39, v52, v11
+v_dot2_f32_f16 v12, v40, v52, v12
+v_dot2_f32_f16 v13, v41, v52, v13
+v_dot2_f32_f16 v14, v38, v53, v14
+v_dot2_f32_f16 v15, v39, v53, v15
+v_dot2_f32_f16 v16, v40, v53, v16
+v_dot2_f32_f16 v17, v41, v53, v17
+v_dot2_f32_f16 v18, v38, v54, v18
+v_dot2_f32_f16 v19, v39, v54, v19
+v_dot2_f32_f16 v20, v40, v54, v20
+v_dot2_f32_f16 v21, v41, v54, v21
+v_dot2_f32_f16 v22, v38, v55, v22
+v_dot2_f32_f16 v23, v39, v55, v23
+v_dot2_f32_f16 v24, v40, v55, v24
+v_dot2_f32_f16 v25, v41, v55, v25
+v_dot2_f32_f16 v26, v38, v56, v26
+v_dot2_f32_f16 v27, v39, v56, v27
+v_dot2_f32_f16 v28, v40, v56, v28
+v_dot2_f32_f16 v29, v41, v56, v29
+v_dot2_f32_f16 v30, v38, v57, v30
+v_dot2_f32_f16 v31, v39, v57, v31
+v_dot2_f32_f16 v32, v40, v57, v32
+v_pk_fma_f16 v60, v59, -1.0, v60 op_sel_hi:[1,0,1]
+v_mov_b32_dpp v115, v58  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v58, v115, v112, v58
+v_mov_b32_dpp v115, v59  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v59, v115, v112, v59
+v_mov_b32_dpp v115, v60  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v60, v115, v112, v60
+v_mov_b32_dpp v115, v61  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v61, v115, v112, v61
+s_setprio 0
+s_nop 0
+v_dot2_f32_f16 v33, v41, v57, v33
+v_cmp_eq_u32_e64 vcc, src_lds_direct, s91
+s_nop 0
+s_nop 0
+s_cbranch_vccz 65531
+s_nop 0
+ds_read_b128 v[38:41], v107 offset:8768
+ds_read_b128 v[50:53], v102 offset:8256
+ds_read_b128 v[54:57], v102 offset:8384
+ds_write_b32 v105, v80 offset:33024
+ds_write_b32 v106, v81 offset:33024
+s_setprio 1
+s_add_u32 s40, s40, s69
+s_addc_u32 s41, s41, 0
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v82, v94, s[40:43], 0 offen
+buffer_load_short_d16 v84, v96, s[40:43], 0 offen
+buffer_load_short_d16 v83, v95, s[40:43], 0 offen
+buffer_load_short_d16 v85, v97, s[40:43], 0 offen
+s_nop 0
+s_waitcnt vmcnt(16) lgkmcnt(5)
+s_bitset1_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 1
+s_call_b64 s[38:39], 2008
+v_dot2_f32_f16 v2, v34, v42, v2
+v_dot2_f32_f16 v3, v35, v42, v3
+v_dot2_f32_f16 v4, v36, v42, v4
+v_dot2_f32_f16 v5, v37, v42, v5
+v_dot2_f32_f16 v6, v34, v43, v6
+v_dot2_f32_f16 v7, v35, v43, v7
+v_dot2_f32_f16 v8, v36, v43, v8
+v_dot2_f32_f16 v9, v37, v43, v9
+v_dot2_f32_f16 v10, v34, v44, v10
+v_dot2_f32_f16 v11, v35, v44, v11
+v_dot2_f32_f16 v12, v36, v44, v12
+v_dot2_f32_f16 v13, v37, v44, v13
+v_dot2_f32_f16 v14, v34, v45, v14
+v_dot2_f32_f16 v15, v35, v45, v15
+v_dot2_f32_f16 v16, v36, v45, v16
+v_dot2_f32_f16 v17, v37, v45, v17
+v_dot2_f32_f16 v18, v34, v46, v18
+v_dot2_f32_f16 v19, v35, v46, v19
+v_dot2_f32_f16 v20, v36, v46, v20
+v_dot2_f32_f16 v21, v37, v46, v21
+v_dot2_f32_f16 v22, v34, v47, v22
+v_dot2_f32_f16 v23, v35, v47, v23
+v_dot2_f32_f16 v24, v36, v47, v24
+v_dot2_f32_f16 v25, v37, v47, v25
+v_dot2_f32_f16 v26, v34, v48, v26
+v_dot2_f32_f16 v27, v35, v48, v27
+v_dot2_f32_f16 v28, v36, v48, v28
+v_dot2_f32_f16 v29, v37, v48, v29
+v_dot2_f32_f16 v30, v34, v49, v30
+v_dot2_f32_f16 v31, v35, v49, v31
+v_pack_b32_f16 v62, v86, v62
+v_pack_b32_f16 v63, v87, v63
+v_pack_b32_f16 v64, v88, v64
+v_pack_b32_f16 v65, v89, v65
+v_pk_fma_f16 v62, v64, -1.0, v62 op_sel_hi:[1,0,1]
+v_pk_mul_f16 v62, v62, 0.5 op_sel_hi:[1,0]
+v_pk_fma_f16 v65, v63, -1.0, v65 op_sel_hi:[1,0,1]
+v_pk_mul_f16 v65, v65, 0.5 op_sel_hi:[1,0]
+v_pk_add_f16 v63, v64, v63
+v_pk_mul_f16 v63, v63, 0.5 op_sel_hi:[1,0]
+s_setprio 0
+s_nop 0
+v_dot2_f32_f16 v32, v36, v49, v32
+v_dot2_f32_f16 v33, v37, v49, v33
+s_nop 0
+ds_read_b128 v[34:37], v107 offset:12928
+ds_read_b128 v[42:45], v102 offset:12416
+ds_read_b128 v[46:49], v102 offset:12544
+ds_write_b32 v103, v78 offset:33024
+ds_write_b32 v104, v79 offset:33024
+s_setprio 1
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v74, v94, s[40:43], 0 offen
+buffer_load_short_d16 v76, v96, s[40:43], 0 offen
+buffer_load_short_d16 v75, v95, s[40:43], 0 offen
+buffer_load_short_d16 v77, v97, s[40:43], 0 offen
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 4
+s_call_b64 s[38:39], 1891
+s_nop 0
+s_nop 0
+s_nop 0
+v_dot2_f32_f16 v2, v38, v50, v2
+v_dot2_f32_f16 v3, v39, v50, v3
+v_dot2_f32_f16 v4, v40, v50, v4
+v_dot2_f32_f16 v5, v41, v50, v5
+v_dot2_f32_f16 v6, v38, v51, v6
+v_dot2_f32_f16 v7, v39, v51, v7
+v_dot2_f32_f16 v8, v40, v51, v8
+v_dot2_f32_f16 v9, v41, v51, v9
+v_dot2_f32_f16 v10, v38, v52, v10
+v_dot2_f32_f16 v11, v39, v52, v11
+v_dot2_f32_f16 v12, v40, v52, v12
+v_dot2_f32_f16 v13, v41, v52, v13
+v_dot2_f32_f16 v14, v38, v53, v14
+v_dot2_f32_f16 v15, v39, v53, v15
+v_dot2_f32_f16 v16, v40, v53, v16
+v_dot2_f32_f16 v17, v41, v53, v17
+v_dot2_f32_f16 v18, v38, v54, v18
+v_dot2_f32_f16 v19, v39, v54, v19
+v_dot2_f32_f16 v20, v40, v54, v20
+v_dot2_f32_f16 v21, v41, v54, v21
+v_dot2_f32_f16 v22, v38, v55, v22
+v_dot2_f32_f16 v23, v39, v55, v23
+v_dot2_f32_f16 v24, v40, v55, v24
+v_dot2_f32_f16 v25, v41, v55, v25
+v_dot2_f32_f16 v26, v38, v56, v26
+v_dot2_f32_f16 v27, v39, v56, v27
+v_dot2_f32_f16 v28, v40, v56, v28
+v_dot2_f32_f16 v29, v41, v56, v29
+v_dot2_f32_f16 v30, v38, v57, v30
+v_dot2_f32_f16 v31, v39, v57, v31
+v_pk_fma_f16 v64, v63, -1.0, v64 op_sel_hi:[1,0,1]
+v_mov_b32_dpp v115, v62  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v62, v115, v112, v62
+v_mov_b32_dpp v115, v63  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v63, v115, v112, v63
+v_mov_b32_dpp v115, v64  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v64, v115, v112, v64
+v_mov_b32_dpp v115, v65  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v65, v115, v112, v65
+s_setprio 0
+s_nop 0
+v_dot2_f32_f16 v32, v40, v57, v32
+v_dot2_f32_f16 v33, v41, v57, v33
+s_nop 0
+ds_read_b128 v[38:41], v107 offset:17024
+ds_read_b128 v[50:53], v102 offset:16512
+ds_read_b128 v[54:57], v102 offset:16640
+ds_write_b32 v105, v60 offset:41280
+ds_write_b32 v106, v61 offset:41280
+s_setprio 1
+s_add_u32 s40, s40, s69
+s_addc_u32 s41, s41, 0
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v86, v94, s[40:43], 0 offen
+buffer_load_short_d16 v88, v96, s[40:43], 0 offen
+buffer_load_short_d16 v87, v95, s[40:43], 0 offen
+buffer_load_short_d16 v89, v97, s[40:43], 0 offen
+s_nop 0
+s_waitcnt vmcnt(16) lgkmcnt(5)
+ds_append v117 offset:65480
+s_bitset1_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 4
+s_call_b64 s[38:39], 1771
+s_nop 0
+s_nop 0
+s_nop 0
+v_dot2_f32_f16 v2, v34, v42, v2
+v_dot2_f32_f16 v3, v35, v42, v3
+v_dot2_f32_f16 v4, v36, v42, v4
+v_dot2_f32_f16 v5, v37, v42, v5
+v_dot2_f32_f16 v6, v34, v43, v6
+v_dot2_f32_f16 v7, v35, v43, v7
+v_dot2_f32_f16 v8, v36, v43, v8
+v_dot2_f32_f16 v9, v37, v43, v9
+v_dot2_f32_f16 v10, v34, v44, v10
+v_dot2_f32_f16 v11, v35, v44, v11
+v_dot2_f32_f16 v12, v36, v44, v12
+v_dot2_f32_f16 v13, v37, v44, v13
+v_dot2_f32_f16 v14, v34, v45, v14
+v_dot2_f32_f16 v15, v35, v45, v15
+v_dot2_f32_f16 v16, v36, v45, v16
+v_dot2_f32_f16 v17, v37, v45, v17
+v_dot2_f32_f16 v18, v34, v46, v18
+v_dot2_f32_f16 v19, v35, v46, v19
+v_dot2_f32_f16 v20, v36, v46, v20
+v_dot2_f32_f16 v21, v37, v46, v21
+v_dot2_f32_f16 v22, v34, v47, v22
+v_dot2_f32_f16 v23, v35, v47, v23
+v_dot2_f32_f16 v24, v36, v47, v24
+v_dot2_f32_f16 v25, v37, v47, v25
+v_dot2_f32_f16 v26, v34, v48, v26
+v_dot2_f32_f16 v27, v35, v48, v27
+v_dot2_f32_f16 v28, v36, v48, v28
+v_dot2_f32_f16 v29, v37, v48, v29
+v_dot2_f32_f16 v30, v34, v49, v30
+v_dot2_f32_f16 v31, v35, v49, v31
+v_pack_b32_f16 v66, v90, v66
+v_pack_b32_f16 v67, v91, v67
+v_pack_b32_f16 v68, v92, v68
+v_pack_b32_f16 v69, v93, v69
+v_pk_fma_f16 v66, v68, -1.0, v66 op_sel_hi:[1,0,1]
+v_pk_mul_f16 v66, v66, 0.5 op_sel_hi:[1,0]
+v_pk_fma_f16 v69, v67, -1.0, v69 op_sel_hi:[1,0,1]
+v_pk_mul_f16 v69, v69, 0.5 op_sel_hi:[1,0]
+v_pk_add_f16 v67, v68, v67
+v_pk_mul_f16 v67, v67, 0.5 op_sel_hi:[1,0]
+s_setprio 0
+s_nop 0
+v_dot2_f32_f16 v32, v36, v49, v32
+v_dot2_f32_f16 v33, v37, v49, v33
+s_nop 0
+ds_read_b128 v[34:37], v107 offset:21184
+ds_read_b128 v[42:45], v102 offset:20672
+ds_read_b128 v[46:49], v102 offset:20800
+ds_write_b32 v103, v58 offset:41280
+ds_write_b32 v104, v59 offset:41280
+s_setprio 1
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v78, v94, s[40:43], 0 offen
+buffer_load_short_d16 v80, v96, s[40:43], 0 offen
+buffer_load_short_d16 v79, v95, s[40:43], 0 offen
+buffer_load_short_d16 v81, v97, s[40:43], 0 offen
+s_mov_b32 m0, 0x2ffc8
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 2
+s_call_b64 s[38:39], 1649
+s_nop 0
+v_dot2_f32_f16 v2, v38, v50, v2
+v_dot2_f32_f16 v3, v39, v50, v3
+v_dot2_f32_f16 v4, v40, v50, v4
+v_dot2_f32_f16 v5, v41, v50, v5
+v_dot2_f32_f16 v6, v38, v51, v6
+v_dot2_f32_f16 v7, v39, v51, v7
+v_dot2_f32_f16 v8, v40, v51, v8
+v_dot2_f32_f16 v9, v41, v51, v9
+v_dot2_f32_f16 v10, v38, v52, v10
+v_dot2_f32_f16 v11, v39, v52, v11
+v_dot2_f32_f16 v12, v40, v52, v12
+v_dot2_f32_f16 v13, v41, v52, v13
+v_dot2_f32_f16 v14, v38, v53, v14
+v_dot2_f32_f16 v15, v39, v53, v15
+v_dot2_f32_f16 v16, v40, v53, v16
+v_dot2_f32_f16 v17, v41, v53, v17
+v_dot2_f32_f16 v18, v38, v54, v18
+v_dot2_f32_f16 v19, v39, v54, v19
+v_dot2_f32_f16 v20, v40, v54, v20
+v_dot2_f32_f16 v21, v41, v54, v21
+v_dot2_f32_f16 v22, v38, v55, v22
+v_dot2_f32_f16 v23, v39, v55, v23
+v_dot2_f32_f16 v24, v40, v55, v24
+v_dot2_f32_f16 v25, v41, v55, v25
+v_dot2_f32_f16 v26, v38, v56, v26
+v_dot2_f32_f16 v27, v39, v56, v27
+v_dot2_f32_f16 v28, v40, v56, v28
+v_dot2_f32_f16 v29, v41, v56, v29
+v_dot2_f32_f16 v30, v38, v57, v30
+v_dot2_f32_f16 v31, v39, v57, v31
+v_dot2_f32_f16 v32, v40, v57, v32
+v_pk_fma_f16 v68, v67, -1.0, v68 op_sel_hi:[1,0,1]
+v_mov_b32_dpp v115, v66  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v66, v115, v112, v66
+v_mov_b32_dpp v115, v67  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v67, v115, v112, v67
+v_mov_b32_dpp v115, v68  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v68, v115, v112, v68
+v_mov_b32_dpp v115, v69  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v69, v115, v112, v69
+s_setprio 0
+s_nop 0
+v_dot2_f32_f16 v33, v41, v57, v33
+v_cmp_eq_u32_e64 vcc, src_lds_direct, s91
+s_nop 0
+s_nop 0
+s_cbranch_vccz 65531
+s_nop 0
+ds_read_b128 v[38:41], v107 offset:25280
+ds_read_b128 v[50:53], v102 offset:24768
+ds_read_b128 v[54:57], v102 offset:24896
+ds_write_b32 v105, v64
+ds_write_b32 v106, v65
+s_setprio 1
+s_add_u32 s40, s40, s69
+s_addc_u32 s41, s41, 0
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v90, v94, s[40:43], 0 offen
+buffer_load_short_d16 v92, v96, s[40:43], 0 offen
+buffer_load_short_d16 v91, v95, s[40:43], 0 offen
+buffer_load_short_d16 v93, v97, s[40:43], 0 offen
+s_nop 0
+s_waitcnt vmcnt(16) lgkmcnt(5)
+s_bitset1_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 64097
+s_call_b64 s[38:39], 1528
+s_branch 64095
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_dot2_f32_f16 v2, v34, v42, v2
+v_dot2_f32_f16 v3, v35, v42, v3
+v_dot2_f32_f16 v4, v36, v42, v4
+v_dot2_f32_f16 v5, v37, v42, v5
+s_setprio 1
+s_nop 0
+v_dot2_f32_f16 v6, v34, v43, v6
+v_dot2_f32_f16 v7, v35, v43, v7
+v_dot2_f32_f16 v8, v36, v43, v8
+v_dot2_f32_f16 v9, v37, v43, v9
+v_dot2_f32_f16 v10, v34, v44, v10
+v_dot2_f32_f16 v11, v35, v44, v11
+v_dot2_f32_f16 v12, v36, v44, v12
+v_dot2_f32_f16 v13, v37, v44, v13
+v_dot2_f32_f16 v14, v34, v45, v14
+v_dot2_f32_f16 v15, v35, v45, v15
+v_dot2_f32_f16 v16, v36, v45, v16
+v_dot2_f32_f16 v17, v37, v45, v17
+v_dot2_f32_f16 v18, v34, v46, v18
+v_dot2_f32_f16 v19, v35, v46, v19
+v_dot2_f32_f16 v20, v36, v46, v20
+v_dot2_f32_f16 v21, v37, v46, v21
+v_dot2_f32_f16 v22, v34, v47, v22
+v_dot2_f32_f16 v23, v35, v47, v23
+v_dot2_f32_f16 v24, v36, v47, v24
+v_dot2_f32_f16 v25, v37, v47, v25
+v_dot2_f32_f16 v26, v34, v48, v26
+v_dot2_f32_f16 v27, v35, v48, v27
+v_dot2_f32_f16 v28, v36, v48, v28
+v_dot2_f32_f16 v29, v37, v48, v29
+v_dot2_f32_f16 v30, v34, v49, v30
+v_dot2_f32_f16 v31, v35, v49, v31
+v_pack_b32_f16 v70, v82, v70
+v_pack_b32_f16 v71, v83, v71
+v_pack_b32_f16 v72, v84, v72
+v_pack_b32_f16 v73, v85, v73
+v_cndmask_b32_dpp v70, v70, v70, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v71, v71, v71, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v72, v72, v72, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v73, v73, v73, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_mov_b32_dpp v70, v71  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_pk_add_f16 v70, v70, v71
+v_mov_b32_dpp v71, v71  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v70, v71, v112, v70
+v_dot2_f32_f16 v32, v36, v49, v32
+v_dot2_f32_f16 v33, v37, v49, v33
+s_nop 0
+ds_read_b128 v[34:37], v107 offset:29440
+ds_read_b128 v[42:45], v102 offset:28928
+ds_read_b128 v[46:49], v102 offset:29056
+ds_write_b32 v103, v62
+ds_write_b32 v104, v63
+s_setprio 0
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v60, v96, s[40:43], 0 offen
+buffer_load_short_d16 v59, v95, s[40:43], 0 offen
+buffer_load_short_d16 v61, v97, s[40:43], 0 offen
+s_add_u32 s91, s91, 0x200
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 8
+s_call_b64 s[38:39], 1399
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_dot2_f32_f16 v2, v38, v50, v2
+v_dot2_f32_f16 v3, v39, v50, v3
+v_dot2_f32_f16 v4, v40, v50, v4
+v_dot2_f32_f16 v5, v41, v50, v5
+s_setprio 1
+s_nop 0
+v_dot2_f32_f16 v6, v38, v51, v6
+v_dot2_f32_f16 v7, v39, v51, v7
+v_dot2_f32_f16 v8, v40, v51, v8
+v_dot2_f32_f16 v9, v41, v51, v9
+v_dot2_f32_f16 v10, v38, v52, v10
+v_dot2_f32_f16 v11, v39, v52, v11
+v_dot2_f32_f16 v12, v40, v52, v12
+v_dot2_f32_f16 v13, v41, v52, v13
+v_dot2_f32_f16 v14, v38, v53, v14
+v_dot2_f32_f16 v15, v39, v53, v15
+v_dot2_f32_f16 v16, v40, v53, v16
+v_dot2_f32_f16 v17, v41, v53, v17
+v_dot2_f32_f16 v18, v38, v54, v18
+v_dot2_f32_f16 v19, v39, v54, v19
+v_dot2_f32_f16 v20, v40, v54, v20
+v_dot2_f32_f16 v21, v41, v54, v21
+v_dot2_f32_f16 v22, v38, v55, v22
+v_dot2_f32_f16 v23, v39, v55, v23
+v_dot2_f32_f16 v24, v40, v55, v24
+v_dot2_f32_f16 v25, v41, v55, v25
+v_dot2_f32_f16 v26, v38, v56, v26
+v_dot2_f32_f16 v27, v39, v56, v27
+v_dot2_f32_f16 v28, v40, v56, v28
+v_dot2_f32_f16 v29, v41, v56, v29
+v_dot2_f32_f16 v30, v38, v57, v30
+v_dot2_f32_f16 v31, v39, v57, v31
+v_mov_b32_dpp v71, v73  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_pk_add_f16 v71, v71, v73
+v_mov_b32_dpp v73, v73  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v71, v73, v112, v71
+v_mov_b32_dpp v73, v72  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_pk_add_f16 v73, v73, v72
+v_mov_b32_dpp v72, v72  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v73, v72, v112, v73
+v_pk_add_f16 v72, v70, v73
+v_pk_add_f16 v71, v71, v72
+v_pk_mul_f16 v71, v71, 0.5 op_sel_hi:[1,0]
+v_pk_fma_f16 v72, -1.0, v71, v72 op_sel_hi:[0,1,1]
+v_dot2_f32_f16 v32, v40, v57, v32
+v_dot2_f32_f16 v33, v41, v57, v33
+s_nop 0
+ds_read_b128 v[38:41], v107 offset:33536
+ds_read_b128 v[50:53], v102 offset:33024
+ds_read_b128 v[54:57], v102 offset:33152
+ds_write_b32 v105, v68 offset:8256
+ds_write_b32 v106, v69 offset:8256
+s_setprio 0
+s_add_u32 s40, s40, s69
+s_addc_u32 s41, s41, 0
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v84, v96, s[40:43], 0 offen
+buffer_load_short_d16 v83, v95, s[40:43], 0 offen
+buffer_load_short_d16 v85, v97, s[40:43], 0 offen
+s_nop 0
+s_waitcnt vmcnt(12) lgkmcnt(5)
+ds_append v117 offset:65472
+s_bitset1_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 8
+s_call_b64 s[38:39], 1271
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_dot2_f32_f16 v2, v34, v42, v2
+v_dot2_f32_f16 v3, v35, v42, v3
+v_dot2_f32_f16 v4, v36, v42, v4
+v_dot2_f32_f16 v5, v37, v42, v5
+s_setprio 1
+s_nop 0
+v_dot2_f32_f16 v6, v34, v43, v6
+v_dot2_f32_f16 v7, v35, v43, v7
+v_dot2_f32_f16 v8, v36, v43, v8
+v_dot2_f32_f16 v9, v37, v43, v9
+v_dot2_f32_f16 v10, v34, v44, v10
+v_dot2_f32_f16 v11, v35, v44, v11
+v_dot2_f32_f16 v12, v36, v44, v12
+v_dot2_f32_f16 v13, v37, v44, v13
+v_dot2_f32_f16 v14, v34, v45, v14
+v_dot2_f32_f16 v15, v35, v45, v15
+v_dot2_f32_f16 v16, v36, v45, v16
+v_dot2_f32_f16 v17, v37, v45, v17
+v_dot2_f32_f16 v18, v34, v46, v18
+v_dot2_f32_f16 v19, v35, v46, v19
+v_dot2_f32_f16 v20, v36, v46, v20
+v_dot2_f32_f16 v21, v37, v46, v21
+v_dot2_f32_f16 v22, v34, v47, v22
+v_dot2_f32_f16 v23, v35, v47, v23
+v_dot2_f32_f16 v24, v36, v47, v24
+v_dot2_f32_f16 v25, v37, v47, v25
+v_dot2_f32_f16 v26, v34, v48, v26
+v_dot2_f32_f16 v27, v35, v48, v27
+v_dot2_f32_f16 v28, v36, v48, v28
+v_dot2_f32_f16 v29, v37, v48, v29
+v_dot2_f32_f16 v30, v34, v49, v30
+v_dot2_f32_f16 v31, v35, v49, v31
+v_pack_b32_f16 v74, v86, v74
+v_pack_b32_f16 v75, v87, v75
+v_pack_b32_f16 v76, v88, v76
+v_pack_b32_f16 v77, v89, v77
+v_cndmask_b32_dpp v74, v74, v74, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v75, v75, v75, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v76, v76, v76, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v77, v77, v77, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_mov_b32_dpp v74, v75  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_pk_add_f16 v74, v74, v75
+v_mov_b32_dpp v75, v75  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v74, v75, v112, v74
+v_dot2_f32_f16 v32, v36, v49, v32
+v_dot2_f32_f16 v33, v37, v49, v33
+s_nop 0
+ds_read_b128 v[34:37], v107 offset:37696
+ds_read_b128 v[42:45], v102 offset:37184
+ds_read_b128 v[46:49], v102 offset:37312
+ds_write_b32 v103, v66 offset:8256
+ds_write_b32 v104, v67 offset:8256
+s_setprio 0
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v64, v96, s[40:43], 0 offen
+buffer_load_short_d16 v63, v95, s[40:43], 0 offen
+buffer_load_short_d16 v65, v97, s[40:43], 0 offen
+s_mov_b32 m0, 0x2ffc0
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 8
+s_call_b64 s[38:39], 1143
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_dot2_f32_f16 v2, v38, v50, v2
+v_dot2_f32_f16 v3, v39, v50, v3
+v_dot2_f32_f16 v4, v40, v50, v4
+v_dot2_f32_f16 v5, v41, v50, v5
+s_setprio 1
+s_nop 0
+v_dot2_f32_f16 v6, v38, v51, v6
+v_dot2_f32_f16 v7, v39, v51, v7
+v_dot2_f32_f16 v8, v40, v51, v8
+v_dot2_f32_f16 v9, v41, v51, v9
+v_dot2_f32_f16 v10, v38, v52, v10
+v_dot2_f32_f16 v11, v39, v52, v11
+v_dot2_f32_f16 v12, v40, v52, v12
+v_dot2_f32_f16 v13, v41, v52, v13
+v_dot2_f32_f16 v14, v38, v53, v14
+v_dot2_f32_f16 v15, v39, v53, v15
+v_dot2_f32_f16 v16, v40, v53, v16
+v_dot2_f32_f16 v17, v41, v53, v17
+v_dot2_f32_f16 v18, v38, v54, v18
+v_dot2_f32_f16 v19, v39, v54, v19
+v_dot2_f32_f16 v20, v40, v54, v20
+v_dot2_f32_f16 v21, v41, v54, v21
+v_dot2_f32_f16 v22, v38, v55, v22
+v_dot2_f32_f16 v23, v39, v55, v23
+v_dot2_f32_f16 v24, v40, v55, v24
+v_dot2_f32_f16 v25, v41, v55, v25
+v_dot2_f32_f16 v26, v38, v56, v26
+v_dot2_f32_f16 v27, v39, v56, v27
+v_dot2_f32_f16 v28, v40, v56, v28
+v_dot2_f32_f16 v29, v41, v56, v29
+v_dot2_f32_f16 v30, v38, v57, v30
+v_dot2_f32_f16 v31, v39, v57, v31
+v_dot2_f32_f16 v32, v40, v57, v32
+v_mov_b32_dpp v75, v77  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_pk_add_f16 v75, v75, v77
+v_mov_b32_dpp v77, v77  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v75, v77, v112, v75
+v_mov_b32_dpp v77, v76  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_pk_add_f16 v77, v77, v76
+v_mov_b32_dpp v76, v76  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v77, v76, v112, v77
+v_pk_add_f16 v76, v74, v77
+v_pk_add_f16 v75, v75, v76
+v_pk_mul_f16 v75, v75, 0.5 op_sel_hi:[1,0]
+v_pk_fma_f16 v76, -1.0, v75, v76 op_sel_hi:[0,1,1]
+v_dot2_f32_f16 v33, v41, v57, v33
+v_cmp_eq_u32_e64 vcc, src_lds_direct, s91
+s_nop 0
+s_nop 0
+s_cbranch_vccz 65531
+s_mov_b64 vcc, s[10:11]
+s_nop 0
+ds_read_b128 v[38:41], v107 offset:41792
+ds_read_b128 v[50:53], v102 offset:41280
+ds_read_b128 v[54:57], v102 offset:41408
+ds_write_b32 v105, v72 offset:16512
+ds_write_b32 v106, v73 offset:16512
+s_setprio 0
+s_add_u32 s40, s40, s69
+s_addc_u32 s41, s41, 0
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v88, v96, s[40:43], 0 offen
+buffer_load_short_d16 v87, v95, s[40:43], 0 offen
+buffer_load_short_d16 v89, v97, s[40:43], 0 offen
+s_nop 0
+s_waitcnt vmcnt(12) lgkmcnt(5)
+s_bitset1_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 4
+s_call_b64 s[38:39], 1011
+s_nop 0
+s_nop 0
+s_nop 0
+v_dot2_f32_f16 v2, v34, v42, v2
+v_dot2_f32_f16 v3, v35, v42, v3
+v_dot2_f32_f16 v4, v36, v42, v4
+v_dot2_f32_f16 v5, v37, v42, v5
+s_setprio 1
+s_nop 0
+v_dot2_f32_f16 v6, v34, v43, v6
+v_dot2_f32_f16 v7, v35, v43, v7
+v_dot2_f32_f16 v8, v36, v43, v8
+v_dot2_f32_f16 v9, v37, v43, v9
+v_dot2_f32_f16 v10, v34, v44, v10
+v_dot2_f32_f16 v11, v35, v44, v11
+v_dot2_f32_f16 v12, v36, v44, v12
+v_dot2_f32_f16 v13, v37, v44, v13
+v_dot2_f32_f16 v14, v34, v45, v14
+v_dot2_f32_f16 v15, v35, v45, v15
+v_dot2_f32_f16 v16, v36, v45, v16
+v_dot2_f32_f16 v17, v37, v45, v17
+v_dot2_f32_f16 v18, v34, v46, v18
+v_dot2_f32_f16 v19, v35, v46, v19
+v_dot2_f32_f16 v20, v36, v46, v20
+v_dot2_f32_f16 v21, v37, v46, v21
+v_dot2_f32_f16 v22, v34, v47, v22
+v_dot2_f32_f16 v23, v35, v47, v23
+v_dot2_f32_f16 v24, v36, v47, v24
+v_dot2_f32_f16 v25, v37, v47, v25
+v_dot2_f32_f16 v26, v34, v48, v26
+v_dot2_f32_f16 v27, v35, v48, v27
+v_dot2_f32_f16 v28, v36, v48, v28
+v_dot2_f32_f16 v29, v37, v48, v29
+v_dot2_f32_f16 v30, v34, v49, v30
+v_dot2_f32_f16 v31, v35, v49, v31
+v_pack_b32_f16 v78, v90, v78
+v_pack_b32_f16 v79, v91, v79
+v_pack_b32_f16 v80, v92, v80
+v_pack_b32_f16 v81, v93, v81
+v_cndmask_b32_dpp v78, v78, v78, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v79, v79, v79, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v80, v80, v80, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v81, v81, v81, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_mov_b32_dpp v78, v79  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_pk_add_f16 v78, v78, v79
+v_mov_b32_dpp v79, v79  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v78, v79, v112, v78
+v_dot2_f32_f16 v32, v36, v49, v32
+v_dot2_f32_f16 v33, v37, v49, v33
+s_nop 0
+ds_read_b128 v[34:37], v107 offset:45952
+ds_read_b128 v[42:45], v102 offset:45440
+ds_read_b128 v[46:49], v102 offset:45568
+ds_write_b32 v103, v70 offset:16512
+ds_write_b32 v104, v71 offset:16512
+s_setprio 0
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v68, v96, s[40:43], 0 offen
+buffer_load_short_d16 v67, v95, s[40:43], 0 offen
+buffer_load_short_d16 v69, v97, s[40:43], 0 offen
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 2
+s_call_b64 s[38:39], 889
+s_nop 0
+v_dot2_f32_f16 v2, v38, v50, v2
+v_dot2_f32_f16 v3, v39, v50, v3
+v_dot2_f32_f16 v4, v40, v50, v4
+v_dot2_f32_f16 v5, v41, v50, v5
+s_setprio 1
+s_nop 0
+v_dot2_f32_f16 v6, v38, v51, v6
+v_dot2_f32_f16 v7, v39, v51, v7
+v_dot2_f32_f16 v8, v40, v51, v8
+v_dot2_f32_f16 v9, v41, v51, v9
+v_dot2_f32_f16 v10, v38, v52, v10
+v_dot2_f32_f16 v11, v39, v52, v11
+v_dot2_f32_f16 v12, v40, v52, v12
+v_dot2_f32_f16 v13, v41, v52, v13
+v_dot2_f32_f16 v14, v38, v53, v14
+v_dot2_f32_f16 v15, v39, v53, v15
+v_dot2_f32_f16 v16, v40, v53, v16
+v_dot2_f32_f16 v17, v41, v53, v17
+v_dot2_f32_f16 v18, v38, v54, v18
+v_dot2_f32_f16 v19, v39, v54, v19
+v_dot2_f32_f16 v20, v40, v54, v20
+v_dot2_f32_f16 v21, v41, v54, v21
+v_dot2_f32_f16 v22, v38, v55, v22
+v_dot2_f32_f16 v23, v39, v55, v23
+v_dot2_f32_f16 v24, v40, v55, v24
+v_dot2_f32_f16 v25, v41, v55, v25
+v_dot2_f32_f16 v26, v38, v56, v26
+v_dot2_f32_f16 v27, v39, v56, v27
+v_dot2_f32_f16 v28, v40, v56, v28
+v_dot2_f32_f16 v29, v41, v56, v29
+v_dot2_f32_f16 v30, v38, v57, v30
+v_dot2_f32_f16 v31, v39, v57, v31
+v_mov_b32_dpp v79, v81  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_pk_add_f16 v79, v79, v81
+v_mov_b32_dpp v81, v81  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v79, v81, v112, v79
+v_mov_b32_dpp v81, v80  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_pk_add_f16 v81, v81, v80
+v_mov_b32_dpp v80, v80  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v81, v80, v112, v81
+v_pk_add_f16 v80, v78, v81
+v_pk_add_f16 v79, v79, v80
+v_pk_mul_f16 v79, v79, 0.5 op_sel_hi:[1,0]
+v_pk_fma_f16 v80, -1.0, v79, v80 op_sel_hi:[0,1,1]
+v_dot2_f32_f16 v32, v40, v57, v32
+v_dot2_f32_f16 v33, v41, v57, v33
+s_nop 0
+ds_read_b128 v[38:41], v107 offset:512
+ds_read_b128 v[50:53], v102
+ds_read_b128 v[54:57], v102 offset:128
+ds_write_b32 v105, v76 offset:24768
+ds_write_b32 v106, v77 offset:24768
+s_setprio 0
+s_add_u32 s40, s40, s69
+s_addc_u32 s41, s41, 0
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v92, v96, s[40:43], 0 offen
+buffer_load_short_d16 v91, v95, s[40:43], 0 offen
+buffer_load_short_d16 v93, v97, s[40:43], 0 offen
+s_nop 0
+s_waitcnt vmcnt(12) lgkmcnt(5)
+ds_append v117 offset:65476
+s_bitset1_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 8
+s_call_b64 s[38:39], 767
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_dot2_f32_f16 v2, v34, v42, v2
+v_dot2_f32_f16 v3, v35, v42, v3
+v_dot2_f32_f16 v4, v36, v42, v4
+v_dot2_f32_f16 v5, v37, v42, v5
+s_setprio 1
+s_nop 0
+v_dot2_f32_f16 v6, v34, v43, v6
+v_dot2_f32_f16 v7, v35, v43, v7
+v_dot2_f32_f16 v8, v36, v43, v8
+v_dot2_f32_f16 v9, v37, v43, v9
+v_dot2_f32_f16 v10, v34, v44, v10
+v_dot2_f32_f16 v11, v35, v44, v11
+v_dot2_f32_f16 v12, v36, v44, v12
+v_dot2_f32_f16 v13, v37, v44, v13
+v_dot2_f32_f16 v14, v34, v45, v14
+v_dot2_f32_f16 v15, v35, v45, v15
+v_dot2_f32_f16 v16, v36, v45, v16
+v_dot2_f32_f16 v17, v37, v45, v17
+v_dot2_f32_f16 v18, v34, v46, v18
+v_dot2_f32_f16 v19, v35, v46, v19
+v_dot2_f32_f16 v20, v36, v46, v20
+v_dot2_f32_f16 v21, v37, v46, v21
+v_dot2_f32_f16 v22, v34, v47, v22
+v_dot2_f32_f16 v23, v35, v47, v23
+v_dot2_f32_f16 v24, v36, v47, v24
+v_dot2_f32_f16 v25, v37, v47, v25
+v_dot2_f32_f16 v26, v34, v48, v26
+v_dot2_f32_f16 v27, v35, v48, v27
+v_dot2_f32_f16 v28, v36, v48, v28
+v_dot2_f32_f16 v29, v37, v48, v29
+v_dot2_f32_f16 v30, v34, v49, v30
+v_dot2_f32_f16 v31, v35, v49, v31
+v_pack_b32_f16 v58, v82, v58
+v_pack_b32_f16 v59, v83, v59
+v_pack_b32_f16 v60, v84, v60
+v_pack_b32_f16 v61, v85, v61
+v_cndmask_b32_dpp v58, v58, v58, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v59, v59, v59, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v60, v60, v60, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v61, v61, v61, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_mov_b32_dpp v58, v59  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_pk_add_f16 v58, v58, v59
+v_mov_b32_dpp v59, v59  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v58, v59, v112, v58
+v_dot2_f32_f16 v32, v36, v49, v32
+v_dot2_f32_f16 v33, v37, v49, v33
+s_nop 0
+ds_read_b128 v[34:37], v107 offset:4672
+ds_read_b128 v[42:45], v102 offset:4160
+ds_read_b128 v[46:49], v102 offset:4288
+ds_write_b32 v103, v74 offset:24768
+ds_write_b32 v104, v75 offset:24768
+s_setprio 0
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v72, v96, s[40:43], 0 offen
+buffer_load_short_d16 v71, v95, s[40:43], 0 offen
+buffer_load_short_d16 v73, v97, s[40:43], 0 offen
+s_mov_b32 m0, 0x2ffc4
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 8
+s_call_b64 s[38:39], 639
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_dot2_f32_f16 v2, v38, v50, v2
+v_dot2_f32_f16 v3, v39, v50, v3
+v_dot2_f32_f16 v4, v40, v50, v4
+v_dot2_f32_f16 v5, v41, v50, v5
+s_setprio 1
+s_nop 0
+v_dot2_f32_f16 v6, v38, v51, v6
+v_dot2_f32_f16 v7, v39, v51, v7
+v_dot2_f32_f16 v8, v40, v51, v8
+v_dot2_f32_f16 v9, v41, v51, v9
+v_dot2_f32_f16 v10, v38, v52, v10
+v_dot2_f32_f16 v11, v39, v52, v11
+v_dot2_f32_f16 v12, v40, v52, v12
+v_dot2_f32_f16 v13, v41, v52, v13
+v_dot2_f32_f16 v14, v38, v53, v14
+v_dot2_f32_f16 v15, v39, v53, v15
+v_dot2_f32_f16 v16, v40, v53, v16
+v_dot2_f32_f16 v17, v41, v53, v17
+v_dot2_f32_f16 v18, v38, v54, v18
+v_dot2_f32_f16 v19, v39, v54, v19
+v_dot2_f32_f16 v20, v40, v54, v20
+v_dot2_f32_f16 v21, v41, v54, v21
+v_dot2_f32_f16 v22, v38, v55, v22
+v_dot2_f32_f16 v23, v39, v55, v23
+v_dot2_f32_f16 v24, v40, v55, v24
+v_dot2_f32_f16 v25, v41, v55, v25
+v_dot2_f32_f16 v26, v38, v56, v26
+v_dot2_f32_f16 v27, v39, v56, v27
+v_dot2_f32_f16 v28, v40, v56, v28
+v_dot2_f32_f16 v29, v41, v56, v29
+v_dot2_f32_f16 v30, v38, v57, v30
+v_dot2_f32_f16 v31, v39, v57, v31
+v_dot2_f32_f16 v32, v40, v57, v32
+v_mov_b32_dpp v59, v61  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_pk_add_f16 v59, v59, v61
+v_mov_b32_dpp v61, v61  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v59, v61, v112, v59
+v_mov_b32_dpp v61, v60  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_pk_add_f16 v61, v61, v60
+v_mov_b32_dpp v60, v60  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v61, v60, v112, v61
+v_pk_add_f16 v60, v58, v61
+v_pk_add_f16 v59, v59, v60
+v_pk_mul_f16 v59, v59, 0.5 op_sel_hi:[1,0]
+v_pk_fma_f16 v60, -1.0, v59, v60 op_sel_hi:[0,1,1]
+v_dot2_f32_f16 v33, v41, v57, v33
+v_cmp_eq_u32_e64 vcc, src_lds_direct, s91
+s_nop 0
+s_nop 0
+s_cbranch_vccz 65531
+s_mov_b64 vcc, s[10:11]
+s_nop 0
+ds_read_b128 v[38:41], v107 offset:8768
+ds_read_b128 v[50:53], v102 offset:8256
+ds_read_b128 v[54:57], v102 offset:8384
+ds_write_b32 v105, v80 offset:33024
+ds_write_b32 v106, v81 offset:33024
+s_setprio 0
+s_add_u32 s40, s40, s69
+s_addc_u32 s41, s41, 0
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v84, v96, s[40:43], 0 offen
+buffer_load_short_d16 v83, v95, s[40:43], 0 offen
+buffer_load_short_d16 v85, v97, s[40:43], 0 offen
+s_nop 0
+s_waitcnt vmcnt(12) lgkmcnt(5)
+s_bitset1_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 4
+s_call_b64 s[38:39], 507
+s_nop 0
+s_nop 0
+s_nop 0
+v_dot2_f32_f16 v2, v34, v42, v2
+v_dot2_f32_f16 v3, v35, v42, v3
+v_dot2_f32_f16 v4, v36, v42, v4
+v_dot2_f32_f16 v5, v37, v42, v5
+s_setprio 1
+s_nop 0
+v_dot2_f32_f16 v6, v34, v43, v6
+v_dot2_f32_f16 v7, v35, v43, v7
+v_dot2_f32_f16 v8, v36, v43, v8
+v_dot2_f32_f16 v9, v37, v43, v9
+v_dot2_f32_f16 v10, v34, v44, v10
+v_dot2_f32_f16 v11, v35, v44, v11
+v_dot2_f32_f16 v12, v36, v44, v12
+v_dot2_f32_f16 v13, v37, v44, v13
+v_dot2_f32_f16 v14, v34, v45, v14
+v_dot2_f32_f16 v15, v35, v45, v15
+v_dot2_f32_f16 v16, v36, v45, v16
+v_dot2_f32_f16 v17, v37, v45, v17
+v_dot2_f32_f16 v18, v34, v46, v18
+v_dot2_f32_f16 v19, v35, v46, v19
+v_dot2_f32_f16 v20, v36, v46, v20
+v_dot2_f32_f16 v21, v37, v46, v21
+v_dot2_f32_f16 v22, v34, v47, v22
+v_dot2_f32_f16 v23, v35, v47, v23
+v_dot2_f32_f16 v24, v36, v47, v24
+v_dot2_f32_f16 v25, v37, v47, v25
+v_dot2_f32_f16 v26, v34, v48, v26
+v_dot2_f32_f16 v27, v35, v48, v27
+v_dot2_f32_f16 v28, v36, v48, v28
+v_dot2_f32_f16 v29, v37, v48, v29
+v_dot2_f32_f16 v30, v34, v49, v30
+v_dot2_f32_f16 v31, v35, v49, v31
+v_pack_b32_f16 v62, v86, v62
+v_pack_b32_f16 v63, v87, v63
+v_pack_b32_f16 v64, v88, v64
+v_pack_b32_f16 v65, v89, v65
+v_cndmask_b32_dpp v62, v62, v62, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v63, v63, v63, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v64, v64, v64, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v65, v65, v65, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_mov_b32_dpp v62, v63  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_pk_add_f16 v62, v62, v63
+v_mov_b32_dpp v63, v63  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v62, v63, v112, v62
+v_dot2_f32_f16 v32, v36, v49, v32
+v_dot2_f32_f16 v33, v37, v49, v33
+s_nop 0
+ds_read_b128 v[34:37], v107 offset:12928
+ds_read_b128 v[42:45], v102 offset:12416
+ds_read_b128 v[46:49], v102 offset:12544
+ds_write_b32 v103, v78 offset:33024
+ds_write_b32 v104, v79 offset:33024
+s_setprio 0
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v76, v96, s[40:43], 0 offen
+buffer_load_short_d16 v75, v95, s[40:43], 0 offen
+buffer_load_short_d16 v77, v97, s[40:43], 0 offen
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 2
+s_call_b64 s[38:39], 385
+s_nop 0
+v_dot2_f32_f16 v2, v38, v50, v2
+v_dot2_f32_f16 v3, v39, v50, v3
+v_dot2_f32_f16 v4, v40, v50, v4
+v_dot2_f32_f16 v5, v41, v50, v5
+s_setprio 1
+s_nop 0
+v_dot2_f32_f16 v6, v38, v51, v6
+v_dot2_f32_f16 v7, v39, v51, v7
+v_dot2_f32_f16 v8, v40, v51, v8
+v_dot2_f32_f16 v9, v41, v51, v9
+v_dot2_f32_f16 v10, v38, v52, v10
+v_dot2_f32_f16 v11, v39, v52, v11
+v_dot2_f32_f16 v12, v40, v52, v12
+v_dot2_f32_f16 v13, v41, v52, v13
+v_dot2_f32_f16 v14, v38, v53, v14
+v_dot2_f32_f16 v15, v39, v53, v15
+v_dot2_f32_f16 v16, v40, v53, v16
+v_dot2_f32_f16 v17, v41, v53, v17
+v_dot2_f32_f16 v18, v38, v54, v18
+v_dot2_f32_f16 v19, v39, v54, v19
+v_dot2_f32_f16 v20, v40, v54, v20
+v_dot2_f32_f16 v21, v41, v54, v21
+v_dot2_f32_f16 v22, v38, v55, v22
+v_dot2_f32_f16 v23, v39, v55, v23
+v_dot2_f32_f16 v24, v40, v55, v24
+v_dot2_f32_f16 v25, v41, v55, v25
+v_dot2_f32_f16 v26, v38, v56, v26
+v_dot2_f32_f16 v27, v39, v56, v27
+v_dot2_f32_f16 v28, v40, v56, v28
+v_dot2_f32_f16 v29, v41, v56, v29
+v_dot2_f32_f16 v30, v38, v57, v30
+v_dot2_f32_f16 v31, v39, v57, v31
+v_mov_b32_dpp v63, v65  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_pk_add_f16 v63, v63, v65
+v_mov_b32_dpp v65, v65  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v63, v65, v112, v63
+v_mov_b32_dpp v65, v64  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_pk_add_f16 v65, v65, v64
+v_mov_b32_dpp v64, v64  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v65, v64, v112, v65
+v_pk_add_f16 v64, v62, v65
+v_pk_add_f16 v63, v63, v64
+v_pk_mul_f16 v63, v63, 0.5 op_sel_hi:[1,0]
+v_pk_fma_f16 v64, -1.0, v63, v64 op_sel_hi:[0,1,1]
+v_dot2_f32_f16 v32, v40, v57, v32
+v_dot2_f32_f16 v33, v41, v57, v33
+s_nop 0
+ds_read_b128 v[38:41], v107 offset:17024
+ds_read_b128 v[50:53], v102 offset:16512
+ds_read_b128 v[54:57], v102 offset:16640
+ds_write_b32 v105, v60 offset:41280
+ds_write_b32 v106, v61 offset:41280
+s_setprio 0
+s_add_u32 s40, s40, s69
+s_addc_u32 s41, s41, 0
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v88, v96, s[40:43], 0 offen
+buffer_load_short_d16 v87, v95, s[40:43], 0 offen
+buffer_load_short_d16 v89, v97, s[40:43], 0 offen
+s_nop 0
+s_waitcnt vmcnt(12) lgkmcnt(5)
+ds_append v117 offset:65480
+s_bitset1_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 8
+s_call_b64 s[38:39], 263
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_dot2_f32_f16 v2, v34, v42, v2
+v_dot2_f32_f16 v3, v35, v42, v3
+v_dot2_f32_f16 v4, v36, v42, v4
+v_dot2_f32_f16 v5, v37, v42, v5
+s_setprio 1
+s_nop 0
+v_dot2_f32_f16 v6, v34, v43, v6
+v_dot2_f32_f16 v7, v35, v43, v7
+v_dot2_f32_f16 v8, v36, v43, v8
+v_dot2_f32_f16 v9, v37, v43, v9
+v_dot2_f32_f16 v10, v34, v44, v10
+v_dot2_f32_f16 v11, v35, v44, v11
+v_dot2_f32_f16 v12, v36, v44, v12
+v_dot2_f32_f16 v13, v37, v44, v13
+v_dot2_f32_f16 v14, v34, v45, v14
+v_dot2_f32_f16 v15, v35, v45, v15
+v_dot2_f32_f16 v16, v36, v45, v16
+v_dot2_f32_f16 v17, v37, v45, v17
+v_dot2_f32_f16 v18, v34, v46, v18
+v_dot2_f32_f16 v19, v35, v46, v19
+v_dot2_f32_f16 v20, v36, v46, v20
+v_dot2_f32_f16 v21, v37, v46, v21
+v_dot2_f32_f16 v22, v34, v47, v22
+v_dot2_f32_f16 v23, v35, v47, v23
+v_dot2_f32_f16 v24, v36, v47, v24
+v_dot2_f32_f16 v25, v37, v47, v25
+v_dot2_f32_f16 v26, v34, v48, v26
+v_dot2_f32_f16 v27, v35, v48, v27
+v_dot2_f32_f16 v28, v36, v48, v28
+v_dot2_f32_f16 v29, v37, v48, v29
+v_dot2_f32_f16 v30, v34, v49, v30
+v_dot2_f32_f16 v31, v35, v49, v31
+v_pack_b32_f16 v66, v90, v66
+v_pack_b32_f16 v67, v91, v67
+v_pack_b32_f16 v68, v92, v68
+v_pack_b32_f16 v69, v93, v69
+v_cndmask_b32_dpp v66, v66, v66, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v67, v67, v67, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v68, v68, v68, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v69, v69, v69, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_mov_b32_dpp v66, v67  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_pk_add_f16 v66, v66, v67
+v_mov_b32_dpp v67, v67  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v66, v67, v112, v66
+v_dot2_f32_f16 v32, v36, v49, v32
+v_dot2_f32_f16 v33, v37, v49, v33
+s_nop 0
+ds_read_b128 v[34:37], v107 offset:21184
+ds_read_b128 v[42:45], v102 offset:20672
+ds_read_b128 v[46:49], v102 offset:20800
+ds_write_b32 v103, v58 offset:41280
+ds_write_b32 v104, v59 offset:41280
+s_setprio 0
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v80, v96, s[40:43], 0 offen
+buffer_load_short_d16 v79, v95, s[40:43], 0 offen
+buffer_load_short_d16 v81, v97, s[40:43], 0 offen
+s_mov_b32 m0, 0x2ffc8
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 8
+s_call_b64 s[38:39], 135
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_dot2_f32_f16 v2, v38, v50, v2
+v_dot2_f32_f16 v3, v39, v50, v3
+v_dot2_f32_f16 v4, v40, v50, v4
+v_dot2_f32_f16 v5, v41, v50, v5
+s_setprio 1
+s_nop 0
+v_dot2_f32_f16 v6, v38, v51, v6
+v_dot2_f32_f16 v7, v39, v51, v7
+v_dot2_f32_f16 v8, v40, v51, v8
+v_dot2_f32_f16 v9, v41, v51, v9
+v_dot2_f32_f16 v10, v38, v52, v10
+v_dot2_f32_f16 v11, v39, v52, v11
+v_dot2_f32_f16 v12, v40, v52, v12
+v_dot2_f32_f16 v13, v41, v52, v13
+v_dot2_f32_f16 v14, v38, v53, v14
+v_dot2_f32_f16 v15, v39, v53, v15
+v_dot2_f32_f16 v16, v40, v53, v16
+v_dot2_f32_f16 v17, v41, v53, v17
+v_dot2_f32_f16 v18, v38, v54, v18
+v_dot2_f32_f16 v19, v39, v54, v19
+v_dot2_f32_f16 v20, v40, v54, v20
+v_dot2_f32_f16 v21, v41, v54, v21
+v_dot2_f32_f16 v22, v38, v55, v22
+v_dot2_f32_f16 v23, v39, v55, v23
+v_dot2_f32_f16 v24, v40, v55, v24
+v_dot2_f32_f16 v25, v41, v55, v25
+v_dot2_f32_f16 v26, v38, v56, v26
+v_dot2_f32_f16 v27, v39, v56, v27
+v_dot2_f32_f16 v28, v40, v56, v28
+v_dot2_f32_f16 v29, v41, v56, v29
+v_dot2_f32_f16 v30, v38, v57, v30
+v_dot2_f32_f16 v31, v39, v57, v31
+v_dot2_f32_f16 v32, v40, v57, v32
+v_mov_b32_dpp v67, v69  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_pk_add_f16 v67, v67, v69
+v_mov_b32_dpp v69, v69  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v67, v69, v112, v67
+v_mov_b32_dpp v69, v68  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_pk_add_f16 v69, v69, v68
+v_mov_b32_dpp v68, v68  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v69, v68, v112, v69
+v_pk_add_f16 v68, v66, v69
+v_pk_add_f16 v67, v67, v68
+v_pk_mul_f16 v67, v67, 0.5 op_sel_hi:[1,0]
+v_pk_fma_f16 v68, -1.0, v67, v68 op_sel_hi:[0,1,1]
+v_dot2_f32_f16 v33, v41, v57, v33
+v_cmp_eq_u32_e64 vcc, src_lds_direct, s91
+s_nop 0
+s_nop 0
+s_cbranch_vccz 65531
+s_mov_b64 vcc, s[10:11]
+s_nop 0
+ds_read_b128 v[38:41], v107 offset:25280
+ds_read_b128 v[50:53], v102 offset:24768
+ds_read_b128 v[54:57], v102 offset:24896
+ds_write_b32 v105, v64
+ds_write_b32 v106, v65
+s_setprio 0
+s_add_u32 s40, s40, s69
+s_addc_u32 s41, s41, 0
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v92, v96, s[40:43], 0 offen
+buffer_load_short_d16 v91, v95, s[40:43], 0 offen
+buffer_load_short_d16 v93, v97, s[40:43], 0 offen
+s_nop 0
+s_waitcnt vmcnt(12) lgkmcnt(5)
+s_bitset1_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 64020
+s_call_b64 s[38:39], 3
+s_branch 64018
+s_nop 0
+s_nop 0
+v_nop
+s_cmp_eq_u32 s82, 0
+s_cbranch_scc0 8
+s_branch 612
+s_add_u32 s82, s82, 3
+s_andn2_b32 s82, s82, 3
+s_bitcmp0_b32 s18, 26
+s_cselect_b32 s52, s69, s70
+s_cselect_b32 s53, 0, s71
+s_sub_u32 s40, s40, s52
+s_subb_u32 s41, s41, s53
+s_cmp_eq_u32 s94, 0
+s_cbranch_scc0 5
+s_cbranch_scc1 642
+s_nop 0
+s_nop 0
+s_add_u32 s94, s94, 1
+s_andn2_b32 s94, s94, 1
+s_min_u32 s72, s82, s94
+s_sub_u32 s82, s82, s72
+s_sub_u32 s94, s94, s72
+s_sub_u32 s72, s72, 2
+s_setpc_b64 s[38:39]
+s_nop 0
+s_bitcmp1_b32 s18, 17
+s_cbranch_scc1 241
+s_add_u32 s88, s88, s17
+s_cmp_eq_u32 s88, 0
+s_cbranch_scc1 238
+s_mov_b32 s89, 0
+s_bitcmp1_b32 s18, 16
+s_cbranch_scc1 227
+s_add_u32 s87, s16, 15
+s_lshr_b32 s87, s87, 4
+v_mov_b32_e32 v119, s88
+v_mul_u32_u24_e32 v119, s87, v119
+v_add_co_u32_e32 v119, vcc, s17, v119
+v_sub_co_u32_e64 v119, vcc, v119, 1
+v_ffbh_u32_e32 v122, s17
+v_lshlrev_b32_e64 v123, v122, s17
+v_and_b32_e32 v124, 0xffffff00, v123
+v_cmp_eq_u32_e32 vcc, 0x80000000, v123
+v_cvt_f32_u32_e32 v124, v124
+v_rcp_f32_e32 v118, v124
+v_subb_co_u32_e32 v121, vcc, 32, v122, vcc
+v_cvt_f32_ubyte0_e32 v122, v123
+v_fma_f32 v124, v124, v118, -1.0
+v_fma_f32 v124, v122, v118, v124
+v_madak_f32 v124, v124, v118, 0x9f000000
+v_mul_f32_e32 v124, 0x5f800000, v124
+v_mov_b32_e32 v122, 0
+v_cvt_flr_i32_f32_e64 v124, -v124
+v_lshl_add_u32 v118, v118, 9, v124
+v_mad_u64_u32 v[122:123], vcc, v123, v118, v[122:123]
+v_subb_co_u32_e64 v118, vcc, v118, -1, vcc
+v_mul_hi_u32 v122, v119, v118
+v_add_co_u32_e32 v118, vcc, v122, v119
+v_addc_co_u32_e64 v122, vcc, 0, 0, vcc
+v_cmp_eq_u32_e32 vcc, 32, v121
+v_cndmask_b32_e32 v118, v118, v122, vcc
+v_alignbit_b32 v118, v122, v118, v121
+v_readfirstlane_b32 s86, v118
+v_mul_u32_u24_e64 v118, v118, s8
+v_ffbh_u32_e32 v122, s87
+v_lshlrev_b32_e64 v123, v122, s87
+v_and_b32_e32 v124, 0xffffff00, v123
+v_cmp_eq_u32_e32 vcc, 0x80000000, v123
+v_cvt_f32_u32_e32 v124, v124
+v_rcp_f32_e32 v119, v124
+v_subb_co_u32_e32 v121, vcc, 32, v122, vcc
+v_cvt_f32_ubyte0_e32 v122, v123
+v_fma_f32 v124, v124, v119, -1.0
+v_fma_f32 v124, v122, v119, v124
+v_madak_f32 v124, v124, v119, 0x9f000000
+v_mul_f32_e32 v124, 0x5f800000, v124
+v_mov_b32_e32 v122, 0
+v_cvt_flr_i32_f32_e64 v124, -v124
+v_lshl_add_u32 v119, v119, 9, v124
+v_mad_u64_u32 v[122:123], vcc, v123, v119, v[122:123]
+v_subb_co_u32_e64 v119, vcc, v119, -1, vcc
+v_mul_hi_u32 v122, v118, v119
+v_add_co_u32_e32 v119, vcc, v122, v118
+v_addc_co_u32_e64 v122, vcc, 0, 0, vcc
+v_cmp_eq_u32_e32 vcc, 32, v121
+v_cndmask_b32_e32 v119, v119, v122, vcc
+v_alignbit_b32 v119, v122, v119, v121
+v_readfirstlane_b32 s52, v118
+v_readfirstlane_b32 s84, v119
+s_mul_i32 s84, s84, s87
+s_sub_u32 s84, s52, s84
+v_sub_co_u32_e32 v119, vcc, s8, v119
+v_sub_co_u32_e32 v119, vcc, s17, v119
+v_and_b32_e64 v121, v0, 63
+v_cmp_eq_u32_e64 vcc, v121, 0
+v_cndmask_b32_e32 v119, 1, v119, vcc
+s_sub_u32 s58, 0, s75
+s_sub_u32 s59, 0, s74
+v_mul_u32_u24_e64 v123, v119, 32
+v_ffbh_u32_e32 v125, s58
+v_lshlrev_b32_e64 v126, v125, s58
+v_and_b32_e32 v127, 0xffffff00, v126
+v_cmp_eq_u32_e32 vcc, 0x80000000, v126
+v_cvt_f32_u32_e32 v127, v127
+v_rcp_f32_e32 v121, v127
+v_subb_co_u32_e32 v124, vcc, 32, v125, vcc
+v_cvt_f32_ubyte0_e32 v125, v126
+v_fma_f32 v127, v127, v121, -1.0
+v_fma_f32 v127, v125, v121, v127
+v_madak_f32 v127, v127, v121, 0x9f000000
+v_mul_f32_e32 v127, 0x5f800000, v127
+v_mov_b32_e32 v125, 0
+v_cvt_flr_i32_f32_e64 v127, -v127
+v_lshl_add_u32 v121, v121, 9, v127
+v_mad_u64_u32 v[125:126], vcc, v126, v121, v[125:126]
+v_subb_co_u32_e64 v121, vcc, v121, -1, vcc
+v_mul_hi_u32 v125, v123, v121
+v_add_co_u32_e32 v121, vcc, v125, v123
+v_addc_co_u32_e64 v125, vcc, 0, 0, vcc
+v_cmp_eq_u32_e32 vcc, 32, v124
+v_cndmask_b32_e32 v121, v121, v125, vcc
+v_alignbit_b32 v121, v125, v121, v124
+v_mad_i32_i24 v122, v121, s75, v123
+v_mul_u32_u24_e64 v123, v121, 1
+v_ffbh_u32_e32 v125, s59
+v_lshlrev_b32_e64 v126, v125, s59
+v_and_b32_e32 v127, 0xffffff00, v126
+v_cmp_eq_u32_e32 vcc, 0x80000000, v126
+v_cvt_f32_u32_e32 v127, v127
+v_rcp_f32_e32 v121, v127
+v_subb_co_u32_e32 v124, vcc, 32, v125, vcc
+v_cvt_f32_ubyte0_e32 v125, v126
+v_fma_f32 v127, v127, v121, -1.0
+v_fma_f32 v127, v125, v121, v127
+v_madak_f32 v127, v127, v121, 0x9f000000
+v_mul_f32_e32 v127, 0x5f800000, v127
+v_mov_b32_e32 v125, 0
+v_cvt_flr_i32_f32_e64 v127, -v127
+v_lshl_add_u32 v121, v121, 9, v127
+v_mad_u64_u32 v[125:126], vcc, v126, v121, v[125:126]
+v_subb_co_u32_e64 v121, vcc, v121, -1, vcc
+v_mul_hi_u32 v125, v123, v121
+v_add_co_u32_e32 v121, vcc, v125, v123
+v_addc_co_u32_e64 v125, vcc, 0, 0, vcc
+v_cmp_eq_u32_e32 vcc, 32, v124
+v_cndmask_b32_e32 v121, v121, v125, vcc
+v_alignbit_b32 v121, v125, v121, v124
+v_mad_i32_i24 v123, v121, s74, v123
+v_readfirstlane_b32 s76, v122
+v_readfirstlane_b32 s77, v123
+v_readfirstlane_b32 s78, v121
+v_add_co_u32_e32 v108, vcc, s76, v108
+v_addc_co_u32_e64 v124, vcc, 0, 0, vcc
+v_mad_i32_i24 v108, v124, s75, v108
+v_mad_i32_i24 v110, v124, s80, v110
+v_mad_i32_i24 v109, v124, s79, v109
+v_cmp_ge_i32_e64 vcc, v109, 0
+v_addc_co_u32_e64 v124, vcc, 0, 0, vcc
+v_add_co_u32_e32 v110, vcc, v110, v124
+v_mad_i32_i24 v109, v124, s74, v109
+v_add_co_u32_e32 v109, vcc, s77, v109
+v_addc_co_u32_e64 v124, vcc, 0, 0, vcc
+v_add_co_u32_e32 v110, vcc, v110, v124
+v_mad_i32_i24 v109, v124, s74, v109
+v_add_co_u32_e32 v110, vcc, s78, v110
+v_readlane_b32 s76, v122, 1
+v_readlane_b32 s77, v123, 1
+v_readlane_b32 s78, v121, 1
+s_add_u32 s85, s84, s86
+s_cmp_le_u32 s85, s87
+s_cselect_b32 s52, 0x20000, 0
+s_cselect_b32 s85, s85, s87
+s_or_b32 s18, s18, s52
+s_lshl_b32 s84, s84, 4
+s_lshl_b32 s85, s85, 4
+s_min_u32 s85, s85, s16
+s_cmp_eq_u32 s8, s17
+s_cselect_b32 s52, 0x20000, 0
+s_or_b32 s18, s18, s52
+s_or_b32 s18, s18, s52
+s_bitset1_b32 s18, 16
+s_branch 43
+s_lshr_b32 s84, s84, 4
+s_add_u32 s85, s84, s86
+s_sub_u32 s85, s85, s87
+s_mov_b32 s84, 0
+s_lshl_b32 s85, s85, 4
+s_min_u32 s85, s85, s16
+s_bitset1_b32 s18, 17
+s_branch 12
+s_bitset1_b32 s18, 18
+s_mov_b32 s43, 0
+s_mov_b32 s73, -1
+s_mov_b32 s82, 40
+s_branch 31
+s_add_u32 s83, s83, 16
+s_cmp_ge_u32 s83, s85
+s_cbranch_scc0 28
+s_bitset1_b32 s18, 22
+s_sub_u32 s88, s88, s17
+s_subb_u32 s89, s89, 0
+s_cbranch_scc1 65281
+v_add_co_u32_e32 v108, vcc, s76, v108
+v_addc_co_u32_e64 v118, vcc, 0, 0, vcc
+v_mad_i32_i24 v108, v118, s75, v108
+v_mad_i32_i24 v110, v118, s80, v110
+v_mad_i32_i24 v109, v118, s79, v109
+v_cmp_ge_i32_e64 vcc, v109, 0
+v_addc_co_u32_e64 v118, vcc, 0, 0, vcc
+v_add_co_u32_e32 v110, vcc, v110, v118
+v_mad_i32_i24 v109, v118, s74, v109
+v_add_co_u32_e32 v109, vcc, s77, v109
+v_addc_co_u32_e64 v118, vcc, 0, 0, vcc
+v_add_co_u32_e32 v110, vcc, v110, v118
+v_mad_i32_i24 v109, v118, s74, v109
+v_add_co_u32_e32 v110, vcc, s78, v110
+s_mov_b32 s83, s84
+v_cmp_le_u32_e32 vcc, 0x100, v0
+s_cbranch_vccz 170
+v_subrev_co_u32_e32 v118, vcc, s75, v108
+v_subrev_co_u32_e32 v119, vcc, s74, v109
+s_bitcmp1_b32 s18, 22
+s_cbranch_scc0 64
+s_bitset0_b32 s18, 22
+s_bfe_u32 s52, s18, 0x10014
+v_mul_u32_u24_e32 v123, 2, v118
+v_mul_u32_u24_e32 v124, 2, v119
+v_cvt_pk_u16_u32 v126, v123, v124
+v_and_b32_e64 v123, v0, 1
+v_cmp_eq_u32_e64 vcc, v123, 1
+v_cndmask_b32_e32 v126, v110, v126, vcc
+v_lshrrev_b32_e32 v122, 1, v0
+v_bfe_u32 v127, v122, s52, 1
+v_lshrrev_b32_e32 v122, 1, v0
+v_bfi_b32 v122, 1, v0, v122
+v_lshrrev_b32_e32 v123, 2, v0
+v_bfi_b32 v123, 1, v0, v123
+v_cmp_eq_u32_e64 vcc, s52, 0
+v_cndmask_b32_e32 v122, v123, v122, vcc
+s_sub_u32 s52, 1, s52
+v_lshrrev_b32_e32 v123, s52, v122
+v_bfi_b32 v122, 32, v123, v122
+v_and_b32_e32 v122, 63, v122
+v_add_co_u32_e32 v123, vcc, 16, v122
+v_and_b32_e64 v124, v0, 2
+v_cmp_eq_u32_e64 vcc, v124, 0
+v_cndmask_b32_e32 v123, v123, v122, vcc
+v_lshlrev_b32_e32 v124, 14, v127
+v_mad_u32_u24 v123, 4, v123, v124
+v_add_co_u32_e32 v122, vcc, s96, v123
+ds_write_b32 v122, v126
+v_writelane_b32 v124, s18, 0
+v_writelane_b32 v124, s85, 1
+v_writelane_b32 v124, s84, 2
+v_and_b32_e64 v122, v0, 63
+v_cmp_ge_u32_e64 vcc, v122, 3
+v_mov_b32_e32 v125, 0x4000
+v_cndmask_b32_e32 v122, v122, v125, vcc
+v_mad_i32_i24 v122, v122, 4, s96
+ds_write_b32 v122, v124 offset:256
+s_add_u32 s96, s96, 0x18c
+s_cmp_eq_u32 s96, 0xffc0
+s_cselect_b32 s96, 0xc1e0, s96
+v_mov_b32_dpp v120, v110  quad_perm:[0,0,0,0] row_mask:0xf bank_mask:0xf
+v_mov_b32_dpp v118, v118  quad_perm:[0,0,0,0] row_mask:0xf bank_mask:0xf
+v_mov_b32_dpp v119, v119  quad_perm:[0,0,0,0] row_mask:0xf bank_mask:0xf
+v_readfirstlane_b32 s81, v120
+v_sub_co_u32_e64 v121, vcc, v120, s81
+v_mul_lo_u32 v121, v121, s65
+v_and_b32_e64 v125, v0, 3
+v_ashrrev_i32_e64 v126, 1, s31
+v_subrev_co_u32_e32 v125, vcc, v126, v125
+v_ashrrev_i32_e64 v126, 1, s62
+v_mad_i32_i24 v122, v126, 3, v125
+s_bfe_u32 s52, s18, 0x10014
+v_lshrrev_b32_e32 v124, 2, v0
+v_and_b32_e32 v124, s52, v124
+v_mad_i32_i24 v122, v124, 3, v122
+v_add_co_u32_e64 v123, vcc, 1, s63
+v_ashrrev_i32_e32 v123, 1, v123
+v_add_co_u32_e64 v124, vcc, 1, s30
+v_ashrrev_i32_e32 v124, 1, v124
+v_sub_i32 v123, v123, v124
+s_lshl_b32 s54, s15, 1
+v_cmp_ge_u32_e64 s[52:53], v120, s12
+v_mad_i32_i24 v118, v118, 2, v122
+v_cmp_ge_u32_e64 s[56:57], v118, s15
+v_mad_i32_i24 v118, 2, v118, v121
+s_or_b64 s[56:57], s[56:57], s[52:53]
+v_mad_i32_i24 v119, v119, 2, v123
+v_cmp_ge_u32_e64 s[58:59], v119, s14
+s_or_b64 s[58:59], s[56:57], s[58:59]
+v_mad_u32_u24 v94, v119, s54, v118
+v_cndmask_b32_e64 v94, v94, -1, s[58:59]
+v_add_co_u32_e32 v119, vcc, 1, v119
+v_cmp_ge_u32_e64 s[58:59], v119, s14
+s_or_b64 s[58:59], s[56:57], s[58:59]
+v_mad_u32_u24 v95, v119, s54, v118
+v_cndmask_b32_e64 v95, v95, -1, s[58:59]
+v_add_co_u32_e32 v119, vcc, 1, v119
+v_cmp_ge_u32_e64 s[58:59], v119, s14
+s_or_b64 s[58:59], s[56:57], s[58:59]
+v_mad_u32_u24 v96, v119, s54, v118
+v_cndmask_b32_e64 v96, v96, -1, s[58:59]
+v_add_co_u32_e32 v119, vcc, 1, v119
+v_cmp_ge_u32_e64 s[58:59], v119, s14
+s_or_b64 s[58:59], s[56:57], s[58:59]
+v_mad_u32_u24 v97, v119, s54, v118
+v_cndmask_b32_e64 v97, v97, -1, s[58:59]
+s_bitcmp1_b32 s18, 18
+s_cbranch_scc1 154
+s_lshr_b32 s52, -1, 16
+s_and_b32 s52, s52, s65
+s_lshr_b32 s53, s65, 16
+s_mul_i32 s53, s53, s81
+s_mul_i32 s40, s52, s81
+s_lshl_b32 s52, s53, 16
+s_lshr_b32 s53, s53, 16
+s_add_u32 s40, s52, s40
+s_addc_u32 s41, s53, 0
+s_add_u32 s40, s40, s20
+s_addc_u32 s41, s41, s21
+s_lshr_b32 s52, s18, 6
+s_xor_b32 s52, s52, s18
+s_and_b32 s52, s52, 0x80000
+s_cselect_b32 s52, s68, 0
+s_and_b32 s53, s18, 0x1100000
+s_cselect_b32 s53, 0, 1
+s_lshl_b32 s52, s52, s53
+s_add_u32 s40, s40, s52
+s_addc_u32 s41, s41, 0
+s_branch 99
+s_bitcmp1_b32 s18, 18
+s_cbranch_scc1 129
+v_mad_u32_u24 v120, 5, v0, 2
+v_lshlrev_b32_e32 v118, 1, v0
+v_bfi_b32 v120, 4, v120, v118
+v_bfe_u32 v118, v120, 2, 2
+v_min_u32_e32 v118, 2, v118
+v_bfe_u32 v120, v0, 1, 1
+v_mad_u32_u24 v118, 2, v118, v120
+v_mad_u32_u24 v118, s62, 3, v118
+v_sub_co_u32_e32 v120, vcc, s29, v118
+v_sub_co_u32_e64 v120, vcc, v120, 1
+s_bfe_u32 s54, s18, 0x10001
+v_cmp_eq_u32_e64 vcc, s54, 1
+v_cndmask_b32_e32 v118, v118, v120, vcc
+v_cmp_ge_u32_e64 s[52:53], v118, s29
+v_lshlrev_b32_e32 v118, 1, v118
+s_bfe_u32 s54, s18, 0x10018
+v_bfe_u32 v121, v0, 2, s54
+v_mul_lo_u32 v121, s68, v121
+v_add_co_u32_e32 v118, vcc, v118, v121
+v_mul_lo_u32 v119, s90, v111
+v_add_co_u32_e32 v119, vcc, v119, v118
+s_sub_u32 s54, s28, s63
+s_sub_u32 s54, s54, 5
+s_bitcmp1_b32 s18, 0
+s_cselect_b32 s54, s54, s63
+v_mov_b32_e32 v121, s54
+s_lshl_b32 s57, s29, 1
+v_cmp_ge_u32_e64 s[54:55], v121, s28
+v_mad_i32_i24 v94, v121, s57, v119
+s_or_b64 s[54:55], s[54:55], s[52:53]
+v_cndmask_b32_e64 v94, v94, -1, s[54:55]
+v_mov_b32_e32 v95, v94
+v_add_co_u32_e64 v121, vcc, v121, 2
+v_cmp_ge_u32_e64 s[54:55], v121, s28
+v_mad_i32_i24 v97, v121, s57, v119
+s_or_b64 s[54:55], s[54:55], s[52:53]
+v_cndmask_b32_e64 v97, v97, -1, s[54:55]
+v_add_co_u32_e64 v121, vcc, v121, 2
+v_cmp_ge_u32_e64 s[54:55], v121, s28
+v_mad_i32_i24 v96, v121, s57, v119
+s_or_b64 s[54:55], s[54:55], s[52:53]
+v_cndmask_b32_e64 v96, v96, -1, s[54:55]
+v_add_co_u32_e64 v118, vcc, v111, s83
+v_cmp_lt_u32_e64 vcc, v118, s16
+v_cndmask_b32_e32 v94, -1, v94, vcc
+v_cndmask_b32_e32 v95, -1, v95, vcc
+v_cndmask_b32_e32 v96, -1, v96, vcc
+v_cndmask_b32_e32 v97, -1, v97, vcc
+s_lshr_b32 s52, -1, 16
+s_and_b32 s52, s52, s90
+s_lshr_b32 s53, s90, 16
+s_mul_i32 s53, s53, s83
+s_mul_i32 s40, s52, s83
+s_lshl_b32 s52, s53, 16
+s_lshr_b32 s53, s53, 16
+s_add_u32 s40, s52, s40
+s_addc_u32 s41, s53, 0
+s_add_u32 s40, s40, s22
+s_addc_u32 s41, s41, s23
+s_lshr_b32 s52, s18, 6
+s_xor_b32 s52, s52, s18
+s_and_b32 s52, s52, 0x80000
+s_cselect_b32 s52, s68, 0
+s_and_b32 s53, s18, 0x1100000
+s_cselect_b32 s53, 0, 1
+s_lshl_b32 s52, s52, s53
+s_add_u32 s40, s40, s52
+s_addc_u32 s41, s41, 0
+s_mov_b32 s43, 0x20000
+s_mov_b32 s73, -1
+s_bitcmp0_b32 s13, 0
+s_cbranch_scc1 4
+s_mov_b32 s43, 0
+s_mov_b32 s73, 1
+s_sub_u32 s40, s40, s68
+s_subb_u32 s41, s41, 0
+s_add_u32 s53, s13, 1
+s_and_b32 s53, s53, -2
+s_bfe_u32 s52, s18, 0x10014
+s_lshl_b32 s82, s53, s52
+s_bfe_u32 s52, s18, 0x10013
+s_bfe_u32 s54, s18, 0x10019
+s_xor_b32 s52, s52, s54
+s_cselect_b32 s52, 2, 0
+s_cselect_b32 s43, 0x20000, s43
+s_and_b32 s52, s52, s82
+s_sub_u32 s82, s82, s52
+s_bitcmp1_b32 s18, 20
+s_cselect_b32 s52, 0, 0x2000000
+s_bitcmp1_b32 s53, 1
+s_cselect_b32 s52, s52, 0
+s_xor_b32 s18, s18, s52
+s_cmp_eq_u32 s82, 0
+s_cbranch_scc1 9
+s_mov_b64 vcc, s[10:11]
+s_branch 64931
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_and_b32 s52, 0x900000, s18
+s_subb_u32 s62, s62, 1
+s_cbranch_scc0 65219
+s_and_b32 s52, 0x900000, s18
+s_subb_u32 s62, s61, 1
+s_add_u32 s63, s63, 6
+s_cmp_ge_u32 s63, s28
+s_cbranch_scc0 65213
+s_mov_b32 s63, 1
+s_cmp_ge_u32 s63, s28
+s_addc_u32 s64, s64, 1
+s_cmp_gt_u32 s64, 1
+s_cbranch_scc0 65208
+s_mov_b32 s64, 0
+s_mov_b32 s63, 0
+s_branch 65174
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_mac_f32_dpp v4, v4, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v5, v5, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v2, v2, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v3, v3, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v3, v4, v3  row_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v2, v5, v2  row_mirror row_mask:0xf bank_mask:0xf
+s_nop 0
+v_mac_f32_dpp v3, v3, v114  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mac_f32_dpp v2, v2, v114  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+s_nop 0
+v_add_f32_dpp v2, v3, v2  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cvt_f16_f32_e32 v2, v2
+v_mac_f32_dpp v8, v8, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v9, v9, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v6, v6, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v7, v7, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v7, v8, v7  row_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v6, v9, v6  row_mirror row_mask:0xf bank_mask:0xf
+s_nop 0
+v_mac_f32_dpp v7, v7, v114  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mac_f32_dpp v6, v6, v114  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+s_nop 0
+v_add_f32_dpp v3, v7, v6  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cvt_f16_f32_e32 v3, v3
+v_mac_f32_dpp v12, v12, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v13, v13, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v10, v10, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v11, v11, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v11, v12, v11  row_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v10, v13, v10  row_mirror row_mask:0xf bank_mask:0xf
+s_nop 0
+v_mac_f32_dpp v11, v11, v114  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mac_f32_dpp v10, v10, v114  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+s_nop 0
+v_add_f32_dpp v4, v11, v10  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cvt_f16_f32_e32 v4, v4
+v_mac_f32_dpp v16, v16, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v17, v17, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v14, v14, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v15, v15, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v15, v16, v15  row_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v14, v17, v14  row_mirror row_mask:0xf bank_mask:0xf
+s_nop 0
+v_mac_f32_dpp v15, v15, v114  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mac_f32_dpp v14, v14, v114  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+s_nop 0
+v_add_f32_dpp v5, v15, v14  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cvt_f16_f32_e32 v5, v5
+v_mac_f32_dpp v20, v20, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v21, v21, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v18, v18, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v19, v19, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v19, v20, v19  row_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v18, v21, v18  row_mirror row_mask:0xf bank_mask:0xf
+s_nop 0
+v_mac_f32_dpp v19, v19, v114  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mac_f32_dpp v18, v18, v114  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+s_nop 0
+v_add_f32_dpp v6, v19, v18  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cvt_f16_f32_e32 v6, v6
+v_mac_f32_dpp v24, v24, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v25, v25, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v22, v22, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v23, v23, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v23, v24, v23  row_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v22, v25, v22  row_mirror row_mask:0xf bank_mask:0xf
+s_nop 0
+v_mac_f32_dpp v23, v23, v114  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mac_f32_dpp v22, v22, v114  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+s_nop 0
+v_add_f32_dpp v7, v23, v22  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cvt_f16_f32_e32 v7, v7
+v_mac_f32_dpp v28, v28, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v29, v29, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v26, v26, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v27, v27, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v27, v28, v27  row_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v26, v29, v26  row_mirror row_mask:0xf bank_mask:0xf
+s_nop 0
+v_mac_f32_dpp v27, v27, v114  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mac_f32_dpp v26, v26, v114  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+s_nop 0
+v_add_f32_dpp v8, v27, v26  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cvt_f16_f32_e32 v8, v8
+v_mac_f32_dpp v32, v32, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v33, v33, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v30, v30, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v31, v31, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v31, v32, v31  row_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v30, v33, v30  row_mirror row_mask:0xf bank_mask:0xf
+s_nop 0
+v_mac_f32_dpp v31, v31, v114  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mac_f32_dpp v30, v30, v114  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+s_nop 0
+v_add_f32_dpp v9, v31, v30  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cvt_f16_f32_e32 v9, v9
+s_waitcnt vmcnt(0)
+s_mov_b64 s[54:55], s[44:45]
+s_mov_b32 s53, s47
+v_bfe_u32 v118, s18, 21, 1
+v_sub_co_u32_e64 v118, vcc, v118, 1
+v_cndmask_b32_e32 v122, v100, v98, vcc
+v_cndmask_b32_e32 v123, v101, v99, vcc
+v_readlane_b32 s52, v116, 0
+v_add_f16_e64 v2, v2, s52
+v_mul_f16_e64 v118, v2, s36
+v_cmp_lt_f16_e64 vcc, v2, 0
+v_cndmask_b32_e32 v2, v2, v118, vcc
+buffer_store_short v2, v122, s[44:47], 0 offen
+v_add_f16_e64 v3, v3, s52
+v_mul_f16_e64 v118, v3, s36
+v_cmp_lt_f16_e64 vcc, v3, 0
+v_cndmask_b32_e32 v3, v3, v118, vcc
+buffer_store_short v3, v123, s[44:47], 0 offen
+s_add_u32 s44, s44, s67
+s_addc_u32 s45, s45, 0
+s_sub_u32 s93, s93, 1
+s_cselect_b32 s47, 0, s47
+v_readlane_b32 s52, v116, 1
+v_add_f16_e64 v4, v4, s52
+v_mul_f16_e64 v118, v4, s36
+v_cmp_lt_f16_e64 vcc, v4, 0
+v_cndmask_b32_e32 v4, v4, v118, vcc
+buffer_store_short v4, v122, s[44:47], 0 offen
+v_add_f16_e64 v5, v5, s52
+v_mul_f16_e64 v118, v5, s36
+v_cmp_lt_f16_e64 vcc, v5, 0
+v_cndmask_b32_e32 v5, v5, v118, vcc
+buffer_store_short v5, v123, s[44:47], 0 offen
+s_add_u32 s44, s44, s67
+s_addc_u32 s45, s45, 0
+s_sub_u32 s93, s93, 1
+s_cselect_b32 s47, 0, s47
+s_lshl_b32 s52, s67, 1
+s_add_u32 s44, s44, s52
+s_addc_u32 s45, s45, 0
+s_sub_u32 s93, s93, 2
+s_cselect_b32 s47, 0, s47
+v_readlane_b32 s52, v116, 4
+v_add_f16_e64 v6, v6, s52
+v_mul_f16_e64 v118, v6, s36
+v_cmp_lt_f16_e64 vcc, v6, 0
+v_cndmask_b32_e32 v6, v6, v118, vcc
+buffer_store_short v6, v122, s[44:47], 0 offen
+v_add_f16_e64 v7, v7, s52
+v_mul_f16_e64 v118, v7, s36
+v_cmp_lt_f16_e64 vcc, v7, 0
+v_cndmask_b32_e32 v7, v7, v118, vcc
+buffer_store_short v7, v123, s[44:47], 0 offen
+s_add_u32 s44, s44, s67
+s_addc_u32 s45, s45, 0
+s_sub_u32 s93, s93, 1
+s_cselect_b32 s47, 0, s47
+v_readlane_b32 s52, v116, 5
+v_add_f16_e64 v8, v8, s52
+v_mul_f16_e64 v118, v8, s36
+v_cmp_lt_f16_e64 vcc, v8, 0
+v_cndmask_b32_e32 v8, v8, v118, vcc
+buffer_store_short v8, v122, s[44:47], 0 offen
+v_add_f16_e64 v9, v9, s52
+v_mul_f16_e64 v118, v9, s36
+v_cmp_lt_f16_e64 vcc, v9, 0
+v_cndmask_b32_e32 v9, v9, v118, vcc
+buffer_store_short v9, v123, s[44:47], 0 offen
+s_add_u32 s44, s44, s67
+s_addc_u32 s45, s45, 0
+s_sub_u32 s93, s93, 1
+s_cselect_b32 s47, 0, s47
+s_lshl_b32 s52, s67, 1
+s_add_u32 s44, s44, s52
+s_addc_u32 s45, s45, 0
+s_lshl_b32 s52, s52, 2
+s_add_u32 s44, s44, s52
+s_addc_u32 s45, s45, 0
+s_sub_u32 s93, s93, 10
+s_cselect_b32 s47, 0, s47
+s_bitcmp1_b32 s18, 21
+s_cselect_b32 s47, s47, s53
+s_cselect_b32 s44, s44, s54
+s_cselect_b32 s45, s45, s55
+s_cselect_b32 s53, 0, 16
+s_cselect_b32 s54, 32, 0
+s_add_u32 s93, s93, s53
+s_add_u32 s48, s48, s54
+s_addc_u32 s49, s49, 0
+s_sub_u32 s50, s50, s54
+s_cselect_b32 s51, 0, s51
+v_mov_b32_e32 v2, 0
+v_mov_b32_e32 v3, 0
+v_mov_b32_e32 v4, 0
+v_mov_b32_e32 v5, 0
+v_mov_b32_e32 v6, 0
+v_mov_b32_e32 v7, 0
+v_mov_b32_e32 v8, 0
+v_mov_b32_e32 v9, 0
+v_mov_b32_e32 v10, 0
+v_mov_b32_e32 v11, 0
+v_mov_b32_e32 v12, 0
+v_mov_b32_e32 v13, 0
+v_mov_b32_e32 v14, 0
+v_mov_b32_e32 v15, 0
+v_mov_b32_e32 v16, 0
+v_mov_b32_e32 v17, 0
+v_mov_b32_e32 v18, 0
+v_mov_b32_e32 v19, 0
+v_mov_b32_e32 v20, 0
+v_mov_b32_e32 v21, 0
+v_mov_b32_e32 v22, 0
+v_mov_b32_e32 v23, 0
+v_mov_b32_e32 v24, 0
+v_mov_b32_e32 v25, 0
+v_mov_b32_e32 v26, 0
+v_mov_b32_e32 v27, 0
+v_mov_b32_e32 v28, 0
+v_mov_b32_e32 v29, 0
+v_mov_b32_e32 v30, 0
+v_mov_b32_e32 v31, 0
+v_mov_b32_e32 v32, 0
+v_mov_b32_e32 v33, 0
+s_xor_b32 s18, s18, 0x200000
+s_bitcmp1_b32 s13, 0
+s_addc_u32 s52, s13, 0
+s_bitcmp0_b32 s18, 21
+s_addc_u32 s94, s60, 0
+s_lshr_b32 s94, s94, 1
+s_mul_i32 s94, s94, s61
+s_lshr_b32 s94, s94, 1
+s_mul_i32 s94, s94, s52
+s_cmp_eq_u32 s94, 0
+s_cbranch_scc1 65195
+s_add_u32 s52, s93, s92
+s_cmp_lt_i32 s52, 0
+s_cbranch_scc0 131
+v_and_b32_e32 v98, 0x7f, v0
+v_lshrrev_b32_e32 v98, 1, v98
+v_bfi_b32 v98, 1, v0, v98
+v_and_b32_e64 v99, v0, 2
+v_mad_u32_u24 v98, v99, 16, v98
+v_lshlrev_b32_e32 v98, 2, v98
+v_add_co_u32_e64 v98, vcc, v98, s97
+v_and_b32_e32 v99, 3, v0
+v_lshlrev_b32_e32 v99, 2, v99
+v_add_co_u32_e64 v99, vcc, v99, s97
+ds_read_b32 v120, v99 offset:256
+ds_read_b32 v98, v98
+s_add_u32 s97, s97, 0x18c
+s_cmp_eq_u32 s97, 0xffc0
+s_cselect_b32 s97, 0xc1e0, s97
+s_waitcnt lgkmcnt(0)
+v_readfirstlane_b32 s95, v98
+v_readlane_b32 s54, v120, 0
+s_bitcmp1_b32 s54, 18
+s_cbranch_scc1 107
+v_readlane_b32 s52, v120, 1
+v_readlane_b32 s53, v120, 2
+s_add_u32 s93, s92, s53
+s_lshr_b32 s55, -1, 16
+s_and_b32 s55, s55, s66
+s_lshr_b32 s56, s66, 16
+s_mul_i32 s56, s56, s95
+s_mul_i32 s44, s55, s95
+s_lshl_b32 s55, s56, 16
+s_lshr_b32 s56, s56, 16
+s_add_u32 s44, s55, s44
+s_addc_u32 s45, s56, 0
+s_add_u32 s44, s44, s24
+s_addc_u32 s45, s45, s25
+s_mul_i32 s55, s67, s93
+s_add_u32 s44, s44, s55
+s_addc_u32 s45, s45, 0
+s_mov_b32 s47, 0x20000
+s_bitcmp1_b32 s18, 7
+s_cselect_b32 s51, 0x20000, 0
+s_lshl_b32 s55, s93, 1
+s_add_u32 s48, s34, s55
+s_addc_u32 s49, s35, 0
+s_lshl_b32 s56, s52, 1
+s_sub_u32 s50, s56, s55
+s_cselect_b32 s51, 0, s51
+s_sub_u32 s93, s52, s53
+s_sub_u32 s93, s93, 1
+s_sub_u32 s93, s93, s92
+s_cselect_b32 s47, 0, s47
+v_bfe_u32 v118, v98, 16, 16
+v_bfe_u32 v119, v98, 0, 16
+v_and_b32_e64 v120, v0, 7
+v_sub_co_u32_e32 v121, vcc, 7, v120
+v_min_u32_e32 v120, v120, v121
+v_bfe_u32 v121, v120, 1, 1
+v_bfe_u32 v120, v120, 0, 1
+v_mov_b32_dpp v118, v118  quad_perm:[1,1,1,1] row_mask:0xf bank_mask:0xf
+v_mov_b32_dpp v119, v119  quad_perm:[1,1,1,1] row_mask:0xf bank_mask:0xf
+v_add_co_u32_e32 v118, vcc, v118, v121
+v_add_co_u32_e32 v119, vcc, v119, v120
+v_mov_b32_dpp v120, v98  quad_perm:[0,0,0,0] row_mask:0xf bank_mask:0xf
+v_cmp_ge_u32_e64 s[52:53], v120, s12
+v_sub_co_u32_e64 v120, vcc, v120, s95
+v_mul_lo_u32 v120, v120, s66
+v_lshlrev_b32_e32 v119, 1, v119
+s_and_b32 s54, 1, s31
+v_add_co_u32_e32 v119, vcc, s54, v119
+v_lshlrev_b32_e32 v118, 1, v118
+s_and_b32 s54, 1, s30
+v_subrev_co_u32_e32 v118, vcc, s54, v118
+v_mad_i32_i24 v98, v118, s33, v119
+v_lshlrev_b32_e32 v98, 1, v98
+v_add_co_u32_e32 v98, vcc, v98, v120
+v_subrev_co_u32_e32 v99, vcc, 2, v98
+v_mad_i32_i24 v100, 2, s33, v98
+v_mad_i32_i24 v101, 2, s33, v99
+v_cmp_ge_u32_e64 s[58:59], v119, s33
+s_or_b64 s[56:57], s[58:59], s[52:53]
+v_subrev_co_u32_e32 v119, vcc, 1, v119
+v_cmp_ge_u32_e64 s[58:59], v119, s33
+s_or_b64 s[58:59], s[58:59], s[52:53]
+v_cmp_ge_u32_e64 s[54:55], v118, s32
+s_or_b64 s[52:53], s[56:57], s[54:55]
+v_cndmask_b32_e64 v98, v98, -1, s[52:53]
+s_or_b64 s[52:53], s[58:59], s[54:55]
+v_cndmask_b32_e64 v99, v99, -1, s[52:53]
+v_add_co_u32_e32 v118, vcc, 1, v118
+v_cmp_ge_u32_e64 s[54:55], v118, s32
+s_or_b64 s[52:53], s[56:57], s[54:55]
+v_cndmask_b32_e64 v100, v100, -1, s[52:53]
+s_or_b64 s[52:53], s[58:59], s[54:55]
+v_cndmask_b32_e64 v101, v101, -1, s[52:53]
+v_and_b32_e64 v116, v0, 63
+v_lshlrev_b32_e32 v116, 1, v116
+s_barrier
+buffer_load_ushort v116, v116, s[48:51], 0 offen
+s_mov_b64 vcc, s[10:11]
+s_branch 64413
+s_endpgm
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0

--- a/src/kernels/Conv_Winograd_v21_1_3_gfx9_fp16_dot2_edc_f2x3_stride1.inc
+++ b/src/kernels/Conv_Winograd_v21_1_3_gfx9_fp16_dot2_edc_f2x3_stride1.inc
@@ -1,0 +1,3057 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2023 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+v_mov_b32_e32 v0, v0
+s_mov_b32 s0, 0
+s_mov_b32 s1, 0
+s_mov_b32 s2, 0
+s_mov_b32 s3, 0
+v_mov_b32_e32 v116, 0
+s_mov_b32 m0, 0x1ffff
+s_mov_b32 s97, 0xc1e0
+s_mov_b32 s96, 0xc1e0
+s_mov_b32 s91, 0
+v_lshlrev_b32_e32 v119, 2, v0
+v_add_co_u32_e32 v119, vcc, 0xffc0, v119
+v_cmp_ge_u32_e32 vcc, 12, v0
+s_cbranch_vccz 5
+v_mov_b32_e32 v118, 0
+v_cndmask_b32_e32 v119, -1, v119, vcc
+ds_write_b32 v119, v118
+s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+s_barrier
+v_readfirstlane_b32 s52, v0
+s_lshr_b32 s52, s52, 5
+s_add_u32 s52, s52, 8
+s_and_b32 s92, s52, 20
+s_mov_b64 s[40:41], s[6:7]
+s_load_dwordx16 s[12:27], s[40:41], 0x0
+s_load_dwordx4 s[28:31], s[40:41], 0x40
+s_load_dwordx2 s[32:33], s[40:41], 0x50
+s_waitcnt lgkmcnt(0)
+s_and_b32 s18, s18, 0xffff
+s_bitcmp1_b32 s18, 6
+s_cbranch_scc0 16
+s_and_b32 s21, s21, 0xffff
+s_and_b32 s23, s23, 0xffff
+s_and_b32 s25, s25, 0xffff
+s_and_b32 s27, s27, 0xffff
+s_load_dwordx2 s[20:21], s[20:21], 0x0
+s_load_dwordx2 s[22:23], s[22:23], 0x0
+s_load_dwordx2 s[24:25], s[24:25], 0x0
+s_load_dwordx2 s[26:27], s[26:27], 0x0
+s_bitcmp1_b32 s18, 7
+s_cbranch_scc0 2
+s_load_dwordx2 s[34:35], s[40:41], 0x58
+s_mov_b32 s36, 1.0
+s_bitcmp1_b32 s18, 8
+s_cbranch_scc0 2
+s_load_dword s36, s[40:41], 0x60
+s_bitcmp1_b32 s18, 7
+s_cbranch_scc0 7
+s_bitcmp1_b32 s18, 6
+s_cbranch_scc0 5
+s_waitcnt lgkmcnt(0)
+s_and_b32 s35, s35, 0xffff
+s_load_dwordx2 s[34:35], s[34:35], 0x0
+s_bitcmp1_b32 s18, 9
+s_cbranch_scc0 72
+s_mov_b32 s42, 0x8c
+s_mov_b32 s43, 0x9c
+v_cmp_le_u32_e32 vcc, 0x100, v0
+s_cmp_eq_u32 1, src_vccz
+s_cselect_b32 s42, s43, s42
+s_load_dword s65, s[40:41], 0x88
+s_load_dword s90, s[40:41], 0x98
+s_load_dword s68, s[40:41], s42
+s_load_dwordx2 s[66:67], s[40:41], 0xa8
+s_bitcmp1_b32 s18, 10
+s_cbranch_scc0 103
+s_load_dwordx4 s[44:47], s[40:41], 0xb8
+v_ffbh_u32_e32 v4, s17
+v_lshlrev_b32_e64 v5, v4, s17
+v_and_b32_e32 v6, 0xffffff00, v5
+v_cmp_eq_u32_e32 vcc, 0x80000000, v5
+v_cvt_f32_u32_e32 v6, v6
+v_rcp_f32_e32 v2, v6
+v_subb_co_u32_e32 v3, vcc, 32, v4, vcc
+v_cvt_f32_ubyte0_e32 v4, v5
+v_fma_f32 v6, v6, v2, -1.0
+v_fma_f32 v6, v4, v2, v6
+v_madak_f32 v6, v6, v2, 0x9f000000
+v_mul_f32_e32 v6, 0x5f800000, v6
+v_mov_b32_e32 v4, 0
+v_cvt_flr_i32_f32_e64 v6, -v6
+v_lshl_add_u32 v2, v2, 9, v6
+v_mad_u64_u32 v[4:5], vcc, v5, v2, v[4:5]
+v_subb_co_u32_e64 v2, vcc, v2, -1, vcc
+v_mul_hi_u32 v4, s8, v2
+v_add_co_u32_e64 v2, vcc, v4, s8
+v_addc_co_u32_e64 v4, vcc, 0, 0, vcc
+v_cmp_eq_u32_e32 vcc, 32, v3
+v_cndmask_b32_e32 v2, v2, v4, vcc
+v_alignbit_b32 v2, v4, v2, v3
+s_waitcnt lgkmcnt(0)
+v_readfirstlane_b32 s48, v2
+s_mul_i32 s49, s48, s17
+s_sub_u32 s8, s8, s49
+s_mul_i32 s49, s45, s48
+s_add_u32 s20, s20, s49
+s_addc_u32 s21, s21, 0
+s_mul_i32 s49, s46, s48
+s_add_u32 s22, s22, s49
+s_addc_u32 s23, s23, 0
+s_mul_i32 s49, s47, s48
+s_add_u32 s24, s24, s49
+s_addc_u32 s25, s25, 0
+s_branch 49
+s_mul_i32 s42, s14, s15
+s_lshr_b32 s46, -1, 16
+s_and_b32 s46, s46, s42
+s_lshr_b32 s47, s42, 16
+s_mul_i32 s47, s47, s13
+s_mul_i32 s44, s46, s13
+s_lshl_b32 s46, s47, 16
+s_lshr_b32 s47, s47, 16
+s_add_u32 s44, s46, s44
+s_addc_u32 s45, s47, 0
+s_lshl_b32 s65, s44, 1
+s_lshl_b32 s68, s42, 1
+s_mul_i32 s43, s32, s33
+s_lshr_b32 s46, -1, 16
+s_and_b32 s46, s46, s43
+s_lshr_b32 s47, s43, 16
+s_mul_i32 s47, s47, s16
+s_mul_i32 s44, s46, s16
+s_lshl_b32 s46, s47, 16
+s_lshr_b32 s47, s47, 16
+s_add_u32 s44, s46, s44
+s_addc_u32 s45, s47, 0
+s_lshl_b32 s66, s44, 1
+s_lshl_b32 s67, s43, 1
+s_bitcmp1_b32 s18, 13
+s_cbranch_scc0 2
+s_load_dwordx8 s[48:55], s[40:41], 0x68
+s_mul_i32 s42, s28, s29
+s_lshl_b32 s42, s42, 1
+s_bitcmp1_b32 s18, 2
+s_cselect_b32 s43, s16, s13
+s_lshr_b32 s44, -1, 16
+s_and_b32 s44, s44, s42
+s_lshr_b32 s45, s42, 16
+s_mul_i32 s45, s45, s43
+s_mul_i32 s56, s44, s43
+s_lshl_b32 s44, s45, 16
+s_lshr_b32 s45, s45, 16
+s_add_u32 s56, s44, s56
+s_addc_u32 s57, s45, 0
+s_mov_b32 s43, s56
+s_bitcmp1_b32 s18, 2
+s_cselect_b32 s44, s43, s42
+s_cselect_b32 s90, s42, s43
+v_cmp_le_u32_e32 vcc, 0x100, v0
+s_cmp_eq_u32 1, src_vccz
+s_cselect_b32 s68, s44, s68
+s_waitcnt lgkmcnt(0)
+s_and_b32 s21, s21, 0xffff
+s_and_b32 s23, s23, 0xffff
+s_and_b32 s25, s25, 0xffff
+s_and_b32 s27, s27, 0xffff
+s_and_b32 s35, s35, 0xffff
+s_bitcmp1_b32 s18, 13
+s_cbranch_scc0 8
+s_add_u32 s20, s20, s48
+s_addc_u32 s21, s21, s49
+s_add_u32 s22, s22, s50
+s_addc_u32 s23, s23, s51
+s_add_u32 s24, s24, s52
+s_addc_u32 s25, s25, s53
+s_add_u32 s34, s34, s54
+s_addc_u32 s35, s35, s55
+v_cvt_f16_f32_e32 v2, s36
+v_readfirstlane_b32 s36, v2
+s_and_b32 s44, 0, s30
+s_addc_u32 s44, s32, 0
+s_ashr_i32 s44, s44, 0
+s_add_u32 s42, s44, 1
+v_mov_b32_e32 v2, 0x80000000
+v_mul_hi_u32 v2, v2, s42
+v_readfirstlane_b32 s42, v2
+s_andn2_b32 s44, 0, s31
+s_addc_u32 s44, s33, 0
+s_ashr_i32 s44, s44, 0
+s_add_u32 s43, s44, 1
+v_mov_b32_e32 v2, 0x80000000
+v_mul_hi_u32 v2, v2, s43
+v_readfirstlane_b32 s43, v2
+s_sub_u32 s75, 0, s43
+s_sub_u32 s74, 0, s42
+s_add_u32 s60, s28, 2
+v_mov_b32_e32 v2, 0x55555556
+v_mul_hi_u32 v2, v2, s60
+v_readfirstlane_b32 s60, v2
+s_add_u32 s61, s29, 2
+v_mov_b32_e32 v2, 0x55555556
+v_mul_hi_u32 v2, v2, s61
+v_readfirstlane_b32 s61, v2
+v_mad_i32_i24 v2, 3, s60, -2
+v_sub_co_u32_e64 v2, vcc, v2, s28
+v_addc_co_u32_e64 v2, vcc, 0, 0, vcc
+v_readfirstlane_b32 s44, v2
+s_and_b32 s44, s44, 0
+s_and_b32 s44, s44, s60
+s_add_u32 s60, s60, s44
+v_readfirstlane_b32 s45, v0
+s_and_b32 s48, s45, 64
+s_cselect_b32 s48, 0x80000, 0
+s_or_b32 s18, s18, s48
+s_lshl_b32 s69, s68, 1
+s_sub_u32 s70, 0, s69
+s_subb_u32 s71, 0, 0
+s_bitcmp1_b32 s18, 12
+s_cselect_b32 s44, 0, -1
+s_bitcmp1_b32 s18, 11
+s_cselect_b32 s44, s44, 1
+s_cmp_gt_u32 s61, s44
+s_cbranch_scc0 8
+s_bitset1_b32 s18, 23
+s_bitset1_b32 s18, 20
+s_bitset0_b32 s18, 19
+s_ashr_i32 s69, s69, 1
+s_ashr_i64 s[70:71], s[70:71], 1
+s_add_u32 s61, s61, 1
+s_and_b32 s61, s61, -2
+s_branch 16
+s_and_b32 s48, s13, 3
+s_cselect_b32 s48, 0, 0x1000000
+s_bitcmp1_b32 s18, 2
+s_cselect_b32 s48, 0, s48
+s_or_b32 s18, s18, s48
+s_cmp_eq_u32 s48, 0
+s_cselect_b32 s69, s68, s69
+s_cselect_b32 s70, s68, s70
+s_cselect_b32 s71, 0, s71
+s_bitcmp0_b32 s45, 8
+s_cselect_b32 s48, s48, 0
+s_cmp_eq_u32 s48, 0
+s_cselect_b32 s48, 0, 0x80000
+s_andn2_b32 s18, s18, s48
+s_add_u32 s70, s70, s69
+s_addc_u32 s71, s71, 0
+s_add_u32 s70, s70, s69
+s_addc_u32 s71, s71, 0
+v_bfe_u32 v3, v0, 2, 6
+v_lshrrev_b32_e32 v111, 1, v3
+s_bitcmp0_b32 s45, 8
+s_cselect_b32 s48, 0x1000000, 0
+s_or_b32 s48, s48, 0x100000
+s_and_b32 s48, s18, s48
+s_cselect_b32 s48, 0, 15
+v_bfi_b32 v111, s48, v3, v111
+s_mul_i32 s88, s12, s42
+s_sub_u32 s88, s88, 1
+s_lshr_b32 s88, s88, 0
+s_add_u32 s88, s88, 1
+s_lshr_b32 s46, -1, 16
+s_and_b32 s46, s46, s88
+s_lshr_b32 s47, s88, 16
+s_mul_i32 s47, s47, s43
+s_mul_i32 s88, s46, s43
+s_lshl_b32 s46, s47, 16
+s_lshr_b32 s47, s47, 16
+s_add_u32 s88, s46, s88
+s_addc_u32 s89, s47, 0
+s_sub_u32 s88, s88, 1
+s_subb_u32 s89, s89, 0
+s_lshr_b64 s[88:89], s[88:89], 5
+s_add_u32 s88, s88, 1
+s_addc_u32 s89, s89, 0
+v_mov_b32_e32 v4, s8
+v_mov_b32_e32 v5, s17
+v_and_b32_e32 v6, 3, v0
+v_cmp_eq_u32_e32 vcc, 2, v6
+v_cndmask_b32_e32 v4, v4, v5, vcc
+v_cmp_eq_u32_e32 vcc, 1, v6
+v_cndmask_b32_e32 v7, 0, v111, vcc
+s_bitcmp1_b32 s18, 20
+s_cbranch_scc0 4
+v_add_co_u32_e64 v5, vcc, v111, 8
+v_cmp_eq_u32_e32 vcc, 0, v6
+v_cndmask_b32_e32 v7, v7, v5, vcc
+v_cmp_eq_u32_e64 s[46:47], 3, v6
+v_bfe_u32 v109, v7, 0, 5
+v_mad_u32_u24 v109, v4, 32, v109
+v_ffbh_u32_e32 v9, s43
+v_lshlrev_b32_e64 v10, v9, s43
+v_and_b32_e32 v11, 0xffffff00, v10
+v_cmp_eq_u32_e32 vcc, 0x80000000, v10
+v_cvt_f32_u32_e32 v11, v11
+v_rcp_f32_e32 v110, v11
+v_subb_co_u32_e32 v8, vcc, 32, v9, vcc
+v_cvt_f32_ubyte0_e32 v9, v10
+v_fma_f32 v11, v11, v110, -1.0
+v_fma_f32 v11, v9, v110, v11
+v_madak_f32 v11, v11, v110, 0x9f000000
+v_mul_f32_e32 v11, 0x5f800000, v11
+v_mov_b32_e32 v9, 0
+v_cvt_flr_i32_f32_e64 v11, -v11
+v_lshl_add_u32 v110, v110, 9, v11
+v_mad_u64_u32 v[9:10], vcc, v10, v110, v[9:10]
+v_subb_co_u32_e64 v110, vcc, v110, -1, vcc
+v_mul_hi_u32 v9, v109, v110
+v_add_co_u32_e32 v110, vcc, v9, v109
+v_addc_co_u32_e64 v9, vcc, 0, 0, vcc
+v_cmp_eq_u32_e32 vcc, 32, v8
+v_cndmask_b32_e32 v110, v110, v9, vcc
+v_alignbit_b32 v110, v9, v110, v8
+v_mad_i32_i24 v108, v110, s75, v109
+v_lshrrev_b32_e32 v109, 5, v7
+v_mad_u32_u24 v109, v110, 1, v109
+v_cndmask_b32_e64 v109, v109, 1, s[46:47]
+v_ffbh_u32_e32 v9, s42
+v_lshlrev_b32_e64 v10, v9, s42
+v_and_b32_e32 v11, 0xffffff00, v10
+v_cmp_eq_u32_e32 vcc, 0x80000000, v10
+v_cvt_f32_u32_e32 v11, v11
+v_rcp_f32_e32 v110, v11
+v_subb_co_u32_e32 v8, vcc, 32, v9, vcc
+v_cvt_f32_ubyte0_e32 v9, v10
+v_fma_f32 v11, v11, v110, -1.0
+v_fma_f32 v11, v9, v110, v11
+v_madak_f32 v11, v11, v110, 0x9f000000
+v_mul_f32_e32 v11, 0x5f800000, v11
+v_mov_b32_e32 v9, 0
+v_cvt_flr_i32_f32_e64 v11, -v11
+v_lshl_add_u32 v110, v110, 9, v11
+v_mad_u64_u32 v[9:10], vcc, v10, v110, v[9:10]
+v_subb_co_u32_e64 v110, vcc, v110, -1, vcc
+v_mul_hi_u32 v9, v109, v110
+v_add_co_u32_e32 v110, vcc, v9, v109
+v_addc_co_u32_e64 v9, vcc, 0, 0, vcc
+v_cmp_eq_u32_e32 vcc, 32, v8
+v_cndmask_b32_e32 v110, v110, v9, vcc
+v_alignbit_b32 v110, v9, v110, v8
+v_mad_i32_i24 v109, v110, s74, v109
+v_readlane_b32 s76, v108, 2
+v_readlane_b32 s77, v109, 2
+v_readlane_b32 s78, v110, 2
+v_readlane_b32 s79, v109, 3
+v_readlane_b32 s80, v110, 3
+v_add_co_u32_e64 v108, vcc, v108, s75
+v_add_co_u32_e64 v109, vcc, v109, s74
+v_mov_b32_dpp v110, v110  quad_perm:[1,1,0,0] row_mask:0xf bank_mask:0xf
+v_mov_b32_dpp v108, v108  quad_perm:[1,1,0,0] row_mask:0xf bank_mask:0xf
+v_mov_b32_dpp v109, v109  quad_perm:[1,1,0,0] row_mask:0xf bank_mask:0xf
+s_mov_b32 s42, 0x80000000
+s_mov_b32 s43, 0x20000
+s_mov_b32 s46, 0x80000000
+s_mov_b32 s47, 0x20000
+v_cmp_le_u32_e32 vcc, 0x100, v0
+s_cbranch_vccnz 7
+v_xor_b32_dpp v112, v0, v0  quad_perm:[1,3,2,2] row_mask:0xf bank_mask:0xf
+v_subrev_co_u32_e32 v112, vcc, 1, v112
+v_cvt_f16_i16_e32 v112, v112
+v_pk_add_f16 v112, v112, 0 op_sel_hi:[0,0]
+s_branch 6
+v_xor_b32_dpp v112, v0, v0  quad_perm:[2,1,0,1] row_mask:0xf bank_mask:0xf
+v_sub_co_u32_e32 v112, vcc, 1, v112
+v_cvt_f16_i16_e32 v112, v112
+v_pk_add_f16 v112, v112, 0 op_sel_hi:[0,0]
+v_mov_b32_e32 v113, 1
+v_xor_b32_dpp v113, v0, v0  quad_perm:[2,3,2,3] row_mask:0xf bank_mask:0x4
+v_xor_b32_dpp v113, v0, v0  quad_perm:[0,1,0,1] row_mask:0xf bank_mask:0x8
+v_subrev_co_u32_e32 v113, vcc, 1, v113
+v_mov_b32_e32 v114, 1
+v_xor_b32_dpp v114, v0, v0  quad_perm:[0,3,2,1] row_mask:0xf bank_mask:0x2
+v_xor_b32_dpp v114, v0, v0  quad_perm:[2,1,0,3] row_mask:0xf bank_mask:0x4
+v_subrev_co_u32_e32 v114, vcc, 1, v114
+v_cvt_f32_i32_e32 v113, v113
+v_cvt_f32_i32_e32 v114, v114
+v_lshrrev_b32_e64 v118, 2, s92
+v_and_b32_e32 v119, 3, v0
+v_bfe_u32 v120, v0, 4, 3
+v_mad_u32_u24 v107, v120, 4, v119
+v_lshlrev_b32_e32 v107, 4, v107
+v_mad_u32_u24 v102, v118, 4, v119
+v_lshlrev_b32_e32 v102, 4, v102
+v_bfe_u32 v118, v0, 2, 2
+v_and_b32_e32 v119, 1, v118
+v_mad_u32_u24 v121, v118, 16, v119
+v_lshlrev_b32_e32 v121, 6, v121
+v_xor_b32_e32 v102, v102, v121
+v_mul_u32_u24_e32 v121, 0x400, v118
+v_xor_b32_e32 v107, v107, v121
+s_lshr_b32 s92, s92, 0
+v_cmp_le_u32_e32 vcc, 0x100, v0
+s_cbranch_vccnz 50
+s_and_b32 s53, s18, 0x1100000
+s_addc_u32 s53, 0, 0
+v_lshrrev_b32_e32 v121, 1, v0
+s_mul_i32 s52, 60, s53
+s_sub_u32 s52, 63, s52
+v_bfi_b32 v121, s52, v0, v121
+v_and_b32_e32 v118, 1, v121
+v_bfe_u32 v119, v121, 1, 1
+v_xor_b32_e32 v118, v118, v119
+v_bfe_u32 v120, v121, 3, 1
+v_mad_u32_u24 v119, v119, 2, v120
+v_mul_u32_u24_e32 v118, 0x118, v118
+v_bfe_u32 v120, v121, 2, 1
+v_mad_u32_u24 v119, v119, 2, v118
+v_xor_b32_e32 v119, v119, v120
+v_and_b32_e32 v120, 0xf0, v121
+v_xor_b32_e32 v119, v119, v120
+s_mul_i32 s52, 4, s53
+s_sub_u32 s52, 6, s52
+v_bfe_u32 v121, v0, s52, 1
+v_mul_u32_u24_e32 v121, 0x1040, v121
+v_xor_b32_e32 v104, 0x314, v119
+v_xor_b32_e32 v105, 0x31c, v119
+v_xor_b32_e32 v106, 8, v119
+s_bitcmp1_b32 s18, 0
+s_cselect_b64 vcc, -1, 0
+v_cndmask_b32_e32 v103, v119, v106, vcc
+v_cndmask_b32_e32 v106, v106, v119, vcc
+v_mad_u32_u24 v103, 4, v103, v121
+v_mad_u32_u24 v104, 4, v104, v121
+v_mad_u32_u24 v105, 4, v105, v121
+v_mad_u32_u24 v106, 4, v106, v121
+s_branch 44
+s_bfe_u32 s53, s18, 0x10014
+v_lshrrev_b32_e32 v121, 1, v0
+s_mul_i32 s52, 60, s53
+s_sub_u32 s52, 63, s52
+v_bfi_b32 v121, s52, v0, v121
+v_and_b32_e32 v118, 1, v121
+v_bfe_u32 v119, v121, 1, 1
+v_bfe_u32 v120, v121, 3, 1
+v_xor_b32_e32 v118, v118, v119
+v_mad_u32_u24 v119, v119, 2, v120
+v_mul_u32_u24_e32 v118, 0x109, v118
+v_bfe_u32 v120, v121, 2, 1
+v_mad_u32_u24 v119, v119, 2, v118
+v_xor_b32_e32 v119, v119, v120
+v_and_b32_e32 v120, 0xf0, v121
+v_or_b32_e32 v119, v119, v120
+s_mul_i32 s52, 4, s53
+s_sub_u32 s52, 6, s52
+v_bfe_u32 v121, v0, s52, 1
+v_mul_u32_u24_e32 v121, 0x1040, v121
+v_mad_u32_u24 v103, 4, v119, v121
+v_xor_b32_e32 v104, 0x307, v119
+v_mad_u32_u24 v104, 4, v104, v121
+v_xor_b32_e32 v105, 0x30f, v119
+v_mad_u32_u24 v105, 4, v105, v121
+v_xor_b32_e32 v106, 8, v119
+v_mad_u32_u24 v106, 4, v106, v121
+v_subrev_co_u32_e32 v108, vcc, s76, v108
+v_mov_b32_e32 v119, s75
+v_cmp_lt_i32_e32 vcc, v108, v119
+v_subb_co_u32_e64 v118, vcc, 0, 0, vcc
+v_mad_i32_i24 v108, v118, s75, v108
+v_mad_i32_i24 v110, v118, s80, v110
+v_mad_i32_i24 v109, v118, s79, v109
+v_mov_b32_e32 v119, s74
+v_cmp_lt_i32_e32 vcc, v109, v119
+v_subb_co_u32_e64 v118, vcc, 0, 0, vcc
+v_add_co_u32_e32 v110, vcc, v110, v118
+v_mad_i32_i24 v109, v118, v119, v109
+v_subrev_co_u32_e32 v109, vcc, s77, v109
+v_cmp_lt_i32_e32 vcc, v109, v119
+v_subb_co_u32_e64 v118, vcc, 0, 0, vcc
+v_add_co_u32_e32 v110, vcc, v110, v118
+v_mad_i32_i24 v109, v118, s74, v109
+v_subrev_co_u32_e32 v110, vcc, s78, v110
+s_mov_b32 s62, 0
+s_mov_b32 s63, s28
+s_mov_b32 s64, 1
+s_mov_b32 s84, 0
+s_mov_b32 s85, s16
+s_mov_b32 s83, s85
+s_sub_u32 s93, -1, s92
+s_sub_u32 s93, s93, 32
+s_bitset1_b32 s18, 21
+s_mov_b32 s47, 0
+s_mov_b32 s51, 0
+s_mov_b32 s94, 34
+s_mov_b32 s82, 0
+s_bitset1_b32 s18, 26
+s_call_b64 s[38:39], 2970
+v_cmp_le_u32_e32 vcc, 0x100, v0
+s_cbranch_vccnz 65
+s_branch 1511
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_dot2_f32_f16 v2, v34, v42, v2
+v_dot2_f32_f16 v3, v35, v42, v3
+v_dot2_f32_f16 v4, v36, v42, v4
+v_dot2_f32_f16 v5, v37, v42, v5
+v_dot2_f32_f16 v6, v34, v43, v6
+v_dot2_f32_f16 v7, v35, v43, v7
+v_dot2_f32_f16 v8, v36, v43, v8
+v_dot2_f32_f16 v9, v37, v43, v9
+v_dot2_f32_f16 v10, v34, v44, v10
+v_dot2_f32_f16 v11, v35, v44, v11
+v_dot2_f32_f16 v12, v36, v44, v12
+v_dot2_f32_f16 v13, v37, v44, v13
+v_dot2_f32_f16 v14, v34, v45, v14
+v_dot2_f32_f16 v15, v35, v45, v15
+v_dot2_f32_f16 v16, v36, v45, v16
+v_dot2_f32_f16 v17, v37, v45, v17
+v_dot2_f32_f16 v18, v34, v46, v18
+v_dot2_f32_f16 v19, v35, v46, v19
+v_dot2_f32_f16 v20, v36, v46, v20
+v_dot2_f32_f16 v21, v37, v46, v21
+v_dot2_f32_f16 v22, v34, v47, v22
+v_dot2_f32_f16 v23, v35, v47, v23
+v_dot2_f32_f16 v24, v36, v47, v24
+v_dot2_f32_f16 v25, v37, v47, v25
+v_dot2_f32_f16 v26, v34, v48, v26
+v_dot2_f32_f16 v27, v35, v48, v27
+v_dot2_f32_f16 v28, v36, v48, v28
+v_dot2_f32_f16 v29, v37, v48, v29
+v_dot2_f32_f16 v30, v34, v49, v30
+v_dot2_f32_f16 v31, v35, v49, v31
+v_pack_b32_f16 v70, v82, v70
+v_pack_b32_f16 v71, v83, v71
+v_pack_b32_f16 v72, v84, v72
+v_pack_b32_f16 v73, v85, v73
+v_pk_fma_f16 v70, v72, -1.0, v70 op_sel_hi:[1,0,1]
+v_pk_mul_f16 v70, v70, 0.5 op_sel_hi:[1,0]
+v_pk_fma_f16 v73, v71, -1.0, v73 op_sel_hi:[1,0,1]
+v_pk_mul_f16 v73, v73, 0.5 op_sel_hi:[1,0]
+v_pk_add_f16 v71, v72, v71
+v_pk_mul_f16 v71, v71, 0.5 op_sel_hi:[1,0]
+s_setprio 0
+s_nop 0
+v_dot2_f32_f16 v32, v36, v49, v32
+v_dot2_f32_f16 v33, v37, v49, v33
+s_nop 0
+ds_read_b128 v[34:37], v107 offset:29440
+ds_read_b128 v[42:45], v102 offset:28928
+ds_read_b128 v[46:49], v102 offset:29056
+ds_write_b32 v103, v62
+ds_write_b32 v104, v63
+s_setprio 1
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v58, v94, s[40:43], 0 offen
+buffer_load_short_d16 v60, v96, s[40:43], 0 offen
+buffer_load_short_d16 v59, v95, s[40:43], 0 offen
+buffer_load_short_d16 v61, v97, s[40:43], 0 offen
+s_add_u32 s91, s91, 0x200
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 2
+s_call_b64 s[38:39], 2777
+s_nop 0
+v_dot2_f32_f16 v2, v38, v50, v2
+v_dot2_f32_f16 v3, v39, v50, v3
+v_dot2_f32_f16 v4, v40, v50, v4
+v_dot2_f32_f16 v5, v41, v50, v5
+v_dot2_f32_f16 v6, v38, v51, v6
+v_dot2_f32_f16 v7, v39, v51, v7
+v_dot2_f32_f16 v8, v40, v51, v8
+v_dot2_f32_f16 v9, v41, v51, v9
+v_dot2_f32_f16 v10, v38, v52, v10
+v_dot2_f32_f16 v11, v39, v52, v11
+v_dot2_f32_f16 v12, v40, v52, v12
+v_dot2_f32_f16 v13, v41, v52, v13
+v_dot2_f32_f16 v14, v38, v53, v14
+v_dot2_f32_f16 v15, v39, v53, v15
+v_dot2_f32_f16 v16, v40, v53, v16
+v_dot2_f32_f16 v17, v41, v53, v17
+v_dot2_f32_f16 v18, v38, v54, v18
+v_dot2_f32_f16 v19, v39, v54, v19
+v_dot2_f32_f16 v20, v40, v54, v20
+v_dot2_f32_f16 v21, v41, v54, v21
+v_dot2_f32_f16 v22, v38, v55, v22
+v_dot2_f32_f16 v23, v39, v55, v23
+v_dot2_f32_f16 v24, v40, v55, v24
+v_dot2_f32_f16 v25, v41, v55, v25
+v_dot2_f32_f16 v26, v38, v56, v26
+v_dot2_f32_f16 v27, v39, v56, v27
+v_dot2_f32_f16 v28, v40, v56, v28
+v_dot2_f32_f16 v29, v41, v56, v29
+v_dot2_f32_f16 v30, v38, v57, v30
+v_dot2_f32_f16 v31, v39, v57, v31
+v_pk_fma_f16 v72, v71, -1.0, v72 op_sel_hi:[1,0,1]
+v_mov_b32_dpp v115, v70  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v70, v115, v112, v70
+v_mov_b32_dpp v115, v71  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v71, v115, v112, v71
+v_mov_b32_dpp v115, v72  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v72, v115, v112, v72
+v_mov_b32_dpp v115, v73  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v73, v115, v112, v73
+s_setprio 0
+s_nop 0
+v_dot2_f32_f16 v32, v40, v57, v32
+v_dot2_f32_f16 v33, v41, v57, v33
+s_nop 0
+ds_read_b128 v[38:41], v107 offset:33536
+ds_read_b128 v[50:53], v102 offset:33024
+ds_read_b128 v[54:57], v102 offset:33152
+ds_write_b32 v105, v68 offset:8256
+ds_write_b32 v106, v69 offset:8256
+s_setprio 1
+s_add_u32 s40, s40, s69
+s_addc_u32 s41, s41, 0
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v82, v94, s[40:43], 0 offen
+buffer_load_short_d16 v84, v96, s[40:43], 0 offen
+buffer_load_short_d16 v83, v95, s[40:43], 0 offen
+buffer_load_short_d16 v85, v97, s[40:43], 0 offen
+s_nop 0
+s_waitcnt vmcnt(16) lgkmcnt(5)
+ds_append v117 offset:65472
+s_bitset1_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 4
+s_call_b64 s[38:39], 2659
+s_nop 0
+s_nop 0
+s_nop 0
+v_dot2_f32_f16 v2, v34, v42, v2
+v_dot2_f32_f16 v3, v35, v42, v3
+v_dot2_f32_f16 v4, v36, v42, v4
+v_dot2_f32_f16 v5, v37, v42, v5
+v_dot2_f32_f16 v6, v34, v43, v6
+v_dot2_f32_f16 v7, v35, v43, v7
+v_dot2_f32_f16 v8, v36, v43, v8
+v_dot2_f32_f16 v9, v37, v43, v9
+v_dot2_f32_f16 v10, v34, v44, v10
+v_dot2_f32_f16 v11, v35, v44, v11
+v_dot2_f32_f16 v12, v36, v44, v12
+v_dot2_f32_f16 v13, v37, v44, v13
+v_dot2_f32_f16 v14, v34, v45, v14
+v_dot2_f32_f16 v15, v35, v45, v15
+v_dot2_f32_f16 v16, v36, v45, v16
+v_dot2_f32_f16 v17, v37, v45, v17
+v_dot2_f32_f16 v18, v34, v46, v18
+v_dot2_f32_f16 v19, v35, v46, v19
+v_dot2_f32_f16 v20, v36, v46, v20
+v_dot2_f32_f16 v21, v37, v46, v21
+v_dot2_f32_f16 v22, v34, v47, v22
+v_dot2_f32_f16 v23, v35, v47, v23
+v_dot2_f32_f16 v24, v36, v47, v24
+v_dot2_f32_f16 v25, v37, v47, v25
+v_dot2_f32_f16 v26, v34, v48, v26
+v_dot2_f32_f16 v27, v35, v48, v27
+v_dot2_f32_f16 v28, v36, v48, v28
+v_dot2_f32_f16 v29, v37, v48, v29
+v_dot2_f32_f16 v30, v34, v49, v30
+v_dot2_f32_f16 v31, v35, v49, v31
+v_pack_b32_f16 v74, v86, v74
+v_pack_b32_f16 v75, v87, v75
+v_pack_b32_f16 v76, v88, v76
+v_pack_b32_f16 v77, v89, v77
+v_pk_fma_f16 v74, v76, -1.0, v74 op_sel_hi:[1,0,1]
+v_pk_mul_f16 v74, v74, 0.5 op_sel_hi:[1,0]
+v_pk_fma_f16 v77, v75, -1.0, v77 op_sel_hi:[1,0,1]
+v_pk_mul_f16 v77, v77, 0.5 op_sel_hi:[1,0]
+v_pk_add_f16 v75, v76, v75
+v_pk_mul_f16 v75, v75, 0.5 op_sel_hi:[1,0]
+s_setprio 0
+s_nop 0
+v_dot2_f32_f16 v32, v36, v49, v32
+v_dot2_f32_f16 v33, v37, v49, v33
+s_nop 0
+ds_read_b128 v[34:37], v107 offset:37696
+ds_read_b128 v[42:45], v102 offset:37184
+ds_read_b128 v[46:49], v102 offset:37312
+ds_write_b32 v103, v66 offset:8256
+ds_write_b32 v104, v67 offset:8256
+s_setprio 1
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v62, v94, s[40:43], 0 offen
+buffer_load_short_d16 v64, v96, s[40:43], 0 offen
+buffer_load_short_d16 v63, v95, s[40:43], 0 offen
+buffer_load_short_d16 v65, v97, s[40:43], 0 offen
+s_mov_b32 m0, 0x2ffc0
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 2
+s_call_b64 s[38:39], 2537
+s_nop 0
+v_dot2_f32_f16 v2, v38, v50, v2
+v_dot2_f32_f16 v3, v39, v50, v3
+v_dot2_f32_f16 v4, v40, v50, v4
+v_dot2_f32_f16 v5, v41, v50, v5
+v_dot2_f32_f16 v6, v38, v51, v6
+v_dot2_f32_f16 v7, v39, v51, v7
+v_dot2_f32_f16 v8, v40, v51, v8
+v_dot2_f32_f16 v9, v41, v51, v9
+v_dot2_f32_f16 v10, v38, v52, v10
+v_dot2_f32_f16 v11, v39, v52, v11
+v_dot2_f32_f16 v12, v40, v52, v12
+v_dot2_f32_f16 v13, v41, v52, v13
+v_dot2_f32_f16 v14, v38, v53, v14
+v_dot2_f32_f16 v15, v39, v53, v15
+v_dot2_f32_f16 v16, v40, v53, v16
+v_dot2_f32_f16 v17, v41, v53, v17
+v_dot2_f32_f16 v18, v38, v54, v18
+v_dot2_f32_f16 v19, v39, v54, v19
+v_dot2_f32_f16 v20, v40, v54, v20
+v_dot2_f32_f16 v21, v41, v54, v21
+v_dot2_f32_f16 v22, v38, v55, v22
+v_dot2_f32_f16 v23, v39, v55, v23
+v_dot2_f32_f16 v24, v40, v55, v24
+v_dot2_f32_f16 v25, v41, v55, v25
+v_dot2_f32_f16 v26, v38, v56, v26
+v_dot2_f32_f16 v27, v39, v56, v27
+v_dot2_f32_f16 v28, v40, v56, v28
+v_dot2_f32_f16 v29, v41, v56, v29
+v_dot2_f32_f16 v30, v38, v57, v30
+v_dot2_f32_f16 v31, v39, v57, v31
+v_dot2_f32_f16 v32, v40, v57, v32
+v_pk_fma_f16 v76, v75, -1.0, v76 op_sel_hi:[1,0,1]
+v_mov_b32_dpp v115, v74  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v74, v115, v112, v74
+v_mov_b32_dpp v115, v75  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v75, v115, v112, v75
+v_mov_b32_dpp v115, v76  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v76, v115, v112, v76
+v_mov_b32_dpp v115, v77  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v77, v115, v112, v77
+s_setprio 0
+s_nop 0
+v_dot2_f32_f16 v33, v41, v57, v33
+v_cmp_eq_u32_e64 vcc, src_lds_direct, s91
+s_nop 0
+s_nop 0
+s_cbranch_vccz 65531
+s_nop 0
+ds_read_b128 v[38:41], v107 offset:41792
+ds_read_b128 v[50:53], v102 offset:41280
+ds_read_b128 v[54:57], v102 offset:41408
+ds_write_b32 v105, v72 offset:16512
+ds_write_b32 v106, v73 offset:16512
+s_setprio 1
+s_add_u32 s40, s40, s69
+s_addc_u32 s41, s41, 0
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v86, v94, s[40:43], 0 offen
+buffer_load_short_d16 v88, v96, s[40:43], 0 offen
+buffer_load_short_d16 v87, v95, s[40:43], 0 offen
+buffer_load_short_d16 v89, v97, s[40:43], 0 offen
+s_nop 0
+s_waitcnt vmcnt(16) lgkmcnt(5)
+s_bitset1_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 1
+s_call_b64 s[38:39], 2416
+v_dot2_f32_f16 v2, v34, v42, v2
+v_dot2_f32_f16 v3, v35, v42, v3
+v_dot2_f32_f16 v4, v36, v42, v4
+v_dot2_f32_f16 v5, v37, v42, v5
+v_dot2_f32_f16 v6, v34, v43, v6
+v_dot2_f32_f16 v7, v35, v43, v7
+v_dot2_f32_f16 v8, v36, v43, v8
+v_dot2_f32_f16 v9, v37, v43, v9
+v_dot2_f32_f16 v10, v34, v44, v10
+v_dot2_f32_f16 v11, v35, v44, v11
+v_dot2_f32_f16 v12, v36, v44, v12
+v_dot2_f32_f16 v13, v37, v44, v13
+v_dot2_f32_f16 v14, v34, v45, v14
+v_dot2_f32_f16 v15, v35, v45, v15
+v_dot2_f32_f16 v16, v36, v45, v16
+v_dot2_f32_f16 v17, v37, v45, v17
+v_dot2_f32_f16 v18, v34, v46, v18
+v_dot2_f32_f16 v19, v35, v46, v19
+v_dot2_f32_f16 v20, v36, v46, v20
+v_dot2_f32_f16 v21, v37, v46, v21
+v_dot2_f32_f16 v22, v34, v47, v22
+v_dot2_f32_f16 v23, v35, v47, v23
+v_dot2_f32_f16 v24, v36, v47, v24
+v_dot2_f32_f16 v25, v37, v47, v25
+v_dot2_f32_f16 v26, v34, v48, v26
+v_dot2_f32_f16 v27, v35, v48, v27
+v_dot2_f32_f16 v28, v36, v48, v28
+v_dot2_f32_f16 v29, v37, v48, v29
+v_dot2_f32_f16 v30, v34, v49, v30
+v_dot2_f32_f16 v31, v35, v49, v31
+v_pack_b32_f16 v78, v90, v78
+v_pack_b32_f16 v79, v91, v79
+v_pack_b32_f16 v80, v92, v80
+v_pack_b32_f16 v81, v93, v81
+v_pk_fma_f16 v78, v80, -1.0, v78 op_sel_hi:[1,0,1]
+v_pk_mul_f16 v78, v78, 0.5 op_sel_hi:[1,0]
+v_pk_fma_f16 v81, v79, -1.0, v81 op_sel_hi:[1,0,1]
+v_pk_mul_f16 v81, v81, 0.5 op_sel_hi:[1,0]
+v_pk_add_f16 v79, v80, v79
+v_pk_mul_f16 v79, v79, 0.5 op_sel_hi:[1,0]
+s_setprio 0
+s_nop 0
+v_dot2_f32_f16 v32, v36, v49, v32
+v_dot2_f32_f16 v33, v37, v49, v33
+s_nop 0
+ds_read_b128 v[34:37], v107 offset:45952
+ds_read_b128 v[42:45], v102 offset:45440
+ds_read_b128 v[46:49], v102 offset:45568
+ds_write_b32 v103, v70 offset:16512
+ds_write_b32 v104, v71 offset:16512
+s_setprio 1
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v66, v94, s[40:43], 0 offen
+buffer_load_short_d16 v68, v96, s[40:43], 0 offen
+buffer_load_short_d16 v67, v95, s[40:43], 0 offen
+buffer_load_short_d16 v69, v97, s[40:43], 0 offen
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 4
+s_call_b64 s[38:39], 2299
+s_nop 0
+s_nop 0
+s_nop 0
+v_dot2_f32_f16 v2, v38, v50, v2
+v_dot2_f32_f16 v3, v39, v50, v3
+v_dot2_f32_f16 v4, v40, v50, v4
+v_dot2_f32_f16 v5, v41, v50, v5
+v_dot2_f32_f16 v6, v38, v51, v6
+v_dot2_f32_f16 v7, v39, v51, v7
+v_dot2_f32_f16 v8, v40, v51, v8
+v_dot2_f32_f16 v9, v41, v51, v9
+v_dot2_f32_f16 v10, v38, v52, v10
+v_dot2_f32_f16 v11, v39, v52, v11
+v_dot2_f32_f16 v12, v40, v52, v12
+v_dot2_f32_f16 v13, v41, v52, v13
+v_dot2_f32_f16 v14, v38, v53, v14
+v_dot2_f32_f16 v15, v39, v53, v15
+v_dot2_f32_f16 v16, v40, v53, v16
+v_dot2_f32_f16 v17, v41, v53, v17
+v_dot2_f32_f16 v18, v38, v54, v18
+v_dot2_f32_f16 v19, v39, v54, v19
+v_dot2_f32_f16 v20, v40, v54, v20
+v_dot2_f32_f16 v21, v41, v54, v21
+v_dot2_f32_f16 v22, v38, v55, v22
+v_dot2_f32_f16 v23, v39, v55, v23
+v_dot2_f32_f16 v24, v40, v55, v24
+v_dot2_f32_f16 v25, v41, v55, v25
+v_dot2_f32_f16 v26, v38, v56, v26
+v_dot2_f32_f16 v27, v39, v56, v27
+v_dot2_f32_f16 v28, v40, v56, v28
+v_dot2_f32_f16 v29, v41, v56, v29
+v_dot2_f32_f16 v30, v38, v57, v30
+v_dot2_f32_f16 v31, v39, v57, v31
+v_pk_fma_f16 v80, v79, -1.0, v80 op_sel_hi:[1,0,1]
+v_mov_b32_dpp v115, v78  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v78, v115, v112, v78
+v_mov_b32_dpp v115, v79  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v79, v115, v112, v79
+v_mov_b32_dpp v115, v80  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v80, v115, v112, v80
+v_mov_b32_dpp v115, v81  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v81, v115, v112, v81
+s_setprio 0
+s_nop 0
+v_dot2_f32_f16 v32, v40, v57, v32
+v_dot2_f32_f16 v33, v41, v57, v33
+s_nop 0
+ds_read_b128 v[38:41], v107 offset:512
+ds_read_b128 v[50:53], v102
+ds_read_b128 v[54:57], v102 offset:128
+ds_write_b32 v105, v76 offset:24768
+ds_write_b32 v106, v77 offset:24768
+s_setprio 1
+s_add_u32 s40, s40, s69
+s_addc_u32 s41, s41, 0
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v90, v94, s[40:43], 0 offen
+buffer_load_short_d16 v92, v96, s[40:43], 0 offen
+buffer_load_short_d16 v91, v95, s[40:43], 0 offen
+buffer_load_short_d16 v93, v97, s[40:43], 0 offen
+s_nop 0
+s_waitcnt vmcnt(16) lgkmcnt(5)
+ds_append v117 offset:65476
+s_bitset1_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 4
+s_call_b64 s[38:39], 2179
+s_nop 0
+s_nop 0
+s_nop 0
+v_dot2_f32_f16 v2, v34, v42, v2
+v_dot2_f32_f16 v3, v35, v42, v3
+v_dot2_f32_f16 v4, v36, v42, v4
+v_dot2_f32_f16 v5, v37, v42, v5
+v_dot2_f32_f16 v6, v34, v43, v6
+v_dot2_f32_f16 v7, v35, v43, v7
+v_dot2_f32_f16 v8, v36, v43, v8
+v_dot2_f32_f16 v9, v37, v43, v9
+v_dot2_f32_f16 v10, v34, v44, v10
+v_dot2_f32_f16 v11, v35, v44, v11
+v_dot2_f32_f16 v12, v36, v44, v12
+v_dot2_f32_f16 v13, v37, v44, v13
+v_dot2_f32_f16 v14, v34, v45, v14
+v_dot2_f32_f16 v15, v35, v45, v15
+v_dot2_f32_f16 v16, v36, v45, v16
+v_dot2_f32_f16 v17, v37, v45, v17
+v_dot2_f32_f16 v18, v34, v46, v18
+v_dot2_f32_f16 v19, v35, v46, v19
+v_dot2_f32_f16 v20, v36, v46, v20
+v_dot2_f32_f16 v21, v37, v46, v21
+v_dot2_f32_f16 v22, v34, v47, v22
+v_dot2_f32_f16 v23, v35, v47, v23
+v_dot2_f32_f16 v24, v36, v47, v24
+v_dot2_f32_f16 v25, v37, v47, v25
+v_dot2_f32_f16 v26, v34, v48, v26
+v_dot2_f32_f16 v27, v35, v48, v27
+v_dot2_f32_f16 v28, v36, v48, v28
+v_dot2_f32_f16 v29, v37, v48, v29
+v_dot2_f32_f16 v30, v34, v49, v30
+v_dot2_f32_f16 v31, v35, v49, v31
+v_pack_b32_f16 v58, v82, v58
+v_pack_b32_f16 v59, v83, v59
+v_pack_b32_f16 v60, v84, v60
+v_pack_b32_f16 v61, v85, v61
+v_pk_fma_f16 v58, v60, -1.0, v58 op_sel_hi:[1,0,1]
+v_pk_mul_f16 v58, v58, 0.5 op_sel_hi:[1,0]
+v_pk_fma_f16 v61, v59, -1.0, v61 op_sel_hi:[1,0,1]
+v_pk_mul_f16 v61, v61, 0.5 op_sel_hi:[1,0]
+v_pk_add_f16 v59, v60, v59
+v_pk_mul_f16 v59, v59, 0.5 op_sel_hi:[1,0]
+s_setprio 0
+s_nop 0
+v_dot2_f32_f16 v32, v36, v49, v32
+v_dot2_f32_f16 v33, v37, v49, v33
+s_nop 0
+ds_read_b128 v[34:37], v107 offset:4672
+ds_read_b128 v[42:45], v102 offset:4160
+ds_read_b128 v[46:49], v102 offset:4288
+ds_write_b32 v103, v74 offset:24768
+ds_write_b32 v104, v75 offset:24768
+s_setprio 1
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v70, v94, s[40:43], 0 offen
+buffer_load_short_d16 v72, v96, s[40:43], 0 offen
+buffer_load_short_d16 v71, v95, s[40:43], 0 offen
+buffer_load_short_d16 v73, v97, s[40:43], 0 offen
+s_mov_b32 m0, 0x2ffc4
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 2
+s_call_b64 s[38:39], 2057
+s_nop 0
+v_dot2_f32_f16 v2, v38, v50, v2
+v_dot2_f32_f16 v3, v39, v50, v3
+v_dot2_f32_f16 v4, v40, v50, v4
+v_dot2_f32_f16 v5, v41, v50, v5
+v_dot2_f32_f16 v6, v38, v51, v6
+v_dot2_f32_f16 v7, v39, v51, v7
+v_dot2_f32_f16 v8, v40, v51, v8
+v_dot2_f32_f16 v9, v41, v51, v9
+v_dot2_f32_f16 v10, v38, v52, v10
+v_dot2_f32_f16 v11, v39, v52, v11
+v_dot2_f32_f16 v12, v40, v52, v12
+v_dot2_f32_f16 v13, v41, v52, v13
+v_dot2_f32_f16 v14, v38, v53, v14
+v_dot2_f32_f16 v15, v39, v53, v15
+v_dot2_f32_f16 v16, v40, v53, v16
+v_dot2_f32_f16 v17, v41, v53, v17
+v_dot2_f32_f16 v18, v38, v54, v18
+v_dot2_f32_f16 v19, v39, v54, v19
+v_dot2_f32_f16 v20, v40, v54, v20
+v_dot2_f32_f16 v21, v41, v54, v21
+v_dot2_f32_f16 v22, v38, v55, v22
+v_dot2_f32_f16 v23, v39, v55, v23
+v_dot2_f32_f16 v24, v40, v55, v24
+v_dot2_f32_f16 v25, v41, v55, v25
+v_dot2_f32_f16 v26, v38, v56, v26
+v_dot2_f32_f16 v27, v39, v56, v27
+v_dot2_f32_f16 v28, v40, v56, v28
+v_dot2_f32_f16 v29, v41, v56, v29
+v_dot2_f32_f16 v30, v38, v57, v30
+v_dot2_f32_f16 v31, v39, v57, v31
+v_dot2_f32_f16 v32, v40, v57, v32
+v_pk_fma_f16 v60, v59, -1.0, v60 op_sel_hi:[1,0,1]
+v_mov_b32_dpp v115, v58  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v58, v115, v112, v58
+v_mov_b32_dpp v115, v59  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v59, v115, v112, v59
+v_mov_b32_dpp v115, v60  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v60, v115, v112, v60
+v_mov_b32_dpp v115, v61  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v61, v115, v112, v61
+s_setprio 0
+s_nop 0
+v_dot2_f32_f16 v33, v41, v57, v33
+v_cmp_eq_u32_e64 vcc, src_lds_direct, s91
+s_nop 0
+s_nop 0
+s_cbranch_vccz 65531
+s_nop 0
+ds_read_b128 v[38:41], v107 offset:8768
+ds_read_b128 v[50:53], v102 offset:8256
+ds_read_b128 v[54:57], v102 offset:8384
+ds_write_b32 v105, v80 offset:33024
+ds_write_b32 v106, v81 offset:33024
+s_setprio 1
+s_add_u32 s40, s40, s69
+s_addc_u32 s41, s41, 0
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v82, v94, s[40:43], 0 offen
+buffer_load_short_d16 v84, v96, s[40:43], 0 offen
+buffer_load_short_d16 v83, v95, s[40:43], 0 offen
+buffer_load_short_d16 v85, v97, s[40:43], 0 offen
+s_nop 0
+s_waitcnt vmcnt(16) lgkmcnt(5)
+s_bitset1_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 1
+s_call_b64 s[38:39], 1936
+v_dot2_f32_f16 v2, v34, v42, v2
+v_dot2_f32_f16 v3, v35, v42, v3
+v_dot2_f32_f16 v4, v36, v42, v4
+v_dot2_f32_f16 v5, v37, v42, v5
+v_dot2_f32_f16 v6, v34, v43, v6
+v_dot2_f32_f16 v7, v35, v43, v7
+v_dot2_f32_f16 v8, v36, v43, v8
+v_dot2_f32_f16 v9, v37, v43, v9
+v_dot2_f32_f16 v10, v34, v44, v10
+v_dot2_f32_f16 v11, v35, v44, v11
+v_dot2_f32_f16 v12, v36, v44, v12
+v_dot2_f32_f16 v13, v37, v44, v13
+v_dot2_f32_f16 v14, v34, v45, v14
+v_dot2_f32_f16 v15, v35, v45, v15
+v_dot2_f32_f16 v16, v36, v45, v16
+v_dot2_f32_f16 v17, v37, v45, v17
+v_dot2_f32_f16 v18, v34, v46, v18
+v_dot2_f32_f16 v19, v35, v46, v19
+v_dot2_f32_f16 v20, v36, v46, v20
+v_dot2_f32_f16 v21, v37, v46, v21
+v_dot2_f32_f16 v22, v34, v47, v22
+v_dot2_f32_f16 v23, v35, v47, v23
+v_dot2_f32_f16 v24, v36, v47, v24
+v_dot2_f32_f16 v25, v37, v47, v25
+v_dot2_f32_f16 v26, v34, v48, v26
+v_dot2_f32_f16 v27, v35, v48, v27
+v_dot2_f32_f16 v28, v36, v48, v28
+v_dot2_f32_f16 v29, v37, v48, v29
+v_dot2_f32_f16 v30, v34, v49, v30
+v_dot2_f32_f16 v31, v35, v49, v31
+v_pack_b32_f16 v62, v86, v62
+v_pack_b32_f16 v63, v87, v63
+v_pack_b32_f16 v64, v88, v64
+v_pack_b32_f16 v65, v89, v65
+v_pk_fma_f16 v62, v64, -1.0, v62 op_sel_hi:[1,0,1]
+v_pk_mul_f16 v62, v62, 0.5 op_sel_hi:[1,0]
+v_pk_fma_f16 v65, v63, -1.0, v65 op_sel_hi:[1,0,1]
+v_pk_mul_f16 v65, v65, 0.5 op_sel_hi:[1,0]
+v_pk_add_f16 v63, v64, v63
+v_pk_mul_f16 v63, v63, 0.5 op_sel_hi:[1,0]
+s_setprio 0
+s_nop 0
+v_dot2_f32_f16 v32, v36, v49, v32
+v_dot2_f32_f16 v33, v37, v49, v33
+s_nop 0
+ds_read_b128 v[34:37], v107 offset:12928
+ds_read_b128 v[42:45], v102 offset:12416
+ds_read_b128 v[46:49], v102 offset:12544
+ds_write_b32 v103, v78 offset:33024
+ds_write_b32 v104, v79 offset:33024
+s_setprio 1
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v74, v94, s[40:43], 0 offen
+buffer_load_short_d16 v76, v96, s[40:43], 0 offen
+buffer_load_short_d16 v75, v95, s[40:43], 0 offen
+buffer_load_short_d16 v77, v97, s[40:43], 0 offen
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 4
+s_call_b64 s[38:39], 1819
+s_nop 0
+s_nop 0
+s_nop 0
+v_dot2_f32_f16 v2, v38, v50, v2
+v_dot2_f32_f16 v3, v39, v50, v3
+v_dot2_f32_f16 v4, v40, v50, v4
+v_dot2_f32_f16 v5, v41, v50, v5
+v_dot2_f32_f16 v6, v38, v51, v6
+v_dot2_f32_f16 v7, v39, v51, v7
+v_dot2_f32_f16 v8, v40, v51, v8
+v_dot2_f32_f16 v9, v41, v51, v9
+v_dot2_f32_f16 v10, v38, v52, v10
+v_dot2_f32_f16 v11, v39, v52, v11
+v_dot2_f32_f16 v12, v40, v52, v12
+v_dot2_f32_f16 v13, v41, v52, v13
+v_dot2_f32_f16 v14, v38, v53, v14
+v_dot2_f32_f16 v15, v39, v53, v15
+v_dot2_f32_f16 v16, v40, v53, v16
+v_dot2_f32_f16 v17, v41, v53, v17
+v_dot2_f32_f16 v18, v38, v54, v18
+v_dot2_f32_f16 v19, v39, v54, v19
+v_dot2_f32_f16 v20, v40, v54, v20
+v_dot2_f32_f16 v21, v41, v54, v21
+v_dot2_f32_f16 v22, v38, v55, v22
+v_dot2_f32_f16 v23, v39, v55, v23
+v_dot2_f32_f16 v24, v40, v55, v24
+v_dot2_f32_f16 v25, v41, v55, v25
+v_dot2_f32_f16 v26, v38, v56, v26
+v_dot2_f32_f16 v27, v39, v56, v27
+v_dot2_f32_f16 v28, v40, v56, v28
+v_dot2_f32_f16 v29, v41, v56, v29
+v_dot2_f32_f16 v30, v38, v57, v30
+v_dot2_f32_f16 v31, v39, v57, v31
+v_pk_fma_f16 v64, v63, -1.0, v64 op_sel_hi:[1,0,1]
+v_mov_b32_dpp v115, v62  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v62, v115, v112, v62
+v_mov_b32_dpp v115, v63  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v63, v115, v112, v63
+v_mov_b32_dpp v115, v64  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v64, v115, v112, v64
+v_mov_b32_dpp v115, v65  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v65, v115, v112, v65
+s_setprio 0
+s_nop 0
+v_dot2_f32_f16 v32, v40, v57, v32
+v_dot2_f32_f16 v33, v41, v57, v33
+s_nop 0
+ds_read_b128 v[38:41], v107 offset:17024
+ds_read_b128 v[50:53], v102 offset:16512
+ds_read_b128 v[54:57], v102 offset:16640
+ds_write_b32 v105, v60 offset:41280
+ds_write_b32 v106, v61 offset:41280
+s_setprio 1
+s_add_u32 s40, s40, s69
+s_addc_u32 s41, s41, 0
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v86, v94, s[40:43], 0 offen
+buffer_load_short_d16 v88, v96, s[40:43], 0 offen
+buffer_load_short_d16 v87, v95, s[40:43], 0 offen
+buffer_load_short_d16 v89, v97, s[40:43], 0 offen
+s_nop 0
+s_waitcnt vmcnt(16) lgkmcnt(5)
+ds_append v117 offset:65480
+s_bitset1_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 4
+s_call_b64 s[38:39], 1699
+s_nop 0
+s_nop 0
+s_nop 0
+v_dot2_f32_f16 v2, v34, v42, v2
+v_dot2_f32_f16 v3, v35, v42, v3
+v_dot2_f32_f16 v4, v36, v42, v4
+v_dot2_f32_f16 v5, v37, v42, v5
+v_dot2_f32_f16 v6, v34, v43, v6
+v_dot2_f32_f16 v7, v35, v43, v7
+v_dot2_f32_f16 v8, v36, v43, v8
+v_dot2_f32_f16 v9, v37, v43, v9
+v_dot2_f32_f16 v10, v34, v44, v10
+v_dot2_f32_f16 v11, v35, v44, v11
+v_dot2_f32_f16 v12, v36, v44, v12
+v_dot2_f32_f16 v13, v37, v44, v13
+v_dot2_f32_f16 v14, v34, v45, v14
+v_dot2_f32_f16 v15, v35, v45, v15
+v_dot2_f32_f16 v16, v36, v45, v16
+v_dot2_f32_f16 v17, v37, v45, v17
+v_dot2_f32_f16 v18, v34, v46, v18
+v_dot2_f32_f16 v19, v35, v46, v19
+v_dot2_f32_f16 v20, v36, v46, v20
+v_dot2_f32_f16 v21, v37, v46, v21
+v_dot2_f32_f16 v22, v34, v47, v22
+v_dot2_f32_f16 v23, v35, v47, v23
+v_dot2_f32_f16 v24, v36, v47, v24
+v_dot2_f32_f16 v25, v37, v47, v25
+v_dot2_f32_f16 v26, v34, v48, v26
+v_dot2_f32_f16 v27, v35, v48, v27
+v_dot2_f32_f16 v28, v36, v48, v28
+v_dot2_f32_f16 v29, v37, v48, v29
+v_dot2_f32_f16 v30, v34, v49, v30
+v_dot2_f32_f16 v31, v35, v49, v31
+v_pack_b32_f16 v66, v90, v66
+v_pack_b32_f16 v67, v91, v67
+v_pack_b32_f16 v68, v92, v68
+v_pack_b32_f16 v69, v93, v69
+v_pk_fma_f16 v66, v68, -1.0, v66 op_sel_hi:[1,0,1]
+v_pk_mul_f16 v66, v66, 0.5 op_sel_hi:[1,0]
+v_pk_fma_f16 v69, v67, -1.0, v69 op_sel_hi:[1,0,1]
+v_pk_mul_f16 v69, v69, 0.5 op_sel_hi:[1,0]
+v_pk_add_f16 v67, v68, v67
+v_pk_mul_f16 v67, v67, 0.5 op_sel_hi:[1,0]
+s_setprio 0
+s_nop 0
+v_dot2_f32_f16 v32, v36, v49, v32
+v_dot2_f32_f16 v33, v37, v49, v33
+s_nop 0
+ds_read_b128 v[34:37], v107 offset:21184
+ds_read_b128 v[42:45], v102 offset:20672
+ds_read_b128 v[46:49], v102 offset:20800
+ds_write_b32 v103, v58 offset:41280
+ds_write_b32 v104, v59 offset:41280
+s_setprio 1
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v78, v94, s[40:43], 0 offen
+buffer_load_short_d16 v80, v96, s[40:43], 0 offen
+buffer_load_short_d16 v79, v95, s[40:43], 0 offen
+buffer_load_short_d16 v81, v97, s[40:43], 0 offen
+s_mov_b32 m0, 0x2ffc8
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 2
+s_call_b64 s[38:39], 1577
+s_nop 0
+v_dot2_f32_f16 v2, v38, v50, v2
+v_dot2_f32_f16 v3, v39, v50, v3
+v_dot2_f32_f16 v4, v40, v50, v4
+v_dot2_f32_f16 v5, v41, v50, v5
+v_dot2_f32_f16 v6, v38, v51, v6
+v_dot2_f32_f16 v7, v39, v51, v7
+v_dot2_f32_f16 v8, v40, v51, v8
+v_dot2_f32_f16 v9, v41, v51, v9
+v_dot2_f32_f16 v10, v38, v52, v10
+v_dot2_f32_f16 v11, v39, v52, v11
+v_dot2_f32_f16 v12, v40, v52, v12
+v_dot2_f32_f16 v13, v41, v52, v13
+v_dot2_f32_f16 v14, v38, v53, v14
+v_dot2_f32_f16 v15, v39, v53, v15
+v_dot2_f32_f16 v16, v40, v53, v16
+v_dot2_f32_f16 v17, v41, v53, v17
+v_dot2_f32_f16 v18, v38, v54, v18
+v_dot2_f32_f16 v19, v39, v54, v19
+v_dot2_f32_f16 v20, v40, v54, v20
+v_dot2_f32_f16 v21, v41, v54, v21
+v_dot2_f32_f16 v22, v38, v55, v22
+v_dot2_f32_f16 v23, v39, v55, v23
+v_dot2_f32_f16 v24, v40, v55, v24
+v_dot2_f32_f16 v25, v41, v55, v25
+v_dot2_f32_f16 v26, v38, v56, v26
+v_dot2_f32_f16 v27, v39, v56, v27
+v_dot2_f32_f16 v28, v40, v56, v28
+v_dot2_f32_f16 v29, v41, v56, v29
+v_dot2_f32_f16 v30, v38, v57, v30
+v_dot2_f32_f16 v31, v39, v57, v31
+v_dot2_f32_f16 v32, v40, v57, v32
+v_pk_fma_f16 v68, v67, -1.0, v68 op_sel_hi:[1,0,1]
+v_mov_b32_dpp v115, v66  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v66, v115, v112, v66
+v_mov_b32_dpp v115, v67  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v67, v115, v112, v67
+v_mov_b32_dpp v115, v68  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v68, v115, v112, v68
+v_mov_b32_dpp v115, v69  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v69, v115, v112, v69
+s_setprio 0
+s_nop 0
+v_dot2_f32_f16 v33, v41, v57, v33
+v_cmp_eq_u32_e64 vcc, src_lds_direct, s91
+s_nop 0
+s_nop 0
+s_cbranch_vccz 65531
+s_nop 0
+ds_read_b128 v[38:41], v107 offset:25280
+ds_read_b128 v[50:53], v102 offset:24768
+ds_read_b128 v[54:57], v102 offset:24896
+ds_write_b32 v105, v64
+ds_write_b32 v106, v65
+s_setprio 1
+s_add_u32 s40, s40, s69
+s_addc_u32 s41, s41, 0
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v90, v94, s[40:43], 0 offen
+buffer_load_short_d16 v92, v96, s[40:43], 0 offen
+buffer_load_short_d16 v91, v95, s[40:43], 0 offen
+buffer_load_short_d16 v93, v97, s[40:43], 0 offen
+s_nop 0
+s_waitcnt vmcnt(16) lgkmcnt(5)
+s_bitset1_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 64097
+s_call_b64 s[38:39], 1456
+s_branch 64095
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_dot2_f32_f16 v2, v34, v42, v2
+v_dot2_f32_f16 v3, v35, v42, v3
+v_dot2_f32_f16 v4, v36, v42, v4
+v_dot2_f32_f16 v5, v37, v42, v5
+s_setprio 1
+s_nop 0
+v_dot2_f32_f16 v6, v34, v43, v6
+v_dot2_f32_f16 v7, v35, v43, v7
+v_dot2_f32_f16 v8, v36, v43, v8
+v_dot2_f32_f16 v9, v37, v43, v9
+v_dot2_f32_f16 v10, v34, v44, v10
+v_dot2_f32_f16 v11, v35, v44, v11
+v_dot2_f32_f16 v12, v36, v44, v12
+v_dot2_f32_f16 v13, v37, v44, v13
+v_dot2_f32_f16 v14, v34, v45, v14
+v_dot2_f32_f16 v15, v35, v45, v15
+v_dot2_f32_f16 v16, v36, v45, v16
+v_dot2_f32_f16 v17, v37, v45, v17
+v_dot2_f32_f16 v18, v34, v46, v18
+v_dot2_f32_f16 v19, v35, v46, v19
+v_dot2_f32_f16 v20, v36, v46, v20
+v_dot2_f32_f16 v21, v37, v46, v21
+v_dot2_f32_f16 v22, v34, v47, v22
+v_dot2_f32_f16 v23, v35, v47, v23
+v_dot2_f32_f16 v24, v36, v47, v24
+v_dot2_f32_f16 v25, v37, v47, v25
+v_dot2_f32_f16 v26, v34, v48, v26
+v_dot2_f32_f16 v27, v35, v48, v27
+v_dot2_f32_f16 v28, v36, v48, v28
+v_dot2_f32_f16 v29, v37, v48, v29
+v_dot2_f32_f16 v30, v34, v49, v30
+v_dot2_f32_f16 v31, v35, v49, v31
+v_pack_b32_f16 v70, v82, v70
+v_pack_b32_f16 v71, v83, v71
+v_pack_b32_f16 v72, v84, v72
+v_pack_b32_f16 v73, v85, v73
+v_mov_b32_dpp v70, v71  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_pk_add_f16 v70, v70, v71
+v_mov_b32_dpp v71, v71  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v70, v71, v112, v70
+v_mov_b32_dpp v71, v73  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_pk_add_f16 v71, v71, v73
+v_dot2_f32_f16 v32, v36, v49, v32
+v_dot2_f32_f16 v33, v37, v49, v33
+s_nop 0
+ds_read_b128 v[34:37], v107 offset:29440
+ds_read_b128 v[42:45], v102 offset:28928
+ds_read_b128 v[46:49], v102 offset:29056
+ds_write_b32 v103, v62
+ds_write_b32 v104, v63
+s_setprio 0
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v60, v96, s[40:43], 0 offen
+buffer_load_short_d16 v59, v95, s[40:43], 0 offen
+buffer_load_short_d16 v61, v97, s[40:43], 0 offen
+s_add_u32 s91, s91, 0x200
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 4
+s_call_b64 s[38:39], 1331
+s_nop 0
+s_nop 0
+s_nop 0
+v_dot2_f32_f16 v2, v38, v50, v2
+v_dot2_f32_f16 v3, v39, v50, v3
+v_dot2_f32_f16 v4, v40, v50, v4
+v_dot2_f32_f16 v5, v41, v50, v5
+s_setprio 1
+s_nop 0
+v_dot2_f32_f16 v6, v38, v51, v6
+v_dot2_f32_f16 v7, v39, v51, v7
+v_dot2_f32_f16 v8, v40, v51, v8
+v_dot2_f32_f16 v9, v41, v51, v9
+v_dot2_f32_f16 v10, v38, v52, v10
+v_dot2_f32_f16 v11, v39, v52, v11
+v_dot2_f32_f16 v12, v40, v52, v12
+v_dot2_f32_f16 v13, v41, v52, v13
+v_dot2_f32_f16 v14, v38, v53, v14
+v_dot2_f32_f16 v15, v39, v53, v15
+v_dot2_f32_f16 v16, v40, v53, v16
+v_dot2_f32_f16 v17, v41, v53, v17
+v_dot2_f32_f16 v18, v38, v54, v18
+v_dot2_f32_f16 v19, v39, v54, v19
+v_dot2_f32_f16 v20, v40, v54, v20
+v_dot2_f32_f16 v21, v41, v54, v21
+v_dot2_f32_f16 v22, v38, v55, v22
+v_dot2_f32_f16 v23, v39, v55, v23
+v_dot2_f32_f16 v24, v40, v55, v24
+v_dot2_f32_f16 v25, v41, v55, v25
+v_dot2_f32_f16 v26, v38, v56, v26
+v_dot2_f32_f16 v27, v39, v56, v27
+v_dot2_f32_f16 v28, v40, v56, v28
+v_dot2_f32_f16 v29, v41, v56, v29
+v_dot2_f32_f16 v30, v38, v57, v30
+v_dot2_f32_f16 v31, v39, v57, v31
+v_mov_b32_dpp v73, v73  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v71, v73, v112, v71
+v_mov_b32_dpp v73, v72  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_pk_add_f16 v73, v73, v72
+v_mov_b32_dpp v72, v72  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v73, v72, v112, v73
+v_pk_add_f16 v72, v70, v73
+v_pk_add_f16 v71, v71, v72
+v_pk_mul_f16 v71, v71, 0.5 op_sel_hi:[1,0]
+v_pk_fma_f16 v72, -1.0, v71, v72 op_sel_hi:[0,1,1]
+v_dot2_f32_f16 v32, v40, v57, v32
+v_dot2_f32_f16 v33, v41, v57, v33
+s_nop 0
+ds_read_b128 v[38:41], v107 offset:33536
+ds_read_b128 v[50:53], v102 offset:33024
+ds_read_b128 v[54:57], v102 offset:33152
+ds_write_b32 v105, v68 offset:8256
+ds_write_b32 v106, v69 offset:8256
+s_setprio 0
+s_add_u32 s40, s40, s69
+s_addc_u32 s41, s41, 0
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v84, v96, s[40:43], 0 offen
+buffer_load_short_d16 v83, v95, s[40:43], 0 offen
+buffer_load_short_d16 v85, v97, s[40:43], 0 offen
+s_nop 0
+s_waitcnt vmcnt(12) lgkmcnt(5)
+ds_append v117 offset:65472
+s_bitset1_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 4
+s_call_b64 s[38:39], 1211
+s_nop 0
+s_nop 0
+s_nop 0
+v_dot2_f32_f16 v2, v34, v42, v2
+v_dot2_f32_f16 v3, v35, v42, v3
+v_dot2_f32_f16 v4, v36, v42, v4
+v_dot2_f32_f16 v5, v37, v42, v5
+s_setprio 1
+s_nop 0
+v_dot2_f32_f16 v6, v34, v43, v6
+v_dot2_f32_f16 v7, v35, v43, v7
+v_dot2_f32_f16 v8, v36, v43, v8
+v_dot2_f32_f16 v9, v37, v43, v9
+v_dot2_f32_f16 v10, v34, v44, v10
+v_dot2_f32_f16 v11, v35, v44, v11
+v_dot2_f32_f16 v12, v36, v44, v12
+v_dot2_f32_f16 v13, v37, v44, v13
+v_dot2_f32_f16 v14, v34, v45, v14
+v_dot2_f32_f16 v15, v35, v45, v15
+v_dot2_f32_f16 v16, v36, v45, v16
+v_dot2_f32_f16 v17, v37, v45, v17
+v_dot2_f32_f16 v18, v34, v46, v18
+v_dot2_f32_f16 v19, v35, v46, v19
+v_dot2_f32_f16 v20, v36, v46, v20
+v_dot2_f32_f16 v21, v37, v46, v21
+v_dot2_f32_f16 v22, v34, v47, v22
+v_dot2_f32_f16 v23, v35, v47, v23
+v_dot2_f32_f16 v24, v36, v47, v24
+v_dot2_f32_f16 v25, v37, v47, v25
+v_dot2_f32_f16 v26, v34, v48, v26
+v_dot2_f32_f16 v27, v35, v48, v27
+v_dot2_f32_f16 v28, v36, v48, v28
+v_dot2_f32_f16 v29, v37, v48, v29
+v_dot2_f32_f16 v30, v34, v49, v30
+v_dot2_f32_f16 v31, v35, v49, v31
+v_pack_b32_f16 v74, v86, v74
+v_pack_b32_f16 v75, v87, v75
+v_pack_b32_f16 v76, v88, v76
+v_pack_b32_f16 v77, v89, v77
+v_mov_b32_dpp v74, v75  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_pk_add_f16 v74, v74, v75
+v_mov_b32_dpp v75, v75  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v74, v75, v112, v74
+v_mov_b32_dpp v75, v77  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_pk_add_f16 v75, v75, v77
+v_dot2_f32_f16 v32, v36, v49, v32
+v_dot2_f32_f16 v33, v37, v49, v33
+s_nop 0
+ds_read_b128 v[34:37], v107 offset:37696
+ds_read_b128 v[42:45], v102 offset:37184
+ds_read_b128 v[46:49], v102 offset:37312
+ds_write_b32 v103, v66 offset:8256
+ds_write_b32 v104, v67 offset:8256
+s_setprio 0
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v64, v96, s[40:43], 0 offen
+buffer_load_short_d16 v63, v95, s[40:43], 0 offen
+buffer_load_short_d16 v65, v97, s[40:43], 0 offen
+s_mov_b32 m0, 0x2ffc0
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 4
+s_call_b64 s[38:39], 1091
+s_nop 0
+s_nop 0
+s_nop 0
+v_dot2_f32_f16 v2, v38, v50, v2
+v_dot2_f32_f16 v3, v39, v50, v3
+v_dot2_f32_f16 v4, v40, v50, v4
+v_dot2_f32_f16 v5, v41, v50, v5
+s_setprio 1
+s_nop 0
+v_dot2_f32_f16 v6, v38, v51, v6
+v_dot2_f32_f16 v7, v39, v51, v7
+v_dot2_f32_f16 v8, v40, v51, v8
+v_dot2_f32_f16 v9, v41, v51, v9
+v_dot2_f32_f16 v10, v38, v52, v10
+v_dot2_f32_f16 v11, v39, v52, v11
+v_dot2_f32_f16 v12, v40, v52, v12
+v_dot2_f32_f16 v13, v41, v52, v13
+v_dot2_f32_f16 v14, v38, v53, v14
+v_dot2_f32_f16 v15, v39, v53, v15
+v_dot2_f32_f16 v16, v40, v53, v16
+v_dot2_f32_f16 v17, v41, v53, v17
+v_dot2_f32_f16 v18, v38, v54, v18
+v_dot2_f32_f16 v19, v39, v54, v19
+v_dot2_f32_f16 v20, v40, v54, v20
+v_dot2_f32_f16 v21, v41, v54, v21
+v_dot2_f32_f16 v22, v38, v55, v22
+v_dot2_f32_f16 v23, v39, v55, v23
+v_dot2_f32_f16 v24, v40, v55, v24
+v_dot2_f32_f16 v25, v41, v55, v25
+v_dot2_f32_f16 v26, v38, v56, v26
+v_dot2_f32_f16 v27, v39, v56, v27
+v_dot2_f32_f16 v28, v40, v56, v28
+v_dot2_f32_f16 v29, v41, v56, v29
+v_dot2_f32_f16 v30, v38, v57, v30
+v_dot2_f32_f16 v31, v39, v57, v31
+v_dot2_f32_f16 v32, v40, v57, v32
+v_mov_b32_dpp v77, v77  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v75, v77, v112, v75
+v_mov_b32_dpp v77, v76  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_pk_add_f16 v77, v77, v76
+v_mov_b32_dpp v76, v76  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v77, v76, v112, v77
+v_pk_add_f16 v76, v74, v77
+v_pk_add_f16 v75, v75, v76
+v_pk_mul_f16 v75, v75, 0.5 op_sel_hi:[1,0]
+v_pk_fma_f16 v76, -1.0, v75, v76 op_sel_hi:[0,1,1]
+v_dot2_f32_f16 v33, v41, v57, v33
+v_cmp_eq_u32_e64 vcc, src_lds_direct, s91
+s_nop 0
+s_nop 0
+s_cbranch_vccz 65531
+s_nop 0
+ds_read_b128 v[38:41], v107 offset:41792
+ds_read_b128 v[50:53], v102 offset:41280
+ds_read_b128 v[54:57], v102 offset:41408
+ds_write_b32 v105, v72 offset:16512
+ds_write_b32 v106, v73 offset:16512
+s_setprio 0
+s_add_u32 s40, s40, s69
+s_addc_u32 s41, s41, 0
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v88, v96, s[40:43], 0 offen
+buffer_load_short_d16 v87, v95, s[40:43], 0 offen
+buffer_load_short_d16 v89, v97, s[40:43], 0 offen
+s_nop 0
+s_waitcnt vmcnt(12) lgkmcnt(5)
+s_bitset1_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 1
+s_call_b64 s[38:39], 968
+v_dot2_f32_f16 v2, v34, v42, v2
+v_dot2_f32_f16 v3, v35, v42, v3
+v_dot2_f32_f16 v4, v36, v42, v4
+v_dot2_f32_f16 v5, v37, v42, v5
+s_setprio 1
+s_nop 0
+v_dot2_f32_f16 v6, v34, v43, v6
+v_dot2_f32_f16 v7, v35, v43, v7
+v_dot2_f32_f16 v8, v36, v43, v8
+v_dot2_f32_f16 v9, v37, v43, v9
+v_dot2_f32_f16 v10, v34, v44, v10
+v_dot2_f32_f16 v11, v35, v44, v11
+v_dot2_f32_f16 v12, v36, v44, v12
+v_dot2_f32_f16 v13, v37, v44, v13
+v_dot2_f32_f16 v14, v34, v45, v14
+v_dot2_f32_f16 v15, v35, v45, v15
+v_dot2_f32_f16 v16, v36, v45, v16
+v_dot2_f32_f16 v17, v37, v45, v17
+v_dot2_f32_f16 v18, v34, v46, v18
+v_dot2_f32_f16 v19, v35, v46, v19
+v_dot2_f32_f16 v20, v36, v46, v20
+v_dot2_f32_f16 v21, v37, v46, v21
+v_dot2_f32_f16 v22, v34, v47, v22
+v_dot2_f32_f16 v23, v35, v47, v23
+v_dot2_f32_f16 v24, v36, v47, v24
+v_dot2_f32_f16 v25, v37, v47, v25
+v_dot2_f32_f16 v26, v34, v48, v26
+v_dot2_f32_f16 v27, v35, v48, v27
+v_dot2_f32_f16 v28, v36, v48, v28
+v_dot2_f32_f16 v29, v37, v48, v29
+v_dot2_f32_f16 v30, v34, v49, v30
+v_dot2_f32_f16 v31, v35, v49, v31
+v_pack_b32_f16 v78, v90, v78
+v_pack_b32_f16 v79, v91, v79
+v_pack_b32_f16 v80, v92, v80
+v_pack_b32_f16 v81, v93, v81
+v_mov_b32_dpp v78, v79  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_pk_add_f16 v78, v78, v79
+v_mov_b32_dpp v79, v79  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v78, v79, v112, v78
+v_mov_b32_dpp v79, v81  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_pk_add_f16 v79, v79, v81
+v_dot2_f32_f16 v32, v36, v49, v32
+v_dot2_f32_f16 v33, v37, v49, v33
+s_nop 0
+ds_read_b128 v[34:37], v107 offset:45952
+ds_read_b128 v[42:45], v102 offset:45440
+ds_read_b128 v[46:49], v102 offset:45568
+ds_write_b32 v103, v70 offset:16512
+ds_write_b32 v104, v71 offset:16512
+s_setprio 0
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v68, v96, s[40:43], 0 offen
+buffer_load_short_d16 v67, v95, s[40:43], 0 offen
+buffer_load_short_d16 v69, v97, s[40:43], 0 offen
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 6
+s_call_b64 s[38:39], 853
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_dot2_f32_f16 v2, v38, v50, v2
+v_dot2_f32_f16 v3, v39, v50, v3
+v_dot2_f32_f16 v4, v40, v50, v4
+v_dot2_f32_f16 v5, v41, v50, v5
+s_setprio 1
+s_nop 0
+v_dot2_f32_f16 v6, v38, v51, v6
+v_dot2_f32_f16 v7, v39, v51, v7
+v_dot2_f32_f16 v8, v40, v51, v8
+v_dot2_f32_f16 v9, v41, v51, v9
+v_dot2_f32_f16 v10, v38, v52, v10
+v_dot2_f32_f16 v11, v39, v52, v11
+v_dot2_f32_f16 v12, v40, v52, v12
+v_dot2_f32_f16 v13, v41, v52, v13
+v_dot2_f32_f16 v14, v38, v53, v14
+v_dot2_f32_f16 v15, v39, v53, v15
+v_dot2_f32_f16 v16, v40, v53, v16
+v_dot2_f32_f16 v17, v41, v53, v17
+v_dot2_f32_f16 v18, v38, v54, v18
+v_dot2_f32_f16 v19, v39, v54, v19
+v_dot2_f32_f16 v20, v40, v54, v20
+v_dot2_f32_f16 v21, v41, v54, v21
+v_dot2_f32_f16 v22, v38, v55, v22
+v_dot2_f32_f16 v23, v39, v55, v23
+v_dot2_f32_f16 v24, v40, v55, v24
+v_dot2_f32_f16 v25, v41, v55, v25
+v_dot2_f32_f16 v26, v38, v56, v26
+v_dot2_f32_f16 v27, v39, v56, v27
+v_dot2_f32_f16 v28, v40, v56, v28
+v_dot2_f32_f16 v29, v41, v56, v29
+v_dot2_f32_f16 v30, v38, v57, v30
+v_dot2_f32_f16 v31, v39, v57, v31
+v_mov_b32_dpp v81, v81  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v79, v81, v112, v79
+v_mov_b32_dpp v81, v80  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_pk_add_f16 v81, v81, v80
+v_mov_b32_dpp v80, v80  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v81, v80, v112, v81
+v_pk_add_f16 v80, v78, v81
+v_pk_add_f16 v79, v79, v80
+v_pk_mul_f16 v79, v79, 0.5 op_sel_hi:[1,0]
+v_pk_fma_f16 v80, -1.0, v79, v80 op_sel_hi:[0,1,1]
+v_dot2_f32_f16 v32, v40, v57, v32
+v_dot2_f32_f16 v33, v41, v57, v33
+s_nop 0
+ds_read_b128 v[38:41], v107 offset:512
+ds_read_b128 v[50:53], v102
+ds_read_b128 v[54:57], v102 offset:128
+ds_write_b32 v105, v76 offset:24768
+ds_write_b32 v106, v77 offset:24768
+s_setprio 0
+s_add_u32 s40, s40, s69
+s_addc_u32 s41, s41, 0
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v92, v96, s[40:43], 0 offen
+buffer_load_short_d16 v91, v95, s[40:43], 0 offen
+buffer_load_short_d16 v93, v97, s[40:43], 0 offen
+s_nop 0
+s_waitcnt vmcnt(12) lgkmcnt(5)
+ds_append v117 offset:65476
+s_bitset1_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 4
+s_call_b64 s[38:39], 731
+s_nop 0
+s_nop 0
+s_nop 0
+v_dot2_f32_f16 v2, v34, v42, v2
+v_dot2_f32_f16 v3, v35, v42, v3
+v_dot2_f32_f16 v4, v36, v42, v4
+v_dot2_f32_f16 v5, v37, v42, v5
+s_setprio 1
+s_nop 0
+v_dot2_f32_f16 v6, v34, v43, v6
+v_dot2_f32_f16 v7, v35, v43, v7
+v_dot2_f32_f16 v8, v36, v43, v8
+v_dot2_f32_f16 v9, v37, v43, v9
+v_dot2_f32_f16 v10, v34, v44, v10
+v_dot2_f32_f16 v11, v35, v44, v11
+v_dot2_f32_f16 v12, v36, v44, v12
+v_dot2_f32_f16 v13, v37, v44, v13
+v_dot2_f32_f16 v14, v34, v45, v14
+v_dot2_f32_f16 v15, v35, v45, v15
+v_dot2_f32_f16 v16, v36, v45, v16
+v_dot2_f32_f16 v17, v37, v45, v17
+v_dot2_f32_f16 v18, v34, v46, v18
+v_dot2_f32_f16 v19, v35, v46, v19
+v_dot2_f32_f16 v20, v36, v46, v20
+v_dot2_f32_f16 v21, v37, v46, v21
+v_dot2_f32_f16 v22, v34, v47, v22
+v_dot2_f32_f16 v23, v35, v47, v23
+v_dot2_f32_f16 v24, v36, v47, v24
+v_dot2_f32_f16 v25, v37, v47, v25
+v_dot2_f32_f16 v26, v34, v48, v26
+v_dot2_f32_f16 v27, v35, v48, v27
+v_dot2_f32_f16 v28, v36, v48, v28
+v_dot2_f32_f16 v29, v37, v48, v29
+v_dot2_f32_f16 v30, v34, v49, v30
+v_dot2_f32_f16 v31, v35, v49, v31
+v_pack_b32_f16 v58, v82, v58
+v_pack_b32_f16 v59, v83, v59
+v_pack_b32_f16 v60, v84, v60
+v_pack_b32_f16 v61, v85, v61
+v_mov_b32_dpp v58, v59  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_pk_add_f16 v58, v58, v59
+v_mov_b32_dpp v59, v59  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v58, v59, v112, v58
+v_mov_b32_dpp v59, v61  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_pk_add_f16 v59, v59, v61
+v_dot2_f32_f16 v32, v36, v49, v32
+v_dot2_f32_f16 v33, v37, v49, v33
+s_nop 0
+ds_read_b128 v[34:37], v107 offset:4672
+ds_read_b128 v[42:45], v102 offset:4160
+ds_read_b128 v[46:49], v102 offset:4288
+ds_write_b32 v103, v74 offset:24768
+ds_write_b32 v104, v75 offset:24768
+s_setprio 0
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v72, v96, s[40:43], 0 offen
+buffer_load_short_d16 v71, v95, s[40:43], 0 offen
+buffer_load_short_d16 v73, v97, s[40:43], 0 offen
+s_mov_b32 m0, 0x2ffc4
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 4
+s_call_b64 s[38:39], 611
+s_nop 0
+s_nop 0
+s_nop 0
+v_dot2_f32_f16 v2, v38, v50, v2
+v_dot2_f32_f16 v3, v39, v50, v3
+v_dot2_f32_f16 v4, v40, v50, v4
+v_dot2_f32_f16 v5, v41, v50, v5
+s_setprio 1
+s_nop 0
+v_dot2_f32_f16 v6, v38, v51, v6
+v_dot2_f32_f16 v7, v39, v51, v7
+v_dot2_f32_f16 v8, v40, v51, v8
+v_dot2_f32_f16 v9, v41, v51, v9
+v_dot2_f32_f16 v10, v38, v52, v10
+v_dot2_f32_f16 v11, v39, v52, v11
+v_dot2_f32_f16 v12, v40, v52, v12
+v_dot2_f32_f16 v13, v41, v52, v13
+v_dot2_f32_f16 v14, v38, v53, v14
+v_dot2_f32_f16 v15, v39, v53, v15
+v_dot2_f32_f16 v16, v40, v53, v16
+v_dot2_f32_f16 v17, v41, v53, v17
+v_dot2_f32_f16 v18, v38, v54, v18
+v_dot2_f32_f16 v19, v39, v54, v19
+v_dot2_f32_f16 v20, v40, v54, v20
+v_dot2_f32_f16 v21, v41, v54, v21
+v_dot2_f32_f16 v22, v38, v55, v22
+v_dot2_f32_f16 v23, v39, v55, v23
+v_dot2_f32_f16 v24, v40, v55, v24
+v_dot2_f32_f16 v25, v41, v55, v25
+v_dot2_f32_f16 v26, v38, v56, v26
+v_dot2_f32_f16 v27, v39, v56, v27
+v_dot2_f32_f16 v28, v40, v56, v28
+v_dot2_f32_f16 v29, v41, v56, v29
+v_dot2_f32_f16 v30, v38, v57, v30
+v_dot2_f32_f16 v31, v39, v57, v31
+v_dot2_f32_f16 v32, v40, v57, v32
+v_mov_b32_dpp v61, v61  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v59, v61, v112, v59
+v_mov_b32_dpp v61, v60  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_pk_add_f16 v61, v61, v60
+v_mov_b32_dpp v60, v60  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v61, v60, v112, v61
+v_pk_add_f16 v60, v58, v61
+v_pk_add_f16 v59, v59, v60
+v_pk_mul_f16 v59, v59, 0.5 op_sel_hi:[1,0]
+v_pk_fma_f16 v60, -1.0, v59, v60 op_sel_hi:[0,1,1]
+v_dot2_f32_f16 v33, v41, v57, v33
+v_cmp_eq_u32_e64 vcc, src_lds_direct, s91
+s_nop 0
+s_nop 0
+s_cbranch_vccz 65531
+s_nop 0
+ds_read_b128 v[38:41], v107 offset:8768
+ds_read_b128 v[50:53], v102 offset:8256
+ds_read_b128 v[54:57], v102 offset:8384
+ds_write_b32 v105, v80 offset:33024
+ds_write_b32 v106, v81 offset:33024
+s_setprio 0
+s_add_u32 s40, s40, s69
+s_addc_u32 s41, s41, 0
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v84, v96, s[40:43], 0 offen
+buffer_load_short_d16 v83, v95, s[40:43], 0 offen
+buffer_load_short_d16 v85, v97, s[40:43], 0 offen
+s_nop 0
+s_waitcnt vmcnt(12) lgkmcnt(5)
+s_bitset1_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 1
+s_call_b64 s[38:39], 488
+v_dot2_f32_f16 v2, v34, v42, v2
+v_dot2_f32_f16 v3, v35, v42, v3
+v_dot2_f32_f16 v4, v36, v42, v4
+v_dot2_f32_f16 v5, v37, v42, v5
+s_setprio 1
+s_nop 0
+v_dot2_f32_f16 v6, v34, v43, v6
+v_dot2_f32_f16 v7, v35, v43, v7
+v_dot2_f32_f16 v8, v36, v43, v8
+v_dot2_f32_f16 v9, v37, v43, v9
+v_dot2_f32_f16 v10, v34, v44, v10
+v_dot2_f32_f16 v11, v35, v44, v11
+v_dot2_f32_f16 v12, v36, v44, v12
+v_dot2_f32_f16 v13, v37, v44, v13
+v_dot2_f32_f16 v14, v34, v45, v14
+v_dot2_f32_f16 v15, v35, v45, v15
+v_dot2_f32_f16 v16, v36, v45, v16
+v_dot2_f32_f16 v17, v37, v45, v17
+v_dot2_f32_f16 v18, v34, v46, v18
+v_dot2_f32_f16 v19, v35, v46, v19
+v_dot2_f32_f16 v20, v36, v46, v20
+v_dot2_f32_f16 v21, v37, v46, v21
+v_dot2_f32_f16 v22, v34, v47, v22
+v_dot2_f32_f16 v23, v35, v47, v23
+v_dot2_f32_f16 v24, v36, v47, v24
+v_dot2_f32_f16 v25, v37, v47, v25
+v_dot2_f32_f16 v26, v34, v48, v26
+v_dot2_f32_f16 v27, v35, v48, v27
+v_dot2_f32_f16 v28, v36, v48, v28
+v_dot2_f32_f16 v29, v37, v48, v29
+v_dot2_f32_f16 v30, v34, v49, v30
+v_dot2_f32_f16 v31, v35, v49, v31
+v_pack_b32_f16 v62, v86, v62
+v_pack_b32_f16 v63, v87, v63
+v_pack_b32_f16 v64, v88, v64
+v_pack_b32_f16 v65, v89, v65
+v_mov_b32_dpp v62, v63  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_pk_add_f16 v62, v62, v63
+v_mov_b32_dpp v63, v63  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v62, v63, v112, v62
+v_mov_b32_dpp v63, v65  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_pk_add_f16 v63, v63, v65
+v_dot2_f32_f16 v32, v36, v49, v32
+v_dot2_f32_f16 v33, v37, v49, v33
+s_nop 0
+ds_read_b128 v[34:37], v107 offset:12928
+ds_read_b128 v[42:45], v102 offset:12416
+ds_read_b128 v[46:49], v102 offset:12544
+ds_write_b32 v103, v78 offset:33024
+ds_write_b32 v104, v79 offset:33024
+s_setprio 0
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v76, v96, s[40:43], 0 offen
+buffer_load_short_d16 v75, v95, s[40:43], 0 offen
+buffer_load_short_d16 v77, v97, s[40:43], 0 offen
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 6
+s_call_b64 s[38:39], 373
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_dot2_f32_f16 v2, v38, v50, v2
+v_dot2_f32_f16 v3, v39, v50, v3
+v_dot2_f32_f16 v4, v40, v50, v4
+v_dot2_f32_f16 v5, v41, v50, v5
+s_setprio 1
+s_nop 0
+v_dot2_f32_f16 v6, v38, v51, v6
+v_dot2_f32_f16 v7, v39, v51, v7
+v_dot2_f32_f16 v8, v40, v51, v8
+v_dot2_f32_f16 v9, v41, v51, v9
+v_dot2_f32_f16 v10, v38, v52, v10
+v_dot2_f32_f16 v11, v39, v52, v11
+v_dot2_f32_f16 v12, v40, v52, v12
+v_dot2_f32_f16 v13, v41, v52, v13
+v_dot2_f32_f16 v14, v38, v53, v14
+v_dot2_f32_f16 v15, v39, v53, v15
+v_dot2_f32_f16 v16, v40, v53, v16
+v_dot2_f32_f16 v17, v41, v53, v17
+v_dot2_f32_f16 v18, v38, v54, v18
+v_dot2_f32_f16 v19, v39, v54, v19
+v_dot2_f32_f16 v20, v40, v54, v20
+v_dot2_f32_f16 v21, v41, v54, v21
+v_dot2_f32_f16 v22, v38, v55, v22
+v_dot2_f32_f16 v23, v39, v55, v23
+v_dot2_f32_f16 v24, v40, v55, v24
+v_dot2_f32_f16 v25, v41, v55, v25
+v_dot2_f32_f16 v26, v38, v56, v26
+v_dot2_f32_f16 v27, v39, v56, v27
+v_dot2_f32_f16 v28, v40, v56, v28
+v_dot2_f32_f16 v29, v41, v56, v29
+v_dot2_f32_f16 v30, v38, v57, v30
+v_dot2_f32_f16 v31, v39, v57, v31
+v_mov_b32_dpp v65, v65  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v63, v65, v112, v63
+v_mov_b32_dpp v65, v64  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_pk_add_f16 v65, v65, v64
+v_mov_b32_dpp v64, v64  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v65, v64, v112, v65
+v_pk_add_f16 v64, v62, v65
+v_pk_add_f16 v63, v63, v64
+v_pk_mul_f16 v63, v63, 0.5 op_sel_hi:[1,0]
+v_pk_fma_f16 v64, -1.0, v63, v64 op_sel_hi:[0,1,1]
+v_dot2_f32_f16 v32, v40, v57, v32
+v_dot2_f32_f16 v33, v41, v57, v33
+s_nop 0
+ds_read_b128 v[38:41], v107 offset:17024
+ds_read_b128 v[50:53], v102 offset:16512
+ds_read_b128 v[54:57], v102 offset:16640
+ds_write_b32 v105, v60 offset:41280
+ds_write_b32 v106, v61 offset:41280
+s_setprio 0
+s_add_u32 s40, s40, s69
+s_addc_u32 s41, s41, 0
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v88, v96, s[40:43], 0 offen
+buffer_load_short_d16 v87, v95, s[40:43], 0 offen
+buffer_load_short_d16 v89, v97, s[40:43], 0 offen
+s_nop 0
+s_waitcnt vmcnt(12) lgkmcnt(5)
+ds_append v117 offset:65480
+s_bitset1_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 4
+s_call_b64 s[38:39], 251
+s_nop 0
+s_nop 0
+s_nop 0
+v_dot2_f32_f16 v2, v34, v42, v2
+v_dot2_f32_f16 v3, v35, v42, v3
+v_dot2_f32_f16 v4, v36, v42, v4
+v_dot2_f32_f16 v5, v37, v42, v5
+s_setprio 1
+s_nop 0
+v_dot2_f32_f16 v6, v34, v43, v6
+v_dot2_f32_f16 v7, v35, v43, v7
+v_dot2_f32_f16 v8, v36, v43, v8
+v_dot2_f32_f16 v9, v37, v43, v9
+v_dot2_f32_f16 v10, v34, v44, v10
+v_dot2_f32_f16 v11, v35, v44, v11
+v_dot2_f32_f16 v12, v36, v44, v12
+v_dot2_f32_f16 v13, v37, v44, v13
+v_dot2_f32_f16 v14, v34, v45, v14
+v_dot2_f32_f16 v15, v35, v45, v15
+v_dot2_f32_f16 v16, v36, v45, v16
+v_dot2_f32_f16 v17, v37, v45, v17
+v_dot2_f32_f16 v18, v34, v46, v18
+v_dot2_f32_f16 v19, v35, v46, v19
+v_dot2_f32_f16 v20, v36, v46, v20
+v_dot2_f32_f16 v21, v37, v46, v21
+v_dot2_f32_f16 v22, v34, v47, v22
+v_dot2_f32_f16 v23, v35, v47, v23
+v_dot2_f32_f16 v24, v36, v47, v24
+v_dot2_f32_f16 v25, v37, v47, v25
+v_dot2_f32_f16 v26, v34, v48, v26
+v_dot2_f32_f16 v27, v35, v48, v27
+v_dot2_f32_f16 v28, v36, v48, v28
+v_dot2_f32_f16 v29, v37, v48, v29
+v_dot2_f32_f16 v30, v34, v49, v30
+v_dot2_f32_f16 v31, v35, v49, v31
+v_pack_b32_f16 v66, v90, v66
+v_pack_b32_f16 v67, v91, v67
+v_pack_b32_f16 v68, v92, v68
+v_pack_b32_f16 v69, v93, v69
+v_mov_b32_dpp v66, v67  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_pk_add_f16 v66, v66, v67
+v_mov_b32_dpp v67, v67  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v66, v67, v112, v66
+v_mov_b32_dpp v67, v69  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_pk_add_f16 v67, v67, v69
+v_dot2_f32_f16 v32, v36, v49, v32
+v_dot2_f32_f16 v33, v37, v49, v33
+s_nop 0
+ds_read_b128 v[34:37], v107 offset:21184
+ds_read_b128 v[42:45], v102 offset:20672
+ds_read_b128 v[46:49], v102 offset:20800
+ds_write_b32 v103, v58 offset:41280
+ds_write_b32 v104, v59 offset:41280
+s_setprio 0
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v80, v96, s[40:43], 0 offen
+buffer_load_short_d16 v79, v95, s[40:43], 0 offen
+buffer_load_short_d16 v81, v97, s[40:43], 0 offen
+s_mov_b32 m0, 0x2ffc8
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 4
+s_call_b64 s[38:39], 131
+s_nop 0
+s_nop 0
+s_nop 0
+v_dot2_f32_f16 v2, v38, v50, v2
+v_dot2_f32_f16 v3, v39, v50, v3
+v_dot2_f32_f16 v4, v40, v50, v4
+v_dot2_f32_f16 v5, v41, v50, v5
+s_setprio 1
+s_nop 0
+v_dot2_f32_f16 v6, v38, v51, v6
+v_dot2_f32_f16 v7, v39, v51, v7
+v_dot2_f32_f16 v8, v40, v51, v8
+v_dot2_f32_f16 v9, v41, v51, v9
+v_dot2_f32_f16 v10, v38, v52, v10
+v_dot2_f32_f16 v11, v39, v52, v11
+v_dot2_f32_f16 v12, v40, v52, v12
+v_dot2_f32_f16 v13, v41, v52, v13
+v_dot2_f32_f16 v14, v38, v53, v14
+v_dot2_f32_f16 v15, v39, v53, v15
+v_dot2_f32_f16 v16, v40, v53, v16
+v_dot2_f32_f16 v17, v41, v53, v17
+v_dot2_f32_f16 v18, v38, v54, v18
+v_dot2_f32_f16 v19, v39, v54, v19
+v_dot2_f32_f16 v20, v40, v54, v20
+v_dot2_f32_f16 v21, v41, v54, v21
+v_dot2_f32_f16 v22, v38, v55, v22
+v_dot2_f32_f16 v23, v39, v55, v23
+v_dot2_f32_f16 v24, v40, v55, v24
+v_dot2_f32_f16 v25, v41, v55, v25
+v_dot2_f32_f16 v26, v38, v56, v26
+v_dot2_f32_f16 v27, v39, v56, v27
+v_dot2_f32_f16 v28, v40, v56, v28
+v_dot2_f32_f16 v29, v41, v56, v29
+v_dot2_f32_f16 v30, v38, v57, v30
+v_dot2_f32_f16 v31, v39, v57, v31
+v_dot2_f32_f16 v32, v40, v57, v32
+v_mov_b32_dpp v69, v69  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v67, v69, v112, v67
+v_mov_b32_dpp v69, v68  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_pk_add_f16 v69, v69, v68
+v_mov_b32_dpp v68, v68  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v69, v68, v112, v69
+v_pk_add_f16 v68, v66, v69
+v_pk_add_f16 v67, v67, v68
+v_pk_mul_f16 v67, v67, 0.5 op_sel_hi:[1,0]
+v_pk_fma_f16 v68, -1.0, v67, v68 op_sel_hi:[0,1,1]
+v_dot2_f32_f16 v33, v41, v57, v33
+v_cmp_eq_u32_e64 vcc, src_lds_direct, s91
+s_nop 0
+s_nop 0
+s_cbranch_vccz 65531
+s_nop 0
+ds_read_b128 v[38:41], v107 offset:25280
+ds_read_b128 v[50:53], v102 offset:24768
+ds_read_b128 v[54:57], v102 offset:24896
+ds_write_b32 v105, v64
+ds_write_b32 v106, v65
+s_setprio 0
+s_add_u32 s40, s40, s69
+s_addc_u32 s41, s41, 0
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v92, v96, s[40:43], 0 offen
+buffer_load_short_d16 v91, v95, s[40:43], 0 offen
+buffer_load_short_d16 v93, v97, s[40:43], 0 offen
+s_nop 0
+s_waitcnt vmcnt(12) lgkmcnt(5)
+s_bitset1_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 64097
+s_call_b64 s[38:39], 8
+s_branch 64095
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_nop
+s_cmp_eq_u32 s82, 0
+s_cbranch_scc0 8
+s_branch 604
+s_add_u32 s82, s82, 3
+s_andn2_b32 s82, s82, 3
+s_bitcmp0_b32 s18, 26
+s_cselect_b32 s52, s69, s70
+s_cselect_b32 s53, 0, s71
+s_sub_u32 s40, s40, s52
+s_subb_u32 s41, s41, s53
+s_cmp_eq_u32 s94, 0
+s_cbranch_scc0 5
+s_cbranch_scc1 626
+s_nop 0
+s_nop 0
+s_add_u32 s94, s94, 1
+s_andn2_b32 s94, s94, 1
+s_min_u32 s72, s82, s94
+s_sub_u32 s82, s82, s72
+s_sub_u32 s94, s94, s72
+s_sub_u32 s72, s72, 2
+s_setpc_b64 s[38:39]
+s_nop 0
+s_bitcmp1_b32 s18, 17
+s_cbranch_scc1 241
+s_add_u32 s88, s88, s17
+s_cmp_eq_u32 s88, 0
+s_cbranch_scc1 238
+s_mov_b32 s89, 0
+s_bitcmp1_b32 s18, 16
+s_cbranch_scc1 227
+s_add_u32 s87, s16, 31
+s_lshr_b32 s87, s87, 5
+v_mov_b32_e32 v119, s88
+v_mul_u32_u24_e32 v119, s87, v119
+v_add_co_u32_e32 v119, vcc, s17, v119
+v_sub_co_u32_e64 v119, vcc, v119, 1
+v_ffbh_u32_e32 v122, s17
+v_lshlrev_b32_e64 v123, v122, s17
+v_and_b32_e32 v124, 0xffffff00, v123
+v_cmp_eq_u32_e32 vcc, 0x80000000, v123
+v_cvt_f32_u32_e32 v124, v124
+v_rcp_f32_e32 v118, v124
+v_subb_co_u32_e32 v121, vcc, 32, v122, vcc
+v_cvt_f32_ubyte0_e32 v122, v123
+v_fma_f32 v124, v124, v118, -1.0
+v_fma_f32 v124, v122, v118, v124
+v_madak_f32 v124, v124, v118, 0x9f000000
+v_mul_f32_e32 v124, 0x5f800000, v124
+v_mov_b32_e32 v122, 0
+v_cvt_flr_i32_f32_e64 v124, -v124
+v_lshl_add_u32 v118, v118, 9, v124
+v_mad_u64_u32 v[122:123], vcc, v123, v118, v[122:123]
+v_subb_co_u32_e64 v118, vcc, v118, -1, vcc
+v_mul_hi_u32 v122, v119, v118
+v_add_co_u32_e32 v118, vcc, v122, v119
+v_addc_co_u32_e64 v122, vcc, 0, 0, vcc
+v_cmp_eq_u32_e32 vcc, 32, v121
+v_cndmask_b32_e32 v118, v118, v122, vcc
+v_alignbit_b32 v118, v122, v118, v121
+v_readfirstlane_b32 s86, v118
+v_mul_u32_u24_e64 v118, v118, s8
+v_ffbh_u32_e32 v122, s87
+v_lshlrev_b32_e64 v123, v122, s87
+v_and_b32_e32 v124, 0xffffff00, v123
+v_cmp_eq_u32_e32 vcc, 0x80000000, v123
+v_cvt_f32_u32_e32 v124, v124
+v_rcp_f32_e32 v119, v124
+v_subb_co_u32_e32 v121, vcc, 32, v122, vcc
+v_cvt_f32_ubyte0_e32 v122, v123
+v_fma_f32 v124, v124, v119, -1.0
+v_fma_f32 v124, v122, v119, v124
+v_madak_f32 v124, v124, v119, 0x9f000000
+v_mul_f32_e32 v124, 0x5f800000, v124
+v_mov_b32_e32 v122, 0
+v_cvt_flr_i32_f32_e64 v124, -v124
+v_lshl_add_u32 v119, v119, 9, v124
+v_mad_u64_u32 v[122:123], vcc, v123, v119, v[122:123]
+v_subb_co_u32_e64 v119, vcc, v119, -1, vcc
+v_mul_hi_u32 v122, v118, v119
+v_add_co_u32_e32 v119, vcc, v122, v118
+v_addc_co_u32_e64 v122, vcc, 0, 0, vcc
+v_cmp_eq_u32_e32 vcc, 32, v121
+v_cndmask_b32_e32 v119, v119, v122, vcc
+v_alignbit_b32 v119, v122, v119, v121
+v_readfirstlane_b32 s52, v118
+v_readfirstlane_b32 s84, v119
+s_mul_i32 s84, s84, s87
+s_sub_u32 s84, s52, s84
+v_sub_co_u32_e32 v119, vcc, s8, v119
+v_sub_co_u32_e32 v119, vcc, s17, v119
+v_and_b32_e64 v121, v0, 63
+v_cmp_eq_u32_e64 vcc, v121, 0
+v_cndmask_b32_e32 v119, 1, v119, vcc
+s_sub_u32 s58, 0, s75
+s_sub_u32 s59, 0, s74
+v_mul_u32_u24_e64 v123, v119, 32
+v_ffbh_u32_e32 v125, s58
+v_lshlrev_b32_e64 v126, v125, s58
+v_and_b32_e32 v127, 0xffffff00, v126
+v_cmp_eq_u32_e32 vcc, 0x80000000, v126
+v_cvt_f32_u32_e32 v127, v127
+v_rcp_f32_e32 v121, v127
+v_subb_co_u32_e32 v124, vcc, 32, v125, vcc
+v_cvt_f32_ubyte0_e32 v125, v126
+v_fma_f32 v127, v127, v121, -1.0
+v_fma_f32 v127, v125, v121, v127
+v_madak_f32 v127, v127, v121, 0x9f000000
+v_mul_f32_e32 v127, 0x5f800000, v127
+v_mov_b32_e32 v125, 0
+v_cvt_flr_i32_f32_e64 v127, -v127
+v_lshl_add_u32 v121, v121, 9, v127
+v_mad_u64_u32 v[125:126], vcc, v126, v121, v[125:126]
+v_subb_co_u32_e64 v121, vcc, v121, -1, vcc
+v_mul_hi_u32 v125, v123, v121
+v_add_co_u32_e32 v121, vcc, v125, v123
+v_addc_co_u32_e64 v125, vcc, 0, 0, vcc
+v_cmp_eq_u32_e32 vcc, 32, v124
+v_cndmask_b32_e32 v121, v121, v125, vcc
+v_alignbit_b32 v121, v125, v121, v124
+v_mad_i32_i24 v122, v121, s75, v123
+v_mul_u32_u24_e64 v123, v121, 1
+v_ffbh_u32_e32 v125, s59
+v_lshlrev_b32_e64 v126, v125, s59
+v_and_b32_e32 v127, 0xffffff00, v126
+v_cmp_eq_u32_e32 vcc, 0x80000000, v126
+v_cvt_f32_u32_e32 v127, v127
+v_rcp_f32_e32 v121, v127
+v_subb_co_u32_e32 v124, vcc, 32, v125, vcc
+v_cvt_f32_ubyte0_e32 v125, v126
+v_fma_f32 v127, v127, v121, -1.0
+v_fma_f32 v127, v125, v121, v127
+v_madak_f32 v127, v127, v121, 0x9f000000
+v_mul_f32_e32 v127, 0x5f800000, v127
+v_mov_b32_e32 v125, 0
+v_cvt_flr_i32_f32_e64 v127, -v127
+v_lshl_add_u32 v121, v121, 9, v127
+v_mad_u64_u32 v[125:126], vcc, v126, v121, v[125:126]
+v_subb_co_u32_e64 v121, vcc, v121, -1, vcc
+v_mul_hi_u32 v125, v123, v121
+v_add_co_u32_e32 v121, vcc, v125, v123
+v_addc_co_u32_e64 v125, vcc, 0, 0, vcc
+v_cmp_eq_u32_e32 vcc, 32, v124
+v_cndmask_b32_e32 v121, v121, v125, vcc
+v_alignbit_b32 v121, v125, v121, v124
+v_mad_i32_i24 v123, v121, s74, v123
+v_readfirstlane_b32 s76, v122
+v_readfirstlane_b32 s77, v123
+v_readfirstlane_b32 s78, v121
+v_add_co_u32_e32 v108, vcc, s76, v108
+v_addc_co_u32_e64 v124, vcc, 0, 0, vcc
+v_mad_i32_i24 v108, v124, s75, v108
+v_mad_i32_i24 v110, v124, s80, v110
+v_mad_i32_i24 v109, v124, s79, v109
+v_cmp_ge_i32_e64 vcc, v109, 0
+v_addc_co_u32_e64 v124, vcc, 0, 0, vcc
+v_add_co_u32_e32 v110, vcc, v110, v124
+v_mad_i32_i24 v109, v124, s74, v109
+v_add_co_u32_e32 v109, vcc, s77, v109
+v_addc_co_u32_e64 v124, vcc, 0, 0, vcc
+v_add_co_u32_e32 v110, vcc, v110, v124
+v_mad_i32_i24 v109, v124, s74, v109
+v_add_co_u32_e32 v110, vcc, s78, v110
+v_readlane_b32 s76, v122, 1
+v_readlane_b32 s77, v123, 1
+v_readlane_b32 s78, v121, 1
+s_add_u32 s85, s84, s86
+s_cmp_le_u32 s85, s87
+s_cselect_b32 s52, 0x20000, 0
+s_cselect_b32 s85, s85, s87
+s_or_b32 s18, s18, s52
+s_lshl_b32 s84, s84, 5
+s_lshl_b32 s85, s85, 5
+s_min_u32 s85, s85, s16
+s_cmp_eq_u32 s8, s17
+s_cselect_b32 s52, 0x20000, 0
+s_or_b32 s18, s18, s52
+s_or_b32 s18, s18, s52
+s_bitset1_b32 s18, 16
+s_branch 43
+s_lshr_b32 s84, s84, 5
+s_add_u32 s85, s84, s86
+s_sub_u32 s85, s85, s87
+s_mov_b32 s84, 0
+s_lshl_b32 s85, s85, 5
+s_min_u32 s85, s85, s16
+s_bitset1_b32 s18, 17
+s_branch 12
+s_bitset1_b32 s18, 18
+s_mov_b32 s43, 0
+s_mov_b32 s73, -1
+s_mov_b32 s82, 40
+s_branch 31
+s_add_u32 s83, s83, 32
+s_cmp_ge_u32 s83, s85
+s_cbranch_scc0 28
+s_bitset1_b32 s18, 22
+s_sub_u32 s88, s88, s17
+s_subb_u32 s89, s89, 0
+s_cbranch_scc1 65281
+v_add_co_u32_e32 v108, vcc, s76, v108
+v_addc_co_u32_e64 v118, vcc, 0, 0, vcc
+v_mad_i32_i24 v108, v118, s75, v108
+v_mad_i32_i24 v110, v118, s80, v110
+v_mad_i32_i24 v109, v118, s79, v109
+v_cmp_ge_i32_e64 vcc, v109, 0
+v_addc_co_u32_e64 v118, vcc, 0, 0, vcc
+v_add_co_u32_e32 v110, vcc, v110, v118
+v_mad_i32_i24 v109, v118, s74, v109
+v_add_co_u32_e32 v109, vcc, s77, v109
+v_addc_co_u32_e64 v118, vcc, 0, 0, vcc
+v_add_co_u32_e32 v110, vcc, v110, v118
+v_mad_i32_i24 v109, v118, s74, v109
+v_add_co_u32_e32 v110, vcc, s78, v110
+s_mov_b32 s83, s84
+v_cmp_le_u32_e32 vcc, 0x100, v0
+s_cbranch_vccz 170
+v_subrev_co_u32_e32 v118, vcc, s75, v108
+v_subrev_co_u32_e32 v119, vcc, s74, v109
+s_bitcmp1_b32 s18, 22
+s_cbranch_scc0 64
+s_bitset0_b32 s18, 22
+s_bfe_u32 s52, s18, 0x10014
+v_mul_u32_u24_e32 v123, 2, v118
+v_mul_u32_u24_e32 v124, 2, v119
+v_cvt_pk_u16_u32 v126, v123, v124
+v_and_b32_e64 v123, v0, 1
+v_cmp_eq_u32_e64 vcc, v123, 1
+v_cndmask_b32_e32 v126, v110, v126, vcc
+v_lshrrev_b32_e32 v122, 1, v0
+v_bfe_u32 v127, v122, s52, 1
+v_lshrrev_b32_e32 v122, 1, v0
+v_bfi_b32 v122, 1, v0, v122
+v_lshrrev_b32_e32 v123, 2, v0
+v_bfi_b32 v123, 1, v0, v123
+v_cmp_eq_u32_e64 vcc, s52, 0
+v_cndmask_b32_e32 v122, v123, v122, vcc
+s_sub_u32 s52, 1, s52
+v_lshrrev_b32_e32 v123, s52, v122
+v_bfi_b32 v122, 32, v123, v122
+v_and_b32_e32 v122, 63, v122
+v_add_co_u32_e32 v123, vcc, 16, v122
+v_and_b32_e64 v124, v0, 2
+v_cmp_eq_u32_e64 vcc, v124, 0
+v_cndmask_b32_e32 v123, v123, v122, vcc
+v_lshlrev_b32_e32 v124, 14, v127
+v_mad_u32_u24 v123, 4, v123, v124
+v_add_co_u32_e32 v122, vcc, s96, v123
+ds_write_b32 v122, v126
+v_writelane_b32 v124, s18, 0
+v_writelane_b32 v124, s85, 1
+v_writelane_b32 v124, s84, 2
+v_and_b32_e64 v122, v0, 63
+v_cmp_ge_u32_e64 vcc, v122, 3
+v_mov_b32_e32 v125, 0x4000
+v_cndmask_b32_e32 v122, v122, v125, vcc
+v_mad_i32_i24 v122, v122, 4, s96
+ds_write_b32 v122, v124 offset:256
+s_add_u32 s96, s96, 0x18c
+s_cmp_eq_u32 s96, 0xffc0
+s_cselect_b32 s96, 0xc1e0, s96
+v_mov_b32_dpp v120, v110  quad_perm:[0,0,0,0] row_mask:0xf bank_mask:0xf
+v_mov_b32_dpp v118, v118  quad_perm:[0,0,0,0] row_mask:0xf bank_mask:0xf
+v_mov_b32_dpp v119, v119  quad_perm:[0,0,0,0] row_mask:0xf bank_mask:0xf
+v_readfirstlane_b32 s81, v120
+v_sub_co_u32_e64 v121, vcc, v120, s81
+v_mul_lo_u32 v121, v121, s65
+v_and_b32_e64 v125, v0, 3
+v_ashrrev_i32_e64 v126, 0, s31
+v_subrev_co_u32_e32 v125, vcc, v126, v125
+v_ashrrev_i32_e64 v126, 0, s62
+v_mad_i32_i24 v122, v126, 3, v125
+s_bfe_u32 s52, s18, 0x10014
+v_lshrrev_b32_e32 v124, 2, v0
+v_and_b32_e32 v124, s52, v124
+v_mad_i32_i24 v122, v124, 3, v122
+v_add_co_u32_e64 v123, vcc, 0, s63
+v_ashrrev_i32_e32 v123, 0, v123
+v_add_co_u32_e64 v124, vcc, 0, s30
+v_ashrrev_i32_e32 v124, 0, v124
+v_sub_i32 v123, v123, v124
+s_lshl_b32 s54, s15, 1
+v_cmp_ge_u32_e64 s[52:53], v120, s12
+v_mad_i32_i24 v118, v118, 2, v122
+v_cmp_ge_u32_e64 s[56:57], v118, s15
+v_mad_i32_i24 v118, 2, v118, v121
+s_or_b64 s[56:57], s[56:57], s[52:53]
+v_mad_i32_i24 v119, v119, 2, v123
+v_cmp_ge_u32_e64 s[58:59], v119, s14
+s_or_b64 s[58:59], s[56:57], s[58:59]
+v_mad_u32_u24 v94, v119, s54, v118
+v_cndmask_b32_e64 v94, v94, -1, s[58:59]
+v_add_co_u32_e32 v119, vcc, 1, v119
+v_cmp_ge_u32_e64 s[58:59], v119, s14
+s_or_b64 s[58:59], s[56:57], s[58:59]
+v_mad_u32_u24 v95, v119, s54, v118
+v_cndmask_b32_e64 v95, v95, -1, s[58:59]
+v_add_co_u32_e32 v119, vcc, 1, v119
+v_cmp_ge_u32_e64 s[58:59], v119, s14
+s_or_b64 s[58:59], s[56:57], s[58:59]
+v_mad_u32_u24 v96, v119, s54, v118
+v_cndmask_b32_e64 v96, v96, -1, s[58:59]
+v_add_co_u32_e32 v119, vcc, 1, v119
+v_cmp_ge_u32_e64 s[58:59], v119, s14
+s_or_b64 s[58:59], s[56:57], s[58:59]
+v_mad_u32_u24 v97, v119, s54, v118
+v_cndmask_b32_e64 v97, v97, -1, s[58:59]
+s_bitcmp1_b32 s18, 18
+s_cbranch_scc1 151
+s_lshr_b32 s52, -1, 16
+s_and_b32 s52, s52, s65
+s_lshr_b32 s53, s65, 16
+s_mul_i32 s53, s53, s81
+s_mul_i32 s40, s52, s81
+s_lshl_b32 s52, s53, 16
+s_lshr_b32 s53, s53, 16
+s_add_u32 s40, s52, s40
+s_addc_u32 s41, s53, 0
+s_add_u32 s40, s40, s20
+s_addc_u32 s41, s41, s21
+s_lshr_b32 s52, s18, 6
+s_xor_b32 s52, s52, s18
+s_and_b32 s52, s52, 0x80000
+s_cselect_b32 s52, s68, 0
+s_and_b32 s53, s18, 0x1100000
+s_cselect_b32 s53, 0, 1
+s_lshl_b32 s52, s52, s53
+s_add_u32 s40, s40, s52
+s_addc_u32 s41, s41, 0
+s_branch 96
+s_bitcmp1_b32 s18, 18
+s_cbranch_scc1 126
+s_bfe_u32 s52, s18, 0x10014
+v_bfe_u32 v118, v0, 0, 2
+v_min_u32_e32 v118, 2, v118
+v_bfe_u32 v120, v0, 2, s52
+v_mad_u32_u24 v118, v120, 3, v118
+v_mad_u32_u24 v118, s62, 3, v118
+v_sub_co_u32_e32 v120, vcc, s29, v118
+v_sub_co_u32_e64 v120, vcc, v120, 1
+s_bfe_u32 s54, s18, 0x10001
+v_cmp_eq_u32_e64 vcc, s54, 1
+v_cndmask_b32_e32 v118, v118, v120, vcc
+v_cmp_ge_u32_e64 s[52:53], v118, s29
+v_lshlrev_b32_e32 v118, 1, v118
+s_bfe_u32 s54, s18, 0x10018
+v_bfe_u32 v121, v0, 2, s54
+v_mul_lo_u32 v121, s68, v121
+v_add_co_u32_e32 v118, vcc, v118, v121
+v_mul_lo_u32 v119, s90, v111
+v_add_co_u32_e32 v119, vcc, v119, v118
+s_sub_u32 s54, s28, s63
+s_sub_u32 s54, s54, 3
+s_bitcmp1_b32 s18, 0
+s_cselect_b32 s54, s54, s63
+v_mov_b32_e32 v121, s54
+s_lshl_b32 s57, s29, 1
+v_cmp_ge_u32_e64 s[54:55], v121, s28
+v_mad_i32_i24 v94, v121, s57, v119
+s_or_b64 s[54:55], s[54:55], s[52:53]
+v_cndmask_b32_e64 v94, v94, -1, s[54:55]
+v_mov_b32_e32 v95, v94
+v_add_co_u32_e64 v121, vcc, v121, 1
+v_cmp_ge_u32_e64 s[54:55], v121, s28
+v_mad_i32_i24 v97, v121, s57, v119
+s_or_b64 s[54:55], s[54:55], s[52:53]
+v_cndmask_b32_e64 v97, v97, -1, s[54:55]
+v_add_co_u32_e64 v121, vcc, v121, 1
+v_cmp_ge_u32_e64 s[54:55], v121, s28
+v_mad_i32_i24 v96, v121, s57, v119
+s_or_b64 s[54:55], s[54:55], s[52:53]
+v_cndmask_b32_e64 v96, v96, -1, s[54:55]
+v_add_co_u32_e64 v118, vcc, v111, s83
+v_cmp_lt_u32_e64 vcc, v118, s16
+v_cndmask_b32_e32 v94, -1, v94, vcc
+v_cndmask_b32_e32 v95, -1, v95, vcc
+v_cndmask_b32_e32 v96, -1, v96, vcc
+v_cndmask_b32_e32 v97, -1, v97, vcc
+s_lshr_b32 s52, -1, 16
+s_and_b32 s52, s52, s90
+s_lshr_b32 s53, s90, 16
+s_mul_i32 s53, s53, s83
+s_mul_i32 s40, s52, s83
+s_lshl_b32 s52, s53, 16
+s_lshr_b32 s53, s53, 16
+s_add_u32 s40, s52, s40
+s_addc_u32 s41, s53, 0
+s_add_u32 s40, s40, s22
+s_addc_u32 s41, s41, s23
+s_lshr_b32 s52, s18, 6
+s_xor_b32 s52, s52, s18
+s_and_b32 s52, s52, 0x80000
+s_cselect_b32 s52, s68, 0
+s_and_b32 s53, s18, 0x1100000
+s_cselect_b32 s53, 0, 1
+s_lshl_b32 s52, s52, s53
+s_add_u32 s40, s40, s52
+s_addc_u32 s41, s41, 0
+s_mov_b32 s43, 0x20000
+s_mov_b32 s73, -1
+s_bitcmp0_b32 s13, 0
+s_cbranch_scc1 4
+s_mov_b32 s43, 0
+s_mov_b32 s73, 1
+s_sub_u32 s40, s40, s68
+s_subb_u32 s41, s41, 0
+s_add_u32 s53, s13, 1
+s_and_b32 s53, s53, -2
+s_bfe_u32 s52, s18, 0x10014
+s_lshl_b32 s82, s53, s52
+s_bfe_u32 s52, s18, 0x10013
+s_bfe_u32 s54, s18, 0x10019
+s_xor_b32 s52, s52, s54
+s_cselect_b32 s52, 2, 0
+s_cselect_b32 s43, 0x20000, s43
+s_and_b32 s52, s52, s82
+s_sub_u32 s82, s82, s52
+s_bitcmp1_b32 s18, 20
+s_cselect_b32 s52, 0, 0x2000000
+s_bitcmp1_b32 s53, 1
+s_cselect_b32 s52, s52, 0
+s_xor_b32 s18, s18, s52
+s_cmp_eq_u32 s82, 0
+s_cbranch_scc1 4
+s_branch 64935
+s_nop 0
+s_nop 0
+s_nop 0
+s_and_b32 s52, 0x900000, s18
+s_subb_u32 s62, s62, 1
+s_cbranch_scc0 65227
+s_and_b32 s52, 0x900000, s18
+s_subb_u32 s62, s61, 1
+s_add_u32 s63, s63, 3
+s_cmp_ge_u32 s63, s28
+s_cbranch_scc0 65221
+s_mov_b32 s63, 0
+s_branch 65188
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_mac_f32_dpp v4, v4, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v5, v5, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v2, v2, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v3, v3, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v3, v4, v3  row_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v2, v5, v2  row_mirror row_mask:0xf bank_mask:0xf
+s_nop 0
+v_mac_f32_dpp v3, v3, v114  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mac_f32_dpp v2, v2, v114  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+s_nop 0
+v_add_f32_dpp v2, v3, v2  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cvt_f16_f32_e32 v2, v2
+v_mac_f32_dpp v8, v8, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v9, v9, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v6, v6, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v7, v7, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v7, v8, v7  row_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v6, v9, v6  row_mirror row_mask:0xf bank_mask:0xf
+s_nop 0
+v_mac_f32_dpp v7, v7, v114  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mac_f32_dpp v6, v6, v114  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+s_nop 0
+v_add_f32_dpp v3, v7, v6  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cvt_f16_f32_e32 v3, v3
+v_mac_f32_dpp v12, v12, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v13, v13, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v10, v10, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v11, v11, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v11, v12, v11  row_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v10, v13, v10  row_mirror row_mask:0xf bank_mask:0xf
+s_nop 0
+v_mac_f32_dpp v11, v11, v114  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mac_f32_dpp v10, v10, v114  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+s_nop 0
+v_add_f32_dpp v4, v11, v10  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cvt_f16_f32_e32 v4, v4
+v_mac_f32_dpp v16, v16, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v17, v17, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v14, v14, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v15, v15, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v15, v16, v15  row_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v14, v17, v14  row_mirror row_mask:0xf bank_mask:0xf
+s_nop 0
+v_mac_f32_dpp v15, v15, v114  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mac_f32_dpp v14, v14, v114  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+s_nop 0
+v_add_f32_dpp v5, v15, v14  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cvt_f16_f32_e32 v5, v5
+v_mac_f32_dpp v20, v20, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v21, v21, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v18, v18, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v19, v19, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v19, v20, v19  row_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v18, v21, v18  row_mirror row_mask:0xf bank_mask:0xf
+s_nop 0
+v_mac_f32_dpp v19, v19, v114  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mac_f32_dpp v18, v18, v114  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+s_nop 0
+v_add_f32_dpp v6, v19, v18  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cvt_f16_f32_e32 v6, v6
+v_mac_f32_dpp v24, v24, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v25, v25, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v22, v22, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v23, v23, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v23, v24, v23  row_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v22, v25, v22  row_mirror row_mask:0xf bank_mask:0xf
+s_nop 0
+v_mac_f32_dpp v23, v23, v114  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mac_f32_dpp v22, v22, v114  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+s_nop 0
+v_add_f32_dpp v7, v23, v22  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cvt_f16_f32_e32 v7, v7
+v_mac_f32_dpp v28, v28, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v29, v29, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v26, v26, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v27, v27, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v27, v28, v27  row_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v26, v29, v26  row_mirror row_mask:0xf bank_mask:0xf
+s_nop 0
+v_mac_f32_dpp v27, v27, v114  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mac_f32_dpp v26, v26, v114  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+s_nop 0
+v_add_f32_dpp v8, v27, v26  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cvt_f16_f32_e32 v8, v8
+v_mac_f32_dpp v32, v32, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v33, v33, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v30, v30, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v31, v31, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v31, v32, v31  row_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v30, v33, v30  row_mirror row_mask:0xf bank_mask:0xf
+s_nop 0
+v_mac_f32_dpp v31, v31, v114  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mac_f32_dpp v30, v30, v114  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+s_nop 0
+v_add_f32_dpp v9, v31, v30  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cvt_f16_f32_e32 v9, v9
+s_waitcnt vmcnt(0)
+v_readlane_b32 s55, v116, 0
+v_add_f16_e64 v2, v2, s55
+v_mul_f16_e64 v118, v2, s36
+v_cmp_lt_f16_e64 vcc, v2, 0
+v_cndmask_b32_e32 v2, v2, v118, vcc
+buffer_store_short v2, v98, s[44:47], 0 offen
+s_add_u32 s44, s44, s67
+s_addc_u32 s45, s45, 0
+s_sub_u32 s93, s93, 1
+s_cselect_b32 s47, 0, s47
+v_readlane_b32 s55, v116, 1
+v_add_f16_e64 v3, v3, s55
+v_mul_f16_e64 v118, v3, s36
+v_cmp_lt_f16_e64 vcc, v3, 0
+v_cndmask_b32_e32 v3, v3, v118, vcc
+buffer_store_short v3, v98, s[44:47], 0 offen
+s_add_u32 s44, s44, s67
+s_addc_u32 s45, s45, 0
+s_sub_u32 s93, s93, 1
+s_cselect_b32 s47, 0, s47
+v_readlane_b32 s55, v116, 2
+v_add_f16_e64 v4, v4, s55
+v_mul_f16_e64 v118, v4, s36
+v_cmp_lt_f16_e64 vcc, v4, 0
+v_cndmask_b32_e32 v4, v4, v118, vcc
+buffer_store_short v4, v98, s[44:47], 0 offen
+s_add_u32 s44, s44, s67
+s_addc_u32 s45, s45, 0
+s_sub_u32 s93, s93, 1
+s_cselect_b32 s47, 0, s47
+v_readlane_b32 s55, v116, 3
+v_add_f16_e64 v5, v5, s55
+v_mul_f16_e64 v118, v5, s36
+v_cmp_lt_f16_e64 vcc, v5, 0
+v_cndmask_b32_e32 v5, v5, v118, vcc
+buffer_store_short v5, v98, s[44:47], 0 offen
+s_add_u32 s44, s44, s67
+s_addc_u32 s45, s45, 0
+s_sub_u32 s93, s93, 1
+s_cselect_b32 s47, 0, s47
+s_lshl_b32 s52, s67, 2
+s_add_u32 s44, s44, s52
+s_addc_u32 s45, s45, 0
+s_sub_u32 s93, s93, 4
+s_cselect_b32 s47, 0, s47
+v_readlane_b32 s55, v116, 8
+v_add_f16_e64 v6, v6, s55
+v_mul_f16_e64 v118, v6, s36
+v_cmp_lt_f16_e64 vcc, v6, 0
+v_cndmask_b32_e32 v6, v6, v118, vcc
+buffer_store_short v6, v98, s[44:47], 0 offen
+s_add_u32 s44, s44, s67
+s_addc_u32 s45, s45, 0
+s_sub_u32 s93, s93, 1
+s_cselect_b32 s47, 0, s47
+v_readlane_b32 s55, v116, 9
+v_add_f16_e64 v7, v7, s55
+v_mul_f16_e64 v118, v7, s36
+v_cmp_lt_f16_e64 vcc, v7, 0
+v_cndmask_b32_e32 v7, v7, v118, vcc
+buffer_store_short v7, v98, s[44:47], 0 offen
+s_add_u32 s44, s44, s67
+s_addc_u32 s45, s45, 0
+s_sub_u32 s93, s93, 1
+s_cselect_b32 s47, 0, s47
+v_readlane_b32 s55, v116, 10
+v_add_f16_e64 v8, v8, s55
+v_mul_f16_e64 v118, v8, s36
+v_cmp_lt_f16_e64 vcc, v8, 0
+v_cndmask_b32_e32 v8, v8, v118, vcc
+buffer_store_short v8, v98, s[44:47], 0 offen
+s_add_u32 s44, s44, s67
+s_addc_u32 s45, s45, 0
+s_sub_u32 s93, s93, 1
+s_cselect_b32 s47, 0, s47
+v_readlane_b32 s55, v116, 11
+v_add_f16_e64 v9, v9, s55
+v_mul_f16_e64 v118, v9, s36
+v_cmp_lt_f16_e64 vcc, v9, 0
+v_cndmask_b32_e32 v9, v9, v118, vcc
+buffer_store_short v9, v98, s[44:47], 0 offen
+s_add_u32 s44, s44, s67
+s_addc_u32 s45, s45, 0
+s_sub_u32 s93, s93, 1
+s_cselect_b32 s47, 0, s47
+s_add_u32 s44, s44, s52
+s_addc_u32 s45, s45, 0
+s_lshl_b32 s52, s52, 2
+s_add_u32 s44, s44, s52
+s_addc_u32 s45, s45, 0
+s_sub_u32 s93, s93, 20
+s_cselect_b32 s47, 0, s47
+s_cselect_b32 s51, 0, s51
+s_add_u32 s48, s48, 64
+s_addc_u32 s49, s49, 0
+s_sub_u32 s50, s50, 64
+s_cselect_b32 s51, 0, s51
+v_mov_b32_e32 v2, 0
+v_mov_b32_e32 v3, 0
+v_mov_b32_e32 v4, 0
+v_mov_b32_e32 v5, 0
+v_mov_b32_e32 v6, 0
+v_mov_b32_e32 v7, 0
+v_mov_b32_e32 v8, 0
+v_mov_b32_e32 v9, 0
+v_mov_b32_e32 v10, 0
+v_mov_b32_e32 v11, 0
+v_mov_b32_e32 v12, 0
+v_mov_b32_e32 v13, 0
+v_mov_b32_e32 v14, 0
+v_mov_b32_e32 v15, 0
+v_mov_b32_e32 v16, 0
+v_mov_b32_e32 v17, 0
+v_mov_b32_e32 v18, 0
+v_mov_b32_e32 v19, 0
+v_mov_b32_e32 v20, 0
+v_mov_b32_e32 v21, 0
+v_mov_b32_e32 v22, 0
+v_mov_b32_e32 v23, 0
+v_mov_b32_e32 v24, 0
+v_mov_b32_e32 v25, 0
+v_mov_b32_e32 v26, 0
+v_mov_b32_e32 v27, 0
+v_mov_b32_e32 v28, 0
+v_mov_b32_e32 v29, 0
+v_mov_b32_e32 v30, 0
+v_mov_b32_e32 v31, 0
+v_mov_b32_e32 v32, 0
+v_mov_b32_e32 v33, 0
+s_xor_b32 s18, s18, 0x200000
+s_bitcmp1_b32 s13, 0
+s_addc_u32 s52, s13, 0
+s_mul_i32 s94, s60, s61
+s_mul_i32 s94, s94, s52
+s_add_u32 s52, s93, s92
+s_cmp_lt_i32 s52, 0
+s_cbranch_scc0 104
+v_and_b32_e32 v98, 0x7f, v0
+v_lshrrev_b32_e32 v98, 1, v98
+v_bfi_b32 v98, 1, v0, v98
+v_and_b32_e64 v99, v0, 2
+v_mad_u32_u24 v98, v99, 16, v98
+v_lshlrev_b32_e32 v98, 2, v98
+v_add_co_u32_e64 v98, vcc, v98, s97
+v_and_b32_e32 v99, 3, v0
+v_lshlrev_b32_e32 v99, 2, v99
+v_add_co_u32_e64 v99, vcc, v99, s97
+ds_read_b32 v120, v99 offset:256
+ds_read_b32 v98, v98
+s_add_u32 s97, s97, 0x18c
+s_cmp_eq_u32 s97, 0xffc0
+s_cselect_b32 s97, 0xc1e0, s97
+s_waitcnt lgkmcnt(0)
+v_readfirstlane_b32 s95, v98
+v_readlane_b32 s54, v120, 0
+s_bitcmp1_b32 s54, 18
+s_cbranch_scc1 79
+v_readlane_b32 s52, v120, 1
+v_readlane_b32 s53, v120, 2
+s_add_u32 s93, s92, s53
+s_lshr_b32 s55, -1, 16
+s_and_b32 s55, s55, s66
+s_lshr_b32 s56, s66, 16
+s_mul_i32 s56, s56, s95
+s_mul_i32 s44, s55, s95
+s_lshl_b32 s55, s56, 16
+s_lshr_b32 s56, s56, 16
+s_add_u32 s44, s55, s44
+s_addc_u32 s45, s56, 0
+s_add_u32 s44, s44, s24
+s_addc_u32 s45, s45, s25
+s_mul_i32 s55, s67, s93
+s_add_u32 s44, s44, s55
+s_addc_u32 s45, s45, 0
+s_mov_b32 s47, 0x20000
+s_bitcmp1_b32 s18, 7
+s_cselect_b32 s51, 0x20000, 0
+s_lshl_b32 s55, s93, 1
+s_add_u32 s48, s34, s55
+s_addc_u32 s49, s35, 0
+s_lshl_b32 s56, s52, 1
+s_sub_u32 s50, s56, s55
+s_cselect_b32 s51, 0, s51
+s_sub_u32 s93, s52, s53
+s_sub_u32 s93, s93, 1
+s_sub_u32 s93, s93, s92
+s_cselect_b32 s47, 0, s47
+v_bfe_u32 v118, v98, 16, 16
+v_bfe_u32 v119, v98, 0, 16
+v_and_b32_e64 v120, v0, 7
+v_sub_co_u32_e32 v121, vcc, 7, v120
+v_min_u32_e32 v120, v120, v121
+v_bfe_u32 v121, v120, 1, 1
+v_bfe_u32 v120, v120, 0, 1
+v_mov_b32_dpp v118, v118  quad_perm:[1,1,1,1] row_mask:0xf bank_mask:0xf
+v_mov_b32_dpp v119, v119  quad_perm:[1,1,1,1] row_mask:0xf bank_mask:0xf
+v_add_co_u32_e32 v118, vcc, v118, v121
+v_add_co_u32_e32 v119, vcc, v119, v120
+v_mov_b32_dpp v120, v98  quad_perm:[0,0,0,0] row_mask:0xf bank_mask:0xf
+v_cmp_ge_u32_e64 s[52:53], v120, s12
+v_sub_co_u32_e64 v120, vcc, v120, s95
+v_mul_lo_u32 v120, v120, s66
+v_mad_i32_i24 v98, v118, s33, v119
+v_lshlrev_b32_e32 v98, 1, v98
+v_add_co_u32_e32 v98, vcc, v98, v120
+v_cmp_ge_u32_e64 s[58:59], v119, s33
+s_or_b64 s[56:57], s[58:59], s[52:53]
+v_cmp_ge_u32_e64 s[54:55], v118, s32
+s_or_b64 s[52:53], s[56:57], s[54:55]
+v_cndmask_b32_e64 v98, v98, -1, s[52:53]
+v_and_b32_e64 v116, v0, 63
+v_lshlrev_b32_e32 v116, 1, v116
+s_barrier
+buffer_load_ushort v116, v116, s[48:51], 0 offen
+s_branch 64454
+s_endpgm
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0

--- a/src/kernels/Conv_Winograd_v21_1_3_gfx9_fp16_dot2_edc_f2x3_stride2.inc
+++ b/src/kernels/Conv_Winograd_v21_1_3_gfx9_fp16_dot2_edc_f2x3_stride2.inc
@@ -1,0 +1,3183 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2023 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+v_mov_b32_e32 v0, v0
+s_mov_b32 s0, 0
+s_mov_b32 s1, 0
+s_mov_b32 s2, 0
+s_mov_b32 s3, 0
+v_mov_b32_e32 v116, 0
+s_mov_b32 m0, 0x1ffff
+s_mov_b32 s97, 0xc1e0
+s_mov_b32 s96, 0xc1e0
+s_mov_b32 s91, 0
+v_lshlrev_b32_e32 v119, 2, v0
+v_add_co_u32_e32 v119, vcc, 0xffc0, v119
+v_cmp_ge_u32_e32 vcc, 12, v0
+s_cbranch_vccz 5
+v_mov_b32_e32 v118, 0
+v_cndmask_b32_e32 v119, -1, v119, vcc
+ds_write_b32 v119, v118
+s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+s_barrier
+v_readfirstlane_b32 s52, v0
+s_lshr_b32 s52, s52, 5
+s_add_u32 s52, s52, 8
+s_and_b32 s92, s52, 20
+s_mov_b64 s[40:41], s[6:7]
+s_load_dwordx16 s[12:27], s[40:41], 0x0
+s_load_dwordx4 s[28:31], s[40:41], 0x40
+s_load_dwordx2 s[32:33], s[40:41], 0x50
+s_waitcnt lgkmcnt(0)
+s_and_b32 s18, s18, 0xffff
+s_bitcmp1_b32 s18, 6
+s_cbranch_scc0 16
+s_and_b32 s21, s21, 0xffff
+s_and_b32 s23, s23, 0xffff
+s_and_b32 s25, s25, 0xffff
+s_and_b32 s27, s27, 0xffff
+s_load_dwordx2 s[20:21], s[20:21], 0x0
+s_load_dwordx2 s[22:23], s[22:23], 0x0
+s_load_dwordx2 s[24:25], s[24:25], 0x0
+s_load_dwordx2 s[26:27], s[26:27], 0x0
+s_bitcmp1_b32 s18, 7
+s_cbranch_scc0 2
+s_load_dwordx2 s[34:35], s[40:41], 0x58
+s_mov_b32 s36, 1.0
+s_bitcmp1_b32 s18, 8
+s_cbranch_scc0 2
+s_load_dword s36, s[40:41], 0x60
+s_bitcmp1_b32 s18, 7
+s_cbranch_scc0 7
+s_bitcmp1_b32 s18, 6
+s_cbranch_scc0 5
+s_waitcnt lgkmcnt(0)
+s_and_b32 s35, s35, 0xffff
+s_load_dwordx2 s[34:35], s[34:35], 0x0
+s_bitcmp1_b32 s18, 9
+s_cbranch_scc0 72
+s_mov_b32 s42, 0x8c
+s_mov_b32 s43, 0x9c
+v_cmp_le_u32_e32 vcc, 0x100, v0
+s_cmp_eq_u32 1, src_vccz
+s_cselect_b32 s42, s43, s42
+s_load_dword s65, s[40:41], 0x88
+s_load_dword s90, s[40:41], 0x98
+s_load_dword s68, s[40:41], s42
+s_load_dwordx2 s[66:67], s[40:41], 0xa8
+s_bitcmp1_b32 s18, 10
+s_cbranch_scc0 103
+s_load_dwordx4 s[44:47], s[40:41], 0xb8
+v_ffbh_u32_e32 v4, s17
+v_lshlrev_b32_e64 v5, v4, s17
+v_and_b32_e32 v6, 0xffffff00, v5
+v_cmp_eq_u32_e32 vcc, 0x80000000, v5
+v_cvt_f32_u32_e32 v6, v6
+v_rcp_f32_e32 v2, v6
+v_subb_co_u32_e32 v3, vcc, 32, v4, vcc
+v_cvt_f32_ubyte0_e32 v4, v5
+v_fma_f32 v6, v6, v2, -1.0
+v_fma_f32 v6, v4, v2, v6
+v_madak_f32 v6, v6, v2, 0x9f000000
+v_mul_f32_e32 v6, 0x5f800000, v6
+v_mov_b32_e32 v4, 0
+v_cvt_flr_i32_f32_e64 v6, -v6
+v_lshl_add_u32 v2, v2, 9, v6
+v_mad_u64_u32 v[4:5], vcc, v5, v2, v[4:5]
+v_subb_co_u32_e64 v2, vcc, v2, -1, vcc
+v_mul_hi_u32 v4, s8, v2
+v_add_co_u32_e64 v2, vcc, v4, s8
+v_addc_co_u32_e64 v4, vcc, 0, 0, vcc
+v_cmp_eq_u32_e32 vcc, 32, v3
+v_cndmask_b32_e32 v2, v2, v4, vcc
+v_alignbit_b32 v2, v4, v2, v3
+s_waitcnt lgkmcnt(0)
+v_readfirstlane_b32 s48, v2
+s_mul_i32 s49, s48, s17
+s_sub_u32 s8, s8, s49
+s_mul_i32 s49, s45, s48
+s_add_u32 s20, s20, s49
+s_addc_u32 s21, s21, 0
+s_mul_i32 s49, s46, s48
+s_add_u32 s22, s22, s49
+s_addc_u32 s23, s23, 0
+s_mul_i32 s49, s47, s48
+s_add_u32 s24, s24, s49
+s_addc_u32 s25, s25, 0
+s_branch 49
+s_mul_i32 s42, s14, s15
+s_lshr_b32 s46, -1, 16
+s_and_b32 s46, s46, s42
+s_lshr_b32 s47, s42, 16
+s_mul_i32 s47, s47, s13
+s_mul_i32 s44, s46, s13
+s_lshl_b32 s46, s47, 16
+s_lshr_b32 s47, s47, 16
+s_add_u32 s44, s46, s44
+s_addc_u32 s45, s47, 0
+s_lshl_b32 s65, s44, 1
+s_lshl_b32 s68, s42, 1
+s_mul_i32 s43, s32, s33
+s_lshr_b32 s46, -1, 16
+s_and_b32 s46, s46, s43
+s_lshr_b32 s47, s43, 16
+s_mul_i32 s47, s47, s16
+s_mul_i32 s44, s46, s16
+s_lshl_b32 s46, s47, 16
+s_lshr_b32 s47, s47, 16
+s_add_u32 s44, s46, s44
+s_addc_u32 s45, s47, 0
+s_lshl_b32 s66, s44, 1
+s_lshl_b32 s67, s43, 1
+s_bitcmp1_b32 s18, 13
+s_cbranch_scc0 2
+s_load_dwordx8 s[48:55], s[40:41], 0x68
+s_mul_i32 s42, s28, s29
+s_lshl_b32 s42, s42, 1
+s_bitcmp1_b32 s18, 2
+s_cselect_b32 s43, s16, s13
+s_lshr_b32 s44, -1, 16
+s_and_b32 s44, s44, s42
+s_lshr_b32 s45, s42, 16
+s_mul_i32 s45, s45, s43
+s_mul_i32 s56, s44, s43
+s_lshl_b32 s44, s45, 16
+s_lshr_b32 s45, s45, 16
+s_add_u32 s56, s44, s56
+s_addc_u32 s57, s45, 0
+s_mov_b32 s43, s56
+s_bitcmp1_b32 s18, 2
+s_cselect_b32 s44, s43, s42
+s_cselect_b32 s90, s42, s43
+v_cmp_le_u32_e32 vcc, 0x100, v0
+s_cmp_eq_u32 1, src_vccz
+s_cselect_b32 s68, s44, s68
+s_waitcnt lgkmcnt(0)
+s_and_b32 s21, s21, 0xffff
+s_and_b32 s23, s23, 0xffff
+s_and_b32 s25, s25, 0xffff
+s_and_b32 s27, s27, 0xffff
+s_and_b32 s35, s35, 0xffff
+s_bitcmp1_b32 s18, 13
+s_cbranch_scc0 8
+s_add_u32 s20, s20, s48
+s_addc_u32 s21, s21, s49
+s_add_u32 s22, s22, s50
+s_addc_u32 s23, s23, s51
+s_add_u32 s24, s24, s52
+s_addc_u32 s25, s25, s53
+s_add_u32 s34, s34, s54
+s_addc_u32 s35, s35, s55
+v_cvt_f16_f32_e32 v2, s36
+v_readfirstlane_b32 s36, v2
+s_and_b32 s44, 0, s30
+s_addc_u32 s44, s32, 0
+s_ashr_i32 s44, s44, 0
+s_add_u32 s42, s44, 1
+v_mov_b32_e32 v2, 0x80000000
+v_mul_hi_u32 v2, v2, s42
+v_readfirstlane_b32 s42, v2
+s_andn2_b32 s44, 0, s31
+s_addc_u32 s44, s33, 0
+s_ashr_i32 s44, s44, 0
+s_add_u32 s43, s44, 1
+v_mov_b32_e32 v2, 0x80000000
+v_mul_hi_u32 v2, v2, s43
+v_readfirstlane_b32 s43, v2
+s_sub_u32 s75, 0, s43
+s_sub_u32 s74, 0, s42
+s_add_u32 s60, s28, 2
+v_mov_b32_e32 v2, 0x55555556
+v_mul_hi_u32 v2, v2, s60
+v_readfirstlane_b32 s60, v2
+s_add_u32 s61, s29, 2
+v_mov_b32_e32 v2, 0x55555556
+v_mul_hi_u32 v2, v2, s61
+v_readfirstlane_b32 s61, v2
+v_mad_i32_i24 v2, 3, s60, -2
+v_sub_co_u32_e64 v2, vcc, v2, s28
+v_addc_co_u32_e64 v2, vcc, 0, 0, vcc
+v_readfirstlane_b32 s44, v2
+s_and_b32 s44, s44, 1
+s_and_b32 s44, s44, s60
+s_add_u32 s60, s60, s44
+v_readfirstlane_b32 s45, v0
+s_and_b32 s48, s45, 64
+s_cselect_b32 s48, 0x80000, 0
+s_or_b32 s18, s18, s48
+s_lshl_b32 s69, s68, 1
+s_sub_u32 s70, 0, s69
+s_subb_u32 s71, 0, 0
+s_bitset1_b32 s18, 23
+s_bitset1_b32 s18, 20
+s_bitset0_b32 s18, 19
+s_ashr_i32 s69, s69, 1
+s_ashr_i64 s[70:71], s[70:71], 1
+s_add_u32 s61, s61, 1
+s_and_b32 s61, s61, -2
+s_branch 16
+s_and_b32 s48, s13, 3
+s_cselect_b32 s48, 0, 0x1000000
+s_bitcmp1_b32 s18, 2
+s_cselect_b32 s48, 0, s48
+s_or_b32 s18, s18, s48
+s_cmp_eq_u32 s48, 0
+s_cselect_b32 s69, s68, s69
+s_cselect_b32 s70, s68, s70
+s_cselect_b32 s71, 0, s71
+s_bitcmp0_b32 s45, 8
+s_cselect_b32 s48, s48, 0
+s_cmp_eq_u32 s48, 0
+s_cselect_b32 s48, 0, 0x80000
+s_andn2_b32 s18, s18, s48
+s_add_u32 s70, s70, s69
+s_addc_u32 s71, s71, 0
+s_add_u32 s70, s70, s69
+s_addc_u32 s71, s71, 0
+v_bfe_u32 v3, v0, 2, 6
+v_lshrrev_b32_e32 v111, 1, v3
+s_bitcmp0_b32 s45, 8
+s_cselect_b32 s48, 0x1000000, 0
+s_or_b32 s48, s48, 0x100000
+s_and_b32 s48, s18, s48
+s_cselect_b32 s48, 0, 15
+v_bfi_b32 v111, s48, v3, v111
+s_mul_i32 s88, s12, s42
+s_sub_u32 s88, s88, 1
+s_lshr_b32 s88, s88, 0
+s_add_u32 s88, s88, 1
+s_lshr_b32 s46, -1, 16
+s_and_b32 s46, s46, s88
+s_lshr_b32 s47, s88, 16
+s_mul_i32 s47, s47, s43
+s_mul_i32 s88, s46, s43
+s_lshl_b32 s46, s47, 16
+s_lshr_b32 s47, s47, 16
+s_add_u32 s88, s46, s88
+s_addc_u32 s89, s47, 0
+s_sub_u32 s88, s88, 1
+s_subb_u32 s89, s89, 0
+s_lshr_b64 s[88:89], s[88:89], 5
+s_add_u32 s88, s88, 1
+s_addc_u32 s89, s89, 0
+v_mov_b32_e32 v4, s8
+v_mov_b32_e32 v5, s17
+v_and_b32_e32 v6, 3, v0
+v_cmp_eq_u32_e32 vcc, 2, v6
+v_cndmask_b32_e32 v4, v4, v5, vcc
+v_cmp_eq_u32_e32 vcc, 1, v6
+v_cndmask_b32_e32 v7, 0, v111, vcc
+s_bitcmp1_b32 s18, 20
+s_cbranch_scc0 4
+v_add_co_u32_e64 v5, vcc, v111, 8
+v_cmp_eq_u32_e32 vcc, 0, v6
+v_cndmask_b32_e32 v7, v7, v5, vcc
+v_cmp_eq_u32_e64 s[46:47], 3, v6
+v_bfe_u32 v109, v7, 0, 5
+v_mad_u32_u24 v109, v4, 32, v109
+v_ffbh_u32_e32 v9, s43
+v_lshlrev_b32_e64 v10, v9, s43
+v_and_b32_e32 v11, 0xffffff00, v10
+v_cmp_eq_u32_e32 vcc, 0x80000000, v10
+v_cvt_f32_u32_e32 v11, v11
+v_rcp_f32_e32 v110, v11
+v_subb_co_u32_e32 v8, vcc, 32, v9, vcc
+v_cvt_f32_ubyte0_e32 v9, v10
+v_fma_f32 v11, v11, v110, -1.0
+v_fma_f32 v11, v9, v110, v11
+v_madak_f32 v11, v11, v110, 0x9f000000
+v_mul_f32_e32 v11, 0x5f800000, v11
+v_mov_b32_e32 v9, 0
+v_cvt_flr_i32_f32_e64 v11, -v11
+v_lshl_add_u32 v110, v110, 9, v11
+v_mad_u64_u32 v[9:10], vcc, v10, v110, v[9:10]
+v_subb_co_u32_e64 v110, vcc, v110, -1, vcc
+v_mul_hi_u32 v9, v109, v110
+v_add_co_u32_e32 v110, vcc, v9, v109
+v_addc_co_u32_e64 v9, vcc, 0, 0, vcc
+v_cmp_eq_u32_e32 vcc, 32, v8
+v_cndmask_b32_e32 v110, v110, v9, vcc
+v_alignbit_b32 v110, v9, v110, v8
+v_mad_i32_i24 v108, v110, s75, v109
+v_lshrrev_b32_e32 v109, 5, v7
+v_mad_u32_u24 v109, v110, 1, v109
+v_cndmask_b32_e64 v109, v109, 1, s[46:47]
+v_ffbh_u32_e32 v9, s42
+v_lshlrev_b32_e64 v10, v9, s42
+v_and_b32_e32 v11, 0xffffff00, v10
+v_cmp_eq_u32_e32 vcc, 0x80000000, v10
+v_cvt_f32_u32_e32 v11, v11
+v_rcp_f32_e32 v110, v11
+v_subb_co_u32_e32 v8, vcc, 32, v9, vcc
+v_cvt_f32_ubyte0_e32 v9, v10
+v_fma_f32 v11, v11, v110, -1.0
+v_fma_f32 v11, v9, v110, v11
+v_madak_f32 v11, v11, v110, 0x9f000000
+v_mul_f32_e32 v11, 0x5f800000, v11
+v_mov_b32_e32 v9, 0
+v_cvt_flr_i32_f32_e64 v11, -v11
+v_lshl_add_u32 v110, v110, 9, v11
+v_mad_u64_u32 v[9:10], vcc, v10, v110, v[9:10]
+v_subb_co_u32_e64 v110, vcc, v110, -1, vcc
+v_mul_hi_u32 v9, v109, v110
+v_add_co_u32_e32 v110, vcc, v9, v109
+v_addc_co_u32_e64 v9, vcc, 0, 0, vcc
+v_cmp_eq_u32_e32 vcc, 32, v8
+v_cndmask_b32_e32 v110, v110, v9, vcc
+v_alignbit_b32 v110, v9, v110, v8
+v_mad_i32_i24 v109, v110, s74, v109
+v_readlane_b32 s76, v108, 2
+v_readlane_b32 s77, v109, 2
+v_readlane_b32 s78, v110, 2
+v_readlane_b32 s79, v109, 3
+v_readlane_b32 s80, v110, 3
+v_add_co_u32_e64 v108, vcc, v108, s75
+v_add_co_u32_e64 v109, vcc, v109, s74
+v_mov_b32_dpp v110, v110  quad_perm:[1,1,0,0] row_mask:0xf bank_mask:0xf
+v_mov_b32_dpp v108, v108  quad_perm:[1,1,0,0] row_mask:0xf bank_mask:0xf
+v_mov_b32_dpp v109, v109  quad_perm:[1,1,0,0] row_mask:0xf bank_mask:0xf
+s_mov_b32 s42, 0x80000000
+s_mov_b32 s43, 0x20000
+s_mov_b32 s46, 0x80000000
+s_mov_b32 s47, 0x20000
+v_cmp_le_u32_e32 vcc, 0x100, v0
+s_cbranch_vccnz 7
+v_xor_b32_dpp v112, v0, v0  quad_perm:[1,3,2,2] row_mask:0xf bank_mask:0xf
+v_subrev_co_u32_e32 v112, vcc, 1, v112
+v_cvt_f16_i16_e32 v112, v112
+v_pk_add_f16 v112, v112, 0 op_sel_hi:[0,0]
+s_branch 6
+v_xor_b32_dpp v112, v0, v0  quad_perm:[2,1,0,1] row_mask:0xf bank_mask:0xf
+v_sub_co_u32_e32 v112, vcc, 1, v112
+v_cvt_f16_i16_e32 v112, v112
+v_pk_add_f16 v112, v112, 0 op_sel_hi:[0,0]
+v_mov_b32_e32 v113, 1
+v_xor_b32_dpp v113, v0, v0  quad_perm:[2,3,2,3] row_mask:0xf bank_mask:0x4
+v_xor_b32_dpp v113, v0, v0  quad_perm:[0,1,0,1] row_mask:0xf bank_mask:0x8
+v_subrev_co_u32_e32 v113, vcc, 1, v113
+v_mov_b32_e32 v114, 1
+v_xor_b32_dpp v114, v0, v0  quad_perm:[0,3,2,1] row_mask:0xf bank_mask:0x2
+v_xor_b32_dpp v114, v0, v0  quad_perm:[2,1,0,3] row_mask:0xf bank_mask:0x4
+v_subrev_co_u32_e32 v114, vcc, 1, v114
+v_cvt_f32_i32_e32 v113, v113
+v_cvt_f32_i32_e32 v114, v114
+v_lshrrev_b32_e64 v118, 2, s92
+v_and_b32_e32 v119, 3, v0
+v_bfe_u32 v120, v0, 4, 3
+v_mad_u32_u24 v107, v120, 4, v119
+v_lshlrev_b32_e32 v107, 4, v107
+v_mad_u32_u24 v102, v118, 4, v119
+v_lshlrev_b32_e32 v102, 4, v102
+v_bfe_u32 v118, v0, 2, 2
+v_and_b32_e32 v119, 1, v118
+v_mad_u32_u24 v121, v118, 16, v119
+v_lshlrev_b32_e32 v121, 6, v121
+v_xor_b32_e32 v102, v102, v121
+v_mul_u32_u24_e32 v121, 0x400, v118
+v_xor_b32_e32 v107, v107, v121
+s_lshr_b32 s92, s92, 0
+v_cmp_le_u32_e32 vcc, 0x100, v0
+s_cbranch_vccnz 50
+s_and_b32 s53, s18, 0x1100000
+s_addc_u32 s53, 0, 0
+v_lshrrev_b32_e32 v121, 1, v0
+s_mul_i32 s52, 60, s53
+s_sub_u32 s52, 63, s52
+v_bfi_b32 v121, s52, v0, v121
+v_and_b32_e32 v118, 1, v121
+v_bfe_u32 v119, v121, 1, 1
+v_xor_b32_e32 v118, v118, v119
+v_bfe_u32 v120, v121, 3, 1
+v_mad_u32_u24 v119, v119, 2, v120
+v_mul_u32_u24_e32 v118, 0x118, v118
+v_bfe_u32 v120, v121, 2, 1
+v_mad_u32_u24 v119, v119, 2, v118
+v_xor_b32_e32 v119, v119, v120
+v_and_b32_e32 v120, 0xf0, v121
+v_xor_b32_e32 v119, v119, v120
+s_mul_i32 s52, 4, s53
+s_sub_u32 s52, 6, s52
+v_bfe_u32 v121, v0, s52, 1
+v_mul_u32_u24_e32 v121, 0x1040, v121
+v_xor_b32_e32 v104, 0x314, v119
+v_xor_b32_e32 v105, 0x31c, v119
+v_xor_b32_e32 v106, 8, v119
+s_bitcmp1_b32 s18, 0
+s_cselect_b64 vcc, -1, 0
+v_cndmask_b32_e32 v103, v119, v106, vcc
+v_cndmask_b32_e32 v106, v106, v119, vcc
+v_mad_u32_u24 v103, 4, v103, v121
+v_mad_u32_u24 v104, 4, v104, v121
+v_mad_u32_u24 v105, 4, v105, v121
+v_mad_u32_u24 v106, 4, v106, v121
+s_branch 44
+s_bfe_u32 s53, s18, 0x10014
+v_lshrrev_b32_e32 v121, 1, v0
+s_mul_i32 s52, 60, s53
+s_sub_u32 s52, 63, s52
+v_bfi_b32 v121, s52, v0, v121
+v_and_b32_e32 v118, 1, v121
+v_bfe_u32 v119, v121, 1, 1
+v_bfe_u32 v120, v121, 3, 1
+v_xor_b32_e32 v118, v118, v119
+v_mad_u32_u24 v119, v119, 2, v120
+v_mul_u32_u24_e32 v118, 0x109, v118
+v_bfe_u32 v120, v121, 2, 1
+v_mad_u32_u24 v119, v119, 2, v118
+v_xor_b32_e32 v119, v119, v120
+v_and_b32_e32 v120, 0xf0, v121
+v_or_b32_e32 v119, v119, v120
+s_mul_i32 s52, 4, s53
+s_sub_u32 s52, 6, s52
+v_bfe_u32 v121, v0, s52, 1
+v_mul_u32_u24_e32 v121, 0x1040, v121
+v_mad_u32_u24 v103, 4, v119, v121
+v_xor_b32_e32 v104, 0x307, v119
+v_mad_u32_u24 v104, 4, v104, v121
+v_xor_b32_e32 v105, 0x30f, v119
+v_mad_u32_u24 v105, 4, v105, v121
+v_xor_b32_e32 v106, 8, v119
+v_mad_u32_u24 v106, 4, v106, v121
+v_subrev_co_u32_e32 v108, vcc, s76, v108
+v_mov_b32_e32 v119, s75
+v_cmp_lt_i32_e32 vcc, v108, v119
+v_subb_co_u32_e64 v118, vcc, 0, 0, vcc
+v_mad_i32_i24 v108, v118, s75, v108
+v_mad_i32_i24 v110, v118, s80, v110
+v_mad_i32_i24 v109, v118, s79, v109
+v_mov_b32_e32 v119, s74
+v_cmp_lt_i32_e32 vcc, v109, v119
+v_subb_co_u32_e64 v118, vcc, 0, 0, vcc
+v_add_co_u32_e32 v110, vcc, v110, v118
+v_mad_i32_i24 v109, v118, v119, v109
+v_subrev_co_u32_e32 v109, vcc, s77, v109
+v_cmp_lt_i32_e32 vcc, v109, v119
+v_subb_co_u32_e64 v118, vcc, 0, 0, vcc
+v_add_co_u32_e32 v110, vcc, v110, v118
+v_mad_i32_i24 v109, v118, s74, v109
+v_subrev_co_u32_e32 v110, vcc, s78, v110
+s_mov_b32 s62, 0
+s_mov_b32 s63, s28
+s_mov_b32 s64, 1
+s_mov_b32 s84, 0
+s_mov_b32 s85, s16
+s_mov_b32 s83, s85
+s_sub_u32 s93, -1, s92
+s_sub_u32 s93, s93, 32
+s_bitset1_b32 s18, 21
+s_mov_b32 s47, 0
+s_mov_b32 s51, 0
+v_add_co_u32_e32 v118, vcc, 2, v0
+v_bfe_u32 v118, v118, 2, 1
+v_cmp_ne_u32_e64 vcc, v118, 1
+s_mov_b64 s[10:11], vcc
+s_mov_b32 s94, 34
+s_mov_b32 s82, 0
+s_bitset1_b32 s18, 26
+s_call_b64 s[38:39], 3130
+v_cmp_le_u32_e32 vcc, 0x100, v0
+s_cbranch_vccnz 65
+s_branch 1604
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_dot2_f32_f16 v2, v34, v42, v2
+v_dot2_f32_f16 v3, v35, v42, v3
+v_dot2_f32_f16 v4, v36, v42, v4
+v_dot2_f32_f16 v5, v37, v42, v5
+v_dot2_f32_f16 v6, v34, v43, v6
+v_dot2_f32_f16 v7, v35, v43, v7
+v_dot2_f32_f16 v8, v36, v43, v8
+v_dot2_f32_f16 v9, v37, v43, v9
+v_dot2_f32_f16 v10, v34, v44, v10
+v_dot2_f32_f16 v11, v35, v44, v11
+v_dot2_f32_f16 v12, v36, v44, v12
+v_dot2_f32_f16 v13, v37, v44, v13
+v_dot2_f32_f16 v14, v34, v45, v14
+v_dot2_f32_f16 v15, v35, v45, v15
+v_dot2_f32_f16 v16, v36, v45, v16
+v_dot2_f32_f16 v17, v37, v45, v17
+v_dot2_f32_f16 v18, v34, v46, v18
+v_dot2_f32_f16 v19, v35, v46, v19
+v_dot2_f32_f16 v20, v36, v46, v20
+v_dot2_f32_f16 v21, v37, v46, v21
+v_dot2_f32_f16 v22, v34, v47, v22
+v_dot2_f32_f16 v23, v35, v47, v23
+v_dot2_f32_f16 v24, v36, v47, v24
+v_dot2_f32_f16 v25, v37, v47, v25
+v_dot2_f32_f16 v26, v34, v48, v26
+v_dot2_f32_f16 v27, v35, v48, v27
+v_dot2_f32_f16 v28, v36, v48, v28
+v_dot2_f32_f16 v29, v37, v48, v29
+v_dot2_f32_f16 v30, v34, v49, v30
+v_dot2_f32_f16 v31, v35, v49, v31
+v_pack_b32_f16 v70, v82, v70
+v_pack_b32_f16 v71, v83, v71
+v_pack_b32_f16 v72, v84, v72
+v_pack_b32_f16 v73, v85, v73
+v_cndmask_b32_dpp v70, v70, v70, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v71, v71, v71, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v72, v72, v72, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v73, v73, v73, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v70, v72, -1.0, v70 op_sel_hi:[1,0,1]
+v_pk_mul_f16 v70, v70, 0.5 op_sel_hi:[1,0]
+v_pk_fma_f16 v73, v71, -1.0, v73 op_sel_hi:[1,0,1]
+v_pk_mul_f16 v73, v73, 0.5 op_sel_hi:[1,0]
+s_setprio 0
+s_nop 0
+v_dot2_f32_f16 v32, v36, v49, v32
+v_dot2_f32_f16 v33, v37, v49, v33
+s_nop 0
+ds_read_b128 v[34:37], v107 offset:29440
+ds_read_b128 v[42:45], v102 offset:28928
+ds_read_b128 v[46:49], v102 offset:29056
+ds_write_b32 v103, v62
+ds_write_b32 v104, v63
+s_setprio 1
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v58, v94, s[40:43], 0 offen
+buffer_load_short_d16 v60, v96, s[40:43], 0 offen
+buffer_load_short_d16 v59, v95, s[40:43], 0 offen
+buffer_load_short_d16 v61, v97, s[40:43], 0 offen
+s_add_u32 s91, s91, 0x200
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 6
+s_call_b64 s[38:39], 2933
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_dot2_f32_f16 v2, v38, v50, v2
+v_dot2_f32_f16 v3, v39, v50, v3
+v_dot2_f32_f16 v4, v40, v50, v4
+v_dot2_f32_f16 v5, v41, v50, v5
+v_dot2_f32_f16 v6, v38, v51, v6
+v_dot2_f32_f16 v7, v39, v51, v7
+v_dot2_f32_f16 v8, v40, v51, v8
+v_dot2_f32_f16 v9, v41, v51, v9
+v_dot2_f32_f16 v10, v38, v52, v10
+v_dot2_f32_f16 v11, v39, v52, v11
+v_dot2_f32_f16 v12, v40, v52, v12
+v_dot2_f32_f16 v13, v41, v52, v13
+v_dot2_f32_f16 v14, v38, v53, v14
+v_dot2_f32_f16 v15, v39, v53, v15
+v_dot2_f32_f16 v16, v40, v53, v16
+v_dot2_f32_f16 v17, v41, v53, v17
+v_dot2_f32_f16 v18, v38, v54, v18
+v_dot2_f32_f16 v19, v39, v54, v19
+v_dot2_f32_f16 v20, v40, v54, v20
+v_dot2_f32_f16 v21, v41, v54, v21
+v_dot2_f32_f16 v22, v38, v55, v22
+v_dot2_f32_f16 v23, v39, v55, v23
+v_dot2_f32_f16 v24, v40, v55, v24
+v_dot2_f32_f16 v25, v41, v55, v25
+v_dot2_f32_f16 v26, v38, v56, v26
+v_dot2_f32_f16 v27, v39, v56, v27
+v_dot2_f32_f16 v28, v40, v56, v28
+v_dot2_f32_f16 v29, v41, v56, v29
+v_dot2_f32_f16 v30, v38, v57, v30
+v_dot2_f32_f16 v31, v39, v57, v31
+v_pk_add_f16 v71, v72, v71
+v_pk_mul_f16 v71, v71, 0.5 op_sel_hi:[1,0]
+v_pk_fma_f16 v72, v71, -1.0, v72 op_sel_hi:[1,0,1]
+v_mov_b32_dpp v115, v70  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v70, v115, v112, v70
+v_mov_b32_dpp v115, v71  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v71, v115, v112, v71
+v_mov_b32_dpp v115, v72  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v72, v115, v112, v72
+v_mov_b32_dpp v115, v73  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v73, v115, v112, v73
+s_setprio 0
+s_nop 0
+v_dot2_f32_f16 v32, v40, v57, v32
+v_dot2_f32_f16 v33, v41, v57, v33
+s_nop 0
+ds_read_b128 v[38:41], v107 offset:33536
+ds_read_b128 v[50:53], v102 offset:33024
+ds_read_b128 v[54:57], v102 offset:33152
+ds_write_b32 v105, v68 offset:8256
+ds_write_b32 v106, v69 offset:8256
+s_setprio 1
+s_add_u32 s40, s40, s69
+s_addc_u32 s41, s41, 0
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v82, v94, s[40:43], 0 offen
+buffer_load_short_d16 v84, v96, s[40:43], 0 offen
+buffer_load_short_d16 v83, v95, s[40:43], 0 offen
+buffer_load_short_d16 v85, v97, s[40:43], 0 offen
+s_nop 0
+s_waitcnt vmcnt(16) lgkmcnt(5)
+ds_append v117 offset:65472
+s_bitset1_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 8
+s_call_b64 s[38:39], 2807
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_dot2_f32_f16 v2, v34, v42, v2
+v_dot2_f32_f16 v3, v35, v42, v3
+v_dot2_f32_f16 v4, v36, v42, v4
+v_dot2_f32_f16 v5, v37, v42, v5
+v_dot2_f32_f16 v6, v34, v43, v6
+v_dot2_f32_f16 v7, v35, v43, v7
+v_dot2_f32_f16 v8, v36, v43, v8
+v_dot2_f32_f16 v9, v37, v43, v9
+v_dot2_f32_f16 v10, v34, v44, v10
+v_dot2_f32_f16 v11, v35, v44, v11
+v_dot2_f32_f16 v12, v36, v44, v12
+v_dot2_f32_f16 v13, v37, v44, v13
+v_dot2_f32_f16 v14, v34, v45, v14
+v_dot2_f32_f16 v15, v35, v45, v15
+v_dot2_f32_f16 v16, v36, v45, v16
+v_dot2_f32_f16 v17, v37, v45, v17
+v_dot2_f32_f16 v18, v34, v46, v18
+v_dot2_f32_f16 v19, v35, v46, v19
+v_dot2_f32_f16 v20, v36, v46, v20
+v_dot2_f32_f16 v21, v37, v46, v21
+v_dot2_f32_f16 v22, v34, v47, v22
+v_dot2_f32_f16 v23, v35, v47, v23
+v_dot2_f32_f16 v24, v36, v47, v24
+v_dot2_f32_f16 v25, v37, v47, v25
+v_dot2_f32_f16 v26, v34, v48, v26
+v_dot2_f32_f16 v27, v35, v48, v27
+v_dot2_f32_f16 v28, v36, v48, v28
+v_dot2_f32_f16 v29, v37, v48, v29
+v_dot2_f32_f16 v30, v34, v49, v30
+v_dot2_f32_f16 v31, v35, v49, v31
+v_pack_b32_f16 v74, v86, v74
+v_pack_b32_f16 v75, v87, v75
+v_pack_b32_f16 v76, v88, v76
+v_pack_b32_f16 v77, v89, v77
+v_cndmask_b32_dpp v74, v74, v74, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v75, v75, v75, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v76, v76, v76, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v77, v77, v77, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v74, v76, -1.0, v74 op_sel_hi:[1,0,1]
+v_pk_mul_f16 v74, v74, 0.5 op_sel_hi:[1,0]
+v_pk_fma_f16 v77, v75, -1.0, v77 op_sel_hi:[1,0,1]
+v_pk_mul_f16 v77, v77, 0.5 op_sel_hi:[1,0]
+s_setprio 0
+s_nop 0
+v_dot2_f32_f16 v32, v36, v49, v32
+v_dot2_f32_f16 v33, v37, v49, v33
+s_nop 0
+ds_read_b128 v[34:37], v107 offset:37696
+ds_read_b128 v[42:45], v102 offset:37184
+ds_read_b128 v[46:49], v102 offset:37312
+ds_write_b32 v103, v66 offset:8256
+ds_write_b32 v104, v67 offset:8256
+s_setprio 1
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v62, v94, s[40:43], 0 offen
+buffer_load_short_d16 v64, v96, s[40:43], 0 offen
+buffer_load_short_d16 v63, v95, s[40:43], 0 offen
+buffer_load_short_d16 v65, v97, s[40:43], 0 offen
+s_mov_b32 m0, 0x2ffc0
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 6
+s_call_b64 s[38:39], 2677
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_dot2_f32_f16 v2, v38, v50, v2
+v_dot2_f32_f16 v3, v39, v50, v3
+v_dot2_f32_f16 v4, v40, v50, v4
+v_dot2_f32_f16 v5, v41, v50, v5
+v_dot2_f32_f16 v6, v38, v51, v6
+v_dot2_f32_f16 v7, v39, v51, v7
+v_dot2_f32_f16 v8, v40, v51, v8
+v_dot2_f32_f16 v9, v41, v51, v9
+v_dot2_f32_f16 v10, v38, v52, v10
+v_dot2_f32_f16 v11, v39, v52, v11
+v_dot2_f32_f16 v12, v40, v52, v12
+v_dot2_f32_f16 v13, v41, v52, v13
+v_dot2_f32_f16 v14, v38, v53, v14
+v_dot2_f32_f16 v15, v39, v53, v15
+v_dot2_f32_f16 v16, v40, v53, v16
+v_dot2_f32_f16 v17, v41, v53, v17
+v_dot2_f32_f16 v18, v38, v54, v18
+v_dot2_f32_f16 v19, v39, v54, v19
+v_dot2_f32_f16 v20, v40, v54, v20
+v_dot2_f32_f16 v21, v41, v54, v21
+v_dot2_f32_f16 v22, v38, v55, v22
+v_dot2_f32_f16 v23, v39, v55, v23
+v_dot2_f32_f16 v24, v40, v55, v24
+v_dot2_f32_f16 v25, v41, v55, v25
+v_dot2_f32_f16 v26, v38, v56, v26
+v_dot2_f32_f16 v27, v39, v56, v27
+v_dot2_f32_f16 v28, v40, v56, v28
+v_dot2_f32_f16 v29, v41, v56, v29
+v_dot2_f32_f16 v30, v38, v57, v30
+v_dot2_f32_f16 v31, v39, v57, v31
+v_dot2_f32_f16 v32, v40, v57, v32
+v_pk_add_f16 v75, v76, v75
+v_pk_mul_f16 v75, v75, 0.5 op_sel_hi:[1,0]
+v_pk_fma_f16 v76, v75, -1.0, v76 op_sel_hi:[1,0,1]
+v_mov_b32_dpp v115, v74  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v74, v115, v112, v74
+v_mov_b32_dpp v115, v75  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v75, v115, v112, v75
+v_mov_b32_dpp v115, v76  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v76, v115, v112, v76
+v_mov_b32_dpp v115, v77  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v77, v115, v112, v77
+s_setprio 0
+s_nop 0
+v_dot2_f32_f16 v33, v41, v57, v33
+v_cmp_eq_u32_e64 vcc, src_lds_direct, s91
+s_nop 0
+s_nop 0
+s_cbranch_vccz 65531
+s_mov_b64 vcc, s[10:11]
+s_nop 0
+ds_read_b128 v[38:41], v107 offset:41792
+ds_read_b128 v[50:53], v102 offset:41280
+ds_read_b128 v[54:57], v102 offset:41408
+ds_write_b32 v105, v72 offset:16512
+ds_write_b32 v106, v73 offset:16512
+s_setprio 1
+s_add_u32 s40, s40, s69
+s_addc_u32 s41, s41, 0
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v86, v94, s[40:43], 0 offen
+buffer_load_short_d16 v88, v96, s[40:43], 0 offen
+buffer_load_short_d16 v87, v95, s[40:43], 0 offen
+buffer_load_short_d16 v89, v97, s[40:43], 0 offen
+s_nop 0
+s_waitcnt vmcnt(16) lgkmcnt(5)
+s_bitset1_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 4
+s_call_b64 s[38:39], 2547
+s_nop 0
+s_nop 0
+s_nop 0
+v_dot2_f32_f16 v2, v34, v42, v2
+v_dot2_f32_f16 v3, v35, v42, v3
+v_dot2_f32_f16 v4, v36, v42, v4
+v_dot2_f32_f16 v5, v37, v42, v5
+v_dot2_f32_f16 v6, v34, v43, v6
+v_dot2_f32_f16 v7, v35, v43, v7
+v_dot2_f32_f16 v8, v36, v43, v8
+v_dot2_f32_f16 v9, v37, v43, v9
+v_dot2_f32_f16 v10, v34, v44, v10
+v_dot2_f32_f16 v11, v35, v44, v11
+v_dot2_f32_f16 v12, v36, v44, v12
+v_dot2_f32_f16 v13, v37, v44, v13
+v_dot2_f32_f16 v14, v34, v45, v14
+v_dot2_f32_f16 v15, v35, v45, v15
+v_dot2_f32_f16 v16, v36, v45, v16
+v_dot2_f32_f16 v17, v37, v45, v17
+v_dot2_f32_f16 v18, v34, v46, v18
+v_dot2_f32_f16 v19, v35, v46, v19
+v_dot2_f32_f16 v20, v36, v46, v20
+v_dot2_f32_f16 v21, v37, v46, v21
+v_dot2_f32_f16 v22, v34, v47, v22
+v_dot2_f32_f16 v23, v35, v47, v23
+v_dot2_f32_f16 v24, v36, v47, v24
+v_dot2_f32_f16 v25, v37, v47, v25
+v_dot2_f32_f16 v26, v34, v48, v26
+v_dot2_f32_f16 v27, v35, v48, v27
+v_dot2_f32_f16 v28, v36, v48, v28
+v_dot2_f32_f16 v29, v37, v48, v29
+v_dot2_f32_f16 v30, v34, v49, v30
+v_dot2_f32_f16 v31, v35, v49, v31
+v_pack_b32_f16 v78, v90, v78
+v_pack_b32_f16 v79, v91, v79
+v_pack_b32_f16 v80, v92, v80
+v_pack_b32_f16 v81, v93, v81
+v_cndmask_b32_dpp v78, v78, v78, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v79, v79, v79, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v80, v80, v80, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v81, v81, v81, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v78, v80, -1.0, v78 op_sel_hi:[1,0,1]
+v_pk_mul_f16 v78, v78, 0.5 op_sel_hi:[1,0]
+v_pk_fma_f16 v81, v79, -1.0, v81 op_sel_hi:[1,0,1]
+v_pk_mul_f16 v81, v81, 0.5 op_sel_hi:[1,0]
+s_setprio 0
+s_nop 0
+v_dot2_f32_f16 v32, v36, v49, v32
+v_dot2_f32_f16 v33, v37, v49, v33
+s_nop 0
+ds_read_b128 v[34:37], v107 offset:45952
+ds_read_b128 v[42:45], v102 offset:45440
+ds_read_b128 v[46:49], v102 offset:45568
+ds_write_b32 v103, v70 offset:16512
+ds_write_b32 v104, v71 offset:16512
+s_setprio 1
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v66, v94, s[40:43], 0 offen
+buffer_load_short_d16 v68, v96, s[40:43], 0 offen
+buffer_load_short_d16 v67, v95, s[40:43], 0 offen
+buffer_load_short_d16 v69, v97, s[40:43], 0 offen
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 8
+s_call_b64 s[38:39], 2423
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_dot2_f32_f16 v2, v38, v50, v2
+v_dot2_f32_f16 v3, v39, v50, v3
+v_dot2_f32_f16 v4, v40, v50, v4
+v_dot2_f32_f16 v5, v41, v50, v5
+v_dot2_f32_f16 v6, v38, v51, v6
+v_dot2_f32_f16 v7, v39, v51, v7
+v_dot2_f32_f16 v8, v40, v51, v8
+v_dot2_f32_f16 v9, v41, v51, v9
+v_dot2_f32_f16 v10, v38, v52, v10
+v_dot2_f32_f16 v11, v39, v52, v11
+v_dot2_f32_f16 v12, v40, v52, v12
+v_dot2_f32_f16 v13, v41, v52, v13
+v_dot2_f32_f16 v14, v38, v53, v14
+v_dot2_f32_f16 v15, v39, v53, v15
+v_dot2_f32_f16 v16, v40, v53, v16
+v_dot2_f32_f16 v17, v41, v53, v17
+v_dot2_f32_f16 v18, v38, v54, v18
+v_dot2_f32_f16 v19, v39, v54, v19
+v_dot2_f32_f16 v20, v40, v54, v20
+v_dot2_f32_f16 v21, v41, v54, v21
+v_dot2_f32_f16 v22, v38, v55, v22
+v_dot2_f32_f16 v23, v39, v55, v23
+v_dot2_f32_f16 v24, v40, v55, v24
+v_dot2_f32_f16 v25, v41, v55, v25
+v_dot2_f32_f16 v26, v38, v56, v26
+v_dot2_f32_f16 v27, v39, v56, v27
+v_dot2_f32_f16 v28, v40, v56, v28
+v_dot2_f32_f16 v29, v41, v56, v29
+v_dot2_f32_f16 v30, v38, v57, v30
+v_dot2_f32_f16 v31, v39, v57, v31
+v_pk_add_f16 v79, v80, v79
+v_pk_mul_f16 v79, v79, 0.5 op_sel_hi:[1,0]
+v_pk_fma_f16 v80, v79, -1.0, v80 op_sel_hi:[1,0,1]
+v_mov_b32_dpp v115, v78  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v78, v115, v112, v78
+v_mov_b32_dpp v115, v79  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v79, v115, v112, v79
+v_mov_b32_dpp v115, v80  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v80, v115, v112, v80
+v_mov_b32_dpp v115, v81  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v81, v115, v112, v81
+s_setprio 0
+s_nop 0
+v_dot2_f32_f16 v32, v40, v57, v32
+v_dot2_f32_f16 v33, v41, v57, v33
+s_nop 0
+ds_read_b128 v[38:41], v107 offset:512
+ds_read_b128 v[50:53], v102
+ds_read_b128 v[54:57], v102 offset:128
+ds_write_b32 v105, v76 offset:24768
+ds_write_b32 v106, v77 offset:24768
+s_setprio 1
+s_add_u32 s40, s40, s69
+s_addc_u32 s41, s41, 0
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v90, v94, s[40:43], 0 offen
+buffer_load_short_d16 v92, v96, s[40:43], 0 offen
+buffer_load_short_d16 v91, v95, s[40:43], 0 offen
+buffer_load_short_d16 v93, v97, s[40:43], 0 offen
+s_nop 0
+s_waitcnt vmcnt(16) lgkmcnt(5)
+ds_append v117 offset:65476
+s_bitset1_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 8
+s_call_b64 s[38:39], 2295
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_dot2_f32_f16 v2, v34, v42, v2
+v_dot2_f32_f16 v3, v35, v42, v3
+v_dot2_f32_f16 v4, v36, v42, v4
+v_dot2_f32_f16 v5, v37, v42, v5
+v_dot2_f32_f16 v6, v34, v43, v6
+v_dot2_f32_f16 v7, v35, v43, v7
+v_dot2_f32_f16 v8, v36, v43, v8
+v_dot2_f32_f16 v9, v37, v43, v9
+v_dot2_f32_f16 v10, v34, v44, v10
+v_dot2_f32_f16 v11, v35, v44, v11
+v_dot2_f32_f16 v12, v36, v44, v12
+v_dot2_f32_f16 v13, v37, v44, v13
+v_dot2_f32_f16 v14, v34, v45, v14
+v_dot2_f32_f16 v15, v35, v45, v15
+v_dot2_f32_f16 v16, v36, v45, v16
+v_dot2_f32_f16 v17, v37, v45, v17
+v_dot2_f32_f16 v18, v34, v46, v18
+v_dot2_f32_f16 v19, v35, v46, v19
+v_dot2_f32_f16 v20, v36, v46, v20
+v_dot2_f32_f16 v21, v37, v46, v21
+v_dot2_f32_f16 v22, v34, v47, v22
+v_dot2_f32_f16 v23, v35, v47, v23
+v_dot2_f32_f16 v24, v36, v47, v24
+v_dot2_f32_f16 v25, v37, v47, v25
+v_dot2_f32_f16 v26, v34, v48, v26
+v_dot2_f32_f16 v27, v35, v48, v27
+v_dot2_f32_f16 v28, v36, v48, v28
+v_dot2_f32_f16 v29, v37, v48, v29
+v_dot2_f32_f16 v30, v34, v49, v30
+v_dot2_f32_f16 v31, v35, v49, v31
+v_pack_b32_f16 v58, v82, v58
+v_pack_b32_f16 v59, v83, v59
+v_pack_b32_f16 v60, v84, v60
+v_pack_b32_f16 v61, v85, v61
+v_cndmask_b32_dpp v58, v58, v58, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v59, v59, v59, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v60, v60, v60, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v61, v61, v61, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v58, v60, -1.0, v58 op_sel_hi:[1,0,1]
+v_pk_mul_f16 v58, v58, 0.5 op_sel_hi:[1,0]
+v_pk_fma_f16 v61, v59, -1.0, v61 op_sel_hi:[1,0,1]
+v_pk_mul_f16 v61, v61, 0.5 op_sel_hi:[1,0]
+s_setprio 0
+s_nop 0
+v_dot2_f32_f16 v32, v36, v49, v32
+v_dot2_f32_f16 v33, v37, v49, v33
+s_nop 0
+ds_read_b128 v[34:37], v107 offset:4672
+ds_read_b128 v[42:45], v102 offset:4160
+ds_read_b128 v[46:49], v102 offset:4288
+ds_write_b32 v103, v74 offset:24768
+ds_write_b32 v104, v75 offset:24768
+s_setprio 1
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v70, v94, s[40:43], 0 offen
+buffer_load_short_d16 v72, v96, s[40:43], 0 offen
+buffer_load_short_d16 v71, v95, s[40:43], 0 offen
+buffer_load_short_d16 v73, v97, s[40:43], 0 offen
+s_mov_b32 m0, 0x2ffc4
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 6
+s_call_b64 s[38:39], 2165
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_dot2_f32_f16 v2, v38, v50, v2
+v_dot2_f32_f16 v3, v39, v50, v3
+v_dot2_f32_f16 v4, v40, v50, v4
+v_dot2_f32_f16 v5, v41, v50, v5
+v_dot2_f32_f16 v6, v38, v51, v6
+v_dot2_f32_f16 v7, v39, v51, v7
+v_dot2_f32_f16 v8, v40, v51, v8
+v_dot2_f32_f16 v9, v41, v51, v9
+v_dot2_f32_f16 v10, v38, v52, v10
+v_dot2_f32_f16 v11, v39, v52, v11
+v_dot2_f32_f16 v12, v40, v52, v12
+v_dot2_f32_f16 v13, v41, v52, v13
+v_dot2_f32_f16 v14, v38, v53, v14
+v_dot2_f32_f16 v15, v39, v53, v15
+v_dot2_f32_f16 v16, v40, v53, v16
+v_dot2_f32_f16 v17, v41, v53, v17
+v_dot2_f32_f16 v18, v38, v54, v18
+v_dot2_f32_f16 v19, v39, v54, v19
+v_dot2_f32_f16 v20, v40, v54, v20
+v_dot2_f32_f16 v21, v41, v54, v21
+v_dot2_f32_f16 v22, v38, v55, v22
+v_dot2_f32_f16 v23, v39, v55, v23
+v_dot2_f32_f16 v24, v40, v55, v24
+v_dot2_f32_f16 v25, v41, v55, v25
+v_dot2_f32_f16 v26, v38, v56, v26
+v_dot2_f32_f16 v27, v39, v56, v27
+v_dot2_f32_f16 v28, v40, v56, v28
+v_dot2_f32_f16 v29, v41, v56, v29
+v_dot2_f32_f16 v30, v38, v57, v30
+v_dot2_f32_f16 v31, v39, v57, v31
+v_dot2_f32_f16 v32, v40, v57, v32
+v_pk_add_f16 v59, v60, v59
+v_pk_mul_f16 v59, v59, 0.5 op_sel_hi:[1,0]
+v_pk_fma_f16 v60, v59, -1.0, v60 op_sel_hi:[1,0,1]
+v_mov_b32_dpp v115, v58  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v58, v115, v112, v58
+v_mov_b32_dpp v115, v59  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v59, v115, v112, v59
+v_mov_b32_dpp v115, v60  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v60, v115, v112, v60
+v_mov_b32_dpp v115, v61  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v61, v115, v112, v61
+s_setprio 0
+s_nop 0
+v_dot2_f32_f16 v33, v41, v57, v33
+v_cmp_eq_u32_e64 vcc, src_lds_direct, s91
+s_nop 0
+s_nop 0
+s_cbranch_vccz 65531
+s_mov_b64 vcc, s[10:11]
+s_nop 0
+ds_read_b128 v[38:41], v107 offset:8768
+ds_read_b128 v[50:53], v102 offset:8256
+ds_read_b128 v[54:57], v102 offset:8384
+ds_write_b32 v105, v80 offset:33024
+ds_write_b32 v106, v81 offset:33024
+s_setprio 1
+s_add_u32 s40, s40, s69
+s_addc_u32 s41, s41, 0
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v82, v94, s[40:43], 0 offen
+buffer_load_short_d16 v84, v96, s[40:43], 0 offen
+buffer_load_short_d16 v83, v95, s[40:43], 0 offen
+buffer_load_short_d16 v85, v97, s[40:43], 0 offen
+s_nop 0
+s_waitcnt vmcnt(16) lgkmcnt(5)
+s_bitset1_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 4
+s_call_b64 s[38:39], 2035
+s_nop 0
+s_nop 0
+s_nop 0
+v_dot2_f32_f16 v2, v34, v42, v2
+v_dot2_f32_f16 v3, v35, v42, v3
+v_dot2_f32_f16 v4, v36, v42, v4
+v_dot2_f32_f16 v5, v37, v42, v5
+v_dot2_f32_f16 v6, v34, v43, v6
+v_dot2_f32_f16 v7, v35, v43, v7
+v_dot2_f32_f16 v8, v36, v43, v8
+v_dot2_f32_f16 v9, v37, v43, v9
+v_dot2_f32_f16 v10, v34, v44, v10
+v_dot2_f32_f16 v11, v35, v44, v11
+v_dot2_f32_f16 v12, v36, v44, v12
+v_dot2_f32_f16 v13, v37, v44, v13
+v_dot2_f32_f16 v14, v34, v45, v14
+v_dot2_f32_f16 v15, v35, v45, v15
+v_dot2_f32_f16 v16, v36, v45, v16
+v_dot2_f32_f16 v17, v37, v45, v17
+v_dot2_f32_f16 v18, v34, v46, v18
+v_dot2_f32_f16 v19, v35, v46, v19
+v_dot2_f32_f16 v20, v36, v46, v20
+v_dot2_f32_f16 v21, v37, v46, v21
+v_dot2_f32_f16 v22, v34, v47, v22
+v_dot2_f32_f16 v23, v35, v47, v23
+v_dot2_f32_f16 v24, v36, v47, v24
+v_dot2_f32_f16 v25, v37, v47, v25
+v_dot2_f32_f16 v26, v34, v48, v26
+v_dot2_f32_f16 v27, v35, v48, v27
+v_dot2_f32_f16 v28, v36, v48, v28
+v_dot2_f32_f16 v29, v37, v48, v29
+v_dot2_f32_f16 v30, v34, v49, v30
+v_dot2_f32_f16 v31, v35, v49, v31
+v_pack_b32_f16 v62, v86, v62
+v_pack_b32_f16 v63, v87, v63
+v_pack_b32_f16 v64, v88, v64
+v_pack_b32_f16 v65, v89, v65
+v_cndmask_b32_dpp v62, v62, v62, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v63, v63, v63, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v64, v64, v64, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v65, v65, v65, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v62, v64, -1.0, v62 op_sel_hi:[1,0,1]
+v_pk_mul_f16 v62, v62, 0.5 op_sel_hi:[1,0]
+v_pk_fma_f16 v65, v63, -1.0, v65 op_sel_hi:[1,0,1]
+v_pk_mul_f16 v65, v65, 0.5 op_sel_hi:[1,0]
+s_setprio 0
+s_nop 0
+v_dot2_f32_f16 v32, v36, v49, v32
+v_dot2_f32_f16 v33, v37, v49, v33
+s_nop 0
+ds_read_b128 v[34:37], v107 offset:12928
+ds_read_b128 v[42:45], v102 offset:12416
+ds_read_b128 v[46:49], v102 offset:12544
+ds_write_b32 v103, v78 offset:33024
+ds_write_b32 v104, v79 offset:33024
+s_setprio 1
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v74, v94, s[40:43], 0 offen
+buffer_load_short_d16 v76, v96, s[40:43], 0 offen
+buffer_load_short_d16 v75, v95, s[40:43], 0 offen
+buffer_load_short_d16 v77, v97, s[40:43], 0 offen
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 8
+s_call_b64 s[38:39], 1911
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_dot2_f32_f16 v2, v38, v50, v2
+v_dot2_f32_f16 v3, v39, v50, v3
+v_dot2_f32_f16 v4, v40, v50, v4
+v_dot2_f32_f16 v5, v41, v50, v5
+v_dot2_f32_f16 v6, v38, v51, v6
+v_dot2_f32_f16 v7, v39, v51, v7
+v_dot2_f32_f16 v8, v40, v51, v8
+v_dot2_f32_f16 v9, v41, v51, v9
+v_dot2_f32_f16 v10, v38, v52, v10
+v_dot2_f32_f16 v11, v39, v52, v11
+v_dot2_f32_f16 v12, v40, v52, v12
+v_dot2_f32_f16 v13, v41, v52, v13
+v_dot2_f32_f16 v14, v38, v53, v14
+v_dot2_f32_f16 v15, v39, v53, v15
+v_dot2_f32_f16 v16, v40, v53, v16
+v_dot2_f32_f16 v17, v41, v53, v17
+v_dot2_f32_f16 v18, v38, v54, v18
+v_dot2_f32_f16 v19, v39, v54, v19
+v_dot2_f32_f16 v20, v40, v54, v20
+v_dot2_f32_f16 v21, v41, v54, v21
+v_dot2_f32_f16 v22, v38, v55, v22
+v_dot2_f32_f16 v23, v39, v55, v23
+v_dot2_f32_f16 v24, v40, v55, v24
+v_dot2_f32_f16 v25, v41, v55, v25
+v_dot2_f32_f16 v26, v38, v56, v26
+v_dot2_f32_f16 v27, v39, v56, v27
+v_dot2_f32_f16 v28, v40, v56, v28
+v_dot2_f32_f16 v29, v41, v56, v29
+v_dot2_f32_f16 v30, v38, v57, v30
+v_dot2_f32_f16 v31, v39, v57, v31
+v_pk_add_f16 v63, v64, v63
+v_pk_mul_f16 v63, v63, 0.5 op_sel_hi:[1,0]
+v_pk_fma_f16 v64, v63, -1.0, v64 op_sel_hi:[1,0,1]
+v_mov_b32_dpp v115, v62  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v62, v115, v112, v62
+v_mov_b32_dpp v115, v63  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v63, v115, v112, v63
+v_mov_b32_dpp v115, v64  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v64, v115, v112, v64
+v_mov_b32_dpp v115, v65  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v65, v115, v112, v65
+s_setprio 0
+s_nop 0
+v_dot2_f32_f16 v32, v40, v57, v32
+v_dot2_f32_f16 v33, v41, v57, v33
+s_nop 0
+ds_read_b128 v[38:41], v107 offset:17024
+ds_read_b128 v[50:53], v102 offset:16512
+ds_read_b128 v[54:57], v102 offset:16640
+ds_write_b32 v105, v60 offset:41280
+ds_write_b32 v106, v61 offset:41280
+s_setprio 1
+s_add_u32 s40, s40, s69
+s_addc_u32 s41, s41, 0
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v86, v94, s[40:43], 0 offen
+buffer_load_short_d16 v88, v96, s[40:43], 0 offen
+buffer_load_short_d16 v87, v95, s[40:43], 0 offen
+buffer_load_short_d16 v89, v97, s[40:43], 0 offen
+s_nop 0
+s_waitcnt vmcnt(16) lgkmcnt(5)
+ds_append v117 offset:65480
+s_bitset1_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 8
+s_call_b64 s[38:39], 1783
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_dot2_f32_f16 v2, v34, v42, v2
+v_dot2_f32_f16 v3, v35, v42, v3
+v_dot2_f32_f16 v4, v36, v42, v4
+v_dot2_f32_f16 v5, v37, v42, v5
+v_dot2_f32_f16 v6, v34, v43, v6
+v_dot2_f32_f16 v7, v35, v43, v7
+v_dot2_f32_f16 v8, v36, v43, v8
+v_dot2_f32_f16 v9, v37, v43, v9
+v_dot2_f32_f16 v10, v34, v44, v10
+v_dot2_f32_f16 v11, v35, v44, v11
+v_dot2_f32_f16 v12, v36, v44, v12
+v_dot2_f32_f16 v13, v37, v44, v13
+v_dot2_f32_f16 v14, v34, v45, v14
+v_dot2_f32_f16 v15, v35, v45, v15
+v_dot2_f32_f16 v16, v36, v45, v16
+v_dot2_f32_f16 v17, v37, v45, v17
+v_dot2_f32_f16 v18, v34, v46, v18
+v_dot2_f32_f16 v19, v35, v46, v19
+v_dot2_f32_f16 v20, v36, v46, v20
+v_dot2_f32_f16 v21, v37, v46, v21
+v_dot2_f32_f16 v22, v34, v47, v22
+v_dot2_f32_f16 v23, v35, v47, v23
+v_dot2_f32_f16 v24, v36, v47, v24
+v_dot2_f32_f16 v25, v37, v47, v25
+v_dot2_f32_f16 v26, v34, v48, v26
+v_dot2_f32_f16 v27, v35, v48, v27
+v_dot2_f32_f16 v28, v36, v48, v28
+v_dot2_f32_f16 v29, v37, v48, v29
+v_dot2_f32_f16 v30, v34, v49, v30
+v_dot2_f32_f16 v31, v35, v49, v31
+v_pack_b32_f16 v66, v90, v66
+v_pack_b32_f16 v67, v91, v67
+v_pack_b32_f16 v68, v92, v68
+v_pack_b32_f16 v69, v93, v69
+v_cndmask_b32_dpp v66, v66, v66, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v67, v67, v67, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v68, v68, v68, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v69, v69, v69, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v66, v68, -1.0, v66 op_sel_hi:[1,0,1]
+v_pk_mul_f16 v66, v66, 0.5 op_sel_hi:[1,0]
+v_pk_fma_f16 v69, v67, -1.0, v69 op_sel_hi:[1,0,1]
+v_pk_mul_f16 v69, v69, 0.5 op_sel_hi:[1,0]
+s_setprio 0
+s_nop 0
+v_dot2_f32_f16 v32, v36, v49, v32
+v_dot2_f32_f16 v33, v37, v49, v33
+s_nop 0
+ds_read_b128 v[34:37], v107 offset:21184
+ds_read_b128 v[42:45], v102 offset:20672
+ds_read_b128 v[46:49], v102 offset:20800
+ds_write_b32 v103, v58 offset:41280
+ds_write_b32 v104, v59 offset:41280
+s_setprio 1
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v78, v94, s[40:43], 0 offen
+buffer_load_short_d16 v80, v96, s[40:43], 0 offen
+buffer_load_short_d16 v79, v95, s[40:43], 0 offen
+buffer_load_short_d16 v81, v97, s[40:43], 0 offen
+s_mov_b32 m0, 0x2ffc8
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 6
+s_call_b64 s[38:39], 1653
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_dot2_f32_f16 v2, v38, v50, v2
+v_dot2_f32_f16 v3, v39, v50, v3
+v_dot2_f32_f16 v4, v40, v50, v4
+v_dot2_f32_f16 v5, v41, v50, v5
+v_dot2_f32_f16 v6, v38, v51, v6
+v_dot2_f32_f16 v7, v39, v51, v7
+v_dot2_f32_f16 v8, v40, v51, v8
+v_dot2_f32_f16 v9, v41, v51, v9
+v_dot2_f32_f16 v10, v38, v52, v10
+v_dot2_f32_f16 v11, v39, v52, v11
+v_dot2_f32_f16 v12, v40, v52, v12
+v_dot2_f32_f16 v13, v41, v52, v13
+v_dot2_f32_f16 v14, v38, v53, v14
+v_dot2_f32_f16 v15, v39, v53, v15
+v_dot2_f32_f16 v16, v40, v53, v16
+v_dot2_f32_f16 v17, v41, v53, v17
+v_dot2_f32_f16 v18, v38, v54, v18
+v_dot2_f32_f16 v19, v39, v54, v19
+v_dot2_f32_f16 v20, v40, v54, v20
+v_dot2_f32_f16 v21, v41, v54, v21
+v_dot2_f32_f16 v22, v38, v55, v22
+v_dot2_f32_f16 v23, v39, v55, v23
+v_dot2_f32_f16 v24, v40, v55, v24
+v_dot2_f32_f16 v25, v41, v55, v25
+v_dot2_f32_f16 v26, v38, v56, v26
+v_dot2_f32_f16 v27, v39, v56, v27
+v_dot2_f32_f16 v28, v40, v56, v28
+v_dot2_f32_f16 v29, v41, v56, v29
+v_dot2_f32_f16 v30, v38, v57, v30
+v_dot2_f32_f16 v31, v39, v57, v31
+v_dot2_f32_f16 v32, v40, v57, v32
+v_pk_add_f16 v67, v68, v67
+v_pk_mul_f16 v67, v67, 0.5 op_sel_hi:[1,0]
+v_pk_fma_f16 v68, v67, -1.0, v68 op_sel_hi:[1,0,1]
+v_mov_b32_dpp v115, v66  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v66, v115, v112, v66
+v_mov_b32_dpp v115, v67  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v67, v115, v112, v67
+v_mov_b32_dpp v115, v68  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v68, v115, v112, v68
+v_mov_b32_dpp v115, v69  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v69, v115, v112, v69
+s_setprio 0
+s_nop 0
+v_dot2_f32_f16 v33, v41, v57, v33
+v_cmp_eq_u32_e64 vcc, src_lds_direct, s91
+s_nop 0
+s_nop 0
+s_cbranch_vccz 65531
+s_mov_b64 vcc, s[10:11]
+s_nop 0
+ds_read_b128 v[38:41], v107 offset:25280
+ds_read_b128 v[50:53], v102 offset:24768
+ds_read_b128 v[54:57], v102 offset:24896
+ds_write_b32 v105, v64
+ds_write_b32 v106, v65
+s_setprio 1
+s_add_u32 s40, s40, s69
+s_addc_u32 s41, s41, 0
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v90, v94, s[40:43], 0 offen
+buffer_load_short_d16 v92, v96, s[40:43], 0 offen
+buffer_load_short_d16 v91, v95, s[40:43], 0 offen
+buffer_load_short_d16 v93, v97, s[40:43], 0 offen
+s_nop 0
+s_waitcnt vmcnt(16) lgkmcnt(5)
+s_bitset1_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 64004
+s_call_b64 s[38:39], 1523
+s_branch 64002
+s_nop 0
+s_nop 0
+v_dot2_f32_f16 v2, v34, v42, v2
+v_dot2_f32_f16 v3, v35, v42, v3
+v_dot2_f32_f16 v4, v36, v42, v4
+v_dot2_f32_f16 v5, v37, v42, v5
+s_setprio 1
+s_nop 0
+v_dot2_f32_f16 v6, v34, v43, v6
+v_dot2_f32_f16 v7, v35, v43, v7
+v_dot2_f32_f16 v8, v36, v43, v8
+v_dot2_f32_f16 v9, v37, v43, v9
+v_dot2_f32_f16 v10, v34, v44, v10
+v_dot2_f32_f16 v11, v35, v44, v11
+v_dot2_f32_f16 v12, v36, v44, v12
+v_dot2_f32_f16 v13, v37, v44, v13
+v_dot2_f32_f16 v14, v34, v45, v14
+v_dot2_f32_f16 v15, v35, v45, v15
+v_dot2_f32_f16 v16, v36, v45, v16
+v_dot2_f32_f16 v17, v37, v45, v17
+v_dot2_f32_f16 v18, v34, v46, v18
+v_dot2_f32_f16 v19, v35, v46, v19
+v_dot2_f32_f16 v20, v36, v46, v20
+v_dot2_f32_f16 v21, v37, v46, v21
+v_dot2_f32_f16 v22, v34, v47, v22
+v_dot2_f32_f16 v23, v35, v47, v23
+v_dot2_f32_f16 v24, v36, v47, v24
+v_dot2_f32_f16 v25, v37, v47, v25
+v_dot2_f32_f16 v26, v34, v48, v26
+v_dot2_f32_f16 v27, v35, v48, v27
+v_dot2_f32_f16 v28, v36, v48, v28
+v_dot2_f32_f16 v29, v37, v48, v29
+v_dot2_f32_f16 v30, v34, v49, v30
+v_dot2_f32_f16 v31, v35, v49, v31
+v_pack_b32_f16 v70, v82, v70
+v_pack_b32_f16 v71, v83, v71
+v_pack_b32_f16 v72, v84, v72
+v_pack_b32_f16 v73, v85, v73
+v_cndmask_b32_dpp v70, v70, v70, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v71, v71, v71, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v72, v72, v72, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v73, v73, v73, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_mov_b32_dpp v70, v71  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_pk_add_f16 v70, v70, v71
+v_mov_b32_dpp v71, v71  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v70, v71, v112, v70
+v_dot2_f32_f16 v32, v36, v49, v32
+v_dot2_f32_f16 v33, v37, v49, v33
+s_nop 0
+ds_read_b128 v[34:37], v107 offset:29440
+ds_read_b128 v[42:45], v102 offset:28928
+ds_read_b128 v[46:49], v102 offset:29056
+ds_write_b32 v103, v62
+ds_write_b32 v104, v63
+s_setprio 0
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v60, v96, s[40:43], 0 offen
+buffer_load_short_d16 v59, v95, s[40:43], 0 offen
+buffer_load_short_d16 v61, v97, s[40:43], 0 offen
+s_add_u32 s91, s91, 0x200
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 8
+s_call_b64 s[38:39], 1399
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_dot2_f32_f16 v2, v38, v50, v2
+v_dot2_f32_f16 v3, v39, v50, v3
+v_dot2_f32_f16 v4, v40, v50, v4
+v_dot2_f32_f16 v5, v41, v50, v5
+s_setprio 1
+s_nop 0
+v_dot2_f32_f16 v6, v38, v51, v6
+v_dot2_f32_f16 v7, v39, v51, v7
+v_dot2_f32_f16 v8, v40, v51, v8
+v_dot2_f32_f16 v9, v41, v51, v9
+v_dot2_f32_f16 v10, v38, v52, v10
+v_dot2_f32_f16 v11, v39, v52, v11
+v_dot2_f32_f16 v12, v40, v52, v12
+v_dot2_f32_f16 v13, v41, v52, v13
+v_dot2_f32_f16 v14, v38, v53, v14
+v_dot2_f32_f16 v15, v39, v53, v15
+v_dot2_f32_f16 v16, v40, v53, v16
+v_dot2_f32_f16 v17, v41, v53, v17
+v_dot2_f32_f16 v18, v38, v54, v18
+v_dot2_f32_f16 v19, v39, v54, v19
+v_dot2_f32_f16 v20, v40, v54, v20
+v_dot2_f32_f16 v21, v41, v54, v21
+v_dot2_f32_f16 v22, v38, v55, v22
+v_dot2_f32_f16 v23, v39, v55, v23
+v_dot2_f32_f16 v24, v40, v55, v24
+v_dot2_f32_f16 v25, v41, v55, v25
+v_dot2_f32_f16 v26, v38, v56, v26
+v_dot2_f32_f16 v27, v39, v56, v27
+v_dot2_f32_f16 v28, v40, v56, v28
+v_dot2_f32_f16 v29, v41, v56, v29
+v_dot2_f32_f16 v30, v38, v57, v30
+v_dot2_f32_f16 v31, v39, v57, v31
+v_mov_b32_dpp v71, v73  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_pk_add_f16 v71, v71, v73
+v_mov_b32_dpp v73, v73  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v71, v73, v112, v71
+v_mov_b32_dpp v73, v72  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_pk_add_f16 v73, v73, v72
+v_mov_b32_dpp v72, v72  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v73, v72, v112, v73
+v_pk_add_f16 v72, v70, v73
+v_pk_add_f16 v71, v71, v72
+v_pk_mul_f16 v71, v71, 0.5 op_sel_hi:[1,0]
+v_pk_fma_f16 v72, -1.0, v71, v72 op_sel_hi:[0,1,1]
+v_dot2_f32_f16 v32, v40, v57, v32
+v_dot2_f32_f16 v33, v41, v57, v33
+s_nop 0
+ds_read_b128 v[38:41], v107 offset:33536
+ds_read_b128 v[50:53], v102 offset:33024
+ds_read_b128 v[54:57], v102 offset:33152
+ds_write_b32 v105, v68 offset:8256
+ds_write_b32 v106, v69 offset:8256
+s_setprio 0
+s_add_u32 s40, s40, s69
+s_addc_u32 s41, s41, 0
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v84, v96, s[40:43], 0 offen
+buffer_load_short_d16 v83, v95, s[40:43], 0 offen
+buffer_load_short_d16 v85, v97, s[40:43], 0 offen
+s_nop 0
+s_waitcnt vmcnt(12) lgkmcnt(5)
+ds_append v117 offset:65472
+s_bitset1_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 8
+s_call_b64 s[38:39], 1271
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_dot2_f32_f16 v2, v34, v42, v2
+v_dot2_f32_f16 v3, v35, v42, v3
+v_dot2_f32_f16 v4, v36, v42, v4
+v_dot2_f32_f16 v5, v37, v42, v5
+s_setprio 1
+s_nop 0
+v_dot2_f32_f16 v6, v34, v43, v6
+v_dot2_f32_f16 v7, v35, v43, v7
+v_dot2_f32_f16 v8, v36, v43, v8
+v_dot2_f32_f16 v9, v37, v43, v9
+v_dot2_f32_f16 v10, v34, v44, v10
+v_dot2_f32_f16 v11, v35, v44, v11
+v_dot2_f32_f16 v12, v36, v44, v12
+v_dot2_f32_f16 v13, v37, v44, v13
+v_dot2_f32_f16 v14, v34, v45, v14
+v_dot2_f32_f16 v15, v35, v45, v15
+v_dot2_f32_f16 v16, v36, v45, v16
+v_dot2_f32_f16 v17, v37, v45, v17
+v_dot2_f32_f16 v18, v34, v46, v18
+v_dot2_f32_f16 v19, v35, v46, v19
+v_dot2_f32_f16 v20, v36, v46, v20
+v_dot2_f32_f16 v21, v37, v46, v21
+v_dot2_f32_f16 v22, v34, v47, v22
+v_dot2_f32_f16 v23, v35, v47, v23
+v_dot2_f32_f16 v24, v36, v47, v24
+v_dot2_f32_f16 v25, v37, v47, v25
+v_dot2_f32_f16 v26, v34, v48, v26
+v_dot2_f32_f16 v27, v35, v48, v27
+v_dot2_f32_f16 v28, v36, v48, v28
+v_dot2_f32_f16 v29, v37, v48, v29
+v_dot2_f32_f16 v30, v34, v49, v30
+v_dot2_f32_f16 v31, v35, v49, v31
+v_pack_b32_f16 v74, v86, v74
+v_pack_b32_f16 v75, v87, v75
+v_pack_b32_f16 v76, v88, v76
+v_pack_b32_f16 v77, v89, v77
+v_cndmask_b32_dpp v74, v74, v74, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v75, v75, v75, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v76, v76, v76, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v77, v77, v77, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_mov_b32_dpp v74, v75  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_pk_add_f16 v74, v74, v75
+v_mov_b32_dpp v75, v75  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v74, v75, v112, v74
+v_dot2_f32_f16 v32, v36, v49, v32
+v_dot2_f32_f16 v33, v37, v49, v33
+s_nop 0
+ds_read_b128 v[34:37], v107 offset:37696
+ds_read_b128 v[42:45], v102 offset:37184
+ds_read_b128 v[46:49], v102 offset:37312
+ds_write_b32 v103, v66 offset:8256
+ds_write_b32 v104, v67 offset:8256
+s_setprio 0
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v64, v96, s[40:43], 0 offen
+buffer_load_short_d16 v63, v95, s[40:43], 0 offen
+buffer_load_short_d16 v65, v97, s[40:43], 0 offen
+s_mov_b32 m0, 0x2ffc0
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 8
+s_call_b64 s[38:39], 1143
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_dot2_f32_f16 v2, v38, v50, v2
+v_dot2_f32_f16 v3, v39, v50, v3
+v_dot2_f32_f16 v4, v40, v50, v4
+v_dot2_f32_f16 v5, v41, v50, v5
+s_setprio 1
+s_nop 0
+v_dot2_f32_f16 v6, v38, v51, v6
+v_dot2_f32_f16 v7, v39, v51, v7
+v_dot2_f32_f16 v8, v40, v51, v8
+v_dot2_f32_f16 v9, v41, v51, v9
+v_dot2_f32_f16 v10, v38, v52, v10
+v_dot2_f32_f16 v11, v39, v52, v11
+v_dot2_f32_f16 v12, v40, v52, v12
+v_dot2_f32_f16 v13, v41, v52, v13
+v_dot2_f32_f16 v14, v38, v53, v14
+v_dot2_f32_f16 v15, v39, v53, v15
+v_dot2_f32_f16 v16, v40, v53, v16
+v_dot2_f32_f16 v17, v41, v53, v17
+v_dot2_f32_f16 v18, v38, v54, v18
+v_dot2_f32_f16 v19, v39, v54, v19
+v_dot2_f32_f16 v20, v40, v54, v20
+v_dot2_f32_f16 v21, v41, v54, v21
+v_dot2_f32_f16 v22, v38, v55, v22
+v_dot2_f32_f16 v23, v39, v55, v23
+v_dot2_f32_f16 v24, v40, v55, v24
+v_dot2_f32_f16 v25, v41, v55, v25
+v_dot2_f32_f16 v26, v38, v56, v26
+v_dot2_f32_f16 v27, v39, v56, v27
+v_dot2_f32_f16 v28, v40, v56, v28
+v_dot2_f32_f16 v29, v41, v56, v29
+v_dot2_f32_f16 v30, v38, v57, v30
+v_dot2_f32_f16 v31, v39, v57, v31
+v_dot2_f32_f16 v32, v40, v57, v32
+v_mov_b32_dpp v75, v77  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_pk_add_f16 v75, v75, v77
+v_mov_b32_dpp v77, v77  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v75, v77, v112, v75
+v_mov_b32_dpp v77, v76  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_pk_add_f16 v77, v77, v76
+v_mov_b32_dpp v76, v76  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v77, v76, v112, v77
+v_pk_add_f16 v76, v74, v77
+v_pk_add_f16 v75, v75, v76
+v_pk_mul_f16 v75, v75, 0.5 op_sel_hi:[1,0]
+v_pk_fma_f16 v76, -1.0, v75, v76 op_sel_hi:[0,1,1]
+v_dot2_f32_f16 v33, v41, v57, v33
+v_cmp_eq_u32_e64 vcc, src_lds_direct, s91
+s_nop 0
+s_nop 0
+s_cbranch_vccz 65531
+s_mov_b64 vcc, s[10:11]
+s_nop 0
+ds_read_b128 v[38:41], v107 offset:41792
+ds_read_b128 v[50:53], v102 offset:41280
+ds_read_b128 v[54:57], v102 offset:41408
+ds_write_b32 v105, v72 offset:16512
+ds_write_b32 v106, v73 offset:16512
+s_setprio 0
+s_add_u32 s40, s40, s69
+s_addc_u32 s41, s41, 0
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v88, v96, s[40:43], 0 offen
+buffer_load_short_d16 v87, v95, s[40:43], 0 offen
+buffer_load_short_d16 v89, v97, s[40:43], 0 offen
+s_nop 0
+s_waitcnt vmcnt(12) lgkmcnt(5)
+s_bitset1_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 4
+s_call_b64 s[38:39], 1011
+s_nop 0
+s_nop 0
+s_nop 0
+v_dot2_f32_f16 v2, v34, v42, v2
+v_dot2_f32_f16 v3, v35, v42, v3
+v_dot2_f32_f16 v4, v36, v42, v4
+v_dot2_f32_f16 v5, v37, v42, v5
+s_setprio 1
+s_nop 0
+v_dot2_f32_f16 v6, v34, v43, v6
+v_dot2_f32_f16 v7, v35, v43, v7
+v_dot2_f32_f16 v8, v36, v43, v8
+v_dot2_f32_f16 v9, v37, v43, v9
+v_dot2_f32_f16 v10, v34, v44, v10
+v_dot2_f32_f16 v11, v35, v44, v11
+v_dot2_f32_f16 v12, v36, v44, v12
+v_dot2_f32_f16 v13, v37, v44, v13
+v_dot2_f32_f16 v14, v34, v45, v14
+v_dot2_f32_f16 v15, v35, v45, v15
+v_dot2_f32_f16 v16, v36, v45, v16
+v_dot2_f32_f16 v17, v37, v45, v17
+v_dot2_f32_f16 v18, v34, v46, v18
+v_dot2_f32_f16 v19, v35, v46, v19
+v_dot2_f32_f16 v20, v36, v46, v20
+v_dot2_f32_f16 v21, v37, v46, v21
+v_dot2_f32_f16 v22, v34, v47, v22
+v_dot2_f32_f16 v23, v35, v47, v23
+v_dot2_f32_f16 v24, v36, v47, v24
+v_dot2_f32_f16 v25, v37, v47, v25
+v_dot2_f32_f16 v26, v34, v48, v26
+v_dot2_f32_f16 v27, v35, v48, v27
+v_dot2_f32_f16 v28, v36, v48, v28
+v_dot2_f32_f16 v29, v37, v48, v29
+v_dot2_f32_f16 v30, v34, v49, v30
+v_dot2_f32_f16 v31, v35, v49, v31
+v_pack_b32_f16 v78, v90, v78
+v_pack_b32_f16 v79, v91, v79
+v_pack_b32_f16 v80, v92, v80
+v_pack_b32_f16 v81, v93, v81
+v_cndmask_b32_dpp v78, v78, v78, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v79, v79, v79, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v80, v80, v80, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v81, v81, v81, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_mov_b32_dpp v78, v79  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_pk_add_f16 v78, v78, v79
+v_mov_b32_dpp v79, v79  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v78, v79, v112, v78
+v_dot2_f32_f16 v32, v36, v49, v32
+v_dot2_f32_f16 v33, v37, v49, v33
+s_nop 0
+ds_read_b128 v[34:37], v107 offset:45952
+ds_read_b128 v[42:45], v102 offset:45440
+ds_read_b128 v[46:49], v102 offset:45568
+ds_write_b32 v103, v70 offset:16512
+ds_write_b32 v104, v71 offset:16512
+s_setprio 0
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v68, v96, s[40:43], 0 offen
+buffer_load_short_d16 v67, v95, s[40:43], 0 offen
+buffer_load_short_d16 v69, v97, s[40:43], 0 offen
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 2
+s_call_b64 s[38:39], 889
+s_nop 0
+v_dot2_f32_f16 v2, v38, v50, v2
+v_dot2_f32_f16 v3, v39, v50, v3
+v_dot2_f32_f16 v4, v40, v50, v4
+v_dot2_f32_f16 v5, v41, v50, v5
+s_setprio 1
+s_nop 0
+v_dot2_f32_f16 v6, v38, v51, v6
+v_dot2_f32_f16 v7, v39, v51, v7
+v_dot2_f32_f16 v8, v40, v51, v8
+v_dot2_f32_f16 v9, v41, v51, v9
+v_dot2_f32_f16 v10, v38, v52, v10
+v_dot2_f32_f16 v11, v39, v52, v11
+v_dot2_f32_f16 v12, v40, v52, v12
+v_dot2_f32_f16 v13, v41, v52, v13
+v_dot2_f32_f16 v14, v38, v53, v14
+v_dot2_f32_f16 v15, v39, v53, v15
+v_dot2_f32_f16 v16, v40, v53, v16
+v_dot2_f32_f16 v17, v41, v53, v17
+v_dot2_f32_f16 v18, v38, v54, v18
+v_dot2_f32_f16 v19, v39, v54, v19
+v_dot2_f32_f16 v20, v40, v54, v20
+v_dot2_f32_f16 v21, v41, v54, v21
+v_dot2_f32_f16 v22, v38, v55, v22
+v_dot2_f32_f16 v23, v39, v55, v23
+v_dot2_f32_f16 v24, v40, v55, v24
+v_dot2_f32_f16 v25, v41, v55, v25
+v_dot2_f32_f16 v26, v38, v56, v26
+v_dot2_f32_f16 v27, v39, v56, v27
+v_dot2_f32_f16 v28, v40, v56, v28
+v_dot2_f32_f16 v29, v41, v56, v29
+v_dot2_f32_f16 v30, v38, v57, v30
+v_dot2_f32_f16 v31, v39, v57, v31
+v_mov_b32_dpp v79, v81  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_pk_add_f16 v79, v79, v81
+v_mov_b32_dpp v81, v81  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v79, v81, v112, v79
+v_mov_b32_dpp v81, v80  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_pk_add_f16 v81, v81, v80
+v_mov_b32_dpp v80, v80  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v81, v80, v112, v81
+v_pk_add_f16 v80, v78, v81
+v_pk_add_f16 v79, v79, v80
+v_pk_mul_f16 v79, v79, 0.5 op_sel_hi:[1,0]
+v_pk_fma_f16 v80, -1.0, v79, v80 op_sel_hi:[0,1,1]
+v_dot2_f32_f16 v32, v40, v57, v32
+v_dot2_f32_f16 v33, v41, v57, v33
+s_nop 0
+ds_read_b128 v[38:41], v107 offset:512
+ds_read_b128 v[50:53], v102
+ds_read_b128 v[54:57], v102 offset:128
+ds_write_b32 v105, v76 offset:24768
+ds_write_b32 v106, v77 offset:24768
+s_setprio 0
+s_add_u32 s40, s40, s69
+s_addc_u32 s41, s41, 0
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v92, v96, s[40:43], 0 offen
+buffer_load_short_d16 v91, v95, s[40:43], 0 offen
+buffer_load_short_d16 v93, v97, s[40:43], 0 offen
+s_nop 0
+s_waitcnt vmcnt(12) lgkmcnt(5)
+ds_append v117 offset:65476
+s_bitset1_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 8
+s_call_b64 s[38:39], 767
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_dot2_f32_f16 v2, v34, v42, v2
+v_dot2_f32_f16 v3, v35, v42, v3
+v_dot2_f32_f16 v4, v36, v42, v4
+v_dot2_f32_f16 v5, v37, v42, v5
+s_setprio 1
+s_nop 0
+v_dot2_f32_f16 v6, v34, v43, v6
+v_dot2_f32_f16 v7, v35, v43, v7
+v_dot2_f32_f16 v8, v36, v43, v8
+v_dot2_f32_f16 v9, v37, v43, v9
+v_dot2_f32_f16 v10, v34, v44, v10
+v_dot2_f32_f16 v11, v35, v44, v11
+v_dot2_f32_f16 v12, v36, v44, v12
+v_dot2_f32_f16 v13, v37, v44, v13
+v_dot2_f32_f16 v14, v34, v45, v14
+v_dot2_f32_f16 v15, v35, v45, v15
+v_dot2_f32_f16 v16, v36, v45, v16
+v_dot2_f32_f16 v17, v37, v45, v17
+v_dot2_f32_f16 v18, v34, v46, v18
+v_dot2_f32_f16 v19, v35, v46, v19
+v_dot2_f32_f16 v20, v36, v46, v20
+v_dot2_f32_f16 v21, v37, v46, v21
+v_dot2_f32_f16 v22, v34, v47, v22
+v_dot2_f32_f16 v23, v35, v47, v23
+v_dot2_f32_f16 v24, v36, v47, v24
+v_dot2_f32_f16 v25, v37, v47, v25
+v_dot2_f32_f16 v26, v34, v48, v26
+v_dot2_f32_f16 v27, v35, v48, v27
+v_dot2_f32_f16 v28, v36, v48, v28
+v_dot2_f32_f16 v29, v37, v48, v29
+v_dot2_f32_f16 v30, v34, v49, v30
+v_dot2_f32_f16 v31, v35, v49, v31
+v_pack_b32_f16 v58, v82, v58
+v_pack_b32_f16 v59, v83, v59
+v_pack_b32_f16 v60, v84, v60
+v_pack_b32_f16 v61, v85, v61
+v_cndmask_b32_dpp v58, v58, v58, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v59, v59, v59, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v60, v60, v60, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v61, v61, v61, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_mov_b32_dpp v58, v59  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_pk_add_f16 v58, v58, v59
+v_mov_b32_dpp v59, v59  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v58, v59, v112, v58
+v_dot2_f32_f16 v32, v36, v49, v32
+v_dot2_f32_f16 v33, v37, v49, v33
+s_nop 0
+ds_read_b128 v[34:37], v107 offset:4672
+ds_read_b128 v[42:45], v102 offset:4160
+ds_read_b128 v[46:49], v102 offset:4288
+ds_write_b32 v103, v74 offset:24768
+ds_write_b32 v104, v75 offset:24768
+s_setprio 0
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v72, v96, s[40:43], 0 offen
+buffer_load_short_d16 v71, v95, s[40:43], 0 offen
+buffer_load_short_d16 v73, v97, s[40:43], 0 offen
+s_mov_b32 m0, 0x2ffc4
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 8
+s_call_b64 s[38:39], 639
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_dot2_f32_f16 v2, v38, v50, v2
+v_dot2_f32_f16 v3, v39, v50, v3
+v_dot2_f32_f16 v4, v40, v50, v4
+v_dot2_f32_f16 v5, v41, v50, v5
+s_setprio 1
+s_nop 0
+v_dot2_f32_f16 v6, v38, v51, v6
+v_dot2_f32_f16 v7, v39, v51, v7
+v_dot2_f32_f16 v8, v40, v51, v8
+v_dot2_f32_f16 v9, v41, v51, v9
+v_dot2_f32_f16 v10, v38, v52, v10
+v_dot2_f32_f16 v11, v39, v52, v11
+v_dot2_f32_f16 v12, v40, v52, v12
+v_dot2_f32_f16 v13, v41, v52, v13
+v_dot2_f32_f16 v14, v38, v53, v14
+v_dot2_f32_f16 v15, v39, v53, v15
+v_dot2_f32_f16 v16, v40, v53, v16
+v_dot2_f32_f16 v17, v41, v53, v17
+v_dot2_f32_f16 v18, v38, v54, v18
+v_dot2_f32_f16 v19, v39, v54, v19
+v_dot2_f32_f16 v20, v40, v54, v20
+v_dot2_f32_f16 v21, v41, v54, v21
+v_dot2_f32_f16 v22, v38, v55, v22
+v_dot2_f32_f16 v23, v39, v55, v23
+v_dot2_f32_f16 v24, v40, v55, v24
+v_dot2_f32_f16 v25, v41, v55, v25
+v_dot2_f32_f16 v26, v38, v56, v26
+v_dot2_f32_f16 v27, v39, v56, v27
+v_dot2_f32_f16 v28, v40, v56, v28
+v_dot2_f32_f16 v29, v41, v56, v29
+v_dot2_f32_f16 v30, v38, v57, v30
+v_dot2_f32_f16 v31, v39, v57, v31
+v_dot2_f32_f16 v32, v40, v57, v32
+v_mov_b32_dpp v59, v61  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_pk_add_f16 v59, v59, v61
+v_mov_b32_dpp v61, v61  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v59, v61, v112, v59
+v_mov_b32_dpp v61, v60  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_pk_add_f16 v61, v61, v60
+v_mov_b32_dpp v60, v60  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v61, v60, v112, v61
+v_pk_add_f16 v60, v58, v61
+v_pk_add_f16 v59, v59, v60
+v_pk_mul_f16 v59, v59, 0.5 op_sel_hi:[1,0]
+v_pk_fma_f16 v60, -1.0, v59, v60 op_sel_hi:[0,1,1]
+v_dot2_f32_f16 v33, v41, v57, v33
+v_cmp_eq_u32_e64 vcc, src_lds_direct, s91
+s_nop 0
+s_nop 0
+s_cbranch_vccz 65531
+s_mov_b64 vcc, s[10:11]
+s_nop 0
+ds_read_b128 v[38:41], v107 offset:8768
+ds_read_b128 v[50:53], v102 offset:8256
+ds_read_b128 v[54:57], v102 offset:8384
+ds_write_b32 v105, v80 offset:33024
+ds_write_b32 v106, v81 offset:33024
+s_setprio 0
+s_add_u32 s40, s40, s69
+s_addc_u32 s41, s41, 0
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v84, v96, s[40:43], 0 offen
+buffer_load_short_d16 v83, v95, s[40:43], 0 offen
+buffer_load_short_d16 v85, v97, s[40:43], 0 offen
+s_nop 0
+s_waitcnt vmcnt(12) lgkmcnt(5)
+s_bitset1_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 4
+s_call_b64 s[38:39], 507
+s_nop 0
+s_nop 0
+s_nop 0
+v_dot2_f32_f16 v2, v34, v42, v2
+v_dot2_f32_f16 v3, v35, v42, v3
+v_dot2_f32_f16 v4, v36, v42, v4
+v_dot2_f32_f16 v5, v37, v42, v5
+s_setprio 1
+s_nop 0
+v_dot2_f32_f16 v6, v34, v43, v6
+v_dot2_f32_f16 v7, v35, v43, v7
+v_dot2_f32_f16 v8, v36, v43, v8
+v_dot2_f32_f16 v9, v37, v43, v9
+v_dot2_f32_f16 v10, v34, v44, v10
+v_dot2_f32_f16 v11, v35, v44, v11
+v_dot2_f32_f16 v12, v36, v44, v12
+v_dot2_f32_f16 v13, v37, v44, v13
+v_dot2_f32_f16 v14, v34, v45, v14
+v_dot2_f32_f16 v15, v35, v45, v15
+v_dot2_f32_f16 v16, v36, v45, v16
+v_dot2_f32_f16 v17, v37, v45, v17
+v_dot2_f32_f16 v18, v34, v46, v18
+v_dot2_f32_f16 v19, v35, v46, v19
+v_dot2_f32_f16 v20, v36, v46, v20
+v_dot2_f32_f16 v21, v37, v46, v21
+v_dot2_f32_f16 v22, v34, v47, v22
+v_dot2_f32_f16 v23, v35, v47, v23
+v_dot2_f32_f16 v24, v36, v47, v24
+v_dot2_f32_f16 v25, v37, v47, v25
+v_dot2_f32_f16 v26, v34, v48, v26
+v_dot2_f32_f16 v27, v35, v48, v27
+v_dot2_f32_f16 v28, v36, v48, v28
+v_dot2_f32_f16 v29, v37, v48, v29
+v_dot2_f32_f16 v30, v34, v49, v30
+v_dot2_f32_f16 v31, v35, v49, v31
+v_pack_b32_f16 v62, v86, v62
+v_pack_b32_f16 v63, v87, v63
+v_pack_b32_f16 v64, v88, v64
+v_pack_b32_f16 v65, v89, v65
+v_cndmask_b32_dpp v62, v62, v62, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v63, v63, v63, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v64, v64, v64, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v65, v65, v65, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_mov_b32_dpp v62, v63  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_pk_add_f16 v62, v62, v63
+v_mov_b32_dpp v63, v63  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v62, v63, v112, v62
+v_dot2_f32_f16 v32, v36, v49, v32
+v_dot2_f32_f16 v33, v37, v49, v33
+s_nop 0
+ds_read_b128 v[34:37], v107 offset:12928
+ds_read_b128 v[42:45], v102 offset:12416
+ds_read_b128 v[46:49], v102 offset:12544
+ds_write_b32 v103, v78 offset:33024
+ds_write_b32 v104, v79 offset:33024
+s_setprio 0
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v76, v96, s[40:43], 0 offen
+buffer_load_short_d16 v75, v95, s[40:43], 0 offen
+buffer_load_short_d16 v77, v97, s[40:43], 0 offen
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 2
+s_call_b64 s[38:39], 385
+s_nop 0
+v_dot2_f32_f16 v2, v38, v50, v2
+v_dot2_f32_f16 v3, v39, v50, v3
+v_dot2_f32_f16 v4, v40, v50, v4
+v_dot2_f32_f16 v5, v41, v50, v5
+s_setprio 1
+s_nop 0
+v_dot2_f32_f16 v6, v38, v51, v6
+v_dot2_f32_f16 v7, v39, v51, v7
+v_dot2_f32_f16 v8, v40, v51, v8
+v_dot2_f32_f16 v9, v41, v51, v9
+v_dot2_f32_f16 v10, v38, v52, v10
+v_dot2_f32_f16 v11, v39, v52, v11
+v_dot2_f32_f16 v12, v40, v52, v12
+v_dot2_f32_f16 v13, v41, v52, v13
+v_dot2_f32_f16 v14, v38, v53, v14
+v_dot2_f32_f16 v15, v39, v53, v15
+v_dot2_f32_f16 v16, v40, v53, v16
+v_dot2_f32_f16 v17, v41, v53, v17
+v_dot2_f32_f16 v18, v38, v54, v18
+v_dot2_f32_f16 v19, v39, v54, v19
+v_dot2_f32_f16 v20, v40, v54, v20
+v_dot2_f32_f16 v21, v41, v54, v21
+v_dot2_f32_f16 v22, v38, v55, v22
+v_dot2_f32_f16 v23, v39, v55, v23
+v_dot2_f32_f16 v24, v40, v55, v24
+v_dot2_f32_f16 v25, v41, v55, v25
+v_dot2_f32_f16 v26, v38, v56, v26
+v_dot2_f32_f16 v27, v39, v56, v27
+v_dot2_f32_f16 v28, v40, v56, v28
+v_dot2_f32_f16 v29, v41, v56, v29
+v_dot2_f32_f16 v30, v38, v57, v30
+v_dot2_f32_f16 v31, v39, v57, v31
+v_mov_b32_dpp v63, v65  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_pk_add_f16 v63, v63, v65
+v_mov_b32_dpp v65, v65  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v63, v65, v112, v63
+v_mov_b32_dpp v65, v64  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_pk_add_f16 v65, v65, v64
+v_mov_b32_dpp v64, v64  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v65, v64, v112, v65
+v_pk_add_f16 v64, v62, v65
+v_pk_add_f16 v63, v63, v64
+v_pk_mul_f16 v63, v63, 0.5 op_sel_hi:[1,0]
+v_pk_fma_f16 v64, -1.0, v63, v64 op_sel_hi:[0,1,1]
+v_dot2_f32_f16 v32, v40, v57, v32
+v_dot2_f32_f16 v33, v41, v57, v33
+s_nop 0
+ds_read_b128 v[38:41], v107 offset:17024
+ds_read_b128 v[50:53], v102 offset:16512
+ds_read_b128 v[54:57], v102 offset:16640
+ds_write_b32 v105, v60 offset:41280
+ds_write_b32 v106, v61 offset:41280
+s_setprio 0
+s_add_u32 s40, s40, s69
+s_addc_u32 s41, s41, 0
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v88, v96, s[40:43], 0 offen
+buffer_load_short_d16 v87, v95, s[40:43], 0 offen
+buffer_load_short_d16 v89, v97, s[40:43], 0 offen
+s_nop 0
+s_waitcnt vmcnt(12) lgkmcnt(5)
+ds_append v117 offset:65480
+s_bitset1_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 8
+s_call_b64 s[38:39], 263
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_dot2_f32_f16 v2, v34, v42, v2
+v_dot2_f32_f16 v3, v35, v42, v3
+v_dot2_f32_f16 v4, v36, v42, v4
+v_dot2_f32_f16 v5, v37, v42, v5
+s_setprio 1
+s_nop 0
+v_dot2_f32_f16 v6, v34, v43, v6
+v_dot2_f32_f16 v7, v35, v43, v7
+v_dot2_f32_f16 v8, v36, v43, v8
+v_dot2_f32_f16 v9, v37, v43, v9
+v_dot2_f32_f16 v10, v34, v44, v10
+v_dot2_f32_f16 v11, v35, v44, v11
+v_dot2_f32_f16 v12, v36, v44, v12
+v_dot2_f32_f16 v13, v37, v44, v13
+v_dot2_f32_f16 v14, v34, v45, v14
+v_dot2_f32_f16 v15, v35, v45, v15
+v_dot2_f32_f16 v16, v36, v45, v16
+v_dot2_f32_f16 v17, v37, v45, v17
+v_dot2_f32_f16 v18, v34, v46, v18
+v_dot2_f32_f16 v19, v35, v46, v19
+v_dot2_f32_f16 v20, v36, v46, v20
+v_dot2_f32_f16 v21, v37, v46, v21
+v_dot2_f32_f16 v22, v34, v47, v22
+v_dot2_f32_f16 v23, v35, v47, v23
+v_dot2_f32_f16 v24, v36, v47, v24
+v_dot2_f32_f16 v25, v37, v47, v25
+v_dot2_f32_f16 v26, v34, v48, v26
+v_dot2_f32_f16 v27, v35, v48, v27
+v_dot2_f32_f16 v28, v36, v48, v28
+v_dot2_f32_f16 v29, v37, v48, v29
+v_dot2_f32_f16 v30, v34, v49, v30
+v_dot2_f32_f16 v31, v35, v49, v31
+v_pack_b32_f16 v66, v90, v66
+v_pack_b32_f16 v67, v91, v67
+v_pack_b32_f16 v68, v92, v68
+v_pack_b32_f16 v69, v93, v69
+v_cndmask_b32_dpp v66, v66, v66, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v67, v67, v67, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v68, v68, v68, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v69, v69, v69, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_mov_b32_dpp v66, v67  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_pk_add_f16 v66, v66, v67
+v_mov_b32_dpp v67, v67  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v66, v67, v112, v66
+v_dot2_f32_f16 v32, v36, v49, v32
+v_dot2_f32_f16 v33, v37, v49, v33
+s_nop 0
+ds_read_b128 v[34:37], v107 offset:21184
+ds_read_b128 v[42:45], v102 offset:20672
+ds_read_b128 v[46:49], v102 offset:20800
+ds_write_b32 v103, v58 offset:41280
+ds_write_b32 v104, v59 offset:41280
+s_setprio 0
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v80, v96, s[40:43], 0 offen
+buffer_load_short_d16 v79, v95, s[40:43], 0 offen
+buffer_load_short_d16 v81, v97, s[40:43], 0 offen
+s_mov_b32 m0, 0x2ffc8
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 8
+s_call_b64 s[38:39], 135
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_dot2_f32_f16 v2, v38, v50, v2
+v_dot2_f32_f16 v3, v39, v50, v3
+v_dot2_f32_f16 v4, v40, v50, v4
+v_dot2_f32_f16 v5, v41, v50, v5
+s_setprio 1
+s_nop 0
+v_dot2_f32_f16 v6, v38, v51, v6
+v_dot2_f32_f16 v7, v39, v51, v7
+v_dot2_f32_f16 v8, v40, v51, v8
+v_dot2_f32_f16 v9, v41, v51, v9
+v_dot2_f32_f16 v10, v38, v52, v10
+v_dot2_f32_f16 v11, v39, v52, v11
+v_dot2_f32_f16 v12, v40, v52, v12
+v_dot2_f32_f16 v13, v41, v52, v13
+v_dot2_f32_f16 v14, v38, v53, v14
+v_dot2_f32_f16 v15, v39, v53, v15
+v_dot2_f32_f16 v16, v40, v53, v16
+v_dot2_f32_f16 v17, v41, v53, v17
+v_dot2_f32_f16 v18, v38, v54, v18
+v_dot2_f32_f16 v19, v39, v54, v19
+v_dot2_f32_f16 v20, v40, v54, v20
+v_dot2_f32_f16 v21, v41, v54, v21
+v_dot2_f32_f16 v22, v38, v55, v22
+v_dot2_f32_f16 v23, v39, v55, v23
+v_dot2_f32_f16 v24, v40, v55, v24
+v_dot2_f32_f16 v25, v41, v55, v25
+v_dot2_f32_f16 v26, v38, v56, v26
+v_dot2_f32_f16 v27, v39, v56, v27
+v_dot2_f32_f16 v28, v40, v56, v28
+v_dot2_f32_f16 v29, v41, v56, v29
+v_dot2_f32_f16 v30, v38, v57, v30
+v_dot2_f32_f16 v31, v39, v57, v31
+v_dot2_f32_f16 v32, v40, v57, v32
+v_mov_b32_dpp v67, v69  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_pk_add_f16 v67, v67, v69
+v_mov_b32_dpp v69, v69  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v67, v69, v112, v67
+v_mov_b32_dpp v69, v68  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_pk_add_f16 v69, v69, v68
+v_mov_b32_dpp v68, v68  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v69, v68, v112, v69
+v_pk_add_f16 v68, v66, v69
+v_pk_add_f16 v67, v67, v68
+v_pk_mul_f16 v67, v67, 0.5 op_sel_hi:[1,0]
+v_pk_fma_f16 v68, -1.0, v67, v68 op_sel_hi:[0,1,1]
+v_dot2_f32_f16 v33, v41, v57, v33
+v_cmp_eq_u32_e64 vcc, src_lds_direct, s91
+s_nop 0
+s_nop 0
+s_cbranch_vccz 65531
+s_mov_b64 vcc, s[10:11]
+s_nop 0
+ds_read_b128 v[38:41], v107 offset:25280
+ds_read_b128 v[50:53], v102 offset:24768
+ds_read_b128 v[54:57], v102 offset:24896
+ds_write_b32 v105, v64
+ds_write_b32 v106, v65
+s_setprio 0
+s_add_u32 s40, s40, s69
+s_addc_u32 s41, s41, 0
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v92, v96, s[40:43], 0 offen
+buffer_load_short_d16 v91, v95, s[40:43], 0 offen
+buffer_load_short_d16 v93, v97, s[40:43], 0 offen
+s_nop 0
+s_waitcnt vmcnt(12) lgkmcnt(5)
+s_bitset1_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 64020
+s_call_b64 s[38:39], 3
+s_branch 64018
+s_nop 0
+s_nop 0
+v_nop
+s_cmp_eq_u32 s82, 0
+s_cbranch_scc0 8
+s_branch 612
+s_add_u32 s82, s82, 3
+s_andn2_b32 s82, s82, 3
+s_bitcmp0_b32 s18, 26
+s_cselect_b32 s52, s69, s70
+s_cselect_b32 s53, 0, s71
+s_sub_u32 s40, s40, s52
+s_subb_u32 s41, s41, s53
+s_cmp_eq_u32 s94, 0
+s_cbranch_scc0 5
+s_cbranch_scc1 642
+s_nop 0
+s_nop 0
+s_add_u32 s94, s94, 1
+s_andn2_b32 s94, s94, 1
+s_min_u32 s72, s82, s94
+s_sub_u32 s82, s82, s72
+s_sub_u32 s94, s94, s72
+s_sub_u32 s72, s72, 2
+s_setpc_b64 s[38:39]
+s_nop 0
+s_bitcmp1_b32 s18, 17
+s_cbranch_scc1 241
+s_add_u32 s88, s88, s17
+s_cmp_eq_u32 s88, 0
+s_cbranch_scc1 238
+s_mov_b32 s89, 0
+s_bitcmp1_b32 s18, 16
+s_cbranch_scc1 227
+s_add_u32 s87, s16, 31
+s_lshr_b32 s87, s87, 5
+v_mov_b32_e32 v119, s88
+v_mul_u32_u24_e32 v119, s87, v119
+v_add_co_u32_e32 v119, vcc, s17, v119
+v_sub_co_u32_e64 v119, vcc, v119, 1
+v_ffbh_u32_e32 v122, s17
+v_lshlrev_b32_e64 v123, v122, s17
+v_and_b32_e32 v124, 0xffffff00, v123
+v_cmp_eq_u32_e32 vcc, 0x80000000, v123
+v_cvt_f32_u32_e32 v124, v124
+v_rcp_f32_e32 v118, v124
+v_subb_co_u32_e32 v121, vcc, 32, v122, vcc
+v_cvt_f32_ubyte0_e32 v122, v123
+v_fma_f32 v124, v124, v118, -1.0
+v_fma_f32 v124, v122, v118, v124
+v_madak_f32 v124, v124, v118, 0x9f000000
+v_mul_f32_e32 v124, 0x5f800000, v124
+v_mov_b32_e32 v122, 0
+v_cvt_flr_i32_f32_e64 v124, -v124
+v_lshl_add_u32 v118, v118, 9, v124
+v_mad_u64_u32 v[122:123], vcc, v123, v118, v[122:123]
+v_subb_co_u32_e64 v118, vcc, v118, -1, vcc
+v_mul_hi_u32 v122, v119, v118
+v_add_co_u32_e32 v118, vcc, v122, v119
+v_addc_co_u32_e64 v122, vcc, 0, 0, vcc
+v_cmp_eq_u32_e32 vcc, 32, v121
+v_cndmask_b32_e32 v118, v118, v122, vcc
+v_alignbit_b32 v118, v122, v118, v121
+v_readfirstlane_b32 s86, v118
+v_mul_u32_u24_e64 v118, v118, s8
+v_ffbh_u32_e32 v122, s87
+v_lshlrev_b32_e64 v123, v122, s87
+v_and_b32_e32 v124, 0xffffff00, v123
+v_cmp_eq_u32_e32 vcc, 0x80000000, v123
+v_cvt_f32_u32_e32 v124, v124
+v_rcp_f32_e32 v119, v124
+v_subb_co_u32_e32 v121, vcc, 32, v122, vcc
+v_cvt_f32_ubyte0_e32 v122, v123
+v_fma_f32 v124, v124, v119, -1.0
+v_fma_f32 v124, v122, v119, v124
+v_madak_f32 v124, v124, v119, 0x9f000000
+v_mul_f32_e32 v124, 0x5f800000, v124
+v_mov_b32_e32 v122, 0
+v_cvt_flr_i32_f32_e64 v124, -v124
+v_lshl_add_u32 v119, v119, 9, v124
+v_mad_u64_u32 v[122:123], vcc, v123, v119, v[122:123]
+v_subb_co_u32_e64 v119, vcc, v119, -1, vcc
+v_mul_hi_u32 v122, v118, v119
+v_add_co_u32_e32 v119, vcc, v122, v118
+v_addc_co_u32_e64 v122, vcc, 0, 0, vcc
+v_cmp_eq_u32_e32 vcc, 32, v121
+v_cndmask_b32_e32 v119, v119, v122, vcc
+v_alignbit_b32 v119, v122, v119, v121
+v_readfirstlane_b32 s52, v118
+v_readfirstlane_b32 s84, v119
+s_mul_i32 s84, s84, s87
+s_sub_u32 s84, s52, s84
+v_sub_co_u32_e32 v119, vcc, s8, v119
+v_sub_co_u32_e32 v119, vcc, s17, v119
+v_and_b32_e64 v121, v0, 63
+v_cmp_eq_u32_e64 vcc, v121, 0
+v_cndmask_b32_e32 v119, 1, v119, vcc
+s_sub_u32 s58, 0, s75
+s_sub_u32 s59, 0, s74
+v_mul_u32_u24_e64 v123, v119, 32
+v_ffbh_u32_e32 v125, s58
+v_lshlrev_b32_e64 v126, v125, s58
+v_and_b32_e32 v127, 0xffffff00, v126
+v_cmp_eq_u32_e32 vcc, 0x80000000, v126
+v_cvt_f32_u32_e32 v127, v127
+v_rcp_f32_e32 v121, v127
+v_subb_co_u32_e32 v124, vcc, 32, v125, vcc
+v_cvt_f32_ubyte0_e32 v125, v126
+v_fma_f32 v127, v127, v121, -1.0
+v_fma_f32 v127, v125, v121, v127
+v_madak_f32 v127, v127, v121, 0x9f000000
+v_mul_f32_e32 v127, 0x5f800000, v127
+v_mov_b32_e32 v125, 0
+v_cvt_flr_i32_f32_e64 v127, -v127
+v_lshl_add_u32 v121, v121, 9, v127
+v_mad_u64_u32 v[125:126], vcc, v126, v121, v[125:126]
+v_subb_co_u32_e64 v121, vcc, v121, -1, vcc
+v_mul_hi_u32 v125, v123, v121
+v_add_co_u32_e32 v121, vcc, v125, v123
+v_addc_co_u32_e64 v125, vcc, 0, 0, vcc
+v_cmp_eq_u32_e32 vcc, 32, v124
+v_cndmask_b32_e32 v121, v121, v125, vcc
+v_alignbit_b32 v121, v125, v121, v124
+v_mad_i32_i24 v122, v121, s75, v123
+v_mul_u32_u24_e64 v123, v121, 1
+v_ffbh_u32_e32 v125, s59
+v_lshlrev_b32_e64 v126, v125, s59
+v_and_b32_e32 v127, 0xffffff00, v126
+v_cmp_eq_u32_e32 vcc, 0x80000000, v126
+v_cvt_f32_u32_e32 v127, v127
+v_rcp_f32_e32 v121, v127
+v_subb_co_u32_e32 v124, vcc, 32, v125, vcc
+v_cvt_f32_ubyte0_e32 v125, v126
+v_fma_f32 v127, v127, v121, -1.0
+v_fma_f32 v127, v125, v121, v127
+v_madak_f32 v127, v127, v121, 0x9f000000
+v_mul_f32_e32 v127, 0x5f800000, v127
+v_mov_b32_e32 v125, 0
+v_cvt_flr_i32_f32_e64 v127, -v127
+v_lshl_add_u32 v121, v121, 9, v127
+v_mad_u64_u32 v[125:126], vcc, v126, v121, v[125:126]
+v_subb_co_u32_e64 v121, vcc, v121, -1, vcc
+v_mul_hi_u32 v125, v123, v121
+v_add_co_u32_e32 v121, vcc, v125, v123
+v_addc_co_u32_e64 v125, vcc, 0, 0, vcc
+v_cmp_eq_u32_e32 vcc, 32, v124
+v_cndmask_b32_e32 v121, v121, v125, vcc
+v_alignbit_b32 v121, v125, v121, v124
+v_mad_i32_i24 v123, v121, s74, v123
+v_readfirstlane_b32 s76, v122
+v_readfirstlane_b32 s77, v123
+v_readfirstlane_b32 s78, v121
+v_add_co_u32_e32 v108, vcc, s76, v108
+v_addc_co_u32_e64 v124, vcc, 0, 0, vcc
+v_mad_i32_i24 v108, v124, s75, v108
+v_mad_i32_i24 v110, v124, s80, v110
+v_mad_i32_i24 v109, v124, s79, v109
+v_cmp_ge_i32_e64 vcc, v109, 0
+v_addc_co_u32_e64 v124, vcc, 0, 0, vcc
+v_add_co_u32_e32 v110, vcc, v110, v124
+v_mad_i32_i24 v109, v124, s74, v109
+v_add_co_u32_e32 v109, vcc, s77, v109
+v_addc_co_u32_e64 v124, vcc, 0, 0, vcc
+v_add_co_u32_e32 v110, vcc, v110, v124
+v_mad_i32_i24 v109, v124, s74, v109
+v_add_co_u32_e32 v110, vcc, s78, v110
+v_readlane_b32 s76, v122, 1
+v_readlane_b32 s77, v123, 1
+v_readlane_b32 s78, v121, 1
+s_add_u32 s85, s84, s86
+s_cmp_le_u32 s85, s87
+s_cselect_b32 s52, 0x20000, 0
+s_cselect_b32 s85, s85, s87
+s_or_b32 s18, s18, s52
+s_lshl_b32 s84, s84, 5
+s_lshl_b32 s85, s85, 5
+s_min_u32 s85, s85, s16
+s_cmp_eq_u32 s8, s17
+s_cselect_b32 s52, 0x20000, 0
+s_or_b32 s18, s18, s52
+s_or_b32 s18, s18, s52
+s_bitset1_b32 s18, 16
+s_branch 43
+s_lshr_b32 s84, s84, 5
+s_add_u32 s85, s84, s86
+s_sub_u32 s85, s85, s87
+s_mov_b32 s84, 0
+s_lshl_b32 s85, s85, 5
+s_min_u32 s85, s85, s16
+s_bitset1_b32 s18, 17
+s_branch 12
+s_bitset1_b32 s18, 18
+s_mov_b32 s43, 0
+s_mov_b32 s73, -1
+s_mov_b32 s82, 40
+s_branch 31
+s_add_u32 s83, s83, 32
+s_cmp_ge_u32 s83, s85
+s_cbranch_scc0 28
+s_bitset1_b32 s18, 22
+s_sub_u32 s88, s88, s17
+s_subb_u32 s89, s89, 0
+s_cbranch_scc1 65281
+v_add_co_u32_e32 v108, vcc, s76, v108
+v_addc_co_u32_e64 v118, vcc, 0, 0, vcc
+v_mad_i32_i24 v108, v118, s75, v108
+v_mad_i32_i24 v110, v118, s80, v110
+v_mad_i32_i24 v109, v118, s79, v109
+v_cmp_ge_i32_e64 vcc, v109, 0
+v_addc_co_u32_e64 v118, vcc, 0, 0, vcc
+v_add_co_u32_e32 v110, vcc, v110, v118
+v_mad_i32_i24 v109, v118, s74, v109
+v_add_co_u32_e32 v109, vcc, s77, v109
+v_addc_co_u32_e64 v118, vcc, 0, 0, vcc
+v_add_co_u32_e32 v110, vcc, v110, v118
+v_mad_i32_i24 v109, v118, s74, v109
+v_add_co_u32_e32 v110, vcc, s78, v110
+s_mov_b32 s83, s84
+v_cmp_le_u32_e32 vcc, 0x100, v0
+s_cbranch_vccz 170
+v_subrev_co_u32_e32 v118, vcc, s75, v108
+v_subrev_co_u32_e32 v119, vcc, s74, v109
+s_bitcmp1_b32 s18, 22
+s_cbranch_scc0 64
+s_bitset0_b32 s18, 22
+s_bfe_u32 s52, s18, 0x10014
+v_mul_u32_u24_e32 v123, 2, v118
+v_mul_u32_u24_e32 v124, 2, v119
+v_cvt_pk_u16_u32 v126, v123, v124
+v_and_b32_e64 v123, v0, 1
+v_cmp_eq_u32_e64 vcc, v123, 1
+v_cndmask_b32_e32 v126, v110, v126, vcc
+v_lshrrev_b32_e32 v122, 1, v0
+v_bfe_u32 v127, v122, s52, 1
+v_lshrrev_b32_e32 v122, 1, v0
+v_bfi_b32 v122, 1, v0, v122
+v_lshrrev_b32_e32 v123, 2, v0
+v_bfi_b32 v123, 1, v0, v123
+v_cmp_eq_u32_e64 vcc, s52, 0
+v_cndmask_b32_e32 v122, v123, v122, vcc
+s_sub_u32 s52, 1, s52
+v_lshrrev_b32_e32 v123, s52, v122
+v_bfi_b32 v122, 32, v123, v122
+v_and_b32_e32 v122, 63, v122
+v_add_co_u32_e32 v123, vcc, 16, v122
+v_and_b32_e64 v124, v0, 2
+v_cmp_eq_u32_e64 vcc, v124, 0
+v_cndmask_b32_e32 v123, v123, v122, vcc
+v_lshlrev_b32_e32 v124, 14, v127
+v_mad_u32_u24 v123, 4, v123, v124
+v_add_co_u32_e32 v122, vcc, s96, v123
+ds_write_b32 v122, v126
+v_writelane_b32 v124, s18, 0
+v_writelane_b32 v124, s85, 1
+v_writelane_b32 v124, s84, 2
+v_and_b32_e64 v122, v0, 63
+v_cmp_ge_u32_e64 vcc, v122, 3
+v_mov_b32_e32 v125, 0x4000
+v_cndmask_b32_e32 v122, v122, v125, vcc
+v_mad_i32_i24 v122, v122, 4, s96
+ds_write_b32 v122, v124 offset:256
+s_add_u32 s96, s96, 0x18c
+s_cmp_eq_u32 s96, 0xffc0
+s_cselect_b32 s96, 0xc1e0, s96
+v_mov_b32_dpp v120, v110  quad_perm:[0,0,0,0] row_mask:0xf bank_mask:0xf
+v_mov_b32_dpp v118, v118  quad_perm:[0,0,0,0] row_mask:0xf bank_mask:0xf
+v_mov_b32_dpp v119, v119  quad_perm:[0,0,0,0] row_mask:0xf bank_mask:0xf
+v_readfirstlane_b32 s81, v120
+v_sub_co_u32_e64 v121, vcc, v120, s81
+v_mul_lo_u32 v121, v121, s65
+v_mad_u32_u24 v124, 5, v0, 2
+v_and_b32_e32 v125, 6, v0
+v_add_co_u32_e32 v125, vcc, 4, v125
+v_bfi_b32 v125, 4, v124, v125
+v_bfe_u32 v125, v125, 1, 3
+v_ashrrev_i32_e64 v126, 0, s31
+v_subrev_co_u32_e32 v125, vcc, v126, v125
+v_ashrrev_i32_e64 v126, 0, s62
+v_mad_i32_i24 v122, v126, 3, v125
+v_add_co_u32_e64 v123, vcc, 0, s63
+v_ashrrev_i32_e32 v123, 0, v123
+v_add_co_u32_e64 v124, vcc, 0, s30
+v_ashrrev_i32_e32 v124, 0, v124
+v_sub_i32 v123, v123, v124
+s_lshl_b32 s54, s15, 1
+v_cmp_ge_u32_e64 s[52:53], v120, s12
+v_mad_i32_i24 v118, v118, 4, v122
+v_cmp_ge_u32_e64 s[56:57], v118, s15
+v_mad_i32_i24 v118, 2, v118, v121
+s_or_b64 s[56:57], s[56:57], s[52:53]
+v_mad_i32_i24 v119, v119, 4, v123
+v_cmp_ge_u32_e64 s[58:59], v119, s14
+s_or_b64 s[58:59], s[56:57], s[58:59]
+v_mad_u32_u24 v94, v119, s54, v118
+v_cndmask_b32_e64 v94, v94, -1, s[58:59]
+v_add_co_u32_e32 v119, vcc, 2, v119
+v_cmp_ge_u32_e64 s[58:59], v119, s14
+s_or_b64 s[58:59], s[56:57], s[58:59]
+v_mad_u32_u24 v95, v119, s54, v118
+v_cndmask_b32_e64 v95, v95, -1, s[58:59]
+v_add_co_u32_e32 v119, vcc, 2, v119
+v_cmp_ge_u32_e64 s[58:59], v119, s14
+s_or_b64 s[58:59], s[56:57], s[58:59]
+v_mad_u32_u24 v96, v119, s54, v118
+v_cndmask_b32_e64 v96, v96, -1, s[58:59]
+v_add_co_u32_e32 v119, vcc, 2, v119
+v_cmp_ge_u32_e64 s[58:59], v119, s14
+s_or_b64 s[58:59], s[56:57], s[58:59]
+v_mad_u32_u24 v97, v119, s54, v118
+v_cndmask_b32_e64 v97, v97, -1, s[58:59]
+s_bitcmp1_b32 s18, 18
+s_cbranch_scc1 154
+s_lshr_b32 s52, -1, 16
+s_and_b32 s52, s52, s65
+s_lshr_b32 s53, s65, 16
+s_mul_i32 s53, s53, s81
+s_mul_i32 s40, s52, s81
+s_lshl_b32 s52, s53, 16
+s_lshr_b32 s53, s53, 16
+s_add_u32 s40, s52, s40
+s_addc_u32 s41, s53, 0
+s_add_u32 s40, s40, s20
+s_addc_u32 s41, s41, s21
+s_lshr_b32 s52, s18, 6
+s_xor_b32 s52, s52, s18
+s_and_b32 s52, s52, 0x80000
+s_cselect_b32 s52, s68, 0
+s_and_b32 s53, s18, 0x1100000
+s_cselect_b32 s53, 0, 1
+s_lshl_b32 s52, s52, s53
+s_add_u32 s40, s40, s52
+s_addc_u32 s41, s41, 0
+s_branch 99
+s_bitcmp1_b32 s18, 18
+s_cbranch_scc1 129
+v_mad_u32_u24 v120, 5, v0, 2
+v_lshlrev_b32_e32 v118, 1, v0
+v_bfi_b32 v120, 4, v120, v118
+v_bfe_u32 v118, v120, 2, 2
+v_min_u32_e32 v118, 2, v118
+v_bfe_u32 v120, v0, 1, 1
+v_mad_u32_u24 v118, 2, v118, v120
+v_mad_u32_u24 v118, s62, 3, v118
+v_sub_co_u32_e32 v120, vcc, s29, v118
+v_sub_co_u32_e64 v120, vcc, v120, 1
+s_bfe_u32 s54, s18, 0x10001
+v_cmp_eq_u32_e64 vcc, s54, 1
+v_cndmask_b32_e32 v118, v118, v120, vcc
+v_cmp_ge_u32_e64 s[52:53], v118, s29
+v_lshlrev_b32_e32 v118, 1, v118
+s_bfe_u32 s54, s18, 0x10018
+v_bfe_u32 v121, v0, 2, s54
+v_mul_lo_u32 v121, s68, v121
+v_add_co_u32_e32 v118, vcc, v118, v121
+v_mul_lo_u32 v119, s90, v111
+v_add_co_u32_e32 v119, vcc, v119, v118
+s_sub_u32 s54, s28, s63
+s_sub_u32 s54, s54, 5
+s_bitcmp1_b32 s18, 0
+s_cselect_b32 s54, s54, s63
+v_mov_b32_e32 v121, s54
+s_lshl_b32 s57, s29, 1
+v_cmp_ge_u32_e64 s[54:55], v121, s28
+v_mad_i32_i24 v94, v121, s57, v119
+s_or_b64 s[54:55], s[54:55], s[52:53]
+v_cndmask_b32_e64 v94, v94, -1, s[54:55]
+v_mov_b32_e32 v95, v94
+v_add_co_u32_e64 v121, vcc, v121, 2
+v_cmp_ge_u32_e64 s[54:55], v121, s28
+v_mad_i32_i24 v97, v121, s57, v119
+s_or_b64 s[54:55], s[54:55], s[52:53]
+v_cndmask_b32_e64 v97, v97, -1, s[54:55]
+v_add_co_u32_e64 v121, vcc, v121, 2
+v_cmp_ge_u32_e64 s[54:55], v121, s28
+v_mad_i32_i24 v96, v121, s57, v119
+s_or_b64 s[54:55], s[54:55], s[52:53]
+v_cndmask_b32_e64 v96, v96, -1, s[54:55]
+v_add_co_u32_e64 v118, vcc, v111, s83
+v_cmp_lt_u32_e64 vcc, v118, s16
+v_cndmask_b32_e32 v94, -1, v94, vcc
+v_cndmask_b32_e32 v95, -1, v95, vcc
+v_cndmask_b32_e32 v96, -1, v96, vcc
+v_cndmask_b32_e32 v97, -1, v97, vcc
+s_lshr_b32 s52, -1, 16
+s_and_b32 s52, s52, s90
+s_lshr_b32 s53, s90, 16
+s_mul_i32 s53, s53, s83
+s_mul_i32 s40, s52, s83
+s_lshl_b32 s52, s53, 16
+s_lshr_b32 s53, s53, 16
+s_add_u32 s40, s52, s40
+s_addc_u32 s41, s53, 0
+s_add_u32 s40, s40, s22
+s_addc_u32 s41, s41, s23
+s_lshr_b32 s52, s18, 6
+s_xor_b32 s52, s52, s18
+s_and_b32 s52, s52, 0x80000
+s_cselect_b32 s52, s68, 0
+s_and_b32 s53, s18, 0x1100000
+s_cselect_b32 s53, 0, 1
+s_lshl_b32 s52, s52, s53
+s_add_u32 s40, s40, s52
+s_addc_u32 s41, s41, 0
+s_mov_b32 s43, 0x20000
+s_mov_b32 s73, -1
+s_bitcmp0_b32 s13, 0
+s_cbranch_scc1 4
+s_mov_b32 s43, 0
+s_mov_b32 s73, 1
+s_sub_u32 s40, s40, s68
+s_subb_u32 s41, s41, 0
+s_add_u32 s53, s13, 1
+s_and_b32 s53, s53, -2
+s_bfe_u32 s52, s18, 0x10014
+s_lshl_b32 s82, s53, s52
+s_bfe_u32 s52, s18, 0x10013
+s_bfe_u32 s54, s18, 0x10019
+s_xor_b32 s52, s52, s54
+s_cselect_b32 s52, 2, 0
+s_cselect_b32 s43, 0x20000, s43
+s_and_b32 s52, s52, s82
+s_sub_u32 s82, s82, s52
+s_bitcmp1_b32 s18, 20
+s_cselect_b32 s52, 0, 0x2000000
+s_bitcmp1_b32 s53, 1
+s_cselect_b32 s52, s52, 0
+s_xor_b32 s18, s18, s52
+s_cmp_eq_u32 s82, 0
+s_cbranch_scc1 9
+s_mov_b64 vcc, s[10:11]
+s_branch 64931
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_and_b32 s52, 0x900000, s18
+s_subb_u32 s62, s62, 1
+s_cbranch_scc0 65219
+s_and_b32 s52, 0x900000, s18
+s_subb_u32 s62, s61, 1
+s_add_u32 s63, s63, 6
+s_cmp_ge_u32 s63, s28
+s_cbranch_scc0 65213
+s_mov_b32 s63, 1
+s_cmp_ge_u32 s63, s28
+s_addc_u32 s64, s64, 1
+s_cmp_gt_u32 s64, 1
+s_cbranch_scc0 65208
+s_mov_b32 s64, 0
+s_mov_b32 s63, 0
+s_branch 65174
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_mac_f32_dpp v4, v4, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v5, v5, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v2, v2, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v3, v3, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v3, v4, v3  row_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v2, v5, v2  row_mirror row_mask:0xf bank_mask:0xf
+s_nop 0
+v_mac_f32_dpp v3, v3, v114  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mac_f32_dpp v2, v2, v114  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+s_nop 0
+v_add_f32_dpp v2, v3, v2  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cvt_f16_f32_e32 v2, v2
+v_mac_f32_dpp v8, v8, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v9, v9, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v6, v6, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v7, v7, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v7, v8, v7  row_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v6, v9, v6  row_mirror row_mask:0xf bank_mask:0xf
+s_nop 0
+v_mac_f32_dpp v7, v7, v114  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mac_f32_dpp v6, v6, v114  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+s_nop 0
+v_add_f32_dpp v3, v7, v6  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cvt_f16_f32_e32 v3, v3
+v_mac_f32_dpp v12, v12, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v13, v13, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v10, v10, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v11, v11, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v11, v12, v11  row_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v10, v13, v10  row_mirror row_mask:0xf bank_mask:0xf
+s_nop 0
+v_mac_f32_dpp v11, v11, v114  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mac_f32_dpp v10, v10, v114  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+s_nop 0
+v_add_f32_dpp v4, v11, v10  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cvt_f16_f32_e32 v4, v4
+v_mac_f32_dpp v16, v16, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v17, v17, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v14, v14, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v15, v15, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v15, v16, v15  row_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v14, v17, v14  row_mirror row_mask:0xf bank_mask:0xf
+s_nop 0
+v_mac_f32_dpp v15, v15, v114  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mac_f32_dpp v14, v14, v114  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+s_nop 0
+v_add_f32_dpp v5, v15, v14  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cvt_f16_f32_e32 v5, v5
+v_mac_f32_dpp v20, v20, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v21, v21, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v18, v18, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v19, v19, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v19, v20, v19  row_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v18, v21, v18  row_mirror row_mask:0xf bank_mask:0xf
+s_nop 0
+v_mac_f32_dpp v19, v19, v114  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mac_f32_dpp v18, v18, v114  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+s_nop 0
+v_add_f32_dpp v6, v19, v18  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cvt_f16_f32_e32 v6, v6
+v_mac_f32_dpp v24, v24, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v25, v25, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v22, v22, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v23, v23, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v23, v24, v23  row_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v22, v25, v22  row_mirror row_mask:0xf bank_mask:0xf
+s_nop 0
+v_mac_f32_dpp v23, v23, v114  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mac_f32_dpp v22, v22, v114  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+s_nop 0
+v_add_f32_dpp v7, v23, v22  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cvt_f16_f32_e32 v7, v7
+v_mac_f32_dpp v28, v28, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v29, v29, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v26, v26, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v27, v27, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v27, v28, v27  row_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v26, v29, v26  row_mirror row_mask:0xf bank_mask:0xf
+s_nop 0
+v_mac_f32_dpp v27, v27, v114  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mac_f32_dpp v26, v26, v114  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+s_nop 0
+v_add_f32_dpp v8, v27, v26  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cvt_f16_f32_e32 v8, v8
+v_mac_f32_dpp v32, v32, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v33, v33, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v30, v30, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v31, v31, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v31, v32, v31  row_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v30, v33, v30  row_mirror row_mask:0xf bank_mask:0xf
+s_nop 0
+v_mac_f32_dpp v31, v31, v114  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mac_f32_dpp v30, v30, v114  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+s_nop 0
+v_add_f32_dpp v9, v31, v30  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cvt_f16_f32_e32 v9, v9
+s_waitcnt vmcnt(0)
+v_readlane_b32 s55, v116, 0
+v_add_f16_e64 v2, v2, s55
+v_mul_f16_e64 v118, v2, s36
+v_cmp_lt_f16_e64 vcc, v2, 0
+v_cndmask_b32_e32 v2, v2, v118, vcc
+buffer_store_short v2, v98, s[44:47], 0 offen
+s_add_u32 s44, s44, s67
+s_addc_u32 s45, s45, 0
+s_sub_u32 s93, s93, 1
+s_cselect_b32 s47, 0, s47
+v_readlane_b32 s55, v116, 1
+v_add_f16_e64 v3, v3, s55
+v_mul_f16_e64 v118, v3, s36
+v_cmp_lt_f16_e64 vcc, v3, 0
+v_cndmask_b32_e32 v3, v3, v118, vcc
+buffer_store_short v3, v98, s[44:47], 0 offen
+s_add_u32 s44, s44, s67
+s_addc_u32 s45, s45, 0
+s_sub_u32 s93, s93, 1
+s_cselect_b32 s47, 0, s47
+v_readlane_b32 s55, v116, 2
+v_add_f16_e64 v4, v4, s55
+v_mul_f16_e64 v118, v4, s36
+v_cmp_lt_f16_e64 vcc, v4, 0
+v_cndmask_b32_e32 v4, v4, v118, vcc
+buffer_store_short v4, v98, s[44:47], 0 offen
+s_add_u32 s44, s44, s67
+s_addc_u32 s45, s45, 0
+s_sub_u32 s93, s93, 1
+s_cselect_b32 s47, 0, s47
+v_readlane_b32 s55, v116, 3
+v_add_f16_e64 v5, v5, s55
+v_mul_f16_e64 v118, v5, s36
+v_cmp_lt_f16_e64 vcc, v5, 0
+v_cndmask_b32_e32 v5, v5, v118, vcc
+buffer_store_short v5, v98, s[44:47], 0 offen
+s_add_u32 s44, s44, s67
+s_addc_u32 s45, s45, 0
+s_sub_u32 s93, s93, 1
+s_cselect_b32 s47, 0, s47
+s_lshl_b32 s52, s67, 2
+s_add_u32 s44, s44, s52
+s_addc_u32 s45, s45, 0
+s_sub_u32 s93, s93, 4
+s_cselect_b32 s47, 0, s47
+v_readlane_b32 s55, v116, 8
+v_add_f16_e64 v6, v6, s55
+v_mul_f16_e64 v118, v6, s36
+v_cmp_lt_f16_e64 vcc, v6, 0
+v_cndmask_b32_e32 v6, v6, v118, vcc
+buffer_store_short v6, v98, s[44:47], 0 offen
+s_add_u32 s44, s44, s67
+s_addc_u32 s45, s45, 0
+s_sub_u32 s93, s93, 1
+s_cselect_b32 s47, 0, s47
+v_readlane_b32 s55, v116, 9
+v_add_f16_e64 v7, v7, s55
+v_mul_f16_e64 v118, v7, s36
+v_cmp_lt_f16_e64 vcc, v7, 0
+v_cndmask_b32_e32 v7, v7, v118, vcc
+buffer_store_short v7, v98, s[44:47], 0 offen
+s_add_u32 s44, s44, s67
+s_addc_u32 s45, s45, 0
+s_sub_u32 s93, s93, 1
+s_cselect_b32 s47, 0, s47
+v_readlane_b32 s55, v116, 10
+v_add_f16_e64 v8, v8, s55
+v_mul_f16_e64 v118, v8, s36
+v_cmp_lt_f16_e64 vcc, v8, 0
+v_cndmask_b32_e32 v8, v8, v118, vcc
+buffer_store_short v8, v98, s[44:47], 0 offen
+s_add_u32 s44, s44, s67
+s_addc_u32 s45, s45, 0
+s_sub_u32 s93, s93, 1
+s_cselect_b32 s47, 0, s47
+v_readlane_b32 s55, v116, 11
+v_add_f16_e64 v9, v9, s55
+v_mul_f16_e64 v118, v9, s36
+v_cmp_lt_f16_e64 vcc, v9, 0
+v_cndmask_b32_e32 v9, v9, v118, vcc
+buffer_store_short v9, v98, s[44:47], 0 offen
+s_add_u32 s44, s44, s67
+s_addc_u32 s45, s45, 0
+s_sub_u32 s93, s93, 1
+s_cselect_b32 s47, 0, s47
+s_add_u32 s44, s44, s52
+s_addc_u32 s45, s45, 0
+s_lshl_b32 s52, s52, 2
+s_add_u32 s44, s44, s52
+s_addc_u32 s45, s45, 0
+s_sub_u32 s93, s93, 20
+s_cselect_b32 s47, 0, s47
+s_cselect_b32 s51, 0, s51
+s_add_u32 s48, s48, 64
+s_addc_u32 s49, s49, 0
+s_sub_u32 s50, s50, 64
+s_cselect_b32 s51, 0, s51
+v_mov_b32_e32 v2, 0
+v_mov_b32_e32 v3, 0
+v_mov_b32_e32 v4, 0
+v_mov_b32_e32 v5, 0
+v_mov_b32_e32 v6, 0
+v_mov_b32_e32 v7, 0
+v_mov_b32_e32 v8, 0
+v_mov_b32_e32 v9, 0
+v_mov_b32_e32 v10, 0
+v_mov_b32_e32 v11, 0
+v_mov_b32_e32 v12, 0
+v_mov_b32_e32 v13, 0
+v_mov_b32_e32 v14, 0
+v_mov_b32_e32 v15, 0
+v_mov_b32_e32 v16, 0
+v_mov_b32_e32 v17, 0
+v_mov_b32_e32 v18, 0
+v_mov_b32_e32 v19, 0
+v_mov_b32_e32 v20, 0
+v_mov_b32_e32 v21, 0
+v_mov_b32_e32 v22, 0
+v_mov_b32_e32 v23, 0
+v_mov_b32_e32 v24, 0
+v_mov_b32_e32 v25, 0
+v_mov_b32_e32 v26, 0
+v_mov_b32_e32 v27, 0
+v_mov_b32_e32 v28, 0
+v_mov_b32_e32 v29, 0
+v_mov_b32_e32 v30, 0
+v_mov_b32_e32 v31, 0
+v_mov_b32_e32 v32, 0
+v_mov_b32_e32 v33, 0
+s_xor_b32 s18, s18, 0x200000
+s_bitcmp1_b32 s13, 0
+s_addc_u32 s52, s13, 0
+s_mul_i32 s94, s60, s61
+s_mul_i32 s94, s94, s52
+s_add_u32 s52, s93, s92
+s_cmp_lt_i32 s52, 0
+s_cbranch_scc0 104
+v_and_b32_e32 v98, 0x7f, v0
+v_lshrrev_b32_e32 v98, 1, v98
+v_bfi_b32 v98, 1, v0, v98
+v_and_b32_e64 v99, v0, 2
+v_mad_u32_u24 v98, v99, 16, v98
+v_lshlrev_b32_e32 v98, 2, v98
+v_add_co_u32_e64 v98, vcc, v98, s97
+v_and_b32_e32 v99, 3, v0
+v_lshlrev_b32_e32 v99, 2, v99
+v_add_co_u32_e64 v99, vcc, v99, s97
+ds_read_b32 v120, v99 offset:256
+ds_read_b32 v98, v98
+s_add_u32 s97, s97, 0x18c
+s_cmp_eq_u32 s97, 0xffc0
+s_cselect_b32 s97, 0xc1e0, s97
+s_waitcnt lgkmcnt(0)
+v_readfirstlane_b32 s95, v98
+v_readlane_b32 s54, v120, 0
+s_bitcmp1_b32 s54, 18
+s_cbranch_scc1 80
+v_readlane_b32 s52, v120, 1
+v_readlane_b32 s53, v120, 2
+s_add_u32 s93, s92, s53
+s_lshr_b32 s55, -1, 16
+s_and_b32 s55, s55, s66
+s_lshr_b32 s56, s66, 16
+s_mul_i32 s56, s56, s95
+s_mul_i32 s44, s55, s95
+s_lshl_b32 s55, s56, 16
+s_lshr_b32 s56, s56, 16
+s_add_u32 s44, s55, s44
+s_addc_u32 s45, s56, 0
+s_add_u32 s44, s44, s24
+s_addc_u32 s45, s45, s25
+s_mul_i32 s55, s67, s93
+s_add_u32 s44, s44, s55
+s_addc_u32 s45, s45, 0
+s_mov_b32 s47, 0x20000
+s_bitcmp1_b32 s18, 7
+s_cselect_b32 s51, 0x20000, 0
+s_lshl_b32 s55, s93, 1
+s_add_u32 s48, s34, s55
+s_addc_u32 s49, s35, 0
+s_lshl_b32 s56, s52, 1
+s_sub_u32 s50, s56, s55
+s_cselect_b32 s51, 0, s51
+s_sub_u32 s93, s52, s53
+s_sub_u32 s93, s93, 1
+s_sub_u32 s93, s93, s92
+s_cselect_b32 s47, 0, s47
+v_bfe_u32 v118, v98, 16, 16
+v_bfe_u32 v119, v98, 0, 16
+v_and_b32_e64 v120, v0, 7
+v_sub_co_u32_e32 v121, vcc, 7, v120
+v_min_u32_e32 v120, v120, v121
+v_bfe_u32 v121, v120, 1, 1
+v_bfe_u32 v120, v120, 0, 1
+v_mov_b32_dpp v118, v118  quad_perm:[1,1,1,1] row_mask:0xf bank_mask:0xf
+v_mov_b32_dpp v119, v119  quad_perm:[1,1,1,1] row_mask:0xf bank_mask:0xf
+v_add_co_u32_e32 v118, vcc, v118, v121
+v_add_co_u32_e32 v119, vcc, v119, v120
+v_mov_b32_dpp v120, v98  quad_perm:[0,0,0,0] row_mask:0xf bank_mask:0xf
+v_cmp_ge_u32_e64 s[52:53], v120, s12
+v_sub_co_u32_e64 v120, vcc, v120, s95
+v_mul_lo_u32 v120, v120, s66
+v_mad_i32_i24 v98, v118, s33, v119
+v_lshlrev_b32_e32 v98, 1, v98
+v_add_co_u32_e32 v98, vcc, v98, v120
+v_cmp_ge_u32_e64 s[58:59], v119, s33
+s_or_b64 s[56:57], s[58:59], s[52:53]
+v_cmp_ge_u32_e64 s[54:55], v118, s32
+s_or_b64 s[52:53], s[56:57], s[54:55]
+v_cndmask_b32_e64 v98, v98, -1, s[52:53]
+v_and_b32_e64 v116, v0, 63
+v_lshlrev_b32_e32 v116, 1, v116
+s_barrier
+buffer_load_ushort v116, v116, s[48:51], 0 offen
+s_mov_b64 vcc, s[10:11]
+s_branch 64437
+s_endpgm
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0

--- a/src/kernels/Conv_Winograd_v21_1_3_gfx9_fp16_dot2_edc_f3x2_stride1.inc
+++ b/src/kernels/Conv_Winograd_v21_1_3_gfx9_fp16_dot2_edc_f3x2_stride1.inc
@@ -1,0 +1,3352 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2023 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+v_mov_b32_e32 v0, v0
+s_mov_b32 s0, 0
+s_mov_b32 s1, 0
+s_mov_b32 s2, 0
+s_mov_b32 s3, 0
+v_mov_b32_e32 v116, 0
+s_mov_b32 m0, 0x1ffff
+s_mov_b32 s97, 0xc1e0
+s_mov_b32 s96, 0xc1e0
+s_mov_b32 s91, 0
+v_lshlrev_b32_e32 v119, 2, v0
+v_add_co_u32_e32 v119, vcc, 0xffc0, v119
+v_cmp_ge_u32_e32 vcc, 12, v0
+s_cbranch_vccz 5
+v_mov_b32_e32 v118, 0
+v_cndmask_b32_e32 v119, -1, v119, vcc
+ds_write_b32 v119, v118
+s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+s_barrier
+v_readfirstlane_b32 s52, v0
+s_lshr_b32 s52, s52, 5
+s_add_u32 s52, s52, 8
+s_and_b32 s92, s52, 20
+s_mov_b64 s[40:41], s[6:7]
+s_load_dwordx16 s[12:27], s[40:41], 0x0
+s_load_dwordx4 s[28:31], s[40:41], 0x40
+s_load_dwordx2 s[32:33], s[40:41], 0x50
+s_waitcnt lgkmcnt(0)
+s_and_b32 s18, s18, 0xffff
+s_bitcmp1_b32 s18, 6
+s_cbranch_scc0 16
+s_and_b32 s21, s21, 0xffff
+s_and_b32 s23, s23, 0xffff
+s_and_b32 s25, s25, 0xffff
+s_and_b32 s27, s27, 0xffff
+s_load_dwordx2 s[20:21], s[20:21], 0x0
+s_load_dwordx2 s[22:23], s[22:23], 0x0
+s_load_dwordx2 s[24:25], s[24:25], 0x0
+s_load_dwordx2 s[26:27], s[26:27], 0x0
+s_bitcmp1_b32 s18, 7
+s_cbranch_scc0 2
+s_load_dwordx2 s[34:35], s[40:41], 0x58
+s_mov_b32 s36, 1.0
+s_bitcmp1_b32 s18, 8
+s_cbranch_scc0 2
+s_load_dword s36, s[40:41], 0x60
+s_bitcmp1_b32 s18, 7
+s_cbranch_scc0 7
+s_bitcmp1_b32 s18, 6
+s_cbranch_scc0 5
+s_waitcnt lgkmcnt(0)
+s_and_b32 s35, s35, 0xffff
+s_load_dwordx2 s[34:35], s[34:35], 0x0
+s_bitcmp1_b32 s18, 9
+s_cbranch_scc0 72
+s_mov_b32 s42, 0x8c
+s_mov_b32 s43, 0x9c
+v_cmp_le_u32_e32 vcc, 0x100, v0
+s_cmp_eq_u32 1, src_vccz
+s_cselect_b32 s42, s43, s42
+s_load_dword s65, s[40:41], 0x88
+s_load_dword s90, s[40:41], 0x98
+s_load_dword s68, s[40:41], s42
+s_load_dwordx2 s[66:67], s[40:41], 0xa8
+s_bitcmp1_b32 s18, 10
+s_cbranch_scc0 103
+s_load_dwordx4 s[44:47], s[40:41], 0xb8
+v_ffbh_u32_e32 v4, s17
+v_lshlrev_b32_e64 v5, v4, s17
+v_and_b32_e32 v6, 0xffffff00, v5
+v_cmp_eq_u32_e32 vcc, 0x80000000, v5
+v_cvt_f32_u32_e32 v6, v6
+v_rcp_f32_e32 v2, v6
+v_subb_co_u32_e32 v3, vcc, 32, v4, vcc
+v_cvt_f32_ubyte0_e32 v4, v5
+v_fma_f32 v6, v6, v2, -1.0
+v_fma_f32 v6, v4, v2, v6
+v_madak_f32 v6, v6, v2, 0x9f000000
+v_mul_f32_e32 v6, 0x5f800000, v6
+v_mov_b32_e32 v4, 0
+v_cvt_flr_i32_f32_e64 v6, -v6
+v_lshl_add_u32 v2, v2, 9, v6
+v_mad_u64_u32 v[4:5], vcc, v5, v2, v[4:5]
+v_subb_co_u32_e64 v2, vcc, v2, -1, vcc
+v_mul_hi_u32 v4, s8, v2
+v_add_co_u32_e64 v2, vcc, v4, s8
+v_addc_co_u32_e64 v4, vcc, 0, 0, vcc
+v_cmp_eq_u32_e32 vcc, 32, v3
+v_cndmask_b32_e32 v2, v2, v4, vcc
+v_alignbit_b32 v2, v4, v2, v3
+s_waitcnt lgkmcnt(0)
+v_readfirstlane_b32 s48, v2
+s_mul_i32 s49, s48, s17
+s_sub_u32 s8, s8, s49
+s_mul_i32 s49, s45, s48
+s_add_u32 s20, s20, s49
+s_addc_u32 s21, s21, 0
+s_mul_i32 s49, s46, s48
+s_add_u32 s22, s22, s49
+s_addc_u32 s23, s23, 0
+s_mul_i32 s49, s47, s48
+s_add_u32 s24, s24, s49
+s_addc_u32 s25, s25, 0
+s_branch 49
+s_mul_i32 s42, s14, s15
+s_lshr_b32 s46, -1, 16
+s_and_b32 s46, s46, s42
+s_lshr_b32 s47, s42, 16
+s_mul_i32 s47, s47, s13
+s_mul_i32 s44, s46, s13
+s_lshl_b32 s46, s47, 16
+s_lshr_b32 s47, s47, 16
+s_add_u32 s44, s46, s44
+s_addc_u32 s45, s47, 0
+s_lshl_b32 s65, s44, 1
+s_lshl_b32 s68, s42, 1
+s_mul_i32 s43, s32, s33
+s_lshr_b32 s46, -1, 16
+s_and_b32 s46, s46, s43
+s_lshr_b32 s47, s43, 16
+s_mul_i32 s47, s47, s16
+s_mul_i32 s44, s46, s16
+s_lshl_b32 s46, s47, 16
+s_lshr_b32 s47, s47, 16
+s_add_u32 s44, s46, s44
+s_addc_u32 s45, s47, 0
+s_lshl_b32 s66, s44, 1
+s_lshl_b32 s67, s43, 1
+s_bitcmp1_b32 s18, 13
+s_cbranch_scc0 2
+s_load_dwordx8 s[48:55], s[40:41], 0x68
+s_mul_i32 s42, s28, s29
+s_lshl_b32 s42, s42, 1
+s_bitcmp1_b32 s18, 2
+s_cselect_b32 s43, s16, s13
+s_lshr_b32 s44, -1, 16
+s_and_b32 s44, s44, s42
+s_lshr_b32 s45, s42, 16
+s_mul_i32 s45, s45, s43
+s_mul_i32 s56, s44, s43
+s_lshl_b32 s44, s45, 16
+s_lshr_b32 s45, s45, 16
+s_add_u32 s56, s44, s56
+s_addc_u32 s57, s45, 0
+s_mov_b32 s43, s56
+s_bitcmp1_b32 s18, 2
+s_cselect_b32 s44, s43, s42
+s_cselect_b32 s90, s42, s43
+v_cmp_le_u32_e32 vcc, 0x100, v0
+s_cmp_eq_u32 1, src_vccz
+s_cselect_b32 s68, s44, s68
+s_waitcnt lgkmcnt(0)
+s_and_b32 s21, s21, 0xffff
+s_and_b32 s23, s23, 0xffff
+s_and_b32 s25, s25, 0xffff
+s_and_b32 s27, s27, 0xffff
+s_and_b32 s35, s35, 0xffff
+s_bitcmp1_b32 s18, 13
+s_cbranch_scc0 8
+s_add_u32 s20, s20, s48
+s_addc_u32 s21, s21, s49
+s_add_u32 s22, s22, s50
+s_addc_u32 s23, s23, s51
+s_add_u32 s24, s24, s52
+s_addc_u32 s25, s25, s53
+s_add_u32 s34, s34, s54
+s_addc_u32 s35, s35, s55
+v_cvt_f16_f32_e32 v2, s36
+v_readfirstlane_b32 s36, v2
+s_and_b32 s44, 0, s30
+s_addc_u32 s44, s32, 0
+s_ashr_i32 s44, s44, 0
+s_add_u32 s42, s44, 2
+v_mov_b32_e32 v2, 0x55555556
+v_mul_hi_u32 v2, v2, s42
+v_readfirstlane_b32 s42, v2
+s_andn2_b32 s44, 0, s31
+s_addc_u32 s44, s33, 0
+s_ashr_i32 s44, s44, 0
+s_add_u32 s43, s44, 2
+v_mov_b32_e32 v2, 0x55555556
+v_mul_hi_u32 v2, v2, s43
+v_readfirstlane_b32 s43, v2
+s_sub_u32 s75, 0, s43
+s_sub_u32 s74, 0, s42
+s_add_u32 s60, s28, 1
+v_mov_b32_e32 v2, 0x80000000
+v_mul_hi_u32 v2, v2, s60
+v_readfirstlane_b32 s60, v2
+s_add_u32 s61, s29, 1
+v_mov_b32_e32 v2, 0x80000000
+v_mul_hi_u32 v2, v2, s61
+v_readfirstlane_b32 s61, v2
+v_mad_i32_i24 v2, 2, s60, -1
+v_sub_co_u32_e64 v2, vcc, v2, s28
+v_addc_co_u32_e64 v2, vcc, 0, 0, vcc
+v_readfirstlane_b32 s44, v2
+s_and_b32 s44, s44, 0
+s_and_b32 s44, s44, s60
+s_add_u32 s60, s60, s44
+v_readfirstlane_b32 s45, v0
+s_and_b32 s48, s45, 64
+s_cselect_b32 s48, 0x80000, 0
+s_or_b32 s18, s18, s48
+s_lshl_b32 s69, s68, 1
+s_sub_u32 s70, 0, s69
+s_subb_u32 s71, 0, 0
+s_bitcmp1_b32 s18, 12
+s_cselect_b32 s44, 0, -1
+s_bitcmp1_b32 s18, 11
+s_cselect_b32 s44, s44, 1
+s_cmp_gt_u32 s61, s44
+s_cbranch_scc0 8
+s_bitset1_b32 s18, 23
+s_bitset1_b32 s18, 20
+s_bitset0_b32 s18, 19
+s_ashr_i32 s69, s69, 1
+s_ashr_i64 s[70:71], s[70:71], 1
+s_add_u32 s61, s61, 1
+s_and_b32 s61, s61, -2
+s_branch 16
+s_and_b32 s48, s13, 3
+s_cselect_b32 s48, 0, 0x1000000
+s_bitcmp1_b32 s18, 2
+s_cselect_b32 s48, 0, s48
+s_or_b32 s18, s18, s48
+s_cmp_eq_u32 s48, 0
+s_cselect_b32 s69, s68, s69
+s_cselect_b32 s70, s68, s70
+s_cselect_b32 s71, 0, s71
+s_bitcmp0_b32 s45, 8
+s_cselect_b32 s48, s48, 0
+s_cmp_eq_u32 s48, 0
+s_cselect_b32 s48, 0, 0x80000
+s_andn2_b32 s18, s18, s48
+s_add_u32 s70, s70, s69
+s_addc_u32 s71, s71, 0
+s_add_u32 s70, s70, s69
+s_addc_u32 s71, s71, 0
+v_bfe_u32 v3, v0, 2, 6
+v_lshrrev_b32_e32 v111, 1, v3
+s_bitcmp0_b32 s45, 8
+s_cselect_b32 s48, 0x1000000, 0
+s_or_b32 s48, s48, 0x100000
+s_and_b32 s48, s18, s48
+s_cselect_b32 s48, 0, 15
+v_bfi_b32 v111, s48, v3, v111
+s_mul_i32 s88, s12, s42
+s_sub_u32 s88, s88, 1
+s_lshr_b32 s88, s88, 0
+s_add_u32 s88, s88, 1
+s_lshr_b32 s46, -1, 16
+s_and_b32 s46, s46, s88
+s_lshr_b32 s47, s88, 16
+s_mul_i32 s47, s47, s43
+s_mul_i32 s88, s46, s43
+s_lshl_b32 s46, s47, 16
+s_lshr_b32 s47, s47, 16
+s_add_u32 s88, s46, s88
+s_addc_u32 s89, s47, 0
+s_sub_u32 s88, s88, 1
+s_subb_u32 s89, s89, 0
+s_lshr_b64 s[88:89], s[88:89], 5
+s_add_u32 s88, s88, 1
+s_addc_u32 s89, s89, 0
+v_mov_b32_e32 v4, s8
+v_mov_b32_e32 v5, s17
+v_and_b32_e32 v6, 3, v0
+v_cmp_eq_u32_e32 vcc, 2, v6
+v_cndmask_b32_e32 v4, v4, v5, vcc
+v_cmp_eq_u32_e32 vcc, 1, v6
+v_cndmask_b32_e32 v7, 0, v111, vcc
+s_bitcmp1_b32 s18, 20
+s_cbranch_scc0 4
+v_add_co_u32_e64 v5, vcc, v111, 8
+v_cmp_eq_u32_e32 vcc, 0, v6
+v_cndmask_b32_e32 v7, v7, v5, vcc
+v_cmp_eq_u32_e64 s[46:47], 3, v6
+v_bfe_u32 v109, v7, 0, 5
+v_mad_u32_u24 v109, v4, 32, v109
+v_ffbh_u32_e32 v9, s43
+v_lshlrev_b32_e64 v10, v9, s43
+v_and_b32_e32 v11, 0xffffff00, v10
+v_cmp_eq_u32_e32 vcc, 0x80000000, v10
+v_cvt_f32_u32_e32 v11, v11
+v_rcp_f32_e32 v110, v11
+v_subb_co_u32_e32 v8, vcc, 32, v9, vcc
+v_cvt_f32_ubyte0_e32 v9, v10
+v_fma_f32 v11, v11, v110, -1.0
+v_fma_f32 v11, v9, v110, v11
+v_madak_f32 v11, v11, v110, 0x9f000000
+v_mul_f32_e32 v11, 0x5f800000, v11
+v_mov_b32_e32 v9, 0
+v_cvt_flr_i32_f32_e64 v11, -v11
+v_lshl_add_u32 v110, v110, 9, v11
+v_mad_u64_u32 v[9:10], vcc, v10, v110, v[9:10]
+v_subb_co_u32_e64 v110, vcc, v110, -1, vcc
+v_mul_hi_u32 v9, v109, v110
+v_add_co_u32_e32 v110, vcc, v9, v109
+v_addc_co_u32_e64 v9, vcc, 0, 0, vcc
+v_cmp_eq_u32_e32 vcc, 32, v8
+v_cndmask_b32_e32 v110, v110, v9, vcc
+v_alignbit_b32 v110, v9, v110, v8
+v_mad_i32_i24 v108, v110, s75, v109
+v_lshrrev_b32_e32 v109, 5, v7
+v_mad_u32_u24 v109, v110, 1, v109
+v_cndmask_b32_e64 v109, v109, 1, s[46:47]
+v_ffbh_u32_e32 v9, s42
+v_lshlrev_b32_e64 v10, v9, s42
+v_and_b32_e32 v11, 0xffffff00, v10
+v_cmp_eq_u32_e32 vcc, 0x80000000, v10
+v_cvt_f32_u32_e32 v11, v11
+v_rcp_f32_e32 v110, v11
+v_subb_co_u32_e32 v8, vcc, 32, v9, vcc
+v_cvt_f32_ubyte0_e32 v9, v10
+v_fma_f32 v11, v11, v110, -1.0
+v_fma_f32 v11, v9, v110, v11
+v_madak_f32 v11, v11, v110, 0x9f000000
+v_mul_f32_e32 v11, 0x5f800000, v11
+v_mov_b32_e32 v9, 0
+v_cvt_flr_i32_f32_e64 v11, -v11
+v_lshl_add_u32 v110, v110, 9, v11
+v_mad_u64_u32 v[9:10], vcc, v10, v110, v[9:10]
+v_subb_co_u32_e64 v110, vcc, v110, -1, vcc
+v_mul_hi_u32 v9, v109, v110
+v_add_co_u32_e32 v110, vcc, v9, v109
+v_addc_co_u32_e64 v9, vcc, 0, 0, vcc
+v_cmp_eq_u32_e32 vcc, 32, v8
+v_cndmask_b32_e32 v110, v110, v9, vcc
+v_alignbit_b32 v110, v9, v110, v8
+v_mad_i32_i24 v109, v110, s74, v109
+v_readlane_b32 s76, v108, 2
+v_readlane_b32 s77, v109, 2
+v_readlane_b32 s78, v110, 2
+v_readlane_b32 s79, v109, 3
+v_readlane_b32 s80, v110, 3
+v_add_co_u32_e64 v108, vcc, v108, s75
+v_add_co_u32_e64 v109, vcc, v109, s74
+v_mov_b32_dpp v110, v110  quad_perm:[1,1,0,0] row_mask:0xf bank_mask:0xf
+v_mov_b32_dpp v108, v108  quad_perm:[1,1,0,0] row_mask:0xf bank_mask:0xf
+v_mov_b32_dpp v109, v109  quad_perm:[1,1,0,0] row_mask:0xf bank_mask:0xf
+s_mov_b32 s42, 0x80000000
+s_mov_b32 s43, 0x20000
+s_mov_b32 s46, 0x80000000
+s_mov_b32 s47, 0x20000
+v_cmp_le_u32_e32 vcc, 0x100, v0
+s_cbranch_vccnz 7
+v_xor_b32_dpp v112, v0, v0  quad_perm:[2,3,2,1] row_mask:0xf bank_mask:0xf
+v_subrev_co_u32_e32 v112, vcc, 1, v112
+v_cvt_f16_i16_e32 v112, v112
+v_pk_add_f16  v112, v112, 0 op_sel_hi:[0,0]
+s_branch 6
+v_xor_b32_dpp v112, v0, v0  quad_perm:[2,1,0,1] row_mask:0xf bank_mask:0xf
+v_sub_co_u32_e32 v112, vcc, 1, v112
+v_cvt_f16_i16_e32 v112, v112
+v_pk_add_f16  v112, v112, 0 op_sel_hi:[0,0]
+v_mov_b32_e32 v113, 1
+v_xor_b32_dpp v113, v0, v0  quad_perm:[2,3,2,3] row_mask:0xf bank_mask:0x4
+v_xor_b32_dpp v113, v0, v0  quad_perm:[0,1,0,1] row_mask:0xf bank_mask:0x8
+v_subrev_co_u32_e32 v113, vcc, 1, v113
+v_mov_b32_e32 v114, 1
+v_xor_b32_dpp v114, v0, v0  quad_perm:[0,3,2,1] row_mask:0xf bank_mask:0x2
+v_xor_b32_dpp v114, v0, v0  quad_perm:[2,1,0,3] row_mask:0xf bank_mask:0x4
+v_subrev_co_u32_e32 v114, vcc, 1, v114
+v_cvt_f32_i32_e32 v113, v113
+v_cvt_f32_i32_e32 v114, v114
+v_lshrrev_b32_e64 v118, 2, s92
+v_and_b32_e32 v119, 3, v0
+v_bfe_u32 v120, v0, 4, 3
+v_mad_u32_u24 v107, v120, 4, v119
+v_lshlrev_b32_e32 v107, 4, v107
+v_mad_u32_u24 v102, v118, 4, v119
+v_lshlrev_b32_e32 v102, 4, v102
+v_bfe_u32 v118, v0, 2, 2
+v_and_b32_e32 v119, 1, v118
+v_mad_u32_u24 v121, v118, 16, v119
+v_lshlrev_b32_e32 v121, 6, v121
+v_xor_b32_e32 v102, v102, v121
+v_mul_u32_u24_e32 v121, 0x400, v118
+v_xor_b32_e32 v107, v107, v121
+s_lshr_b32 s92, s92, 0
+v_cmp_le_u32_e32 vcc, 0x100, v0
+s_cbranch_vccnz 47
+s_and_b32 s53, s18, 0x1100000
+s_addc_u32 s53, 0, 0
+v_lshrrev_b32_e32 v121, 1, v0
+s_mul_i32 s52, 60, s53
+s_sub_u32 s52, 63, s52
+v_bfi_b32 v121, s52, v0, v121
+v_and_b32_e32 v118, 1, v121
+v_bfe_u32 v119, v121, 1, 1
+v_xor_b32_e32 v118, v118, v119
+v_bfe_u32 v120, v121, 3, 1
+v_mad_u32_u24 v119, v119, 2, v120
+v_mul_u32_u24_e32 v118, 0x118, v118
+v_bfe_u32 v120, v121, 2, 1
+v_mad_u32_u24 v119, v119, 2, v118
+v_xor_b32_e32 v119, v119, v120
+v_and_b32_e32 v120, 0xf0, v121
+v_xor_b32_e32 v119, v119, v120
+s_mul_i32 s52, 4, s53
+s_sub_u32 s52, 6, s52
+v_bfe_u32 v121, v0, s52, 1
+v_mul_u32_u24_e32 v121, 0x1040, v121
+v_xor_b32_e32 v104, 0x314, v119
+v_xor_b32_e32 v105, 0x31c, v119
+v_xor_b32_e32 v106, 8, v119
+v_mov_b32_e32 v103, v119
+v_mad_u32_u24 v103, 4, v103, v121
+v_mad_u32_u24 v104, 4, v104, v121
+v_mad_u32_u24 v105, 4, v105, v121
+v_mad_u32_u24 v106, 4, v106, v121
+s_branch 44
+s_bfe_u32 s53, s18, 0x10014
+v_lshrrev_b32_e32 v121, 1, v0
+s_mul_i32 s52, 60, s53
+s_sub_u32 s52, 63, s52
+v_bfi_b32 v121, s52, v0, v121
+v_and_b32_e32 v118, 1, v121
+v_bfe_u32 v119, v121, 1, 1
+v_bfe_u32 v120, v121, 3, 1
+v_xor_b32_e32 v118, v118, v119
+v_mad_u32_u24 v119, v119, 2, v120
+v_mul_u32_u24_e32 v118, 0x109, v118
+v_bfe_u32 v120, v121, 2, 1
+v_mad_u32_u24 v119, v119, 2, v118
+v_xor_b32_e32 v119, v119, v120
+v_and_b32_e32 v120, 0xf0, v121
+v_or_b32_e32 v119, v119, v120
+s_mul_i32 s52, 4, s53
+s_sub_u32 s52, 6, s52
+v_bfe_u32 v121, v0, s52, 1
+v_mul_u32_u24_e32 v121, 0x1040, v121
+v_mad_u32_u24 v103, 4, v119, v121
+v_xor_b32_e32 v104, 0x307, v119
+v_mad_u32_u24 v104, 4, v104, v121
+v_xor_b32_e32 v105, 0x30f, v119
+v_mad_u32_u24 v105, 4, v105, v121
+v_xor_b32_e32 v106, 8, v119
+v_mad_u32_u24 v106, 4, v106, v121
+v_subrev_co_u32_e32 v108, vcc, s76, v108
+v_mov_b32_e32 v119, s75
+v_cmp_lt_i32_e32 vcc, v108, v119
+v_subb_co_u32_e64 v118, vcc, 0, 0, vcc
+v_mad_i32_i24 v108, v118, s75, v108
+v_mad_i32_i24 v110, v118, s80, v110
+v_mad_i32_i24 v109, v118, s79, v109
+v_mov_b32_e32 v119, s74
+v_cmp_lt_i32_e32 vcc, v109, v119
+v_subb_co_u32_e64 v118, vcc, 0, 0, vcc
+v_add_co_u32_e32 v110, vcc, v110, v118
+v_mad_i32_i24 v109, v118, v119, v109
+v_subrev_co_u32_e32 v109, vcc, s77, v109
+v_cmp_lt_i32_e32 vcc, v109, v119
+v_subb_co_u32_e64 v118, vcc, 0, 0, vcc
+v_add_co_u32_e32 v110, vcc, v110, v118
+v_mad_i32_i24 v109, v118, s74, v109
+v_subrev_co_u32_e32 v110, vcc, s78, v110
+s_mov_b32 s62, 0
+s_mov_b32 s63, s28
+s_mov_b32 s64, 1
+s_mov_b32 s84, 0
+s_mov_b32 s85, s16
+s_mov_b32 s83, s85
+s_sub_u32 s93, -1, s92
+s_sub_u32 s93, s93, 32
+s_bitset1_b32 s18, 21
+s_mov_b32 s47, 0
+s_mov_b32 s51, 0
+s_mov_b32 s94, 34
+s_mov_b32 s82, 0
+s_bitset1_b32 s18, 26
+s_call_b64 s[38:39], 2861
+v_cmp_le_u32_e32 vcc, 0x100, v0
+s_cbranch_vccnz 65
+s_branch 1506
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_dot2_f32_f16 v2, v34, v42, v2
+v_dot2_f32_f16 v3, v35, v42, v3
+v_dot2_f32_f16 v4, v36, v42, v4
+v_dot2_f32_f16 v5, v37, v42, v5
+v_dot2_f32_f16 v6, v34, v43, v6
+v_dot2_f32_f16 v7, v35, v43, v7
+v_dot2_f32_f16 v8, v36, v43, v8
+v_dot2_f32_f16 v9, v37, v43, v9
+v_dot2_f32_f16 v10, v34, v44, v10
+v_dot2_f32_f16 v11, v35, v44, v11
+v_dot2_f32_f16 v12, v36, v44, v12
+v_dot2_f32_f16 v13, v37, v44, v13
+v_dot2_f32_f16 v14, v34, v45, v14
+v_dot2_f32_f16 v15, v35, v45, v15
+v_dot2_f32_f16 v16, v36, v45, v16
+v_dot2_f32_f16 v17, v37, v45, v17
+v_dot2_f32_f16 v18, v34, v46, v18
+v_dot2_f32_f16 v19, v35, v46, v19
+v_dot2_f32_f16 v20, v36, v46, v20
+v_dot2_f32_f16 v21, v37, v46, v21
+v_dot2_f32_f16 v22, v34, v47, v22
+v_dot2_f32_f16 v23, v35, v47, v23
+v_dot2_f32_f16 v24, v36, v47, v24
+v_dot2_f32_f16 v25, v37, v47, v25
+v_dot2_f32_f16 v26, v34, v48, v26
+v_dot2_f32_f16 v27, v35, v48, v27
+v_dot2_f32_f16 v28, v36, v48, v28
+v_dot2_f32_f16 v29, v37, v48, v29
+v_dot2_f32_f16 v30, v34, v49, v30
+v_dot2_f32_f16 v31, v35, v49, v31
+v_pack_b32_f16 v70, v82, v70
+v_pack_b32_f16 v71, v83, v71
+v_pack_b32_f16 v72, v84, v72
+v_pack_b32_f16 v73, v85, v73
+v_pk_fma_f16 v70, v72, -1.0, v70 op_sel_hi:[1,0,1]
+v_pk_mul_f16 v70, v70, 0.5 op_sel_hi:[1,0]
+v_pk_fma_f16 v73, v71, -1.0, v73 op_sel_hi:[1,0,1]
+v_pk_mul_f16 v73, v73, 0.5 op_sel_hi:[1,0]
+v_pk_add_f16 v71, v72, v71
+v_pk_mul_f16 v71, v71, 0.5 op_sel_hi:[1,0]
+s_setprio 0
+s_nop 0
+v_dot2_f32_f16 v32, v36, v49, v32
+v_dot2_f32_f16 v33, v37, v49, v33
+s_nop 0
+ds_read_b128 v[34:37], v107 offset:29440
+ds_read_b128 v[42:45], v102 offset:28928
+ds_read_b128 v[46:49], v102 offset:29056
+ds_write_b32 v103, v62
+ds_write_b32 v104, v63
+s_setprio 1
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v58, v94, s[40:43], 0 offen
+buffer_load_short_d16 v60, v96, s[40:43], 0 offen
+buffer_load_short_d16 v59, v95, s[40:43], 0 offen
+buffer_load_short_d16 v61, v97, s[40:43], 0 offen
+s_add_u32 s91, s91, 0x200
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 2
+s_call_b64 s[38:39], 2673
+s_nop 0
+v_dot2_f32_f16 v2, v38, v50, v2
+v_dot2_f32_f16 v3, v39, v50, v3
+v_dot2_f32_f16 v4, v40, v50, v4
+v_dot2_f32_f16 v5, v41, v50, v5
+v_dot2_f32_f16 v6, v38, v51, v6
+v_dot2_f32_f16 v7, v39, v51, v7
+v_dot2_f32_f16 v8, v40, v51, v8
+v_dot2_f32_f16 v9, v41, v51, v9
+v_dot2_f32_f16 v10, v38, v52, v10
+v_dot2_f32_f16 v11, v39, v52, v11
+v_dot2_f32_f16 v12, v40, v52, v12
+v_dot2_f32_f16 v13, v41, v52, v13
+v_dot2_f32_f16 v14, v38, v53, v14
+v_dot2_f32_f16 v15, v39, v53, v15
+v_dot2_f32_f16 v16, v40, v53, v16
+v_dot2_f32_f16 v17, v41, v53, v17
+v_dot2_f32_f16 v18, v38, v54, v18
+v_dot2_f32_f16 v19, v39, v54, v19
+v_dot2_f32_f16 v20, v40, v54, v20
+v_dot2_f32_f16 v21, v41, v54, v21
+v_dot2_f32_f16 v22, v38, v55, v22
+v_dot2_f32_f16 v23, v39, v55, v23
+v_dot2_f32_f16 v24, v40, v55, v24
+v_dot2_f32_f16 v25, v41, v55, v25
+v_dot2_f32_f16 v26, v38, v56, v26
+v_dot2_f32_f16 v27, v39, v56, v27
+v_dot2_f32_f16 v28, v40, v56, v28
+v_dot2_f32_f16 v29, v41, v56, v29
+v_dot2_f32_f16 v30, v38, v57, v30
+v_dot2_f32_f16 v31, v39, v57, v31
+v_pk_fma_f16 v72, v71, -1.0, v72 op_sel_hi:[1,0,1]
+v_mov_b32_dpp v115, v70  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v70, v115, v112, v70
+v_mov_b32_dpp v115, v71  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v71, v115, v112, v71
+v_mov_b32_dpp v115, v72  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v72, v115, v112, v72
+v_mov_b32_dpp v115, v73  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v73, v115, v112, v73
+s_setprio 0
+s_nop 0
+v_dot2_f32_f16 v32, v40, v57, v32
+v_dot2_f32_f16 v33, v41, v57, v33
+s_nop 0
+ds_read_b128 v[38:41], v107 offset:33536
+ds_read_b128 v[50:53], v102 offset:33024
+ds_read_b128 v[54:57], v102 offset:33152
+ds_write_b32 v105, v68 offset:8256
+ds_write_b32 v106, v69 offset:8256
+s_setprio 1
+s_add_u32 s40, s40, s69
+s_addc_u32 s41, s41, 0
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v82, v94, s[40:43], 0 offen
+buffer_load_short_d16 v84, v96, s[40:43], 0 offen
+buffer_load_short_d16 v83, v95, s[40:43], 0 offen
+buffer_load_short_d16 v85, v97, s[40:43], 0 offen
+s_nop 0
+s_waitcnt vmcnt(16) lgkmcnt(5)
+ds_append v117 offset:65472
+s_bitset1_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 4
+s_call_b64 s[38:39], 2555
+s_nop 0
+s_nop 0
+s_nop 0
+v_dot2_f32_f16 v2, v34, v42, v2
+v_dot2_f32_f16 v3, v35, v42, v3
+v_dot2_f32_f16 v4, v36, v42, v4
+v_dot2_f32_f16 v5, v37, v42, v5
+v_dot2_f32_f16 v6, v34, v43, v6
+v_dot2_f32_f16 v7, v35, v43, v7
+v_dot2_f32_f16 v8, v36, v43, v8
+v_dot2_f32_f16 v9, v37, v43, v9
+v_dot2_f32_f16 v10, v34, v44, v10
+v_dot2_f32_f16 v11, v35, v44, v11
+v_dot2_f32_f16 v12, v36, v44, v12
+v_dot2_f32_f16 v13, v37, v44, v13
+v_dot2_f32_f16 v14, v34, v45, v14
+v_dot2_f32_f16 v15, v35, v45, v15
+v_dot2_f32_f16 v16, v36, v45, v16
+v_dot2_f32_f16 v17, v37, v45, v17
+v_dot2_f32_f16 v18, v34, v46, v18
+v_dot2_f32_f16 v19, v35, v46, v19
+v_dot2_f32_f16 v20, v36, v46, v20
+v_dot2_f32_f16 v21, v37, v46, v21
+v_dot2_f32_f16 v22, v34, v47, v22
+v_dot2_f32_f16 v23, v35, v47, v23
+v_dot2_f32_f16 v24, v36, v47, v24
+v_dot2_f32_f16 v25, v37, v47, v25
+v_dot2_f32_f16 v26, v34, v48, v26
+v_dot2_f32_f16 v27, v35, v48, v27
+v_dot2_f32_f16 v28, v36, v48, v28
+v_dot2_f32_f16 v29, v37, v48, v29
+v_dot2_f32_f16 v30, v34, v49, v30
+v_dot2_f32_f16 v31, v35, v49, v31
+v_pack_b32_f16 v74, v86, v74
+v_pack_b32_f16 v75, v87, v75
+v_pack_b32_f16 v76, v88, v76
+v_pack_b32_f16 v77, v89, v77
+v_pk_fma_f16 v74, v76, -1.0, v74 op_sel_hi:[1,0,1]
+v_pk_mul_f16 v74, v74, 0.5 op_sel_hi:[1,0]
+v_pk_fma_f16 v77, v75, -1.0, v77 op_sel_hi:[1,0,1]
+v_pk_mul_f16 v77, v77, 0.5 op_sel_hi:[1,0]
+v_pk_add_f16 v75, v76, v75
+v_pk_mul_f16 v75, v75, 0.5 op_sel_hi:[1,0]
+s_setprio 0
+s_nop 0
+v_dot2_f32_f16 v32, v36, v49, v32
+v_dot2_f32_f16 v33, v37, v49, v33
+s_nop 0
+ds_read_b128 v[34:37], v107 offset:37696
+ds_read_b128 v[42:45], v102 offset:37184
+ds_read_b128 v[46:49], v102 offset:37312
+ds_write_b32 v103, v66 offset:8256
+ds_write_b32 v104, v67 offset:8256
+s_setprio 1
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v62, v94, s[40:43], 0 offen
+buffer_load_short_d16 v64, v96, s[40:43], 0 offen
+buffer_load_short_d16 v63, v95, s[40:43], 0 offen
+buffer_load_short_d16 v65, v97, s[40:43], 0 offen
+s_mov_b32 m0, 0x2ffc0
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 2
+s_call_b64 s[38:39], 2433
+s_nop 0
+v_dot2_f32_f16 v2, v38, v50, v2
+v_dot2_f32_f16 v3, v39, v50, v3
+v_dot2_f32_f16 v4, v40, v50, v4
+v_dot2_f32_f16 v5, v41, v50, v5
+v_dot2_f32_f16 v6, v38, v51, v6
+v_dot2_f32_f16 v7, v39, v51, v7
+v_dot2_f32_f16 v8, v40, v51, v8
+v_dot2_f32_f16 v9, v41, v51, v9
+v_dot2_f32_f16 v10, v38, v52, v10
+v_dot2_f32_f16 v11, v39, v52, v11
+v_dot2_f32_f16 v12, v40, v52, v12
+v_dot2_f32_f16 v13, v41, v52, v13
+v_dot2_f32_f16 v14, v38, v53, v14
+v_dot2_f32_f16 v15, v39, v53, v15
+v_dot2_f32_f16 v16, v40, v53, v16
+v_dot2_f32_f16 v17, v41, v53, v17
+v_dot2_f32_f16 v18, v38, v54, v18
+v_dot2_f32_f16 v19, v39, v54, v19
+v_dot2_f32_f16 v20, v40, v54, v20
+v_dot2_f32_f16 v21, v41, v54, v21
+v_dot2_f32_f16 v22, v38, v55, v22
+v_dot2_f32_f16 v23, v39, v55, v23
+v_dot2_f32_f16 v24, v40, v55, v24
+v_dot2_f32_f16 v25, v41, v55, v25
+v_dot2_f32_f16 v26, v38, v56, v26
+v_dot2_f32_f16 v27, v39, v56, v27
+v_dot2_f32_f16 v28, v40, v56, v28
+v_dot2_f32_f16 v29, v41, v56, v29
+v_dot2_f32_f16 v30, v38, v57, v30
+v_dot2_f32_f16 v31, v39, v57, v31
+v_dot2_f32_f16 v32, v40, v57, v32
+v_pk_fma_f16 v76, v75, -1.0, v76 op_sel_hi:[1,0,1]
+v_mov_b32_dpp v115, v74  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v74, v115, v112, v74
+v_mov_b32_dpp v115, v75  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v75, v115, v112, v75
+v_mov_b32_dpp v115, v76  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v76, v115, v112, v76
+v_mov_b32_dpp v115, v77  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v77, v115, v112, v77
+s_setprio 0
+s_nop 0
+v_dot2_f32_f16 v33, v41, v57, v33
+v_cmp_eq_u32_e64 vcc, src_lds_direct, s91
+s_nop 0
+s_nop 0
+s_cbranch_vccz 65531
+s_nop 0
+ds_read_b128 v[38:41], v107 offset:41792
+ds_read_b128 v[50:53], v102 offset:41280
+ds_read_b128 v[54:57], v102 offset:41408
+ds_write_b32 v105, v72 offset:16512
+ds_write_b32 v106, v73 offset:16512
+s_setprio 1
+s_add_u32 s40, s40, s69
+s_addc_u32 s41, s41, 0
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v86, v94, s[40:43], 0 offen
+buffer_load_short_d16 v88, v96, s[40:43], 0 offen
+buffer_load_short_d16 v87, v95, s[40:43], 0 offen
+buffer_load_short_d16 v89, v97, s[40:43], 0 offen
+s_nop 0
+s_waitcnt vmcnt(16) lgkmcnt(5)
+s_bitset1_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 1
+s_call_b64 s[38:39], 2312
+v_dot2_f32_f16 v2, v34, v42, v2
+v_dot2_f32_f16 v3, v35, v42, v3
+v_dot2_f32_f16 v4, v36, v42, v4
+v_dot2_f32_f16 v5, v37, v42, v5
+v_dot2_f32_f16 v6, v34, v43, v6
+v_dot2_f32_f16 v7, v35, v43, v7
+v_dot2_f32_f16 v8, v36, v43, v8
+v_dot2_f32_f16 v9, v37, v43, v9
+v_dot2_f32_f16 v10, v34, v44, v10
+v_dot2_f32_f16 v11, v35, v44, v11
+v_dot2_f32_f16 v12, v36, v44, v12
+v_dot2_f32_f16 v13, v37, v44, v13
+v_dot2_f32_f16 v14, v34, v45, v14
+v_dot2_f32_f16 v15, v35, v45, v15
+v_dot2_f32_f16 v16, v36, v45, v16
+v_dot2_f32_f16 v17, v37, v45, v17
+v_dot2_f32_f16 v18, v34, v46, v18
+v_dot2_f32_f16 v19, v35, v46, v19
+v_dot2_f32_f16 v20, v36, v46, v20
+v_dot2_f32_f16 v21, v37, v46, v21
+v_dot2_f32_f16 v22, v34, v47, v22
+v_dot2_f32_f16 v23, v35, v47, v23
+v_dot2_f32_f16 v24, v36, v47, v24
+v_dot2_f32_f16 v25, v37, v47, v25
+v_dot2_f32_f16 v26, v34, v48, v26
+v_dot2_f32_f16 v27, v35, v48, v27
+v_dot2_f32_f16 v28, v36, v48, v28
+v_dot2_f32_f16 v29, v37, v48, v29
+v_dot2_f32_f16 v30, v34, v49, v30
+v_dot2_f32_f16 v31, v35, v49, v31
+v_pack_b32_f16 v78, v90, v78
+v_pack_b32_f16 v79, v91, v79
+v_pack_b32_f16 v80, v92, v80
+v_pack_b32_f16 v81, v93, v81
+v_pk_fma_f16 v78, v80, -1.0, v78 op_sel_hi:[1,0,1]
+v_pk_mul_f16 v78, v78, 0.5 op_sel_hi:[1,0]
+v_pk_fma_f16 v81, v79, -1.0, v81 op_sel_hi:[1,0,1]
+v_pk_mul_f16 v81, v81, 0.5 op_sel_hi:[1,0]
+v_pk_add_f16 v79, v80, v79
+v_pk_mul_f16 v79, v79, 0.5 op_sel_hi:[1,0]
+s_setprio 0
+s_nop 0
+v_dot2_f32_f16 v32, v36, v49, v32
+v_dot2_f32_f16 v33, v37, v49, v33
+s_nop 0
+ds_read_b128 v[34:37], v107 offset:45952
+ds_read_b128 v[42:45], v102 offset:45440
+ds_read_b128 v[46:49], v102 offset:45568
+ds_write_b32 v103, v70 offset:16512
+ds_write_b32 v104, v71 offset:16512
+s_setprio 1
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v66, v94, s[40:43], 0 offen
+buffer_load_short_d16 v68, v96, s[40:43], 0 offen
+buffer_load_short_d16 v67, v95, s[40:43], 0 offen
+buffer_load_short_d16 v69, v97, s[40:43], 0 offen
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 4
+s_call_b64 s[38:39], 2195
+s_nop 0
+s_nop 0
+s_nop 0
+v_dot2_f32_f16 v2, v38, v50, v2
+v_dot2_f32_f16 v3, v39, v50, v3
+v_dot2_f32_f16 v4, v40, v50, v4
+v_dot2_f32_f16 v5, v41, v50, v5
+v_dot2_f32_f16 v6, v38, v51, v6
+v_dot2_f32_f16 v7, v39, v51, v7
+v_dot2_f32_f16 v8, v40, v51, v8
+v_dot2_f32_f16 v9, v41, v51, v9
+v_dot2_f32_f16 v10, v38, v52, v10
+v_dot2_f32_f16 v11, v39, v52, v11
+v_dot2_f32_f16 v12, v40, v52, v12
+v_dot2_f32_f16 v13, v41, v52, v13
+v_dot2_f32_f16 v14, v38, v53, v14
+v_dot2_f32_f16 v15, v39, v53, v15
+v_dot2_f32_f16 v16, v40, v53, v16
+v_dot2_f32_f16 v17, v41, v53, v17
+v_dot2_f32_f16 v18, v38, v54, v18
+v_dot2_f32_f16 v19, v39, v54, v19
+v_dot2_f32_f16 v20, v40, v54, v20
+v_dot2_f32_f16 v21, v41, v54, v21
+v_dot2_f32_f16 v22, v38, v55, v22
+v_dot2_f32_f16 v23, v39, v55, v23
+v_dot2_f32_f16 v24, v40, v55, v24
+v_dot2_f32_f16 v25, v41, v55, v25
+v_dot2_f32_f16 v26, v38, v56, v26
+v_dot2_f32_f16 v27, v39, v56, v27
+v_dot2_f32_f16 v28, v40, v56, v28
+v_dot2_f32_f16 v29, v41, v56, v29
+v_dot2_f32_f16 v30, v38, v57, v30
+v_dot2_f32_f16 v31, v39, v57, v31
+v_pk_fma_f16 v80, v79, -1.0, v80 op_sel_hi:[1,0,1]
+v_mov_b32_dpp v115, v78  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v78, v115, v112, v78
+v_mov_b32_dpp v115, v79  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v79, v115, v112, v79
+v_mov_b32_dpp v115, v80  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v80, v115, v112, v80
+v_mov_b32_dpp v115, v81  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v81, v115, v112, v81
+s_setprio 0
+s_nop 0
+v_dot2_f32_f16 v32, v40, v57, v32
+v_dot2_f32_f16 v33, v41, v57, v33
+s_nop 0
+ds_read_b128 v[38:41], v107 offset:512
+ds_read_b128 v[50:53], v102
+ds_read_b128 v[54:57], v102 offset:128
+ds_write_b32 v105, v76 offset:24768
+ds_write_b32 v106, v77 offset:24768
+s_setprio 1
+s_add_u32 s40, s40, s69
+s_addc_u32 s41, s41, 0
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v90, v94, s[40:43], 0 offen
+buffer_load_short_d16 v92, v96, s[40:43], 0 offen
+buffer_load_short_d16 v91, v95, s[40:43], 0 offen
+buffer_load_short_d16 v93, v97, s[40:43], 0 offen
+s_nop 0
+s_waitcnt vmcnt(16) lgkmcnt(5)
+ds_append v117 offset:65476
+s_bitset1_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 4
+s_call_b64 s[38:39], 2075
+s_nop 0
+s_nop 0
+s_nop 0
+v_dot2_f32_f16 v2, v34, v42, v2
+v_dot2_f32_f16 v3, v35, v42, v3
+v_dot2_f32_f16 v4, v36, v42, v4
+v_dot2_f32_f16 v5, v37, v42, v5
+v_dot2_f32_f16 v6, v34, v43, v6
+v_dot2_f32_f16 v7, v35, v43, v7
+v_dot2_f32_f16 v8, v36, v43, v8
+v_dot2_f32_f16 v9, v37, v43, v9
+v_dot2_f32_f16 v10, v34, v44, v10
+v_dot2_f32_f16 v11, v35, v44, v11
+v_dot2_f32_f16 v12, v36, v44, v12
+v_dot2_f32_f16 v13, v37, v44, v13
+v_dot2_f32_f16 v14, v34, v45, v14
+v_dot2_f32_f16 v15, v35, v45, v15
+v_dot2_f32_f16 v16, v36, v45, v16
+v_dot2_f32_f16 v17, v37, v45, v17
+v_dot2_f32_f16 v18, v34, v46, v18
+v_dot2_f32_f16 v19, v35, v46, v19
+v_dot2_f32_f16 v20, v36, v46, v20
+v_dot2_f32_f16 v21, v37, v46, v21
+v_dot2_f32_f16 v22, v34, v47, v22
+v_dot2_f32_f16 v23, v35, v47, v23
+v_dot2_f32_f16 v24, v36, v47, v24
+v_dot2_f32_f16 v25, v37, v47, v25
+v_dot2_f32_f16 v26, v34, v48, v26
+v_dot2_f32_f16 v27, v35, v48, v27
+v_dot2_f32_f16 v28, v36, v48, v28
+v_dot2_f32_f16 v29, v37, v48, v29
+v_dot2_f32_f16 v30, v34, v49, v30
+v_dot2_f32_f16 v31, v35, v49, v31
+v_pack_b32_f16 v58, v82, v58
+v_pack_b32_f16 v59, v83, v59
+v_pack_b32_f16 v60, v84, v60
+v_pack_b32_f16 v61, v85, v61
+v_pk_fma_f16 v58, v60, -1.0, v58 op_sel_hi:[1,0,1]
+v_pk_mul_f16 v58, v58, 0.5 op_sel_hi:[1,0]
+v_pk_fma_f16 v61, v59, -1.0, v61 op_sel_hi:[1,0,1]
+v_pk_mul_f16 v61, v61, 0.5 op_sel_hi:[1,0]
+v_pk_add_f16 v59, v60, v59
+v_pk_mul_f16 v59, v59, 0.5 op_sel_hi:[1,0]
+s_setprio 0
+s_nop 0
+v_dot2_f32_f16 v32, v36, v49, v32
+v_dot2_f32_f16 v33, v37, v49, v33
+s_nop 0
+ds_read_b128 v[34:37], v107 offset:4672
+ds_read_b128 v[42:45], v102 offset:4160
+ds_read_b128 v[46:49], v102 offset:4288
+ds_write_b32 v103, v74 offset:24768
+ds_write_b32 v104, v75 offset:24768
+s_setprio 1
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v70, v94, s[40:43], 0 offen
+buffer_load_short_d16 v72, v96, s[40:43], 0 offen
+buffer_load_short_d16 v71, v95, s[40:43], 0 offen
+buffer_load_short_d16 v73, v97, s[40:43], 0 offen
+s_mov_b32 m0, 0x2ffc4
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 2
+s_call_b64 s[38:39], 1953
+s_nop 0
+v_dot2_f32_f16 v2, v38, v50, v2
+v_dot2_f32_f16 v3, v39, v50, v3
+v_dot2_f32_f16 v4, v40, v50, v4
+v_dot2_f32_f16 v5, v41, v50, v5
+v_dot2_f32_f16 v6, v38, v51, v6
+v_dot2_f32_f16 v7, v39, v51, v7
+v_dot2_f32_f16 v8, v40, v51, v8
+v_dot2_f32_f16 v9, v41, v51, v9
+v_dot2_f32_f16 v10, v38, v52, v10
+v_dot2_f32_f16 v11, v39, v52, v11
+v_dot2_f32_f16 v12, v40, v52, v12
+v_dot2_f32_f16 v13, v41, v52, v13
+v_dot2_f32_f16 v14, v38, v53, v14
+v_dot2_f32_f16 v15, v39, v53, v15
+v_dot2_f32_f16 v16, v40, v53, v16
+v_dot2_f32_f16 v17, v41, v53, v17
+v_dot2_f32_f16 v18, v38, v54, v18
+v_dot2_f32_f16 v19, v39, v54, v19
+v_dot2_f32_f16 v20, v40, v54, v20
+v_dot2_f32_f16 v21, v41, v54, v21
+v_dot2_f32_f16 v22, v38, v55, v22
+v_dot2_f32_f16 v23, v39, v55, v23
+v_dot2_f32_f16 v24, v40, v55, v24
+v_dot2_f32_f16 v25, v41, v55, v25
+v_dot2_f32_f16 v26, v38, v56, v26
+v_dot2_f32_f16 v27, v39, v56, v27
+v_dot2_f32_f16 v28, v40, v56, v28
+v_dot2_f32_f16 v29, v41, v56, v29
+v_dot2_f32_f16 v30, v38, v57, v30
+v_dot2_f32_f16 v31, v39, v57, v31
+v_dot2_f32_f16 v32, v40, v57, v32
+v_pk_fma_f16 v60, v59, -1.0, v60 op_sel_hi:[1,0,1]
+v_mov_b32_dpp v115, v58  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v58, v115, v112, v58
+v_mov_b32_dpp v115, v59  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v59, v115, v112, v59
+v_mov_b32_dpp v115, v60  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v60, v115, v112, v60
+v_mov_b32_dpp v115, v61  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v61, v115, v112, v61
+s_setprio 0
+s_nop 0
+v_dot2_f32_f16 v33, v41, v57, v33
+v_cmp_eq_u32_e64 vcc, src_lds_direct, s91
+s_nop 0
+s_nop 0
+s_cbranch_vccz 65531
+s_nop 0
+ds_read_b128 v[38:41], v107 offset:8768
+ds_read_b128 v[50:53], v102 offset:8256
+ds_read_b128 v[54:57], v102 offset:8384
+ds_write_b32 v105, v80 offset:33024
+ds_write_b32 v106, v81 offset:33024
+s_setprio 1
+s_add_u32 s40, s40, s69
+s_addc_u32 s41, s41, 0
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v82, v94, s[40:43], 0 offen
+buffer_load_short_d16 v84, v96, s[40:43], 0 offen
+buffer_load_short_d16 v83, v95, s[40:43], 0 offen
+buffer_load_short_d16 v85, v97, s[40:43], 0 offen
+s_nop 0
+s_waitcnt vmcnt(16) lgkmcnt(5)
+s_bitset1_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 1
+s_call_b64 s[38:39], 1832
+v_dot2_f32_f16 v2, v34, v42, v2
+v_dot2_f32_f16 v3, v35, v42, v3
+v_dot2_f32_f16 v4, v36, v42, v4
+v_dot2_f32_f16 v5, v37, v42, v5
+v_dot2_f32_f16 v6, v34, v43, v6
+v_dot2_f32_f16 v7, v35, v43, v7
+v_dot2_f32_f16 v8, v36, v43, v8
+v_dot2_f32_f16 v9, v37, v43, v9
+v_dot2_f32_f16 v10, v34, v44, v10
+v_dot2_f32_f16 v11, v35, v44, v11
+v_dot2_f32_f16 v12, v36, v44, v12
+v_dot2_f32_f16 v13, v37, v44, v13
+v_dot2_f32_f16 v14, v34, v45, v14
+v_dot2_f32_f16 v15, v35, v45, v15
+v_dot2_f32_f16 v16, v36, v45, v16
+v_dot2_f32_f16 v17, v37, v45, v17
+v_dot2_f32_f16 v18, v34, v46, v18
+v_dot2_f32_f16 v19, v35, v46, v19
+v_dot2_f32_f16 v20, v36, v46, v20
+v_dot2_f32_f16 v21, v37, v46, v21
+v_dot2_f32_f16 v22, v34, v47, v22
+v_dot2_f32_f16 v23, v35, v47, v23
+v_dot2_f32_f16 v24, v36, v47, v24
+v_dot2_f32_f16 v25, v37, v47, v25
+v_dot2_f32_f16 v26, v34, v48, v26
+v_dot2_f32_f16 v27, v35, v48, v27
+v_dot2_f32_f16 v28, v36, v48, v28
+v_dot2_f32_f16 v29, v37, v48, v29
+v_dot2_f32_f16 v30, v34, v49, v30
+v_dot2_f32_f16 v31, v35, v49, v31
+v_pack_b32_f16 v62, v86, v62
+v_pack_b32_f16 v63, v87, v63
+v_pack_b32_f16 v64, v88, v64
+v_pack_b32_f16 v65, v89, v65
+v_pk_fma_f16 v62, v64, -1.0, v62 op_sel_hi:[1,0,1]
+v_pk_mul_f16 v62, v62, 0.5 op_sel_hi:[1,0]
+v_pk_fma_f16 v65, v63, -1.0, v65 op_sel_hi:[1,0,1]
+v_pk_mul_f16 v65, v65, 0.5 op_sel_hi:[1,0]
+v_pk_add_f16 v63, v64, v63
+v_pk_mul_f16 v63, v63, 0.5 op_sel_hi:[1,0]
+s_setprio 0
+s_nop 0
+v_dot2_f32_f16 v32, v36, v49, v32
+v_dot2_f32_f16 v33, v37, v49, v33
+s_nop 0
+ds_read_b128 v[34:37], v107 offset:12928
+ds_read_b128 v[42:45], v102 offset:12416
+ds_read_b128 v[46:49], v102 offset:12544
+ds_write_b32 v103, v78 offset:33024
+ds_write_b32 v104, v79 offset:33024
+s_setprio 1
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v74, v94, s[40:43], 0 offen
+buffer_load_short_d16 v76, v96, s[40:43], 0 offen
+buffer_load_short_d16 v75, v95, s[40:43], 0 offen
+buffer_load_short_d16 v77, v97, s[40:43], 0 offen
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 4
+s_call_b64 s[38:39], 1715
+s_nop 0
+s_nop 0
+s_nop 0
+v_dot2_f32_f16 v2, v38, v50, v2
+v_dot2_f32_f16 v3, v39, v50, v3
+v_dot2_f32_f16 v4, v40, v50, v4
+v_dot2_f32_f16 v5, v41, v50, v5
+v_dot2_f32_f16 v6, v38, v51, v6
+v_dot2_f32_f16 v7, v39, v51, v7
+v_dot2_f32_f16 v8, v40, v51, v8
+v_dot2_f32_f16 v9, v41, v51, v9
+v_dot2_f32_f16 v10, v38, v52, v10
+v_dot2_f32_f16 v11, v39, v52, v11
+v_dot2_f32_f16 v12, v40, v52, v12
+v_dot2_f32_f16 v13, v41, v52, v13
+v_dot2_f32_f16 v14, v38, v53, v14
+v_dot2_f32_f16 v15, v39, v53, v15
+v_dot2_f32_f16 v16, v40, v53, v16
+v_dot2_f32_f16 v17, v41, v53, v17
+v_dot2_f32_f16 v18, v38, v54, v18
+v_dot2_f32_f16 v19, v39, v54, v19
+v_dot2_f32_f16 v20, v40, v54, v20
+v_dot2_f32_f16 v21, v41, v54, v21
+v_dot2_f32_f16 v22, v38, v55, v22
+v_dot2_f32_f16 v23, v39, v55, v23
+v_dot2_f32_f16 v24, v40, v55, v24
+v_dot2_f32_f16 v25, v41, v55, v25
+v_dot2_f32_f16 v26, v38, v56, v26
+v_dot2_f32_f16 v27, v39, v56, v27
+v_dot2_f32_f16 v28, v40, v56, v28
+v_dot2_f32_f16 v29, v41, v56, v29
+v_dot2_f32_f16 v30, v38, v57, v30
+v_dot2_f32_f16 v31, v39, v57, v31
+v_pk_fma_f16 v64, v63, -1.0, v64 op_sel_hi:[1,0,1]
+v_mov_b32_dpp v115, v62  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v62, v115, v112, v62
+v_mov_b32_dpp v115, v63  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v63, v115, v112, v63
+v_mov_b32_dpp v115, v64  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v64, v115, v112, v64
+v_mov_b32_dpp v115, v65  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v65, v115, v112, v65
+s_setprio 0
+s_nop 0
+v_dot2_f32_f16 v32, v40, v57, v32
+v_dot2_f32_f16 v33, v41, v57, v33
+s_nop 0
+ds_read_b128 v[38:41], v107 offset:17024
+ds_read_b128 v[50:53], v102 offset:16512
+ds_read_b128 v[54:57], v102 offset:16640
+ds_write_b32 v105, v60 offset:41280
+ds_write_b32 v106, v61 offset:41280
+s_setprio 1
+s_add_u32 s40, s40, s69
+s_addc_u32 s41, s41, 0
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v86, v94, s[40:43], 0 offen
+buffer_load_short_d16 v88, v96, s[40:43], 0 offen
+buffer_load_short_d16 v87, v95, s[40:43], 0 offen
+buffer_load_short_d16 v89, v97, s[40:43], 0 offen
+s_nop 0
+s_waitcnt vmcnt(16) lgkmcnt(5)
+ds_append v117 offset:65480
+s_bitset1_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 4
+s_call_b64 s[38:39], 1595
+s_nop 0
+s_nop 0
+s_nop 0
+v_dot2_f32_f16 v2, v34, v42, v2
+v_dot2_f32_f16 v3, v35, v42, v3
+v_dot2_f32_f16 v4, v36, v42, v4
+v_dot2_f32_f16 v5, v37, v42, v5
+v_dot2_f32_f16 v6, v34, v43, v6
+v_dot2_f32_f16 v7, v35, v43, v7
+v_dot2_f32_f16 v8, v36, v43, v8
+v_dot2_f32_f16 v9, v37, v43, v9
+v_dot2_f32_f16 v10, v34, v44, v10
+v_dot2_f32_f16 v11, v35, v44, v11
+v_dot2_f32_f16 v12, v36, v44, v12
+v_dot2_f32_f16 v13, v37, v44, v13
+v_dot2_f32_f16 v14, v34, v45, v14
+v_dot2_f32_f16 v15, v35, v45, v15
+v_dot2_f32_f16 v16, v36, v45, v16
+v_dot2_f32_f16 v17, v37, v45, v17
+v_dot2_f32_f16 v18, v34, v46, v18
+v_dot2_f32_f16 v19, v35, v46, v19
+v_dot2_f32_f16 v20, v36, v46, v20
+v_dot2_f32_f16 v21, v37, v46, v21
+v_dot2_f32_f16 v22, v34, v47, v22
+v_dot2_f32_f16 v23, v35, v47, v23
+v_dot2_f32_f16 v24, v36, v47, v24
+v_dot2_f32_f16 v25, v37, v47, v25
+v_dot2_f32_f16 v26, v34, v48, v26
+v_dot2_f32_f16 v27, v35, v48, v27
+v_dot2_f32_f16 v28, v36, v48, v28
+v_dot2_f32_f16 v29, v37, v48, v29
+v_dot2_f32_f16 v30, v34, v49, v30
+v_dot2_f32_f16 v31, v35, v49, v31
+v_pack_b32_f16 v66, v90, v66
+v_pack_b32_f16 v67, v91, v67
+v_pack_b32_f16 v68, v92, v68
+v_pack_b32_f16 v69, v93, v69
+v_pk_fma_f16 v66, v68, -1.0, v66 op_sel_hi:[1,0,1]
+v_pk_mul_f16 v66, v66, 0.5 op_sel_hi:[1,0]
+v_pk_fma_f16 v69, v67, -1.0, v69 op_sel_hi:[1,0,1]
+v_pk_mul_f16 v69, v69, 0.5 op_sel_hi:[1,0]
+v_pk_add_f16 v67, v68, v67
+v_pk_mul_f16 v67, v67, 0.5 op_sel_hi:[1,0]
+s_setprio 0
+s_nop 0
+v_dot2_f32_f16 v32, v36, v49, v32
+v_dot2_f32_f16 v33, v37, v49, v33
+s_nop 0
+ds_read_b128 v[34:37], v107 offset:21184
+ds_read_b128 v[42:45], v102 offset:20672
+ds_read_b128 v[46:49], v102 offset:20800
+ds_write_b32 v103, v58 offset:41280
+ds_write_b32 v104, v59 offset:41280
+s_setprio 1
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v78, v94, s[40:43], 0 offen
+buffer_load_short_d16 v80, v96, s[40:43], 0 offen
+buffer_load_short_d16 v79, v95, s[40:43], 0 offen
+buffer_load_short_d16 v81, v97, s[40:43], 0 offen
+s_mov_b32 m0, 0x2ffc8
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 2
+s_call_b64 s[38:39], 1473
+s_nop 0
+v_dot2_f32_f16 v2, v38, v50, v2
+v_dot2_f32_f16 v3, v39, v50, v3
+v_dot2_f32_f16 v4, v40, v50, v4
+v_dot2_f32_f16 v5, v41, v50, v5
+v_dot2_f32_f16 v6, v38, v51, v6
+v_dot2_f32_f16 v7, v39, v51, v7
+v_dot2_f32_f16 v8, v40, v51, v8
+v_dot2_f32_f16 v9, v41, v51, v9
+v_dot2_f32_f16 v10, v38, v52, v10
+v_dot2_f32_f16 v11, v39, v52, v11
+v_dot2_f32_f16 v12, v40, v52, v12
+v_dot2_f32_f16 v13, v41, v52, v13
+v_dot2_f32_f16 v14, v38, v53, v14
+v_dot2_f32_f16 v15, v39, v53, v15
+v_dot2_f32_f16 v16, v40, v53, v16
+v_dot2_f32_f16 v17, v41, v53, v17
+v_dot2_f32_f16 v18, v38, v54, v18
+v_dot2_f32_f16 v19, v39, v54, v19
+v_dot2_f32_f16 v20, v40, v54, v20
+v_dot2_f32_f16 v21, v41, v54, v21
+v_dot2_f32_f16 v22, v38, v55, v22
+v_dot2_f32_f16 v23, v39, v55, v23
+v_dot2_f32_f16 v24, v40, v55, v24
+v_dot2_f32_f16 v25, v41, v55, v25
+v_dot2_f32_f16 v26, v38, v56, v26
+v_dot2_f32_f16 v27, v39, v56, v27
+v_dot2_f32_f16 v28, v40, v56, v28
+v_dot2_f32_f16 v29, v41, v56, v29
+v_dot2_f32_f16 v30, v38, v57, v30
+v_dot2_f32_f16 v31, v39, v57, v31
+v_dot2_f32_f16 v32, v40, v57, v32
+v_pk_fma_f16 v68, v67, -1.0, v68 op_sel_hi:[1,0,1]
+v_mov_b32_dpp v115, v66  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v66, v115, v112, v66
+v_mov_b32_dpp v115, v67  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v67, v115, v112, v67
+v_mov_b32_dpp v115, v68  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v68, v115, v112, v68
+v_mov_b32_dpp v115, v69  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v69, v115, v112, v69
+s_setprio 0
+s_nop 0
+v_dot2_f32_f16 v33, v41, v57, v33
+v_cmp_eq_u32_e64 vcc, src_lds_direct, s91
+s_nop 0
+s_nop 0
+s_cbranch_vccz 65531
+s_nop 0
+ds_read_b128 v[38:41], v107 offset:25280
+ds_read_b128 v[50:53], v102 offset:24768
+ds_read_b128 v[54:57], v102 offset:24896
+ds_write_b32 v105, v64
+ds_write_b32 v106, v65
+s_setprio 1
+s_add_u32 s40, s40, s69
+s_addc_u32 s41, s41, 0
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v90, v94, s[40:43], 0 offen
+buffer_load_short_d16 v92, v96, s[40:43], 0 offen
+buffer_load_short_d16 v91, v95, s[40:43], 0 offen
+buffer_load_short_d16 v93, v97, s[40:43], 0 offen
+s_nop 0
+s_waitcnt vmcnt(16) lgkmcnt(5)
+s_bitset1_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 64097
+s_call_b64 s[38:39], 1352
+s_branch 64095
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_dot2_f32_f16 v2, v34, v42, v2
+v_dot2_f32_f16 v3, v35, v42, v3
+v_dot2_f32_f16 v4, v36, v42, v4
+v_dot2_f32_f16 v5, v37, v42, v5
+s_setprio 1
+s_nop 0
+v_dot2_f32_f16 v6, v34, v43, v6
+v_dot2_f32_f16 v7, v35, v43, v7
+v_dot2_f32_f16 v8, v36, v43, v8
+v_dot2_f32_f16 v9, v37, v43, v9
+v_dot2_f32_f16 v10, v34, v44, v10
+v_dot2_f32_f16 v11, v35, v44, v11
+v_dot2_f32_f16 v12, v36, v44, v12
+v_dot2_f32_f16 v13, v37, v44, v13
+v_dot2_f32_f16 v14, v34, v45, v14
+v_dot2_f32_f16 v15, v35, v45, v15
+v_dot2_f32_f16 v16, v36, v45, v16
+v_dot2_f32_f16 v17, v37, v45, v17
+v_dot2_f32_f16 v18, v34, v46, v18
+v_dot2_f32_f16 v19, v35, v46, v19
+v_dot2_f32_f16 v20, v36, v46, v20
+v_dot2_f32_f16 v21, v37, v46, v21
+v_dot2_f32_f16 v22, v34, v47, v22
+v_dot2_f32_f16 v23, v35, v47, v23
+v_dot2_f32_f16 v24, v36, v47, v24
+v_dot2_f32_f16 v25, v37, v47, v25
+v_dot2_f32_f16 v26, v34, v48, v26
+v_dot2_f32_f16 v27, v35, v48, v27
+v_dot2_f32_f16 v28, v36, v48, v28
+v_dot2_f32_f16 v29, v37, v48, v29
+v_dot2_f32_f16 v30, v34, v49, v30
+v_dot2_f32_f16 v31, v35, v49, v31
+v_pack_b32_f16 v70, v82, v70
+v_pack_b32_f16 v71, v83, v71
+v_pack_b32_f16 v72, v84, v72
+v_pack_b32_f16 v73, v85, v73
+v_mov_b32_dpp v115, v70  quad_perm:[0,0,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v70, v115, v112, v70
+v_dot2_f32_f16 v32, v36, v49, v32
+v_dot2_f32_f16 v33, v37, v49, v33
+s_nop 0
+ds_read_b128 v[34:37], v107 offset:29440
+ds_read_b128 v[42:45], v102 offset:28928
+ds_read_b128 v[46:49], v102 offset:29056
+ds_write_b32 v103, v62
+ds_write_b32 v104, v63
+s_setprio 0
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v58, v94, s[40:43], 0 offen
+buffer_load_short_d16 v61, v97, s[40:43], 0 offen
+s_add_u32 s91, s91, 0x200
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 6
+s_call_b64 s[38:39], 1237
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_dot2_f32_f16 v2, v38, v50, v2
+v_dot2_f32_f16 v3, v39, v50, v3
+v_dot2_f32_f16 v4, v40, v50, v4
+v_dot2_f32_f16 v5, v41, v50, v5
+s_setprio 1
+s_nop 0
+v_dot2_f32_f16 v6, v38, v51, v6
+v_dot2_f32_f16 v7, v39, v51, v7
+v_dot2_f32_f16 v8, v40, v51, v8
+v_dot2_f32_f16 v9, v41, v51, v9
+v_dot2_f32_f16 v10, v38, v52, v10
+v_dot2_f32_f16 v11, v39, v52, v11
+v_dot2_f32_f16 v12, v40, v52, v12
+v_dot2_f32_f16 v13, v41, v52, v13
+v_dot2_f32_f16 v14, v38, v53, v14
+v_dot2_f32_f16 v15, v39, v53, v15
+v_dot2_f32_f16 v16, v40, v53, v16
+v_dot2_f32_f16 v17, v41, v53, v17
+v_dot2_f32_f16 v18, v38, v54, v18
+v_dot2_f32_f16 v19, v39, v54, v19
+v_dot2_f32_f16 v20, v40, v54, v20
+v_dot2_f32_f16 v21, v41, v54, v21
+v_dot2_f32_f16 v22, v38, v55, v22
+v_dot2_f32_f16 v23, v39, v55, v23
+v_dot2_f32_f16 v24, v40, v55, v24
+v_dot2_f32_f16 v25, v41, v55, v25
+v_dot2_f32_f16 v26, v38, v56, v26
+v_dot2_f32_f16 v27, v39, v56, v27
+v_dot2_f32_f16 v28, v40, v56, v28
+v_dot2_f32_f16 v29, v41, v56, v29
+v_dot2_f32_f16 v30, v38, v57, v30
+v_dot2_f32_f16 v31, v39, v57, v31
+v_mov_b32_dpp v115, v73  quad_perm:[0,0,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v73, v115, v112, v73
+v_pk_add_f16 v71, v70, v73
+v_pk_mul_f16 v71, v71, 0.5 op_sel_hi:[1,0]
+v_pk_fma_f16 v72, -1.0, v73, v70 op_sel_hi:[0,1,1]
+v_pk_mul_f16 v72, v72, 0.5 op_sel_hi:[1,0]
+v_dot2_f32_f16 v32, v40, v57, v32
+v_dot2_f32_f16 v33, v41, v57, v33
+s_nop 0
+ds_read_b128 v[38:41], v107 offset:33536
+ds_read_b128 v[50:53], v102 offset:33024
+ds_read_b128 v[54:57], v102 offset:33152
+ds_write_b32 v105, v68 offset:8256
+ds_write_b32 v106, v69 offset:8256
+s_setprio 0
+s_add_u32 s40, s40, s69
+s_addc_u32 s41, s41, 0
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v82, v94, s[40:43], 0 offen
+buffer_load_short_d16 v85, v97, s[40:43], 0 offen
+s_nop 0
+s_waitcnt vmcnt(8) lgkmcnt(5)
+ds_append v117 offset:65472
+s_bitset1_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 6
+s_call_b64 s[38:39], 1125
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_dot2_f32_f16 v2, v34, v42, v2
+v_dot2_f32_f16 v3, v35, v42, v3
+v_dot2_f32_f16 v4, v36, v42, v4
+v_dot2_f32_f16 v5, v37, v42, v5
+s_setprio 1
+s_nop 0
+v_dot2_f32_f16 v6, v34, v43, v6
+v_dot2_f32_f16 v7, v35, v43, v7
+v_dot2_f32_f16 v8, v36, v43, v8
+v_dot2_f32_f16 v9, v37, v43, v9
+v_dot2_f32_f16 v10, v34, v44, v10
+v_dot2_f32_f16 v11, v35, v44, v11
+v_dot2_f32_f16 v12, v36, v44, v12
+v_dot2_f32_f16 v13, v37, v44, v13
+v_dot2_f32_f16 v14, v34, v45, v14
+v_dot2_f32_f16 v15, v35, v45, v15
+v_dot2_f32_f16 v16, v36, v45, v16
+v_dot2_f32_f16 v17, v37, v45, v17
+v_dot2_f32_f16 v18, v34, v46, v18
+v_dot2_f32_f16 v19, v35, v46, v19
+v_dot2_f32_f16 v20, v36, v46, v20
+v_dot2_f32_f16 v21, v37, v46, v21
+v_dot2_f32_f16 v22, v34, v47, v22
+v_dot2_f32_f16 v23, v35, v47, v23
+v_dot2_f32_f16 v24, v36, v47, v24
+v_dot2_f32_f16 v25, v37, v47, v25
+v_dot2_f32_f16 v26, v34, v48, v26
+v_dot2_f32_f16 v27, v35, v48, v27
+v_dot2_f32_f16 v28, v36, v48, v28
+v_dot2_f32_f16 v29, v37, v48, v29
+v_dot2_f32_f16 v30, v34, v49, v30
+v_dot2_f32_f16 v31, v35, v49, v31
+v_pack_b32_f16 v74, v86, v74
+v_pack_b32_f16 v75, v87, v75
+v_pack_b32_f16 v76, v88, v76
+v_pack_b32_f16 v77, v89, v77
+v_mov_b32_dpp v115, v74  quad_perm:[0,0,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v74, v115, v112, v74
+v_dot2_f32_f16 v32, v36, v49, v32
+v_dot2_f32_f16 v33, v37, v49, v33
+s_nop 0
+ds_read_b128 v[34:37], v107 offset:37696
+ds_read_b128 v[42:45], v102 offset:37184
+ds_read_b128 v[46:49], v102 offset:37312
+ds_write_b32 v103, v66 offset:8256
+ds_write_b32 v104, v67 offset:8256
+s_setprio 0
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v62, v94, s[40:43], 0 offen
+buffer_load_short_d16 v65, v97, s[40:43], 0 offen
+s_mov_b32 m0, 0x2ffc0
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 6
+s_call_b64 s[38:39], 1013
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_dot2_f32_f16 v2, v38, v50, v2
+v_dot2_f32_f16 v3, v39, v50, v3
+v_dot2_f32_f16 v4, v40, v50, v4
+v_dot2_f32_f16 v5, v41, v50, v5
+s_setprio 1
+s_nop 0
+v_dot2_f32_f16 v6, v38, v51, v6
+v_dot2_f32_f16 v7, v39, v51, v7
+v_dot2_f32_f16 v8, v40, v51, v8
+v_dot2_f32_f16 v9, v41, v51, v9
+v_dot2_f32_f16 v10, v38, v52, v10
+v_dot2_f32_f16 v11, v39, v52, v11
+v_dot2_f32_f16 v12, v40, v52, v12
+v_dot2_f32_f16 v13, v41, v52, v13
+v_dot2_f32_f16 v14, v38, v53, v14
+v_dot2_f32_f16 v15, v39, v53, v15
+v_dot2_f32_f16 v16, v40, v53, v16
+v_dot2_f32_f16 v17, v41, v53, v17
+v_dot2_f32_f16 v18, v38, v54, v18
+v_dot2_f32_f16 v19, v39, v54, v19
+v_dot2_f32_f16 v20, v40, v54, v20
+v_dot2_f32_f16 v21, v41, v54, v21
+v_dot2_f32_f16 v22, v38, v55, v22
+v_dot2_f32_f16 v23, v39, v55, v23
+v_dot2_f32_f16 v24, v40, v55, v24
+v_dot2_f32_f16 v25, v41, v55, v25
+v_dot2_f32_f16 v26, v38, v56, v26
+v_dot2_f32_f16 v27, v39, v56, v27
+v_dot2_f32_f16 v28, v40, v56, v28
+v_dot2_f32_f16 v29, v41, v56, v29
+v_dot2_f32_f16 v30, v38, v57, v30
+v_dot2_f32_f16 v31, v39, v57, v31
+v_dot2_f32_f16 v32, v40, v57, v32
+v_mov_b32_dpp v115, v77  quad_perm:[0,0,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v77, v115, v112, v77
+v_pk_add_f16 v75, v74, v77
+v_pk_mul_f16 v75, v75, 0.5 op_sel_hi:[1,0]
+v_pk_fma_f16 v76, -1.0, v77, v74 op_sel_hi:[0,1,1]
+v_pk_mul_f16 v76, v76, 0.5 op_sel_hi:[1,0]
+v_dot2_f32_f16 v33, v41, v57, v33
+v_cmp_eq_u32_e64 vcc, src_lds_direct, s91
+s_nop 0
+s_nop 0
+s_cbranch_vccz 65531
+s_nop 0
+ds_read_b128 v[38:41], v107 offset:41792
+ds_read_b128 v[50:53], v102 offset:41280
+ds_read_b128 v[54:57], v102 offset:41408
+ds_write_b32 v105, v72 offset:16512
+ds_write_b32 v106, v73 offset:16512
+s_setprio 0
+s_add_u32 s40, s40, s69
+s_addc_u32 s41, s41, 0
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v86, v94, s[40:43], 0 offen
+buffer_load_short_d16 v89, v97, s[40:43], 0 offen
+s_nop 0
+s_waitcnt vmcnt(8) lgkmcnt(5)
+s_bitset1_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 3
+s_call_b64 s[38:39], 898
+s_nop 0
+s_nop 0
+v_dot2_f32_f16 v2, v34, v42, v2
+v_dot2_f32_f16 v3, v35, v42, v3
+v_dot2_f32_f16 v4, v36, v42, v4
+v_dot2_f32_f16 v5, v37, v42, v5
+s_setprio 1
+s_nop 0
+v_dot2_f32_f16 v6, v34, v43, v6
+v_dot2_f32_f16 v7, v35, v43, v7
+v_dot2_f32_f16 v8, v36, v43, v8
+v_dot2_f32_f16 v9, v37, v43, v9
+v_dot2_f32_f16 v10, v34, v44, v10
+v_dot2_f32_f16 v11, v35, v44, v11
+v_dot2_f32_f16 v12, v36, v44, v12
+v_dot2_f32_f16 v13, v37, v44, v13
+v_dot2_f32_f16 v14, v34, v45, v14
+v_dot2_f32_f16 v15, v35, v45, v15
+v_dot2_f32_f16 v16, v36, v45, v16
+v_dot2_f32_f16 v17, v37, v45, v17
+v_dot2_f32_f16 v18, v34, v46, v18
+v_dot2_f32_f16 v19, v35, v46, v19
+v_dot2_f32_f16 v20, v36, v46, v20
+v_dot2_f32_f16 v21, v37, v46, v21
+v_dot2_f32_f16 v22, v34, v47, v22
+v_dot2_f32_f16 v23, v35, v47, v23
+v_dot2_f32_f16 v24, v36, v47, v24
+v_dot2_f32_f16 v25, v37, v47, v25
+v_dot2_f32_f16 v26, v34, v48, v26
+v_dot2_f32_f16 v27, v35, v48, v27
+v_dot2_f32_f16 v28, v36, v48, v28
+v_dot2_f32_f16 v29, v37, v48, v29
+v_dot2_f32_f16 v30, v34, v49, v30
+v_dot2_f32_f16 v31, v35, v49, v31
+v_pack_b32_f16 v78, v90, v78
+v_pack_b32_f16 v79, v91, v79
+v_pack_b32_f16 v80, v92, v80
+v_pack_b32_f16 v81, v93, v81
+v_mov_b32_dpp v115, v78  quad_perm:[0,0,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v78, v115, v112, v78
+v_dot2_f32_f16 v32, v36, v49, v32
+v_dot2_f32_f16 v33, v37, v49, v33
+s_nop 0
+ds_read_b128 v[34:37], v107 offset:45952
+ds_read_b128 v[42:45], v102 offset:45440
+ds_read_b128 v[46:49], v102 offset:45568
+ds_write_b32 v103, v70 offset:16512
+ds_write_b32 v104, v71 offset:16512
+s_setprio 0
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v66, v94, s[40:43], 0 offen
+buffer_load_short_d16 v69, v97, s[40:43], 0 offen
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 8
+s_call_b64 s[38:39], 791
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_dot2_f32_f16 v2, v38, v50, v2
+v_dot2_f32_f16 v3, v39, v50, v3
+v_dot2_f32_f16 v4, v40, v50, v4
+v_dot2_f32_f16 v5, v41, v50, v5
+s_setprio 1
+s_nop 0
+v_dot2_f32_f16 v6, v38, v51, v6
+v_dot2_f32_f16 v7, v39, v51, v7
+v_dot2_f32_f16 v8, v40, v51, v8
+v_dot2_f32_f16 v9, v41, v51, v9
+v_dot2_f32_f16 v10, v38, v52, v10
+v_dot2_f32_f16 v11, v39, v52, v11
+v_dot2_f32_f16 v12, v40, v52, v12
+v_dot2_f32_f16 v13, v41, v52, v13
+v_dot2_f32_f16 v14, v38, v53, v14
+v_dot2_f32_f16 v15, v39, v53, v15
+v_dot2_f32_f16 v16, v40, v53, v16
+v_dot2_f32_f16 v17, v41, v53, v17
+v_dot2_f32_f16 v18, v38, v54, v18
+v_dot2_f32_f16 v19, v39, v54, v19
+v_dot2_f32_f16 v20, v40, v54, v20
+v_dot2_f32_f16 v21, v41, v54, v21
+v_dot2_f32_f16 v22, v38, v55, v22
+v_dot2_f32_f16 v23, v39, v55, v23
+v_dot2_f32_f16 v24, v40, v55, v24
+v_dot2_f32_f16 v25, v41, v55, v25
+v_dot2_f32_f16 v26, v38, v56, v26
+v_dot2_f32_f16 v27, v39, v56, v27
+v_dot2_f32_f16 v28, v40, v56, v28
+v_dot2_f32_f16 v29, v41, v56, v29
+v_dot2_f32_f16 v30, v38, v57, v30
+v_dot2_f32_f16 v31, v39, v57, v31
+v_mov_b32_dpp v115, v81  quad_perm:[0,0,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v81, v115, v112, v81
+v_pk_add_f16 v79, v78, v81
+v_pk_mul_f16 v79, v79, 0.5 op_sel_hi:[1,0]
+v_pk_fma_f16 v80, -1.0, v81, v78 op_sel_hi:[0,1,1]
+v_pk_mul_f16 v80, v80, 0.5 op_sel_hi:[1,0]
+v_dot2_f32_f16 v32, v40, v57, v32
+v_dot2_f32_f16 v33, v41, v57, v33
+s_nop 0
+ds_read_b128 v[38:41], v107 offset:512
+ds_read_b128 v[50:53], v102
+ds_read_b128 v[54:57], v102 offset:128
+ds_write_b32 v105, v76 offset:24768
+ds_write_b32 v106, v77 offset:24768
+s_setprio 0
+s_add_u32 s40, s40, s69
+s_addc_u32 s41, s41, 0
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v90, v94, s[40:43], 0 offen
+buffer_load_short_d16 v93, v97, s[40:43], 0 offen
+s_nop 0
+s_waitcnt vmcnt(8) lgkmcnt(5)
+ds_append v117 offset:65476
+s_bitset1_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 6
+s_call_b64 s[38:39], 677
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_dot2_f32_f16 v2, v34, v42, v2
+v_dot2_f32_f16 v3, v35, v42, v3
+v_dot2_f32_f16 v4, v36, v42, v4
+v_dot2_f32_f16 v5, v37, v42, v5
+s_setprio 1
+s_nop 0
+v_dot2_f32_f16 v6, v34, v43, v6
+v_dot2_f32_f16 v7, v35, v43, v7
+v_dot2_f32_f16 v8, v36, v43, v8
+v_dot2_f32_f16 v9, v37, v43, v9
+v_dot2_f32_f16 v10, v34, v44, v10
+v_dot2_f32_f16 v11, v35, v44, v11
+v_dot2_f32_f16 v12, v36, v44, v12
+v_dot2_f32_f16 v13, v37, v44, v13
+v_dot2_f32_f16 v14, v34, v45, v14
+v_dot2_f32_f16 v15, v35, v45, v15
+v_dot2_f32_f16 v16, v36, v45, v16
+v_dot2_f32_f16 v17, v37, v45, v17
+v_dot2_f32_f16 v18, v34, v46, v18
+v_dot2_f32_f16 v19, v35, v46, v19
+v_dot2_f32_f16 v20, v36, v46, v20
+v_dot2_f32_f16 v21, v37, v46, v21
+v_dot2_f32_f16 v22, v34, v47, v22
+v_dot2_f32_f16 v23, v35, v47, v23
+v_dot2_f32_f16 v24, v36, v47, v24
+v_dot2_f32_f16 v25, v37, v47, v25
+v_dot2_f32_f16 v26, v34, v48, v26
+v_dot2_f32_f16 v27, v35, v48, v27
+v_dot2_f32_f16 v28, v36, v48, v28
+v_dot2_f32_f16 v29, v37, v48, v29
+v_dot2_f32_f16 v30, v34, v49, v30
+v_dot2_f32_f16 v31, v35, v49, v31
+v_pack_b32_f16 v58, v82, v58
+v_pack_b32_f16 v59, v83, v59
+v_pack_b32_f16 v60, v84, v60
+v_pack_b32_f16 v61, v85, v61
+v_mov_b32_dpp v115, v58  quad_perm:[0,0,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v58, v115, v112, v58
+v_dot2_f32_f16 v32, v36, v49, v32
+v_dot2_f32_f16 v33, v37, v49, v33
+s_nop 0
+ds_read_b128 v[34:37], v107 offset:4672
+ds_read_b128 v[42:45], v102 offset:4160
+ds_read_b128 v[46:49], v102 offset:4288
+ds_write_b32 v103, v74 offset:24768
+ds_write_b32 v104, v75 offset:24768
+s_setprio 0
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v70, v94, s[40:43], 0 offen
+buffer_load_short_d16 v73, v97, s[40:43], 0 offen
+s_mov_b32 m0, 0x2ffc4
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 6
+s_call_b64 s[38:39], 565
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_dot2_f32_f16 v2, v38, v50, v2
+v_dot2_f32_f16 v3, v39, v50, v3
+v_dot2_f32_f16 v4, v40, v50, v4
+v_dot2_f32_f16 v5, v41, v50, v5
+s_setprio 1
+s_nop 0
+v_dot2_f32_f16 v6, v38, v51, v6
+v_dot2_f32_f16 v7, v39, v51, v7
+v_dot2_f32_f16 v8, v40, v51, v8
+v_dot2_f32_f16 v9, v41, v51, v9
+v_dot2_f32_f16 v10, v38, v52, v10
+v_dot2_f32_f16 v11, v39, v52, v11
+v_dot2_f32_f16 v12, v40, v52, v12
+v_dot2_f32_f16 v13, v41, v52, v13
+v_dot2_f32_f16 v14, v38, v53, v14
+v_dot2_f32_f16 v15, v39, v53, v15
+v_dot2_f32_f16 v16, v40, v53, v16
+v_dot2_f32_f16 v17, v41, v53, v17
+v_dot2_f32_f16 v18, v38, v54, v18
+v_dot2_f32_f16 v19, v39, v54, v19
+v_dot2_f32_f16 v20, v40, v54, v20
+v_dot2_f32_f16 v21, v41, v54, v21
+v_dot2_f32_f16 v22, v38, v55, v22
+v_dot2_f32_f16 v23, v39, v55, v23
+v_dot2_f32_f16 v24, v40, v55, v24
+v_dot2_f32_f16 v25, v41, v55, v25
+v_dot2_f32_f16 v26, v38, v56, v26
+v_dot2_f32_f16 v27, v39, v56, v27
+v_dot2_f32_f16 v28, v40, v56, v28
+v_dot2_f32_f16 v29, v41, v56, v29
+v_dot2_f32_f16 v30, v38, v57, v30
+v_dot2_f32_f16 v31, v39, v57, v31
+v_dot2_f32_f16 v32, v40, v57, v32
+v_mov_b32_dpp v115, v61  quad_perm:[0,0,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v61, v115, v112, v61
+v_pk_add_f16 v59, v58, v61
+v_pk_mul_f16 v59, v59, 0.5 op_sel_hi:[1,0]
+v_pk_fma_f16 v60, -1.0, v61, v58 op_sel_hi:[0,1,1]
+v_pk_mul_f16 v60, v60, 0.5 op_sel_hi:[1,0]
+v_dot2_f32_f16 v33, v41, v57, v33
+v_cmp_eq_u32_e64 vcc, src_lds_direct, s91
+s_nop 0
+s_nop 0
+s_cbranch_vccz 65531
+s_nop 0
+ds_read_b128 v[38:41], v107 offset:8768
+ds_read_b128 v[50:53], v102 offset:8256
+ds_read_b128 v[54:57], v102 offset:8384
+ds_write_b32 v105, v80 offset:33024
+ds_write_b32 v106, v81 offset:33024
+s_setprio 0
+s_add_u32 s40, s40, s69
+s_addc_u32 s41, s41, 0
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v82, v94, s[40:43], 0 offen
+buffer_load_short_d16 v85, v97, s[40:43], 0 offen
+s_nop 0
+s_waitcnt vmcnt(8) lgkmcnt(5)
+s_bitset1_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 3
+s_call_b64 s[38:39], 450
+s_nop 0
+s_nop 0
+v_dot2_f32_f16 v2, v34, v42, v2
+v_dot2_f32_f16 v3, v35, v42, v3
+v_dot2_f32_f16 v4, v36, v42, v4
+v_dot2_f32_f16 v5, v37, v42, v5
+s_setprio 1
+s_nop 0
+v_dot2_f32_f16 v6, v34, v43, v6
+v_dot2_f32_f16 v7, v35, v43, v7
+v_dot2_f32_f16 v8, v36, v43, v8
+v_dot2_f32_f16 v9, v37, v43, v9
+v_dot2_f32_f16 v10, v34, v44, v10
+v_dot2_f32_f16 v11, v35, v44, v11
+v_dot2_f32_f16 v12, v36, v44, v12
+v_dot2_f32_f16 v13, v37, v44, v13
+v_dot2_f32_f16 v14, v34, v45, v14
+v_dot2_f32_f16 v15, v35, v45, v15
+v_dot2_f32_f16 v16, v36, v45, v16
+v_dot2_f32_f16 v17, v37, v45, v17
+v_dot2_f32_f16 v18, v34, v46, v18
+v_dot2_f32_f16 v19, v35, v46, v19
+v_dot2_f32_f16 v20, v36, v46, v20
+v_dot2_f32_f16 v21, v37, v46, v21
+v_dot2_f32_f16 v22, v34, v47, v22
+v_dot2_f32_f16 v23, v35, v47, v23
+v_dot2_f32_f16 v24, v36, v47, v24
+v_dot2_f32_f16 v25, v37, v47, v25
+v_dot2_f32_f16 v26, v34, v48, v26
+v_dot2_f32_f16 v27, v35, v48, v27
+v_dot2_f32_f16 v28, v36, v48, v28
+v_dot2_f32_f16 v29, v37, v48, v29
+v_dot2_f32_f16 v30, v34, v49, v30
+v_dot2_f32_f16 v31, v35, v49, v31
+v_pack_b32_f16 v62, v86, v62
+v_pack_b32_f16 v63, v87, v63
+v_pack_b32_f16 v64, v88, v64
+v_pack_b32_f16 v65, v89, v65
+v_mov_b32_dpp v115, v62  quad_perm:[0,0,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v62, v115, v112, v62
+v_dot2_f32_f16 v32, v36, v49, v32
+v_dot2_f32_f16 v33, v37, v49, v33
+s_nop 0
+ds_read_b128 v[34:37], v107 offset:12928
+ds_read_b128 v[42:45], v102 offset:12416
+ds_read_b128 v[46:49], v102 offset:12544
+ds_write_b32 v103, v78 offset:33024
+ds_write_b32 v104, v79 offset:33024
+s_setprio 0
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v74, v94, s[40:43], 0 offen
+buffer_load_short_d16 v77, v97, s[40:43], 0 offen
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 8
+s_call_b64 s[38:39], 343
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_dot2_f32_f16 v2, v38, v50, v2
+v_dot2_f32_f16 v3, v39, v50, v3
+v_dot2_f32_f16 v4, v40, v50, v4
+v_dot2_f32_f16 v5, v41, v50, v5
+s_setprio 1
+s_nop 0
+v_dot2_f32_f16 v6, v38, v51, v6
+v_dot2_f32_f16 v7, v39, v51, v7
+v_dot2_f32_f16 v8, v40, v51, v8
+v_dot2_f32_f16 v9, v41, v51, v9
+v_dot2_f32_f16 v10, v38, v52, v10
+v_dot2_f32_f16 v11, v39, v52, v11
+v_dot2_f32_f16 v12, v40, v52, v12
+v_dot2_f32_f16 v13, v41, v52, v13
+v_dot2_f32_f16 v14, v38, v53, v14
+v_dot2_f32_f16 v15, v39, v53, v15
+v_dot2_f32_f16 v16, v40, v53, v16
+v_dot2_f32_f16 v17, v41, v53, v17
+v_dot2_f32_f16 v18, v38, v54, v18
+v_dot2_f32_f16 v19, v39, v54, v19
+v_dot2_f32_f16 v20, v40, v54, v20
+v_dot2_f32_f16 v21, v41, v54, v21
+v_dot2_f32_f16 v22, v38, v55, v22
+v_dot2_f32_f16 v23, v39, v55, v23
+v_dot2_f32_f16 v24, v40, v55, v24
+v_dot2_f32_f16 v25, v41, v55, v25
+v_dot2_f32_f16 v26, v38, v56, v26
+v_dot2_f32_f16 v27, v39, v56, v27
+v_dot2_f32_f16 v28, v40, v56, v28
+v_dot2_f32_f16 v29, v41, v56, v29
+v_dot2_f32_f16 v30, v38, v57, v30
+v_dot2_f32_f16 v31, v39, v57, v31
+v_mov_b32_dpp v115, v65  quad_perm:[0,0,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v65, v115, v112, v65
+v_pk_add_f16 v63, v62, v65
+v_pk_mul_f16 v63, v63, 0.5 op_sel_hi:[1,0]
+v_pk_fma_f16 v64, -1.0, v65, v62 op_sel_hi:[0,1,1]
+v_pk_mul_f16 v64, v64, 0.5 op_sel_hi:[1,0]
+v_dot2_f32_f16 v32, v40, v57, v32
+v_dot2_f32_f16 v33, v41, v57, v33
+s_nop 0
+ds_read_b128 v[38:41], v107 offset:17024
+ds_read_b128 v[50:53], v102 offset:16512
+ds_read_b128 v[54:57], v102 offset:16640
+ds_write_b32 v105, v60 offset:41280
+ds_write_b32 v106, v61 offset:41280
+s_setprio 0
+s_add_u32 s40, s40, s69
+s_addc_u32 s41, s41, 0
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v86, v94, s[40:43], 0 offen
+buffer_load_short_d16 v89, v97, s[40:43], 0 offen
+s_nop 0
+s_waitcnt vmcnt(8) lgkmcnt(5)
+ds_append v117 offset:65480
+s_bitset1_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 6
+s_call_b64 s[38:39], 229
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_dot2_f32_f16 v2, v34, v42, v2
+v_dot2_f32_f16 v3, v35, v42, v3
+v_dot2_f32_f16 v4, v36, v42, v4
+v_dot2_f32_f16 v5, v37, v42, v5
+s_setprio 1
+s_nop 0
+v_dot2_f32_f16 v6, v34, v43, v6
+v_dot2_f32_f16 v7, v35, v43, v7
+v_dot2_f32_f16 v8, v36, v43, v8
+v_dot2_f32_f16 v9, v37, v43, v9
+v_dot2_f32_f16 v10, v34, v44, v10
+v_dot2_f32_f16 v11, v35, v44, v11
+v_dot2_f32_f16 v12, v36, v44, v12
+v_dot2_f32_f16 v13, v37, v44, v13
+v_dot2_f32_f16 v14, v34, v45, v14
+v_dot2_f32_f16 v15, v35, v45, v15
+v_dot2_f32_f16 v16, v36, v45, v16
+v_dot2_f32_f16 v17, v37, v45, v17
+v_dot2_f32_f16 v18, v34, v46, v18
+v_dot2_f32_f16 v19, v35, v46, v19
+v_dot2_f32_f16 v20, v36, v46, v20
+v_dot2_f32_f16 v21, v37, v46, v21
+v_dot2_f32_f16 v22, v34, v47, v22
+v_dot2_f32_f16 v23, v35, v47, v23
+v_dot2_f32_f16 v24, v36, v47, v24
+v_dot2_f32_f16 v25, v37, v47, v25
+v_dot2_f32_f16 v26, v34, v48, v26
+v_dot2_f32_f16 v27, v35, v48, v27
+v_dot2_f32_f16 v28, v36, v48, v28
+v_dot2_f32_f16 v29, v37, v48, v29
+v_dot2_f32_f16 v30, v34, v49, v30
+v_dot2_f32_f16 v31, v35, v49, v31
+v_pack_b32_f16 v66, v90, v66
+v_pack_b32_f16 v67, v91, v67
+v_pack_b32_f16 v68, v92, v68
+v_pack_b32_f16 v69, v93, v69
+v_mov_b32_dpp v115, v66  quad_perm:[0,0,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v66, v115, v112, v66
+v_dot2_f32_f16 v32, v36, v49, v32
+v_dot2_f32_f16 v33, v37, v49, v33
+s_nop 0
+ds_read_b128 v[34:37], v107 offset:21184
+ds_read_b128 v[42:45], v102 offset:20672
+ds_read_b128 v[46:49], v102 offset:20800
+ds_write_b32 v103, v58 offset:41280
+ds_write_b32 v104, v59 offset:41280
+s_setprio 0
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v78, v94, s[40:43], 0 offen
+buffer_load_short_d16 v81, v97, s[40:43], 0 offen
+s_mov_b32 m0, 0x2ffc8
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 6
+s_call_b64 s[38:39], 117
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_dot2_f32_f16 v2, v38, v50, v2
+v_dot2_f32_f16 v3, v39, v50, v3
+v_dot2_f32_f16 v4, v40, v50, v4
+v_dot2_f32_f16 v5, v41, v50, v5
+s_setprio 1
+s_nop 0
+v_dot2_f32_f16 v6, v38, v51, v6
+v_dot2_f32_f16 v7, v39, v51, v7
+v_dot2_f32_f16 v8, v40, v51, v8
+v_dot2_f32_f16 v9, v41, v51, v9
+v_dot2_f32_f16 v10, v38, v52, v10
+v_dot2_f32_f16 v11, v39, v52, v11
+v_dot2_f32_f16 v12, v40, v52, v12
+v_dot2_f32_f16 v13, v41, v52, v13
+v_dot2_f32_f16 v14, v38, v53, v14
+v_dot2_f32_f16 v15, v39, v53, v15
+v_dot2_f32_f16 v16, v40, v53, v16
+v_dot2_f32_f16 v17, v41, v53, v17
+v_dot2_f32_f16 v18, v38, v54, v18
+v_dot2_f32_f16 v19, v39, v54, v19
+v_dot2_f32_f16 v20, v40, v54, v20
+v_dot2_f32_f16 v21, v41, v54, v21
+v_dot2_f32_f16 v22, v38, v55, v22
+v_dot2_f32_f16 v23, v39, v55, v23
+v_dot2_f32_f16 v24, v40, v55, v24
+v_dot2_f32_f16 v25, v41, v55, v25
+v_dot2_f32_f16 v26, v38, v56, v26
+v_dot2_f32_f16 v27, v39, v56, v27
+v_dot2_f32_f16 v28, v40, v56, v28
+v_dot2_f32_f16 v29, v41, v56, v29
+v_dot2_f32_f16 v30, v38, v57, v30
+v_dot2_f32_f16 v31, v39, v57, v31
+v_dot2_f32_f16 v32, v40, v57, v32
+v_mov_b32_dpp v115, v69  quad_perm:[0,0,1,1] row_mask:0xf bank_mask:0xf
+v_pk_fma_f16 v69, v115, v112, v69
+v_pk_add_f16 v67, v66, v69
+v_pk_mul_f16 v67, v67, 0.5 op_sel_hi:[1,0]
+v_pk_fma_f16 v68, -1.0, v69, v66 op_sel_hi:[0,1,1]
+v_pk_mul_f16 v68, v68, 0.5 op_sel_hi:[1,0]
+v_dot2_f32_f16 v33, v41, v57, v33
+v_cmp_eq_u32_e64 vcc, src_lds_direct, s91
+s_nop 0
+s_nop 0
+s_cbranch_vccz 65531
+s_nop 0
+ds_read_b128 v[38:41], v107 offset:25280
+ds_read_b128 v[50:53], v102 offset:24768
+ds_read_b128 v[54:57], v102 offset:24896
+ds_write_b32 v105, v64
+ds_write_b32 v106, v65
+s_setprio 0
+s_add_u32 s40, s40, s69
+s_addc_u32 s41, s41, 0
+s_sub_u32 s73, s73, 1
+s_cselect_b32 s43, 0x20000, s43
+buffer_load_short_d16 v90, v94, s[40:43], 0 offen
+buffer_load_short_d16 v93, v97, s[40:43], 0 offen
+s_nop 0
+s_waitcnt vmcnt(8) lgkmcnt(5)
+s_bitset1_b32 s18, 26
+s_add_u32 s72, s72, -2
+s_cbranch_scc1 64195
+s_call_b64 s[38:39], 2
+s_branch 64193
+s_nop 0
+v_nop
+s_cmp_eq_u32 s82, 0
+s_cbranch_scc0 8
+s_branch 604
+s_add_u32 s82, s82, 3
+s_andn2_b32 s82, s82, 3
+s_bitcmp0_b32 s18, 26
+s_cselect_b32 s52, s69, s70
+s_cselect_b32 s53, 0, s71
+s_sub_u32 s40, s40, s52
+s_subb_u32 s41, s41, s53
+s_cmp_eq_u32 s94, 0
+s_cbranch_scc0 5
+s_cbranch_scc1 626
+s_nop 0
+s_nop 0
+s_add_u32 s94, s94, 1
+s_andn2_b32 s94, s94, 1
+s_min_u32 s72, s82, s94
+s_sub_u32 s82, s82, s72
+s_sub_u32 s94, s94, s72
+s_sub_u32 s72, s72, 2
+s_setpc_b64 s[38:39]
+s_nop 0
+s_bitcmp1_b32 s18, 17
+s_cbranch_scc1 241
+s_add_u32 s88, s88, s17
+s_cmp_eq_u32 s88, 0
+s_cbranch_scc1 238
+s_mov_b32 s89, 0
+s_bitcmp1_b32 s18, 16
+s_cbranch_scc1 227
+s_add_u32 s87, s16, 31
+s_lshr_b32 s87, s87, 5
+v_mov_b32_e32 v119, s88
+v_mul_u32_u24_e32 v119, s87, v119
+v_add_co_u32_e32 v119, vcc, s17, v119
+v_sub_co_u32_e64 v119, vcc, v119, 1
+v_ffbh_u32_e32 v122, s17
+v_lshlrev_b32_e64 v123, v122, s17
+v_and_b32_e32 v124, 0xffffff00, v123
+v_cmp_eq_u32_e32 vcc, 0x80000000, v123
+v_cvt_f32_u32_e32 v124, v124
+v_rcp_f32_e32 v118, v124
+v_subb_co_u32_e32 v121, vcc, 32, v122, vcc
+v_cvt_f32_ubyte0_e32 v122, v123
+v_fma_f32 v124, v124, v118, -1.0
+v_fma_f32 v124, v122, v118, v124
+v_madak_f32 v124, v124, v118, 0x9f000000
+v_mul_f32_e32 v124, 0x5f800000, v124
+v_mov_b32_e32 v122, 0
+v_cvt_flr_i32_f32_e64 v124, -v124
+v_lshl_add_u32 v118, v118, 9, v124
+v_mad_u64_u32 v[122:123], vcc, v123, v118, v[122:123]
+v_subb_co_u32_e64 v118, vcc, v118, -1, vcc
+v_mul_hi_u32 v122, v119, v118
+v_add_co_u32_e32 v118, vcc, v122, v119
+v_addc_co_u32_e64 v122, vcc, 0, 0, vcc
+v_cmp_eq_u32_e32 vcc, 32, v121
+v_cndmask_b32_e32 v118, v118, v122, vcc
+v_alignbit_b32 v118, v122, v118, v121
+v_readfirstlane_b32 s86, v118
+v_mul_u32_u24_e64 v118, v118, s8
+v_ffbh_u32_e32 v122, s87
+v_lshlrev_b32_e64 v123, v122, s87
+v_and_b32_e32 v124, 0xffffff00, v123
+v_cmp_eq_u32_e32 vcc, 0x80000000, v123
+v_cvt_f32_u32_e32 v124, v124
+v_rcp_f32_e32 v119, v124
+v_subb_co_u32_e32 v121, vcc, 32, v122, vcc
+v_cvt_f32_ubyte0_e32 v122, v123
+v_fma_f32 v124, v124, v119, -1.0
+v_fma_f32 v124, v122, v119, v124
+v_madak_f32 v124, v124, v119, 0x9f000000
+v_mul_f32_e32 v124, 0x5f800000, v124
+v_mov_b32_e32 v122, 0
+v_cvt_flr_i32_f32_e64 v124, -v124
+v_lshl_add_u32 v119, v119, 9, v124
+v_mad_u64_u32 v[122:123], vcc, v123, v119, v[122:123]
+v_subb_co_u32_e64 v119, vcc, v119, -1, vcc
+v_mul_hi_u32 v122, v118, v119
+v_add_co_u32_e32 v119, vcc, v122, v118
+v_addc_co_u32_e64 v122, vcc, 0, 0, vcc
+v_cmp_eq_u32_e32 vcc, 32, v121
+v_cndmask_b32_e32 v119, v119, v122, vcc
+v_alignbit_b32 v119, v122, v119, v121
+v_readfirstlane_b32 s52, v118
+v_readfirstlane_b32 s84, v119
+s_mul_i32 s84, s84, s87
+s_sub_u32 s84, s52, s84
+v_sub_co_u32_e32 v119, vcc, s8, v119
+v_sub_co_u32_e32 v119, vcc, s17, v119
+v_and_b32_e64 v121, v0, 63
+v_cmp_eq_u32_e64 vcc, v121, 0
+v_cndmask_b32_e32 v119, 1, v119, vcc
+s_sub_u32 s58, 0, s75
+s_sub_u32 s59, 0, s74
+v_mul_u32_u24_e64 v123, v119, 32
+v_ffbh_u32_e32 v125, s58
+v_lshlrev_b32_e64 v126, v125, s58
+v_and_b32_e32 v127, 0xffffff00, v126
+v_cmp_eq_u32_e32 vcc, 0x80000000, v126
+v_cvt_f32_u32_e32 v127, v127
+v_rcp_f32_e32 v121, v127
+v_subb_co_u32_e32 v124, vcc, 32, v125, vcc
+v_cvt_f32_ubyte0_e32 v125, v126
+v_fma_f32 v127, v127, v121, -1.0
+v_fma_f32 v127, v125, v121, v127
+v_madak_f32 v127, v127, v121, 0x9f000000
+v_mul_f32_e32 v127, 0x5f800000, v127
+v_mov_b32_e32 v125, 0
+v_cvt_flr_i32_f32_e64 v127, -v127
+v_lshl_add_u32 v121, v121, 9, v127
+v_mad_u64_u32 v[125:126], vcc, v126, v121, v[125:126]
+v_subb_co_u32_e64 v121, vcc, v121, -1, vcc
+v_mul_hi_u32 v125, v123, v121
+v_add_co_u32_e32 v121, vcc, v125, v123
+v_addc_co_u32_e64 v125, vcc, 0, 0, vcc
+v_cmp_eq_u32_e32 vcc, 32, v124
+v_cndmask_b32_e32 v121, v121, v125, vcc
+v_alignbit_b32 v121, v125, v121, v124
+v_mad_i32_i24 v122, v121, s75, v123
+v_mul_u32_u24_e64 v123, v121, 1
+v_ffbh_u32_e32 v125, s59
+v_lshlrev_b32_e64 v126, v125, s59
+v_and_b32_e32 v127, 0xffffff00, v126
+v_cmp_eq_u32_e32 vcc, 0x80000000, v126
+v_cvt_f32_u32_e32 v127, v127
+v_rcp_f32_e32 v121, v127
+v_subb_co_u32_e32 v124, vcc, 32, v125, vcc
+v_cvt_f32_ubyte0_e32 v125, v126
+v_fma_f32 v127, v127, v121, -1.0
+v_fma_f32 v127, v125, v121, v127
+v_madak_f32 v127, v127, v121, 0x9f000000
+v_mul_f32_e32 v127, 0x5f800000, v127
+v_mov_b32_e32 v125, 0
+v_cvt_flr_i32_f32_e64 v127, -v127
+v_lshl_add_u32 v121, v121, 9, v127
+v_mad_u64_u32 v[125:126], vcc, v126, v121, v[125:126]
+v_subb_co_u32_e64 v121, vcc, v121, -1, vcc
+v_mul_hi_u32 v125, v123, v121
+v_add_co_u32_e32 v121, vcc, v125, v123
+v_addc_co_u32_e64 v125, vcc, 0, 0, vcc
+v_cmp_eq_u32_e32 vcc, 32, v124
+v_cndmask_b32_e32 v121, v121, v125, vcc
+v_alignbit_b32 v121, v125, v121, v124
+v_mad_i32_i24 v123, v121, s74, v123
+v_readfirstlane_b32 s76, v122
+v_readfirstlane_b32 s77, v123
+v_readfirstlane_b32 s78, v121
+v_add_co_u32_e32 v108, vcc, s76, v108
+v_addc_co_u32_e64 v124, vcc, 0, 0, vcc
+v_mad_i32_i24 v108, v124, s75, v108
+v_mad_i32_i24 v110, v124, s80, v110
+v_mad_i32_i24 v109, v124, s79, v109
+v_cmp_ge_i32_e64 vcc, v109, 0
+v_addc_co_u32_e64 v124, vcc, 0, 0, vcc
+v_add_co_u32_e32 v110, vcc, v110, v124
+v_mad_i32_i24 v109, v124, s74, v109
+v_add_co_u32_e32 v109, vcc, s77, v109
+v_addc_co_u32_e64 v124, vcc, 0, 0, vcc
+v_add_co_u32_e32 v110, vcc, v110, v124
+v_mad_i32_i24 v109, v124, s74, v109
+v_add_co_u32_e32 v110, vcc, s78, v110
+v_readlane_b32 s76, v122, 1
+v_readlane_b32 s77, v123, 1
+v_readlane_b32 s78, v121, 1
+s_add_u32 s85, s84, s86
+s_cmp_le_u32 s85, s87
+s_cselect_b32 s52, 0x20000, 0
+s_cselect_b32 s85, s85, s87
+s_or_b32 s18, s18, s52
+s_lshl_b32 s84, s84, 5
+s_lshl_b32 s85, s85, 5
+s_min_u32 s85, s85, s16
+s_cmp_eq_u32 s8, s17
+s_cselect_b32 s52, 0x20000, 0
+s_or_b32 s18, s18, s52
+s_or_b32 s18, s18, s52
+s_bitset1_b32 s18, 16
+s_branch 43
+s_lshr_b32 s84, s84, 5
+s_add_u32 s85, s84, s86
+s_sub_u32 s85, s85, s87
+s_mov_b32 s84, 0
+s_lshl_b32 s85, s85, 5
+s_min_u32 s85, s85, s16
+s_bitset1_b32 s18, 17
+s_branch 12
+s_bitset1_b32 s18, 18
+s_mov_b32 s43, 0
+s_mov_b32 s73, -1
+s_mov_b32 s82, 40
+s_branch 31
+s_add_u32 s83, s83, 32
+s_cmp_ge_u32 s83, s85
+s_cbranch_scc0 28
+s_bitset1_b32 s18, 22
+s_sub_u32 s88, s88, s17
+s_subb_u32 s89, s89, 0
+s_cbranch_scc1 65281
+v_add_co_u32_e32 v108, vcc, s76, v108
+v_addc_co_u32_e64 v118, vcc, 0, 0, vcc
+v_mad_i32_i24 v108, v118, s75, v108
+v_mad_i32_i24 v110, v118, s80, v110
+v_mad_i32_i24 v109, v118, s79, v109
+v_cmp_ge_i32_e64 vcc, v109, 0
+v_addc_co_u32_e64 v118, vcc, 0, 0, vcc
+v_add_co_u32_e32 v110, vcc, v110, v118
+v_mad_i32_i24 v109, v118, s74, v109
+v_add_co_u32_e32 v109, vcc, s77, v109
+v_addc_co_u32_e64 v118, vcc, 0, 0, vcc
+v_add_co_u32_e32 v110, vcc, v110, v118
+v_mad_i32_i24 v109, v118, s74, v109
+v_add_co_u32_e32 v110, vcc, s78, v110
+s_mov_b32 s83, s84
+v_cmp_le_u32_e32 vcc, 0x100, v0
+s_cbranch_vccz 170
+v_subrev_co_u32_e32 v118, vcc, s75, v108
+v_subrev_co_u32_e32 v119, vcc, s74, v109
+s_bitcmp1_b32 s18, 22
+s_cbranch_scc0 64
+s_bitset0_b32 s18, 22
+s_bfe_u32 s52, s18, 0x10014
+v_mul_u32_u24_e32 v123, 3, v118
+v_mul_u32_u24_e32 v124, 3, v119
+v_cvt_pk_u16_u32 v126, v123, v124
+v_and_b32_e64 v123, v0, 1
+v_cmp_eq_u32_e64 vcc, v123, 1
+v_cndmask_b32_e32 v126, v110, v126, vcc
+v_lshrrev_b32_e32 v122, 1, v0
+v_bfe_u32 v127, v122, s52, 1
+v_lshrrev_b32_e32 v122, 1, v0
+v_bfi_b32 v122, 1, v0, v122
+v_lshrrev_b32_e32 v123, 2, v0
+v_bfi_b32 v123, 1, v0, v123
+v_cmp_eq_u32_e64 vcc, s52, 0
+v_cndmask_b32_e32 v122, v123, v122, vcc
+s_sub_u32 s52, 1, s52
+v_lshrrev_b32_e32 v123, s52, v122
+v_bfi_b32 v122, 32, v123, v122
+v_and_b32_e32 v122, 63, v122
+v_add_co_u32_e32 v123, vcc, 16, v122
+v_and_b32_e64 v124, v0, 2
+v_cmp_eq_u32_e64 vcc, v124, 0
+v_cndmask_b32_e32 v123, v123, v122, vcc
+v_lshlrev_b32_e32 v124, 14, v127
+v_mad_u32_u24 v123, 4, v123, v124
+v_add_co_u32_e32 v122, vcc, s96, v123
+ds_write_b32 v122, v126
+v_writelane_b32 v124, s18, 0
+v_writelane_b32 v124, s85, 1
+v_writelane_b32 v124, s84, 2
+v_and_b32_e64 v122, v0, 63
+v_cmp_ge_u32_e64 vcc, v122, 3
+v_mov_b32_e32 v125, 0x4000
+v_cndmask_b32_e32 v122, v122, v125, vcc
+v_mad_i32_i24 v122, v122, 4, s96
+ds_write_b32 v122, v124 offset:256
+s_add_u32 s96, s96, 0x18c
+s_cmp_eq_u32 s96, 0xffc0
+s_cselect_b32 s96, 0xc1e0, s96
+v_mov_b32_dpp v120, v110  quad_perm:[0,0,0,0] row_mask:0xf bank_mask:0xf
+v_mov_b32_dpp v118, v118  quad_perm:[0,0,0,0] row_mask:0xf bank_mask:0xf
+v_mov_b32_dpp v119, v119  quad_perm:[0,0,0,0] row_mask:0xf bank_mask:0xf
+v_readfirstlane_b32 s81, v120
+v_sub_co_u32_e64 v121, vcc, v120, s81
+v_mul_lo_u32 v121, v121, s65
+v_and_b32_e64 v125, v0, 3
+v_ashrrev_i32_e64 v126, 0, s31
+v_subrev_co_u32_e32 v125, vcc, v126, v125
+v_ashrrev_i32_e64 v126, 0, s62
+v_mad_i32_i24 v122, v126, 2, v125
+s_bfe_u32 s52, s18, 0x10014
+v_lshrrev_b32_e32 v124, 2, v0
+v_and_b32_e32 v124, s52, v124
+v_mad_i32_i24 v122, v124, 2, v122
+v_add_co_u32_e64 v123, vcc, 0, s63
+v_ashrrev_i32_e32 v123, 0, v123
+v_add_co_u32_e64 v124, vcc, 0, s30
+v_ashrrev_i32_e32 v124, 0, v124
+v_sub_i32 v123, v123, v124
+s_lshl_b32 s54, s15, 1
+v_cmp_ge_u32_e64 s[52:53], v120, s12
+v_mad_i32_i24 v118, v118, 3, v122
+v_cmp_ge_u32_e64 s[56:57], v118, s15
+v_mad_i32_i24 v118, 2, v118, v121
+s_or_b64 s[56:57], s[56:57], s[52:53]
+v_mad_i32_i24 v119, v119, 3, v123
+v_cmp_ge_u32_e64 s[58:59], v119, s14
+s_or_b64 s[58:59], s[56:57], s[58:59]
+v_mad_u32_u24 v94, v119, s54, v118
+v_cndmask_b32_e64 v94, v94, -1, s[58:59]
+v_add_co_u32_e32 v119, vcc, 1, v119
+v_cmp_ge_u32_e64 s[58:59], v119, s14
+s_or_b64 s[58:59], s[56:57], s[58:59]
+v_mad_u32_u24 v95, v119, s54, v118
+v_cndmask_b32_e64 v95, v95, -1, s[58:59]
+v_add_co_u32_e32 v119, vcc, 1, v119
+v_cmp_ge_u32_e64 s[58:59], v119, s14
+s_or_b64 s[58:59], s[56:57], s[58:59]
+v_mad_u32_u24 v96, v119, s54, v118
+v_cndmask_b32_e64 v96, v96, -1, s[58:59]
+v_add_co_u32_e32 v119, vcc, 1, v119
+v_cmp_ge_u32_e64 s[58:59], v119, s14
+s_or_b64 s[58:59], s[56:57], s[58:59]
+v_mad_u32_u24 v97, v119, s54, v118
+v_cndmask_b32_e64 v97, v97, -1, s[58:59]
+s_bitcmp1_b32 s18, 18
+s_cbranch_scc1 154
+s_lshr_b32 s52, -1, 16
+s_and_b32 s52, s52, s65
+s_lshr_b32 s53, s65, 16
+s_mul_i32 s53, s53, s81
+s_mul_i32 s40, s52, s81
+s_lshl_b32 s52, s53, 16
+s_lshr_b32 s53, s53, 16
+s_add_u32 s40, s52, s40
+s_addc_u32 s41, s53, 0
+s_add_u32 s40, s40, s20
+s_addc_u32 s41, s41, s21
+s_lshr_b32 s52, s18, 6
+s_xor_b32 s52, s52, s18
+s_and_b32 s52, s52, 0x80000
+s_cselect_b32 s52, s68, 0
+s_and_b32 s53, s18, 0x1100000
+s_cselect_b32 s53, 0, 1
+s_lshl_b32 s52, s52, s53
+s_add_u32 s40, s40, s52
+s_addc_u32 s41, s41, 0
+s_branch 99
+s_bitcmp1_b32 s18, 18
+s_cbranch_scc1 129
+s_bfe_u32 s52, s18, 0x10014
+v_xor_b32_dpp v118, v0, v0  quad_perm:[0,0,2,2] row_mask:0xf bank_mask:0xf
+v_bfe_u32 v120, v0, 2, s52
+v_mad_u32_u24 v118, v120, 2, v118
+v_mad_u32_u24 v118, s62, 2, v118
+v_sub_co_u32_e32 v120, vcc, s29, v118
+v_sub_co_u32_e64 v120, vcc, v120, 1
+s_bfe_u32 s54, s18, 0x10001
+v_cmp_eq_u32_e64 vcc, s54, 1
+v_cndmask_b32_e32 v118, v118, v120, vcc
+v_cmp_ge_u32_e64 s[52:53], v118, s29
+v_lshlrev_b32_e32 v118, 1, v118
+s_bfe_u32 s54, s18, 0x10018
+v_bfe_u32 v121, v0, 2, s54
+v_mul_lo_u32 v121, s68, v121
+v_add_co_u32_e32 v118, vcc, v118, v121
+v_mul_lo_u32 v119, s90, v111
+v_add_co_u32_e32 v119, vcc, v119, v118
+s_sub_u32 s54, s28, s63
+s_sub_u32 s54, s54, 2
+s_bitcmp1_b32 s18, 0
+s_cselect_b32 s54, s54, s63
+v_mov_b32_e32 v121, s54
+s_lshl_b32 s57, s29, 1
+v_cmp_ge_u32_e64 s[54:55], v121, s28
+v_mad_i32_i24 v94, v121, s57, v119
+s_or_b64 s[54:55], s[54:55], s[52:53]
+v_cndmask_b32_e64 v94, v94, -1, s[54:55]
+v_mov_b32_e32 v95, v94
+v_add_co_u32_e64 v121, vcc, v121, 1
+v_cmp_ge_u32_e64 s[54:55], v121, s28
+v_mad_i32_i24 v97, v121, s57, v119
+s_or_b64 s[54:55], s[54:55], s[52:53]
+v_cndmask_b32_e64 v97, v97, -1, s[54:55]
+v_add_co_u32_e64 v121, vcc, v121, 1
+v_cmp_ge_u32_e64 s[54:55], v121, s28
+v_mad_i32_i24 v96, v121, s57, v119
+s_or_b64 s[54:55], s[54:55], s[52:53]
+v_cndmask_b32_e64 v96, v96, -1, s[54:55]
+s_bitcmp1_b32 s18, 0
+s_cselect_b64 vcc, -1, 0
+v_cndmask_b32_e32 v94, v95, v97, vcc
+v_cndmask_b32_e32 v97, v97, v95, vcc
+v_add_co_u32_e64 v118, vcc, v111, s83
+v_cmp_lt_u32_e64 vcc, v118, s16
+v_cndmask_b32_e32 v94, -1, v94, vcc
+v_cndmask_b32_e32 v95, -1, v95, vcc
+v_cndmask_b32_e32 v96, -1, v96, vcc
+v_cndmask_b32_e32 v97, -1, v97, vcc
+s_lshr_b32 s52, -1, 16
+s_and_b32 s52, s52, s90
+s_lshr_b32 s53, s90, 16
+s_mul_i32 s53, s53, s83
+s_mul_i32 s40, s52, s83
+s_lshl_b32 s52, s53, 16
+s_lshr_b32 s53, s53, 16
+s_add_u32 s40, s52, s40
+s_addc_u32 s41, s53, 0
+s_add_u32 s40, s40, s22
+s_addc_u32 s41, s41, s23
+s_lshr_b32 s52, s18, 6
+s_xor_b32 s52, s52, s18
+s_and_b32 s52, s52, 0x80000
+s_cselect_b32 s52, s68, 0
+s_and_b32 s53, s18, 0x1100000
+s_cselect_b32 s53, 0, 1
+s_lshl_b32 s52, s52, s53
+s_add_u32 s40, s40, s52
+s_addc_u32 s41, s41, 0
+s_mov_b32 s43, 0x20000
+s_mov_b32 s73, -1
+s_bitcmp0_b32 s13, 0
+s_cbranch_scc1 4
+s_mov_b32 s43, 0
+s_mov_b32 s73, 1
+s_sub_u32 s40, s40, s68
+s_subb_u32 s41, s41, 0
+s_add_u32 s53, s13, 1
+s_and_b32 s53, s53, -2
+s_bfe_u32 s52, s18, 0x10014
+s_lshl_b32 s82, s53, s52
+s_bfe_u32 s52, s18, 0x10013
+s_bfe_u32 s54, s18, 0x10019
+s_xor_b32 s52, s52, s54
+s_cselect_b32 s52, 2, 0
+s_cselect_b32 s43, 0x20000, s43
+s_and_b32 s52, s52, s82
+s_sub_u32 s82, s82, s52
+s_bitcmp1_b32 s18, 20
+s_cselect_b32 s52, 0, 0x2000000
+s_bitcmp1_b32 s53, 1
+s_cselect_b32 s52, s52, 0
+s_xor_b32 s18, s18, s52
+s_cmp_eq_u32 s82, 0
+s_cbranch_scc1 1
+s_branch 64932
+s_and_b32 s52, 0x900000, s18
+s_subb_u32 s62, s62, 1
+s_cbranch_scc0 65227
+s_and_b32 s52, 0x900000, s18
+s_subb_u32 s62, s61, 1
+s_add_u32 s63, s63, 2
+s_cmp_ge_u32 s63, s28
+s_cbranch_scc0 65221
+s_mov_b32 s63, 0
+s_branch 65188
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_mov_b32 s52, 0x3c3c3c3c
+s_mov_b32 s53, s52
+v_mov_b32_e32 v119, v3
+v_mov_b32_e32 v120, v4
+v_mov_b32_e32 v121, v5
+s_waitcnt lgkmcnt(0)
+v_mov_b32_e32 v118, v2
+v_add_f32_dpp v118, v2, v2  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v119, v3, v3  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v120, v4, v4  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v121, v5, v5  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v4, v4, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v5, v5, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v2, v2, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v3, v3, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mov_b32_dpp v3, v4  row_mirror row_mask:0xf bank_mask:0x3
+v_mov_b32_dpp v2, v5  row_mirror row_mask:0xf bank_mask:0x3
+v_add_f32_dpp v119, v120, v119  row_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v118, v121, v118  row_mirror row_mask:0xf bank_mask:0xf
+v_sub_f32_dpp v121, v3, v3  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_add_f32_dpp v3, v3, v3  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_sub_f32_dpp v120, v2, v2  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_add_f32_dpp v2, v2, v2  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mov_b32_e32 v5, v119
+v_add_f32_dpp v5, v119, v119  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mov_b32_dpp v120, v121  row_ror:12 row_mask:0xf bank_mask:0x1
+v_mov_b32_dpp v120, v121  row_ror:4 row_mask:0xf bank_mask:0x8
+v_mov_b32_e32 v4, v118
+v_add_f32_dpp v4, v118, v118  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mov_b32_dpp v120, v120  quad_perm:[1,1,1,1] row_mask:0xf bank_mask:0x3
+v_sub_f32_dpp v121, v119, v119  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_add_f32_dpp v3, v3, v2  row_half_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v2, v5, v4  row_half_mirror row_mask:0xf bank_mask:0xf
+v_sub_f32_dpp v4, v118, v118  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mov_b32_dpp v4, v121  row_half_mirror row_mask:0xf bank_mask:0x9
+v_mov_b32_dpp v120, v120  quad_perm:[2,2,2,2] row_mask:0xf bank_mask:0xc
+v_cndmask_b32_e64 v3, v120, v3, s[52:53]
+v_mov_b32_dpp v4, v4  quad_perm:[0,0,2,2] row_mask:0xf bank_mask:0x5
+s_nop 1
+v_mov_b32_dpp v4, v4  quad_perm:[1,1,3,3] row_mask:0xf bank_mask:0xa
+v_cvt_f16_f32_e32 v2, v2
+v_cvt_f16_f32_e32 v3, v3
+v_cvt_f16_f32_e32 v4, v4
+v_mov_b32_e32 v119, v7
+v_mov_b32_e32 v120, v8
+v_mov_b32_e32 v121, v9
+s_waitcnt lgkmcnt(0)
+v_mov_b32_e32 v118, v6
+v_add_f32_dpp v118, v6, v6  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v119, v7, v7  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v120, v8, v8  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v121, v9, v9  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v8, v8, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v9, v9, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v6, v6, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v7, v7, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mov_b32_dpp v7, v8  row_mirror row_mask:0xf bank_mask:0x3
+v_mov_b32_dpp v6, v9  row_mirror row_mask:0xf bank_mask:0x3
+v_add_f32_dpp v119, v120, v119  row_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v118, v121, v118  row_mirror row_mask:0xf bank_mask:0xf
+v_sub_f32_dpp v121, v7, v7  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_add_f32_dpp v7, v7, v7  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_sub_f32_dpp v120, v6, v6  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_add_f32_dpp v6, v6, v6  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mov_b32_e32 v9, v119
+v_add_f32_dpp v9, v119, v119  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mov_b32_dpp v120, v121  row_ror:12 row_mask:0xf bank_mask:0x1
+v_mov_b32_dpp v120, v121  row_ror:4 row_mask:0xf bank_mask:0x8
+v_mov_b32_e32 v8, v118
+v_add_f32_dpp v8, v118, v118  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mov_b32_dpp v120, v120  quad_perm:[1,1,1,1] row_mask:0xf bank_mask:0x3
+v_sub_f32_dpp v121, v119, v119  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_add_f32_dpp v7, v7, v6  row_half_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v5, v9, v8  row_half_mirror row_mask:0xf bank_mask:0xf
+v_sub_f32_dpp v8, v118, v118  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mov_b32_dpp v8, v121  row_half_mirror row_mask:0xf bank_mask:0x9
+v_mov_b32_dpp v120, v120  quad_perm:[2,2,2,2] row_mask:0xf bank_mask:0xc
+v_cndmask_b32_e64 v6, v120, v7, s[52:53]
+v_mov_b32_dpp v7, v8  quad_perm:[0,0,2,2] row_mask:0xf bank_mask:0x5
+s_nop 1
+v_mov_b32_dpp v7, v8  quad_perm:[1,1,3,3] row_mask:0xf bank_mask:0xa
+v_cvt_f16_f32_e32 v5, v5
+v_cvt_f16_f32_e32 v6, v6
+v_cvt_f16_f32_e32 v7, v7
+v_mov_b32_e32 v119, v11
+v_mov_b32_e32 v120, v12
+v_mov_b32_e32 v121, v13
+s_waitcnt lgkmcnt(0)
+v_mov_b32_e32 v118, v10
+v_add_f32_dpp v118, v10, v10  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v119, v11, v11  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v120, v12, v12  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v121, v13, v13  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v12, v12, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v13, v13, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v10, v10, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v11, v11, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mov_b32_dpp v11, v12  row_mirror row_mask:0xf bank_mask:0x3
+v_mov_b32_dpp v10, v13  row_mirror row_mask:0xf bank_mask:0x3
+v_add_f32_dpp v119, v120, v119  row_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v118, v121, v118  row_mirror row_mask:0xf bank_mask:0xf
+v_sub_f32_dpp v121, v11, v11  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_add_f32_dpp v11, v11, v11  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_sub_f32_dpp v120, v10, v10  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_add_f32_dpp v10, v10, v10  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mov_b32_e32 v13, v119
+v_add_f32_dpp v13, v119, v119  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mov_b32_dpp v120, v121  row_ror:12 row_mask:0xf bank_mask:0x1
+v_mov_b32_dpp v120, v121  row_ror:4 row_mask:0xf bank_mask:0x8
+v_mov_b32_e32 v12, v118
+v_add_f32_dpp v12, v118, v118  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mov_b32_dpp v120, v120  quad_perm:[1,1,1,1] row_mask:0xf bank_mask:0x3
+v_sub_f32_dpp v121, v119, v119  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_add_f32_dpp v11, v11, v10  row_half_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v8, v13, v12  row_half_mirror row_mask:0xf bank_mask:0xf
+v_sub_f32_dpp v12, v118, v118  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mov_b32_dpp v12, v121  row_half_mirror row_mask:0xf bank_mask:0x9
+v_mov_b32_dpp v120, v120  quad_perm:[2,2,2,2] row_mask:0xf bank_mask:0xc
+v_cndmask_b32_e64 v9, v120, v11, s[52:53]
+v_mov_b32_dpp v10, v12  quad_perm:[0,0,2,2] row_mask:0xf bank_mask:0x5
+s_nop 1
+v_mov_b32_dpp v10, v12  quad_perm:[1,1,3,3] row_mask:0xf bank_mask:0xa
+v_cvt_f16_f32_e32 v8, v8
+v_cvt_f16_f32_e32 v9, v9
+v_cvt_f16_f32_e32 v10, v10
+v_mov_b32_e32 v119, v15
+v_mov_b32_e32 v120, v16
+v_mov_b32_e32 v121, v17
+s_waitcnt lgkmcnt(0)
+v_mov_b32_e32 v118, v14
+v_add_f32_dpp v118, v14, v14  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v119, v15, v15  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v120, v16, v16  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v121, v17, v17  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v16, v16, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v17, v17, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v14, v14, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v15, v15, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mov_b32_dpp v15, v16  row_mirror row_mask:0xf bank_mask:0x3
+v_mov_b32_dpp v14, v17  row_mirror row_mask:0xf bank_mask:0x3
+v_add_f32_dpp v119, v120, v119  row_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v118, v121, v118  row_mirror row_mask:0xf bank_mask:0xf
+v_sub_f32_dpp v121, v15, v15  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_add_f32_dpp v15, v15, v15  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_sub_f32_dpp v120, v14, v14  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_add_f32_dpp v14, v14, v14  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mov_b32_e32 v17, v119
+v_add_f32_dpp v17, v119, v119  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mov_b32_dpp v120, v121  row_ror:12 row_mask:0xf bank_mask:0x1
+v_mov_b32_dpp v120, v121  row_ror:4 row_mask:0xf bank_mask:0x8
+v_mov_b32_e32 v16, v118
+v_add_f32_dpp v16, v118, v118  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mov_b32_dpp v120, v120  quad_perm:[1,1,1,1] row_mask:0xf bank_mask:0x3
+v_sub_f32_dpp v121, v119, v119  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_add_f32_dpp v15, v15, v14  row_half_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v11, v17, v16  row_half_mirror row_mask:0xf bank_mask:0xf
+v_sub_f32_dpp v16, v118, v118  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mov_b32_dpp v16, v121  row_half_mirror row_mask:0xf bank_mask:0x9
+v_mov_b32_dpp v120, v120  quad_perm:[2,2,2,2] row_mask:0xf bank_mask:0xc
+v_cndmask_b32_e64 v12, v120, v15, s[52:53]
+v_mov_b32_dpp v13, v16  quad_perm:[0,0,2,2] row_mask:0xf bank_mask:0x5
+s_nop 1
+v_mov_b32_dpp v13, v16  quad_perm:[1,1,3,3] row_mask:0xf bank_mask:0xa
+v_cvt_f16_f32_e32 v11, v11
+v_cvt_f16_f32_e32 v12, v12
+v_cvt_f16_f32_e32 v13, v13
+v_mov_b32_e32 v119, v19
+v_mov_b32_e32 v120, v20
+v_mov_b32_e32 v121, v21
+s_waitcnt lgkmcnt(0)
+v_mov_b32_e32 v118, v18
+v_add_f32_dpp v118, v18, v18  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v119, v19, v19  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v120, v20, v20  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v121, v21, v21  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v20, v20, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v21, v21, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v18, v18, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v19, v19, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mov_b32_dpp v19, v20  row_mirror row_mask:0xf bank_mask:0x3
+v_mov_b32_dpp v18, v21  row_mirror row_mask:0xf bank_mask:0x3
+v_add_f32_dpp v119, v120, v119  row_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v118, v121, v118  row_mirror row_mask:0xf bank_mask:0xf
+v_sub_f32_dpp v121, v19, v19  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_add_f32_dpp v19, v19, v19  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_sub_f32_dpp v120, v18, v18  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_add_f32_dpp v18, v18, v18  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mov_b32_e32 v21, v119
+v_add_f32_dpp v21, v119, v119  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mov_b32_dpp v120, v121  row_ror:12 row_mask:0xf bank_mask:0x1
+v_mov_b32_dpp v120, v121  row_ror:4 row_mask:0xf bank_mask:0x8
+v_mov_b32_e32 v20, v118
+v_add_f32_dpp v20, v118, v118  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mov_b32_dpp v120, v120  quad_perm:[1,1,1,1] row_mask:0xf bank_mask:0x3
+v_sub_f32_dpp v121, v119, v119  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_add_f32_dpp v19, v19, v18  row_half_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v14, v21, v20  row_half_mirror row_mask:0xf bank_mask:0xf
+v_sub_f32_dpp v20, v118, v118  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mov_b32_dpp v20, v121  row_half_mirror row_mask:0xf bank_mask:0x9
+v_mov_b32_dpp v120, v120  quad_perm:[2,2,2,2] row_mask:0xf bank_mask:0xc
+v_cndmask_b32_e64 v15, v120, v19, s[52:53]
+v_mov_b32_dpp v16, v20  quad_perm:[0,0,2,2] row_mask:0xf bank_mask:0x5
+s_nop 1
+v_mov_b32_dpp v16, v20  quad_perm:[1,1,3,3] row_mask:0xf bank_mask:0xa
+v_cvt_f16_f32_e32 v14, v14
+v_cvt_f16_f32_e32 v15, v15
+v_cvt_f16_f32_e32 v16, v16
+v_mov_b32_e32 v119, v23
+v_mov_b32_e32 v120, v24
+v_mov_b32_e32 v121, v25
+s_waitcnt lgkmcnt(0)
+v_mov_b32_e32 v118, v22
+v_add_f32_dpp v118, v22, v22  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v119, v23, v23  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v120, v24, v24  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v121, v25, v25  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v24, v24, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v25, v25, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v22, v22, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v23, v23, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mov_b32_dpp v23, v24  row_mirror row_mask:0xf bank_mask:0x3
+v_mov_b32_dpp v22, v25  row_mirror row_mask:0xf bank_mask:0x3
+v_add_f32_dpp v119, v120, v119  row_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v118, v121, v118  row_mirror row_mask:0xf bank_mask:0xf
+v_sub_f32_dpp v121, v23, v23  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_add_f32_dpp v23, v23, v23  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_sub_f32_dpp v120, v22, v22  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_add_f32_dpp v22, v22, v22  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mov_b32_e32 v25, v119
+v_add_f32_dpp v25, v119, v119  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mov_b32_dpp v120, v121  row_ror:12 row_mask:0xf bank_mask:0x1
+v_mov_b32_dpp v120, v121  row_ror:4 row_mask:0xf bank_mask:0x8
+v_mov_b32_e32 v24, v118
+v_add_f32_dpp v24, v118, v118  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mov_b32_dpp v120, v120  quad_perm:[1,1,1,1] row_mask:0xf bank_mask:0x3
+v_sub_f32_dpp v121, v119, v119  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_add_f32_dpp v23, v23, v22  row_half_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v17, v25, v24  row_half_mirror row_mask:0xf bank_mask:0xf
+v_sub_f32_dpp v24, v118, v118  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mov_b32_dpp v24, v121  row_half_mirror row_mask:0xf bank_mask:0x9
+v_mov_b32_dpp v120, v120  quad_perm:[2,2,2,2] row_mask:0xf bank_mask:0xc
+v_cndmask_b32_e64 v18, v120, v23, s[52:53]
+v_mov_b32_dpp v19, v24  quad_perm:[0,0,2,2] row_mask:0xf bank_mask:0x5
+s_nop 1
+v_mov_b32_dpp v19, v24  quad_perm:[1,1,3,3] row_mask:0xf bank_mask:0xa
+v_cvt_f16_f32_e32 v17, v17
+v_cvt_f16_f32_e32 v18, v18
+v_cvt_f16_f32_e32 v19, v19
+v_mov_b32_e32 v119, v27
+v_mov_b32_e32 v120, v28
+v_mov_b32_e32 v121, v29
+s_waitcnt lgkmcnt(0)
+v_mov_b32_e32 v118, v26
+v_add_f32_dpp v118, v26, v26  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v119, v27, v27  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v120, v28, v28  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v121, v29, v29  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v28, v28, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v29, v29, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v26, v26, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v27, v27, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mov_b32_dpp v27, v28  row_mirror row_mask:0xf bank_mask:0x3
+v_mov_b32_dpp v26, v29  row_mirror row_mask:0xf bank_mask:0x3
+v_add_f32_dpp v119, v120, v119  row_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v118, v121, v118  row_mirror row_mask:0xf bank_mask:0xf
+v_sub_f32_dpp v121, v27, v27  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_add_f32_dpp v27, v27, v27  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_sub_f32_dpp v120, v26, v26  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_add_f32_dpp v26, v26, v26  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mov_b32_e32 v29, v119
+v_add_f32_dpp v29, v119, v119  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mov_b32_dpp v120, v121  row_ror:12 row_mask:0xf bank_mask:0x1
+v_mov_b32_dpp v120, v121  row_ror:4 row_mask:0xf bank_mask:0x8
+v_mov_b32_e32 v28, v118
+v_add_f32_dpp v28, v118, v118  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mov_b32_dpp v120, v120  quad_perm:[1,1,1,1] row_mask:0xf bank_mask:0x3
+v_sub_f32_dpp v121, v119, v119  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_add_f32_dpp v27, v27, v26  row_half_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v20, v29, v28  row_half_mirror row_mask:0xf bank_mask:0xf
+v_sub_f32_dpp v28, v118, v118  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mov_b32_dpp v28, v121  row_half_mirror row_mask:0xf bank_mask:0x9
+v_mov_b32_dpp v120, v120  quad_perm:[2,2,2,2] row_mask:0xf bank_mask:0xc
+v_cndmask_b32_e64 v21, v120, v27, s[52:53]
+v_mov_b32_dpp v22, v28  quad_perm:[0,0,2,2] row_mask:0xf bank_mask:0x5
+s_nop 1
+v_mov_b32_dpp v22, v28  quad_perm:[1,1,3,3] row_mask:0xf bank_mask:0xa
+v_cvt_f16_f32_e32 v20, v20
+v_cvt_f16_f32_e32 v21, v21
+v_cvt_f16_f32_e32 v22, v22
+v_mov_b32_e32 v119, v31
+v_mov_b32_e32 v120, v32
+v_mov_b32_e32 v121, v33
+s_waitcnt lgkmcnt(0)
+v_mov_b32_e32 v118, v30
+v_add_f32_dpp v118, v30, v30  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v119, v31, v31  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v120, v32, v32  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v121, v33, v33  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v32, v32, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v33, v33, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v30, v30, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v31, v31, v113  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mov_b32_dpp v31, v32  row_mirror row_mask:0xf bank_mask:0x3
+v_mov_b32_dpp v30, v33  row_mirror row_mask:0xf bank_mask:0x3
+v_add_f32_dpp v119, v120, v119  row_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v118, v121, v118  row_mirror row_mask:0xf bank_mask:0xf
+v_sub_f32_dpp v121, v31, v31  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_add_f32_dpp v31, v31, v31  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_sub_f32_dpp v120, v30, v30  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_add_f32_dpp v30, v30, v30  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mov_b32_e32 v33, v119
+v_add_f32_dpp v33, v119, v119  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mov_b32_dpp v120, v121  row_ror:12 row_mask:0xf bank_mask:0x1
+v_mov_b32_dpp v120, v121  row_ror:4 row_mask:0xf bank_mask:0x8
+v_mov_b32_e32 v32, v118
+v_add_f32_dpp v32, v118, v118  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mov_b32_dpp v120, v120  quad_perm:[1,1,1,1] row_mask:0xf bank_mask:0x3
+v_sub_f32_dpp v121, v119, v119  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_add_f32_dpp v31, v31, v30  row_half_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v23, v33, v32  row_half_mirror row_mask:0xf bank_mask:0xf
+v_sub_f32_dpp v32, v118, v118  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mov_b32_dpp v32, v121  row_half_mirror row_mask:0xf bank_mask:0x9
+v_mov_b32_dpp v120, v120  quad_perm:[2,2,2,2] row_mask:0xf bank_mask:0xc
+v_cndmask_b32_e64 v24, v120, v31, s[52:53]
+v_mov_b32_dpp v25, v32  quad_perm:[0,0,2,2] row_mask:0xf bank_mask:0x5
+s_nop 1
+v_mov_b32_dpp v25, v32  quad_perm:[1,1,3,3] row_mask:0xf bank_mask:0xa
+v_cvt_f16_f32_e32 v23, v23
+v_cvt_f16_f32_e32 v24, v24
+v_cvt_f16_f32_e32 v25, v25
+s_waitcnt vmcnt(0)
+v_readlane_b32 s55, v116, 0
+v_add_f16_e64 v2, v2, s55
+v_mul_f16_e64 v118, v2, s36
+v_cmp_lt_f16_e64 vcc, v2, 0
+v_cndmask_b32_e32 v2, v2, v118, vcc
+v_add_f16_e64 v3, v3, s55
+v_mul_f16_e64 v118, v3, s36
+v_cmp_lt_f16_e64 vcc, v3, 0
+v_cndmask_b32_e32 v3, v3, v118, vcc
+v_add_f16_e64 v4, v4, s55
+v_mul_f16_e64 v118, v4, s36
+v_cmp_lt_f16_e64 vcc, v4, 0
+v_cndmask_b32_e32 v4, v4, v118, vcc
+buffer_store_short v2, v98, s[44:47], 0 offen
+buffer_store_short v3, v99, s[44:47], 0 offen
+buffer_store_short v4, v100, s[44:47], 0 offen
+s_add_u32 s44, s44, s67
+s_addc_u32 s45, s45, 0
+s_sub_u32 s93, s93, 1
+s_cselect_b32 s47, 0, s47
+v_readlane_b32 s55, v116, 1
+v_add_f16_e64 v5, v5, s55
+v_mul_f16_e64 v118, v5, s36
+v_cmp_lt_f16_e64 vcc, v5, 0
+v_cndmask_b32_e32 v5, v5, v118, vcc
+v_add_f16_e64 v6, v6, s55
+v_mul_f16_e64 v118, v6, s36
+v_cmp_lt_f16_e64 vcc, v6, 0
+v_cndmask_b32_e32 v6, v6, v118, vcc
+v_add_f16_e64 v7, v7, s55
+v_mul_f16_e64 v118, v7, s36
+v_cmp_lt_f16_e64 vcc, v7, 0
+v_cndmask_b32_e32 v7, v7, v118, vcc
+buffer_store_short v5, v98, s[44:47], 0 offen
+buffer_store_short v6, v99, s[44:47], 0 offen
+buffer_store_short v7, v100, s[44:47], 0 offen
+s_add_u32 s44, s44, s67
+s_addc_u32 s45, s45, 0
+s_sub_u32 s93, s93, 1
+s_cselect_b32 s47, 0, s47
+v_readlane_b32 s55, v116, 2
+v_add_f16_e64 v8, v8, s55
+v_mul_f16_e64 v118, v8, s36
+v_cmp_lt_f16_e64 vcc, v8, 0
+v_cndmask_b32_e32 v8, v8, v118, vcc
+v_add_f16_e64 v9, v9, s55
+v_mul_f16_e64 v118, v9, s36
+v_cmp_lt_f16_e64 vcc, v9, 0
+v_cndmask_b32_e32 v9, v9, v118, vcc
+v_add_f16_e64 v10, v10, s55
+v_mul_f16_e64 v118, v10, s36
+v_cmp_lt_f16_e64 vcc, v10, 0
+v_cndmask_b32_e32 v10, v10, v118, vcc
+buffer_store_short v8, v98, s[44:47], 0 offen
+buffer_store_short v9, v99, s[44:47], 0 offen
+buffer_store_short v10, v100, s[44:47], 0 offen
+s_add_u32 s44, s44, s67
+s_addc_u32 s45, s45, 0
+s_sub_u32 s93, s93, 1
+s_cselect_b32 s47, 0, s47
+v_readlane_b32 s55, v116, 3
+v_add_f16_e64 v11, v11, s55
+v_mul_f16_e64 v118, v11, s36
+v_cmp_lt_f16_e64 vcc, v11, 0
+v_cndmask_b32_e32 v11, v11, v118, vcc
+v_add_f16_e64 v12, v12, s55
+v_mul_f16_e64 v118, v12, s36
+v_cmp_lt_f16_e64 vcc, v12, 0
+v_cndmask_b32_e32 v12, v12, v118, vcc
+v_add_f16_e64 v13, v13, s55
+v_mul_f16_e64 v118, v13, s36
+v_cmp_lt_f16_e64 vcc, v13, 0
+v_cndmask_b32_e32 v13, v13, v118, vcc
+buffer_store_short v11, v98, s[44:47], 0 offen
+buffer_store_short v12, v99, s[44:47], 0 offen
+buffer_store_short v13, v100, s[44:47], 0 offen
+s_add_u32 s44, s44, s67
+s_addc_u32 s45, s45, 0
+s_sub_u32 s93, s93, 1
+s_cselect_b32 s47, 0, s47
+s_lshl_b32 s52, s67, 2
+s_add_u32 s44, s44, s52
+s_addc_u32 s45, s45, 0
+s_sub_u32 s93, s93, 4
+s_cselect_b32 s47, 0, s47
+v_readlane_b32 s55, v116, 8
+v_add_f16_e64 v14, v14, s55
+v_mul_f16_e64 v118, v14, s36
+v_cmp_lt_f16_e64 vcc, v14, 0
+v_cndmask_b32_e32 v14, v14, v118, vcc
+v_add_f16_e64 v15, v15, s55
+v_mul_f16_e64 v118, v15, s36
+v_cmp_lt_f16_e64 vcc, v15, 0
+v_cndmask_b32_e32 v15, v15, v118, vcc
+v_add_f16_e64 v16, v16, s55
+v_mul_f16_e64 v118, v16, s36
+v_cmp_lt_f16_e64 vcc, v16, 0
+v_cndmask_b32_e32 v16, v16, v118, vcc
+buffer_store_short v14, v98, s[44:47], 0 offen
+buffer_store_short v15, v99, s[44:47], 0 offen
+buffer_store_short v16, v100, s[44:47], 0 offen
+s_add_u32 s44, s44, s67
+s_addc_u32 s45, s45, 0
+s_sub_u32 s93, s93, 1
+s_cselect_b32 s47, 0, s47
+v_readlane_b32 s55, v116, 9
+v_add_f16_e64 v17, v17, s55
+v_mul_f16_e64 v118, v17, s36
+v_cmp_lt_f16_e64 vcc, v17, 0
+v_cndmask_b32_e32 v17, v17, v118, vcc
+v_add_f16_e64 v18, v18, s55
+v_mul_f16_e64 v118, v18, s36
+v_cmp_lt_f16_e64 vcc, v18, 0
+v_cndmask_b32_e32 v18, v18, v118, vcc
+v_add_f16_e64 v19, v19, s55
+v_mul_f16_e64 v118, v19, s36
+v_cmp_lt_f16_e64 vcc, v19, 0
+v_cndmask_b32_e32 v19, v19, v118, vcc
+buffer_store_short v17, v98, s[44:47], 0 offen
+buffer_store_short v18, v99, s[44:47], 0 offen
+buffer_store_short v19, v100, s[44:47], 0 offen
+s_add_u32 s44, s44, s67
+s_addc_u32 s45, s45, 0
+s_sub_u32 s93, s93, 1
+s_cselect_b32 s47, 0, s47
+v_readlane_b32 s55, v116, 10
+v_add_f16_e64 v20, v20, s55
+v_mul_f16_e64 v118, v20, s36
+v_cmp_lt_f16_e64 vcc, v20, 0
+v_cndmask_b32_e32 v20, v20, v118, vcc
+v_add_f16_e64 v21, v21, s55
+v_mul_f16_e64 v118, v21, s36
+v_cmp_lt_f16_e64 vcc, v21, 0
+v_cndmask_b32_e32 v21, v21, v118, vcc
+v_add_f16_e64 v22, v22, s55
+v_mul_f16_e64 v118, v22, s36
+v_cmp_lt_f16_e64 vcc, v22, 0
+v_cndmask_b32_e32 v22, v22, v118, vcc
+buffer_store_short v20, v98, s[44:47], 0 offen
+buffer_store_short v21, v99, s[44:47], 0 offen
+buffer_store_short v22, v100, s[44:47], 0 offen
+s_add_u32 s44, s44, s67
+s_addc_u32 s45, s45, 0
+s_sub_u32 s93, s93, 1
+s_cselect_b32 s47, 0, s47
+v_readlane_b32 s55, v116, 11
+v_add_f16_e64 v23, v23, s55
+v_mul_f16_e64 v118, v23, s36
+v_cmp_lt_f16_e64 vcc, v23, 0
+v_cndmask_b32_e32 v23, v23, v118, vcc
+v_add_f16_e64 v24, v24, s55
+v_mul_f16_e64 v118, v24, s36
+v_cmp_lt_f16_e64 vcc, v24, 0
+v_cndmask_b32_e32 v24, v24, v118, vcc
+v_add_f16_e64 v25, v25, s55
+v_mul_f16_e64 v118, v25, s36
+v_cmp_lt_f16_e64 vcc, v25, 0
+v_cndmask_b32_e32 v25, v25, v118, vcc
+buffer_store_short v23, v98, s[44:47], 0 offen
+buffer_store_short v24, v99, s[44:47], 0 offen
+buffer_store_short v25, v100, s[44:47], 0 offen
+s_add_u32 s44, s44, s67
+s_addc_u32 s45, s45, 0
+s_sub_u32 s93, s93, 1
+s_cselect_b32 s47, 0, s47
+s_add_u32 s44, s44, s52
+s_addc_u32 s45, s45, 0
+s_lshl_b32 s52, s52, 2
+s_add_u32 s44, s44, s52
+s_addc_u32 s45, s45, 0
+s_sub_u32 s93, s93, 20
+s_cselect_b32 s47, 0, s47
+s_cselect_b32 s51, 0, s51
+s_add_u32 s48, s48, 64
+s_addc_u32 s49, s49, 0
+s_sub_u32 s50, s50, 64
+s_cselect_b32 s51, 0, s51
+v_mov_b32_e32 v2, 0
+v_mov_b32_e32 v3, 0
+v_mov_b32_e32 v4, 0
+v_mov_b32_e32 v5, 0
+v_mov_b32_e32 v6, 0
+v_mov_b32_e32 v7, 0
+v_mov_b32_e32 v8, 0
+v_mov_b32_e32 v9, 0
+v_mov_b32_e32 v10, 0
+v_mov_b32_e32 v11, 0
+v_mov_b32_e32 v12, 0
+v_mov_b32_e32 v13, 0
+v_mov_b32_e32 v14, 0
+v_mov_b32_e32 v15, 0
+v_mov_b32_e32 v16, 0
+v_mov_b32_e32 v17, 0
+v_mov_b32_e32 v18, 0
+v_mov_b32_e32 v19, 0
+v_mov_b32_e32 v20, 0
+v_mov_b32_e32 v21, 0
+v_mov_b32_e32 v22, 0
+v_mov_b32_e32 v23, 0
+v_mov_b32_e32 v24, 0
+v_mov_b32_e32 v25, 0
+v_mov_b32_e32 v26, 0
+v_mov_b32_e32 v27, 0
+v_mov_b32_e32 v28, 0
+v_mov_b32_e32 v29, 0
+v_mov_b32_e32 v30, 0
+v_mov_b32_e32 v31, 0
+v_mov_b32_e32 v32, 0
+v_mov_b32_e32 v33, 0
+s_xor_b32 s18, s18, 0x200000
+s_bitcmp1_b32 s13, 0
+s_addc_u32 s52, s13, 0
+s_mul_i32 s94, s60, s61
+s_mul_i32 s94, s94, s52
+s_add_u32 s52, s93, s92
+s_cmp_lt_i32 s52, 0
+s_cbranch_scc0 156
+v_and_b32_e32 v98, 0x7f, v0
+v_lshrrev_b32_e32 v98, 1, v98
+v_bfi_b32 v98, 1, v0, v98
+v_and_b32_e64 v99, v0, 2
+v_mad_u32_u24 v98, v99, 16, v98
+v_lshlrev_b32_e32 v98, 2, v98
+v_add_co_u32_e64 v98, vcc, v98, s97
+v_and_b32_e32 v99, 3, v0
+v_lshlrev_b32_e32 v99, 2, v99
+v_add_co_u32_e64 v99, vcc, v99, s97
+ds_read_b32 v120, v99 offset:256
+ds_read_b32 v98, v98
+s_add_u32 s97, s97, 0x18c
+s_cmp_eq_u32 s97, 0xffc0
+s_cselect_b32 s97, 0xc1e0, s97
+s_waitcnt lgkmcnt(0)
+v_readfirstlane_b32 s95, v98
+v_readlane_b32 s54, v120, 0
+s_bitcmp1_b32 s54, 18
+s_cbranch_scc1 131
+v_readlane_b32 s52, v120, 1
+v_readlane_b32 s53, v120, 2
+s_add_u32 s93, s92, s53
+s_lshr_b32 s55, -1, 16
+s_and_b32 s55, s55, s66
+s_lshr_b32 s56, s66, 16
+s_mul_i32 s56, s56, s95
+s_mul_i32 s44, s55, s95
+s_lshl_b32 s55, s56, 16
+s_lshr_b32 s56, s56, 16
+s_add_u32 s44, s55, s44
+s_addc_u32 s45, s56, 0
+s_add_u32 s44, s44, s24
+s_addc_u32 s45, s45, s25
+s_mul_i32 s55, s67, s93
+s_add_u32 s44, s44, s55
+s_addc_u32 s45, s45, 0
+s_mov_b32 s47, 0x20000
+s_bitcmp1_b32 s18, 7
+s_cselect_b32 s51, 0x20000, 0
+s_lshl_b32 s55, s93, 1
+s_add_u32 s48, s34, s55
+s_addc_u32 s49, s35, 0
+s_lshl_b32 s56, s52, 1
+s_sub_u32 s50, s56, s55
+s_cselect_b32 s51, 0, s51
+s_sub_u32 s93, s52, s53
+s_sub_u32 s93, s93, 1
+s_sub_u32 s93, s93, s92
+s_cselect_b32 s47, 0, s47
+v_bfe_u32 v118, v98, 16, 16
+v_bfe_u32 v119, v98, 0, 16
+v_and_b32_e64 v120, v0, 7
+v_sub_co_u32_e32 v121, vcc, 7, v120
+v_min_u32_e32 v120, v120, v121
+v_bfe_u32 v121, v120, 1, 1
+v_bfe_u32 v120, v120, 0, 1
+v_mov_b32_dpp v118, v118  quad_perm:[1,1,1,1] row_mask:0xf bank_mask:0xf
+v_mov_b32_dpp v119, v119  quad_perm:[1,1,1,1] row_mask:0xf bank_mask:0xf
+v_add_co_u32_e32 v118, vcc, v118, v121
+v_add_co_u32_e32 v119, vcc, v119, v120
+v_mov_b32_dpp v120, v98  quad_perm:[0,0,0,0] row_mask:0xf bank_mask:0xf
+v_cmp_ge_u32_e64 s[52:53], v120, s12
+v_sub_co_u32_e64 v120, vcc, v120, s95
+v_mul_lo_u32 v120, v120, s66
+v_xor_b32_dpp v121, v0, v0  quad_perm:[0,1,3,2] row_mask:0xf bank_mask:0xf
+v_xor_b32_dpp v121, v0, v0  quad_perm:[1,0,2,3] row_mask:0xf bank_mask:0xa
+v_xor_b32_dpp v101, v0, v0  quad_perm:[0,0,2,2] row_mask:0xf bank_mask:0xf
+v_xor_b32_dpp v101, v0, v0  quad_perm:[1,1,3,3] row_mask:0xf bank_mask:0xa
+v_add_co_u32_e32 v101, vcc, v119, v101
+v_add_co_u32_e32 v121, vcc, v118, v121
+v_mad_i32_i24 v98, v121, s33, v101
+v_lshlrev_b32_e32 v98, 1, v98
+v_add_co_u32_e32 v98, vcc, v98, v120
+v_cmp_ge_u32_e64 s[56:57], v101, s33
+s_or_b64 s[56:57], s[56:57], s[52:53]
+v_cmp_ge_u32_e64 s[54:55], v121, s32
+s_or_b64 s[56:57], s[56:57], s[54:55]
+v_cndmask_b32_e64 v98, v98, -1, s[56:57]
+v_xor_b32_dpp v121, v0, v0  quad_perm:[1,0,2,3] row_mask:0xf bank_mask:0xf
+v_xor_b32_dpp v121, v0, v0  quad_perm:[0,1,3,2] row_mask:0xf bank_mask:0xa
+v_xor_b32_dpp v101, v0, v0  quad_perm:[1,1,2,2] row_mask:0xf bank_mask:0xf
+v_add_co_u32_e32 v101, vcc, v119, v101
+v_add_co_u32_e32 v121, vcc, v118, v121
+v_mad_i32_i24 v99, v121, s33, v101
+v_lshlrev_b32_e32 v99, 1, v99
+v_add_co_u32_e32 v99, vcc, v99, v120
+v_cmp_ge_u32_e64 s[56:57], v101, s33
+s_or_b64 s[56:57], s[56:57], s[52:53]
+v_cmp_ge_u32_e64 s[54:55], v121, s32
+s_or_b64 s[56:57], s[56:57], s[54:55]
+v_cndmask_b32_e64 v99, v99, -1, s[56:57]
+v_xor_b32_dpp v121, v0, v0  quad_perm:[0,1,3,2] row_mask:0xf bank_mask:0xf
+v_xor_b32_dpp v121, v0, v0  quad_perm:[1,0,2,3] row_mask:0xf bank_mask:0xa
+v_xor_b32_dpp v101, v0, v0  quad_perm:[1,1,3,3] row_mask:0xf bank_mask:0xf
+v_xor_b32_dpp v101, v0, v0  quad_perm:[0,0,2,2] row_mask:0xf bank_mask:0xa
+v_add_co_u32_e32 v101, vcc, v119, v101
+v_add_co_u32_e32 v121, vcc, v118, v121
+v_mad_i32_i24 v100, v121, s33, v101
+v_lshlrev_b32_e32 v100, 1, v100
+v_add_co_u32_e32 v100, vcc, v100, v120
+v_cmp_ge_u32_e64 s[56:57], v101, s33
+s_or_b64 s[56:57], s[56:57], s[52:53]
+v_cmp_ge_u32_e64 s[54:55], v121, s32
+s_or_b64 s[56:57], s[56:57], s[54:55]
+v_cndmask_b32_e64 v100, v100, -1, s[56:57]
+v_and_b32_e64 v116, v0, 63
+v_lshlrev_b32_e32 v116, 1, v116
+s_barrier
+buffer_load_ushort v116, v116, s[48:51], 0 offen
+s_branch 63855
+s_endpgm
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0

--- a/src/kernels/Conv_Winograd_v21_1_3_gfx9_fp32_f2x3_dilation2.inc
+++ b/src/kernels/Conv_Winograd_v21_1_3_gfx9_fp32_f2x3_dilation2.inc
@@ -1,0 +1,2846 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2023 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+v_mov_b32_e32 v0, v0
+s_mov_b32 s0, 0
+s_mov_b32 s1, 0
+s_mov_b32 s2, 0
+s_mov_b32 s3, 0
+v_mov_b32_e32 v104, 0
+s_mov_b32 m0, 0x1ffff
+s_mov_b32 s97, 0xc1e0
+s_mov_b32 s96, 0xc1e0
+s_mov_b32 s91, 0
+v_lshlrev_b32_e32 v107, 2, v0
+v_add_co_u32_e32 v107, vcc, 0xffc0, v107
+v_cmp_ge_u32_e32 vcc, 12, v0
+s_cbranch_vccz 5
+v_mov_b32_e32 v106, 0
+v_cndmask_b32_e32 v107, -1, v107, vcc
+ds_write_b32 v107, v106
+s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+s_barrier
+v_readfirstlane_b32 s52, v0
+s_lshr_b32 s52, s52, 5
+s_add_u32 s52, s52, 8
+s_and_b32 s92, s52, 20
+s_mov_b64 s[40:41], s[6:7]
+s_load_dwordx16 s[12:27], s[40:41], 0x0
+s_load_dwordx4 s[28:31], s[40:41], 0x40
+s_load_dwordx2 s[32:33], s[40:41], 0x50
+s_waitcnt lgkmcnt(0)
+s_and_b32 s18, s18, 0xffff
+s_bitcmp1_b32 s18, 6
+s_cbranch_scc0 16
+s_and_b32 s21, s21, 0xffff
+s_and_b32 s23, s23, 0xffff
+s_and_b32 s25, s25, 0xffff
+s_and_b32 s27, s27, 0xffff
+s_load_dwordx2 s[20:21], s[20:21], 0x0
+s_load_dwordx2 s[22:23], s[22:23], 0x0
+s_load_dwordx2 s[24:25], s[24:25], 0x0
+s_load_dwordx2 s[26:27], s[26:27], 0x0
+s_bitcmp1_b32 s18, 7
+s_cbranch_scc0 2
+s_load_dwordx2 s[34:35], s[40:41], 0x58
+s_mov_b32 s36, 1.0
+s_bitcmp1_b32 s18, 8
+s_cbranch_scc0 2
+s_load_dword s36, s[40:41], 0x60
+s_bitcmp1_b32 s18, 7
+s_cbranch_scc0 7
+s_bitcmp1_b32 s18, 6
+s_cbranch_scc0 5
+s_waitcnt lgkmcnt(0)
+s_and_b32 s35, s35, 0xffff
+s_load_dwordx2 s[34:35], s[34:35], 0x0
+s_bitcmp1_b32 s18, 9
+s_cbranch_scc0 72
+s_mov_b32 s42, 0x8c
+s_mov_b32 s43, 0x9c
+v_cmp_le_u32_e32 vcc, 0x100, v0
+s_cmp_eq_u32 1, src_vccz
+s_cselect_b32 s42, s43, s42
+s_load_dword s65, s[40:41], 0x88
+s_load_dword s90, s[40:41], 0x98
+s_load_dword s68, s[40:41], s42
+s_load_dwordx2 s[66:67], s[40:41], 0xa8
+s_bitcmp1_b32 s18, 10
+s_cbranch_scc0 103
+s_load_dwordx4 s[44:47], s[40:41], 0xb8
+v_ffbh_u32_e32 v4, s17
+v_lshlrev_b32_e64 v5, v4, s17
+v_and_b32_e32 v6, 0xffffff00, v5
+v_cmp_eq_u32_e32 vcc, 0x80000000, v5
+v_cvt_f32_u32_e32 v6, v6
+v_rcp_f32_e32 v2, v6
+v_subb_co_u32_e32 v3, vcc, 32, v4, vcc
+v_cvt_f32_ubyte0_e32 v4, v5
+v_fma_f32 v6, v6, v2, -1.0
+v_fma_f32 v6, v4, v2, v6
+v_madak_f32 v6, v6, v2, 0x9f000000
+v_mul_f32_e32 v6, 0x5f800000, v6
+v_mov_b32_e32 v4, 0
+v_cvt_flr_i32_f32_e64 v6, -v6
+v_lshl_add_u32 v2, v2, 9, v6
+v_mad_u64_u32 v[4:5], vcc, v5, v2, v[4:5]
+v_subb_co_u32_e64 v2, vcc, v2, -1, vcc
+v_mul_hi_u32 v4, s8, v2
+v_add_co_u32_e64 v2, vcc, v4, s8
+v_addc_co_u32_e64 v4, vcc, 0, 0, vcc
+v_cmp_eq_u32_e32 vcc, 32, v3
+v_cndmask_b32_e32 v2, v2, v4, vcc
+v_alignbit_b32 v2, v4, v2, v3
+s_waitcnt lgkmcnt(0)
+v_readfirstlane_b32 s48, v2
+s_mul_i32 s49, s48, s17
+s_sub_u32 s8, s8, s49
+s_mul_i32 s49, s45, s48
+s_add_u32 s20, s20, s49
+s_addc_u32 s21, s21, 0
+s_mul_i32 s49, s46, s48
+s_add_u32 s22, s22, s49
+s_addc_u32 s23, s23, 0
+s_mul_i32 s49, s47, s48
+s_add_u32 s24, s24, s49
+s_addc_u32 s25, s25, 0
+s_branch 49
+s_mul_i32 s42, s14, s15
+s_lshr_b32 s46, -1, 16
+s_and_b32 s46, s46, s42
+s_lshr_b32 s47, s42, 16
+s_mul_i32 s47, s47, s13
+s_mul_i32 s44, s46, s13
+s_lshl_b32 s46, s47, 16
+s_lshr_b32 s47, s47, 16
+s_add_u32 s44, s46, s44
+s_addc_u32 s45, s47, 0
+s_lshl_b32 s65, s44, 2
+s_lshl_b32 s68, s42, 2
+s_mul_i32 s43, s32, s33
+s_lshr_b32 s46, -1, 16
+s_and_b32 s46, s46, s43
+s_lshr_b32 s47, s43, 16
+s_mul_i32 s47, s47, s16
+s_mul_i32 s44, s46, s16
+s_lshl_b32 s46, s47, 16
+s_lshr_b32 s47, s47, 16
+s_add_u32 s44, s46, s44
+s_addc_u32 s45, s47, 0
+s_lshl_b32 s66, s44, 2
+s_lshl_b32 s67, s43, 2
+s_bitcmp1_b32 s18, 13
+s_cbranch_scc0 2
+s_load_dwordx8 s[48:55], s[40:41], 0x68
+s_mul_i32 s42, s28, s29
+s_lshl_b32 s42, s42, 2
+s_bitcmp1_b32 s18, 2
+s_cselect_b32 s43, s16, s13
+s_lshr_b32 s44, -1, 16
+s_and_b32 s44, s44, s42
+s_lshr_b32 s45, s42, 16
+s_mul_i32 s45, s45, s43
+s_mul_i32 s56, s44, s43
+s_lshl_b32 s44, s45, 16
+s_lshr_b32 s45, s45, 16
+s_add_u32 s56, s44, s56
+s_addc_u32 s57, s45, 0
+s_mov_b32 s43, s56
+s_bitcmp1_b32 s18, 2
+s_cselect_b32 s44, s43, s42
+s_cselect_b32 s90, s42, s43
+v_cmp_le_u32_e32 vcc, 0x100, v0
+s_cmp_eq_u32 1, src_vccz
+s_cselect_b32 s68, s44, s68
+s_waitcnt lgkmcnt(0)
+s_and_b32 s21, s21, 0xffff
+s_and_b32 s23, s23, 0xffff
+s_and_b32 s25, s25, 0xffff
+s_and_b32 s27, s27, 0xffff
+s_and_b32 s35, s35, 0xffff
+s_bitcmp1_b32 s18, 13
+s_cbranch_scc0 8
+s_add_u32 s20, s20, s48
+s_addc_u32 s21, s21, s49
+s_add_u32 s22, s22, s50
+s_addc_u32 s23, s23, s51
+s_add_u32 s24, s24, s52
+s_addc_u32 s25, s25, s53
+s_add_u32 s34, s34, s54
+s_addc_u32 s35, s35, s55
+s_and_b32 s44, 1, s30
+s_addc_u32 s44, s32, 1
+s_ashr_i32 s44, s44, 1
+s_add_u32 s42, s44, 1
+v_mov_b32_e32 v2, 0x80000000
+v_mul_hi_u32 v2, v2, s42
+v_readfirstlane_b32 s42, v2
+s_andn2_b32 s44, 1, s31
+s_addc_u32 s44, s33, 1
+s_ashr_i32 s44, s44, 1
+s_add_u32 s43, s44, 1
+v_mov_b32_e32 v2, 0x80000000
+v_mul_hi_u32 v2, v2, s43
+v_readfirstlane_b32 s43, v2
+s_sub_u32 s75, 0, s43
+s_sub_u32 s74, 0, s42
+s_add_u32 s60, s28, 2
+v_mov_b32_e32 v2, 0x55555556
+v_mul_hi_u32 v2, v2, s60
+v_readfirstlane_b32 s60, v2
+s_add_u32 s61, s29, 2
+v_mov_b32_e32 v2, 0x55555556
+v_mul_hi_u32 v2, v2, s61
+v_readfirstlane_b32 s61, v2
+v_mad_i32_i24 v2, 3, s60, -2
+v_sub_co_u32_e64 v2, vcc, v2, s28
+v_addc_co_u32_e64 v2, vcc, 0, 0, vcc
+v_readfirstlane_b32 s44, v2
+s_and_b32 s44, s44, 1
+s_and_b32 s44, s44, s60
+s_add_u32 s60, s60, s44
+v_readfirstlane_b32 s45, v0
+s_and_b32 s48, s45, 64
+s_cselect_b32 s48, 0x80000, 0
+s_or_b32 s18, s18, s48
+s_lshl_b32 s69, s68, 1
+s_mov_b64 s[70:71], 0
+s_bitset1_b32 s18, 23
+s_mov_b32 s69, s68
+s_mov_b32 s70, s68
+s_mov_b32 s71, 0
+s_add_u32 s61, s61, 1
+s_and_b32 s61, s61, -2
+s_branch 16
+s_and_b32 s48, s13, 1
+s_cselect_b32 s48, 0, 0x1000000
+s_bitcmp1_b32 s18, 2
+s_cselect_b32 s48, 0, s48
+s_or_b32 s18, s18, s48
+s_cmp_eq_u32 s48, 0
+s_cselect_b32 s69, s68, s69
+s_cselect_b32 s70, s68, s70
+s_cselect_b32 s71, 0, s71
+s_bitcmp0_b32 s45, 8
+s_cselect_b32 s48, s48, 0
+s_cmp_eq_u32 s48, 0
+s_cselect_b32 s48, 0, 0x80000
+s_andn2_b32 s18, s18, s48
+s_add_u32 s70, s70, s69
+s_addc_u32 s71, s71, 0
+v_bfe_u32 v3, v0, 2, 6
+v_lshrrev_b32_e32 v99, 1, v3
+s_bitcmp0_b32 s45, 8
+s_cselect_b32 s48, 0x1000000, 0
+s_or_b32 s48, s48, 0x100000
+s_and_b32 s48, s18, s48
+s_cselect_b32 s48, 0, 15
+v_bfi_b32 v99, s48, v3, v99
+v_bfe_u32 v3, s45, 8, 1
+v_xor_b32_e64 v3, v3, 1
+v_lshrrev_b32_e32 v99, v3, v99
+s_mul_i32 s88, s12, s42
+s_sub_u32 s88, s88, 1
+s_lshr_b32 s88, s88, 0
+s_add_u32 s88, s88, 1
+s_lshr_b32 s46, -1, 16
+s_and_b32 s46, s46, s88
+s_lshr_b32 s47, s88, 16
+s_mul_i32 s47, s47, s43
+s_mul_i32 s88, s46, s43
+s_lshl_b32 s46, s47, 16
+s_lshr_b32 s47, s47, 16
+s_add_u32 s88, s46, s88
+s_addc_u32 s89, s47, 0
+s_sub_u32 s88, s88, 1
+s_subb_u32 s89, s89, 0
+s_lshr_b64 s[88:89], s[88:89], 5
+s_add_u32 s88, s88, 1
+s_addc_u32 s89, s89, 0
+v_mov_b32_e32 v4, s8
+v_mov_b32_e32 v5, s17
+v_and_b32_e32 v6, 3, v0
+v_cmp_eq_u32_e32 vcc, 2, v6
+v_cndmask_b32_e32 v4, v4, v5, vcc
+v_cmp_eq_u32_e32 vcc, 1, v6
+v_cndmask_b32_e32 v7, 0, v99, vcc
+s_bitcmp1_b32 s18, 20
+s_cbranch_scc0 4
+v_add_co_u32_e64 v5, vcc, v99, 8
+v_cmp_eq_u32_e32 vcc, 0, v6
+v_cndmask_b32_e32 v7, v7, v5, vcc
+v_cmp_eq_u32_e64 s[46:47], 3, v6
+v_bfe_u32 v97, v7, 0, 5
+v_mad_u32_u24 v97, v4, 32, v97
+v_ffbh_u32_e32 v9, s43
+v_lshlrev_b32_e64 v10, v9, s43
+v_and_b32_e32 v11, 0xffffff00, v10
+v_cmp_eq_u32_e32 vcc, 0x80000000, v10
+v_cvt_f32_u32_e32 v11, v11
+v_rcp_f32_e32 v98, v11
+v_subb_co_u32_e32 v8, vcc, 32, v9, vcc
+v_cvt_f32_ubyte0_e32 v9, v10
+v_fma_f32 v11, v11, v98, -1.0
+v_fma_f32 v11, v9, v98, v11
+v_madak_f32 v11, v11, v98, 0x9f000000
+v_mul_f32_e32 v11, 0x5f800000, v11
+v_mov_b32_e32 v9, 0
+v_cvt_flr_i32_f32_e64 v11, -v11
+v_lshl_add_u32 v98, v98, 9, v11
+v_mad_u64_u32 v[9:10], vcc, v10, v98, v[9:10]
+v_subb_co_u32_e64 v98, vcc, v98, -1, vcc
+v_mul_hi_u32 v9, v97, v98
+v_add_co_u32_e32 v98, vcc, v9, v97
+v_addc_co_u32_e64 v9, vcc, 0, 0, vcc
+v_cmp_eq_u32_e32 vcc, 32, v8
+v_cndmask_b32_e32 v98, v98, v9, vcc
+v_alignbit_b32 v98, v9, v98, v8
+v_mad_i32_i24 v96, v98, s75, v97
+v_lshrrev_b32_e32 v97, 5, v7
+v_mad_u32_u24 v97, v98, 1, v97
+v_cndmask_b32_e64 v97, v97, 1, s[46:47]
+v_ffbh_u32_e32 v9, s42
+v_lshlrev_b32_e64 v10, v9, s42
+v_and_b32_e32 v11, 0xffffff00, v10
+v_cmp_eq_u32_e32 vcc, 0x80000000, v10
+v_cvt_f32_u32_e32 v11, v11
+v_rcp_f32_e32 v98, v11
+v_subb_co_u32_e32 v8, vcc, 32, v9, vcc
+v_cvt_f32_ubyte0_e32 v9, v10
+v_fma_f32 v11, v11, v98, -1.0
+v_fma_f32 v11, v9, v98, v11
+v_madak_f32 v11, v11, v98, 0x9f000000
+v_mul_f32_e32 v11, 0x5f800000, v11
+v_mov_b32_e32 v9, 0
+v_cvt_flr_i32_f32_e64 v11, -v11
+v_lshl_add_u32 v98, v98, 9, v11
+v_mad_u64_u32 v[9:10], vcc, v10, v98, v[9:10]
+v_subb_co_u32_e64 v98, vcc, v98, -1, vcc
+v_mul_hi_u32 v9, v97, v98
+v_add_co_u32_e32 v98, vcc, v9, v97
+v_addc_co_u32_e64 v9, vcc, 0, 0, vcc
+v_cmp_eq_u32_e32 vcc, 32, v8
+v_cndmask_b32_e32 v98, v98, v9, vcc
+v_alignbit_b32 v98, v9, v98, v8
+v_mad_i32_i24 v97, v98, s74, v97
+v_readlane_b32 s76, v96, 2
+v_readlane_b32 s77, v97, 2
+v_readlane_b32 s78, v98, 2
+v_readlane_b32 s79, v97, 3
+v_readlane_b32 s80, v98, 3
+v_add_co_u32_e64 v96, vcc, v96, s75
+v_add_co_u32_e64 v97, vcc, v97, s74
+v_mov_b32_dpp v98, v98  quad_perm:[1,1,0,0] row_mask:0xf bank_mask:0xf
+v_mov_b32_dpp v96, v96  quad_perm:[1,1,0,0] row_mask:0xf bank_mask:0xf
+v_mov_b32_dpp v97, v97  quad_perm:[1,1,0,0] row_mask:0xf bank_mask:0xf
+s_mov_b32 s42, 0x80000000
+s_mov_b32 s43, 0x20000
+s_mov_b32 s46, 0x80000000
+s_mov_b32 s47, 0x20000
+v_cmp_le_u32_e32 vcc, 0x100, v0
+s_cbranch_vccnz 5
+v_xor_b32_dpp v100, v0, v0  quad_perm:[1,3,2,2] row_mask:0xf bank_mask:0xf
+v_subrev_co_u32_e32 v100, vcc, 1, v100
+v_cvt_f32_i32_e32 v100, v100
+s_branch 4
+v_xor_b32_dpp v100, v0, v0  quad_perm:[2,1,0,1] row_mask:0xf bank_mask:0xf
+v_sub_co_u32_e32 v100, vcc, 1, v100
+v_cvt_f32_i32_e32 v100, v100
+v_mov_b32_e32 v101, 1
+v_xor_b32_dpp v101, v0, v0  quad_perm:[2,3,2,3] row_mask:0xf bank_mask:0x4
+v_xor_b32_dpp v101, v0, v0  quad_perm:[0,1,0,1] row_mask:0xf bank_mask:0x8
+v_subrev_co_u32_e32 v101, vcc, 1, v101
+v_mov_b32_e32 v102, 1
+v_xor_b32_dpp v102, v0, v0  quad_perm:[0,3,2,1] row_mask:0xf bank_mask:0x2
+v_xor_b32_dpp v102, v0, v0  quad_perm:[2,1,0,3] row_mask:0xf bank_mask:0x4
+v_subrev_co_u32_e32 v102, vcc, 1, v102
+v_cvt_f32_i32_e32 v101, v101
+v_cvt_f32_i32_e32 v102, v102
+v_lshrrev_b32_e64 v106, 2, s92
+v_and_b32_e32 v107, 3, v0
+v_bfe_u32 v108, v0, 4, 3
+v_mad_u32_u24 v95, v108, 4, v107
+v_lshlrev_b32_e32 v95, 4, v95
+v_mad_u32_u24 v90, v106, 4, v107
+v_lshlrev_b32_e32 v90, 4, v90
+v_bfe_u32 v106, v0, 2, 2
+v_and_b32_e32 v107, 1, v106
+v_mad_u32_u24 v109, v106, 16, v107
+v_lshlrev_b32_e32 v109, 6, v109
+v_xor_b32_e32 v90, v90, v109
+v_mul_u32_u24_e32 v109, 0x400, v106
+v_xor_b32_e32 v95, v95, v109
+s_lshr_b32 s92, s92, 1
+v_cmp_le_u32_e32 vcc, 0x100, v0
+s_cbranch_vccnz 50
+s_and_b32 s53, s18, 0x1100000
+s_addc_u32 s53, 0, 0
+v_lshrrev_b32_e32 v109, 1, v0
+s_mul_i32 s52, 60, s53
+s_sub_u32 s52, 63, s52
+v_bfi_b32 v109, s52, v0, v109
+v_and_b32_e32 v106, 1, v109
+v_bfe_u32 v107, v109, 1, 1
+v_xor_b32_e32 v106, v106, v107
+v_bfe_u32 v108, v109, 3, 1
+v_mad_u32_u24 v107, v107, 2, v108
+v_mul_u32_u24_e32 v106, 0x118, v106
+v_bfe_u32 v108, v109, 2, 1
+v_mad_u32_u24 v107, v107, 2, v106
+v_xor_b32_e32 v107, v107, v108
+v_and_b32_e32 v108, 0xf0, v109
+v_xor_b32_e32 v107, v107, v108
+s_mul_i32 s52, 4, s53
+s_sub_u32 s52, 6, s52
+v_bfe_u32 v109, v0, s52, 1
+v_mul_u32_u24_e32 v109, 0x1040, v109
+v_xor_b32_e32 v92, 0x314, v107
+v_xor_b32_e32 v93, 0x31c, v107
+v_xor_b32_e32 v94, 8, v107
+s_bitcmp1_b32 s18, 0
+s_cselect_b64 vcc, -1, 0
+v_cndmask_b32_e32 v91, v107, v94, vcc
+v_cndmask_b32_e32 v94, v94, v107, vcc
+v_mad_u32_u24 v91, 4, v91, v109
+v_mad_u32_u24 v92, 4, v92, v109
+v_mad_u32_u24 v93, 4, v93, v109
+v_mad_u32_u24 v94, 4, v94, v109
+s_branch 44
+s_bfe_u32 s53, s18, 0x10014
+v_lshrrev_b32_e32 v109, 1, v0
+s_mul_i32 s52, 60, s53
+s_sub_u32 s52, 63, s52
+v_bfi_b32 v109, s52, v0, v109
+v_and_b32_e32 v106, 1, v109
+v_bfe_u32 v107, v109, 1, 1
+v_bfe_u32 v108, v109, 3, 1
+v_xor_b32_e32 v106, v106, v107
+v_mad_u32_u24 v107, v107, 2, v108
+v_mul_u32_u24_e32 v106, 0x109, v106
+v_bfe_u32 v108, v109, 2, 1
+v_mad_u32_u24 v107, v107, 2, v106
+v_xor_b32_e32 v107, v107, v108
+v_and_b32_e32 v108, 0xf0, v109
+v_or_b32_e32 v107, v107, v108
+s_mul_i32 s52, 4, s53
+s_sub_u32 s52, 6, s52
+v_bfe_u32 v109, v0, s52, 1
+v_mul_u32_u24_e32 v109, 0x1040, v109
+v_mad_u32_u24 v91, 4, v107, v109
+v_xor_b32_e32 v92, 0x307, v107
+v_mad_u32_u24 v92, 4, v92, v109
+v_xor_b32_e32 v93, 0x30f, v107
+v_mad_u32_u24 v93, 4, v93, v109
+v_xor_b32_e32 v94, 8, v107
+v_mad_u32_u24 v94, 4, v94, v109
+v_subrev_co_u32_e32 v96, vcc, s76, v96
+v_mov_b32_e32 v107, s75
+v_cmp_lt_i32_e32 vcc, v96, v107
+v_subb_co_u32_e64 v106, vcc, 0, 0, vcc
+v_mad_i32_i24 v96, v106, s75, v96
+v_mad_i32_i24 v98, v106, s80, v98
+v_mad_i32_i24 v97, v106, s79, v97
+v_mov_b32_e32 v107, s74
+v_cmp_lt_i32_e32 vcc, v97, v107
+v_subb_co_u32_e64 v106, vcc, 0, 0, vcc
+v_add_co_u32_e32 v98, vcc, v98, v106
+v_mad_i32_i24 v97, v106, v107, v97
+v_subrev_co_u32_e32 v97, vcc, s77, v97
+v_cmp_lt_i32_e32 vcc, v97, v107
+v_subb_co_u32_e64 v106, vcc, 0, 0, vcc
+v_add_co_u32_e32 v98, vcc, v98, v106
+v_mad_i32_i24 v97, v106, s74, v97
+v_subrev_co_u32_e32 v98, vcc, s78, v98
+s_mov_b32 s62, 0
+s_mov_b32 s63, s28
+s_mov_b32 s64, 1
+s_mov_b32 s84, 0
+s_mov_b32 s85, s16
+s_mov_b32 s83, s85
+s_sub_u32 s93, -1, s92
+s_sub_u32 s93, s93, 16
+s_bitset1_b32 s18, 21
+s_mov_b32 s47, 0
+s_mov_b32 s51, 0
+v_add_co_u32_e32 v106, vcc, 2, v0
+v_bfe_u32 v106, v106, 2, 1
+v_cmp_ne_u32_e64 vcc, v106, 1
+s_mov_b64 s[10:11], vcc
+s_mov_b32 s94, 17
+s_mov_b32 s82, 0
+s_bitset1_b32 s18, 26
+s_call_b64 s[38:39], 1807
+v_cmp_le_u32_e32 vcc, 0x100, v0
+s_cbranch_vccnz 65
+s_branch 901
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_mac_f32_e32 v2, v34, v42
+v_mac_f32_e32 v3, v35, v42
+v_mac_f32_e32 v4, v36, v42
+v_mac_f32_e32 v5, v37, v42
+v_mac_f32_e32 v6, v34, v43
+v_mac_f32_e32 v7, v35, v43
+v_mac_f32_e32 v8, v36, v43
+v_mac_f32_e32 v9, v37, v43
+v_mac_f32_e32 v10, v34, v44
+v_mac_f32_e32 v11, v35, v44
+v_mac_f32_e32 v12, v36, v44
+v_mac_f32_e32 v13, v37, v44
+v_mac_f32_e32 v14, v34, v45
+v_mac_f32_e32 v15, v35, v45
+v_mac_f32_e32 v16, v36, v45
+v_mac_f32_e32 v17, v37, v45
+v_mac_f32_e32 v18, v34, v46
+v_mac_f32_e32 v19, v35, v46
+v_mac_f32_e32 v20, v36, v46
+v_mac_f32_e32 v21, v37, v46
+v_mac_f32_e32 v22, v34, v47
+v_mac_f32_e32 v23, v35, v47
+v_mac_f32_e32 v24, v36, v47
+v_mac_f32_e32 v25, v37, v47
+v_mac_f32_e32 v26, v34, v48
+v_mac_f32_e32 v27, v35, v48
+v_mac_f32_e32 v28, v36, v48
+v_mac_f32_e32 v29, v37, v48
+v_mac_f32_e32 v30, v34, v49
+v_mac_f32_e32 v31, v35, v49
+v_subrev_f32_e64 v66, v68, v66 div:2
+v_subrev_f32_e64 v69, v67, v69 div:2
+v_add_f32_e64 v67, v68, v67 div:2
+v_mad_f32 v68, v68, 1.0, -v67
+s_setprio 0
+s_nop 0
+v_mac_f32_e32 v32, v36, v49
+v_mac_f32_e32 v33, v37, v49
+s_nop 0
+ds_read_b128 v[34:37], v95 offset:29440
+ds_read_b128 v[42:45], v90 offset:28928
+ds_read_b128 v[46:49], v90 offset:29056
+ds_write_b32 v91, v62
+ds_write_b32 v92, v63
+s_setprio 1
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+buffer_load_dword v58, v82, s[40:43], 0 offen
+buffer_load_dword v60, v84, s[40:43], 0 offen
+buffer_load_dword v59, v83, s[40:43], 0 offen
+buffer_load_dword v61, v85, s[40:43], 0 offen
+s_add_u32 s91, s91, 0x200
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 1
+s_call_b64 s[38:39], 1664
+v_mac_f32_e32 v2, v38, v50
+v_mac_f32_e32 v3, v39, v50
+v_mac_f32_e32 v4, v40, v50
+v_mac_f32_e32 v5, v41, v50
+v_mac_f32_e32 v6, v38, v51
+v_mac_f32_e32 v7, v39, v51
+v_mac_f32_e32 v8, v40, v51
+v_mac_f32_e32 v9, v41, v51
+v_mac_f32_e32 v10, v38, v52
+v_mac_f32_e32 v11, v39, v52
+v_mac_f32_e32 v12, v40, v52
+v_mac_f32_e32 v13, v41, v52
+v_mac_f32_e32 v14, v38, v53
+v_mac_f32_e32 v15, v39, v53
+v_mac_f32_e32 v16, v40, v53
+v_mac_f32_e32 v17, v41, v53
+v_mac_f32_e32 v18, v38, v54
+v_mac_f32_e32 v19, v39, v54
+v_mac_f32_e32 v20, v40, v54
+v_mac_f32_e32 v21, v41, v54
+v_mac_f32_e32 v22, v38, v55
+v_mac_f32_e32 v23, v39, v55
+v_mac_f32_e32 v24, v40, v55
+v_mac_f32_e32 v25, v41, v55
+v_mac_f32_e32 v26, v38, v56
+v_mac_f32_e32 v27, v39, v56
+v_mac_f32_e32 v28, v40, v56
+v_mac_f32_e32 v29, v41, v56
+v_mac_f32_e32 v30, v38, v57
+v_mac_f32_e32 v31, v39, v57
+v_mac_f32_dpp v66, v66, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v67, v67, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v68, v68, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v69, v69, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+s_setprio 0
+s_nop 0
+v_mac_f32_e32 v32, v40, v57
+v_mac_f32_e32 v33, v41, v57
+s_nop 0
+ds_read_b128 v[38:41], v95 offset:33536
+ds_read_b128 v[50:53], v90 offset:33024
+ds_read_b128 v[54:57], v90 offset:33152
+ds_write_b32 v93, v68 offset:8256
+ds_write_b32 v94, v69 offset:8256
+s_setprio 1
+s_nop 0
+s_waitcnt vmcnt(12) lgkmcnt(5)
+ds_append v105 offset:65472
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 3
+s_call_b64 s[38:39], 1602
+s_nop 0
+s_nop 0
+v_mac_f32_e32 v2, v34, v42
+v_mac_f32_e32 v3, v35, v42
+v_mac_f32_e32 v4, v36, v42
+v_mac_f32_e32 v5, v37, v42
+v_mac_f32_e32 v6, v34, v43
+v_mac_f32_e32 v7, v35, v43
+v_mac_f32_e32 v8, v36, v43
+v_mac_f32_e32 v9, v37, v43
+v_mac_f32_e32 v10, v34, v44
+v_mac_f32_e32 v11, v35, v44
+v_mac_f32_e32 v12, v36, v44
+v_mac_f32_e32 v13, v37, v44
+v_mac_f32_e32 v14, v34, v45
+v_mac_f32_e32 v15, v35, v45
+v_mac_f32_e32 v16, v36, v45
+v_mac_f32_e32 v17, v37, v45
+v_mac_f32_e32 v18, v34, v46
+v_mac_f32_e32 v19, v35, v46
+v_mac_f32_e32 v20, v36, v46
+v_mac_f32_e32 v21, v37, v46
+v_mac_f32_e32 v22, v34, v47
+v_mac_f32_e32 v23, v35, v47
+v_mac_f32_e32 v24, v36, v47
+v_mac_f32_e32 v25, v37, v47
+v_mac_f32_e32 v26, v34, v48
+v_mac_f32_e32 v27, v35, v48
+v_mac_f32_e32 v28, v36, v48
+v_mac_f32_e32 v29, v37, v48
+v_mac_f32_e32 v30, v34, v49
+v_mac_f32_e32 v31, v35, v49
+v_subrev_f32_e64 v70, v72, v70 div:2
+v_subrev_f32_e64 v73, v71, v73 div:2
+v_add_f32_e64 v71, v72, v71 div:2
+v_mad_f32 v72, v72, 1.0, -v71
+s_setprio 0
+s_nop 0
+v_mac_f32_e32 v32, v36, v49
+v_mac_f32_e32 v33, v37, v49
+s_nop 0
+ds_read_b128 v[34:37], v95 offset:37696
+ds_read_b128 v[42:45], v90 offset:37184
+ds_read_b128 v[46:49], v90 offset:37312
+ds_write_b32 v91, v66 offset:8256
+ds_write_b32 v92, v67 offset:8256
+s_setprio 1
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+buffer_load_dword v62, v82, s[40:43], 0 offen
+buffer_load_dword v64, v84, s[40:43], 0 offen
+buffer_load_dword v63, v83, s[40:43], 0 offen
+buffer_load_dword v65, v85, s[40:43], 0 offen
+s_mov_b32 m0, 0x2ffc0
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 1
+s_call_b64 s[38:39], 1528
+v_mac_f32_e32 v2, v38, v50
+v_mac_f32_e32 v3, v39, v50
+v_mac_f32_e32 v4, v40, v50
+v_mac_f32_e32 v5, v41, v50
+v_mac_f32_e32 v6, v38, v51
+v_mac_f32_e32 v7, v39, v51
+v_mac_f32_e32 v8, v40, v51
+v_mac_f32_e32 v9, v41, v51
+v_mac_f32_e32 v10, v38, v52
+v_mac_f32_e32 v11, v39, v52
+v_mac_f32_e32 v12, v40, v52
+v_mac_f32_e32 v13, v41, v52
+v_mac_f32_e32 v14, v38, v53
+v_mac_f32_e32 v15, v39, v53
+v_mac_f32_e32 v16, v40, v53
+v_mac_f32_e32 v17, v41, v53
+v_mac_f32_e32 v18, v38, v54
+v_mac_f32_e32 v19, v39, v54
+v_mac_f32_e32 v20, v40, v54
+v_mac_f32_e32 v21, v41, v54
+v_mac_f32_e32 v22, v38, v55
+v_mac_f32_e32 v23, v39, v55
+v_mac_f32_e32 v24, v40, v55
+v_mac_f32_e32 v25, v41, v55
+v_mac_f32_e32 v26, v38, v56
+v_mac_f32_e32 v27, v39, v56
+v_mac_f32_e32 v28, v40, v56
+v_mac_f32_e32 v29, v41, v56
+v_mac_f32_e32 v30, v38, v57
+v_mac_f32_e32 v31, v39, v57
+v_mac_f32_e32 v32, v40, v57
+v_mac_f32_dpp v70, v70, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v71, v71, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v72, v72, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v73, v73, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+s_setprio 0
+s_nop 0
+v_mac_f32_e32 v33, v41, v57
+v_cmp_eq_u32_e64 vcc, src_lds_direct, s91
+s_nop 0
+s_nop 0
+s_cbranch_vccz 65531
+s_nop 0
+ds_read_b128 v[38:41], v95 offset:41792
+ds_read_b128 v[50:53], v90 offset:41280
+ds_read_b128 v[54:57], v90 offset:41408
+ds_write_b32 v93, v72 offset:16512
+ds_write_b32 v94, v73 offset:16512
+s_setprio 1
+s_nop 0
+s_waitcnt vmcnt(12) lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 8
+s_call_b64 s[38:39], 1463
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_mac_f32_e32 v2, v34, v42
+v_mac_f32_e32 v3, v35, v42
+v_mac_f32_e32 v4, v36, v42
+v_mac_f32_e32 v5, v37, v42
+v_mac_f32_e32 v6, v34, v43
+v_mac_f32_e32 v7, v35, v43
+v_mac_f32_e32 v8, v36, v43
+v_mac_f32_e32 v9, v37, v43
+v_mac_f32_e32 v10, v34, v44
+v_mac_f32_e32 v11, v35, v44
+v_mac_f32_e32 v12, v36, v44
+v_mac_f32_e32 v13, v37, v44
+v_mac_f32_e32 v14, v34, v45
+v_mac_f32_e32 v15, v35, v45
+v_mac_f32_e32 v16, v36, v45
+v_mac_f32_e32 v17, v37, v45
+v_mac_f32_e32 v18, v34, v46
+v_mac_f32_e32 v19, v35, v46
+v_mac_f32_e32 v20, v36, v46
+v_mac_f32_e32 v21, v37, v46
+v_mac_f32_e32 v22, v34, v47
+v_mac_f32_e32 v23, v35, v47
+v_mac_f32_e32 v24, v36, v47
+v_mac_f32_e32 v25, v37, v47
+v_mac_f32_e32 v26, v34, v48
+v_mac_f32_e32 v27, v35, v48
+v_mac_f32_e32 v28, v36, v48
+v_mac_f32_e32 v29, v37, v48
+v_mac_f32_e32 v30, v34, v49
+v_mac_f32_e32 v31, v35, v49
+v_subrev_f32_e64 v74, v76, v74 div:2
+v_subrev_f32_e64 v77, v75, v77 div:2
+v_add_f32_e64 v75, v76, v75 div:2
+v_mad_f32 v76, v76, 1.0, -v75
+s_setprio 0
+s_nop 0
+v_mac_f32_e32 v32, v36, v49
+v_mac_f32_e32 v33, v37, v49
+s_nop 0
+ds_read_b128 v[34:37], v95 offset:45952
+ds_read_b128 v[42:45], v90 offset:45440
+ds_read_b128 v[46:49], v90 offset:45568
+ds_write_b32 v91, v70 offset:16512
+ds_write_b32 v92, v71 offset:16512
+s_setprio 1
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+buffer_load_dword v66, v82, s[40:43], 0 offen
+buffer_load_dword v68, v84, s[40:43], 0 offen
+buffer_load_dword v67, v83, s[40:43], 0 offen
+buffer_load_dword v69, v85, s[40:43], 0 offen
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 3
+s_call_b64 s[38:39], 1386
+s_nop 0
+s_nop 0
+v_mac_f32_e32 v2, v38, v50
+v_mac_f32_e32 v3, v39, v50
+v_mac_f32_e32 v4, v40, v50
+v_mac_f32_e32 v5, v41, v50
+v_mac_f32_e32 v6, v38, v51
+v_mac_f32_e32 v7, v39, v51
+v_mac_f32_e32 v8, v40, v51
+v_mac_f32_e32 v9, v41, v51
+v_mac_f32_e32 v10, v38, v52
+v_mac_f32_e32 v11, v39, v52
+v_mac_f32_e32 v12, v40, v52
+v_mac_f32_e32 v13, v41, v52
+v_mac_f32_e32 v14, v38, v53
+v_mac_f32_e32 v15, v39, v53
+v_mac_f32_e32 v16, v40, v53
+v_mac_f32_e32 v17, v41, v53
+v_mac_f32_e32 v18, v38, v54
+v_mac_f32_e32 v19, v39, v54
+v_mac_f32_e32 v20, v40, v54
+v_mac_f32_e32 v21, v41, v54
+v_mac_f32_e32 v22, v38, v55
+v_mac_f32_e32 v23, v39, v55
+v_mac_f32_e32 v24, v40, v55
+v_mac_f32_e32 v25, v41, v55
+v_mac_f32_e32 v26, v38, v56
+v_mac_f32_e32 v27, v39, v56
+v_mac_f32_e32 v28, v40, v56
+v_mac_f32_e32 v29, v41, v56
+v_mac_f32_e32 v30, v38, v57
+v_mac_f32_e32 v31, v39, v57
+v_mac_f32_dpp v74, v74, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v75, v75, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v76, v76, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v77, v77, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+s_setprio 0
+s_nop 0
+v_mac_f32_e32 v32, v40, v57
+v_mac_f32_e32 v33, v41, v57
+s_nop 0
+ds_read_b128 v[38:41], v95 offset:512
+ds_read_b128 v[50:53], v90
+ds_read_b128 v[54:57], v90 offset:128
+ds_write_b32 v93, v76 offset:24768
+ds_write_b32 v94, v77 offset:24768
+s_setprio 1
+s_nop 0
+s_waitcnt vmcnt(12) lgkmcnt(5)
+ds_append v105 offset:65476
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 3
+s_call_b64 s[38:39], 1322
+s_nop 0
+s_nop 0
+v_mac_f32_e32 v2, v34, v42
+v_mac_f32_e32 v3, v35, v42
+v_mac_f32_e32 v4, v36, v42
+v_mac_f32_e32 v5, v37, v42
+v_mac_f32_e32 v6, v34, v43
+v_mac_f32_e32 v7, v35, v43
+v_mac_f32_e32 v8, v36, v43
+v_mac_f32_e32 v9, v37, v43
+v_mac_f32_e32 v10, v34, v44
+v_mac_f32_e32 v11, v35, v44
+v_mac_f32_e32 v12, v36, v44
+v_mac_f32_e32 v13, v37, v44
+v_mac_f32_e32 v14, v34, v45
+v_mac_f32_e32 v15, v35, v45
+v_mac_f32_e32 v16, v36, v45
+v_mac_f32_e32 v17, v37, v45
+v_mac_f32_e32 v18, v34, v46
+v_mac_f32_e32 v19, v35, v46
+v_mac_f32_e32 v20, v36, v46
+v_mac_f32_e32 v21, v37, v46
+v_mac_f32_e32 v22, v34, v47
+v_mac_f32_e32 v23, v35, v47
+v_mac_f32_e32 v24, v36, v47
+v_mac_f32_e32 v25, v37, v47
+v_mac_f32_e32 v26, v34, v48
+v_mac_f32_e32 v27, v35, v48
+v_mac_f32_e32 v28, v36, v48
+v_mac_f32_e32 v29, v37, v48
+v_mac_f32_e32 v30, v34, v49
+v_mac_f32_e32 v31, v35, v49
+v_subrev_f32_e64 v78, v80, v78 div:2
+v_subrev_f32_e64 v81, v79, v81 div:2
+v_add_f32_e64 v79, v80, v79 div:2
+v_mad_f32 v80, v80, 1.0, -v79
+s_setprio 0
+s_nop 0
+v_mac_f32_e32 v32, v36, v49
+v_mac_f32_e32 v33, v37, v49
+s_nop 0
+ds_read_b128 v[34:37], v95 offset:4672
+ds_read_b128 v[42:45], v90 offset:4160
+ds_read_b128 v[46:49], v90 offset:4288
+ds_write_b32 v91, v74 offset:24768
+ds_write_b32 v92, v75 offset:24768
+s_setprio 1
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+buffer_load_dword v70, v82, s[40:43], 0 offen
+buffer_load_dword v72, v84, s[40:43], 0 offen
+buffer_load_dword v71, v83, s[40:43], 0 offen
+buffer_load_dword v73, v85, s[40:43], 0 offen
+s_mov_b32 m0, 0x2ffc4
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 1
+s_call_b64 s[38:39], 1248
+v_mac_f32_e32 v2, v38, v50
+v_mac_f32_e32 v3, v39, v50
+v_mac_f32_e32 v4, v40, v50
+v_mac_f32_e32 v5, v41, v50
+v_mac_f32_e32 v6, v38, v51
+v_mac_f32_e32 v7, v39, v51
+v_mac_f32_e32 v8, v40, v51
+v_mac_f32_e32 v9, v41, v51
+v_mac_f32_e32 v10, v38, v52
+v_mac_f32_e32 v11, v39, v52
+v_mac_f32_e32 v12, v40, v52
+v_mac_f32_e32 v13, v41, v52
+v_mac_f32_e32 v14, v38, v53
+v_mac_f32_e32 v15, v39, v53
+v_mac_f32_e32 v16, v40, v53
+v_mac_f32_e32 v17, v41, v53
+v_mac_f32_e32 v18, v38, v54
+v_mac_f32_e32 v19, v39, v54
+v_mac_f32_e32 v20, v40, v54
+v_mac_f32_e32 v21, v41, v54
+v_mac_f32_e32 v22, v38, v55
+v_mac_f32_e32 v23, v39, v55
+v_mac_f32_e32 v24, v40, v55
+v_mac_f32_e32 v25, v41, v55
+v_mac_f32_e32 v26, v38, v56
+v_mac_f32_e32 v27, v39, v56
+v_mac_f32_e32 v28, v40, v56
+v_mac_f32_e32 v29, v41, v56
+v_mac_f32_e32 v30, v38, v57
+v_mac_f32_e32 v31, v39, v57
+v_mac_f32_e32 v32, v40, v57
+v_mac_f32_dpp v78, v78, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v79, v79, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v80, v80, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v81, v81, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+s_setprio 0
+s_nop 0
+v_mac_f32_e32 v33, v41, v57
+v_cmp_eq_u32_e64 vcc, src_lds_direct, s91
+s_nop 0
+s_nop 0
+s_cbranch_vccz 65531
+s_nop 0
+ds_read_b128 v[38:41], v95 offset:8768
+ds_read_b128 v[50:53], v90 offset:8256
+ds_read_b128 v[54:57], v90 offset:8384
+ds_write_b32 v93, v80 offset:33024
+ds_write_b32 v94, v81 offset:33024
+s_setprio 1
+s_nop 0
+s_waitcnt vmcnt(12) lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 8
+s_call_b64 s[38:39], 1183
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_mac_f32_e32 v2, v34, v42
+v_mac_f32_e32 v3, v35, v42
+v_mac_f32_e32 v4, v36, v42
+v_mac_f32_e32 v5, v37, v42
+v_mac_f32_e32 v6, v34, v43
+v_mac_f32_e32 v7, v35, v43
+v_mac_f32_e32 v8, v36, v43
+v_mac_f32_e32 v9, v37, v43
+v_mac_f32_e32 v10, v34, v44
+v_mac_f32_e32 v11, v35, v44
+v_mac_f32_e32 v12, v36, v44
+v_mac_f32_e32 v13, v37, v44
+v_mac_f32_e32 v14, v34, v45
+v_mac_f32_e32 v15, v35, v45
+v_mac_f32_e32 v16, v36, v45
+v_mac_f32_e32 v17, v37, v45
+v_mac_f32_e32 v18, v34, v46
+v_mac_f32_e32 v19, v35, v46
+v_mac_f32_e32 v20, v36, v46
+v_mac_f32_e32 v21, v37, v46
+v_mac_f32_e32 v22, v34, v47
+v_mac_f32_e32 v23, v35, v47
+v_mac_f32_e32 v24, v36, v47
+v_mac_f32_e32 v25, v37, v47
+v_mac_f32_e32 v26, v34, v48
+v_mac_f32_e32 v27, v35, v48
+v_mac_f32_e32 v28, v36, v48
+v_mac_f32_e32 v29, v37, v48
+v_mac_f32_e32 v30, v34, v49
+v_mac_f32_e32 v31, v35, v49
+v_subrev_f32_e64 v58, v60, v58 div:2
+v_subrev_f32_e64 v61, v59, v61 div:2
+v_add_f32_e64 v59, v60, v59 div:2
+v_mad_f32 v60, v60, 1.0, -v59
+s_setprio 0
+s_nop 0
+v_mac_f32_e32 v32, v36, v49
+v_mac_f32_e32 v33, v37, v49
+s_nop 0
+ds_read_b128 v[34:37], v95 offset:12928
+ds_read_b128 v[42:45], v90 offset:12416
+ds_read_b128 v[46:49], v90 offset:12544
+ds_write_b32 v91, v78 offset:33024
+ds_write_b32 v92, v79 offset:33024
+s_setprio 1
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+buffer_load_dword v74, v82, s[40:43], 0 offen
+buffer_load_dword v76, v84, s[40:43], 0 offen
+buffer_load_dword v75, v83, s[40:43], 0 offen
+buffer_load_dword v77, v85, s[40:43], 0 offen
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 3
+s_call_b64 s[38:39], 1106
+s_nop 0
+s_nop 0
+v_mac_f32_e32 v2, v38, v50
+v_mac_f32_e32 v3, v39, v50
+v_mac_f32_e32 v4, v40, v50
+v_mac_f32_e32 v5, v41, v50
+v_mac_f32_e32 v6, v38, v51
+v_mac_f32_e32 v7, v39, v51
+v_mac_f32_e32 v8, v40, v51
+v_mac_f32_e32 v9, v41, v51
+v_mac_f32_e32 v10, v38, v52
+v_mac_f32_e32 v11, v39, v52
+v_mac_f32_e32 v12, v40, v52
+v_mac_f32_e32 v13, v41, v52
+v_mac_f32_e32 v14, v38, v53
+v_mac_f32_e32 v15, v39, v53
+v_mac_f32_e32 v16, v40, v53
+v_mac_f32_e32 v17, v41, v53
+v_mac_f32_e32 v18, v38, v54
+v_mac_f32_e32 v19, v39, v54
+v_mac_f32_e32 v20, v40, v54
+v_mac_f32_e32 v21, v41, v54
+v_mac_f32_e32 v22, v38, v55
+v_mac_f32_e32 v23, v39, v55
+v_mac_f32_e32 v24, v40, v55
+v_mac_f32_e32 v25, v41, v55
+v_mac_f32_e32 v26, v38, v56
+v_mac_f32_e32 v27, v39, v56
+v_mac_f32_e32 v28, v40, v56
+v_mac_f32_e32 v29, v41, v56
+v_mac_f32_e32 v30, v38, v57
+v_mac_f32_e32 v31, v39, v57
+v_mac_f32_dpp v58, v58, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v59, v59, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v60, v60, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v61, v61, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+s_setprio 0
+s_nop 0
+v_mac_f32_e32 v32, v40, v57
+v_mac_f32_e32 v33, v41, v57
+s_nop 0
+ds_read_b128 v[38:41], v95 offset:17024
+ds_read_b128 v[50:53], v90 offset:16512
+ds_read_b128 v[54:57], v90 offset:16640
+ds_write_b32 v93, v60 offset:41280
+ds_write_b32 v94, v61 offset:41280
+s_setprio 1
+s_nop 0
+s_waitcnt vmcnt(12) lgkmcnt(5)
+ds_append v105 offset:65480
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 3
+s_call_b64 s[38:39], 1042
+s_nop 0
+s_nop 0
+v_mac_f32_e32 v2, v34, v42
+v_mac_f32_e32 v3, v35, v42
+v_mac_f32_e32 v4, v36, v42
+v_mac_f32_e32 v5, v37, v42
+v_mac_f32_e32 v6, v34, v43
+v_mac_f32_e32 v7, v35, v43
+v_mac_f32_e32 v8, v36, v43
+v_mac_f32_e32 v9, v37, v43
+v_mac_f32_e32 v10, v34, v44
+v_mac_f32_e32 v11, v35, v44
+v_mac_f32_e32 v12, v36, v44
+v_mac_f32_e32 v13, v37, v44
+v_mac_f32_e32 v14, v34, v45
+v_mac_f32_e32 v15, v35, v45
+v_mac_f32_e32 v16, v36, v45
+v_mac_f32_e32 v17, v37, v45
+v_mac_f32_e32 v18, v34, v46
+v_mac_f32_e32 v19, v35, v46
+v_mac_f32_e32 v20, v36, v46
+v_mac_f32_e32 v21, v37, v46
+v_mac_f32_e32 v22, v34, v47
+v_mac_f32_e32 v23, v35, v47
+v_mac_f32_e32 v24, v36, v47
+v_mac_f32_e32 v25, v37, v47
+v_mac_f32_e32 v26, v34, v48
+v_mac_f32_e32 v27, v35, v48
+v_mac_f32_e32 v28, v36, v48
+v_mac_f32_e32 v29, v37, v48
+v_mac_f32_e32 v30, v34, v49
+v_mac_f32_e32 v31, v35, v49
+v_subrev_f32_e64 v62, v64, v62 div:2
+v_subrev_f32_e64 v65, v63, v65 div:2
+v_add_f32_e64 v63, v64, v63 div:2
+v_mad_f32 v64, v64, 1.0, -v63
+s_setprio 0
+s_nop 0
+v_mac_f32_e32 v32, v36, v49
+v_mac_f32_e32 v33, v37, v49
+s_nop 0
+ds_read_b128 v[34:37], v95 offset:21184
+ds_read_b128 v[42:45], v90 offset:20672
+ds_read_b128 v[46:49], v90 offset:20800
+ds_write_b32 v91, v58 offset:41280
+ds_write_b32 v92, v59 offset:41280
+s_setprio 1
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+buffer_load_dword v78, v82, s[40:43], 0 offen
+buffer_load_dword v80, v84, s[40:43], 0 offen
+buffer_load_dword v79, v83, s[40:43], 0 offen
+buffer_load_dword v81, v85, s[40:43], 0 offen
+s_mov_b32 m0, 0x2ffc8
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 1
+s_call_b64 s[38:39], 968
+v_mac_f32_e32 v2, v38, v50
+v_mac_f32_e32 v3, v39, v50
+v_mac_f32_e32 v4, v40, v50
+v_mac_f32_e32 v5, v41, v50
+v_mac_f32_e32 v6, v38, v51
+v_mac_f32_e32 v7, v39, v51
+v_mac_f32_e32 v8, v40, v51
+v_mac_f32_e32 v9, v41, v51
+v_mac_f32_e32 v10, v38, v52
+v_mac_f32_e32 v11, v39, v52
+v_mac_f32_e32 v12, v40, v52
+v_mac_f32_e32 v13, v41, v52
+v_mac_f32_e32 v14, v38, v53
+v_mac_f32_e32 v15, v39, v53
+v_mac_f32_e32 v16, v40, v53
+v_mac_f32_e32 v17, v41, v53
+v_mac_f32_e32 v18, v38, v54
+v_mac_f32_e32 v19, v39, v54
+v_mac_f32_e32 v20, v40, v54
+v_mac_f32_e32 v21, v41, v54
+v_mac_f32_e32 v22, v38, v55
+v_mac_f32_e32 v23, v39, v55
+v_mac_f32_e32 v24, v40, v55
+v_mac_f32_e32 v25, v41, v55
+v_mac_f32_e32 v26, v38, v56
+v_mac_f32_e32 v27, v39, v56
+v_mac_f32_e32 v28, v40, v56
+v_mac_f32_e32 v29, v41, v56
+v_mac_f32_e32 v30, v38, v57
+v_mac_f32_e32 v31, v39, v57
+v_mac_f32_e32 v32, v40, v57
+v_mac_f32_dpp v62, v62, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v63, v63, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v64, v64, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v65, v65, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+s_setprio 0
+s_nop 0
+v_mac_f32_e32 v33, v41, v57
+v_cmp_eq_u32_e64 vcc, src_lds_direct, s91
+s_nop 0
+s_nop 0
+s_cbranch_vccz 65531
+s_nop 0
+ds_read_b128 v[38:41], v95 offset:25280
+ds_read_b128 v[50:53], v90 offset:24768
+ds_read_b128 v[54:57], v90 offset:24896
+ds_write_b32 v93, v64
+ds_write_b32 v94, v65
+s_setprio 1
+s_nop 0
+s_waitcnt vmcnt(12) lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 64704
+s_call_b64 s[38:39], 903
+s_branch 64702
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_mac_f32_e32 v2, v34, v42
+v_mac_f32_e32 v3, v35, v42
+v_mac_f32_e32 v4, v36, v42
+s_setprio 1
+s_nop 0
+v_mac_f32_e32 v5, v37, v42
+v_mac_f32_e32 v6, v34, v43
+v_mac_f32_e32 v7, v35, v43
+v_mac_f32_e32 v8, v36, v43
+v_mac_f32_e32 v9, v37, v43
+v_mac_f32_e32 v10, v34, v44
+v_mac_f32_e32 v11, v35, v44
+v_mac_f32_e32 v12, v36, v44
+v_mac_f32_e32 v13, v37, v44
+v_mac_f32_e32 v14, v34, v45
+v_mac_f32_e32 v15, v35, v45
+v_mac_f32_e32 v16, v36, v45
+v_mac_f32_e32 v17, v37, v45
+v_mac_f32_e32 v18, v34, v46
+v_mac_f32_e32 v19, v35, v46
+v_mac_f32_e32 v20, v36, v46
+v_mac_f32_e32 v21, v37, v46
+v_mac_f32_e32 v22, v34, v47
+v_mac_f32_e32 v23, v35, v47
+v_mac_f32_e32 v24, v36, v47
+v_mac_f32_e32 v25, v37, v47
+v_mac_f32_e32 v26, v34, v48
+v_mac_f32_e32 v27, v35, v48
+v_mac_f32_e32 v28, v36, v48
+v_mac_f32_e32 v29, v37, v48
+v_mac_f32_e32 v30, v34, v49
+v_mac_f32_e32 v31, v35, v49
+v_cndmask_b32_dpp v66, v66, v66, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v67, v67, v67, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v68, v68, v68, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v69, v69, v69, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v66, v67, v67  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v66, v67, v100  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_mac_f32_e32 v32, v36, v49
+v_mac_f32_e32 v33, v37, v49
+s_nop 0
+ds_read_b128 v[34:37], v95 offset:29440
+ds_read_b128 v[42:45], v90 offset:28928
+ds_read_b128 v[46:49], v90 offset:29056
+ds_write_b32 v91, v62
+ds_write_b32 v92, v63
+s_setprio 0
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+buffer_load_dword v60, v84, s[40:43], 0 offen
+buffer_load_dword v59, v83, s[40:43], 0 offen
+buffer_load_dword v61, v85, s[40:43], 0 offen
+s_add_u32 s91, s91, 0x200
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 7
+s_call_b64 s[38:39], 822
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_mac_f32_e32 v2, v38, v50
+v_mac_f32_e32 v3, v39, v50
+v_mac_f32_e32 v4, v40, v50
+s_setprio 1
+s_nop 0
+v_mac_f32_e32 v5, v41, v50
+v_mac_f32_e32 v6, v38, v51
+v_mac_f32_e32 v7, v39, v51
+v_mac_f32_e32 v8, v40, v51
+v_mac_f32_e32 v9, v41, v51
+v_mac_f32_e32 v10, v38, v52
+v_mac_f32_e32 v11, v39, v52
+v_mac_f32_e32 v12, v40, v52
+v_mac_f32_e32 v13, v41, v52
+v_mac_f32_e32 v14, v38, v53
+v_mac_f32_e32 v15, v39, v53
+v_mac_f32_e32 v16, v40, v53
+v_mac_f32_e32 v17, v41, v53
+v_mac_f32_e32 v18, v38, v54
+v_mac_f32_e32 v19, v39, v54
+v_mac_f32_e32 v20, v40, v54
+v_mac_f32_e32 v21, v41, v54
+v_mac_f32_e32 v22, v38, v55
+v_mac_f32_e32 v23, v39, v55
+v_mac_f32_e32 v24, v40, v55
+v_mac_f32_e32 v25, v41, v55
+v_mac_f32_e32 v26, v38, v56
+v_mac_f32_e32 v27, v39, v56
+v_mac_f32_e32 v28, v40, v56
+v_mac_f32_e32 v29, v41, v56
+v_mac_f32_e32 v30, v38, v57
+v_mac_f32_e32 v31, v39, v57
+v_add_f32_dpp v103, v69, v69  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v103, v69, v100  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v69, v68, v68  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v69, v68, v100  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_add_f32_e32 v68, v66, v69
+v_add_f32_e64 v67, v103, v68 div:2
+v_add_f32_e64 v68, -v103, v68 div:2
+v_mac_f32_e32 v32, v40, v57
+v_mac_f32_e32 v33, v41, v57
+s_nop 0
+ds_read_b128 v[38:41], v95 offset:33536
+ds_read_b128 v[50:53], v90 offset:33024
+ds_read_b128 v[54:57], v90 offset:33152
+ds_write_b32 v93, v68 offset:8256
+ds_write_b32 v94, v69 offset:8256
+s_setprio 0
+s_nop 0
+s_waitcnt vmcnt(9) lgkmcnt(5)
+ds_append v105 offset:65472
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 6
+s_call_b64 s[38:39], 749
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_mac_f32_e32 v2, v34, v42
+v_mac_f32_e32 v3, v35, v42
+v_mac_f32_e32 v4, v36, v42
+s_setprio 1
+s_nop 0
+v_mac_f32_e32 v5, v37, v42
+v_mac_f32_e32 v6, v34, v43
+v_mac_f32_e32 v7, v35, v43
+v_mac_f32_e32 v8, v36, v43
+v_mac_f32_e32 v9, v37, v43
+v_mac_f32_e32 v10, v34, v44
+v_mac_f32_e32 v11, v35, v44
+v_mac_f32_e32 v12, v36, v44
+v_mac_f32_e32 v13, v37, v44
+v_mac_f32_e32 v14, v34, v45
+v_mac_f32_e32 v15, v35, v45
+v_mac_f32_e32 v16, v36, v45
+v_mac_f32_e32 v17, v37, v45
+v_mac_f32_e32 v18, v34, v46
+v_mac_f32_e32 v19, v35, v46
+v_mac_f32_e32 v20, v36, v46
+v_mac_f32_e32 v21, v37, v46
+v_mac_f32_e32 v22, v34, v47
+v_mac_f32_e32 v23, v35, v47
+v_mac_f32_e32 v24, v36, v47
+v_mac_f32_e32 v25, v37, v47
+v_mac_f32_e32 v26, v34, v48
+v_mac_f32_e32 v27, v35, v48
+v_mac_f32_e32 v28, v36, v48
+v_mac_f32_e32 v29, v37, v48
+v_mac_f32_e32 v30, v34, v49
+v_mac_f32_e32 v31, v35, v49
+v_cndmask_b32_dpp v70, v70, v70, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v71, v71, v71, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v72, v72, v72, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v73, v73, v73, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v70, v71, v71  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v70, v71, v100  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_mac_f32_e32 v32, v36, v49
+v_mac_f32_e32 v33, v37, v49
+s_nop 0
+ds_read_b128 v[34:37], v95 offset:37696
+ds_read_b128 v[42:45], v90 offset:37184
+ds_read_b128 v[46:49], v90 offset:37312
+ds_write_b32 v91, v66 offset:8256
+ds_write_b32 v92, v67 offset:8256
+s_setprio 0
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+buffer_load_dword v64, v84, s[40:43], 0 offen
+buffer_load_dword v63, v83, s[40:43], 0 offen
+buffer_load_dword v65, v85, s[40:43], 0 offen
+s_mov_b32 m0, 0x2ffc0
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 7
+s_call_b64 s[38:39], 670
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_mac_f32_e32 v2, v38, v50
+v_mac_f32_e32 v3, v39, v50
+v_mac_f32_e32 v4, v40, v50
+s_setprio 1
+s_nop 0
+v_mac_f32_e32 v5, v41, v50
+v_mac_f32_e32 v6, v38, v51
+v_mac_f32_e32 v7, v39, v51
+v_mac_f32_e32 v8, v40, v51
+v_mac_f32_e32 v9, v41, v51
+v_mac_f32_e32 v10, v38, v52
+v_mac_f32_e32 v11, v39, v52
+v_mac_f32_e32 v12, v40, v52
+v_mac_f32_e32 v13, v41, v52
+v_mac_f32_e32 v14, v38, v53
+v_mac_f32_e32 v15, v39, v53
+v_mac_f32_e32 v16, v40, v53
+v_mac_f32_e32 v17, v41, v53
+v_mac_f32_e32 v18, v38, v54
+v_mac_f32_e32 v19, v39, v54
+v_mac_f32_e32 v20, v40, v54
+v_mac_f32_e32 v21, v41, v54
+v_mac_f32_e32 v22, v38, v55
+v_mac_f32_e32 v23, v39, v55
+v_mac_f32_e32 v24, v40, v55
+v_mac_f32_e32 v25, v41, v55
+v_mac_f32_e32 v26, v38, v56
+v_mac_f32_e32 v27, v39, v56
+v_mac_f32_e32 v28, v40, v56
+v_mac_f32_e32 v29, v41, v56
+v_mac_f32_e32 v30, v38, v57
+v_mac_f32_e32 v31, v39, v57
+v_mac_f32_e32 v32, v40, v57
+v_add_f32_dpp v103, v73, v73  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v103, v73, v100  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v73, v72, v72  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v73, v72, v100  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_add_f32_e32 v72, v70, v73
+v_add_f32_e64 v71, v103, v72 div:2
+v_add_f32_e64 v72, -v103, v72 div:2
+v_mac_f32_e32 v33, v41, v57
+v_cmp_eq_u32_e64 vcc, src_lds_direct, s91
+s_nop 0
+s_nop 0
+s_cbranch_vccz 65531
+s_mov_b64 vcc, s[10:11]
+s_nop 0
+ds_read_b128 v[38:41], v95 offset:41792
+ds_read_b128 v[50:53], v90 offset:41280
+ds_read_b128 v[54:57], v90 offset:41408
+ds_write_b32 v93, v72 offset:16512
+ds_write_b32 v94, v73 offset:16512
+s_setprio 0
+s_nop 0
+s_waitcnt vmcnt(9) lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 2
+s_call_b64 s[38:39], 593
+s_nop 0
+v_mac_f32_e32 v2, v34, v42
+v_mac_f32_e32 v3, v35, v42
+v_mac_f32_e32 v4, v36, v42
+s_setprio 1
+s_nop 0
+v_mac_f32_e32 v5, v37, v42
+v_mac_f32_e32 v6, v34, v43
+v_mac_f32_e32 v7, v35, v43
+v_mac_f32_e32 v8, v36, v43
+v_mac_f32_e32 v9, v37, v43
+v_mac_f32_e32 v10, v34, v44
+v_mac_f32_e32 v11, v35, v44
+v_mac_f32_e32 v12, v36, v44
+v_mac_f32_e32 v13, v37, v44
+v_mac_f32_e32 v14, v34, v45
+v_mac_f32_e32 v15, v35, v45
+v_mac_f32_e32 v16, v36, v45
+v_mac_f32_e32 v17, v37, v45
+v_mac_f32_e32 v18, v34, v46
+v_mac_f32_e32 v19, v35, v46
+v_mac_f32_e32 v20, v36, v46
+v_mac_f32_e32 v21, v37, v46
+v_mac_f32_e32 v22, v34, v47
+v_mac_f32_e32 v23, v35, v47
+v_mac_f32_e32 v24, v36, v47
+v_mac_f32_e32 v25, v37, v47
+v_mac_f32_e32 v26, v34, v48
+v_mac_f32_e32 v27, v35, v48
+v_mac_f32_e32 v28, v36, v48
+v_mac_f32_e32 v29, v37, v48
+v_mac_f32_e32 v30, v34, v49
+v_mac_f32_e32 v31, v35, v49
+v_cndmask_b32_dpp v74, v74, v74, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v75, v75, v75, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v76, v76, v76, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v77, v77, v77, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v74, v75, v75  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v74, v75, v100  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_mac_f32_e32 v32, v36, v49
+v_mac_f32_e32 v33, v37, v49
+s_nop 0
+ds_read_b128 v[34:37], v95 offset:45952
+ds_read_b128 v[42:45], v90 offset:45440
+ds_read_b128 v[46:49], v90 offset:45568
+ds_write_b32 v91, v70 offset:16512
+ds_write_b32 v92, v71 offset:16512
+s_setprio 0
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+buffer_load_dword v68, v84, s[40:43], 0 offen
+buffer_load_dword v67, v83, s[40:43], 0 offen
+buffer_load_dword v69, v85, s[40:43], 0 offen
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 1
+s_call_b64 s[38:39], 520
+v_mac_f32_e32 v2, v38, v50
+v_mac_f32_e32 v3, v39, v50
+v_mac_f32_e32 v4, v40, v50
+s_setprio 1
+s_nop 0
+v_mac_f32_e32 v5, v41, v50
+v_mac_f32_e32 v6, v38, v51
+v_mac_f32_e32 v7, v39, v51
+v_mac_f32_e32 v8, v40, v51
+v_mac_f32_e32 v9, v41, v51
+v_mac_f32_e32 v10, v38, v52
+v_mac_f32_e32 v11, v39, v52
+v_mac_f32_e32 v12, v40, v52
+v_mac_f32_e32 v13, v41, v52
+v_mac_f32_e32 v14, v38, v53
+v_mac_f32_e32 v15, v39, v53
+v_mac_f32_e32 v16, v40, v53
+v_mac_f32_e32 v17, v41, v53
+v_mac_f32_e32 v18, v38, v54
+v_mac_f32_e32 v19, v39, v54
+v_mac_f32_e32 v20, v40, v54
+v_mac_f32_e32 v21, v41, v54
+v_mac_f32_e32 v22, v38, v55
+v_mac_f32_e32 v23, v39, v55
+v_mac_f32_e32 v24, v40, v55
+v_mac_f32_e32 v25, v41, v55
+v_mac_f32_e32 v26, v38, v56
+v_mac_f32_e32 v27, v39, v56
+v_mac_f32_e32 v28, v40, v56
+v_mac_f32_e32 v29, v41, v56
+v_mac_f32_e32 v30, v38, v57
+v_mac_f32_e32 v31, v39, v57
+v_add_f32_dpp v103, v77, v77  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v103, v77, v100  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v77, v76, v76  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v77, v76, v100  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_add_f32_e32 v76, v74, v77
+v_add_f32_e64 v75, v103, v76 div:2
+v_add_f32_e64 v76, -v103, v76 div:2
+v_mac_f32_e32 v32, v40, v57
+v_mac_f32_e32 v33, v41, v57
+s_nop 0
+ds_read_b128 v[38:41], v95 offset:512
+ds_read_b128 v[50:53], v90
+ds_read_b128 v[54:57], v90 offset:128
+ds_write_b32 v93, v76 offset:24768
+ds_write_b32 v94, v77 offset:24768
+s_setprio 0
+s_nop 0
+s_waitcnt vmcnt(9) lgkmcnt(5)
+ds_append v105 offset:65476
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 6
+s_call_b64 s[38:39], 453
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_mac_f32_e32 v2, v34, v42
+v_mac_f32_e32 v3, v35, v42
+v_mac_f32_e32 v4, v36, v42
+s_setprio 1
+s_nop 0
+v_mac_f32_e32 v5, v37, v42
+v_mac_f32_e32 v6, v34, v43
+v_mac_f32_e32 v7, v35, v43
+v_mac_f32_e32 v8, v36, v43
+v_mac_f32_e32 v9, v37, v43
+v_mac_f32_e32 v10, v34, v44
+v_mac_f32_e32 v11, v35, v44
+v_mac_f32_e32 v12, v36, v44
+v_mac_f32_e32 v13, v37, v44
+v_mac_f32_e32 v14, v34, v45
+v_mac_f32_e32 v15, v35, v45
+v_mac_f32_e32 v16, v36, v45
+v_mac_f32_e32 v17, v37, v45
+v_mac_f32_e32 v18, v34, v46
+v_mac_f32_e32 v19, v35, v46
+v_mac_f32_e32 v20, v36, v46
+v_mac_f32_e32 v21, v37, v46
+v_mac_f32_e32 v22, v34, v47
+v_mac_f32_e32 v23, v35, v47
+v_mac_f32_e32 v24, v36, v47
+v_mac_f32_e32 v25, v37, v47
+v_mac_f32_e32 v26, v34, v48
+v_mac_f32_e32 v27, v35, v48
+v_mac_f32_e32 v28, v36, v48
+v_mac_f32_e32 v29, v37, v48
+v_mac_f32_e32 v30, v34, v49
+v_mac_f32_e32 v31, v35, v49
+v_cndmask_b32_dpp v78, v78, v78, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v79, v79, v79, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v80, v80, v80, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v81, v81, v81, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v78, v79, v79  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v78, v79, v100  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_mac_f32_e32 v32, v36, v49
+v_mac_f32_e32 v33, v37, v49
+s_nop 0
+ds_read_b128 v[34:37], v95 offset:4672
+ds_read_b128 v[42:45], v90 offset:4160
+ds_read_b128 v[46:49], v90 offset:4288
+ds_write_b32 v91, v74 offset:24768
+ds_write_b32 v92, v75 offset:24768
+s_setprio 0
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+buffer_load_dword v72, v84, s[40:43], 0 offen
+buffer_load_dword v71, v83, s[40:43], 0 offen
+buffer_load_dword v73, v85, s[40:43], 0 offen
+s_mov_b32 m0, 0x2ffc4
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 7
+s_call_b64 s[38:39], 374
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_mac_f32_e32 v2, v38, v50
+v_mac_f32_e32 v3, v39, v50
+v_mac_f32_e32 v4, v40, v50
+s_setprio 1
+s_nop 0
+v_mac_f32_e32 v5, v41, v50
+v_mac_f32_e32 v6, v38, v51
+v_mac_f32_e32 v7, v39, v51
+v_mac_f32_e32 v8, v40, v51
+v_mac_f32_e32 v9, v41, v51
+v_mac_f32_e32 v10, v38, v52
+v_mac_f32_e32 v11, v39, v52
+v_mac_f32_e32 v12, v40, v52
+v_mac_f32_e32 v13, v41, v52
+v_mac_f32_e32 v14, v38, v53
+v_mac_f32_e32 v15, v39, v53
+v_mac_f32_e32 v16, v40, v53
+v_mac_f32_e32 v17, v41, v53
+v_mac_f32_e32 v18, v38, v54
+v_mac_f32_e32 v19, v39, v54
+v_mac_f32_e32 v20, v40, v54
+v_mac_f32_e32 v21, v41, v54
+v_mac_f32_e32 v22, v38, v55
+v_mac_f32_e32 v23, v39, v55
+v_mac_f32_e32 v24, v40, v55
+v_mac_f32_e32 v25, v41, v55
+v_mac_f32_e32 v26, v38, v56
+v_mac_f32_e32 v27, v39, v56
+v_mac_f32_e32 v28, v40, v56
+v_mac_f32_e32 v29, v41, v56
+v_mac_f32_e32 v30, v38, v57
+v_mac_f32_e32 v31, v39, v57
+v_mac_f32_e32 v32, v40, v57
+v_add_f32_dpp v103, v81, v81  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v103, v81, v100  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v81, v80, v80  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v81, v80, v100  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_add_f32_e32 v80, v78, v81
+v_add_f32_e64 v79, v103, v80 div:2
+v_add_f32_e64 v80, -v103, v80 div:2
+v_mac_f32_e32 v33, v41, v57
+v_cmp_eq_u32_e64 vcc, src_lds_direct, s91
+s_nop 0
+s_nop 0
+s_cbranch_vccz 65531
+s_mov_b64 vcc, s[10:11]
+s_nop 0
+ds_read_b128 v[38:41], v95 offset:8768
+ds_read_b128 v[50:53], v90 offset:8256
+ds_read_b128 v[54:57], v90 offset:8384
+ds_write_b32 v93, v80 offset:33024
+ds_write_b32 v94, v81 offset:33024
+s_setprio 0
+s_nop 0
+s_waitcnt vmcnt(9) lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 2
+s_call_b64 s[38:39], 297
+s_nop 0
+v_mac_f32_e32 v2, v34, v42
+v_mac_f32_e32 v3, v35, v42
+v_mac_f32_e32 v4, v36, v42
+s_setprio 1
+s_nop 0
+v_mac_f32_e32 v5, v37, v42
+v_mac_f32_e32 v6, v34, v43
+v_mac_f32_e32 v7, v35, v43
+v_mac_f32_e32 v8, v36, v43
+v_mac_f32_e32 v9, v37, v43
+v_mac_f32_e32 v10, v34, v44
+v_mac_f32_e32 v11, v35, v44
+v_mac_f32_e32 v12, v36, v44
+v_mac_f32_e32 v13, v37, v44
+v_mac_f32_e32 v14, v34, v45
+v_mac_f32_e32 v15, v35, v45
+v_mac_f32_e32 v16, v36, v45
+v_mac_f32_e32 v17, v37, v45
+v_mac_f32_e32 v18, v34, v46
+v_mac_f32_e32 v19, v35, v46
+v_mac_f32_e32 v20, v36, v46
+v_mac_f32_e32 v21, v37, v46
+v_mac_f32_e32 v22, v34, v47
+v_mac_f32_e32 v23, v35, v47
+v_mac_f32_e32 v24, v36, v47
+v_mac_f32_e32 v25, v37, v47
+v_mac_f32_e32 v26, v34, v48
+v_mac_f32_e32 v27, v35, v48
+v_mac_f32_e32 v28, v36, v48
+v_mac_f32_e32 v29, v37, v48
+v_mac_f32_e32 v30, v34, v49
+v_mac_f32_e32 v31, v35, v49
+v_cndmask_b32_dpp v58, v58, v58, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v59, v59, v59, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v60, v60, v60, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v61, v61, v61, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v58, v59, v59  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v58, v59, v100  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_mac_f32_e32 v32, v36, v49
+v_mac_f32_e32 v33, v37, v49
+s_nop 0
+ds_read_b128 v[34:37], v95 offset:12928
+ds_read_b128 v[42:45], v90 offset:12416
+ds_read_b128 v[46:49], v90 offset:12544
+ds_write_b32 v91, v78 offset:33024
+ds_write_b32 v92, v79 offset:33024
+s_setprio 0
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+buffer_load_dword v76, v84, s[40:43], 0 offen
+buffer_load_dword v75, v83, s[40:43], 0 offen
+buffer_load_dword v77, v85, s[40:43], 0 offen
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 1
+s_call_b64 s[38:39], 224
+v_mac_f32_e32 v2, v38, v50
+v_mac_f32_e32 v3, v39, v50
+v_mac_f32_e32 v4, v40, v50
+s_setprio 1
+s_nop 0
+v_mac_f32_e32 v5, v41, v50
+v_mac_f32_e32 v6, v38, v51
+v_mac_f32_e32 v7, v39, v51
+v_mac_f32_e32 v8, v40, v51
+v_mac_f32_e32 v9, v41, v51
+v_mac_f32_e32 v10, v38, v52
+v_mac_f32_e32 v11, v39, v52
+v_mac_f32_e32 v12, v40, v52
+v_mac_f32_e32 v13, v41, v52
+v_mac_f32_e32 v14, v38, v53
+v_mac_f32_e32 v15, v39, v53
+v_mac_f32_e32 v16, v40, v53
+v_mac_f32_e32 v17, v41, v53
+v_mac_f32_e32 v18, v38, v54
+v_mac_f32_e32 v19, v39, v54
+v_mac_f32_e32 v20, v40, v54
+v_mac_f32_e32 v21, v41, v54
+v_mac_f32_e32 v22, v38, v55
+v_mac_f32_e32 v23, v39, v55
+v_mac_f32_e32 v24, v40, v55
+v_mac_f32_e32 v25, v41, v55
+v_mac_f32_e32 v26, v38, v56
+v_mac_f32_e32 v27, v39, v56
+v_mac_f32_e32 v28, v40, v56
+v_mac_f32_e32 v29, v41, v56
+v_mac_f32_e32 v30, v38, v57
+v_mac_f32_e32 v31, v39, v57
+v_add_f32_dpp v103, v61, v61  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v103, v61, v100  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v61, v60, v60  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v61, v60, v100  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_add_f32_e32 v60, v58, v61
+v_add_f32_e64 v59, v103, v60 div:2
+v_add_f32_e64 v60, -v103, v60 div:2
+v_mac_f32_e32 v32, v40, v57
+v_mac_f32_e32 v33, v41, v57
+s_nop 0
+ds_read_b128 v[38:41], v95 offset:17024
+ds_read_b128 v[50:53], v90 offset:16512
+ds_read_b128 v[54:57], v90 offset:16640
+ds_write_b32 v93, v60 offset:41280
+ds_write_b32 v94, v61 offset:41280
+s_setprio 0
+s_nop 0
+s_waitcnt vmcnt(9) lgkmcnt(5)
+ds_append v105 offset:65480
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 6
+s_call_b64 s[38:39], 157
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_mac_f32_e32 v2, v34, v42
+v_mac_f32_e32 v3, v35, v42
+v_mac_f32_e32 v4, v36, v42
+s_setprio 1
+s_nop 0
+v_mac_f32_e32 v5, v37, v42
+v_mac_f32_e32 v6, v34, v43
+v_mac_f32_e32 v7, v35, v43
+v_mac_f32_e32 v8, v36, v43
+v_mac_f32_e32 v9, v37, v43
+v_mac_f32_e32 v10, v34, v44
+v_mac_f32_e32 v11, v35, v44
+v_mac_f32_e32 v12, v36, v44
+v_mac_f32_e32 v13, v37, v44
+v_mac_f32_e32 v14, v34, v45
+v_mac_f32_e32 v15, v35, v45
+v_mac_f32_e32 v16, v36, v45
+v_mac_f32_e32 v17, v37, v45
+v_mac_f32_e32 v18, v34, v46
+v_mac_f32_e32 v19, v35, v46
+v_mac_f32_e32 v20, v36, v46
+v_mac_f32_e32 v21, v37, v46
+v_mac_f32_e32 v22, v34, v47
+v_mac_f32_e32 v23, v35, v47
+v_mac_f32_e32 v24, v36, v47
+v_mac_f32_e32 v25, v37, v47
+v_mac_f32_e32 v26, v34, v48
+v_mac_f32_e32 v27, v35, v48
+v_mac_f32_e32 v28, v36, v48
+v_mac_f32_e32 v29, v37, v48
+v_mac_f32_e32 v30, v34, v49
+v_mac_f32_e32 v31, v35, v49
+v_cndmask_b32_dpp v62, v62, v62, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v63, v63, v63, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v64, v64, v64, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v65, v65, v65, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v62, v63, v63  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v62, v63, v100  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_mac_f32_e32 v32, v36, v49
+v_mac_f32_e32 v33, v37, v49
+s_nop 0
+ds_read_b128 v[34:37], v95 offset:21184
+ds_read_b128 v[42:45], v90 offset:20672
+ds_read_b128 v[46:49], v90 offset:20800
+ds_write_b32 v91, v58 offset:41280
+ds_write_b32 v92, v59 offset:41280
+s_setprio 0
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+buffer_load_dword v80, v84, s[40:43], 0 offen
+buffer_load_dword v79, v83, s[40:43], 0 offen
+buffer_load_dword v81, v85, s[40:43], 0 offen
+s_mov_b32 m0, 0x2ffc8
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 7
+s_call_b64 s[38:39], 78
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_mac_f32_e32 v2, v38, v50
+v_mac_f32_e32 v3, v39, v50
+v_mac_f32_e32 v4, v40, v50
+s_setprio 1
+s_nop 0
+v_mac_f32_e32 v5, v41, v50
+v_mac_f32_e32 v6, v38, v51
+v_mac_f32_e32 v7, v39, v51
+v_mac_f32_e32 v8, v40, v51
+v_mac_f32_e32 v9, v41, v51
+v_mac_f32_e32 v10, v38, v52
+v_mac_f32_e32 v11, v39, v52
+v_mac_f32_e32 v12, v40, v52
+v_mac_f32_e32 v13, v41, v52
+v_mac_f32_e32 v14, v38, v53
+v_mac_f32_e32 v15, v39, v53
+v_mac_f32_e32 v16, v40, v53
+v_mac_f32_e32 v17, v41, v53
+v_mac_f32_e32 v18, v38, v54
+v_mac_f32_e32 v19, v39, v54
+v_mac_f32_e32 v20, v40, v54
+v_mac_f32_e32 v21, v41, v54
+v_mac_f32_e32 v22, v38, v55
+v_mac_f32_e32 v23, v39, v55
+v_mac_f32_e32 v24, v40, v55
+v_mac_f32_e32 v25, v41, v55
+v_mac_f32_e32 v26, v38, v56
+v_mac_f32_e32 v27, v39, v56
+v_mac_f32_e32 v28, v40, v56
+v_mac_f32_e32 v29, v41, v56
+v_mac_f32_e32 v30, v38, v57
+v_mac_f32_e32 v31, v39, v57
+v_mac_f32_e32 v32, v40, v57
+v_add_f32_dpp v103, v65, v65  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v103, v65, v100  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v65, v64, v64  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v65, v64, v100  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_add_f32_e32 v64, v62, v65
+v_add_f32_e64 v63, v103, v64 div:2
+v_add_f32_e64 v64, -v103, v64 div:2
+v_mac_f32_e32 v33, v41, v57
+v_cmp_eq_u32_e64 vcc, src_lds_direct, s91
+s_nop 0
+s_nop 0
+s_cbranch_vccz 65531
+s_mov_b64 vcc, s[10:11]
+s_nop 0
+ds_read_b128 v[38:41], v95 offset:25280
+ds_read_b128 v[50:53], v90 offset:24768
+ds_read_b128 v[54:57], v90 offset:24896
+ds_write_b32 v93, v64
+ds_write_b32 v94, v65
+s_setprio 0
+s_nop 0
+s_waitcnt vmcnt(9) lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 64642
+s_call_b64 s[38:39], 1
+s_branch 64640
+v_nop
+s_cmp_eq_u32 s82, 0
+s_cbranch_scc0 8
+s_branch 596
+s_add_u32 s82, s82, 1
+s_andn2_b32 s82, s82, 1
+s_bitcmp1_b32 0, 26
+s_cselect_b32 s52, s69, s70
+s_cselect_b32 s53, 0, s71
+s_sub_u32 s40, s40, s52
+s_subb_u32 s41, s41, s53
+s_cmp_eq_u32 s94, 0
+s_cbranch_scc0 3
+s_cbranch_scc1 626
+s_nop 0
+s_nop 0
+s_min_u32 s72, s82, s94
+s_sub_u32 s82, s82, s72
+s_sub_u32 s94, s94, s72
+s_sub_u32 s72, s72, 1
+s_setpc_b64 s[38:39]
+s_nop 0
+s_nop 0
+s_nop 0
+s_bitcmp1_b32 s18, 17
+s_cbranch_scc1 241
+s_add_u32 s88, s88, s17
+s_cmp_eq_u32 s88, 0
+s_cbranch_scc1 238
+s_mov_b32 s89, 0
+s_bitcmp1_b32 s18, 16
+s_cbranch_scc1 227
+s_add_u32 s87, s16, 15
+s_lshr_b32 s87, s87, 4
+v_mov_b32_e32 v107, s88
+v_mul_u32_u24_e32 v107, s87, v107
+v_add_co_u32_e32 v107, vcc, s17, v107
+v_sub_co_u32_e64 v107, vcc, v107, 1
+v_ffbh_u32_e32 v110, s17
+v_lshlrev_b32_e64 v111, v110, s17
+v_and_b32_e32 v112, 0xffffff00, v111
+v_cmp_eq_u32_e32 vcc, 0x80000000, v111
+v_cvt_f32_u32_e32 v112, v112
+v_rcp_f32_e32 v106, v112
+v_subb_co_u32_e32 v109, vcc, 32, v110, vcc
+v_cvt_f32_ubyte0_e32 v110, v111
+v_fma_f32 v112, v112, v106, -1.0
+v_fma_f32 v112, v110, v106, v112
+v_madak_f32 v112, v112, v106, 0x9f000000
+v_mul_f32_e32 v112, 0x5f800000, v112
+v_mov_b32_e32 v110, 0
+v_cvt_flr_i32_f32_e64 v112, -v112
+v_lshl_add_u32 v106, v106, 9, v112
+v_mad_u64_u32 v[110:111], vcc, v111, v106, v[110:111]
+v_subb_co_u32_e64 v106, vcc, v106, -1, vcc
+v_mul_hi_u32 v110, v107, v106
+v_add_co_u32_e32 v106, vcc, v110, v107
+v_addc_co_u32_e64 v110, vcc, 0, 0, vcc
+v_cmp_eq_u32_e32 vcc, 32, v109
+v_cndmask_b32_e32 v106, v106, v110, vcc
+v_alignbit_b32 v106, v110, v106, v109
+v_readfirstlane_b32 s86, v106
+v_mul_u32_u24_e64 v106, v106, s8
+v_ffbh_u32_e32 v110, s87
+v_lshlrev_b32_e64 v111, v110, s87
+v_and_b32_e32 v112, 0xffffff00, v111
+v_cmp_eq_u32_e32 vcc, 0x80000000, v111
+v_cvt_f32_u32_e32 v112, v112
+v_rcp_f32_e32 v107, v112
+v_subb_co_u32_e32 v109, vcc, 32, v110, vcc
+v_cvt_f32_ubyte0_e32 v110, v111
+v_fma_f32 v112, v112, v107, -1.0
+v_fma_f32 v112, v110, v107, v112
+v_madak_f32 v112, v112, v107, 0x9f000000
+v_mul_f32_e32 v112, 0x5f800000, v112
+v_mov_b32_e32 v110, 0
+v_cvt_flr_i32_f32_e64 v112, -v112
+v_lshl_add_u32 v107, v107, 9, v112
+v_mad_u64_u32 v[110:111], vcc, v111, v107, v[110:111]
+v_subb_co_u32_e64 v107, vcc, v107, -1, vcc
+v_mul_hi_u32 v110, v106, v107
+v_add_co_u32_e32 v107, vcc, v110, v106
+v_addc_co_u32_e64 v110, vcc, 0, 0, vcc
+v_cmp_eq_u32_e32 vcc, 32, v109
+v_cndmask_b32_e32 v107, v107, v110, vcc
+v_alignbit_b32 v107, v110, v107, v109
+v_readfirstlane_b32 s52, v106
+v_readfirstlane_b32 s84, v107
+s_mul_i32 s84, s84, s87
+s_sub_u32 s84, s52, s84
+v_sub_co_u32_e32 v107, vcc, s8, v107
+v_sub_co_u32_e32 v107, vcc, s17, v107
+v_and_b32_e64 v109, v0, 63
+v_cmp_eq_u32_e64 vcc, v109, 0
+v_cndmask_b32_e32 v107, 1, v107, vcc
+s_sub_u32 s58, 0, s75
+s_sub_u32 s59, 0, s74
+v_mul_u32_u24_e64 v111, v107, 32
+v_ffbh_u32_e32 v113, s58
+v_lshlrev_b32_e64 v114, v113, s58
+v_and_b32_e32 v115, 0xffffff00, v114
+v_cmp_eq_u32_e32 vcc, 0x80000000, v114
+v_cvt_f32_u32_e32 v115, v115
+v_rcp_f32_e32 v109, v115
+v_subb_co_u32_e32 v112, vcc, 32, v113, vcc
+v_cvt_f32_ubyte0_e32 v113, v114
+v_fma_f32 v115, v115, v109, -1.0
+v_fma_f32 v115, v113, v109, v115
+v_madak_f32 v115, v115, v109, 0x9f000000
+v_mul_f32_e32 v115, 0x5f800000, v115
+v_mov_b32_e32 v113, 0
+v_cvt_flr_i32_f32_e64 v115, -v115
+v_lshl_add_u32 v109, v109, 9, v115
+v_mad_u64_u32 v[113:114], vcc, v114, v109, v[113:114]
+v_subb_co_u32_e64 v109, vcc, v109, -1, vcc
+v_mul_hi_u32 v113, v111, v109
+v_add_co_u32_e32 v109, vcc, v113, v111
+v_addc_co_u32_e64 v113, vcc, 0, 0, vcc
+v_cmp_eq_u32_e32 vcc, 32, v112
+v_cndmask_b32_e32 v109, v109, v113, vcc
+v_alignbit_b32 v109, v113, v109, v112
+v_mad_i32_i24 v110, v109, s75, v111
+v_mul_u32_u24_e64 v111, v109, 1
+v_ffbh_u32_e32 v113, s59
+v_lshlrev_b32_e64 v114, v113, s59
+v_and_b32_e32 v115, 0xffffff00, v114
+v_cmp_eq_u32_e32 vcc, 0x80000000, v114
+v_cvt_f32_u32_e32 v115, v115
+v_rcp_f32_e32 v109, v115
+v_subb_co_u32_e32 v112, vcc, 32, v113, vcc
+v_cvt_f32_ubyte0_e32 v113, v114
+v_fma_f32 v115, v115, v109, -1.0
+v_fma_f32 v115, v113, v109, v115
+v_madak_f32 v115, v115, v109, 0x9f000000
+v_mul_f32_e32 v115, 0x5f800000, v115
+v_mov_b32_e32 v113, 0
+v_cvt_flr_i32_f32_e64 v115, -v115
+v_lshl_add_u32 v109, v109, 9, v115
+v_mad_u64_u32 v[113:114], vcc, v114, v109, v[113:114]
+v_subb_co_u32_e64 v109, vcc, v109, -1, vcc
+v_mul_hi_u32 v113, v111, v109
+v_add_co_u32_e32 v109, vcc, v113, v111
+v_addc_co_u32_e64 v113, vcc, 0, 0, vcc
+v_cmp_eq_u32_e32 vcc, 32, v112
+v_cndmask_b32_e32 v109, v109, v113, vcc
+v_alignbit_b32 v109, v113, v109, v112
+v_mad_i32_i24 v111, v109, s74, v111
+v_readfirstlane_b32 s76, v110
+v_readfirstlane_b32 s77, v111
+v_readfirstlane_b32 s78, v109
+v_add_co_u32_e32 v96, vcc, s76, v96
+v_addc_co_u32_e64 v112, vcc, 0, 0, vcc
+v_mad_i32_i24 v96, v112, s75, v96
+v_mad_i32_i24 v98, v112, s80, v98
+v_mad_i32_i24 v97, v112, s79, v97
+v_cmp_ge_i32_e64 vcc, v97, 0
+v_addc_co_u32_e64 v112, vcc, 0, 0, vcc
+v_add_co_u32_e32 v98, vcc, v98, v112
+v_mad_i32_i24 v97, v112, s74, v97
+v_add_co_u32_e32 v97, vcc, s77, v97
+v_addc_co_u32_e64 v112, vcc, 0, 0, vcc
+v_add_co_u32_e32 v98, vcc, v98, v112
+v_mad_i32_i24 v97, v112, s74, v97
+v_add_co_u32_e32 v98, vcc, s78, v98
+v_readlane_b32 s76, v110, 1
+v_readlane_b32 s77, v111, 1
+v_readlane_b32 s78, v109, 1
+s_add_u32 s85, s84, s86
+s_cmp_le_u32 s85, s87
+s_cselect_b32 s52, 0x20000, 0
+s_cselect_b32 s85, s85, s87
+s_or_b32 s18, s18, s52
+s_lshl_b32 s84, s84, 4
+s_lshl_b32 s85, s85, 4
+s_min_u32 s85, s85, s16
+s_cmp_eq_u32 s8, s17
+s_cselect_b32 s52, 0x20000, 0
+s_or_b32 s18, s18, s52
+s_or_b32 s18, s18, s52
+s_bitset1_b32 s18, 16
+s_branch 43
+s_lshr_b32 s84, s84, 4
+s_add_u32 s85, s84, s86
+s_sub_u32 s85, s85, s87
+s_mov_b32 s84, 0
+s_lshl_b32 s85, s85, 4
+s_min_u32 s85, s85, s16
+s_bitset1_b32 s18, 17
+s_branch 12
+s_bitset1_b32 s18, 18
+s_mov_b32 s43, 0
+s_mov_b32 s73, -1
+s_mov_b32 s82, 40
+s_branch 31
+s_add_u32 s83, s83, 16
+s_cmp_ge_u32 s83, s85
+s_cbranch_scc0 28
+s_bitset1_b32 s18, 22
+s_sub_u32 s88, s88, s17
+s_subb_u32 s89, s89, 0
+s_cbranch_scc1 65281
+v_add_co_u32_e32 v96, vcc, s76, v96
+v_addc_co_u32_e64 v106, vcc, 0, 0, vcc
+v_mad_i32_i24 v96, v106, s75, v96
+v_mad_i32_i24 v98, v106, s80, v98
+v_mad_i32_i24 v97, v106, s79, v97
+v_cmp_ge_i32_e64 vcc, v97, 0
+v_addc_co_u32_e64 v106, vcc, 0, 0, vcc
+v_add_co_u32_e32 v98, vcc, v98, v106
+v_mad_i32_i24 v97, v106, s74, v97
+v_add_co_u32_e32 v97, vcc, s77, v97
+v_addc_co_u32_e64 v106, vcc, 0, 0, vcc
+v_add_co_u32_e32 v98, vcc, v98, v106
+v_mad_i32_i24 v97, v106, s74, v97
+v_add_co_u32_e32 v98, vcc, s78, v98
+s_mov_b32 s83, s84
+v_cmp_le_u32_e32 vcc, 0x100, v0
+s_cbranch_vccz 166
+v_subrev_co_u32_e32 v106, vcc, s75, v96
+v_subrev_co_u32_e32 v107, vcc, s74, v97
+s_bitcmp1_b32 s18, 22
+s_cbranch_scc0 64
+s_bitset0_b32 s18, 22
+s_bfe_u32 s52, s18, 0x10014
+v_mul_u32_u24_e32 v111, 2, v106
+v_mul_u32_u24_e32 v112, 2, v107
+v_cvt_pk_u16_u32 v114, v111, v112
+v_and_b32_e64 v111, v0, 1
+v_cmp_eq_u32_e64 vcc, v111, 1
+v_cndmask_b32_e32 v114, v98, v114, vcc
+v_lshrrev_b32_e32 v110, 1, v0
+v_bfe_u32 v115, v110, s52, 1
+v_lshrrev_b32_e32 v110, 1, v0
+v_bfi_b32 v110, 1, v0, v110
+v_lshrrev_b32_e32 v111, 2, v0
+v_bfi_b32 v111, 1, v0, v111
+v_cmp_eq_u32_e64 vcc, s52, 0
+v_cndmask_b32_e32 v110, v111, v110, vcc
+s_sub_u32 s52, 1, s52
+v_lshrrev_b32_e32 v111, s52, v110
+v_bfi_b32 v110, 32, v111, v110
+v_and_b32_e32 v110, 63, v110
+v_add_co_u32_e32 v111, vcc, 16, v110
+v_and_b32_e64 v112, v0, 2
+v_cmp_eq_u32_e64 vcc, v112, 0
+v_cndmask_b32_e32 v111, v111, v110, vcc
+v_lshlrev_b32_e32 v112, 14, v115
+v_mad_u32_u24 v111, 4, v111, v112
+v_add_co_u32_e32 v110, vcc, s96, v111
+ds_write_b32 v110, v114
+v_writelane_b32 v112, s18, 0
+v_writelane_b32 v112, s85, 1
+v_writelane_b32 v112, s84, 2
+v_and_b32_e64 v110, v0, 63
+v_cmp_ge_u32_e64 vcc, v110, 3
+v_mov_b32_e32 v113, 0x4000
+v_cndmask_b32_e32 v110, v110, v113, vcc
+v_mad_i32_i24 v110, v110, 4, s96
+ds_write_b32 v110, v112 offset:256
+s_add_u32 s96, s96, 0x18c
+s_cmp_eq_u32 s96, 0xffc0
+s_cselect_b32 s96, 0xc1e0, s96
+v_mov_b32_dpp v108, v98  quad_perm:[0,0,0,0] row_mask:0xf bank_mask:0xf
+v_mov_b32_dpp v106, v106  quad_perm:[0,0,0,0] row_mask:0xf bank_mask:0xf
+v_mov_b32_dpp v107, v107  quad_perm:[0,0,0,0] row_mask:0xf bank_mask:0xf
+v_readfirstlane_b32 s81, v108
+v_sub_co_u32_e64 v109, vcc, v108, s81
+v_mul_lo_u32 v109, v109, s65
+v_and_b32_e64 v113, v0, 3
+v_ashrrev_i32_e64 v114, 1, s31
+v_subrev_co_u32_e32 v113, vcc, v114, v113
+v_ashrrev_i32_e64 v114, 1, s62
+v_mad_i32_i24 v110, v114, 3, v113
+s_bfe_u32 s52, s18, 0x10014
+v_lshrrev_b32_e32 v112, 2, v0
+v_and_b32_e32 v112, s52, v112
+v_mad_i32_i24 v110, v112, 3, v110
+v_add_co_u32_e64 v111, vcc, 1, s63
+v_ashrrev_i32_e32 v111, 1, v111
+v_add_co_u32_e64 v112, vcc, 1, s30
+v_ashrrev_i32_e32 v112, 1, v112
+v_sub_i32 v111, v111, v112
+s_lshl_b32 s54, s15, 2
+v_cmp_ge_u32_e64 s[52:53], v108, s12
+v_mad_i32_i24 v106, v106, 2, v110
+v_cmp_ge_u32_e64 s[56:57], v106, s15
+v_mad_i32_i24 v106, 4, v106, v109
+s_or_b64 s[56:57], s[56:57], s[52:53]
+v_mad_i32_i24 v107, v107, 2, v111
+v_cmp_ge_u32_e64 s[58:59], v107, s14
+s_or_b64 s[58:59], s[56:57], s[58:59]
+v_mad_u32_u24 v82, v107, s54, v106
+v_cndmask_b32_e64 v82, v82, -1, s[58:59]
+v_add_co_u32_e32 v107, vcc, 1, v107
+v_cmp_ge_u32_e64 s[58:59], v107, s14
+s_or_b64 s[58:59], s[56:57], s[58:59]
+v_mad_u32_u24 v83, v107, s54, v106
+v_cndmask_b32_e64 v83, v83, -1, s[58:59]
+v_add_co_u32_e32 v107, vcc, 1, v107
+v_cmp_ge_u32_e64 s[58:59], v107, s14
+s_or_b64 s[58:59], s[56:57], s[58:59]
+v_mad_u32_u24 v84, v107, s54, v106
+v_cndmask_b32_e64 v84, v84, -1, s[58:59]
+v_add_co_u32_e32 v107, vcc, 1, v107
+v_cmp_ge_u32_e64 s[58:59], v107, s14
+s_or_b64 s[58:59], s[56:57], s[58:59]
+v_mad_u32_u24 v85, v107, s54, v106
+v_cndmask_b32_e64 v85, v85, -1, s[58:59]
+s_bitcmp1_b32 s18, 18
+s_cbranch_scc1 138
+s_lshr_b32 s52, -1, 16
+s_and_b32 s52, s52, s65
+s_lshr_b32 s53, s65, 16
+s_mul_i32 s53, s53, s81
+s_mul_i32 s40, s52, s81
+s_lshl_b32 s52, s53, 16
+s_lshr_b32 s53, s53, 16
+s_add_u32 s40, s52, s40
+s_addc_u32 s41, s53, 0
+s_add_u32 s40, s40, s20
+s_addc_u32 s41, s41, s21
+s_lshr_b32 s52, s18, 6
+s_xor_b32 s52, s52, s18
+s_and_b32 s52, s52, 0x80000
+s_cselect_b32 s52, s68, 0
+s_add_u32 s40, s40, s52
+s_addc_u32 s41, s41, 0
+s_branch 95
+s_bitcmp1_b32 s18, 18
+s_cbranch_scc1 117
+v_mad_u32_u24 v108, 5, v0, 2
+v_lshlrev_b32_e32 v106, 1, v0
+v_bfi_b32 v108, 4, v108, v106
+v_bfe_u32 v106, v108, 2, 2
+v_min_u32_e32 v106, 2, v106
+v_bfe_u32 v108, v0, 1, 1
+v_mad_u32_u24 v106, 2, v106, v108
+v_mad_u32_u24 v106, s62, 3, v106
+v_sub_co_u32_e32 v108, vcc, s29, v106
+v_sub_co_u32_e64 v108, vcc, v108, 1
+s_bfe_u32 s54, s18, 0x10001
+v_cmp_eq_u32_e64 vcc, s54, 1
+v_cndmask_b32_e32 v106, v106, v108, vcc
+v_cmp_ge_u32_e64 s[52:53], v106, s29
+v_lshlrev_b32_e32 v106, 2, v106
+s_bfe_u32 s54, s18, 0x10018
+v_bfe_u32 v109, v0, 2, s54
+v_mul_lo_u32 v109, s68, v109
+v_add_co_u32_e32 v106, vcc, v106, v109
+v_mul_lo_u32 v107, s90, v99
+v_add_co_u32_e32 v107, vcc, v107, v106
+s_sub_u32 s54, s28, s63
+s_sub_u32 s54, s54, 5
+s_bitcmp1_b32 s18, 0
+s_cselect_b32 s54, s54, s63
+v_mov_b32_e32 v109, s54
+s_lshl_b32 s57, s29, 2
+v_cmp_ge_u32_e64 s[54:55], v109, s28
+v_mad_i32_i24 v82, v109, s57, v107
+s_or_b64 s[54:55], s[54:55], s[52:53]
+v_cndmask_b32_e64 v82, v82, -1, s[54:55]
+v_mov_b32_e32 v83, v82
+v_add_co_u32_e64 v109, vcc, v109, 2
+v_cmp_ge_u32_e64 s[54:55], v109, s28
+v_mad_i32_i24 v85, v109, s57, v107
+s_or_b64 s[54:55], s[54:55], s[52:53]
+v_cndmask_b32_e64 v85, v85, -1, s[54:55]
+v_add_co_u32_e64 v109, vcc, v109, 2
+v_cmp_ge_u32_e64 s[54:55], v109, s28
+v_mad_i32_i24 v84, v109, s57, v107
+s_or_b64 s[54:55], s[54:55], s[52:53]
+v_cndmask_b32_e64 v84, v84, -1, s[54:55]
+v_add_co_u32_e64 v106, vcc, v99, s83
+v_cmp_lt_u32_e64 vcc, v106, s16
+v_cndmask_b32_e32 v82, -1, v82, vcc
+v_cndmask_b32_e32 v83, -1, v83, vcc
+v_cndmask_b32_e32 v84, -1, v84, vcc
+v_cndmask_b32_e32 v85, -1, v85, vcc
+s_lshr_b32 s52, -1, 16
+s_and_b32 s52, s52, s90
+s_lshr_b32 s53, s90, 16
+s_mul_i32 s53, s53, s83
+s_mul_i32 s40, s52, s83
+s_lshl_b32 s52, s53, 16
+s_lshr_b32 s53, s53, 16
+s_add_u32 s40, s52, s40
+s_addc_u32 s41, s53, 0
+s_add_u32 s40, s40, s22
+s_addc_u32 s41, s41, s23
+s_lshr_b32 s52, s18, 6
+s_xor_b32 s52, s52, s18
+s_and_b32 s52, s52, 0x80000
+s_cselect_b32 s52, s68, 0
+s_add_u32 s40, s40, s52
+s_addc_u32 s41, s41, 0
+s_mov_b32 s43, 0x20000
+s_mov_b32 s73, -1
+s_bfe_u32 s52, s18, 0x10014
+s_lshl_b32 s82, s13, s52
+s_bfe_u32 s52, s18, 0x10013
+s_bfe_u32 s54, s18, 0x10019
+s_xor_b32 s52, s52, s54
+s_cselect_b32 s52, 1, 0
+s_cselect_b32 s43, 0x20000, s43
+s_and_b32 s52, s52, s82
+s_sub_u32 s82, s82, s52
+s_bitcmp1_b32 s18, 20
+s_cselect_b32 s52, 0, 0x2000000
+s_bitcmp1_b32 s13, 0
+s_cselect_b32 s52, s52, 0
+s_xor_b32 s18, s18, s52
+s_cmp_eq_u32 s82, 0
+s_cbranch_scc1 9
+s_mov_b64 vcc, s[10:11]
+s_branch 64947
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_and_b32 s52, 0x900000, s18
+s_subb_u32 s62, s62, 1
+s_cbranch_scc0 65235
+s_and_b32 s52, 0x900000, s18
+s_subb_u32 s62, s61, 1
+s_add_u32 s63, s63, 6
+s_cmp_ge_u32 s63, s28
+s_cbranch_scc0 65229
+s_mov_b32 s63, 1
+s_cmp_ge_u32 s63, s28
+s_addc_u32 s64, s64, 1
+s_cmp_gt_u32 s64, 1
+s_cbranch_scc0 65224
+s_mov_b32 s64, 0
+s_mov_b32 s63, 0
+s_branch 65190
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_mac_f32_dpp v4, v4, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v5, v5, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v2, v2, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v3, v3, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v3, v4, v3  row_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v2, v5, v2  row_mirror row_mask:0xf bank_mask:0xf
+s_nop 0
+v_mac_f32_dpp v3, v3, v102  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mac_f32_dpp v2, v2, v102  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+s_nop 0
+v_add_f32_dpp v2, v3, v2  row_half_mirror row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v8, v8, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v9, v9, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v6, v6, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v7, v7, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v7, v8, v7  row_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v6, v9, v6  row_mirror row_mask:0xf bank_mask:0xf
+s_nop 0
+v_mac_f32_dpp v7, v7, v102  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mac_f32_dpp v6, v6, v102  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+s_nop 0
+v_add_f32_dpp v3, v7, v6  row_half_mirror row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v12, v12, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v13, v13, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v10, v10, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v11, v11, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v11, v12, v11  row_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v10, v13, v10  row_mirror row_mask:0xf bank_mask:0xf
+s_nop 0
+v_mac_f32_dpp v11, v11, v102  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mac_f32_dpp v10, v10, v102  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+s_nop 0
+v_add_f32_dpp v4, v11, v10  row_half_mirror row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v16, v16, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v17, v17, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v14, v14, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v15, v15, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v15, v16, v15  row_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v14, v17, v14  row_mirror row_mask:0xf bank_mask:0xf
+s_nop 0
+v_mac_f32_dpp v15, v15, v102  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mac_f32_dpp v14, v14, v102  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+s_nop 0
+v_add_f32_dpp v5, v15, v14  row_half_mirror row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v20, v20, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v21, v21, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v18, v18, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v19, v19, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v19, v20, v19  row_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v18, v21, v18  row_mirror row_mask:0xf bank_mask:0xf
+s_nop 0
+v_mac_f32_dpp v19, v19, v102  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mac_f32_dpp v18, v18, v102  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+s_nop 0
+v_add_f32_dpp v6, v19, v18  row_half_mirror row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v24, v24, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v25, v25, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v22, v22, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v23, v23, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v23, v24, v23  row_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v22, v25, v22  row_mirror row_mask:0xf bank_mask:0xf
+s_nop 0
+v_mac_f32_dpp v23, v23, v102  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mac_f32_dpp v22, v22, v102  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+s_nop 0
+v_add_f32_dpp v7, v23, v22  row_half_mirror row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v28, v28, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v29, v29, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v26, v26, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v27, v27, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v27, v28, v27  row_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v26, v29, v26  row_mirror row_mask:0xf bank_mask:0xf
+s_nop 0
+v_mac_f32_dpp v27, v27, v102  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mac_f32_dpp v26, v26, v102  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+s_nop 0
+v_add_f32_dpp v8, v27, v26  row_half_mirror row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v32, v32, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v33, v33, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v30, v30, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v31, v31, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v31, v32, v31  row_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v30, v33, v30  row_mirror row_mask:0xf bank_mask:0xf
+s_nop 0
+v_mac_f32_dpp v31, v31, v102  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mac_f32_dpp v30, v30, v102  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+s_nop 0
+v_add_f32_dpp v9, v31, v30  row_half_mirror row_mask:0xf bank_mask:0xf
+s_waitcnt vmcnt(0)
+s_mov_b64 s[54:55], s[44:45]
+s_mov_b32 s53, s47
+v_bfe_u32 v106, s18, 21, 1
+v_sub_co_u32_e64 v106, vcc, v106, 1
+v_cndmask_b32_e32 v110, v88, v86, vcc
+v_cndmask_b32_e32 v111, v89, v87, vcc
+v_readlane_b32 s52, v104, 0
+v_add_f32_e64 v2, v2, s52
+v_mul_f32_e64 v106, v2, s36
+v_cmp_lt_f32_e64 vcc, v2, 0
+v_cndmask_b32_e32 v2, v2, v106, vcc
+buffer_store_dword v2, v110, s[44:47], 0 offen
+v_add_f32_e64 v3, v3, s52
+v_mul_f32_e64 v106, v3, s36
+v_cmp_lt_f32_e64 vcc, v3, 0
+v_cndmask_b32_e32 v3, v3, v106, vcc
+buffer_store_dword v3, v111, s[44:47], 0 offen
+s_add_u32 s44, s44, s67
+s_addc_u32 s45, s45, 0
+s_sub_u32 s93, s93, 1
+s_cselect_b32 s47, 0, s47
+v_readlane_b32 s52, v104, 1
+v_add_f32_e64 v4, v4, s52
+v_mul_f32_e64 v106, v4, s36
+v_cmp_lt_f32_e64 vcc, v4, 0
+v_cndmask_b32_e32 v4, v4, v106, vcc
+buffer_store_dword v4, v110, s[44:47], 0 offen
+v_add_f32_e64 v5, v5, s52
+v_mul_f32_e64 v106, v5, s36
+v_cmp_lt_f32_e64 vcc, v5, 0
+v_cndmask_b32_e32 v5, v5, v106, vcc
+buffer_store_dword v5, v111, s[44:47], 0 offen
+s_add_u32 s44, s44, s67
+s_addc_u32 s45, s45, 0
+s_sub_u32 s93, s93, 1
+s_cselect_b32 s47, 0, s47
+s_lshl_b32 s52, s67, 1
+s_add_u32 s44, s44, s52
+s_addc_u32 s45, s45, 0
+s_sub_u32 s93, s93, 2
+s_cselect_b32 s47, 0, s47
+v_readlane_b32 s52, v104, 4
+v_add_f32_e64 v6, v6, s52
+v_mul_f32_e64 v106, v6, s36
+v_cmp_lt_f32_e64 vcc, v6, 0
+v_cndmask_b32_e32 v6, v6, v106, vcc
+buffer_store_dword v6, v110, s[44:47], 0 offen
+v_add_f32_e64 v7, v7, s52
+v_mul_f32_e64 v106, v7, s36
+v_cmp_lt_f32_e64 vcc, v7, 0
+v_cndmask_b32_e32 v7, v7, v106, vcc
+buffer_store_dword v7, v111, s[44:47], 0 offen
+s_add_u32 s44, s44, s67
+s_addc_u32 s45, s45, 0
+s_sub_u32 s93, s93, 1
+s_cselect_b32 s47, 0, s47
+v_readlane_b32 s52, v104, 5
+v_add_f32_e64 v8, v8, s52
+v_mul_f32_e64 v106, v8, s36
+v_cmp_lt_f32_e64 vcc, v8, 0
+v_cndmask_b32_e32 v8, v8, v106, vcc
+buffer_store_dword v8, v110, s[44:47], 0 offen
+v_add_f32_e64 v9, v9, s52
+v_mul_f32_e64 v106, v9, s36
+v_cmp_lt_f32_e64 vcc, v9, 0
+v_cndmask_b32_e32 v9, v9, v106, vcc
+buffer_store_dword v9, v111, s[44:47], 0 offen
+s_add_u32 s44, s44, s67
+s_addc_u32 s45, s45, 0
+s_sub_u32 s93, s93, 1
+s_cselect_b32 s47, 0, s47
+s_lshl_b32 s52, s67, 1
+s_add_u32 s44, s44, s52
+s_addc_u32 s45, s45, 0
+s_lshl_b32 s52, s52, 2
+s_add_u32 s44, s44, s52
+s_addc_u32 s45, s45, 0
+s_sub_u32 s93, s93, 10
+s_cselect_b32 s47, 0, s47
+s_bitcmp1_b32 s18, 21
+s_cselect_b32 s47, s47, s53
+s_cselect_b32 s44, s44, s54
+s_cselect_b32 s45, s45, s55
+s_cselect_b32 s53, 0, 16
+s_cselect_b32 s54, 64, 0
+s_add_u32 s93, s93, s53
+s_add_u32 s48, s48, s54
+s_addc_u32 s49, s49, 0
+s_sub_u32 s50, s50, s54
+s_cselect_b32 s51, 0, s51
+v_mov_b32_e32 v2, 0
+v_mov_b32_e32 v3, 0
+v_mov_b32_e32 v4, 0
+v_mov_b32_e32 v5, 0
+v_mov_b32_e32 v6, 0
+v_mov_b32_e32 v7, 0
+v_mov_b32_e32 v8, 0
+v_mov_b32_e32 v9, 0
+v_mov_b32_e32 v10, 0
+v_mov_b32_e32 v11, 0
+v_mov_b32_e32 v12, 0
+v_mov_b32_e32 v13, 0
+v_mov_b32_e32 v14, 0
+v_mov_b32_e32 v15, 0
+v_mov_b32_e32 v16, 0
+v_mov_b32_e32 v17, 0
+v_mov_b32_e32 v18, 0
+v_mov_b32_e32 v19, 0
+v_mov_b32_e32 v20, 0
+v_mov_b32_e32 v21, 0
+v_mov_b32_e32 v22, 0
+v_mov_b32_e32 v23, 0
+v_mov_b32_e32 v24, 0
+v_mov_b32_e32 v25, 0
+v_mov_b32_e32 v26, 0
+v_mov_b32_e32 v27, 0
+v_mov_b32_e32 v28, 0
+v_mov_b32_e32 v29, 0
+v_mov_b32_e32 v30, 0
+v_mov_b32_e32 v31, 0
+v_mov_b32_e32 v32, 0
+v_mov_b32_e32 v33, 0
+s_xor_b32 s18, s18, 0x200000
+s_bitcmp0_b32 s18, 21
+s_addc_u32 s94, s60, 0
+s_lshr_b32 s94, s94, 1
+s_mul_i32 s94, s94, s61
+s_lshr_b32 s94, s94, 1
+s_mul_i32 s94, s94, s13
+s_cmp_eq_u32 s94, 0
+s_cbranch_scc1 65205
+s_add_u32 s52, s93, s92
+s_cmp_lt_i32 s52, 0
+s_cbranch_scc0 131
+v_and_b32_e32 v86, 0x7f, v0
+v_lshrrev_b32_e32 v86, 1, v86
+v_bfi_b32 v86, 1, v0, v86
+v_and_b32_e64 v87, v0, 2
+v_mad_u32_u24 v86, v87, 16, v86
+v_lshlrev_b32_e32 v86, 2, v86
+v_add_co_u32_e64 v86, vcc, v86, s97
+v_and_b32_e32 v87, 3, v0
+v_lshlrev_b32_e32 v87, 2, v87
+v_add_co_u32_e64 v87, vcc, v87, s97
+ds_read_b32 v108, v87 offset:256
+ds_read_b32 v86, v86
+s_add_u32 s97, s97, 0x18c
+s_cmp_eq_u32 s97, 0xffc0
+s_cselect_b32 s97, 0xc1e0, s97
+s_waitcnt lgkmcnt(0)
+v_readfirstlane_b32 s95, v86
+v_readlane_b32 s54, v108, 0
+s_bitcmp1_b32 s54, 18
+s_cbranch_scc1 107
+v_readlane_b32 s52, v108, 1
+v_readlane_b32 s53, v108, 2
+s_add_u32 s93, s92, s53
+s_lshr_b32 s55, -1, 16
+s_and_b32 s55, s55, s66
+s_lshr_b32 s56, s66, 16
+s_mul_i32 s56, s56, s95
+s_mul_i32 s44, s55, s95
+s_lshl_b32 s55, s56, 16
+s_lshr_b32 s56, s56, 16
+s_add_u32 s44, s55, s44
+s_addc_u32 s45, s56, 0
+s_add_u32 s44, s44, s24
+s_addc_u32 s45, s45, s25
+s_mul_i32 s55, s67, s93
+s_add_u32 s44, s44, s55
+s_addc_u32 s45, s45, 0
+s_mov_b32 s47, 0x20000
+s_bitcmp1_b32 s18, 7
+s_cselect_b32 s51, 0x20000, 0
+s_lshl_b32 s55, s93, 2
+s_add_u32 s48, s34, s55
+s_addc_u32 s49, s35, 0
+s_lshl_b32 s56, s52, 2
+s_sub_u32 s50, s56, s55
+s_cselect_b32 s51, 0, s51
+s_sub_u32 s93, s52, s53
+s_sub_u32 s93, s93, 1
+s_sub_u32 s93, s93, s92
+s_cselect_b32 s47, 0, s47
+v_bfe_u32 v106, v86, 16, 16
+v_bfe_u32 v107, v86, 0, 16
+v_and_b32_e64 v108, v0, 7
+v_sub_co_u32_e32 v109, vcc, 7, v108
+v_min_u32_e32 v108, v108, v109
+v_bfe_u32 v109, v108, 1, 1
+v_bfe_u32 v108, v108, 0, 1
+v_mov_b32_dpp v106, v106  quad_perm:[1,1,1,1] row_mask:0xf bank_mask:0xf
+v_mov_b32_dpp v107, v107  quad_perm:[1,1,1,1] row_mask:0xf bank_mask:0xf
+v_add_co_u32_e32 v106, vcc, v106, v109
+v_add_co_u32_e32 v107, vcc, v107, v108
+v_mov_b32_dpp v108, v86  quad_perm:[0,0,0,0] row_mask:0xf bank_mask:0xf
+v_cmp_ge_u32_e64 s[52:53], v108, s12
+v_sub_co_u32_e64 v108, vcc, v108, s95
+v_mul_lo_u32 v108, v108, s66
+v_lshlrev_b32_e32 v107, 1, v107
+s_and_b32 s54, 1, s31
+v_add_co_u32_e32 v107, vcc, s54, v107
+v_lshlrev_b32_e32 v106, 1, v106
+s_and_b32 s54, 1, s30
+v_subrev_co_u32_e32 v106, vcc, s54, v106
+v_mad_i32_i24 v86, v106, s33, v107
+v_lshlrev_b32_e32 v86, 2, v86
+v_add_co_u32_e32 v86, vcc, v86, v108
+v_subrev_co_u32_e32 v87, vcc, 4, v86
+v_mad_i32_i24 v88, 4, s33, v86
+v_mad_i32_i24 v89, 4, s33, v87
+v_cmp_ge_u32_e64 s[58:59], v107, s33
+s_or_b64 s[56:57], s[58:59], s[52:53]
+v_subrev_co_u32_e32 v107, vcc, 1, v107
+v_cmp_ge_u32_e64 s[58:59], v107, s33
+s_or_b64 s[58:59], s[58:59], s[52:53]
+v_cmp_ge_u32_e64 s[54:55], v106, s32
+s_or_b64 s[52:53], s[56:57], s[54:55]
+v_cndmask_b32_e64 v86, v86, -1, s[52:53]
+s_or_b64 s[52:53], s[58:59], s[54:55]
+v_cndmask_b32_e64 v87, v87, -1, s[52:53]
+v_add_co_u32_e32 v106, vcc, 1, v106
+v_cmp_ge_u32_e64 s[54:55], v106, s32
+s_or_b64 s[52:53], s[56:57], s[54:55]
+v_cndmask_b32_e64 v88, v88, -1, s[52:53]
+s_or_b64 s[52:53], s[58:59], s[54:55]
+v_cndmask_b32_e64 v89, v89, -1, s[52:53]
+v_and_b32_e64 v104, v0, 63
+v_lshlrev_b32_e32 v104, 2, v104
+s_barrier
+buffer_load_dword v104, v104, s[48:51], 0 offen
+s_mov_b64 vcc, s[10:11]
+s_branch 64439
+s_endpgm
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0

--- a/src/kernels/Conv_Winograd_v21_1_3_gfx9_fp32_f2x3_stride1.inc
+++ b/src/kernels/Conv_Winograd_v21_1_3_gfx9_fp32_f2x3_stride1.inc
@@ -1,0 +1,2783 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2023 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+v_mov_b32_e32 v0, v0
+s_mov_b32 s0, 0
+s_mov_b32 s1, 0
+s_mov_b32 s2, 0
+s_mov_b32 s3, 0
+v_mov_b32_e32 v104, 0
+s_mov_b32 m0, 0x1ffff
+s_mov_b32 s97, 0xc1e0
+s_mov_b32 s96, 0xc1e0
+s_mov_b32 s91, 0
+v_lshlrev_b32_e32 v107, 2, v0
+v_add_co_u32_e32 v107, vcc, 0xffc0, v107
+v_cmp_ge_u32_e32 vcc, 12, v0
+s_cbranch_vccz 5
+v_mov_b32_e32 v106, 0
+v_cndmask_b32_e32 v107, -1, v107, vcc
+ds_write_b32 v107, v106
+s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+s_barrier
+v_readfirstlane_b32 s52, v0
+s_lshr_b32 s52, s52, 5
+s_add_u32 s52, s52, 8
+s_and_b32 s92, s52, 20
+s_mov_b64 s[40:41], s[6:7]
+s_load_dwordx16 s[12:27], s[40:41], 0x0
+s_load_dwordx4 s[28:31], s[40:41], 0x40
+s_load_dwordx2 s[32:33], s[40:41], 0x50
+s_waitcnt lgkmcnt(0)
+s_and_b32 s18, s18, 0xffff
+s_bitcmp1_b32 s18, 6
+s_cbranch_scc0 16
+s_and_b32 s21, s21, 0xffff
+s_and_b32 s23, s23, 0xffff
+s_and_b32 s25, s25, 0xffff
+s_and_b32 s27, s27, 0xffff
+s_load_dwordx2 s[20:21], s[20:21], 0x0
+s_load_dwordx2 s[22:23], s[22:23], 0x0
+s_load_dwordx2 s[24:25], s[24:25], 0x0
+s_load_dwordx2 s[26:27], s[26:27], 0x0
+s_bitcmp1_b32 s18, 7
+s_cbranch_scc0 2
+s_load_dwordx2 s[34:35], s[40:41], 0x58
+s_mov_b32 s36, 1.0
+s_bitcmp1_b32 s18, 8
+s_cbranch_scc0 2
+s_load_dword s36, s[40:41], 0x60
+s_bitcmp1_b32 s18, 7
+s_cbranch_scc0 7
+s_bitcmp1_b32 s18, 6
+s_cbranch_scc0 5
+s_waitcnt lgkmcnt(0)
+s_and_b32 s35, s35, 0xffff
+s_load_dwordx2 s[34:35], s[34:35], 0x0
+s_bitcmp1_b32 s18, 9
+s_cbranch_scc0 72
+s_mov_b32 s42, 0x8c
+s_mov_b32 s43, 0x9c
+v_cmp_le_u32_e32 vcc, 0x100, v0
+s_cmp_eq_u32 1, src_vccz
+s_cselect_b32 s42, s43, s42
+s_load_dword s65, s[40:41], 0x88
+s_load_dword s90, s[40:41], 0x98
+s_load_dword s68, s[40:41], s42
+s_load_dwordx2 s[66:67], s[40:41], 0xa8
+s_bitcmp1_b32 s18, 10
+s_cbranch_scc0 103
+s_load_dwordx4 s[44:47], s[40:41], 0xb8
+v_ffbh_u32_e32 v4, s17
+v_lshlrev_b32_e64 v5, v4, s17
+v_and_b32_e32 v6, 0xffffff00, v5
+v_cmp_eq_u32_e32 vcc, 0x80000000, v5
+v_cvt_f32_u32_e32 v6, v6
+v_rcp_f32_e32 v2, v6
+v_subb_co_u32_e32 v3, vcc, 32, v4, vcc
+v_cvt_f32_ubyte0_e32 v4, v5
+v_fma_f32 v6, v6, v2, -1.0
+v_fma_f32 v6, v4, v2, v6
+v_madak_f32 v6, v6, v2, 0x9f000000
+v_mul_f32_e32 v6, 0x5f800000, v6
+v_mov_b32_e32 v4, 0
+v_cvt_flr_i32_f32_e64 v6, -v6
+v_lshl_add_u32 v2, v2, 9, v6
+v_mad_u64_u32 v[4:5], vcc, v5, v2, v[4:5]
+v_subb_co_u32_e64 v2, vcc, v2, -1, vcc
+v_mul_hi_u32 v4, s8, v2
+v_add_co_u32_e64 v2, vcc, v4, s8
+v_addc_co_u32_e64 v4, vcc, 0, 0, vcc
+v_cmp_eq_u32_e32 vcc, 32, v3
+v_cndmask_b32_e32 v2, v2, v4, vcc
+v_alignbit_b32 v2, v4, v2, v3
+s_waitcnt lgkmcnt(0)
+v_readfirstlane_b32 s48, v2
+s_mul_i32 s49, s48, s17
+s_sub_u32 s8, s8, s49
+s_mul_i32 s49, s45, s48
+s_add_u32 s20, s20, s49
+s_addc_u32 s21, s21, 0
+s_mul_i32 s49, s46, s48
+s_add_u32 s22, s22, s49
+s_addc_u32 s23, s23, 0
+s_mul_i32 s49, s47, s48
+s_add_u32 s24, s24, s49
+s_addc_u32 s25, s25, 0
+s_branch 49
+s_mul_i32 s42, s14, s15
+s_lshr_b32 s46, -1, 16
+s_and_b32 s46, s46, s42
+s_lshr_b32 s47, s42, 16
+s_mul_i32 s47, s47, s13
+s_mul_i32 s44, s46, s13
+s_lshl_b32 s46, s47, 16
+s_lshr_b32 s47, s47, 16
+s_add_u32 s44, s46, s44
+s_addc_u32 s45, s47, 0
+s_lshl_b32 s65, s44, 2
+s_lshl_b32 s68, s42, 2
+s_mul_i32 s43, s32, s33
+s_lshr_b32 s46, -1, 16
+s_and_b32 s46, s46, s43
+s_lshr_b32 s47, s43, 16
+s_mul_i32 s47, s47, s16
+s_mul_i32 s44, s46, s16
+s_lshl_b32 s46, s47, 16
+s_lshr_b32 s47, s47, 16
+s_add_u32 s44, s46, s44
+s_addc_u32 s45, s47, 0
+s_lshl_b32 s66, s44, 2
+s_lshl_b32 s67, s43, 2
+s_bitcmp1_b32 s18, 13
+s_cbranch_scc0 2
+s_load_dwordx8 s[48:55], s[40:41], 0x68
+s_mul_i32 s42, s28, s29
+s_lshl_b32 s42, s42, 2
+s_bitcmp1_b32 s18, 2
+s_cselect_b32 s43, s16, s13
+s_lshr_b32 s44, -1, 16
+s_and_b32 s44, s44, s42
+s_lshr_b32 s45, s42, 16
+s_mul_i32 s45, s45, s43
+s_mul_i32 s56, s44, s43
+s_lshl_b32 s44, s45, 16
+s_lshr_b32 s45, s45, 16
+s_add_u32 s56, s44, s56
+s_addc_u32 s57, s45, 0
+s_mov_b32 s43, s56
+s_bitcmp1_b32 s18, 2
+s_cselect_b32 s44, s43, s42
+s_cselect_b32 s90, s42, s43
+v_cmp_le_u32_e32 vcc, 0x100, v0
+s_cmp_eq_u32 1, src_vccz
+s_cselect_b32 s68, s44, s68
+s_waitcnt lgkmcnt(0)
+s_and_b32 s21, s21, 0xffff
+s_and_b32 s23, s23, 0xffff
+s_and_b32 s25, s25, 0xffff
+s_and_b32 s27, s27, 0xffff
+s_and_b32 s35, s35, 0xffff
+s_bitcmp1_b32 s18, 13
+s_cbranch_scc0 8
+s_add_u32 s20, s20, s48
+s_addc_u32 s21, s21, s49
+s_add_u32 s22, s22, s50
+s_addc_u32 s23, s23, s51
+s_add_u32 s24, s24, s52
+s_addc_u32 s25, s25, s53
+s_add_u32 s34, s34, s54
+s_addc_u32 s35, s35, s55
+s_and_b32 s44, 0, s30
+s_addc_u32 s44, s32, 0
+s_ashr_i32 s44, s44, 0
+s_add_u32 s42, s44, 1
+v_mov_b32_e32 v2, 0x80000000
+v_mul_hi_u32 v2, v2, s42
+v_readfirstlane_b32 s42, v2
+s_andn2_b32 s44, 0, s31
+s_addc_u32 s44, s33, 0
+s_ashr_i32 s44, s44, 0
+s_add_u32 s43, s44, 1
+v_mov_b32_e32 v2, 0x80000000
+v_mul_hi_u32 v2, v2, s43
+v_readfirstlane_b32 s43, v2
+s_sub_u32 s75, 0, s43
+s_sub_u32 s74, 0, s42
+s_add_u32 s60, s28, 2
+v_mov_b32_e32 v2, 0x55555556
+v_mul_hi_u32 v2, v2, s60
+v_readfirstlane_b32 s60, v2
+s_add_u32 s61, s29, 2
+v_mov_b32_e32 v2, 0x55555556
+v_mul_hi_u32 v2, v2, s61
+v_readfirstlane_b32 s61, v2
+v_mad_i32_i24 v2, 3, s60, -2
+v_sub_co_u32_e64 v2, vcc, v2, s28
+v_addc_co_u32_e64 v2, vcc, 0, 0, vcc
+v_readfirstlane_b32 s44, v2
+s_and_b32 s44, s44, 0
+s_and_b32 s44, s44, s60
+s_add_u32 s60, s60, s44
+v_readfirstlane_b32 s45, v0
+s_and_b32 s48, s45, 64
+s_cselect_b32 s48, 0x80000, 0
+s_or_b32 s18, s18, s48
+s_lshl_b32 s69, s68, 1
+s_mov_b64 s[70:71], 0
+s_bitcmp1_b32 s18, 12
+s_cselect_b32 s44, 0, -1
+s_bitcmp1_b32 s18, 11
+s_cselect_b32 s44, s44, 1
+s_cmp_gt_u32 s61, s44
+s_cbranch_scc0 8
+s_bitset1_b32 s18, 23
+s_bitset1_b32 s18, 20
+s_bitset0_b32 s18, 19
+s_ashr_i32 s69, s69, 1
+s_ashr_i64 s[70:71], s[70:71], 1
+s_add_u32 s61, s61, 1
+s_and_b32 s61, s61, -2
+s_branch 16
+s_and_b32 s48, s13, 1
+s_cselect_b32 s48, 0, 0x1000000
+s_bitcmp1_b32 s18, 2
+s_cselect_b32 s48, 0, s48
+s_or_b32 s18, s18, s48
+s_cmp_eq_u32 s48, 0
+s_cselect_b32 s69, s68, s69
+s_cselect_b32 s70, s68, s70
+s_cselect_b32 s71, 0, s71
+s_bitcmp0_b32 s45, 8
+s_cselect_b32 s48, s48, 0
+s_cmp_eq_u32 s48, 0
+s_cselect_b32 s48, 0, 0x80000
+s_andn2_b32 s18, s18, s48
+s_add_u32 s70, s70, s69
+s_addc_u32 s71, s71, 0
+v_bfe_u32 v3, v0, 2, 6
+v_lshrrev_b32_e32 v99, 1, v3
+s_bitcmp0_b32 s45, 8
+s_cselect_b32 s48, 0x1000000, 0
+s_or_b32 s48, s48, 0x100000
+s_and_b32 s48, s18, s48
+s_cselect_b32 s48, 0, 15
+v_bfi_b32 v99, s48, v3, v99
+s_mul_i32 s88, s12, s42
+s_sub_u32 s88, s88, 1
+s_lshr_b32 s88, s88, 0
+s_add_u32 s88, s88, 1
+s_lshr_b32 s46, -1, 16
+s_and_b32 s46, s46, s88
+s_lshr_b32 s47, s88, 16
+s_mul_i32 s47, s47, s43
+s_mul_i32 s88, s46, s43
+s_lshl_b32 s46, s47, 16
+s_lshr_b32 s47, s47, 16
+s_add_u32 s88, s46, s88
+s_addc_u32 s89, s47, 0
+s_sub_u32 s88, s88, 1
+s_subb_u32 s89, s89, 0
+s_lshr_b64 s[88:89], s[88:89], 5
+s_add_u32 s88, s88, 1
+s_addc_u32 s89, s89, 0
+v_mov_b32_e32 v4, s8
+v_mov_b32_e32 v5, s17
+v_and_b32_e32 v6, 3, v0
+v_cmp_eq_u32_e32 vcc, 2, v6
+v_cndmask_b32_e32 v4, v4, v5, vcc
+v_cmp_eq_u32_e32 vcc, 1, v6
+v_cndmask_b32_e32 v7, 0, v99, vcc
+s_bitcmp1_b32 s18, 20
+s_cbranch_scc0 4
+v_add_co_u32_e64 v5, vcc, v99, 8
+v_cmp_eq_u32_e32 vcc, 0, v6
+v_cndmask_b32_e32 v7, v7, v5, vcc
+v_cmp_eq_u32_e64 s[46:47], 3, v6
+v_bfe_u32 v97, v7, 0, 5
+v_mad_u32_u24 v97, v4, 32, v97
+v_ffbh_u32_e32 v9, s43
+v_lshlrev_b32_e64 v10, v9, s43
+v_and_b32_e32 v11, 0xffffff00, v10
+v_cmp_eq_u32_e32 vcc, 0x80000000, v10
+v_cvt_f32_u32_e32 v11, v11
+v_rcp_f32_e32 v98, v11
+v_subb_co_u32_e32 v8, vcc, 32, v9, vcc
+v_cvt_f32_ubyte0_e32 v9, v10
+v_fma_f32 v11, v11, v98, -1.0
+v_fma_f32 v11, v9, v98, v11
+v_madak_f32 v11, v11, v98, 0x9f000000
+v_mul_f32_e32 v11, 0x5f800000, v11
+v_mov_b32_e32 v9, 0
+v_cvt_flr_i32_f32_e64 v11, -v11
+v_lshl_add_u32 v98, v98, 9, v11
+v_mad_u64_u32 v[9:10], vcc, v10, v98, v[9:10]
+v_subb_co_u32_e64 v98, vcc, v98, -1, vcc
+v_mul_hi_u32 v9, v97, v98
+v_add_co_u32_e32 v98, vcc, v9, v97
+v_addc_co_u32_e64 v9, vcc, 0, 0, vcc
+v_cmp_eq_u32_e32 vcc, 32, v8
+v_cndmask_b32_e32 v98, v98, v9, vcc
+v_alignbit_b32 v98, v9, v98, v8
+v_mad_i32_i24 v96, v98, s75, v97
+v_lshrrev_b32_e32 v97, 5, v7
+v_mad_u32_u24 v97, v98, 1, v97
+v_cndmask_b32_e64 v97, v97, 1, s[46:47]
+v_ffbh_u32_e32 v9, s42
+v_lshlrev_b32_e64 v10, v9, s42
+v_and_b32_e32 v11, 0xffffff00, v10
+v_cmp_eq_u32_e32 vcc, 0x80000000, v10
+v_cvt_f32_u32_e32 v11, v11
+v_rcp_f32_e32 v98, v11
+v_subb_co_u32_e32 v8, vcc, 32, v9, vcc
+v_cvt_f32_ubyte0_e32 v9, v10
+v_fma_f32 v11, v11, v98, -1.0
+v_fma_f32 v11, v9, v98, v11
+v_madak_f32 v11, v11, v98, 0x9f000000
+v_mul_f32_e32 v11, 0x5f800000, v11
+v_mov_b32_e32 v9, 0
+v_cvt_flr_i32_f32_e64 v11, -v11
+v_lshl_add_u32 v98, v98, 9, v11
+v_mad_u64_u32 v[9:10], vcc, v10, v98, v[9:10]
+v_subb_co_u32_e64 v98, vcc, v98, -1, vcc
+v_mul_hi_u32 v9, v97, v98
+v_add_co_u32_e32 v98, vcc, v9, v97
+v_addc_co_u32_e64 v9, vcc, 0, 0, vcc
+v_cmp_eq_u32_e32 vcc, 32, v8
+v_cndmask_b32_e32 v98, v98, v9, vcc
+v_alignbit_b32 v98, v9, v98, v8
+v_mad_i32_i24 v97, v98, s74, v97
+v_readlane_b32 s76, v96, 2
+v_readlane_b32 s77, v97, 2
+v_readlane_b32 s78, v98, 2
+v_readlane_b32 s79, v97, 3
+v_readlane_b32 s80, v98, 3
+v_add_co_u32_e64 v96, vcc, v96, s75
+v_add_co_u32_e64 v97, vcc, v97, s74
+v_mov_b32_dpp v98, v98  quad_perm:[1,1,0,0] row_mask:0xf bank_mask:0xf
+v_mov_b32_dpp v96, v96  quad_perm:[1,1,0,0] row_mask:0xf bank_mask:0xf
+v_mov_b32_dpp v97, v97  quad_perm:[1,1,0,0] row_mask:0xf bank_mask:0xf
+s_mov_b32 s42, 0x80000000
+s_mov_b32 s43, 0x20000
+s_mov_b32 s46, 0x80000000
+s_mov_b32 s47, 0x20000
+v_cmp_le_u32_e32 vcc, 0x100, v0
+s_cbranch_vccnz 5
+v_xor_b32_dpp v100, v0, v0  quad_perm:[1,3,2,2] row_mask:0xf bank_mask:0xf
+v_subrev_co_u32_e32 v100, vcc, 1, v100
+v_cvt_f32_i32_e32 v100, v100
+s_branch 4
+v_xor_b32_dpp v100, v0, v0  quad_perm:[2,1,0,1] row_mask:0xf bank_mask:0xf
+v_sub_co_u32_e32 v100, vcc, 1, v100
+v_cvt_f32_i32_e32 v100, v100
+v_mov_b32_e32 v101, 1
+v_xor_b32_dpp v101, v0, v0  quad_perm:[2,3,2,3] row_mask:0xf bank_mask:0x4
+v_xor_b32_dpp v101, v0, v0  quad_perm:[0,1,0,1] row_mask:0xf bank_mask:0x8
+v_subrev_co_u32_e32 v101, vcc, 1, v101
+v_mov_b32_e32 v102, 1
+v_xor_b32_dpp v102, v0, v0  quad_perm:[0,3,2,1] row_mask:0xf bank_mask:0x2
+v_xor_b32_dpp v102, v0, v0  quad_perm:[2,1,0,3] row_mask:0xf bank_mask:0x4
+v_subrev_co_u32_e32 v102, vcc, 1, v102
+v_cvt_f32_i32_e32 v101, v101
+v_cvt_f32_i32_e32 v102, v102
+v_lshrrev_b32_e64 v106, 2, s92
+v_and_b32_e32 v107, 3, v0
+v_bfe_u32 v108, v0, 4, 3
+v_mad_u32_u24 v95, v108, 4, v107
+v_lshlrev_b32_e32 v95, 4, v95
+v_mad_u32_u24 v90, v106, 4, v107
+v_lshlrev_b32_e32 v90, 4, v90
+v_bfe_u32 v106, v0, 2, 2
+v_and_b32_e32 v107, 1, v106
+v_mad_u32_u24 v109, v106, 16, v107
+v_lshlrev_b32_e32 v109, 6, v109
+v_xor_b32_e32 v90, v90, v109
+v_mul_u32_u24_e32 v109, 0x400, v106
+v_xor_b32_e32 v95, v95, v109
+s_lshr_b32 s92, s92, 0
+v_cmp_le_u32_e32 vcc, 0x100, v0
+s_cbranch_vccnz 50
+s_and_b32 s53, s18, 0x1100000
+s_addc_u32 s53, 0, 0
+v_lshrrev_b32_e32 v109, 1, v0
+s_mul_i32 s52, 60, s53
+s_sub_u32 s52, 63, s52
+v_bfi_b32 v109, s52, v0, v109
+v_and_b32_e32 v106, 1, v109
+v_bfe_u32 v107, v109, 1, 1
+v_xor_b32_e32 v106, v106, v107
+v_bfe_u32 v108, v109, 3, 1
+v_mad_u32_u24 v107, v107, 2, v108
+v_mul_u32_u24_e32 v106, 0x118, v106
+v_bfe_u32 v108, v109, 2, 1
+v_mad_u32_u24 v107, v107, 2, v106
+v_xor_b32_e32 v107, v107, v108
+v_and_b32_e32 v108, 0xf0, v109
+v_xor_b32_e32 v107, v107, v108
+s_mul_i32 s52, 4, s53
+s_sub_u32 s52, 6, s52
+v_bfe_u32 v109, v0, s52, 1
+v_mul_u32_u24_e32 v109, 0x1040, v109
+v_xor_b32_e32 v92, 0x314, v107
+v_xor_b32_e32 v93, 0x31c, v107
+v_xor_b32_e32 v94, 8, v107
+s_bitcmp1_b32 s18, 0
+s_cselect_b64 vcc, -1, 0
+v_cndmask_b32_e32 v91, v107, v94, vcc
+v_cndmask_b32_e32 v94, v94, v107, vcc
+v_mad_u32_u24 v91, 4, v91, v109
+v_mad_u32_u24 v92, 4, v92, v109
+v_mad_u32_u24 v93, 4, v93, v109
+v_mad_u32_u24 v94, 4, v94, v109
+s_branch 44
+s_bfe_u32 s53, s18, 0x10014
+v_lshrrev_b32_e32 v109, 1, v0
+s_mul_i32 s52, 60, s53
+s_sub_u32 s52, 63, s52
+v_bfi_b32 v109, s52, v0, v109
+v_and_b32_e32 v106, 1, v109
+v_bfe_u32 v107, v109, 1, 1
+v_bfe_u32 v108, v109, 3, 1
+v_xor_b32_e32 v106, v106, v107
+v_mad_u32_u24 v107, v107, 2, v108
+v_mul_u32_u24_e32 v106, 0x109, v106
+v_bfe_u32 v108, v109, 2, 1
+v_mad_u32_u24 v107, v107, 2, v106
+v_xor_b32_e32 v107, v107, v108
+v_and_b32_e32 v108, 0xf0, v109
+v_or_b32_e32 v107, v107, v108
+s_mul_i32 s52, 4, s53
+s_sub_u32 s52, 6, s52
+v_bfe_u32 v109, v0, s52, 1
+v_mul_u32_u24_e32 v109, 0x1040, v109
+v_mad_u32_u24 v91, 4, v107, v109
+v_xor_b32_e32 v92, 0x307, v107
+v_mad_u32_u24 v92, 4, v92, v109
+v_xor_b32_e32 v93, 0x30f, v107
+v_mad_u32_u24 v93, 4, v93, v109
+v_xor_b32_e32 v94, 8, v107
+v_mad_u32_u24 v94, 4, v94, v109
+v_subrev_co_u32_e32 v96, vcc, s76, v96
+v_mov_b32_e32 v107, s75
+v_cmp_lt_i32_e32 vcc, v96, v107
+v_subb_co_u32_e64 v106, vcc, 0, 0, vcc
+v_mad_i32_i24 v96, v106, s75, v96
+v_mad_i32_i24 v98, v106, s80, v98
+v_mad_i32_i24 v97, v106, s79, v97
+v_mov_b32_e32 v107, s74
+v_cmp_lt_i32_e32 vcc, v97, v107
+v_subb_co_u32_e64 v106, vcc, 0, 0, vcc
+v_add_co_u32_e32 v98, vcc, v98, v106
+v_mad_i32_i24 v97, v106, v107, v97
+v_subrev_co_u32_e32 v97, vcc, s77, v97
+v_cmp_lt_i32_e32 vcc, v97, v107
+v_subb_co_u32_e64 v106, vcc, 0, 0, vcc
+v_add_co_u32_e32 v98, vcc, v98, v106
+v_mad_i32_i24 v97, v106, s74, v97
+v_subrev_co_u32_e32 v98, vcc, s78, v98
+s_mov_b32 s62, 0
+s_mov_b32 s63, s28
+s_mov_b32 s64, 1
+s_mov_b32 s84, 0
+s_mov_b32 s85, s16
+s_mov_b32 s83, s85
+s_sub_u32 s93, -1, s92
+s_sub_u32 s93, s93, 32
+s_bitset1_b32 s18, 21
+s_mov_b32 s47, 0
+s_mov_b32 s51, 0
+s_mov_b32 s94, 17
+s_mov_b32 s82, 0
+s_bitset1_b32 s18, 26
+s_call_b64 s[38:39], 1755
+v_cmp_le_u32_e32 vcc, 0x100, v0
+s_cbranch_vccnz 65
+s_branch 905
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_mac_f32_e32 v2, v34, v42
+v_mac_f32_e32 v3, v35, v42
+v_mac_f32_e32 v4, v36, v42
+v_mac_f32_e32 v5, v37, v42
+v_mac_f32_e32 v6, v34, v43
+v_mac_f32_e32 v7, v35, v43
+v_mac_f32_e32 v8, v36, v43
+v_mac_f32_e32 v9, v37, v43
+v_mac_f32_e32 v10, v34, v44
+v_mac_f32_e32 v11, v35, v44
+v_mac_f32_e32 v12, v36, v44
+v_mac_f32_e32 v13, v37, v44
+v_mac_f32_e32 v14, v34, v45
+v_mac_f32_e32 v15, v35, v45
+v_mac_f32_e32 v16, v36, v45
+v_mac_f32_e32 v17, v37, v45
+v_mac_f32_e32 v18, v34, v46
+v_mac_f32_e32 v19, v35, v46
+v_mac_f32_e32 v20, v36, v46
+v_mac_f32_e32 v21, v37, v46
+v_mac_f32_e32 v22, v34, v47
+v_mac_f32_e32 v23, v35, v47
+v_mac_f32_e32 v24, v36, v47
+v_mac_f32_e32 v25, v37, v47
+v_mac_f32_e32 v26, v34, v48
+v_mac_f32_e32 v27, v35, v48
+v_mac_f32_e32 v28, v36, v48
+v_mac_f32_e32 v29, v37, v48
+v_mac_f32_e32 v30, v34, v49
+v_mac_f32_e32 v31, v35, v49
+v_subrev_f32_e64 v66, v68, v66 div:2
+v_subrev_f32_e64 v69, v67, v69 div:2
+v_add_f32_e64 v67, v68, v67 div:2
+v_mad_f32 v68, v68, 1.0, -v67
+s_setprio 0
+s_nop 0
+v_mac_f32_e32 v32, v36, v49
+v_mac_f32_e32 v33, v37, v49
+s_nop 0
+ds_read_b128 v[34:37], v95 offset:29440
+ds_read_b128 v[42:45], v90 offset:28928
+ds_read_b128 v[46:49], v90 offset:29056
+ds_write_b32 v91, v62
+ds_write_b32 v92, v63
+s_setprio 1
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+buffer_load_dword v58, v82, s[40:43], 0 offen
+buffer_load_dword v60, v84, s[40:43], 0 offen
+buffer_load_dword v59, v83, s[40:43], 0 offen
+buffer_load_dword v61, v85, s[40:43], 0 offen
+s_add_u32 s91, s91, 0x200
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 1
+s_call_b64 s[38:39], 1608
+v_mac_f32_e32 v2, v38, v50
+v_mac_f32_e32 v3, v39, v50
+v_mac_f32_e32 v4, v40, v50
+v_mac_f32_e32 v5, v41, v50
+v_mac_f32_e32 v6, v38, v51
+v_mac_f32_e32 v7, v39, v51
+v_mac_f32_e32 v8, v40, v51
+v_mac_f32_e32 v9, v41, v51
+v_mac_f32_e32 v10, v38, v52
+v_mac_f32_e32 v11, v39, v52
+v_mac_f32_e32 v12, v40, v52
+v_mac_f32_e32 v13, v41, v52
+v_mac_f32_e32 v14, v38, v53
+v_mac_f32_e32 v15, v39, v53
+v_mac_f32_e32 v16, v40, v53
+v_mac_f32_e32 v17, v41, v53
+v_mac_f32_e32 v18, v38, v54
+v_mac_f32_e32 v19, v39, v54
+v_mac_f32_e32 v20, v40, v54
+v_mac_f32_e32 v21, v41, v54
+v_mac_f32_e32 v22, v38, v55
+v_mac_f32_e32 v23, v39, v55
+v_mac_f32_e32 v24, v40, v55
+v_mac_f32_e32 v25, v41, v55
+v_mac_f32_e32 v26, v38, v56
+v_mac_f32_e32 v27, v39, v56
+v_mac_f32_e32 v28, v40, v56
+v_mac_f32_e32 v29, v41, v56
+v_mac_f32_e32 v30, v38, v57
+v_mac_f32_e32 v31, v39, v57
+v_mac_f32_dpp v66, v66, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v67, v67, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v68, v68, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v69, v69, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+s_setprio 0
+s_nop 0
+v_mac_f32_e32 v32, v40, v57
+v_mac_f32_e32 v33, v41, v57
+s_nop 0
+ds_read_b128 v[38:41], v95 offset:33536
+ds_read_b128 v[50:53], v90 offset:33024
+ds_read_b128 v[54:57], v90 offset:33152
+ds_write_b32 v93, v68 offset:8256
+ds_write_b32 v94, v69 offset:8256
+s_setprio 1
+s_nop 0
+s_waitcnt vmcnt(12) lgkmcnt(5)
+ds_append v105 offset:65472
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 3
+s_call_b64 s[38:39], 1546
+s_nop 0
+s_nop 0
+v_mac_f32_e32 v2, v34, v42
+v_mac_f32_e32 v3, v35, v42
+v_mac_f32_e32 v4, v36, v42
+v_mac_f32_e32 v5, v37, v42
+v_mac_f32_e32 v6, v34, v43
+v_mac_f32_e32 v7, v35, v43
+v_mac_f32_e32 v8, v36, v43
+v_mac_f32_e32 v9, v37, v43
+v_mac_f32_e32 v10, v34, v44
+v_mac_f32_e32 v11, v35, v44
+v_mac_f32_e32 v12, v36, v44
+v_mac_f32_e32 v13, v37, v44
+v_mac_f32_e32 v14, v34, v45
+v_mac_f32_e32 v15, v35, v45
+v_mac_f32_e32 v16, v36, v45
+v_mac_f32_e32 v17, v37, v45
+v_mac_f32_e32 v18, v34, v46
+v_mac_f32_e32 v19, v35, v46
+v_mac_f32_e32 v20, v36, v46
+v_mac_f32_e32 v21, v37, v46
+v_mac_f32_e32 v22, v34, v47
+v_mac_f32_e32 v23, v35, v47
+v_mac_f32_e32 v24, v36, v47
+v_mac_f32_e32 v25, v37, v47
+v_mac_f32_e32 v26, v34, v48
+v_mac_f32_e32 v27, v35, v48
+v_mac_f32_e32 v28, v36, v48
+v_mac_f32_e32 v29, v37, v48
+v_mac_f32_e32 v30, v34, v49
+v_mac_f32_e32 v31, v35, v49
+v_subrev_f32_e64 v70, v72, v70 div:2
+v_subrev_f32_e64 v73, v71, v73 div:2
+v_add_f32_e64 v71, v72, v71 div:2
+v_mad_f32 v72, v72, 1.0, -v71
+s_setprio 0
+s_nop 0
+v_mac_f32_e32 v32, v36, v49
+v_mac_f32_e32 v33, v37, v49
+s_nop 0
+ds_read_b128 v[34:37], v95 offset:37696
+ds_read_b128 v[42:45], v90 offset:37184
+ds_read_b128 v[46:49], v90 offset:37312
+ds_write_b32 v91, v66 offset:8256
+ds_write_b32 v92, v67 offset:8256
+s_setprio 1
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+buffer_load_dword v62, v82, s[40:43], 0 offen
+buffer_load_dword v64, v84, s[40:43], 0 offen
+buffer_load_dword v63, v83, s[40:43], 0 offen
+buffer_load_dword v65, v85, s[40:43], 0 offen
+s_mov_b32 m0, 0x2ffc0
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 1
+s_call_b64 s[38:39], 1472
+v_mac_f32_e32 v2, v38, v50
+v_mac_f32_e32 v3, v39, v50
+v_mac_f32_e32 v4, v40, v50
+v_mac_f32_e32 v5, v41, v50
+v_mac_f32_e32 v6, v38, v51
+v_mac_f32_e32 v7, v39, v51
+v_mac_f32_e32 v8, v40, v51
+v_mac_f32_e32 v9, v41, v51
+v_mac_f32_e32 v10, v38, v52
+v_mac_f32_e32 v11, v39, v52
+v_mac_f32_e32 v12, v40, v52
+v_mac_f32_e32 v13, v41, v52
+v_mac_f32_e32 v14, v38, v53
+v_mac_f32_e32 v15, v39, v53
+v_mac_f32_e32 v16, v40, v53
+v_mac_f32_e32 v17, v41, v53
+v_mac_f32_e32 v18, v38, v54
+v_mac_f32_e32 v19, v39, v54
+v_mac_f32_e32 v20, v40, v54
+v_mac_f32_e32 v21, v41, v54
+v_mac_f32_e32 v22, v38, v55
+v_mac_f32_e32 v23, v39, v55
+v_mac_f32_e32 v24, v40, v55
+v_mac_f32_e32 v25, v41, v55
+v_mac_f32_e32 v26, v38, v56
+v_mac_f32_e32 v27, v39, v56
+v_mac_f32_e32 v28, v40, v56
+v_mac_f32_e32 v29, v41, v56
+v_mac_f32_e32 v30, v38, v57
+v_mac_f32_e32 v31, v39, v57
+v_mac_f32_e32 v32, v40, v57
+v_mac_f32_dpp v70, v70, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v71, v71, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v72, v72, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v73, v73, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+s_setprio 0
+s_nop 0
+v_mac_f32_e32 v33, v41, v57
+v_cmp_eq_u32_e64 vcc, src_lds_direct, s91
+s_nop 0
+s_nop 0
+s_cbranch_vccz 65531
+s_nop 0
+ds_read_b128 v[38:41], v95 offset:41792
+ds_read_b128 v[50:53], v90 offset:41280
+ds_read_b128 v[54:57], v90 offset:41408
+ds_write_b32 v93, v72 offset:16512
+ds_write_b32 v94, v73 offset:16512
+s_setprio 1
+s_nop 0
+s_waitcnt vmcnt(12) lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 8
+s_call_b64 s[38:39], 1407
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_mac_f32_e32 v2, v34, v42
+v_mac_f32_e32 v3, v35, v42
+v_mac_f32_e32 v4, v36, v42
+v_mac_f32_e32 v5, v37, v42
+v_mac_f32_e32 v6, v34, v43
+v_mac_f32_e32 v7, v35, v43
+v_mac_f32_e32 v8, v36, v43
+v_mac_f32_e32 v9, v37, v43
+v_mac_f32_e32 v10, v34, v44
+v_mac_f32_e32 v11, v35, v44
+v_mac_f32_e32 v12, v36, v44
+v_mac_f32_e32 v13, v37, v44
+v_mac_f32_e32 v14, v34, v45
+v_mac_f32_e32 v15, v35, v45
+v_mac_f32_e32 v16, v36, v45
+v_mac_f32_e32 v17, v37, v45
+v_mac_f32_e32 v18, v34, v46
+v_mac_f32_e32 v19, v35, v46
+v_mac_f32_e32 v20, v36, v46
+v_mac_f32_e32 v21, v37, v46
+v_mac_f32_e32 v22, v34, v47
+v_mac_f32_e32 v23, v35, v47
+v_mac_f32_e32 v24, v36, v47
+v_mac_f32_e32 v25, v37, v47
+v_mac_f32_e32 v26, v34, v48
+v_mac_f32_e32 v27, v35, v48
+v_mac_f32_e32 v28, v36, v48
+v_mac_f32_e32 v29, v37, v48
+v_mac_f32_e32 v30, v34, v49
+v_mac_f32_e32 v31, v35, v49
+v_subrev_f32_e64 v74, v76, v74 div:2
+v_subrev_f32_e64 v77, v75, v77 div:2
+v_add_f32_e64 v75, v76, v75 div:2
+v_mad_f32 v76, v76, 1.0, -v75
+s_setprio 0
+s_nop 0
+v_mac_f32_e32 v32, v36, v49
+v_mac_f32_e32 v33, v37, v49
+s_nop 0
+ds_read_b128 v[34:37], v95 offset:45952
+ds_read_b128 v[42:45], v90 offset:45440
+ds_read_b128 v[46:49], v90 offset:45568
+ds_write_b32 v91, v70 offset:16512
+ds_write_b32 v92, v71 offset:16512
+s_setprio 1
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+buffer_load_dword v66, v82, s[40:43], 0 offen
+buffer_load_dword v68, v84, s[40:43], 0 offen
+buffer_load_dword v67, v83, s[40:43], 0 offen
+buffer_load_dword v69, v85, s[40:43], 0 offen
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 3
+s_call_b64 s[38:39], 1330
+s_nop 0
+s_nop 0
+v_mac_f32_e32 v2, v38, v50
+v_mac_f32_e32 v3, v39, v50
+v_mac_f32_e32 v4, v40, v50
+v_mac_f32_e32 v5, v41, v50
+v_mac_f32_e32 v6, v38, v51
+v_mac_f32_e32 v7, v39, v51
+v_mac_f32_e32 v8, v40, v51
+v_mac_f32_e32 v9, v41, v51
+v_mac_f32_e32 v10, v38, v52
+v_mac_f32_e32 v11, v39, v52
+v_mac_f32_e32 v12, v40, v52
+v_mac_f32_e32 v13, v41, v52
+v_mac_f32_e32 v14, v38, v53
+v_mac_f32_e32 v15, v39, v53
+v_mac_f32_e32 v16, v40, v53
+v_mac_f32_e32 v17, v41, v53
+v_mac_f32_e32 v18, v38, v54
+v_mac_f32_e32 v19, v39, v54
+v_mac_f32_e32 v20, v40, v54
+v_mac_f32_e32 v21, v41, v54
+v_mac_f32_e32 v22, v38, v55
+v_mac_f32_e32 v23, v39, v55
+v_mac_f32_e32 v24, v40, v55
+v_mac_f32_e32 v25, v41, v55
+v_mac_f32_e32 v26, v38, v56
+v_mac_f32_e32 v27, v39, v56
+v_mac_f32_e32 v28, v40, v56
+v_mac_f32_e32 v29, v41, v56
+v_mac_f32_e32 v30, v38, v57
+v_mac_f32_e32 v31, v39, v57
+v_mac_f32_dpp v74, v74, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v75, v75, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v76, v76, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v77, v77, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+s_setprio 0
+s_nop 0
+v_mac_f32_e32 v32, v40, v57
+v_mac_f32_e32 v33, v41, v57
+s_nop 0
+ds_read_b128 v[38:41], v95 offset:512
+ds_read_b128 v[50:53], v90
+ds_read_b128 v[54:57], v90 offset:128
+ds_write_b32 v93, v76 offset:24768
+ds_write_b32 v94, v77 offset:24768
+s_setprio 1
+s_nop 0
+s_waitcnt vmcnt(12) lgkmcnt(5)
+ds_append v105 offset:65476
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 3
+s_call_b64 s[38:39], 1266
+s_nop 0
+s_nop 0
+v_mac_f32_e32 v2, v34, v42
+v_mac_f32_e32 v3, v35, v42
+v_mac_f32_e32 v4, v36, v42
+v_mac_f32_e32 v5, v37, v42
+v_mac_f32_e32 v6, v34, v43
+v_mac_f32_e32 v7, v35, v43
+v_mac_f32_e32 v8, v36, v43
+v_mac_f32_e32 v9, v37, v43
+v_mac_f32_e32 v10, v34, v44
+v_mac_f32_e32 v11, v35, v44
+v_mac_f32_e32 v12, v36, v44
+v_mac_f32_e32 v13, v37, v44
+v_mac_f32_e32 v14, v34, v45
+v_mac_f32_e32 v15, v35, v45
+v_mac_f32_e32 v16, v36, v45
+v_mac_f32_e32 v17, v37, v45
+v_mac_f32_e32 v18, v34, v46
+v_mac_f32_e32 v19, v35, v46
+v_mac_f32_e32 v20, v36, v46
+v_mac_f32_e32 v21, v37, v46
+v_mac_f32_e32 v22, v34, v47
+v_mac_f32_e32 v23, v35, v47
+v_mac_f32_e32 v24, v36, v47
+v_mac_f32_e32 v25, v37, v47
+v_mac_f32_e32 v26, v34, v48
+v_mac_f32_e32 v27, v35, v48
+v_mac_f32_e32 v28, v36, v48
+v_mac_f32_e32 v29, v37, v48
+v_mac_f32_e32 v30, v34, v49
+v_mac_f32_e32 v31, v35, v49
+v_subrev_f32_e64 v78, v80, v78 div:2
+v_subrev_f32_e64 v81, v79, v81 div:2
+v_add_f32_e64 v79, v80, v79 div:2
+v_mad_f32 v80, v80, 1.0, -v79
+s_setprio 0
+s_nop 0
+v_mac_f32_e32 v32, v36, v49
+v_mac_f32_e32 v33, v37, v49
+s_nop 0
+ds_read_b128 v[34:37], v95 offset:4672
+ds_read_b128 v[42:45], v90 offset:4160
+ds_read_b128 v[46:49], v90 offset:4288
+ds_write_b32 v91, v74 offset:24768
+ds_write_b32 v92, v75 offset:24768
+s_setprio 1
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+buffer_load_dword v70, v82, s[40:43], 0 offen
+buffer_load_dword v72, v84, s[40:43], 0 offen
+buffer_load_dword v71, v83, s[40:43], 0 offen
+buffer_load_dword v73, v85, s[40:43], 0 offen
+s_mov_b32 m0, 0x2ffc4
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 1
+s_call_b64 s[38:39], 1192
+v_mac_f32_e32 v2, v38, v50
+v_mac_f32_e32 v3, v39, v50
+v_mac_f32_e32 v4, v40, v50
+v_mac_f32_e32 v5, v41, v50
+v_mac_f32_e32 v6, v38, v51
+v_mac_f32_e32 v7, v39, v51
+v_mac_f32_e32 v8, v40, v51
+v_mac_f32_e32 v9, v41, v51
+v_mac_f32_e32 v10, v38, v52
+v_mac_f32_e32 v11, v39, v52
+v_mac_f32_e32 v12, v40, v52
+v_mac_f32_e32 v13, v41, v52
+v_mac_f32_e32 v14, v38, v53
+v_mac_f32_e32 v15, v39, v53
+v_mac_f32_e32 v16, v40, v53
+v_mac_f32_e32 v17, v41, v53
+v_mac_f32_e32 v18, v38, v54
+v_mac_f32_e32 v19, v39, v54
+v_mac_f32_e32 v20, v40, v54
+v_mac_f32_e32 v21, v41, v54
+v_mac_f32_e32 v22, v38, v55
+v_mac_f32_e32 v23, v39, v55
+v_mac_f32_e32 v24, v40, v55
+v_mac_f32_e32 v25, v41, v55
+v_mac_f32_e32 v26, v38, v56
+v_mac_f32_e32 v27, v39, v56
+v_mac_f32_e32 v28, v40, v56
+v_mac_f32_e32 v29, v41, v56
+v_mac_f32_e32 v30, v38, v57
+v_mac_f32_e32 v31, v39, v57
+v_mac_f32_e32 v32, v40, v57
+v_mac_f32_dpp v78, v78, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v79, v79, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v80, v80, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v81, v81, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+s_setprio 0
+s_nop 0
+v_mac_f32_e32 v33, v41, v57
+v_cmp_eq_u32_e64 vcc, src_lds_direct, s91
+s_nop 0
+s_nop 0
+s_cbranch_vccz 65531
+s_nop 0
+ds_read_b128 v[38:41], v95 offset:8768
+ds_read_b128 v[50:53], v90 offset:8256
+ds_read_b128 v[54:57], v90 offset:8384
+ds_write_b32 v93, v80 offset:33024
+ds_write_b32 v94, v81 offset:33024
+s_setprio 1
+s_nop 0
+s_waitcnt vmcnt(12) lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 8
+s_call_b64 s[38:39], 1127
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_mac_f32_e32 v2, v34, v42
+v_mac_f32_e32 v3, v35, v42
+v_mac_f32_e32 v4, v36, v42
+v_mac_f32_e32 v5, v37, v42
+v_mac_f32_e32 v6, v34, v43
+v_mac_f32_e32 v7, v35, v43
+v_mac_f32_e32 v8, v36, v43
+v_mac_f32_e32 v9, v37, v43
+v_mac_f32_e32 v10, v34, v44
+v_mac_f32_e32 v11, v35, v44
+v_mac_f32_e32 v12, v36, v44
+v_mac_f32_e32 v13, v37, v44
+v_mac_f32_e32 v14, v34, v45
+v_mac_f32_e32 v15, v35, v45
+v_mac_f32_e32 v16, v36, v45
+v_mac_f32_e32 v17, v37, v45
+v_mac_f32_e32 v18, v34, v46
+v_mac_f32_e32 v19, v35, v46
+v_mac_f32_e32 v20, v36, v46
+v_mac_f32_e32 v21, v37, v46
+v_mac_f32_e32 v22, v34, v47
+v_mac_f32_e32 v23, v35, v47
+v_mac_f32_e32 v24, v36, v47
+v_mac_f32_e32 v25, v37, v47
+v_mac_f32_e32 v26, v34, v48
+v_mac_f32_e32 v27, v35, v48
+v_mac_f32_e32 v28, v36, v48
+v_mac_f32_e32 v29, v37, v48
+v_mac_f32_e32 v30, v34, v49
+v_mac_f32_e32 v31, v35, v49
+v_subrev_f32_e64 v58, v60, v58 div:2
+v_subrev_f32_e64 v61, v59, v61 div:2
+v_add_f32_e64 v59, v60, v59 div:2
+v_mad_f32 v60, v60, 1.0, -v59
+s_setprio 0
+s_nop 0
+v_mac_f32_e32 v32, v36, v49
+v_mac_f32_e32 v33, v37, v49
+s_nop 0
+ds_read_b128 v[34:37], v95 offset:12928
+ds_read_b128 v[42:45], v90 offset:12416
+ds_read_b128 v[46:49], v90 offset:12544
+ds_write_b32 v91, v78 offset:33024
+ds_write_b32 v92, v79 offset:33024
+s_setprio 1
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+buffer_load_dword v74, v82, s[40:43], 0 offen
+buffer_load_dword v76, v84, s[40:43], 0 offen
+buffer_load_dword v75, v83, s[40:43], 0 offen
+buffer_load_dword v77, v85, s[40:43], 0 offen
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 3
+s_call_b64 s[38:39], 1050
+s_nop 0
+s_nop 0
+v_mac_f32_e32 v2, v38, v50
+v_mac_f32_e32 v3, v39, v50
+v_mac_f32_e32 v4, v40, v50
+v_mac_f32_e32 v5, v41, v50
+v_mac_f32_e32 v6, v38, v51
+v_mac_f32_e32 v7, v39, v51
+v_mac_f32_e32 v8, v40, v51
+v_mac_f32_e32 v9, v41, v51
+v_mac_f32_e32 v10, v38, v52
+v_mac_f32_e32 v11, v39, v52
+v_mac_f32_e32 v12, v40, v52
+v_mac_f32_e32 v13, v41, v52
+v_mac_f32_e32 v14, v38, v53
+v_mac_f32_e32 v15, v39, v53
+v_mac_f32_e32 v16, v40, v53
+v_mac_f32_e32 v17, v41, v53
+v_mac_f32_e32 v18, v38, v54
+v_mac_f32_e32 v19, v39, v54
+v_mac_f32_e32 v20, v40, v54
+v_mac_f32_e32 v21, v41, v54
+v_mac_f32_e32 v22, v38, v55
+v_mac_f32_e32 v23, v39, v55
+v_mac_f32_e32 v24, v40, v55
+v_mac_f32_e32 v25, v41, v55
+v_mac_f32_e32 v26, v38, v56
+v_mac_f32_e32 v27, v39, v56
+v_mac_f32_e32 v28, v40, v56
+v_mac_f32_e32 v29, v41, v56
+v_mac_f32_e32 v30, v38, v57
+v_mac_f32_e32 v31, v39, v57
+v_mac_f32_dpp v58, v58, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v59, v59, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v60, v60, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v61, v61, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+s_setprio 0
+s_nop 0
+v_mac_f32_e32 v32, v40, v57
+v_mac_f32_e32 v33, v41, v57
+s_nop 0
+ds_read_b128 v[38:41], v95 offset:17024
+ds_read_b128 v[50:53], v90 offset:16512
+ds_read_b128 v[54:57], v90 offset:16640
+ds_write_b32 v93, v60 offset:41280
+ds_write_b32 v94, v61 offset:41280
+s_setprio 1
+s_nop 0
+s_waitcnt vmcnt(12) lgkmcnt(5)
+ds_append v105 offset:65480
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 3
+s_call_b64 s[38:39], 986
+s_nop 0
+s_nop 0
+v_mac_f32_e32 v2, v34, v42
+v_mac_f32_e32 v3, v35, v42
+v_mac_f32_e32 v4, v36, v42
+v_mac_f32_e32 v5, v37, v42
+v_mac_f32_e32 v6, v34, v43
+v_mac_f32_e32 v7, v35, v43
+v_mac_f32_e32 v8, v36, v43
+v_mac_f32_e32 v9, v37, v43
+v_mac_f32_e32 v10, v34, v44
+v_mac_f32_e32 v11, v35, v44
+v_mac_f32_e32 v12, v36, v44
+v_mac_f32_e32 v13, v37, v44
+v_mac_f32_e32 v14, v34, v45
+v_mac_f32_e32 v15, v35, v45
+v_mac_f32_e32 v16, v36, v45
+v_mac_f32_e32 v17, v37, v45
+v_mac_f32_e32 v18, v34, v46
+v_mac_f32_e32 v19, v35, v46
+v_mac_f32_e32 v20, v36, v46
+v_mac_f32_e32 v21, v37, v46
+v_mac_f32_e32 v22, v34, v47
+v_mac_f32_e32 v23, v35, v47
+v_mac_f32_e32 v24, v36, v47
+v_mac_f32_e32 v25, v37, v47
+v_mac_f32_e32 v26, v34, v48
+v_mac_f32_e32 v27, v35, v48
+v_mac_f32_e32 v28, v36, v48
+v_mac_f32_e32 v29, v37, v48
+v_mac_f32_e32 v30, v34, v49
+v_mac_f32_e32 v31, v35, v49
+v_subrev_f32_e64 v62, v64, v62 div:2
+v_subrev_f32_e64 v65, v63, v65 div:2
+v_add_f32_e64 v63, v64, v63 div:2
+v_mad_f32 v64, v64, 1.0, -v63
+s_setprio 0
+s_nop 0
+v_mac_f32_e32 v32, v36, v49
+v_mac_f32_e32 v33, v37, v49
+s_nop 0
+ds_read_b128 v[34:37], v95 offset:21184
+ds_read_b128 v[42:45], v90 offset:20672
+ds_read_b128 v[46:49], v90 offset:20800
+ds_write_b32 v91, v58 offset:41280
+ds_write_b32 v92, v59 offset:41280
+s_setprio 1
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+buffer_load_dword v78, v82, s[40:43], 0 offen
+buffer_load_dword v80, v84, s[40:43], 0 offen
+buffer_load_dword v79, v83, s[40:43], 0 offen
+buffer_load_dword v81, v85, s[40:43], 0 offen
+s_mov_b32 m0, 0x2ffc8
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 1
+s_call_b64 s[38:39], 912
+v_mac_f32_e32 v2, v38, v50
+v_mac_f32_e32 v3, v39, v50
+v_mac_f32_e32 v4, v40, v50
+v_mac_f32_e32 v5, v41, v50
+v_mac_f32_e32 v6, v38, v51
+v_mac_f32_e32 v7, v39, v51
+v_mac_f32_e32 v8, v40, v51
+v_mac_f32_e32 v9, v41, v51
+v_mac_f32_e32 v10, v38, v52
+v_mac_f32_e32 v11, v39, v52
+v_mac_f32_e32 v12, v40, v52
+v_mac_f32_e32 v13, v41, v52
+v_mac_f32_e32 v14, v38, v53
+v_mac_f32_e32 v15, v39, v53
+v_mac_f32_e32 v16, v40, v53
+v_mac_f32_e32 v17, v41, v53
+v_mac_f32_e32 v18, v38, v54
+v_mac_f32_e32 v19, v39, v54
+v_mac_f32_e32 v20, v40, v54
+v_mac_f32_e32 v21, v41, v54
+v_mac_f32_e32 v22, v38, v55
+v_mac_f32_e32 v23, v39, v55
+v_mac_f32_e32 v24, v40, v55
+v_mac_f32_e32 v25, v41, v55
+v_mac_f32_e32 v26, v38, v56
+v_mac_f32_e32 v27, v39, v56
+v_mac_f32_e32 v28, v40, v56
+v_mac_f32_e32 v29, v41, v56
+v_mac_f32_e32 v30, v38, v57
+v_mac_f32_e32 v31, v39, v57
+v_mac_f32_e32 v32, v40, v57
+v_mac_f32_dpp v62, v62, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v63, v63, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v64, v64, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v65, v65, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+s_setprio 0
+s_nop 0
+v_mac_f32_e32 v33, v41, v57
+v_cmp_eq_u32_e64 vcc, src_lds_direct, s91
+s_nop 0
+s_nop 0
+s_cbranch_vccz 65531
+s_nop 0
+ds_read_b128 v[38:41], v95 offset:25280
+ds_read_b128 v[50:53], v90 offset:24768
+ds_read_b128 v[54:57], v90 offset:24896
+ds_write_b32 v93, v64
+ds_write_b32 v94, v65
+s_setprio 1
+s_nop 0
+s_waitcnt vmcnt(12) lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 64704
+s_call_b64 s[38:39], 847
+s_branch 64702
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_mac_f32_e32 v2, v34, v42
+v_mac_f32_e32 v3, v35, v42
+v_mac_f32_e32 v4, v36, v42
+s_setprio 1
+s_nop 0
+v_mac_f32_e32 v5, v37, v42
+v_mac_f32_e32 v6, v34, v43
+v_mac_f32_e32 v7, v35, v43
+v_mac_f32_e32 v8, v36, v43
+v_mac_f32_e32 v9, v37, v43
+v_mac_f32_e32 v10, v34, v44
+v_mac_f32_e32 v11, v35, v44
+v_mac_f32_e32 v12, v36, v44
+v_mac_f32_e32 v13, v37, v44
+v_mac_f32_e32 v14, v34, v45
+v_mac_f32_e32 v15, v35, v45
+v_mac_f32_e32 v16, v36, v45
+v_mac_f32_e32 v17, v37, v45
+v_mac_f32_e32 v18, v34, v46
+v_mac_f32_e32 v19, v35, v46
+v_mac_f32_e32 v20, v36, v46
+v_mac_f32_e32 v21, v37, v46
+v_mac_f32_e32 v22, v34, v47
+v_mac_f32_e32 v23, v35, v47
+v_mac_f32_e32 v24, v36, v47
+v_mac_f32_e32 v25, v37, v47
+v_mac_f32_e32 v26, v34, v48
+v_mac_f32_e32 v27, v35, v48
+v_mac_f32_e32 v28, v36, v48
+v_mac_f32_e32 v29, v37, v48
+v_mac_f32_e32 v30, v34, v49
+v_mac_f32_e32 v31, v35, v49
+v_add_f32_dpp v66, v67, v67  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v66, v67, v100  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v103, v69, v69  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v103, v69, v100  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_mac_f32_e32 v32, v36, v49
+v_mac_f32_e32 v33, v37, v49
+s_nop 0
+ds_read_b128 v[34:37], v95 offset:29440
+ds_read_b128 v[42:45], v90 offset:28928
+ds_read_b128 v[46:49], v90 offset:29056
+ds_write_b32 v91, v62
+ds_write_b32 v92, v63
+s_setprio 0
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+buffer_load_dword v60, v84, s[40:43], 0 offen
+buffer_load_dword v59, v83, s[40:43], 0 offen
+buffer_load_dword v61, v85, s[40:43], 0 offen
+s_add_u32 s91, s91, 0x200
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 3
+s_call_b64 s[38:39], 770
+s_nop 0
+s_nop 0
+v_mac_f32_e32 v2, v38, v50
+v_mac_f32_e32 v3, v39, v50
+v_mac_f32_e32 v4, v40, v50
+s_setprio 1
+s_nop 0
+v_mac_f32_e32 v5, v41, v50
+v_mac_f32_e32 v6, v38, v51
+v_mac_f32_e32 v7, v39, v51
+v_mac_f32_e32 v8, v40, v51
+v_mac_f32_e32 v9, v41, v51
+v_mac_f32_e32 v10, v38, v52
+v_mac_f32_e32 v11, v39, v52
+v_mac_f32_e32 v12, v40, v52
+v_mac_f32_e32 v13, v41, v52
+v_mac_f32_e32 v14, v38, v53
+v_mac_f32_e32 v15, v39, v53
+v_mac_f32_e32 v16, v40, v53
+v_mac_f32_e32 v17, v41, v53
+v_mac_f32_e32 v18, v38, v54
+v_mac_f32_e32 v19, v39, v54
+v_mac_f32_e32 v20, v40, v54
+v_mac_f32_e32 v21, v41, v54
+v_mac_f32_e32 v22, v38, v55
+v_mac_f32_e32 v23, v39, v55
+v_mac_f32_e32 v24, v40, v55
+v_mac_f32_e32 v25, v41, v55
+v_mac_f32_e32 v26, v38, v56
+v_mac_f32_e32 v27, v39, v56
+v_mac_f32_e32 v28, v40, v56
+v_mac_f32_e32 v29, v41, v56
+v_mac_f32_e32 v30, v38, v57
+v_mac_f32_e32 v31, v39, v57
+v_add_f32_dpp v69, v68, v68  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v69, v68, v100  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_add_f32_e32 v68, v66, v69
+v_add_f32_e64 v67, v103, v68 div:2
+v_add_f32_e64 v68, -v103, v68 div:2
+v_mac_f32_e32 v32, v40, v57
+v_mac_f32_e32 v33, v41, v57
+s_nop 0
+ds_read_b128 v[38:41], v95 offset:33536
+ds_read_b128 v[50:53], v90 offset:33024
+ds_read_b128 v[54:57], v90 offset:33152
+ds_write_b32 v93, v68 offset:8256
+ds_write_b32 v94, v69 offset:8256
+s_setprio 0
+s_nop 0
+s_waitcnt vmcnt(9) lgkmcnt(5)
+ds_append v105 offset:65472
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 2
+s_call_b64 s[38:39], 705
+s_nop 0
+v_mac_f32_e32 v2, v34, v42
+v_mac_f32_e32 v3, v35, v42
+v_mac_f32_e32 v4, v36, v42
+s_setprio 1
+s_nop 0
+v_mac_f32_e32 v5, v37, v42
+v_mac_f32_e32 v6, v34, v43
+v_mac_f32_e32 v7, v35, v43
+v_mac_f32_e32 v8, v36, v43
+v_mac_f32_e32 v9, v37, v43
+v_mac_f32_e32 v10, v34, v44
+v_mac_f32_e32 v11, v35, v44
+v_mac_f32_e32 v12, v36, v44
+v_mac_f32_e32 v13, v37, v44
+v_mac_f32_e32 v14, v34, v45
+v_mac_f32_e32 v15, v35, v45
+v_mac_f32_e32 v16, v36, v45
+v_mac_f32_e32 v17, v37, v45
+v_mac_f32_e32 v18, v34, v46
+v_mac_f32_e32 v19, v35, v46
+v_mac_f32_e32 v20, v36, v46
+v_mac_f32_e32 v21, v37, v46
+v_mac_f32_e32 v22, v34, v47
+v_mac_f32_e32 v23, v35, v47
+v_mac_f32_e32 v24, v36, v47
+v_mac_f32_e32 v25, v37, v47
+v_mac_f32_e32 v26, v34, v48
+v_mac_f32_e32 v27, v35, v48
+v_mac_f32_e32 v28, v36, v48
+v_mac_f32_e32 v29, v37, v48
+v_mac_f32_e32 v30, v34, v49
+v_mac_f32_e32 v31, v35, v49
+v_add_f32_dpp v70, v71, v71  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v70, v71, v100  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v103, v73, v73  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v103, v73, v100  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_mac_f32_e32 v32, v36, v49
+v_mac_f32_e32 v33, v37, v49
+s_nop 0
+ds_read_b128 v[34:37], v95 offset:37696
+ds_read_b128 v[42:45], v90 offset:37184
+ds_read_b128 v[46:49], v90 offset:37312
+ds_write_b32 v91, v66 offset:8256
+ds_write_b32 v92, v67 offset:8256
+s_setprio 0
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+buffer_load_dword v64, v84, s[40:43], 0 offen
+buffer_load_dword v63, v83, s[40:43], 0 offen
+buffer_load_dword v65, v85, s[40:43], 0 offen
+s_mov_b32 m0, 0x2ffc0
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 3
+s_call_b64 s[38:39], 634
+s_nop 0
+s_nop 0
+v_mac_f32_e32 v2, v38, v50
+v_mac_f32_e32 v3, v39, v50
+v_mac_f32_e32 v4, v40, v50
+s_setprio 1
+s_nop 0
+v_mac_f32_e32 v5, v41, v50
+v_mac_f32_e32 v6, v38, v51
+v_mac_f32_e32 v7, v39, v51
+v_mac_f32_e32 v8, v40, v51
+v_mac_f32_e32 v9, v41, v51
+v_mac_f32_e32 v10, v38, v52
+v_mac_f32_e32 v11, v39, v52
+v_mac_f32_e32 v12, v40, v52
+v_mac_f32_e32 v13, v41, v52
+v_mac_f32_e32 v14, v38, v53
+v_mac_f32_e32 v15, v39, v53
+v_mac_f32_e32 v16, v40, v53
+v_mac_f32_e32 v17, v41, v53
+v_mac_f32_e32 v18, v38, v54
+v_mac_f32_e32 v19, v39, v54
+v_mac_f32_e32 v20, v40, v54
+v_mac_f32_e32 v21, v41, v54
+v_mac_f32_e32 v22, v38, v55
+v_mac_f32_e32 v23, v39, v55
+v_mac_f32_e32 v24, v40, v55
+v_mac_f32_e32 v25, v41, v55
+v_mac_f32_e32 v26, v38, v56
+v_mac_f32_e32 v27, v39, v56
+v_mac_f32_e32 v28, v40, v56
+v_mac_f32_e32 v29, v41, v56
+v_mac_f32_e32 v30, v38, v57
+v_mac_f32_e32 v31, v39, v57
+v_mac_f32_e32 v32, v40, v57
+v_add_f32_dpp v73, v72, v72  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v73, v72, v100  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_add_f32_e32 v72, v70, v73
+v_add_f32_e64 v71, v103, v72 div:2
+v_add_f32_e64 v72, -v103, v72 div:2
+v_mac_f32_e32 v33, v41, v57
+v_cmp_eq_u32_e64 vcc, src_lds_direct, s91
+s_nop 0
+s_nop 0
+s_cbranch_vccz 65531
+s_nop 0
+ds_read_b128 v[38:41], v95 offset:41792
+ds_read_b128 v[50:53], v90 offset:41280
+ds_read_b128 v[54:57], v90 offset:41408
+ds_write_b32 v93, v72 offset:16512
+ds_write_b32 v94, v73 offset:16512
+s_setprio 0
+s_nop 0
+s_waitcnt vmcnt(9) lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 7
+s_call_b64 s[38:39], 566
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_mac_f32_e32 v2, v34, v42
+v_mac_f32_e32 v3, v35, v42
+v_mac_f32_e32 v4, v36, v42
+s_setprio 1
+s_nop 0
+v_mac_f32_e32 v5, v37, v42
+v_mac_f32_e32 v6, v34, v43
+v_mac_f32_e32 v7, v35, v43
+v_mac_f32_e32 v8, v36, v43
+v_mac_f32_e32 v9, v37, v43
+v_mac_f32_e32 v10, v34, v44
+v_mac_f32_e32 v11, v35, v44
+v_mac_f32_e32 v12, v36, v44
+v_mac_f32_e32 v13, v37, v44
+v_mac_f32_e32 v14, v34, v45
+v_mac_f32_e32 v15, v35, v45
+v_mac_f32_e32 v16, v36, v45
+v_mac_f32_e32 v17, v37, v45
+v_mac_f32_e32 v18, v34, v46
+v_mac_f32_e32 v19, v35, v46
+v_mac_f32_e32 v20, v36, v46
+v_mac_f32_e32 v21, v37, v46
+v_mac_f32_e32 v22, v34, v47
+v_mac_f32_e32 v23, v35, v47
+v_mac_f32_e32 v24, v36, v47
+v_mac_f32_e32 v25, v37, v47
+v_mac_f32_e32 v26, v34, v48
+v_mac_f32_e32 v27, v35, v48
+v_mac_f32_e32 v28, v36, v48
+v_mac_f32_e32 v29, v37, v48
+v_mac_f32_e32 v30, v34, v49
+v_mac_f32_e32 v31, v35, v49
+v_add_f32_dpp v74, v75, v75  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v74, v75, v100  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v103, v77, v77  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v103, v77, v100  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_mac_f32_e32 v32, v36, v49
+v_mac_f32_e32 v33, v37, v49
+s_nop 0
+ds_read_b128 v[34:37], v95 offset:45952
+ds_read_b128 v[42:45], v90 offset:45440
+ds_read_b128 v[46:49], v90 offset:45568
+ds_write_b32 v91, v70 offset:16512
+ds_write_b32 v92, v71 offset:16512
+s_setprio 0
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+buffer_load_dword v68, v84, s[40:43], 0 offen
+buffer_load_dword v67, v83, s[40:43], 0 offen
+buffer_load_dword v69, v85, s[40:43], 0 offen
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 5
+s_call_b64 s[38:39], 492
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_mac_f32_e32 v2, v38, v50
+v_mac_f32_e32 v3, v39, v50
+v_mac_f32_e32 v4, v40, v50
+s_setprio 1
+s_nop 0
+v_mac_f32_e32 v5, v41, v50
+v_mac_f32_e32 v6, v38, v51
+v_mac_f32_e32 v7, v39, v51
+v_mac_f32_e32 v8, v40, v51
+v_mac_f32_e32 v9, v41, v51
+v_mac_f32_e32 v10, v38, v52
+v_mac_f32_e32 v11, v39, v52
+v_mac_f32_e32 v12, v40, v52
+v_mac_f32_e32 v13, v41, v52
+v_mac_f32_e32 v14, v38, v53
+v_mac_f32_e32 v15, v39, v53
+v_mac_f32_e32 v16, v40, v53
+v_mac_f32_e32 v17, v41, v53
+v_mac_f32_e32 v18, v38, v54
+v_mac_f32_e32 v19, v39, v54
+v_mac_f32_e32 v20, v40, v54
+v_mac_f32_e32 v21, v41, v54
+v_mac_f32_e32 v22, v38, v55
+v_mac_f32_e32 v23, v39, v55
+v_mac_f32_e32 v24, v40, v55
+v_mac_f32_e32 v25, v41, v55
+v_mac_f32_e32 v26, v38, v56
+v_mac_f32_e32 v27, v39, v56
+v_mac_f32_e32 v28, v40, v56
+v_mac_f32_e32 v29, v41, v56
+v_mac_f32_e32 v30, v38, v57
+v_mac_f32_e32 v31, v39, v57
+v_add_f32_dpp v77, v76, v76  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v77, v76, v100  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_add_f32_e32 v76, v74, v77
+v_add_f32_e64 v75, v103, v76 div:2
+v_add_f32_e64 v76, -v103, v76 div:2
+v_mac_f32_e32 v32, v40, v57
+v_mac_f32_e32 v33, v41, v57
+s_nop 0
+ds_read_b128 v[38:41], v95 offset:512
+ds_read_b128 v[50:53], v90
+ds_read_b128 v[54:57], v90 offset:128
+ds_write_b32 v93, v76 offset:24768
+ds_write_b32 v94, v77 offset:24768
+s_setprio 0
+s_nop 0
+s_waitcnt vmcnt(9) lgkmcnt(5)
+ds_append v105 offset:65476
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 2
+s_call_b64 s[38:39], 425
+s_nop 0
+v_mac_f32_e32 v2, v34, v42
+v_mac_f32_e32 v3, v35, v42
+v_mac_f32_e32 v4, v36, v42
+s_setprio 1
+s_nop 0
+v_mac_f32_e32 v5, v37, v42
+v_mac_f32_e32 v6, v34, v43
+v_mac_f32_e32 v7, v35, v43
+v_mac_f32_e32 v8, v36, v43
+v_mac_f32_e32 v9, v37, v43
+v_mac_f32_e32 v10, v34, v44
+v_mac_f32_e32 v11, v35, v44
+v_mac_f32_e32 v12, v36, v44
+v_mac_f32_e32 v13, v37, v44
+v_mac_f32_e32 v14, v34, v45
+v_mac_f32_e32 v15, v35, v45
+v_mac_f32_e32 v16, v36, v45
+v_mac_f32_e32 v17, v37, v45
+v_mac_f32_e32 v18, v34, v46
+v_mac_f32_e32 v19, v35, v46
+v_mac_f32_e32 v20, v36, v46
+v_mac_f32_e32 v21, v37, v46
+v_mac_f32_e32 v22, v34, v47
+v_mac_f32_e32 v23, v35, v47
+v_mac_f32_e32 v24, v36, v47
+v_mac_f32_e32 v25, v37, v47
+v_mac_f32_e32 v26, v34, v48
+v_mac_f32_e32 v27, v35, v48
+v_mac_f32_e32 v28, v36, v48
+v_mac_f32_e32 v29, v37, v48
+v_mac_f32_e32 v30, v34, v49
+v_mac_f32_e32 v31, v35, v49
+v_add_f32_dpp v78, v79, v79  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v78, v79, v100  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v103, v81, v81  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v103, v81, v100  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_mac_f32_e32 v32, v36, v49
+v_mac_f32_e32 v33, v37, v49
+s_nop 0
+ds_read_b128 v[34:37], v95 offset:4672
+ds_read_b128 v[42:45], v90 offset:4160
+ds_read_b128 v[46:49], v90 offset:4288
+ds_write_b32 v91, v74 offset:24768
+ds_write_b32 v92, v75 offset:24768
+s_setprio 0
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+buffer_load_dword v72, v84, s[40:43], 0 offen
+buffer_load_dword v71, v83, s[40:43], 0 offen
+buffer_load_dword v73, v85, s[40:43], 0 offen
+s_mov_b32 m0, 0x2ffc4
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 3
+s_call_b64 s[38:39], 354
+s_nop 0
+s_nop 0
+v_mac_f32_e32 v2, v38, v50
+v_mac_f32_e32 v3, v39, v50
+v_mac_f32_e32 v4, v40, v50
+s_setprio 1
+s_nop 0
+v_mac_f32_e32 v5, v41, v50
+v_mac_f32_e32 v6, v38, v51
+v_mac_f32_e32 v7, v39, v51
+v_mac_f32_e32 v8, v40, v51
+v_mac_f32_e32 v9, v41, v51
+v_mac_f32_e32 v10, v38, v52
+v_mac_f32_e32 v11, v39, v52
+v_mac_f32_e32 v12, v40, v52
+v_mac_f32_e32 v13, v41, v52
+v_mac_f32_e32 v14, v38, v53
+v_mac_f32_e32 v15, v39, v53
+v_mac_f32_e32 v16, v40, v53
+v_mac_f32_e32 v17, v41, v53
+v_mac_f32_e32 v18, v38, v54
+v_mac_f32_e32 v19, v39, v54
+v_mac_f32_e32 v20, v40, v54
+v_mac_f32_e32 v21, v41, v54
+v_mac_f32_e32 v22, v38, v55
+v_mac_f32_e32 v23, v39, v55
+v_mac_f32_e32 v24, v40, v55
+v_mac_f32_e32 v25, v41, v55
+v_mac_f32_e32 v26, v38, v56
+v_mac_f32_e32 v27, v39, v56
+v_mac_f32_e32 v28, v40, v56
+v_mac_f32_e32 v29, v41, v56
+v_mac_f32_e32 v30, v38, v57
+v_mac_f32_e32 v31, v39, v57
+v_mac_f32_e32 v32, v40, v57
+v_add_f32_dpp v81, v80, v80  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v81, v80, v100  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_add_f32_e32 v80, v78, v81
+v_add_f32_e64 v79, v103, v80 div:2
+v_add_f32_e64 v80, -v103, v80 div:2
+v_mac_f32_e32 v33, v41, v57
+v_cmp_eq_u32_e64 vcc, src_lds_direct, s91
+s_nop 0
+s_nop 0
+s_cbranch_vccz 65531
+s_nop 0
+ds_read_b128 v[38:41], v95 offset:8768
+ds_read_b128 v[50:53], v90 offset:8256
+ds_read_b128 v[54:57], v90 offset:8384
+ds_write_b32 v93, v80 offset:33024
+ds_write_b32 v94, v81 offset:33024
+s_setprio 0
+s_nop 0
+s_waitcnt vmcnt(9) lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 7
+s_call_b64 s[38:39], 286
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_mac_f32_e32 v2, v34, v42
+v_mac_f32_e32 v3, v35, v42
+v_mac_f32_e32 v4, v36, v42
+s_setprio 1
+s_nop 0
+v_mac_f32_e32 v5, v37, v42
+v_mac_f32_e32 v6, v34, v43
+v_mac_f32_e32 v7, v35, v43
+v_mac_f32_e32 v8, v36, v43
+v_mac_f32_e32 v9, v37, v43
+v_mac_f32_e32 v10, v34, v44
+v_mac_f32_e32 v11, v35, v44
+v_mac_f32_e32 v12, v36, v44
+v_mac_f32_e32 v13, v37, v44
+v_mac_f32_e32 v14, v34, v45
+v_mac_f32_e32 v15, v35, v45
+v_mac_f32_e32 v16, v36, v45
+v_mac_f32_e32 v17, v37, v45
+v_mac_f32_e32 v18, v34, v46
+v_mac_f32_e32 v19, v35, v46
+v_mac_f32_e32 v20, v36, v46
+v_mac_f32_e32 v21, v37, v46
+v_mac_f32_e32 v22, v34, v47
+v_mac_f32_e32 v23, v35, v47
+v_mac_f32_e32 v24, v36, v47
+v_mac_f32_e32 v25, v37, v47
+v_mac_f32_e32 v26, v34, v48
+v_mac_f32_e32 v27, v35, v48
+v_mac_f32_e32 v28, v36, v48
+v_mac_f32_e32 v29, v37, v48
+v_mac_f32_e32 v30, v34, v49
+v_mac_f32_e32 v31, v35, v49
+v_add_f32_dpp v58, v59, v59  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v58, v59, v100  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v103, v61, v61  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v103, v61, v100  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_mac_f32_e32 v32, v36, v49
+v_mac_f32_e32 v33, v37, v49
+s_nop 0
+ds_read_b128 v[34:37], v95 offset:12928
+ds_read_b128 v[42:45], v90 offset:12416
+ds_read_b128 v[46:49], v90 offset:12544
+ds_write_b32 v91, v78 offset:33024
+ds_write_b32 v92, v79 offset:33024
+s_setprio 0
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+buffer_load_dword v76, v84, s[40:43], 0 offen
+buffer_load_dword v75, v83, s[40:43], 0 offen
+buffer_load_dword v77, v85, s[40:43], 0 offen
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 5
+s_call_b64 s[38:39], 212
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_mac_f32_e32 v2, v38, v50
+v_mac_f32_e32 v3, v39, v50
+v_mac_f32_e32 v4, v40, v50
+s_setprio 1
+s_nop 0
+v_mac_f32_e32 v5, v41, v50
+v_mac_f32_e32 v6, v38, v51
+v_mac_f32_e32 v7, v39, v51
+v_mac_f32_e32 v8, v40, v51
+v_mac_f32_e32 v9, v41, v51
+v_mac_f32_e32 v10, v38, v52
+v_mac_f32_e32 v11, v39, v52
+v_mac_f32_e32 v12, v40, v52
+v_mac_f32_e32 v13, v41, v52
+v_mac_f32_e32 v14, v38, v53
+v_mac_f32_e32 v15, v39, v53
+v_mac_f32_e32 v16, v40, v53
+v_mac_f32_e32 v17, v41, v53
+v_mac_f32_e32 v18, v38, v54
+v_mac_f32_e32 v19, v39, v54
+v_mac_f32_e32 v20, v40, v54
+v_mac_f32_e32 v21, v41, v54
+v_mac_f32_e32 v22, v38, v55
+v_mac_f32_e32 v23, v39, v55
+v_mac_f32_e32 v24, v40, v55
+v_mac_f32_e32 v25, v41, v55
+v_mac_f32_e32 v26, v38, v56
+v_mac_f32_e32 v27, v39, v56
+v_mac_f32_e32 v28, v40, v56
+v_mac_f32_e32 v29, v41, v56
+v_mac_f32_e32 v30, v38, v57
+v_mac_f32_e32 v31, v39, v57
+v_add_f32_dpp v61, v60, v60  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v61, v60, v100  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_add_f32_e32 v60, v58, v61
+v_add_f32_e64 v59, v103, v60 div:2
+v_add_f32_e64 v60, -v103, v60 div:2
+v_mac_f32_e32 v32, v40, v57
+v_mac_f32_e32 v33, v41, v57
+s_nop 0
+ds_read_b128 v[38:41], v95 offset:17024
+ds_read_b128 v[50:53], v90 offset:16512
+ds_read_b128 v[54:57], v90 offset:16640
+ds_write_b32 v93, v60 offset:41280
+ds_write_b32 v94, v61 offset:41280
+s_setprio 0
+s_nop 0
+s_waitcnt vmcnt(9) lgkmcnt(5)
+ds_append v105 offset:65480
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 2
+s_call_b64 s[38:39], 145
+s_nop 0
+v_mac_f32_e32 v2, v34, v42
+v_mac_f32_e32 v3, v35, v42
+v_mac_f32_e32 v4, v36, v42
+s_setprio 1
+s_nop 0
+v_mac_f32_e32 v5, v37, v42
+v_mac_f32_e32 v6, v34, v43
+v_mac_f32_e32 v7, v35, v43
+v_mac_f32_e32 v8, v36, v43
+v_mac_f32_e32 v9, v37, v43
+v_mac_f32_e32 v10, v34, v44
+v_mac_f32_e32 v11, v35, v44
+v_mac_f32_e32 v12, v36, v44
+v_mac_f32_e32 v13, v37, v44
+v_mac_f32_e32 v14, v34, v45
+v_mac_f32_e32 v15, v35, v45
+v_mac_f32_e32 v16, v36, v45
+v_mac_f32_e32 v17, v37, v45
+v_mac_f32_e32 v18, v34, v46
+v_mac_f32_e32 v19, v35, v46
+v_mac_f32_e32 v20, v36, v46
+v_mac_f32_e32 v21, v37, v46
+v_mac_f32_e32 v22, v34, v47
+v_mac_f32_e32 v23, v35, v47
+v_mac_f32_e32 v24, v36, v47
+v_mac_f32_e32 v25, v37, v47
+v_mac_f32_e32 v26, v34, v48
+v_mac_f32_e32 v27, v35, v48
+v_mac_f32_e32 v28, v36, v48
+v_mac_f32_e32 v29, v37, v48
+v_mac_f32_e32 v30, v34, v49
+v_mac_f32_e32 v31, v35, v49
+v_add_f32_dpp v62, v63, v63  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v62, v63, v100  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v103, v65, v65  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v103, v65, v100  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_mac_f32_e32 v32, v36, v49
+v_mac_f32_e32 v33, v37, v49
+s_nop 0
+ds_read_b128 v[34:37], v95 offset:21184
+ds_read_b128 v[42:45], v90 offset:20672
+ds_read_b128 v[46:49], v90 offset:20800
+ds_write_b32 v91, v58 offset:41280
+ds_write_b32 v92, v59 offset:41280
+s_setprio 0
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+buffer_load_dword v80, v84, s[40:43], 0 offen
+buffer_load_dword v79, v83, s[40:43], 0 offen
+buffer_load_dword v81, v85, s[40:43], 0 offen
+s_mov_b32 m0, 0x2ffc8
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 3
+s_call_b64 s[38:39], 74
+s_nop 0
+s_nop 0
+v_mac_f32_e32 v2, v38, v50
+v_mac_f32_e32 v3, v39, v50
+v_mac_f32_e32 v4, v40, v50
+s_setprio 1
+s_nop 0
+v_mac_f32_e32 v5, v41, v50
+v_mac_f32_e32 v6, v38, v51
+v_mac_f32_e32 v7, v39, v51
+v_mac_f32_e32 v8, v40, v51
+v_mac_f32_e32 v9, v41, v51
+v_mac_f32_e32 v10, v38, v52
+v_mac_f32_e32 v11, v39, v52
+v_mac_f32_e32 v12, v40, v52
+v_mac_f32_e32 v13, v41, v52
+v_mac_f32_e32 v14, v38, v53
+v_mac_f32_e32 v15, v39, v53
+v_mac_f32_e32 v16, v40, v53
+v_mac_f32_e32 v17, v41, v53
+v_mac_f32_e32 v18, v38, v54
+v_mac_f32_e32 v19, v39, v54
+v_mac_f32_e32 v20, v40, v54
+v_mac_f32_e32 v21, v41, v54
+v_mac_f32_e32 v22, v38, v55
+v_mac_f32_e32 v23, v39, v55
+v_mac_f32_e32 v24, v40, v55
+v_mac_f32_e32 v25, v41, v55
+v_mac_f32_e32 v26, v38, v56
+v_mac_f32_e32 v27, v39, v56
+v_mac_f32_e32 v28, v40, v56
+v_mac_f32_e32 v29, v41, v56
+v_mac_f32_e32 v30, v38, v57
+v_mac_f32_e32 v31, v39, v57
+v_mac_f32_e32 v32, v40, v57
+v_add_f32_dpp v65, v64, v64  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v65, v64, v100  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_add_f32_e32 v64, v62, v65
+v_add_f32_e64 v63, v103, v64 div:2
+v_add_f32_e64 v64, -v103, v64 div:2
+v_mac_f32_e32 v33, v41, v57
+v_cmp_eq_u32_e64 vcc, src_lds_direct, s91
+s_nop 0
+s_nop 0
+s_cbranch_vccz 65531
+s_nop 0
+ds_read_b128 v[38:41], v95 offset:25280
+ds_read_b128 v[50:53], v90 offset:24768
+ds_read_b128 v[54:57], v90 offset:24896
+ds_write_b32 v93, v64
+ds_write_b32 v94, v65
+s_setprio 0
+s_nop 0
+s_waitcnt vmcnt(9) lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 64703
+s_call_b64 s[38:39], 6
+s_branch 64701
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_nop
+s_cmp_eq_u32 s82, 0
+s_cbranch_scc0 8
+s_branch 588
+s_add_u32 s82, s82, 1
+s_andn2_b32 s82, s82, 1
+s_bitcmp1_b32 0, 26
+s_cselect_b32 s52, s69, s70
+s_cselect_b32 s53, 0, s71
+s_sub_u32 s40, s40, s52
+s_subb_u32 s41, s41, s53
+s_cmp_eq_u32 s94, 0
+s_cbranch_scc0 3
+s_cbranch_scc1 610
+s_nop 0
+s_nop 0
+s_min_u32 s72, s82, s94
+s_sub_u32 s82, s82, s72
+s_sub_u32 s94, s94, s72
+s_sub_u32 s72, s72, 1
+s_setpc_b64 s[38:39]
+s_nop 0
+s_nop 0
+s_nop 0
+s_bitcmp1_b32 s18, 17
+s_cbranch_scc1 241
+s_add_u32 s88, s88, s17
+s_cmp_eq_u32 s88, 0
+s_cbranch_scc1 238
+s_mov_b32 s89, 0
+s_bitcmp1_b32 s18, 16
+s_cbranch_scc1 227
+s_add_u32 s87, s16, 31
+s_lshr_b32 s87, s87, 5
+v_mov_b32_e32 v107, s88
+v_mul_u32_u24_e32 v107, s87, v107
+v_add_co_u32_e32 v107, vcc, s17, v107
+v_sub_co_u32_e64 v107, vcc, v107, 1
+v_ffbh_u32_e32 v110, s17
+v_lshlrev_b32_e64 v111, v110, s17
+v_and_b32_e32 v112, 0xffffff00, v111
+v_cmp_eq_u32_e32 vcc, 0x80000000, v111
+v_cvt_f32_u32_e32 v112, v112
+v_rcp_f32_e32 v106, v112
+v_subb_co_u32_e32 v109, vcc, 32, v110, vcc
+v_cvt_f32_ubyte0_e32 v110, v111
+v_fma_f32 v112, v112, v106, -1.0
+v_fma_f32 v112, v110, v106, v112
+v_madak_f32 v112, v112, v106, 0x9f000000
+v_mul_f32_e32 v112, 0x5f800000, v112
+v_mov_b32_e32 v110, 0
+v_cvt_flr_i32_f32_e64 v112, -v112
+v_lshl_add_u32 v106, v106, 9, v112
+v_mad_u64_u32 v[110:111], vcc, v111, v106, v[110:111]
+v_subb_co_u32_e64 v106, vcc, v106, -1, vcc
+v_mul_hi_u32 v110, v107, v106
+v_add_co_u32_e32 v106, vcc, v110, v107
+v_addc_co_u32_e64 v110, vcc, 0, 0, vcc
+v_cmp_eq_u32_e32 vcc, 32, v109
+v_cndmask_b32_e32 v106, v106, v110, vcc
+v_alignbit_b32 v106, v110, v106, v109
+v_readfirstlane_b32 s86, v106
+v_mul_u32_u24_e64 v106, v106, s8
+v_ffbh_u32_e32 v110, s87
+v_lshlrev_b32_e64 v111, v110, s87
+v_and_b32_e32 v112, 0xffffff00, v111
+v_cmp_eq_u32_e32 vcc, 0x80000000, v111
+v_cvt_f32_u32_e32 v112, v112
+v_rcp_f32_e32 v107, v112
+v_subb_co_u32_e32 v109, vcc, 32, v110, vcc
+v_cvt_f32_ubyte0_e32 v110, v111
+v_fma_f32 v112, v112, v107, -1.0
+v_fma_f32 v112, v110, v107, v112
+v_madak_f32 v112, v112, v107, 0x9f000000
+v_mul_f32_e32 v112, 0x5f800000, v112
+v_mov_b32_e32 v110, 0
+v_cvt_flr_i32_f32_e64 v112, -v112
+v_lshl_add_u32 v107, v107, 9, v112
+v_mad_u64_u32 v[110:111], vcc, v111, v107, v[110:111]
+v_subb_co_u32_e64 v107, vcc, v107, -1, vcc
+v_mul_hi_u32 v110, v106, v107
+v_add_co_u32_e32 v107, vcc, v110, v106
+v_addc_co_u32_e64 v110, vcc, 0, 0, vcc
+v_cmp_eq_u32_e32 vcc, 32, v109
+v_cndmask_b32_e32 v107, v107, v110, vcc
+v_alignbit_b32 v107, v110, v107, v109
+v_readfirstlane_b32 s52, v106
+v_readfirstlane_b32 s84, v107
+s_mul_i32 s84, s84, s87
+s_sub_u32 s84, s52, s84
+v_sub_co_u32_e32 v107, vcc, s8, v107
+v_sub_co_u32_e32 v107, vcc, s17, v107
+v_and_b32_e64 v109, v0, 63
+v_cmp_eq_u32_e64 vcc, v109, 0
+v_cndmask_b32_e32 v107, 1, v107, vcc
+s_sub_u32 s58, 0, s75
+s_sub_u32 s59, 0, s74
+v_mul_u32_u24_e64 v111, v107, 32
+v_ffbh_u32_e32 v113, s58
+v_lshlrev_b32_e64 v114, v113, s58
+v_and_b32_e32 v115, 0xffffff00, v114
+v_cmp_eq_u32_e32 vcc, 0x80000000, v114
+v_cvt_f32_u32_e32 v115, v115
+v_rcp_f32_e32 v109, v115
+v_subb_co_u32_e32 v112, vcc, 32, v113, vcc
+v_cvt_f32_ubyte0_e32 v113, v114
+v_fma_f32 v115, v115, v109, -1.0
+v_fma_f32 v115, v113, v109, v115
+v_madak_f32 v115, v115, v109, 0x9f000000
+v_mul_f32_e32 v115, 0x5f800000, v115
+v_mov_b32_e32 v113, 0
+v_cvt_flr_i32_f32_e64 v115, -v115
+v_lshl_add_u32 v109, v109, 9, v115
+v_mad_u64_u32 v[113:114], vcc, v114, v109, v[113:114]
+v_subb_co_u32_e64 v109, vcc, v109, -1, vcc
+v_mul_hi_u32 v113, v111, v109
+v_add_co_u32_e32 v109, vcc, v113, v111
+v_addc_co_u32_e64 v113, vcc, 0, 0, vcc
+v_cmp_eq_u32_e32 vcc, 32, v112
+v_cndmask_b32_e32 v109, v109, v113, vcc
+v_alignbit_b32 v109, v113, v109, v112
+v_mad_i32_i24 v110, v109, s75, v111
+v_mul_u32_u24_e64 v111, v109, 1
+v_ffbh_u32_e32 v113, s59
+v_lshlrev_b32_e64 v114, v113, s59
+v_and_b32_e32 v115, 0xffffff00, v114
+v_cmp_eq_u32_e32 vcc, 0x80000000, v114
+v_cvt_f32_u32_e32 v115, v115
+v_rcp_f32_e32 v109, v115
+v_subb_co_u32_e32 v112, vcc, 32, v113, vcc
+v_cvt_f32_ubyte0_e32 v113, v114
+v_fma_f32 v115, v115, v109, -1.0
+v_fma_f32 v115, v113, v109, v115
+v_madak_f32 v115, v115, v109, 0x9f000000
+v_mul_f32_e32 v115, 0x5f800000, v115
+v_mov_b32_e32 v113, 0
+v_cvt_flr_i32_f32_e64 v115, -v115
+v_lshl_add_u32 v109, v109, 9, v115
+v_mad_u64_u32 v[113:114], vcc, v114, v109, v[113:114]
+v_subb_co_u32_e64 v109, vcc, v109, -1, vcc
+v_mul_hi_u32 v113, v111, v109
+v_add_co_u32_e32 v109, vcc, v113, v111
+v_addc_co_u32_e64 v113, vcc, 0, 0, vcc
+v_cmp_eq_u32_e32 vcc, 32, v112
+v_cndmask_b32_e32 v109, v109, v113, vcc
+v_alignbit_b32 v109, v113, v109, v112
+v_mad_i32_i24 v111, v109, s74, v111
+v_readfirstlane_b32 s76, v110
+v_readfirstlane_b32 s77, v111
+v_readfirstlane_b32 s78, v109
+v_add_co_u32_e32 v96, vcc, s76, v96
+v_addc_co_u32_e64 v112, vcc, 0, 0, vcc
+v_mad_i32_i24 v96, v112, s75, v96
+v_mad_i32_i24 v98, v112, s80, v98
+v_mad_i32_i24 v97, v112, s79, v97
+v_cmp_ge_i32_e64 vcc, v97, 0
+v_addc_co_u32_e64 v112, vcc, 0, 0, vcc
+v_add_co_u32_e32 v98, vcc, v98, v112
+v_mad_i32_i24 v97, v112, s74, v97
+v_add_co_u32_e32 v97, vcc, s77, v97
+v_addc_co_u32_e64 v112, vcc, 0, 0, vcc
+v_add_co_u32_e32 v98, vcc, v98, v112
+v_mad_i32_i24 v97, v112, s74, v97
+v_add_co_u32_e32 v98, vcc, s78, v98
+v_readlane_b32 s76, v110, 1
+v_readlane_b32 s77, v111, 1
+v_readlane_b32 s78, v109, 1
+s_add_u32 s85, s84, s86
+s_cmp_le_u32 s85, s87
+s_cselect_b32 s52, 0x20000, 0
+s_cselect_b32 s85, s85, s87
+s_or_b32 s18, s18, s52
+s_lshl_b32 s84, s84, 5
+s_lshl_b32 s85, s85, 5
+s_min_u32 s85, s85, s16
+s_cmp_eq_u32 s8, s17
+s_cselect_b32 s52, 0x20000, 0
+s_or_b32 s18, s18, s52
+s_or_b32 s18, s18, s52
+s_bitset1_b32 s18, 16
+s_branch 43
+s_lshr_b32 s84, s84, 5
+s_add_u32 s85, s84, s86
+s_sub_u32 s85, s85, s87
+s_mov_b32 s84, 0
+s_lshl_b32 s85, s85, 5
+s_min_u32 s85, s85, s16
+s_bitset1_b32 s18, 17
+s_branch 12
+s_bitset1_b32 s18, 18
+s_mov_b32 s43, 0
+s_mov_b32 s73, -1
+s_mov_b32 s82, 40
+s_branch 31
+s_add_u32 s83, s83, 32
+s_cmp_ge_u32 s83, s85
+s_cbranch_scc0 28
+s_bitset1_b32 s18, 22
+s_sub_u32 s88, s88, s17
+s_subb_u32 s89, s89, 0
+s_cbranch_scc1 65281
+v_add_co_u32_e32 v96, vcc, s76, v96
+v_addc_co_u32_e64 v106, vcc, 0, 0, vcc
+v_mad_i32_i24 v96, v106, s75, v96
+v_mad_i32_i24 v98, v106, s80, v98
+v_mad_i32_i24 v97, v106, s79, v97
+v_cmp_ge_i32_e64 vcc, v97, 0
+v_addc_co_u32_e64 v106, vcc, 0, 0, vcc
+v_add_co_u32_e32 v98, vcc, v98, v106
+v_mad_i32_i24 v97, v106, s74, v97
+v_add_co_u32_e32 v97, vcc, s77, v97
+v_addc_co_u32_e64 v106, vcc, 0, 0, vcc
+v_add_co_u32_e32 v98, vcc, v98, v106
+v_mad_i32_i24 v97, v106, s74, v97
+v_add_co_u32_e32 v98, vcc, s78, v98
+s_mov_b32 s83, s84
+v_cmp_le_u32_e32 vcc, 0x100, v0
+s_cbranch_vccz 166
+v_subrev_co_u32_e32 v106, vcc, s75, v96
+v_subrev_co_u32_e32 v107, vcc, s74, v97
+s_bitcmp1_b32 s18, 22
+s_cbranch_scc0 64
+s_bitset0_b32 s18, 22
+s_bfe_u32 s52, s18, 0x10014
+v_mul_u32_u24_e32 v111, 2, v106
+v_mul_u32_u24_e32 v112, 2, v107
+v_cvt_pk_u16_u32 v114, v111, v112
+v_and_b32_e64 v111, v0, 1
+v_cmp_eq_u32_e64 vcc, v111, 1
+v_cndmask_b32_e32 v114, v98, v114, vcc
+v_lshrrev_b32_e32 v110, 1, v0
+v_bfe_u32 v115, v110, s52, 1
+v_lshrrev_b32_e32 v110, 1, v0
+v_bfi_b32 v110, 1, v0, v110
+v_lshrrev_b32_e32 v111, 2, v0
+v_bfi_b32 v111, 1, v0, v111
+v_cmp_eq_u32_e64 vcc, s52, 0
+v_cndmask_b32_e32 v110, v111, v110, vcc
+s_sub_u32 s52, 1, s52
+v_lshrrev_b32_e32 v111, s52, v110
+v_bfi_b32 v110, 32, v111, v110
+v_and_b32_e32 v110, 63, v110
+v_add_co_u32_e32 v111, vcc, 16, v110
+v_and_b32_e64 v112, v0, 2
+v_cmp_eq_u32_e64 vcc, v112, 0
+v_cndmask_b32_e32 v111, v111, v110, vcc
+v_lshlrev_b32_e32 v112, 14, v115
+v_mad_u32_u24 v111, 4, v111, v112
+v_add_co_u32_e32 v110, vcc, s96, v111
+ds_write_b32 v110, v114
+v_writelane_b32 v112, s18, 0
+v_writelane_b32 v112, s85, 1
+v_writelane_b32 v112, s84, 2
+v_and_b32_e64 v110, v0, 63
+v_cmp_ge_u32_e64 vcc, v110, 3
+v_mov_b32_e32 v113, 0x4000
+v_cndmask_b32_e32 v110, v110, v113, vcc
+v_mad_i32_i24 v110, v110, 4, s96
+ds_write_b32 v110, v112 offset:256
+s_add_u32 s96, s96, 0x18c
+s_cmp_eq_u32 s96, 0xffc0
+s_cselect_b32 s96, 0xc1e0, s96
+v_mov_b32_dpp v108, v98  quad_perm:[0,0,0,0] row_mask:0xf bank_mask:0xf
+v_mov_b32_dpp v106, v106  quad_perm:[0,0,0,0] row_mask:0xf bank_mask:0xf
+v_mov_b32_dpp v107, v107  quad_perm:[0,0,0,0] row_mask:0xf bank_mask:0xf
+v_readfirstlane_b32 s81, v108
+v_sub_co_u32_e64 v109, vcc, v108, s81
+v_mul_lo_u32 v109, v109, s65
+v_and_b32_e64 v113, v0, 3
+v_ashrrev_i32_e64 v114, 0, s31
+v_subrev_co_u32_e32 v113, vcc, v114, v113
+v_ashrrev_i32_e64 v114, 0, s62
+v_mad_i32_i24 v110, v114, 3, v113
+s_bfe_u32 s52, s18, 0x10014
+v_lshrrev_b32_e32 v112, 2, v0
+v_and_b32_e32 v112, s52, v112
+v_mad_i32_i24 v110, v112, 3, v110
+v_add_co_u32_e64 v111, vcc, 0, s63
+v_ashrrev_i32_e32 v111, 0, v111
+v_add_co_u32_e64 v112, vcc, 0, s30
+v_ashrrev_i32_e32 v112, 0, v112
+v_sub_i32 v111, v111, v112
+s_lshl_b32 s54, s15, 2
+v_cmp_ge_u32_e64 s[52:53], v108, s12
+v_mad_i32_i24 v106, v106, 2, v110
+v_cmp_ge_u32_e64 s[56:57], v106, s15
+v_mad_i32_i24 v106, 4, v106, v109
+s_or_b64 s[56:57], s[56:57], s[52:53]
+v_mad_i32_i24 v107, v107, 2, v111
+v_cmp_ge_u32_e64 s[58:59], v107, s14
+s_or_b64 s[58:59], s[56:57], s[58:59]
+v_mad_u32_u24 v82, v107, s54, v106
+v_cndmask_b32_e64 v82, v82, -1, s[58:59]
+v_add_co_u32_e32 v107, vcc, 1, v107
+v_cmp_ge_u32_e64 s[58:59], v107, s14
+s_or_b64 s[58:59], s[56:57], s[58:59]
+v_mad_u32_u24 v83, v107, s54, v106
+v_cndmask_b32_e64 v83, v83, -1, s[58:59]
+v_add_co_u32_e32 v107, vcc, 1, v107
+v_cmp_ge_u32_e64 s[58:59], v107, s14
+s_or_b64 s[58:59], s[56:57], s[58:59]
+v_mad_u32_u24 v84, v107, s54, v106
+v_cndmask_b32_e64 v84, v84, -1, s[58:59]
+v_add_co_u32_e32 v107, vcc, 1, v107
+v_cmp_ge_u32_e64 s[58:59], v107, s14
+s_or_b64 s[58:59], s[56:57], s[58:59]
+v_mad_u32_u24 v85, v107, s54, v106
+v_cndmask_b32_e64 v85, v85, -1, s[58:59]
+s_bitcmp1_b32 s18, 18
+s_cbranch_scc1 135
+s_lshr_b32 s52, -1, 16
+s_and_b32 s52, s52, s65
+s_lshr_b32 s53, s65, 16
+s_mul_i32 s53, s53, s81
+s_mul_i32 s40, s52, s81
+s_lshl_b32 s52, s53, 16
+s_lshr_b32 s53, s53, 16
+s_add_u32 s40, s52, s40
+s_addc_u32 s41, s53, 0
+s_add_u32 s40, s40, s20
+s_addc_u32 s41, s41, s21
+s_lshr_b32 s52, s18, 6
+s_xor_b32 s52, s52, s18
+s_and_b32 s52, s52, 0x80000
+s_cselect_b32 s52, s68, 0
+s_add_u32 s40, s40, s52
+s_addc_u32 s41, s41, 0
+s_branch 92
+s_bitcmp1_b32 s18, 18
+s_cbranch_scc1 114
+s_bfe_u32 s52, s18, 0x10014
+v_bfe_u32 v106, v0, 0, 2
+v_min_u32_e32 v106, 2, v106
+v_bfe_u32 v108, v0, 2, s52
+v_mad_u32_u24 v106, v108, 3, v106
+v_mad_u32_u24 v106, s62, 3, v106
+v_sub_co_u32_e32 v108, vcc, s29, v106
+v_sub_co_u32_e64 v108, vcc, v108, 1
+s_bfe_u32 s54, s18, 0x10001
+v_cmp_eq_u32_e64 vcc, s54, 1
+v_cndmask_b32_e32 v106, v106, v108, vcc
+v_cmp_ge_u32_e64 s[52:53], v106, s29
+v_lshlrev_b32_e32 v106, 2, v106
+s_bfe_u32 s54, s18, 0x10018
+v_bfe_u32 v109, v0, 2, s54
+v_mul_lo_u32 v109, s68, v109
+v_add_co_u32_e32 v106, vcc, v106, v109
+v_mul_lo_u32 v107, s90, v99
+v_add_co_u32_e32 v107, vcc, v107, v106
+s_sub_u32 s54, s28, s63
+s_sub_u32 s54, s54, 3
+s_bitcmp1_b32 s18, 0
+s_cselect_b32 s54, s54, s63
+v_mov_b32_e32 v109, s54
+s_lshl_b32 s57, s29, 2
+v_cmp_ge_u32_e64 s[54:55], v109, s28
+v_mad_i32_i24 v82, v109, s57, v107
+s_or_b64 s[54:55], s[54:55], s[52:53]
+v_cndmask_b32_e64 v82, v82, -1, s[54:55]
+v_mov_b32_e32 v83, v82
+v_add_co_u32_e64 v109, vcc, v109, 1
+v_cmp_ge_u32_e64 s[54:55], v109, s28
+v_mad_i32_i24 v85, v109, s57, v107
+s_or_b64 s[54:55], s[54:55], s[52:53]
+v_cndmask_b32_e64 v85, v85, -1, s[54:55]
+v_add_co_u32_e64 v109, vcc, v109, 1
+v_cmp_ge_u32_e64 s[54:55], v109, s28
+v_mad_i32_i24 v84, v109, s57, v107
+s_or_b64 s[54:55], s[54:55], s[52:53]
+v_cndmask_b32_e64 v84, v84, -1, s[54:55]
+v_add_co_u32_e64 v106, vcc, v99, s83
+v_cmp_lt_u32_e64 vcc, v106, s16
+v_cndmask_b32_e32 v82, -1, v82, vcc
+v_cndmask_b32_e32 v83, -1, v83, vcc
+v_cndmask_b32_e32 v84, -1, v84, vcc
+v_cndmask_b32_e32 v85, -1, v85, vcc
+s_lshr_b32 s52, -1, 16
+s_and_b32 s52, s52, s90
+s_lshr_b32 s53, s90, 16
+s_mul_i32 s53, s53, s83
+s_mul_i32 s40, s52, s83
+s_lshl_b32 s52, s53, 16
+s_lshr_b32 s53, s53, 16
+s_add_u32 s40, s52, s40
+s_addc_u32 s41, s53, 0
+s_add_u32 s40, s40, s22
+s_addc_u32 s41, s41, s23
+s_lshr_b32 s52, s18, 6
+s_xor_b32 s52, s52, s18
+s_and_b32 s52, s52, 0x80000
+s_cselect_b32 s52, s68, 0
+s_add_u32 s40, s40, s52
+s_addc_u32 s41, s41, 0
+s_mov_b32 s43, 0x20000
+s_mov_b32 s73, -1
+s_bfe_u32 s52, s18, 0x10014
+s_lshl_b32 s82, s13, s52
+s_bfe_u32 s52, s18, 0x10013
+s_bfe_u32 s54, s18, 0x10019
+s_xor_b32 s52, s52, s54
+s_cselect_b32 s52, 1, 0
+s_cselect_b32 s43, 0x20000, s43
+s_and_b32 s52, s52, s82
+s_sub_u32 s82, s82, s52
+s_bitcmp1_b32 s18, 20
+s_cselect_b32 s52, 0, 0x2000000
+s_bitcmp1_b32 s13, 0
+s_cselect_b32 s52, s52, 0
+s_xor_b32 s18, s18, s52
+s_cmp_eq_u32 s82, 0
+s_cbranch_scc1 4
+s_branch 64951
+s_nop 0
+s_nop 0
+s_nop 0
+s_and_b32 s52, 0x900000, s18
+s_subb_u32 s62, s62, 1
+s_cbranch_scc0 65243
+s_and_b32 s52, 0x900000, s18
+s_subb_u32 s62, s61, 1
+s_add_u32 s63, s63, 3
+s_cmp_ge_u32 s63, s28
+s_cbranch_scc0 65237
+s_mov_b32 s63, 0
+s_branch 65204
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_mac_f32_dpp v4, v4, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v5, v5, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v2, v2, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v3, v3, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v3, v4, v3  row_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v2, v5, v2  row_mirror row_mask:0xf bank_mask:0xf
+s_nop 0
+v_mac_f32_dpp v3, v3, v102  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mac_f32_dpp v2, v2, v102  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+s_nop 0
+v_add_f32_dpp v2, v3, v2  row_half_mirror row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v8, v8, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v9, v9, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v6, v6, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v7, v7, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v7, v8, v7  row_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v6, v9, v6  row_mirror row_mask:0xf bank_mask:0xf
+s_nop 0
+v_mac_f32_dpp v7, v7, v102  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mac_f32_dpp v6, v6, v102  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+s_nop 0
+v_add_f32_dpp v3, v7, v6  row_half_mirror row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v12, v12, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v13, v13, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v10, v10, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v11, v11, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v11, v12, v11  row_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v10, v13, v10  row_mirror row_mask:0xf bank_mask:0xf
+s_nop 0
+v_mac_f32_dpp v11, v11, v102  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mac_f32_dpp v10, v10, v102  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+s_nop 0
+v_add_f32_dpp v4, v11, v10  row_half_mirror row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v16, v16, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v17, v17, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v14, v14, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v15, v15, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v15, v16, v15  row_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v14, v17, v14  row_mirror row_mask:0xf bank_mask:0xf
+s_nop 0
+v_mac_f32_dpp v15, v15, v102  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mac_f32_dpp v14, v14, v102  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+s_nop 0
+v_add_f32_dpp v5, v15, v14  row_half_mirror row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v20, v20, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v21, v21, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v18, v18, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v19, v19, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v19, v20, v19  row_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v18, v21, v18  row_mirror row_mask:0xf bank_mask:0xf
+s_nop 0
+v_mac_f32_dpp v19, v19, v102  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mac_f32_dpp v18, v18, v102  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+s_nop 0
+v_add_f32_dpp v6, v19, v18  row_half_mirror row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v24, v24, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v25, v25, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v22, v22, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v23, v23, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v23, v24, v23  row_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v22, v25, v22  row_mirror row_mask:0xf bank_mask:0xf
+s_nop 0
+v_mac_f32_dpp v23, v23, v102  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mac_f32_dpp v22, v22, v102  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+s_nop 0
+v_add_f32_dpp v7, v23, v22  row_half_mirror row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v28, v28, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v29, v29, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v26, v26, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v27, v27, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v27, v28, v27  row_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v26, v29, v26  row_mirror row_mask:0xf bank_mask:0xf
+s_nop 0
+v_mac_f32_dpp v27, v27, v102  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mac_f32_dpp v26, v26, v102  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+s_nop 0
+v_add_f32_dpp v8, v27, v26  row_half_mirror row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v32, v32, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v33, v33, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v30, v30, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v31, v31, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v31, v32, v31  row_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v30, v33, v30  row_mirror row_mask:0xf bank_mask:0xf
+s_nop 0
+v_mac_f32_dpp v31, v31, v102  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mac_f32_dpp v30, v30, v102  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+s_nop 0
+v_add_f32_dpp v9, v31, v30  row_half_mirror row_mask:0xf bank_mask:0xf
+s_waitcnt vmcnt(0)
+v_readlane_b32 s55, v104, 0
+v_add_f32_e64 v2, v2, s55
+v_mul_f32_e64 v106, v2, s36
+v_cmp_lt_f32_e64 vcc, v2, 0
+v_cndmask_b32_e32 v2, v2, v106, vcc
+buffer_store_dword v2, v86, s[44:47], 0 offen
+s_add_u32 s44, s44, s67
+s_addc_u32 s45, s45, 0
+s_sub_u32 s93, s93, 1
+s_cselect_b32 s47, 0, s47
+v_readlane_b32 s55, v104, 1
+v_add_f32_e64 v3, v3, s55
+v_mul_f32_e64 v106, v3, s36
+v_cmp_lt_f32_e64 vcc, v3, 0
+v_cndmask_b32_e32 v3, v3, v106, vcc
+buffer_store_dword v3, v86, s[44:47], 0 offen
+s_add_u32 s44, s44, s67
+s_addc_u32 s45, s45, 0
+s_sub_u32 s93, s93, 1
+s_cselect_b32 s47, 0, s47
+v_readlane_b32 s55, v104, 2
+v_add_f32_e64 v4, v4, s55
+v_mul_f32_e64 v106, v4, s36
+v_cmp_lt_f32_e64 vcc, v4, 0
+v_cndmask_b32_e32 v4, v4, v106, vcc
+buffer_store_dword v4, v86, s[44:47], 0 offen
+s_add_u32 s44, s44, s67
+s_addc_u32 s45, s45, 0
+s_sub_u32 s93, s93, 1
+s_cselect_b32 s47, 0, s47
+v_readlane_b32 s55, v104, 3
+v_add_f32_e64 v5, v5, s55
+v_mul_f32_e64 v106, v5, s36
+v_cmp_lt_f32_e64 vcc, v5, 0
+v_cndmask_b32_e32 v5, v5, v106, vcc
+buffer_store_dword v5, v86, s[44:47], 0 offen
+s_add_u32 s44, s44, s67
+s_addc_u32 s45, s45, 0
+s_sub_u32 s93, s93, 1
+s_cselect_b32 s47, 0, s47
+s_lshl_b32 s52, s67, 2
+s_add_u32 s44, s44, s52
+s_addc_u32 s45, s45, 0
+s_sub_u32 s93, s93, 4
+s_cselect_b32 s47, 0, s47
+v_readlane_b32 s55, v104, 8
+v_add_f32_e64 v6, v6, s55
+v_mul_f32_e64 v106, v6, s36
+v_cmp_lt_f32_e64 vcc, v6, 0
+v_cndmask_b32_e32 v6, v6, v106, vcc
+buffer_store_dword v6, v86, s[44:47], 0 offen
+s_add_u32 s44, s44, s67
+s_addc_u32 s45, s45, 0
+s_sub_u32 s93, s93, 1
+s_cselect_b32 s47, 0, s47
+v_readlane_b32 s55, v104, 9
+v_add_f32_e64 v7, v7, s55
+v_mul_f32_e64 v106, v7, s36
+v_cmp_lt_f32_e64 vcc, v7, 0
+v_cndmask_b32_e32 v7, v7, v106, vcc
+buffer_store_dword v7, v86, s[44:47], 0 offen
+s_add_u32 s44, s44, s67
+s_addc_u32 s45, s45, 0
+s_sub_u32 s93, s93, 1
+s_cselect_b32 s47, 0, s47
+v_readlane_b32 s55, v104, 10
+v_add_f32_e64 v8, v8, s55
+v_mul_f32_e64 v106, v8, s36
+v_cmp_lt_f32_e64 vcc, v8, 0
+v_cndmask_b32_e32 v8, v8, v106, vcc
+buffer_store_dword v8, v86, s[44:47], 0 offen
+s_add_u32 s44, s44, s67
+s_addc_u32 s45, s45, 0
+s_sub_u32 s93, s93, 1
+s_cselect_b32 s47, 0, s47
+v_readlane_b32 s55, v104, 11
+v_add_f32_e64 v9, v9, s55
+v_mul_f32_e64 v106, v9, s36
+v_cmp_lt_f32_e64 vcc, v9, 0
+v_cndmask_b32_e32 v9, v9, v106, vcc
+buffer_store_dword v9, v86, s[44:47], 0 offen
+s_add_u32 s44, s44, s67
+s_addc_u32 s45, s45, 0
+s_sub_u32 s93, s93, 1
+s_cselect_b32 s47, 0, s47
+s_add_u32 s44, s44, s52
+s_addc_u32 s45, s45, 0
+s_lshl_b32 s52, s52, 2
+s_add_u32 s44, s44, s52
+s_addc_u32 s45, s45, 0
+s_sub_u32 s93, s93, 20
+s_cselect_b32 s47, 0, s47
+s_cselect_b32 s51, 0, s51
+s_add_u32 s48, s48, 0x80
+s_addc_u32 s49, s49, 0
+s_sub_u32 s50, s50, 0x80
+s_cselect_b32 s51, 0, s51
+v_mov_b32_e32 v2, 0
+v_mov_b32_e32 v3, 0
+v_mov_b32_e32 v4, 0
+v_mov_b32_e32 v5, 0
+v_mov_b32_e32 v6, 0
+v_mov_b32_e32 v7, 0
+v_mov_b32_e32 v8, 0
+v_mov_b32_e32 v9, 0
+v_mov_b32_e32 v10, 0
+v_mov_b32_e32 v11, 0
+v_mov_b32_e32 v12, 0
+v_mov_b32_e32 v13, 0
+v_mov_b32_e32 v14, 0
+v_mov_b32_e32 v15, 0
+v_mov_b32_e32 v16, 0
+v_mov_b32_e32 v17, 0
+v_mov_b32_e32 v18, 0
+v_mov_b32_e32 v19, 0
+v_mov_b32_e32 v20, 0
+v_mov_b32_e32 v21, 0
+v_mov_b32_e32 v22, 0
+v_mov_b32_e32 v23, 0
+v_mov_b32_e32 v24, 0
+v_mov_b32_e32 v25, 0
+v_mov_b32_e32 v26, 0
+v_mov_b32_e32 v27, 0
+v_mov_b32_e32 v28, 0
+v_mov_b32_e32 v29, 0
+v_mov_b32_e32 v30, 0
+v_mov_b32_e32 v31, 0
+v_mov_b32_e32 v32, 0
+v_mov_b32_e32 v33, 0
+s_xor_b32 s18, s18, 0x200000
+s_mul_i32 s94, s60, s61
+s_mul_i32 s94, s94, s13
+s_add_u32 s52, s93, s92
+s_cmp_lt_i32 s52, 0
+s_cbranch_scc0 104
+v_and_b32_e32 v86, 0x7f, v0
+v_lshrrev_b32_e32 v86, 1, v86
+v_bfi_b32 v86, 1, v0, v86
+v_and_b32_e64 v87, v0, 2
+v_mad_u32_u24 v86, v87, 16, v86
+v_lshlrev_b32_e32 v86, 2, v86
+v_add_co_u32_e64 v86, vcc, v86, s97
+v_and_b32_e32 v87, 3, v0
+v_lshlrev_b32_e32 v87, 2, v87
+v_add_co_u32_e64 v87, vcc, v87, s97
+ds_read_b32 v108, v87 offset:256
+ds_read_b32 v86, v86
+s_add_u32 s97, s97, 0x18c
+s_cmp_eq_u32 s97, 0xffc0
+s_cselect_b32 s97, 0xc1e0, s97
+s_waitcnt lgkmcnt(0)
+v_readfirstlane_b32 s95, v86
+v_readlane_b32 s54, v108, 0
+s_bitcmp1_b32 s54, 18
+s_cbranch_scc1 79
+v_readlane_b32 s52, v108, 1
+v_readlane_b32 s53, v108, 2
+s_add_u32 s93, s92, s53
+s_lshr_b32 s55, -1, 16
+s_and_b32 s55, s55, s66
+s_lshr_b32 s56, s66, 16
+s_mul_i32 s56, s56, s95
+s_mul_i32 s44, s55, s95
+s_lshl_b32 s55, s56, 16
+s_lshr_b32 s56, s56, 16
+s_add_u32 s44, s55, s44
+s_addc_u32 s45, s56, 0
+s_add_u32 s44, s44, s24
+s_addc_u32 s45, s45, s25
+s_mul_i32 s55, s67, s93
+s_add_u32 s44, s44, s55
+s_addc_u32 s45, s45, 0
+s_mov_b32 s47, 0x20000
+s_bitcmp1_b32 s18, 7
+s_cselect_b32 s51, 0x20000, 0
+s_lshl_b32 s55, s93, 2
+s_add_u32 s48, s34, s55
+s_addc_u32 s49, s35, 0
+s_lshl_b32 s56, s52, 2
+s_sub_u32 s50, s56, s55
+s_cselect_b32 s51, 0, s51
+s_sub_u32 s93, s52, s53
+s_sub_u32 s93, s93, 1
+s_sub_u32 s93, s93, s92
+s_cselect_b32 s47, 0, s47
+v_bfe_u32 v106, v86, 16, 16
+v_bfe_u32 v107, v86, 0, 16
+v_and_b32_e64 v108, v0, 7
+v_sub_co_u32_e32 v109, vcc, 7, v108
+v_min_u32_e32 v108, v108, v109
+v_bfe_u32 v109, v108, 1, 1
+v_bfe_u32 v108, v108, 0, 1
+v_mov_b32_dpp v106, v106  quad_perm:[1,1,1,1] row_mask:0xf bank_mask:0xf
+v_mov_b32_dpp v107, v107  quad_perm:[1,1,1,1] row_mask:0xf bank_mask:0xf
+v_add_co_u32_e32 v106, vcc, v106, v109
+v_add_co_u32_e32 v107, vcc, v107, v108
+v_mov_b32_dpp v108, v86  quad_perm:[0,0,0,0] row_mask:0xf bank_mask:0xf
+v_cmp_ge_u32_e64 s[52:53], v108, s12
+v_sub_co_u32_e64 v108, vcc, v108, s95
+v_mul_lo_u32 v108, v108, s66
+v_mad_i32_i24 v86, v106, s33, v107
+v_lshlrev_b32_e32 v86, 2, v86
+v_add_co_u32_e32 v86, vcc, v86, v108
+v_cmp_ge_u32_e64 s[58:59], v107, s33
+s_or_b64 s[56:57], s[58:59], s[52:53]
+v_cmp_ge_u32_e64 s[54:55], v106, s32
+s_or_b64 s[52:53], s[56:57], s[54:55]
+v_cndmask_b32_e64 v86, v86, -1, s[52:53]
+v_and_b32_e64 v104, v0, 63
+v_lshlrev_b32_e32 v104, 2, v104
+s_barrier
+buffer_load_dword v104, v104, s[48:51], 0 offen
+s_branch 64478
+s_endpgm
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0

--- a/src/kernels/Conv_Winograd_v21_1_3_gfx9_fp32_f2x3_stride2.inc
+++ b/src/kernels/Conv_Winograd_v21_1_3_gfx9_fp32_f2x3_stride2.inc
@@ -1,0 +1,2877 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2023 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+v_mov_b32_e32 v0, v0
+s_mov_b32 s0, 0
+s_mov_b32 s1, 0
+s_mov_b32 s2, 0
+s_mov_b32 s3, 0
+v_mov_b32_e32 v104, 0
+s_mov_b32 m0, 0x1ffff
+s_mov_b32 s97, 0xc1e0
+s_mov_b32 s96, 0xc1e0
+s_mov_b32 s91, 0
+v_lshlrev_b32_e32 v107, 2, v0
+v_add_co_u32_e32 v107, vcc, 0xffc0, v107
+v_cmp_ge_u32_e32 vcc, 12, v0
+s_cbranch_vccz 5
+v_mov_b32_e32 v106, 0
+v_cndmask_b32_e32 v107, -1, v107, vcc
+ds_write_b32 v107, v106
+s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+s_barrier
+v_readfirstlane_b32 s52, v0
+s_lshr_b32 s52, s52, 5
+s_add_u32 s52, s52, 8
+s_and_b32 s92, s52, 20
+s_mov_b64 s[40:41], s[6:7]
+s_load_dwordx16 s[12:27], s[40:41], 0x0
+s_load_dwordx4 s[28:31], s[40:41], 0x40
+s_load_dwordx2 s[32:33], s[40:41], 0x50
+s_waitcnt lgkmcnt(0)
+s_and_b32 s18, s18, 0xffff
+s_bitcmp1_b32 s18, 6
+s_cbranch_scc0 16
+s_and_b32 s21, s21, 0xffff
+s_and_b32 s23, s23, 0xffff
+s_and_b32 s25, s25, 0xffff
+s_and_b32 s27, s27, 0xffff
+s_load_dwordx2 s[20:21], s[20:21], 0x0
+s_load_dwordx2 s[22:23], s[22:23], 0x0
+s_load_dwordx2 s[24:25], s[24:25], 0x0
+s_load_dwordx2 s[26:27], s[26:27], 0x0
+s_bitcmp1_b32 s18, 7
+s_cbranch_scc0 2
+s_load_dwordx2 s[34:35], s[40:41], 0x58
+s_mov_b32 s36, 1.0
+s_bitcmp1_b32 s18, 8
+s_cbranch_scc0 2
+s_load_dword s36, s[40:41], 0x60
+s_bitcmp1_b32 s18, 7
+s_cbranch_scc0 7
+s_bitcmp1_b32 s18, 6
+s_cbranch_scc0 5
+s_waitcnt lgkmcnt(0)
+s_and_b32 s35, s35, 0xffff
+s_load_dwordx2 s[34:35], s[34:35], 0x0
+s_bitcmp1_b32 s18, 9
+s_cbranch_scc0 72
+s_mov_b32 s42, 0x8c
+s_mov_b32 s43, 0x9c
+v_cmp_le_u32_e32 vcc, 0x100, v0
+s_cmp_eq_u32 1, src_vccz
+s_cselect_b32 s42, s43, s42
+s_load_dword s65, s[40:41], 0x88
+s_load_dword s90, s[40:41], 0x98
+s_load_dword s68, s[40:41], s42
+s_load_dwordx2 s[66:67], s[40:41], 0xa8
+s_bitcmp1_b32 s18, 10
+s_cbranch_scc0 103
+s_load_dwordx4 s[44:47], s[40:41], 0xb8
+v_ffbh_u32_e32 v4, s17
+v_lshlrev_b32_e64 v5, v4, s17
+v_and_b32_e32 v6, 0xffffff00, v5
+v_cmp_eq_u32_e32 vcc, 0x80000000, v5
+v_cvt_f32_u32_e32 v6, v6
+v_rcp_f32_e32 v2, v6
+v_subb_co_u32_e32 v3, vcc, 32, v4, vcc
+v_cvt_f32_ubyte0_e32 v4, v5
+v_fma_f32 v6, v6, v2, -1.0
+v_fma_f32 v6, v4, v2, v6
+v_madak_f32 v6, v6, v2, 0x9f000000
+v_mul_f32_e32 v6, 0x5f800000, v6
+v_mov_b32_e32 v4, 0
+v_cvt_flr_i32_f32_e64 v6, -v6
+v_lshl_add_u32 v2, v2, 9, v6
+v_mad_u64_u32 v[4:5], vcc, v5, v2, v[4:5]
+v_subb_co_u32_e64 v2, vcc, v2, -1, vcc
+v_mul_hi_u32 v4, s8, v2
+v_add_co_u32_e64 v2, vcc, v4, s8
+v_addc_co_u32_e64 v4, vcc, 0, 0, vcc
+v_cmp_eq_u32_e32 vcc, 32, v3
+v_cndmask_b32_e32 v2, v2, v4, vcc
+v_alignbit_b32 v2, v4, v2, v3
+s_waitcnt lgkmcnt(0)
+v_readfirstlane_b32 s48, v2
+s_mul_i32 s49, s48, s17
+s_sub_u32 s8, s8, s49
+s_mul_i32 s49, s45, s48
+s_add_u32 s20, s20, s49
+s_addc_u32 s21, s21, 0
+s_mul_i32 s49, s46, s48
+s_add_u32 s22, s22, s49
+s_addc_u32 s23, s23, 0
+s_mul_i32 s49, s47, s48
+s_add_u32 s24, s24, s49
+s_addc_u32 s25, s25, 0
+s_branch 49
+s_mul_i32 s42, s14, s15
+s_lshr_b32 s46, -1, 16
+s_and_b32 s46, s46, s42
+s_lshr_b32 s47, s42, 16
+s_mul_i32 s47, s47, s13
+s_mul_i32 s44, s46, s13
+s_lshl_b32 s46, s47, 16
+s_lshr_b32 s47, s47, 16
+s_add_u32 s44, s46, s44
+s_addc_u32 s45, s47, 0
+s_lshl_b32 s65, s44, 2
+s_lshl_b32 s68, s42, 2
+s_mul_i32 s43, s32, s33
+s_lshr_b32 s46, -1, 16
+s_and_b32 s46, s46, s43
+s_lshr_b32 s47, s43, 16
+s_mul_i32 s47, s47, s16
+s_mul_i32 s44, s46, s16
+s_lshl_b32 s46, s47, 16
+s_lshr_b32 s47, s47, 16
+s_add_u32 s44, s46, s44
+s_addc_u32 s45, s47, 0
+s_lshl_b32 s66, s44, 2
+s_lshl_b32 s67, s43, 2
+s_bitcmp1_b32 s18, 13
+s_cbranch_scc0 2
+s_load_dwordx8 s[48:55], s[40:41], 0x68
+s_mul_i32 s42, s28, s29
+s_lshl_b32 s42, s42, 2
+s_bitcmp1_b32 s18, 2
+s_cselect_b32 s43, s16, s13
+s_lshr_b32 s44, -1, 16
+s_and_b32 s44, s44, s42
+s_lshr_b32 s45, s42, 16
+s_mul_i32 s45, s45, s43
+s_mul_i32 s56, s44, s43
+s_lshl_b32 s44, s45, 16
+s_lshr_b32 s45, s45, 16
+s_add_u32 s56, s44, s56
+s_addc_u32 s57, s45, 0
+s_mov_b32 s43, s56
+s_bitcmp1_b32 s18, 2
+s_cselect_b32 s44, s43, s42
+s_cselect_b32 s90, s42, s43
+v_cmp_le_u32_e32 vcc, 0x100, v0
+s_cmp_eq_u32 1, src_vccz
+s_cselect_b32 s68, s44, s68
+s_waitcnt lgkmcnt(0)
+s_and_b32 s21, s21, 0xffff
+s_and_b32 s23, s23, 0xffff
+s_and_b32 s25, s25, 0xffff
+s_and_b32 s27, s27, 0xffff
+s_and_b32 s35, s35, 0xffff
+s_bitcmp1_b32 s18, 13
+s_cbranch_scc0 8
+s_add_u32 s20, s20, s48
+s_addc_u32 s21, s21, s49
+s_add_u32 s22, s22, s50
+s_addc_u32 s23, s23, s51
+s_add_u32 s24, s24, s52
+s_addc_u32 s25, s25, s53
+s_add_u32 s34, s34, s54
+s_addc_u32 s35, s35, s55
+s_and_b32 s44, 0, s30
+s_addc_u32 s44, s32, 0
+s_ashr_i32 s44, s44, 0
+s_add_u32 s42, s44, 1
+v_mov_b32_e32 v2, 0x80000000
+v_mul_hi_u32 v2, v2, s42
+v_readfirstlane_b32 s42, v2
+s_andn2_b32 s44, 0, s31
+s_addc_u32 s44, s33, 0
+s_ashr_i32 s44, s44, 0
+s_add_u32 s43, s44, 1
+v_mov_b32_e32 v2, 0x80000000
+v_mul_hi_u32 v2, v2, s43
+v_readfirstlane_b32 s43, v2
+s_sub_u32 s75, 0, s43
+s_sub_u32 s74, 0, s42
+s_add_u32 s60, s28, 2
+v_mov_b32_e32 v2, 0x55555556
+v_mul_hi_u32 v2, v2, s60
+v_readfirstlane_b32 s60, v2
+s_add_u32 s61, s29, 2
+v_mov_b32_e32 v2, 0x55555556
+v_mul_hi_u32 v2, v2, s61
+v_readfirstlane_b32 s61, v2
+v_mad_i32_i24 v2, 3, s60, -2
+v_sub_co_u32_e64 v2, vcc, v2, s28
+v_addc_co_u32_e64 v2, vcc, 0, 0, vcc
+v_readfirstlane_b32 s44, v2
+s_and_b32 s44, s44, 1
+s_and_b32 s44, s44, s60
+s_add_u32 s60, s60, s44
+v_readfirstlane_b32 s45, v0
+s_and_b32 s48, s45, 64
+s_cselect_b32 s48, 0x80000, 0
+s_or_b32 s18, s18, s48
+s_lshl_b32 s69, s68, 1
+s_mov_b64 s[70:71], 0
+s_bitset1_b32 s18, 23
+s_bitset1_b32 s18, 20
+s_bitset0_b32 s18, 19
+s_ashr_i32 s69, s69, 1
+s_ashr_i64 s[70:71], s[70:71], 1
+s_add_u32 s61, s61, 1
+s_and_b32 s61, s61, -2
+s_branch 16
+s_and_b32 s48, s13, 1
+s_cselect_b32 s48, 0, 0x1000000
+s_bitcmp1_b32 s18, 2
+s_cselect_b32 s48, 0, s48
+s_or_b32 s18, s18, s48
+s_cmp_eq_u32 s48, 0
+s_cselect_b32 s69, s68, s69
+s_cselect_b32 s70, s68, s70
+s_cselect_b32 s71, 0, s71
+s_bitcmp0_b32 s45, 8
+s_cselect_b32 s48, s48, 0
+s_cmp_eq_u32 s48, 0
+s_cselect_b32 s48, 0, 0x80000
+s_andn2_b32 s18, s18, s48
+s_add_u32 s70, s70, s69
+s_addc_u32 s71, s71, 0
+v_bfe_u32 v3, v0, 2, 6
+v_lshrrev_b32_e32 v99, 1, v3
+s_bitcmp0_b32 s45, 8
+s_cselect_b32 s48, 0x1000000, 0
+s_or_b32 s48, s48, 0x100000
+s_and_b32 s48, s18, s48
+s_cselect_b32 s48, 0, 15
+v_bfi_b32 v99, s48, v3, v99
+s_mul_i32 s88, s12, s42
+s_sub_u32 s88, s88, 1
+s_lshr_b32 s88, s88, 0
+s_add_u32 s88, s88, 1
+s_lshr_b32 s46, -1, 16
+s_and_b32 s46, s46, s88
+s_lshr_b32 s47, s88, 16
+s_mul_i32 s47, s47, s43
+s_mul_i32 s88, s46, s43
+s_lshl_b32 s46, s47, 16
+s_lshr_b32 s47, s47, 16
+s_add_u32 s88, s46, s88
+s_addc_u32 s89, s47, 0
+s_sub_u32 s88, s88, 1
+s_subb_u32 s89, s89, 0
+s_lshr_b64 s[88:89], s[88:89], 5
+s_add_u32 s88, s88, 1
+s_addc_u32 s89, s89, 0
+v_mov_b32_e32 v4, s8
+v_mov_b32_e32 v5, s17
+v_and_b32_e32 v6, 3, v0
+v_cmp_eq_u32_e32 vcc, 2, v6
+v_cndmask_b32_e32 v4, v4, v5, vcc
+v_cmp_eq_u32_e32 vcc, 1, v6
+v_cndmask_b32_e32 v7, 0, v99, vcc
+s_bitcmp1_b32 s18, 20
+s_cbranch_scc0 4
+v_add_co_u32_e64 v5, vcc, v99, 8
+v_cmp_eq_u32_e32 vcc, 0, v6
+v_cndmask_b32_e32 v7, v7, v5, vcc
+v_cmp_eq_u32_e64 s[46:47], 3, v6
+v_bfe_u32 v97, v7, 0, 5
+v_mad_u32_u24 v97, v4, 32, v97
+v_ffbh_u32_e32 v9, s43
+v_lshlrev_b32_e64 v10, v9, s43
+v_and_b32_e32 v11, 0xffffff00, v10
+v_cmp_eq_u32_e32 vcc, 0x80000000, v10
+v_cvt_f32_u32_e32 v11, v11
+v_rcp_f32_e32 v98, v11
+v_subb_co_u32_e32 v8, vcc, 32, v9, vcc
+v_cvt_f32_ubyte0_e32 v9, v10
+v_fma_f32 v11, v11, v98, -1.0
+v_fma_f32 v11, v9, v98, v11
+v_madak_f32 v11, v11, v98, 0x9f000000
+v_mul_f32_e32 v11, 0x5f800000, v11
+v_mov_b32_e32 v9, 0
+v_cvt_flr_i32_f32_e64 v11, -v11
+v_lshl_add_u32 v98, v98, 9, v11
+v_mad_u64_u32 v[9:10], vcc, v10, v98, v[9:10]
+v_subb_co_u32_e64 v98, vcc, v98, -1, vcc
+v_mul_hi_u32 v9, v97, v98
+v_add_co_u32_e32 v98, vcc, v9, v97
+v_addc_co_u32_e64 v9, vcc, 0, 0, vcc
+v_cmp_eq_u32_e32 vcc, 32, v8
+v_cndmask_b32_e32 v98, v98, v9, vcc
+v_alignbit_b32 v98, v9, v98, v8
+v_mad_i32_i24 v96, v98, s75, v97
+v_lshrrev_b32_e32 v97, 5, v7
+v_mad_u32_u24 v97, v98, 1, v97
+v_cndmask_b32_e64 v97, v97, 1, s[46:47]
+v_ffbh_u32_e32 v9, s42
+v_lshlrev_b32_e64 v10, v9, s42
+v_and_b32_e32 v11, 0xffffff00, v10
+v_cmp_eq_u32_e32 vcc, 0x80000000, v10
+v_cvt_f32_u32_e32 v11, v11
+v_rcp_f32_e32 v98, v11
+v_subb_co_u32_e32 v8, vcc, 32, v9, vcc
+v_cvt_f32_ubyte0_e32 v9, v10
+v_fma_f32 v11, v11, v98, -1.0
+v_fma_f32 v11, v9, v98, v11
+v_madak_f32 v11, v11, v98, 0x9f000000
+v_mul_f32_e32 v11, 0x5f800000, v11
+v_mov_b32_e32 v9, 0
+v_cvt_flr_i32_f32_e64 v11, -v11
+v_lshl_add_u32 v98, v98, 9, v11
+v_mad_u64_u32 v[9:10], vcc, v10, v98, v[9:10]
+v_subb_co_u32_e64 v98, vcc, v98, -1, vcc
+v_mul_hi_u32 v9, v97, v98
+v_add_co_u32_e32 v98, vcc, v9, v97
+v_addc_co_u32_e64 v9, vcc, 0, 0, vcc
+v_cmp_eq_u32_e32 vcc, 32, v8
+v_cndmask_b32_e32 v98, v98, v9, vcc
+v_alignbit_b32 v98, v9, v98, v8
+v_mad_i32_i24 v97, v98, s74, v97
+v_readlane_b32 s76, v96, 2
+v_readlane_b32 s77, v97, 2
+v_readlane_b32 s78, v98, 2
+v_readlane_b32 s79, v97, 3
+v_readlane_b32 s80, v98, 3
+v_add_co_u32_e64 v96, vcc, v96, s75
+v_add_co_u32_e64 v97, vcc, v97, s74
+v_mov_b32_dpp v98, v98  quad_perm:[1,1,0,0] row_mask:0xf bank_mask:0xf
+v_mov_b32_dpp v96, v96  quad_perm:[1,1,0,0] row_mask:0xf bank_mask:0xf
+v_mov_b32_dpp v97, v97  quad_perm:[1,1,0,0] row_mask:0xf bank_mask:0xf
+s_mov_b32 s42, 0x80000000
+s_mov_b32 s43, 0x20000
+s_mov_b32 s46, 0x80000000
+s_mov_b32 s47, 0x20000
+v_cmp_le_u32_e32 vcc, 0x100, v0
+s_cbranch_vccnz 5
+v_xor_b32_dpp v100, v0, v0  quad_perm:[1,3,2,2] row_mask:0xf bank_mask:0xf
+v_subrev_co_u32_e32 v100, vcc, 1, v100
+v_cvt_f32_i32_e32 v100, v100
+s_branch 4
+v_xor_b32_dpp v100, v0, v0  quad_perm:[2,1,0,1] row_mask:0xf bank_mask:0xf
+v_sub_co_u32_e32 v100, vcc, 1, v100
+v_cvt_f32_i32_e32 v100, v100
+v_mov_b32_e32 v101, 1
+v_xor_b32_dpp v101, v0, v0  quad_perm:[2,3,2,3] row_mask:0xf bank_mask:0x4
+v_xor_b32_dpp v101, v0, v0  quad_perm:[0,1,0,1] row_mask:0xf bank_mask:0x8
+v_subrev_co_u32_e32 v101, vcc, 1, v101
+v_mov_b32_e32 v102, 1
+v_xor_b32_dpp v102, v0, v0  quad_perm:[0,3,2,1] row_mask:0xf bank_mask:0x2
+v_xor_b32_dpp v102, v0, v0  quad_perm:[2,1,0,3] row_mask:0xf bank_mask:0x4
+v_subrev_co_u32_e32 v102, vcc, 1, v102
+v_cvt_f32_i32_e32 v101, v101
+v_cvt_f32_i32_e32 v102, v102
+v_lshrrev_b32_e64 v106, 2, s92
+v_and_b32_e32 v107, 3, v0
+v_bfe_u32 v108, v0, 4, 3
+v_mad_u32_u24 v95, v108, 4, v107
+v_lshlrev_b32_e32 v95, 4, v95
+v_mad_u32_u24 v90, v106, 4, v107
+v_lshlrev_b32_e32 v90, 4, v90
+v_bfe_u32 v106, v0, 2, 2
+v_and_b32_e32 v107, 1, v106
+v_mad_u32_u24 v109, v106, 16, v107
+v_lshlrev_b32_e32 v109, 6, v109
+v_xor_b32_e32 v90, v90, v109
+v_mul_u32_u24_e32 v109, 0x400, v106
+v_xor_b32_e32 v95, v95, v109
+s_lshr_b32 s92, s92, 0
+v_cmp_le_u32_e32 vcc, 0x100, v0
+s_cbranch_vccnz 50
+s_and_b32 s53, s18, 0x1100000
+s_addc_u32 s53, 0, 0
+v_lshrrev_b32_e32 v109, 1, v0
+s_mul_i32 s52, 60, s53
+s_sub_u32 s52, 63, s52
+v_bfi_b32 v109, s52, v0, v109
+v_and_b32_e32 v106, 1, v109
+v_bfe_u32 v107, v109, 1, 1
+v_xor_b32_e32 v106, v106, v107
+v_bfe_u32 v108, v109, 3, 1
+v_mad_u32_u24 v107, v107, 2, v108
+v_mul_u32_u24_e32 v106, 0x118, v106
+v_bfe_u32 v108, v109, 2, 1
+v_mad_u32_u24 v107, v107, 2, v106
+v_xor_b32_e32 v107, v107, v108
+v_and_b32_e32 v108, 0xf0, v109
+v_xor_b32_e32 v107, v107, v108
+s_mul_i32 s52, 4, s53
+s_sub_u32 s52, 6, s52
+v_bfe_u32 v109, v0, s52, 1
+v_mul_u32_u24_e32 v109, 0x1040, v109
+v_xor_b32_e32 v92, 0x314, v107
+v_xor_b32_e32 v93, 0x31c, v107
+v_xor_b32_e32 v94, 8, v107
+s_bitcmp1_b32 s18, 0
+s_cselect_b64 vcc, -1, 0
+v_cndmask_b32_e32 v91, v107, v94, vcc
+v_cndmask_b32_e32 v94, v94, v107, vcc
+v_mad_u32_u24 v91, 4, v91, v109
+v_mad_u32_u24 v92, 4, v92, v109
+v_mad_u32_u24 v93, 4, v93, v109
+v_mad_u32_u24 v94, 4, v94, v109
+s_branch 44
+s_bfe_u32 s53, s18, 0x10014
+v_lshrrev_b32_e32 v109, 1, v0
+s_mul_i32 s52, 60, s53
+s_sub_u32 s52, 63, s52
+v_bfi_b32 v109, s52, v0, v109
+v_and_b32_e32 v106, 1, v109
+v_bfe_u32 v107, v109, 1, 1
+v_bfe_u32 v108, v109, 3, 1
+v_xor_b32_e32 v106, v106, v107
+v_mad_u32_u24 v107, v107, 2, v108
+v_mul_u32_u24_e32 v106, 0x109, v106
+v_bfe_u32 v108, v109, 2, 1
+v_mad_u32_u24 v107, v107, 2, v106
+v_xor_b32_e32 v107, v107, v108
+v_and_b32_e32 v108, 0xf0, v109
+v_or_b32_e32 v107, v107, v108
+s_mul_i32 s52, 4, s53
+s_sub_u32 s52, 6, s52
+v_bfe_u32 v109, v0, s52, 1
+v_mul_u32_u24_e32 v109, 0x1040, v109
+v_mad_u32_u24 v91, 4, v107, v109
+v_xor_b32_e32 v92, 0x307, v107
+v_mad_u32_u24 v92, 4, v92, v109
+v_xor_b32_e32 v93, 0x30f, v107
+v_mad_u32_u24 v93, 4, v93, v109
+v_xor_b32_e32 v94, 8, v107
+v_mad_u32_u24 v94, 4, v94, v109
+v_subrev_co_u32_e32 v96, vcc, s76, v96
+v_mov_b32_e32 v107, s75
+v_cmp_lt_i32_e32 vcc, v96, v107
+v_subb_co_u32_e64 v106, vcc, 0, 0, vcc
+v_mad_i32_i24 v96, v106, s75, v96
+v_mad_i32_i24 v98, v106, s80, v98
+v_mad_i32_i24 v97, v106, s79, v97
+v_mov_b32_e32 v107, s74
+v_cmp_lt_i32_e32 vcc, v97, v107
+v_subb_co_u32_e64 v106, vcc, 0, 0, vcc
+v_add_co_u32_e32 v98, vcc, v98, v106
+v_mad_i32_i24 v97, v106, v107, v97
+v_subrev_co_u32_e32 v97, vcc, s77, v97
+v_cmp_lt_i32_e32 vcc, v97, v107
+v_subb_co_u32_e64 v106, vcc, 0, 0, vcc
+v_add_co_u32_e32 v98, vcc, v98, v106
+v_mad_i32_i24 v97, v106, s74, v97
+v_subrev_co_u32_e32 v98, vcc, s78, v98
+s_mov_b32 s62, 0
+s_mov_b32 s63, s28
+s_mov_b32 s64, 1
+s_mov_b32 s84, 0
+s_mov_b32 s85, s16
+s_mov_b32 s83, s85
+s_sub_u32 s93, -1, s92
+s_sub_u32 s93, s93, 32
+s_bitset1_b32 s18, 21
+s_mov_b32 s47, 0
+s_mov_b32 s51, 0
+v_add_co_u32_e32 v106, vcc, 2, v0
+v_bfe_u32 v106, v106, 2, 1
+v_cmp_ne_u32_e64 vcc, v106, 1
+s_mov_b64 s[10:11], vcc
+s_mov_b32 s94, 17
+s_mov_b32 s82, 0
+s_bitset1_b32 s18, 26
+s_call_b64 s[38:39], 1883
+v_cmp_le_u32_e32 vcc, 0x100, v0
+s_cbranch_vccnz 65
+s_branch 982
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_mac_f32_e32 v2, v34, v42
+v_mac_f32_e32 v3, v35, v42
+v_mac_f32_e32 v4, v36, v42
+v_mac_f32_e32 v5, v37, v42
+v_mac_f32_e32 v6, v34, v43
+v_mac_f32_e32 v7, v35, v43
+v_mac_f32_e32 v8, v36, v43
+v_mac_f32_e32 v9, v37, v43
+v_mac_f32_e32 v10, v34, v44
+v_mac_f32_e32 v11, v35, v44
+v_mac_f32_e32 v12, v36, v44
+v_mac_f32_e32 v13, v37, v44
+v_mac_f32_e32 v14, v34, v45
+v_mac_f32_e32 v15, v35, v45
+v_mac_f32_e32 v16, v36, v45
+v_mac_f32_e32 v17, v37, v45
+v_mac_f32_e32 v18, v34, v46
+v_mac_f32_e32 v19, v35, v46
+v_mac_f32_e32 v20, v36, v46
+v_mac_f32_e32 v21, v37, v46
+v_mac_f32_e32 v22, v34, v47
+v_mac_f32_e32 v23, v35, v47
+v_mac_f32_e32 v24, v36, v47
+v_mac_f32_e32 v25, v37, v47
+v_mac_f32_e32 v26, v34, v48
+v_mac_f32_e32 v27, v35, v48
+v_mac_f32_e32 v28, v36, v48
+v_mac_f32_e32 v29, v37, v48
+v_mac_f32_e32 v30, v34, v49
+v_mac_f32_e32 v31, v35, v49
+v_cndmask_b32_dpp v66, v66, v66, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v67, v67, v67, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v68, v68, v68, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v69, v69, v69, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_subrev_f32_e64 v66, v68, v66 div:2
+v_subrev_f32_e64 v69, v67, v69 div:2
+s_setprio 0
+s_nop 0
+v_mac_f32_e32 v32, v36, v49
+v_mac_f32_e32 v33, v37, v49
+s_nop 0
+ds_read_b128 v[34:37], v95 offset:29440
+ds_read_b128 v[42:45], v90 offset:28928
+ds_read_b128 v[46:49], v90 offset:29056
+ds_write_b32 v91, v62
+ds_write_b32 v92, v63
+s_setprio 1
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+buffer_load_dword v58, v82, s[40:43], 0 offen
+buffer_load_dword v60, v84, s[40:43], 0 offen
+buffer_load_dword v59, v83, s[40:43], 0 offen
+buffer_load_dword v61, v85, s[40:43], 0 offen
+s_add_u32 s91, s91, 0x200
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 5
+s_call_b64 s[38:39], 1732
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_mac_f32_e32 v2, v38, v50
+v_mac_f32_e32 v3, v39, v50
+v_mac_f32_e32 v4, v40, v50
+v_mac_f32_e32 v5, v41, v50
+v_mac_f32_e32 v6, v38, v51
+v_mac_f32_e32 v7, v39, v51
+v_mac_f32_e32 v8, v40, v51
+v_mac_f32_e32 v9, v41, v51
+v_mac_f32_e32 v10, v38, v52
+v_mac_f32_e32 v11, v39, v52
+v_mac_f32_e32 v12, v40, v52
+v_mac_f32_e32 v13, v41, v52
+v_mac_f32_e32 v14, v38, v53
+v_mac_f32_e32 v15, v39, v53
+v_mac_f32_e32 v16, v40, v53
+v_mac_f32_e32 v17, v41, v53
+v_mac_f32_e32 v18, v38, v54
+v_mac_f32_e32 v19, v39, v54
+v_mac_f32_e32 v20, v40, v54
+v_mac_f32_e32 v21, v41, v54
+v_mac_f32_e32 v22, v38, v55
+v_mac_f32_e32 v23, v39, v55
+v_mac_f32_e32 v24, v40, v55
+v_mac_f32_e32 v25, v41, v55
+v_mac_f32_e32 v26, v38, v56
+v_mac_f32_e32 v27, v39, v56
+v_mac_f32_e32 v28, v40, v56
+v_mac_f32_e32 v29, v41, v56
+v_mac_f32_e32 v30, v38, v57
+v_mac_f32_e32 v31, v39, v57
+v_add_f32_e64 v67, v68, v67 div:2
+v_mad_f32 v68, v68, 1.0, -v67
+v_mac_f32_dpp v66, v66, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v67, v67, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v68, v68, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v69, v69, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+s_setprio 0
+s_nop 0
+v_mac_f32_e32 v32, v40, v57
+v_mac_f32_e32 v33, v41, v57
+s_nop 0
+ds_read_b128 v[38:41], v95 offset:33536
+ds_read_b128 v[50:53], v90 offset:33024
+ds_read_b128 v[54:57], v90 offset:33152
+ds_write_b32 v93, v68 offset:8256
+ds_write_b32 v94, v69 offset:8256
+s_setprio 1
+s_nop 0
+s_waitcnt vmcnt(12) lgkmcnt(5)
+ds_append v105 offset:65472
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 7
+s_call_b64 s[38:39], 1662
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_mac_f32_e32 v2, v34, v42
+v_mac_f32_e32 v3, v35, v42
+v_mac_f32_e32 v4, v36, v42
+v_mac_f32_e32 v5, v37, v42
+v_mac_f32_e32 v6, v34, v43
+v_mac_f32_e32 v7, v35, v43
+v_mac_f32_e32 v8, v36, v43
+v_mac_f32_e32 v9, v37, v43
+v_mac_f32_e32 v10, v34, v44
+v_mac_f32_e32 v11, v35, v44
+v_mac_f32_e32 v12, v36, v44
+v_mac_f32_e32 v13, v37, v44
+v_mac_f32_e32 v14, v34, v45
+v_mac_f32_e32 v15, v35, v45
+v_mac_f32_e32 v16, v36, v45
+v_mac_f32_e32 v17, v37, v45
+v_mac_f32_e32 v18, v34, v46
+v_mac_f32_e32 v19, v35, v46
+v_mac_f32_e32 v20, v36, v46
+v_mac_f32_e32 v21, v37, v46
+v_mac_f32_e32 v22, v34, v47
+v_mac_f32_e32 v23, v35, v47
+v_mac_f32_e32 v24, v36, v47
+v_mac_f32_e32 v25, v37, v47
+v_mac_f32_e32 v26, v34, v48
+v_mac_f32_e32 v27, v35, v48
+v_mac_f32_e32 v28, v36, v48
+v_mac_f32_e32 v29, v37, v48
+v_mac_f32_e32 v30, v34, v49
+v_mac_f32_e32 v31, v35, v49
+v_cndmask_b32_dpp v70, v70, v70, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v71, v71, v71, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v72, v72, v72, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v73, v73, v73, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_subrev_f32_e64 v70, v72, v70 div:2
+v_subrev_f32_e64 v73, v71, v73 div:2
+s_setprio 0
+s_nop 0
+v_mac_f32_e32 v32, v36, v49
+v_mac_f32_e32 v33, v37, v49
+s_nop 0
+ds_read_b128 v[34:37], v95 offset:37696
+ds_read_b128 v[42:45], v90 offset:37184
+ds_read_b128 v[46:49], v90 offset:37312
+ds_write_b32 v91, v66 offset:8256
+ds_write_b32 v92, v67 offset:8256
+s_setprio 1
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+buffer_load_dword v62, v82, s[40:43], 0 offen
+buffer_load_dword v64, v84, s[40:43], 0 offen
+buffer_load_dword v63, v83, s[40:43], 0 offen
+buffer_load_dword v65, v85, s[40:43], 0 offen
+s_mov_b32 m0, 0x2ffc0
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 5
+s_call_b64 s[38:39], 1580
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_mac_f32_e32 v2, v38, v50
+v_mac_f32_e32 v3, v39, v50
+v_mac_f32_e32 v4, v40, v50
+v_mac_f32_e32 v5, v41, v50
+v_mac_f32_e32 v6, v38, v51
+v_mac_f32_e32 v7, v39, v51
+v_mac_f32_e32 v8, v40, v51
+v_mac_f32_e32 v9, v41, v51
+v_mac_f32_e32 v10, v38, v52
+v_mac_f32_e32 v11, v39, v52
+v_mac_f32_e32 v12, v40, v52
+v_mac_f32_e32 v13, v41, v52
+v_mac_f32_e32 v14, v38, v53
+v_mac_f32_e32 v15, v39, v53
+v_mac_f32_e32 v16, v40, v53
+v_mac_f32_e32 v17, v41, v53
+v_mac_f32_e32 v18, v38, v54
+v_mac_f32_e32 v19, v39, v54
+v_mac_f32_e32 v20, v40, v54
+v_mac_f32_e32 v21, v41, v54
+v_mac_f32_e32 v22, v38, v55
+v_mac_f32_e32 v23, v39, v55
+v_mac_f32_e32 v24, v40, v55
+v_mac_f32_e32 v25, v41, v55
+v_mac_f32_e32 v26, v38, v56
+v_mac_f32_e32 v27, v39, v56
+v_mac_f32_e32 v28, v40, v56
+v_mac_f32_e32 v29, v41, v56
+v_mac_f32_e32 v30, v38, v57
+v_mac_f32_e32 v31, v39, v57
+v_mac_f32_e32 v32, v40, v57
+v_add_f32_e64 v71, v72, v71 div:2
+v_mad_f32 v72, v72, 1.0, -v71
+v_mac_f32_dpp v70, v70, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v71, v71, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v72, v72, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v73, v73, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+s_setprio 0
+s_nop 0
+v_mac_f32_e32 v33, v41, v57
+v_cmp_eq_u32_e64 vcc, src_lds_direct, s91
+s_nop 0
+s_nop 0
+s_cbranch_vccz 65531
+s_mov_b64 vcc, s[10:11]
+s_nop 0
+ds_read_b128 v[38:41], v95 offset:41792
+ds_read_b128 v[50:53], v90 offset:41280
+ds_read_b128 v[54:57], v90 offset:41408
+ds_write_b32 v93, v72 offset:16512
+ds_write_b32 v94, v73 offset:16512
+s_setprio 1
+s_nop 0
+s_waitcnt vmcnt(12) lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 3
+s_call_b64 s[38:39], 1506
+s_nop 0
+s_nop 0
+v_mac_f32_e32 v2, v34, v42
+v_mac_f32_e32 v3, v35, v42
+v_mac_f32_e32 v4, v36, v42
+v_mac_f32_e32 v5, v37, v42
+v_mac_f32_e32 v6, v34, v43
+v_mac_f32_e32 v7, v35, v43
+v_mac_f32_e32 v8, v36, v43
+v_mac_f32_e32 v9, v37, v43
+v_mac_f32_e32 v10, v34, v44
+v_mac_f32_e32 v11, v35, v44
+v_mac_f32_e32 v12, v36, v44
+v_mac_f32_e32 v13, v37, v44
+v_mac_f32_e32 v14, v34, v45
+v_mac_f32_e32 v15, v35, v45
+v_mac_f32_e32 v16, v36, v45
+v_mac_f32_e32 v17, v37, v45
+v_mac_f32_e32 v18, v34, v46
+v_mac_f32_e32 v19, v35, v46
+v_mac_f32_e32 v20, v36, v46
+v_mac_f32_e32 v21, v37, v46
+v_mac_f32_e32 v22, v34, v47
+v_mac_f32_e32 v23, v35, v47
+v_mac_f32_e32 v24, v36, v47
+v_mac_f32_e32 v25, v37, v47
+v_mac_f32_e32 v26, v34, v48
+v_mac_f32_e32 v27, v35, v48
+v_mac_f32_e32 v28, v36, v48
+v_mac_f32_e32 v29, v37, v48
+v_mac_f32_e32 v30, v34, v49
+v_mac_f32_e32 v31, v35, v49
+v_cndmask_b32_dpp v74, v74, v74, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v75, v75, v75, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v76, v76, v76, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v77, v77, v77, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_subrev_f32_e64 v74, v76, v74 div:2
+v_subrev_f32_e64 v77, v75, v77 div:2
+s_setprio 0
+s_nop 0
+v_mac_f32_e32 v32, v36, v49
+v_mac_f32_e32 v33, v37, v49
+s_nop 0
+ds_read_b128 v[34:37], v95 offset:45952
+ds_read_b128 v[42:45], v90 offset:45440
+ds_read_b128 v[46:49], v90 offset:45568
+ds_write_b32 v91, v70 offset:16512
+ds_write_b32 v92, v71 offset:16512
+s_setprio 1
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+buffer_load_dword v66, v82, s[40:43], 0 offen
+buffer_load_dword v68, v84, s[40:43], 0 offen
+buffer_load_dword v67, v83, s[40:43], 0 offen
+buffer_load_dword v69, v85, s[40:43], 0 offen
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 7
+s_call_b64 s[38:39], 1430
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_mac_f32_e32 v2, v38, v50
+v_mac_f32_e32 v3, v39, v50
+v_mac_f32_e32 v4, v40, v50
+v_mac_f32_e32 v5, v41, v50
+v_mac_f32_e32 v6, v38, v51
+v_mac_f32_e32 v7, v39, v51
+v_mac_f32_e32 v8, v40, v51
+v_mac_f32_e32 v9, v41, v51
+v_mac_f32_e32 v10, v38, v52
+v_mac_f32_e32 v11, v39, v52
+v_mac_f32_e32 v12, v40, v52
+v_mac_f32_e32 v13, v41, v52
+v_mac_f32_e32 v14, v38, v53
+v_mac_f32_e32 v15, v39, v53
+v_mac_f32_e32 v16, v40, v53
+v_mac_f32_e32 v17, v41, v53
+v_mac_f32_e32 v18, v38, v54
+v_mac_f32_e32 v19, v39, v54
+v_mac_f32_e32 v20, v40, v54
+v_mac_f32_e32 v21, v41, v54
+v_mac_f32_e32 v22, v38, v55
+v_mac_f32_e32 v23, v39, v55
+v_mac_f32_e32 v24, v40, v55
+v_mac_f32_e32 v25, v41, v55
+v_mac_f32_e32 v26, v38, v56
+v_mac_f32_e32 v27, v39, v56
+v_mac_f32_e32 v28, v40, v56
+v_mac_f32_e32 v29, v41, v56
+v_mac_f32_e32 v30, v38, v57
+v_mac_f32_e32 v31, v39, v57
+v_add_f32_e64 v75, v76, v75 div:2
+v_mad_f32 v76, v76, 1.0, -v75
+v_mac_f32_dpp v74, v74, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v75, v75, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v76, v76, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v77, v77, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+s_setprio 0
+s_nop 0
+v_mac_f32_e32 v32, v40, v57
+v_mac_f32_e32 v33, v41, v57
+s_nop 0
+ds_read_b128 v[38:41], v95 offset:512
+ds_read_b128 v[50:53], v90
+ds_read_b128 v[54:57], v90 offset:128
+ds_write_b32 v93, v76 offset:24768
+ds_write_b32 v94, v77 offset:24768
+s_setprio 1
+s_nop 0
+s_waitcnt vmcnt(12) lgkmcnt(5)
+ds_append v105 offset:65476
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 7
+s_call_b64 s[38:39], 1358
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_mac_f32_e32 v2, v34, v42
+v_mac_f32_e32 v3, v35, v42
+v_mac_f32_e32 v4, v36, v42
+v_mac_f32_e32 v5, v37, v42
+v_mac_f32_e32 v6, v34, v43
+v_mac_f32_e32 v7, v35, v43
+v_mac_f32_e32 v8, v36, v43
+v_mac_f32_e32 v9, v37, v43
+v_mac_f32_e32 v10, v34, v44
+v_mac_f32_e32 v11, v35, v44
+v_mac_f32_e32 v12, v36, v44
+v_mac_f32_e32 v13, v37, v44
+v_mac_f32_e32 v14, v34, v45
+v_mac_f32_e32 v15, v35, v45
+v_mac_f32_e32 v16, v36, v45
+v_mac_f32_e32 v17, v37, v45
+v_mac_f32_e32 v18, v34, v46
+v_mac_f32_e32 v19, v35, v46
+v_mac_f32_e32 v20, v36, v46
+v_mac_f32_e32 v21, v37, v46
+v_mac_f32_e32 v22, v34, v47
+v_mac_f32_e32 v23, v35, v47
+v_mac_f32_e32 v24, v36, v47
+v_mac_f32_e32 v25, v37, v47
+v_mac_f32_e32 v26, v34, v48
+v_mac_f32_e32 v27, v35, v48
+v_mac_f32_e32 v28, v36, v48
+v_mac_f32_e32 v29, v37, v48
+v_mac_f32_e32 v30, v34, v49
+v_mac_f32_e32 v31, v35, v49
+v_cndmask_b32_dpp v78, v78, v78, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v79, v79, v79, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v80, v80, v80, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v81, v81, v81, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_subrev_f32_e64 v78, v80, v78 div:2
+v_subrev_f32_e64 v81, v79, v81 div:2
+s_setprio 0
+s_nop 0
+v_mac_f32_e32 v32, v36, v49
+v_mac_f32_e32 v33, v37, v49
+s_nop 0
+ds_read_b128 v[34:37], v95 offset:4672
+ds_read_b128 v[42:45], v90 offset:4160
+ds_read_b128 v[46:49], v90 offset:4288
+ds_write_b32 v91, v74 offset:24768
+ds_write_b32 v92, v75 offset:24768
+s_setprio 1
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+buffer_load_dword v70, v82, s[40:43], 0 offen
+buffer_load_dword v72, v84, s[40:43], 0 offen
+buffer_load_dword v71, v83, s[40:43], 0 offen
+buffer_load_dword v73, v85, s[40:43], 0 offen
+s_mov_b32 m0, 0x2ffc4
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 5
+s_call_b64 s[38:39], 1276
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_mac_f32_e32 v2, v38, v50
+v_mac_f32_e32 v3, v39, v50
+v_mac_f32_e32 v4, v40, v50
+v_mac_f32_e32 v5, v41, v50
+v_mac_f32_e32 v6, v38, v51
+v_mac_f32_e32 v7, v39, v51
+v_mac_f32_e32 v8, v40, v51
+v_mac_f32_e32 v9, v41, v51
+v_mac_f32_e32 v10, v38, v52
+v_mac_f32_e32 v11, v39, v52
+v_mac_f32_e32 v12, v40, v52
+v_mac_f32_e32 v13, v41, v52
+v_mac_f32_e32 v14, v38, v53
+v_mac_f32_e32 v15, v39, v53
+v_mac_f32_e32 v16, v40, v53
+v_mac_f32_e32 v17, v41, v53
+v_mac_f32_e32 v18, v38, v54
+v_mac_f32_e32 v19, v39, v54
+v_mac_f32_e32 v20, v40, v54
+v_mac_f32_e32 v21, v41, v54
+v_mac_f32_e32 v22, v38, v55
+v_mac_f32_e32 v23, v39, v55
+v_mac_f32_e32 v24, v40, v55
+v_mac_f32_e32 v25, v41, v55
+v_mac_f32_e32 v26, v38, v56
+v_mac_f32_e32 v27, v39, v56
+v_mac_f32_e32 v28, v40, v56
+v_mac_f32_e32 v29, v41, v56
+v_mac_f32_e32 v30, v38, v57
+v_mac_f32_e32 v31, v39, v57
+v_mac_f32_e32 v32, v40, v57
+v_add_f32_e64 v79, v80, v79 div:2
+v_mad_f32 v80, v80, 1.0, -v79
+v_mac_f32_dpp v78, v78, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v79, v79, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v80, v80, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v81, v81, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+s_setprio 0
+s_nop 0
+v_mac_f32_e32 v33, v41, v57
+v_cmp_eq_u32_e64 vcc, src_lds_direct, s91
+s_nop 0
+s_nop 0
+s_cbranch_vccz 65531
+s_mov_b64 vcc, s[10:11]
+s_nop 0
+ds_read_b128 v[38:41], v95 offset:8768
+ds_read_b128 v[50:53], v90 offset:8256
+ds_read_b128 v[54:57], v90 offset:8384
+ds_write_b32 v93, v80 offset:33024
+ds_write_b32 v94, v81 offset:33024
+s_setprio 1
+s_nop 0
+s_waitcnt vmcnt(12) lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 3
+s_call_b64 s[38:39], 1202
+s_nop 0
+s_nop 0
+v_mac_f32_e32 v2, v34, v42
+v_mac_f32_e32 v3, v35, v42
+v_mac_f32_e32 v4, v36, v42
+v_mac_f32_e32 v5, v37, v42
+v_mac_f32_e32 v6, v34, v43
+v_mac_f32_e32 v7, v35, v43
+v_mac_f32_e32 v8, v36, v43
+v_mac_f32_e32 v9, v37, v43
+v_mac_f32_e32 v10, v34, v44
+v_mac_f32_e32 v11, v35, v44
+v_mac_f32_e32 v12, v36, v44
+v_mac_f32_e32 v13, v37, v44
+v_mac_f32_e32 v14, v34, v45
+v_mac_f32_e32 v15, v35, v45
+v_mac_f32_e32 v16, v36, v45
+v_mac_f32_e32 v17, v37, v45
+v_mac_f32_e32 v18, v34, v46
+v_mac_f32_e32 v19, v35, v46
+v_mac_f32_e32 v20, v36, v46
+v_mac_f32_e32 v21, v37, v46
+v_mac_f32_e32 v22, v34, v47
+v_mac_f32_e32 v23, v35, v47
+v_mac_f32_e32 v24, v36, v47
+v_mac_f32_e32 v25, v37, v47
+v_mac_f32_e32 v26, v34, v48
+v_mac_f32_e32 v27, v35, v48
+v_mac_f32_e32 v28, v36, v48
+v_mac_f32_e32 v29, v37, v48
+v_mac_f32_e32 v30, v34, v49
+v_mac_f32_e32 v31, v35, v49
+v_cndmask_b32_dpp v58, v58, v58, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v59, v59, v59, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v60, v60, v60, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v61, v61, v61, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_subrev_f32_e64 v58, v60, v58 div:2
+v_subrev_f32_e64 v61, v59, v61 div:2
+s_setprio 0
+s_nop 0
+v_mac_f32_e32 v32, v36, v49
+v_mac_f32_e32 v33, v37, v49
+s_nop 0
+ds_read_b128 v[34:37], v95 offset:12928
+ds_read_b128 v[42:45], v90 offset:12416
+ds_read_b128 v[46:49], v90 offset:12544
+ds_write_b32 v91, v78 offset:33024
+ds_write_b32 v92, v79 offset:33024
+s_setprio 1
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+buffer_load_dword v74, v82, s[40:43], 0 offen
+buffer_load_dword v76, v84, s[40:43], 0 offen
+buffer_load_dword v75, v83, s[40:43], 0 offen
+buffer_load_dword v77, v85, s[40:43], 0 offen
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 7
+s_call_b64 s[38:39], 1126
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_mac_f32_e32 v2, v38, v50
+v_mac_f32_e32 v3, v39, v50
+v_mac_f32_e32 v4, v40, v50
+v_mac_f32_e32 v5, v41, v50
+v_mac_f32_e32 v6, v38, v51
+v_mac_f32_e32 v7, v39, v51
+v_mac_f32_e32 v8, v40, v51
+v_mac_f32_e32 v9, v41, v51
+v_mac_f32_e32 v10, v38, v52
+v_mac_f32_e32 v11, v39, v52
+v_mac_f32_e32 v12, v40, v52
+v_mac_f32_e32 v13, v41, v52
+v_mac_f32_e32 v14, v38, v53
+v_mac_f32_e32 v15, v39, v53
+v_mac_f32_e32 v16, v40, v53
+v_mac_f32_e32 v17, v41, v53
+v_mac_f32_e32 v18, v38, v54
+v_mac_f32_e32 v19, v39, v54
+v_mac_f32_e32 v20, v40, v54
+v_mac_f32_e32 v21, v41, v54
+v_mac_f32_e32 v22, v38, v55
+v_mac_f32_e32 v23, v39, v55
+v_mac_f32_e32 v24, v40, v55
+v_mac_f32_e32 v25, v41, v55
+v_mac_f32_e32 v26, v38, v56
+v_mac_f32_e32 v27, v39, v56
+v_mac_f32_e32 v28, v40, v56
+v_mac_f32_e32 v29, v41, v56
+v_mac_f32_e32 v30, v38, v57
+v_mac_f32_e32 v31, v39, v57
+v_add_f32_e64 v59, v60, v59 div:2
+v_mad_f32 v60, v60, 1.0, -v59
+v_mac_f32_dpp v58, v58, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v59, v59, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v60, v60, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v61, v61, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+s_setprio 0
+s_nop 0
+v_mac_f32_e32 v32, v40, v57
+v_mac_f32_e32 v33, v41, v57
+s_nop 0
+ds_read_b128 v[38:41], v95 offset:17024
+ds_read_b128 v[50:53], v90 offset:16512
+ds_read_b128 v[54:57], v90 offset:16640
+ds_write_b32 v93, v60 offset:41280
+ds_write_b32 v94, v61 offset:41280
+s_setprio 1
+s_nop 0
+s_waitcnt vmcnt(12) lgkmcnt(5)
+ds_append v105 offset:65480
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 7
+s_call_b64 s[38:39], 1054
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_mac_f32_e32 v2, v34, v42
+v_mac_f32_e32 v3, v35, v42
+v_mac_f32_e32 v4, v36, v42
+v_mac_f32_e32 v5, v37, v42
+v_mac_f32_e32 v6, v34, v43
+v_mac_f32_e32 v7, v35, v43
+v_mac_f32_e32 v8, v36, v43
+v_mac_f32_e32 v9, v37, v43
+v_mac_f32_e32 v10, v34, v44
+v_mac_f32_e32 v11, v35, v44
+v_mac_f32_e32 v12, v36, v44
+v_mac_f32_e32 v13, v37, v44
+v_mac_f32_e32 v14, v34, v45
+v_mac_f32_e32 v15, v35, v45
+v_mac_f32_e32 v16, v36, v45
+v_mac_f32_e32 v17, v37, v45
+v_mac_f32_e32 v18, v34, v46
+v_mac_f32_e32 v19, v35, v46
+v_mac_f32_e32 v20, v36, v46
+v_mac_f32_e32 v21, v37, v46
+v_mac_f32_e32 v22, v34, v47
+v_mac_f32_e32 v23, v35, v47
+v_mac_f32_e32 v24, v36, v47
+v_mac_f32_e32 v25, v37, v47
+v_mac_f32_e32 v26, v34, v48
+v_mac_f32_e32 v27, v35, v48
+v_mac_f32_e32 v28, v36, v48
+v_mac_f32_e32 v29, v37, v48
+v_mac_f32_e32 v30, v34, v49
+v_mac_f32_e32 v31, v35, v49
+v_cndmask_b32_dpp v62, v62, v62, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v63, v63, v63, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v64, v64, v64, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v65, v65, v65, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_subrev_f32_e64 v62, v64, v62 div:2
+v_subrev_f32_e64 v65, v63, v65 div:2
+s_setprio 0
+s_nop 0
+v_mac_f32_e32 v32, v36, v49
+v_mac_f32_e32 v33, v37, v49
+s_nop 0
+ds_read_b128 v[34:37], v95 offset:21184
+ds_read_b128 v[42:45], v90 offset:20672
+ds_read_b128 v[46:49], v90 offset:20800
+ds_write_b32 v91, v58 offset:41280
+ds_write_b32 v92, v59 offset:41280
+s_setprio 1
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+buffer_load_dword v78, v82, s[40:43], 0 offen
+buffer_load_dword v80, v84, s[40:43], 0 offen
+buffer_load_dword v79, v83, s[40:43], 0 offen
+buffer_load_dword v81, v85, s[40:43], 0 offen
+s_mov_b32 m0, 0x2ffc8
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 5
+s_call_b64 s[38:39], 972
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_mac_f32_e32 v2, v38, v50
+v_mac_f32_e32 v3, v39, v50
+v_mac_f32_e32 v4, v40, v50
+v_mac_f32_e32 v5, v41, v50
+v_mac_f32_e32 v6, v38, v51
+v_mac_f32_e32 v7, v39, v51
+v_mac_f32_e32 v8, v40, v51
+v_mac_f32_e32 v9, v41, v51
+v_mac_f32_e32 v10, v38, v52
+v_mac_f32_e32 v11, v39, v52
+v_mac_f32_e32 v12, v40, v52
+v_mac_f32_e32 v13, v41, v52
+v_mac_f32_e32 v14, v38, v53
+v_mac_f32_e32 v15, v39, v53
+v_mac_f32_e32 v16, v40, v53
+v_mac_f32_e32 v17, v41, v53
+v_mac_f32_e32 v18, v38, v54
+v_mac_f32_e32 v19, v39, v54
+v_mac_f32_e32 v20, v40, v54
+v_mac_f32_e32 v21, v41, v54
+v_mac_f32_e32 v22, v38, v55
+v_mac_f32_e32 v23, v39, v55
+v_mac_f32_e32 v24, v40, v55
+v_mac_f32_e32 v25, v41, v55
+v_mac_f32_e32 v26, v38, v56
+v_mac_f32_e32 v27, v39, v56
+v_mac_f32_e32 v28, v40, v56
+v_mac_f32_e32 v29, v41, v56
+v_mac_f32_e32 v30, v38, v57
+v_mac_f32_e32 v31, v39, v57
+v_mac_f32_e32 v32, v40, v57
+v_add_f32_e64 v63, v64, v63 div:2
+v_mad_f32 v64, v64, 1.0, -v63
+v_mac_f32_dpp v62, v62, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v63, v63, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v64, v64, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v65, v65, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+s_setprio 0
+s_nop 0
+v_mac_f32_e32 v33, v41, v57
+v_cmp_eq_u32_e64 vcc, src_lds_direct, s91
+s_nop 0
+s_nop 0
+s_cbranch_vccz 65531
+s_mov_b64 vcc, s[10:11]
+s_nop 0
+ds_read_b128 v[38:41], v95 offset:25280
+ds_read_b128 v[50:53], v90 offset:24768
+ds_read_b128 v[54:57], v90 offset:24896
+ds_write_b32 v93, v64
+ds_write_b32 v94, v65
+s_setprio 1
+s_nop 0
+s_waitcnt vmcnt(12) lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 64627
+s_call_b64 s[38:39], 898
+s_branch 64625
+s_nop 0
+v_mac_f32_e32 v2, v34, v42
+v_mac_f32_e32 v3, v35, v42
+v_mac_f32_e32 v4, v36, v42
+s_setprio 1
+s_nop 0
+v_mac_f32_e32 v5, v37, v42
+v_mac_f32_e32 v6, v34, v43
+v_mac_f32_e32 v7, v35, v43
+v_mac_f32_e32 v8, v36, v43
+v_mac_f32_e32 v9, v37, v43
+v_mac_f32_e32 v10, v34, v44
+v_mac_f32_e32 v11, v35, v44
+v_mac_f32_e32 v12, v36, v44
+v_mac_f32_e32 v13, v37, v44
+v_mac_f32_e32 v14, v34, v45
+v_mac_f32_e32 v15, v35, v45
+v_mac_f32_e32 v16, v36, v45
+v_mac_f32_e32 v17, v37, v45
+v_mac_f32_e32 v18, v34, v46
+v_mac_f32_e32 v19, v35, v46
+v_mac_f32_e32 v20, v36, v46
+v_mac_f32_e32 v21, v37, v46
+v_mac_f32_e32 v22, v34, v47
+v_mac_f32_e32 v23, v35, v47
+v_mac_f32_e32 v24, v36, v47
+v_mac_f32_e32 v25, v37, v47
+v_mac_f32_e32 v26, v34, v48
+v_mac_f32_e32 v27, v35, v48
+v_mac_f32_e32 v28, v36, v48
+v_mac_f32_e32 v29, v37, v48
+v_mac_f32_e32 v30, v34, v49
+v_mac_f32_e32 v31, v35, v49
+v_cndmask_b32_dpp v66, v66, v66, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v67, v67, v67, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v68, v68, v68, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v69, v69, v69, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v66, v67, v67  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v66, v67, v100  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_mac_f32_e32 v32, v36, v49
+v_mac_f32_e32 v33, v37, v49
+s_nop 0
+ds_read_b128 v[34:37], v95 offset:29440
+ds_read_b128 v[42:45], v90 offset:28928
+ds_read_b128 v[46:49], v90 offset:29056
+ds_write_b32 v91, v62
+ds_write_b32 v92, v63
+s_setprio 0
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+buffer_load_dword v60, v84, s[40:43], 0 offen
+buffer_load_dword v59, v83, s[40:43], 0 offen
+buffer_load_dword v61, v85, s[40:43], 0 offen
+s_add_u32 s91, s91, 0x200
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 7
+s_call_b64 s[38:39], 822
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_mac_f32_e32 v2, v38, v50
+v_mac_f32_e32 v3, v39, v50
+v_mac_f32_e32 v4, v40, v50
+s_setprio 1
+s_nop 0
+v_mac_f32_e32 v5, v41, v50
+v_mac_f32_e32 v6, v38, v51
+v_mac_f32_e32 v7, v39, v51
+v_mac_f32_e32 v8, v40, v51
+v_mac_f32_e32 v9, v41, v51
+v_mac_f32_e32 v10, v38, v52
+v_mac_f32_e32 v11, v39, v52
+v_mac_f32_e32 v12, v40, v52
+v_mac_f32_e32 v13, v41, v52
+v_mac_f32_e32 v14, v38, v53
+v_mac_f32_e32 v15, v39, v53
+v_mac_f32_e32 v16, v40, v53
+v_mac_f32_e32 v17, v41, v53
+v_mac_f32_e32 v18, v38, v54
+v_mac_f32_e32 v19, v39, v54
+v_mac_f32_e32 v20, v40, v54
+v_mac_f32_e32 v21, v41, v54
+v_mac_f32_e32 v22, v38, v55
+v_mac_f32_e32 v23, v39, v55
+v_mac_f32_e32 v24, v40, v55
+v_mac_f32_e32 v25, v41, v55
+v_mac_f32_e32 v26, v38, v56
+v_mac_f32_e32 v27, v39, v56
+v_mac_f32_e32 v28, v40, v56
+v_mac_f32_e32 v29, v41, v56
+v_mac_f32_e32 v30, v38, v57
+v_mac_f32_e32 v31, v39, v57
+v_add_f32_dpp v103, v69, v69  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v103, v69, v100  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v69, v68, v68  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v69, v68, v100  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_add_f32_e32 v68, v66, v69
+v_add_f32_e64 v67, v103, v68 div:2
+v_add_f32_e64 v68, -v103, v68 div:2
+v_mac_f32_e32 v32, v40, v57
+v_mac_f32_e32 v33, v41, v57
+s_nop 0
+ds_read_b128 v[38:41], v95 offset:33536
+ds_read_b128 v[50:53], v90 offset:33024
+ds_read_b128 v[54:57], v90 offset:33152
+ds_write_b32 v93, v68 offset:8256
+ds_write_b32 v94, v69 offset:8256
+s_setprio 0
+s_nop 0
+s_waitcnt vmcnt(9) lgkmcnt(5)
+ds_append v105 offset:65472
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 6
+s_call_b64 s[38:39], 749
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_mac_f32_e32 v2, v34, v42
+v_mac_f32_e32 v3, v35, v42
+v_mac_f32_e32 v4, v36, v42
+s_setprio 1
+s_nop 0
+v_mac_f32_e32 v5, v37, v42
+v_mac_f32_e32 v6, v34, v43
+v_mac_f32_e32 v7, v35, v43
+v_mac_f32_e32 v8, v36, v43
+v_mac_f32_e32 v9, v37, v43
+v_mac_f32_e32 v10, v34, v44
+v_mac_f32_e32 v11, v35, v44
+v_mac_f32_e32 v12, v36, v44
+v_mac_f32_e32 v13, v37, v44
+v_mac_f32_e32 v14, v34, v45
+v_mac_f32_e32 v15, v35, v45
+v_mac_f32_e32 v16, v36, v45
+v_mac_f32_e32 v17, v37, v45
+v_mac_f32_e32 v18, v34, v46
+v_mac_f32_e32 v19, v35, v46
+v_mac_f32_e32 v20, v36, v46
+v_mac_f32_e32 v21, v37, v46
+v_mac_f32_e32 v22, v34, v47
+v_mac_f32_e32 v23, v35, v47
+v_mac_f32_e32 v24, v36, v47
+v_mac_f32_e32 v25, v37, v47
+v_mac_f32_e32 v26, v34, v48
+v_mac_f32_e32 v27, v35, v48
+v_mac_f32_e32 v28, v36, v48
+v_mac_f32_e32 v29, v37, v48
+v_mac_f32_e32 v30, v34, v49
+v_mac_f32_e32 v31, v35, v49
+v_cndmask_b32_dpp v70, v70, v70, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v71, v71, v71, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v72, v72, v72, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v73, v73, v73, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v70, v71, v71  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v70, v71, v100  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_mac_f32_e32 v32, v36, v49
+v_mac_f32_e32 v33, v37, v49
+s_nop 0
+ds_read_b128 v[34:37], v95 offset:37696
+ds_read_b128 v[42:45], v90 offset:37184
+ds_read_b128 v[46:49], v90 offset:37312
+ds_write_b32 v91, v66 offset:8256
+ds_write_b32 v92, v67 offset:8256
+s_setprio 0
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+buffer_load_dword v64, v84, s[40:43], 0 offen
+buffer_load_dword v63, v83, s[40:43], 0 offen
+buffer_load_dword v65, v85, s[40:43], 0 offen
+s_mov_b32 m0, 0x2ffc0
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 7
+s_call_b64 s[38:39], 670
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_mac_f32_e32 v2, v38, v50
+v_mac_f32_e32 v3, v39, v50
+v_mac_f32_e32 v4, v40, v50
+s_setprio 1
+s_nop 0
+v_mac_f32_e32 v5, v41, v50
+v_mac_f32_e32 v6, v38, v51
+v_mac_f32_e32 v7, v39, v51
+v_mac_f32_e32 v8, v40, v51
+v_mac_f32_e32 v9, v41, v51
+v_mac_f32_e32 v10, v38, v52
+v_mac_f32_e32 v11, v39, v52
+v_mac_f32_e32 v12, v40, v52
+v_mac_f32_e32 v13, v41, v52
+v_mac_f32_e32 v14, v38, v53
+v_mac_f32_e32 v15, v39, v53
+v_mac_f32_e32 v16, v40, v53
+v_mac_f32_e32 v17, v41, v53
+v_mac_f32_e32 v18, v38, v54
+v_mac_f32_e32 v19, v39, v54
+v_mac_f32_e32 v20, v40, v54
+v_mac_f32_e32 v21, v41, v54
+v_mac_f32_e32 v22, v38, v55
+v_mac_f32_e32 v23, v39, v55
+v_mac_f32_e32 v24, v40, v55
+v_mac_f32_e32 v25, v41, v55
+v_mac_f32_e32 v26, v38, v56
+v_mac_f32_e32 v27, v39, v56
+v_mac_f32_e32 v28, v40, v56
+v_mac_f32_e32 v29, v41, v56
+v_mac_f32_e32 v30, v38, v57
+v_mac_f32_e32 v31, v39, v57
+v_mac_f32_e32 v32, v40, v57
+v_add_f32_dpp v103, v73, v73  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v103, v73, v100  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v73, v72, v72  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v73, v72, v100  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_add_f32_e32 v72, v70, v73
+v_add_f32_e64 v71, v103, v72 div:2
+v_add_f32_e64 v72, -v103, v72 div:2
+v_mac_f32_e32 v33, v41, v57
+v_cmp_eq_u32_e64 vcc, src_lds_direct, s91
+s_nop 0
+s_nop 0
+s_cbranch_vccz 65531
+s_mov_b64 vcc, s[10:11]
+s_nop 0
+ds_read_b128 v[38:41], v95 offset:41792
+ds_read_b128 v[50:53], v90 offset:41280
+ds_read_b128 v[54:57], v90 offset:41408
+ds_write_b32 v93, v72 offset:16512
+ds_write_b32 v94, v73 offset:16512
+s_setprio 0
+s_nop 0
+s_waitcnt vmcnt(9) lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 2
+s_call_b64 s[38:39], 593
+s_nop 0
+v_mac_f32_e32 v2, v34, v42
+v_mac_f32_e32 v3, v35, v42
+v_mac_f32_e32 v4, v36, v42
+s_setprio 1
+s_nop 0
+v_mac_f32_e32 v5, v37, v42
+v_mac_f32_e32 v6, v34, v43
+v_mac_f32_e32 v7, v35, v43
+v_mac_f32_e32 v8, v36, v43
+v_mac_f32_e32 v9, v37, v43
+v_mac_f32_e32 v10, v34, v44
+v_mac_f32_e32 v11, v35, v44
+v_mac_f32_e32 v12, v36, v44
+v_mac_f32_e32 v13, v37, v44
+v_mac_f32_e32 v14, v34, v45
+v_mac_f32_e32 v15, v35, v45
+v_mac_f32_e32 v16, v36, v45
+v_mac_f32_e32 v17, v37, v45
+v_mac_f32_e32 v18, v34, v46
+v_mac_f32_e32 v19, v35, v46
+v_mac_f32_e32 v20, v36, v46
+v_mac_f32_e32 v21, v37, v46
+v_mac_f32_e32 v22, v34, v47
+v_mac_f32_e32 v23, v35, v47
+v_mac_f32_e32 v24, v36, v47
+v_mac_f32_e32 v25, v37, v47
+v_mac_f32_e32 v26, v34, v48
+v_mac_f32_e32 v27, v35, v48
+v_mac_f32_e32 v28, v36, v48
+v_mac_f32_e32 v29, v37, v48
+v_mac_f32_e32 v30, v34, v49
+v_mac_f32_e32 v31, v35, v49
+v_cndmask_b32_dpp v74, v74, v74, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v75, v75, v75, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v76, v76, v76, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v77, v77, v77, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v74, v75, v75  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v74, v75, v100  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_mac_f32_e32 v32, v36, v49
+v_mac_f32_e32 v33, v37, v49
+s_nop 0
+ds_read_b128 v[34:37], v95 offset:45952
+ds_read_b128 v[42:45], v90 offset:45440
+ds_read_b128 v[46:49], v90 offset:45568
+ds_write_b32 v91, v70 offset:16512
+ds_write_b32 v92, v71 offset:16512
+s_setprio 0
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+buffer_load_dword v68, v84, s[40:43], 0 offen
+buffer_load_dword v67, v83, s[40:43], 0 offen
+buffer_load_dword v69, v85, s[40:43], 0 offen
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 1
+s_call_b64 s[38:39], 520
+v_mac_f32_e32 v2, v38, v50
+v_mac_f32_e32 v3, v39, v50
+v_mac_f32_e32 v4, v40, v50
+s_setprio 1
+s_nop 0
+v_mac_f32_e32 v5, v41, v50
+v_mac_f32_e32 v6, v38, v51
+v_mac_f32_e32 v7, v39, v51
+v_mac_f32_e32 v8, v40, v51
+v_mac_f32_e32 v9, v41, v51
+v_mac_f32_e32 v10, v38, v52
+v_mac_f32_e32 v11, v39, v52
+v_mac_f32_e32 v12, v40, v52
+v_mac_f32_e32 v13, v41, v52
+v_mac_f32_e32 v14, v38, v53
+v_mac_f32_e32 v15, v39, v53
+v_mac_f32_e32 v16, v40, v53
+v_mac_f32_e32 v17, v41, v53
+v_mac_f32_e32 v18, v38, v54
+v_mac_f32_e32 v19, v39, v54
+v_mac_f32_e32 v20, v40, v54
+v_mac_f32_e32 v21, v41, v54
+v_mac_f32_e32 v22, v38, v55
+v_mac_f32_e32 v23, v39, v55
+v_mac_f32_e32 v24, v40, v55
+v_mac_f32_e32 v25, v41, v55
+v_mac_f32_e32 v26, v38, v56
+v_mac_f32_e32 v27, v39, v56
+v_mac_f32_e32 v28, v40, v56
+v_mac_f32_e32 v29, v41, v56
+v_mac_f32_e32 v30, v38, v57
+v_mac_f32_e32 v31, v39, v57
+v_add_f32_dpp v103, v77, v77  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v103, v77, v100  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v77, v76, v76  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v77, v76, v100  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_add_f32_e32 v76, v74, v77
+v_add_f32_e64 v75, v103, v76 div:2
+v_add_f32_e64 v76, -v103, v76 div:2
+v_mac_f32_e32 v32, v40, v57
+v_mac_f32_e32 v33, v41, v57
+s_nop 0
+ds_read_b128 v[38:41], v95 offset:512
+ds_read_b128 v[50:53], v90
+ds_read_b128 v[54:57], v90 offset:128
+ds_write_b32 v93, v76 offset:24768
+ds_write_b32 v94, v77 offset:24768
+s_setprio 0
+s_nop 0
+s_waitcnt vmcnt(9) lgkmcnt(5)
+ds_append v105 offset:65476
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 6
+s_call_b64 s[38:39], 453
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_mac_f32_e32 v2, v34, v42
+v_mac_f32_e32 v3, v35, v42
+v_mac_f32_e32 v4, v36, v42
+s_setprio 1
+s_nop 0
+v_mac_f32_e32 v5, v37, v42
+v_mac_f32_e32 v6, v34, v43
+v_mac_f32_e32 v7, v35, v43
+v_mac_f32_e32 v8, v36, v43
+v_mac_f32_e32 v9, v37, v43
+v_mac_f32_e32 v10, v34, v44
+v_mac_f32_e32 v11, v35, v44
+v_mac_f32_e32 v12, v36, v44
+v_mac_f32_e32 v13, v37, v44
+v_mac_f32_e32 v14, v34, v45
+v_mac_f32_e32 v15, v35, v45
+v_mac_f32_e32 v16, v36, v45
+v_mac_f32_e32 v17, v37, v45
+v_mac_f32_e32 v18, v34, v46
+v_mac_f32_e32 v19, v35, v46
+v_mac_f32_e32 v20, v36, v46
+v_mac_f32_e32 v21, v37, v46
+v_mac_f32_e32 v22, v34, v47
+v_mac_f32_e32 v23, v35, v47
+v_mac_f32_e32 v24, v36, v47
+v_mac_f32_e32 v25, v37, v47
+v_mac_f32_e32 v26, v34, v48
+v_mac_f32_e32 v27, v35, v48
+v_mac_f32_e32 v28, v36, v48
+v_mac_f32_e32 v29, v37, v48
+v_mac_f32_e32 v30, v34, v49
+v_mac_f32_e32 v31, v35, v49
+v_cndmask_b32_dpp v78, v78, v78, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v79, v79, v79, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v80, v80, v80, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v81, v81, v81, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v78, v79, v79  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v78, v79, v100  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_mac_f32_e32 v32, v36, v49
+v_mac_f32_e32 v33, v37, v49
+s_nop 0
+ds_read_b128 v[34:37], v95 offset:4672
+ds_read_b128 v[42:45], v90 offset:4160
+ds_read_b128 v[46:49], v90 offset:4288
+ds_write_b32 v91, v74 offset:24768
+ds_write_b32 v92, v75 offset:24768
+s_setprio 0
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+buffer_load_dword v72, v84, s[40:43], 0 offen
+buffer_load_dword v71, v83, s[40:43], 0 offen
+buffer_load_dword v73, v85, s[40:43], 0 offen
+s_mov_b32 m0, 0x2ffc4
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 7
+s_call_b64 s[38:39], 374
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_mac_f32_e32 v2, v38, v50
+v_mac_f32_e32 v3, v39, v50
+v_mac_f32_e32 v4, v40, v50
+s_setprio 1
+s_nop 0
+v_mac_f32_e32 v5, v41, v50
+v_mac_f32_e32 v6, v38, v51
+v_mac_f32_e32 v7, v39, v51
+v_mac_f32_e32 v8, v40, v51
+v_mac_f32_e32 v9, v41, v51
+v_mac_f32_e32 v10, v38, v52
+v_mac_f32_e32 v11, v39, v52
+v_mac_f32_e32 v12, v40, v52
+v_mac_f32_e32 v13, v41, v52
+v_mac_f32_e32 v14, v38, v53
+v_mac_f32_e32 v15, v39, v53
+v_mac_f32_e32 v16, v40, v53
+v_mac_f32_e32 v17, v41, v53
+v_mac_f32_e32 v18, v38, v54
+v_mac_f32_e32 v19, v39, v54
+v_mac_f32_e32 v20, v40, v54
+v_mac_f32_e32 v21, v41, v54
+v_mac_f32_e32 v22, v38, v55
+v_mac_f32_e32 v23, v39, v55
+v_mac_f32_e32 v24, v40, v55
+v_mac_f32_e32 v25, v41, v55
+v_mac_f32_e32 v26, v38, v56
+v_mac_f32_e32 v27, v39, v56
+v_mac_f32_e32 v28, v40, v56
+v_mac_f32_e32 v29, v41, v56
+v_mac_f32_e32 v30, v38, v57
+v_mac_f32_e32 v31, v39, v57
+v_mac_f32_e32 v32, v40, v57
+v_add_f32_dpp v103, v81, v81  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v103, v81, v100  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v81, v80, v80  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v81, v80, v100  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_add_f32_e32 v80, v78, v81
+v_add_f32_e64 v79, v103, v80 div:2
+v_add_f32_e64 v80, -v103, v80 div:2
+v_mac_f32_e32 v33, v41, v57
+v_cmp_eq_u32_e64 vcc, src_lds_direct, s91
+s_nop 0
+s_nop 0
+s_cbranch_vccz 65531
+s_mov_b64 vcc, s[10:11]
+s_nop 0
+ds_read_b128 v[38:41], v95 offset:8768
+ds_read_b128 v[50:53], v90 offset:8256
+ds_read_b128 v[54:57], v90 offset:8384
+ds_write_b32 v93, v80 offset:33024
+ds_write_b32 v94, v81 offset:33024
+s_setprio 0
+s_nop 0
+s_waitcnt vmcnt(9) lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 2
+s_call_b64 s[38:39], 297
+s_nop 0
+v_mac_f32_e32 v2, v34, v42
+v_mac_f32_e32 v3, v35, v42
+v_mac_f32_e32 v4, v36, v42
+s_setprio 1
+s_nop 0
+v_mac_f32_e32 v5, v37, v42
+v_mac_f32_e32 v6, v34, v43
+v_mac_f32_e32 v7, v35, v43
+v_mac_f32_e32 v8, v36, v43
+v_mac_f32_e32 v9, v37, v43
+v_mac_f32_e32 v10, v34, v44
+v_mac_f32_e32 v11, v35, v44
+v_mac_f32_e32 v12, v36, v44
+v_mac_f32_e32 v13, v37, v44
+v_mac_f32_e32 v14, v34, v45
+v_mac_f32_e32 v15, v35, v45
+v_mac_f32_e32 v16, v36, v45
+v_mac_f32_e32 v17, v37, v45
+v_mac_f32_e32 v18, v34, v46
+v_mac_f32_e32 v19, v35, v46
+v_mac_f32_e32 v20, v36, v46
+v_mac_f32_e32 v21, v37, v46
+v_mac_f32_e32 v22, v34, v47
+v_mac_f32_e32 v23, v35, v47
+v_mac_f32_e32 v24, v36, v47
+v_mac_f32_e32 v25, v37, v47
+v_mac_f32_e32 v26, v34, v48
+v_mac_f32_e32 v27, v35, v48
+v_mac_f32_e32 v28, v36, v48
+v_mac_f32_e32 v29, v37, v48
+v_mac_f32_e32 v30, v34, v49
+v_mac_f32_e32 v31, v35, v49
+v_cndmask_b32_dpp v58, v58, v58, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v59, v59, v59, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v60, v60, v60, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v61, v61, v61, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v58, v59, v59  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v58, v59, v100  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_mac_f32_e32 v32, v36, v49
+v_mac_f32_e32 v33, v37, v49
+s_nop 0
+ds_read_b128 v[34:37], v95 offset:12928
+ds_read_b128 v[42:45], v90 offset:12416
+ds_read_b128 v[46:49], v90 offset:12544
+ds_write_b32 v91, v78 offset:33024
+ds_write_b32 v92, v79 offset:33024
+s_setprio 0
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+buffer_load_dword v76, v84, s[40:43], 0 offen
+buffer_load_dword v75, v83, s[40:43], 0 offen
+buffer_load_dword v77, v85, s[40:43], 0 offen
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 1
+s_call_b64 s[38:39], 224
+v_mac_f32_e32 v2, v38, v50
+v_mac_f32_e32 v3, v39, v50
+v_mac_f32_e32 v4, v40, v50
+s_setprio 1
+s_nop 0
+v_mac_f32_e32 v5, v41, v50
+v_mac_f32_e32 v6, v38, v51
+v_mac_f32_e32 v7, v39, v51
+v_mac_f32_e32 v8, v40, v51
+v_mac_f32_e32 v9, v41, v51
+v_mac_f32_e32 v10, v38, v52
+v_mac_f32_e32 v11, v39, v52
+v_mac_f32_e32 v12, v40, v52
+v_mac_f32_e32 v13, v41, v52
+v_mac_f32_e32 v14, v38, v53
+v_mac_f32_e32 v15, v39, v53
+v_mac_f32_e32 v16, v40, v53
+v_mac_f32_e32 v17, v41, v53
+v_mac_f32_e32 v18, v38, v54
+v_mac_f32_e32 v19, v39, v54
+v_mac_f32_e32 v20, v40, v54
+v_mac_f32_e32 v21, v41, v54
+v_mac_f32_e32 v22, v38, v55
+v_mac_f32_e32 v23, v39, v55
+v_mac_f32_e32 v24, v40, v55
+v_mac_f32_e32 v25, v41, v55
+v_mac_f32_e32 v26, v38, v56
+v_mac_f32_e32 v27, v39, v56
+v_mac_f32_e32 v28, v40, v56
+v_mac_f32_e32 v29, v41, v56
+v_mac_f32_e32 v30, v38, v57
+v_mac_f32_e32 v31, v39, v57
+v_add_f32_dpp v103, v61, v61  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v103, v61, v100  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v61, v60, v60  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v61, v60, v100  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_add_f32_e32 v60, v58, v61
+v_add_f32_e64 v59, v103, v60 div:2
+v_add_f32_e64 v60, -v103, v60 div:2
+v_mac_f32_e32 v32, v40, v57
+v_mac_f32_e32 v33, v41, v57
+s_nop 0
+ds_read_b128 v[38:41], v95 offset:17024
+ds_read_b128 v[50:53], v90 offset:16512
+ds_read_b128 v[54:57], v90 offset:16640
+ds_write_b32 v93, v60 offset:41280
+ds_write_b32 v94, v61 offset:41280
+s_setprio 0
+s_nop 0
+s_waitcnt vmcnt(9) lgkmcnt(5)
+ds_append v105 offset:65480
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 6
+s_call_b64 s[38:39], 157
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_mac_f32_e32 v2, v34, v42
+v_mac_f32_e32 v3, v35, v42
+v_mac_f32_e32 v4, v36, v42
+s_setprio 1
+s_nop 0
+v_mac_f32_e32 v5, v37, v42
+v_mac_f32_e32 v6, v34, v43
+v_mac_f32_e32 v7, v35, v43
+v_mac_f32_e32 v8, v36, v43
+v_mac_f32_e32 v9, v37, v43
+v_mac_f32_e32 v10, v34, v44
+v_mac_f32_e32 v11, v35, v44
+v_mac_f32_e32 v12, v36, v44
+v_mac_f32_e32 v13, v37, v44
+v_mac_f32_e32 v14, v34, v45
+v_mac_f32_e32 v15, v35, v45
+v_mac_f32_e32 v16, v36, v45
+v_mac_f32_e32 v17, v37, v45
+v_mac_f32_e32 v18, v34, v46
+v_mac_f32_e32 v19, v35, v46
+v_mac_f32_e32 v20, v36, v46
+v_mac_f32_e32 v21, v37, v46
+v_mac_f32_e32 v22, v34, v47
+v_mac_f32_e32 v23, v35, v47
+v_mac_f32_e32 v24, v36, v47
+v_mac_f32_e32 v25, v37, v47
+v_mac_f32_e32 v26, v34, v48
+v_mac_f32_e32 v27, v35, v48
+v_mac_f32_e32 v28, v36, v48
+v_mac_f32_e32 v29, v37, v48
+v_mac_f32_e32 v30, v34, v49
+v_mac_f32_e32 v31, v35, v49
+v_cndmask_b32_dpp v62, v62, v62, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v63, v63, v63, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v64, v64, v64, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_cndmask_b32_dpp v65, v65, v65, vcc  row_half_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v62, v63, v63  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v62, v63, v100  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_mac_f32_e32 v32, v36, v49
+v_mac_f32_e32 v33, v37, v49
+s_nop 0
+ds_read_b128 v[34:37], v95 offset:21184
+ds_read_b128 v[42:45], v90 offset:20672
+ds_read_b128 v[46:49], v90 offset:20800
+ds_write_b32 v91, v58 offset:41280
+ds_write_b32 v92, v59 offset:41280
+s_setprio 0
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+buffer_load_dword v80, v84, s[40:43], 0 offen
+buffer_load_dword v79, v83, s[40:43], 0 offen
+buffer_load_dword v81, v85, s[40:43], 0 offen
+s_mov_b32 m0, 0x2ffc8
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 7
+s_call_b64 s[38:39], 78
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_mac_f32_e32 v2, v38, v50
+v_mac_f32_e32 v3, v39, v50
+v_mac_f32_e32 v4, v40, v50
+s_setprio 1
+s_nop 0
+v_mac_f32_e32 v5, v41, v50
+v_mac_f32_e32 v6, v38, v51
+v_mac_f32_e32 v7, v39, v51
+v_mac_f32_e32 v8, v40, v51
+v_mac_f32_e32 v9, v41, v51
+v_mac_f32_e32 v10, v38, v52
+v_mac_f32_e32 v11, v39, v52
+v_mac_f32_e32 v12, v40, v52
+v_mac_f32_e32 v13, v41, v52
+v_mac_f32_e32 v14, v38, v53
+v_mac_f32_e32 v15, v39, v53
+v_mac_f32_e32 v16, v40, v53
+v_mac_f32_e32 v17, v41, v53
+v_mac_f32_e32 v18, v38, v54
+v_mac_f32_e32 v19, v39, v54
+v_mac_f32_e32 v20, v40, v54
+v_mac_f32_e32 v21, v41, v54
+v_mac_f32_e32 v22, v38, v55
+v_mac_f32_e32 v23, v39, v55
+v_mac_f32_e32 v24, v40, v55
+v_mac_f32_e32 v25, v41, v55
+v_mac_f32_e32 v26, v38, v56
+v_mac_f32_e32 v27, v39, v56
+v_mac_f32_e32 v28, v40, v56
+v_mac_f32_e32 v29, v41, v56
+v_mac_f32_e32 v30, v38, v57
+v_mac_f32_e32 v31, v39, v57
+v_mac_f32_e32 v32, v40, v57
+v_add_f32_dpp v103, v65, v65  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v103, v65, v100  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v65, v64, v64  quad_perm:[0,0,0,2] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v65, v64, v100  quad_perm:[0,2,1,3] row_mask:0xf bank_mask:0xf
+v_add_f32_e32 v64, v62, v65
+v_add_f32_e64 v63, v103, v64 div:2
+v_add_f32_e64 v64, -v103, v64 div:2
+v_mac_f32_e32 v33, v41, v57
+v_cmp_eq_u32_e64 vcc, src_lds_direct, s91
+s_nop 0
+s_nop 0
+s_cbranch_vccz 65531
+s_mov_b64 vcc, s[10:11]
+s_nop 0
+ds_read_b128 v[38:41], v95 offset:25280
+ds_read_b128 v[50:53], v90 offset:24768
+ds_read_b128 v[54:57], v90 offset:24896
+ds_write_b32 v93, v64
+ds_write_b32 v94, v65
+s_setprio 0
+s_nop 0
+s_waitcnt vmcnt(9) lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 64642
+s_call_b64 s[38:39], 1
+s_branch 64640
+v_nop
+s_cmp_eq_u32 s82, 0
+s_cbranch_scc0 8
+s_branch 596
+s_add_u32 s82, s82, 1
+s_andn2_b32 s82, s82, 1
+s_bitcmp1_b32 0, 26
+s_cselect_b32 s52, s69, s70
+s_cselect_b32 s53, 0, s71
+s_sub_u32 s40, s40, s52
+s_subb_u32 s41, s41, s53
+s_cmp_eq_u32 s94, 0
+s_cbranch_scc0 3
+s_cbranch_scc1 626
+s_nop 0
+s_nop 0
+s_min_u32 s72, s82, s94
+s_sub_u32 s82, s82, s72
+s_sub_u32 s94, s94, s72
+s_sub_u32 s72, s72, 1
+s_setpc_b64 s[38:39]
+s_nop 0
+s_nop 0
+s_nop 0
+s_bitcmp1_b32 s18, 17
+s_cbranch_scc1 241
+s_add_u32 s88, s88, s17
+s_cmp_eq_u32 s88, 0
+s_cbranch_scc1 238
+s_mov_b32 s89, 0
+s_bitcmp1_b32 s18, 16
+s_cbranch_scc1 227
+s_add_u32 s87, s16, 31
+s_lshr_b32 s87, s87, 5
+v_mov_b32_e32 v107, s88
+v_mul_u32_u24_e32 v107, s87, v107
+v_add_co_u32_e32 v107, vcc, s17, v107
+v_sub_co_u32_e64 v107, vcc, v107, 1
+v_ffbh_u32_e32 v110, s17
+v_lshlrev_b32_e64 v111, v110, s17
+v_and_b32_e32 v112, 0xffffff00, v111
+v_cmp_eq_u32_e32 vcc, 0x80000000, v111
+v_cvt_f32_u32_e32 v112, v112
+v_rcp_f32_e32 v106, v112
+v_subb_co_u32_e32 v109, vcc, 32, v110, vcc
+v_cvt_f32_ubyte0_e32 v110, v111
+v_fma_f32 v112, v112, v106, -1.0
+v_fma_f32 v112, v110, v106, v112
+v_madak_f32 v112, v112, v106, 0x9f000000
+v_mul_f32_e32 v112, 0x5f800000, v112
+v_mov_b32_e32 v110, 0
+v_cvt_flr_i32_f32_e64 v112, -v112
+v_lshl_add_u32 v106, v106, 9, v112
+v_mad_u64_u32 v[110:111], vcc, v111, v106, v[110:111]
+v_subb_co_u32_e64 v106, vcc, v106, -1, vcc
+v_mul_hi_u32 v110, v107, v106
+v_add_co_u32_e32 v106, vcc, v110, v107
+v_addc_co_u32_e64 v110, vcc, 0, 0, vcc
+v_cmp_eq_u32_e32 vcc, 32, v109
+v_cndmask_b32_e32 v106, v106, v110, vcc
+v_alignbit_b32 v106, v110, v106, v109
+v_readfirstlane_b32 s86, v106
+v_mul_u32_u24_e64 v106, v106, s8
+v_ffbh_u32_e32 v110, s87
+v_lshlrev_b32_e64 v111, v110, s87
+v_and_b32_e32 v112, 0xffffff00, v111
+v_cmp_eq_u32_e32 vcc, 0x80000000, v111
+v_cvt_f32_u32_e32 v112, v112
+v_rcp_f32_e32 v107, v112
+v_subb_co_u32_e32 v109, vcc, 32, v110, vcc
+v_cvt_f32_ubyte0_e32 v110, v111
+v_fma_f32 v112, v112, v107, -1.0
+v_fma_f32 v112, v110, v107, v112
+v_madak_f32 v112, v112, v107, 0x9f000000
+v_mul_f32_e32 v112, 0x5f800000, v112
+v_mov_b32_e32 v110, 0
+v_cvt_flr_i32_f32_e64 v112, -v112
+v_lshl_add_u32 v107, v107, 9, v112
+v_mad_u64_u32 v[110:111], vcc, v111, v107, v[110:111]
+v_subb_co_u32_e64 v107, vcc, v107, -1, vcc
+v_mul_hi_u32 v110, v106, v107
+v_add_co_u32_e32 v107, vcc, v110, v106
+v_addc_co_u32_e64 v110, vcc, 0, 0, vcc
+v_cmp_eq_u32_e32 vcc, 32, v109
+v_cndmask_b32_e32 v107, v107, v110, vcc
+v_alignbit_b32 v107, v110, v107, v109
+v_readfirstlane_b32 s52, v106
+v_readfirstlane_b32 s84, v107
+s_mul_i32 s84, s84, s87
+s_sub_u32 s84, s52, s84
+v_sub_co_u32_e32 v107, vcc, s8, v107
+v_sub_co_u32_e32 v107, vcc, s17, v107
+v_and_b32_e64 v109, v0, 63
+v_cmp_eq_u32_e64 vcc, v109, 0
+v_cndmask_b32_e32 v107, 1, v107, vcc
+s_sub_u32 s58, 0, s75
+s_sub_u32 s59, 0, s74
+v_mul_u32_u24_e64 v111, v107, 32
+v_ffbh_u32_e32 v113, s58
+v_lshlrev_b32_e64 v114, v113, s58
+v_and_b32_e32 v115, 0xffffff00, v114
+v_cmp_eq_u32_e32 vcc, 0x80000000, v114
+v_cvt_f32_u32_e32 v115, v115
+v_rcp_f32_e32 v109, v115
+v_subb_co_u32_e32 v112, vcc, 32, v113, vcc
+v_cvt_f32_ubyte0_e32 v113, v114
+v_fma_f32 v115, v115, v109, -1.0
+v_fma_f32 v115, v113, v109, v115
+v_madak_f32 v115, v115, v109, 0x9f000000
+v_mul_f32_e32 v115, 0x5f800000, v115
+v_mov_b32_e32 v113, 0
+v_cvt_flr_i32_f32_e64 v115, -v115
+v_lshl_add_u32 v109, v109, 9, v115
+v_mad_u64_u32 v[113:114], vcc, v114, v109, v[113:114]
+v_subb_co_u32_e64 v109, vcc, v109, -1, vcc
+v_mul_hi_u32 v113, v111, v109
+v_add_co_u32_e32 v109, vcc, v113, v111
+v_addc_co_u32_e64 v113, vcc, 0, 0, vcc
+v_cmp_eq_u32_e32 vcc, 32, v112
+v_cndmask_b32_e32 v109, v109, v113, vcc
+v_alignbit_b32 v109, v113, v109, v112
+v_mad_i32_i24 v110, v109, s75, v111
+v_mul_u32_u24_e64 v111, v109, 1
+v_ffbh_u32_e32 v113, s59
+v_lshlrev_b32_e64 v114, v113, s59
+v_and_b32_e32 v115, 0xffffff00, v114
+v_cmp_eq_u32_e32 vcc, 0x80000000, v114
+v_cvt_f32_u32_e32 v115, v115
+v_rcp_f32_e32 v109, v115
+v_subb_co_u32_e32 v112, vcc, 32, v113, vcc
+v_cvt_f32_ubyte0_e32 v113, v114
+v_fma_f32 v115, v115, v109, -1.0
+v_fma_f32 v115, v113, v109, v115
+v_madak_f32 v115, v115, v109, 0x9f000000
+v_mul_f32_e32 v115, 0x5f800000, v115
+v_mov_b32_e32 v113, 0
+v_cvt_flr_i32_f32_e64 v115, -v115
+v_lshl_add_u32 v109, v109, 9, v115
+v_mad_u64_u32 v[113:114], vcc, v114, v109, v[113:114]
+v_subb_co_u32_e64 v109, vcc, v109, -1, vcc
+v_mul_hi_u32 v113, v111, v109
+v_add_co_u32_e32 v109, vcc, v113, v111
+v_addc_co_u32_e64 v113, vcc, 0, 0, vcc
+v_cmp_eq_u32_e32 vcc, 32, v112
+v_cndmask_b32_e32 v109, v109, v113, vcc
+v_alignbit_b32 v109, v113, v109, v112
+v_mad_i32_i24 v111, v109, s74, v111
+v_readfirstlane_b32 s76, v110
+v_readfirstlane_b32 s77, v111
+v_readfirstlane_b32 s78, v109
+v_add_co_u32_e32 v96, vcc, s76, v96
+v_addc_co_u32_e64 v112, vcc, 0, 0, vcc
+v_mad_i32_i24 v96, v112, s75, v96
+v_mad_i32_i24 v98, v112, s80, v98
+v_mad_i32_i24 v97, v112, s79, v97
+v_cmp_ge_i32_e64 vcc, v97, 0
+v_addc_co_u32_e64 v112, vcc, 0, 0, vcc
+v_add_co_u32_e32 v98, vcc, v98, v112
+v_mad_i32_i24 v97, v112, s74, v97
+v_add_co_u32_e32 v97, vcc, s77, v97
+v_addc_co_u32_e64 v112, vcc, 0, 0, vcc
+v_add_co_u32_e32 v98, vcc, v98, v112
+v_mad_i32_i24 v97, v112, s74, v97
+v_add_co_u32_e32 v98, vcc, s78, v98
+v_readlane_b32 s76, v110, 1
+v_readlane_b32 s77, v111, 1
+v_readlane_b32 s78, v109, 1
+s_add_u32 s85, s84, s86
+s_cmp_le_u32 s85, s87
+s_cselect_b32 s52, 0x20000, 0
+s_cselect_b32 s85, s85, s87
+s_or_b32 s18, s18, s52
+s_lshl_b32 s84, s84, 5
+s_lshl_b32 s85, s85, 5
+s_min_u32 s85, s85, s16
+s_cmp_eq_u32 s8, s17
+s_cselect_b32 s52, 0x20000, 0
+s_or_b32 s18, s18, s52
+s_or_b32 s18, s18, s52
+s_bitset1_b32 s18, 16
+s_branch 43
+s_lshr_b32 s84, s84, 5
+s_add_u32 s85, s84, s86
+s_sub_u32 s85, s85, s87
+s_mov_b32 s84, 0
+s_lshl_b32 s85, s85, 5
+s_min_u32 s85, s85, s16
+s_bitset1_b32 s18, 17
+s_branch 12
+s_bitset1_b32 s18, 18
+s_mov_b32 s43, 0
+s_mov_b32 s73, -1
+s_mov_b32 s82, 40
+s_branch 31
+s_add_u32 s83, s83, 32
+s_cmp_ge_u32 s83, s85
+s_cbranch_scc0 28
+s_bitset1_b32 s18, 22
+s_sub_u32 s88, s88, s17
+s_subb_u32 s89, s89, 0
+s_cbranch_scc1 65281
+v_add_co_u32_e32 v96, vcc, s76, v96
+v_addc_co_u32_e64 v106, vcc, 0, 0, vcc
+v_mad_i32_i24 v96, v106, s75, v96
+v_mad_i32_i24 v98, v106, s80, v98
+v_mad_i32_i24 v97, v106, s79, v97
+v_cmp_ge_i32_e64 vcc, v97, 0
+v_addc_co_u32_e64 v106, vcc, 0, 0, vcc
+v_add_co_u32_e32 v98, vcc, v98, v106
+v_mad_i32_i24 v97, v106, s74, v97
+v_add_co_u32_e32 v97, vcc, s77, v97
+v_addc_co_u32_e64 v106, vcc, 0, 0, vcc
+v_add_co_u32_e32 v98, vcc, v98, v106
+v_mad_i32_i24 v97, v106, s74, v97
+v_add_co_u32_e32 v98, vcc, s78, v98
+s_mov_b32 s83, s84
+v_cmp_le_u32_e32 vcc, 0x100, v0
+s_cbranch_vccz 166
+v_subrev_co_u32_e32 v106, vcc, s75, v96
+v_subrev_co_u32_e32 v107, vcc, s74, v97
+s_bitcmp1_b32 s18, 22
+s_cbranch_scc0 64
+s_bitset0_b32 s18, 22
+s_bfe_u32 s52, s18, 0x10014
+v_mul_u32_u24_e32 v111, 2, v106
+v_mul_u32_u24_e32 v112, 2, v107
+v_cvt_pk_u16_u32 v114, v111, v112
+v_and_b32_e64 v111, v0, 1
+v_cmp_eq_u32_e64 vcc, v111, 1
+v_cndmask_b32_e32 v114, v98, v114, vcc
+v_lshrrev_b32_e32 v110, 1, v0
+v_bfe_u32 v115, v110, s52, 1
+v_lshrrev_b32_e32 v110, 1, v0
+v_bfi_b32 v110, 1, v0, v110
+v_lshrrev_b32_e32 v111, 2, v0
+v_bfi_b32 v111, 1, v0, v111
+v_cmp_eq_u32_e64 vcc, s52, 0
+v_cndmask_b32_e32 v110, v111, v110, vcc
+s_sub_u32 s52, 1, s52
+v_lshrrev_b32_e32 v111, s52, v110
+v_bfi_b32 v110, 32, v111, v110
+v_and_b32_e32 v110, 63, v110
+v_add_co_u32_e32 v111, vcc, 16, v110
+v_and_b32_e64 v112, v0, 2
+v_cmp_eq_u32_e64 vcc, v112, 0
+v_cndmask_b32_e32 v111, v111, v110, vcc
+v_lshlrev_b32_e32 v112, 14, v115
+v_mad_u32_u24 v111, 4, v111, v112
+v_add_co_u32_e32 v110, vcc, s96, v111
+ds_write_b32 v110, v114
+v_writelane_b32 v112, s18, 0
+v_writelane_b32 v112, s85, 1
+v_writelane_b32 v112, s84, 2
+v_and_b32_e64 v110, v0, 63
+v_cmp_ge_u32_e64 vcc, v110, 3
+v_mov_b32_e32 v113, 0x4000
+v_cndmask_b32_e32 v110, v110, v113, vcc
+v_mad_i32_i24 v110, v110, 4, s96
+ds_write_b32 v110, v112 offset:256
+s_add_u32 s96, s96, 0x18c
+s_cmp_eq_u32 s96, 0xffc0
+s_cselect_b32 s96, 0xc1e0, s96
+v_mov_b32_dpp v108, v98  quad_perm:[0,0,0,0] row_mask:0xf bank_mask:0xf
+v_mov_b32_dpp v106, v106  quad_perm:[0,0,0,0] row_mask:0xf bank_mask:0xf
+v_mov_b32_dpp v107, v107  quad_perm:[0,0,0,0] row_mask:0xf bank_mask:0xf
+v_readfirstlane_b32 s81, v108
+v_sub_co_u32_e64 v109, vcc, v108, s81
+v_mul_lo_u32 v109, v109, s65
+v_mad_u32_u24 v112, 5, v0, 2
+v_and_b32_e32 v113, 6, v0
+v_add_co_u32_e32 v113, vcc, 4, v113
+v_bfi_b32 v113, 4, v112, v113
+v_bfe_u32 v113, v113, 1, 3
+v_ashrrev_i32_e64 v114, 0, s31
+v_subrev_co_u32_e32 v113, vcc, v114, v113
+v_ashrrev_i32_e64 v114, 0, s62
+v_mad_i32_i24 v110, v114, 3, v113
+v_add_co_u32_e64 v111, vcc, 0, s63
+v_ashrrev_i32_e32 v111, 0, v111
+v_add_co_u32_e64 v112, vcc, 0, s30
+v_ashrrev_i32_e32 v112, 0, v112
+v_sub_i32 v111, v111, v112
+s_lshl_b32 s54, s15, 2
+v_cmp_ge_u32_e64 s[52:53], v108, s12
+v_mad_i32_i24 v106, v106, 4, v110
+v_cmp_ge_u32_e64 s[56:57], v106, s15
+v_mad_i32_i24 v106, 4, v106, v109
+s_or_b64 s[56:57], s[56:57], s[52:53]
+v_mad_i32_i24 v107, v107, 4, v111
+v_cmp_ge_u32_e64 s[58:59], v107, s14
+s_or_b64 s[58:59], s[56:57], s[58:59]
+v_mad_u32_u24 v82, v107, s54, v106
+v_cndmask_b32_e64 v82, v82, -1, s[58:59]
+v_add_co_u32_e32 v107, vcc, 2, v107
+v_cmp_ge_u32_e64 s[58:59], v107, s14
+s_or_b64 s[58:59], s[56:57], s[58:59]
+v_mad_u32_u24 v83, v107, s54, v106
+v_cndmask_b32_e64 v83, v83, -1, s[58:59]
+v_add_co_u32_e32 v107, vcc, 2, v107
+v_cmp_ge_u32_e64 s[58:59], v107, s14
+s_or_b64 s[58:59], s[56:57], s[58:59]
+v_mad_u32_u24 v84, v107, s54, v106
+v_cndmask_b32_e64 v84, v84, -1, s[58:59]
+v_add_co_u32_e32 v107, vcc, 2, v107
+v_cmp_ge_u32_e64 s[58:59], v107, s14
+s_or_b64 s[58:59], s[56:57], s[58:59]
+v_mad_u32_u24 v85, v107, s54, v106
+v_cndmask_b32_e64 v85, v85, -1, s[58:59]
+s_bitcmp1_b32 s18, 18
+s_cbranch_scc1 138
+s_lshr_b32 s52, -1, 16
+s_and_b32 s52, s52, s65
+s_lshr_b32 s53, s65, 16
+s_mul_i32 s53, s53, s81
+s_mul_i32 s40, s52, s81
+s_lshl_b32 s52, s53, 16
+s_lshr_b32 s53, s53, 16
+s_add_u32 s40, s52, s40
+s_addc_u32 s41, s53, 0
+s_add_u32 s40, s40, s20
+s_addc_u32 s41, s41, s21
+s_lshr_b32 s52, s18, 6
+s_xor_b32 s52, s52, s18
+s_and_b32 s52, s52, 0x80000
+s_cselect_b32 s52, s68, 0
+s_add_u32 s40, s40, s52
+s_addc_u32 s41, s41, 0
+s_branch 95
+s_bitcmp1_b32 s18, 18
+s_cbranch_scc1 117
+v_mad_u32_u24 v108, 5, v0, 2
+v_lshlrev_b32_e32 v106, 1, v0
+v_bfi_b32 v108, 4, v108, v106
+v_bfe_u32 v106, v108, 2, 2
+v_min_u32_e32 v106, 2, v106
+v_bfe_u32 v108, v0, 1, 1
+v_mad_u32_u24 v106, 2, v106, v108
+v_mad_u32_u24 v106, s62, 3, v106
+v_sub_co_u32_e32 v108, vcc, s29, v106
+v_sub_co_u32_e64 v108, vcc, v108, 1
+s_bfe_u32 s54, s18, 0x10001
+v_cmp_eq_u32_e64 vcc, s54, 1
+v_cndmask_b32_e32 v106, v106, v108, vcc
+v_cmp_ge_u32_e64 s[52:53], v106, s29
+v_lshlrev_b32_e32 v106, 2, v106
+s_bfe_u32 s54, s18, 0x10018
+v_bfe_u32 v109, v0, 2, s54
+v_mul_lo_u32 v109, s68, v109
+v_add_co_u32_e32 v106, vcc, v106, v109
+v_mul_lo_u32 v107, s90, v99
+v_add_co_u32_e32 v107, vcc, v107, v106
+s_sub_u32 s54, s28, s63
+s_sub_u32 s54, s54, 5
+s_bitcmp1_b32 s18, 0
+s_cselect_b32 s54, s54, s63
+v_mov_b32_e32 v109, s54
+s_lshl_b32 s57, s29, 2
+v_cmp_ge_u32_e64 s[54:55], v109, s28
+v_mad_i32_i24 v82, v109, s57, v107
+s_or_b64 s[54:55], s[54:55], s[52:53]
+v_cndmask_b32_e64 v82, v82, -1, s[54:55]
+v_mov_b32_e32 v83, v82
+v_add_co_u32_e64 v109, vcc, v109, 2
+v_cmp_ge_u32_e64 s[54:55], v109, s28
+v_mad_i32_i24 v85, v109, s57, v107
+s_or_b64 s[54:55], s[54:55], s[52:53]
+v_cndmask_b32_e64 v85, v85, -1, s[54:55]
+v_add_co_u32_e64 v109, vcc, v109, 2
+v_cmp_ge_u32_e64 s[54:55], v109, s28
+v_mad_i32_i24 v84, v109, s57, v107
+s_or_b64 s[54:55], s[54:55], s[52:53]
+v_cndmask_b32_e64 v84, v84, -1, s[54:55]
+v_add_co_u32_e64 v106, vcc, v99, s83
+v_cmp_lt_u32_e64 vcc, v106, s16
+v_cndmask_b32_e32 v82, -1, v82, vcc
+v_cndmask_b32_e32 v83, -1, v83, vcc
+v_cndmask_b32_e32 v84, -1, v84, vcc
+v_cndmask_b32_e32 v85, -1, v85, vcc
+s_lshr_b32 s52, -1, 16
+s_and_b32 s52, s52, s90
+s_lshr_b32 s53, s90, 16
+s_mul_i32 s53, s53, s83
+s_mul_i32 s40, s52, s83
+s_lshl_b32 s52, s53, 16
+s_lshr_b32 s53, s53, 16
+s_add_u32 s40, s52, s40
+s_addc_u32 s41, s53, 0
+s_add_u32 s40, s40, s22
+s_addc_u32 s41, s41, s23
+s_lshr_b32 s52, s18, 6
+s_xor_b32 s52, s52, s18
+s_and_b32 s52, s52, 0x80000
+s_cselect_b32 s52, s68, 0
+s_add_u32 s40, s40, s52
+s_addc_u32 s41, s41, 0
+s_mov_b32 s43, 0x20000
+s_mov_b32 s73, -1
+s_bfe_u32 s52, s18, 0x10014
+s_lshl_b32 s82, s13, s52
+s_bfe_u32 s52, s18, 0x10013
+s_bfe_u32 s54, s18, 0x10019
+s_xor_b32 s52, s52, s54
+s_cselect_b32 s52, 1, 0
+s_cselect_b32 s43, 0x20000, s43
+s_and_b32 s52, s52, s82
+s_sub_u32 s82, s82, s52
+s_bitcmp1_b32 s18, 20
+s_cselect_b32 s52, 0, 0x2000000
+s_bitcmp1_b32 s13, 0
+s_cselect_b32 s52, s52, 0
+s_xor_b32 s18, s18, s52
+s_cmp_eq_u32 s82, 0
+s_cbranch_scc1 9
+s_mov_b64 vcc, s[10:11]
+s_branch 64947
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_and_b32 s52, 0x900000, s18
+s_subb_u32 s62, s62, 1
+s_cbranch_scc0 65235
+s_and_b32 s52, 0x900000, s18
+s_subb_u32 s62, s61, 1
+s_add_u32 s63, s63, 6
+s_cmp_ge_u32 s63, s28
+s_cbranch_scc0 65229
+s_mov_b32 s63, 1
+s_cmp_ge_u32 s63, s28
+s_addc_u32 s64, s64, 1
+s_cmp_gt_u32 s64, 1
+s_cbranch_scc0 65224
+s_mov_b32 s64, 0
+s_mov_b32 s63, 0
+s_branch 65190
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_mac_f32_dpp v4, v4, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v5, v5, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v2, v2, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v3, v3, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v3, v4, v3  row_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v2, v5, v2  row_mirror row_mask:0xf bank_mask:0xf
+s_nop 0
+v_mac_f32_dpp v3, v3, v102  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mac_f32_dpp v2, v2, v102  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+s_nop 0
+v_add_f32_dpp v2, v3, v2  row_half_mirror row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v8, v8, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v9, v9, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v6, v6, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v7, v7, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v7, v8, v7  row_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v6, v9, v6  row_mirror row_mask:0xf bank_mask:0xf
+s_nop 0
+v_mac_f32_dpp v7, v7, v102  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mac_f32_dpp v6, v6, v102  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+s_nop 0
+v_add_f32_dpp v3, v7, v6  row_half_mirror row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v12, v12, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v13, v13, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v10, v10, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v11, v11, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v11, v12, v11  row_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v10, v13, v10  row_mirror row_mask:0xf bank_mask:0xf
+s_nop 0
+v_mac_f32_dpp v11, v11, v102  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mac_f32_dpp v10, v10, v102  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+s_nop 0
+v_add_f32_dpp v4, v11, v10  row_half_mirror row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v16, v16, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v17, v17, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v14, v14, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v15, v15, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v15, v16, v15  row_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v14, v17, v14  row_mirror row_mask:0xf bank_mask:0xf
+s_nop 0
+v_mac_f32_dpp v15, v15, v102  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mac_f32_dpp v14, v14, v102  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+s_nop 0
+v_add_f32_dpp v5, v15, v14  row_half_mirror row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v20, v20, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v21, v21, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v18, v18, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v19, v19, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v19, v20, v19  row_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v18, v21, v18  row_mirror row_mask:0xf bank_mask:0xf
+s_nop 0
+v_mac_f32_dpp v19, v19, v102  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mac_f32_dpp v18, v18, v102  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+s_nop 0
+v_add_f32_dpp v6, v19, v18  row_half_mirror row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v24, v24, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v25, v25, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v22, v22, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v23, v23, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v23, v24, v23  row_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v22, v25, v22  row_mirror row_mask:0xf bank_mask:0xf
+s_nop 0
+v_mac_f32_dpp v23, v23, v102  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mac_f32_dpp v22, v22, v102  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+s_nop 0
+v_add_f32_dpp v7, v23, v22  row_half_mirror row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v28, v28, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v29, v29, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v26, v26, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v27, v27, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v27, v28, v27  row_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v26, v29, v26  row_mirror row_mask:0xf bank_mask:0xf
+s_nop 0
+v_mac_f32_dpp v27, v27, v102  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mac_f32_dpp v26, v26, v102  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+s_nop 0
+v_add_f32_dpp v8, v27, v26  row_half_mirror row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v32, v32, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v33, v33, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v30, v30, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v31, v31, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v31, v32, v31  row_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v30, v33, v30  row_mirror row_mask:0xf bank_mask:0xf
+s_nop 0
+v_mac_f32_dpp v31, v31, v102  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mac_f32_dpp v30, v30, v102  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+s_nop 0
+v_add_f32_dpp v9, v31, v30  row_half_mirror row_mask:0xf bank_mask:0xf
+s_waitcnt vmcnt(0)
+v_readlane_b32 s55, v104, 0
+v_add_f32_e64 v2, v2, s55
+v_mul_f32_e64 v106, v2, s36
+v_cmp_lt_f32_e64 vcc, v2, 0
+v_cndmask_b32_e32 v2, v2, v106, vcc
+buffer_store_dword v2, v86, s[44:47], 0 offen
+s_add_u32 s44, s44, s67
+s_addc_u32 s45, s45, 0
+s_sub_u32 s93, s93, 1
+s_cselect_b32 s47, 0, s47
+v_readlane_b32 s55, v104, 1
+v_add_f32_e64 v3, v3, s55
+v_mul_f32_e64 v106, v3, s36
+v_cmp_lt_f32_e64 vcc, v3, 0
+v_cndmask_b32_e32 v3, v3, v106, vcc
+buffer_store_dword v3, v86, s[44:47], 0 offen
+s_add_u32 s44, s44, s67
+s_addc_u32 s45, s45, 0
+s_sub_u32 s93, s93, 1
+s_cselect_b32 s47, 0, s47
+v_readlane_b32 s55, v104, 2
+v_add_f32_e64 v4, v4, s55
+v_mul_f32_e64 v106, v4, s36
+v_cmp_lt_f32_e64 vcc, v4, 0
+v_cndmask_b32_e32 v4, v4, v106, vcc
+buffer_store_dword v4, v86, s[44:47], 0 offen
+s_add_u32 s44, s44, s67
+s_addc_u32 s45, s45, 0
+s_sub_u32 s93, s93, 1
+s_cselect_b32 s47, 0, s47
+v_readlane_b32 s55, v104, 3
+v_add_f32_e64 v5, v5, s55
+v_mul_f32_e64 v106, v5, s36
+v_cmp_lt_f32_e64 vcc, v5, 0
+v_cndmask_b32_e32 v5, v5, v106, vcc
+buffer_store_dword v5, v86, s[44:47], 0 offen
+s_add_u32 s44, s44, s67
+s_addc_u32 s45, s45, 0
+s_sub_u32 s93, s93, 1
+s_cselect_b32 s47, 0, s47
+s_lshl_b32 s52, s67, 2
+s_add_u32 s44, s44, s52
+s_addc_u32 s45, s45, 0
+s_sub_u32 s93, s93, 4
+s_cselect_b32 s47, 0, s47
+v_readlane_b32 s55, v104, 8
+v_add_f32_e64 v6, v6, s55
+v_mul_f32_e64 v106, v6, s36
+v_cmp_lt_f32_e64 vcc, v6, 0
+v_cndmask_b32_e32 v6, v6, v106, vcc
+buffer_store_dword v6, v86, s[44:47], 0 offen
+s_add_u32 s44, s44, s67
+s_addc_u32 s45, s45, 0
+s_sub_u32 s93, s93, 1
+s_cselect_b32 s47, 0, s47
+v_readlane_b32 s55, v104, 9
+v_add_f32_e64 v7, v7, s55
+v_mul_f32_e64 v106, v7, s36
+v_cmp_lt_f32_e64 vcc, v7, 0
+v_cndmask_b32_e32 v7, v7, v106, vcc
+buffer_store_dword v7, v86, s[44:47], 0 offen
+s_add_u32 s44, s44, s67
+s_addc_u32 s45, s45, 0
+s_sub_u32 s93, s93, 1
+s_cselect_b32 s47, 0, s47
+v_readlane_b32 s55, v104, 10
+v_add_f32_e64 v8, v8, s55
+v_mul_f32_e64 v106, v8, s36
+v_cmp_lt_f32_e64 vcc, v8, 0
+v_cndmask_b32_e32 v8, v8, v106, vcc
+buffer_store_dword v8, v86, s[44:47], 0 offen
+s_add_u32 s44, s44, s67
+s_addc_u32 s45, s45, 0
+s_sub_u32 s93, s93, 1
+s_cselect_b32 s47, 0, s47
+v_readlane_b32 s55, v104, 11
+v_add_f32_e64 v9, v9, s55
+v_mul_f32_e64 v106, v9, s36
+v_cmp_lt_f32_e64 vcc, v9, 0
+v_cndmask_b32_e32 v9, v9, v106, vcc
+buffer_store_dword v9, v86, s[44:47], 0 offen
+s_add_u32 s44, s44, s67
+s_addc_u32 s45, s45, 0
+s_sub_u32 s93, s93, 1
+s_cselect_b32 s47, 0, s47
+s_add_u32 s44, s44, s52
+s_addc_u32 s45, s45, 0
+s_lshl_b32 s52, s52, 2
+s_add_u32 s44, s44, s52
+s_addc_u32 s45, s45, 0
+s_sub_u32 s93, s93, 20
+s_cselect_b32 s47, 0, s47
+s_cselect_b32 s51, 0, s51
+s_add_u32 s48, s48, 0x80
+s_addc_u32 s49, s49, 0
+s_sub_u32 s50, s50, 0x80
+s_cselect_b32 s51, 0, s51
+v_mov_b32_e32 v2, 0
+v_mov_b32_e32 v3, 0
+v_mov_b32_e32 v4, 0
+v_mov_b32_e32 v5, 0
+v_mov_b32_e32 v6, 0
+v_mov_b32_e32 v7, 0
+v_mov_b32_e32 v8, 0
+v_mov_b32_e32 v9, 0
+v_mov_b32_e32 v10, 0
+v_mov_b32_e32 v11, 0
+v_mov_b32_e32 v12, 0
+v_mov_b32_e32 v13, 0
+v_mov_b32_e32 v14, 0
+v_mov_b32_e32 v15, 0
+v_mov_b32_e32 v16, 0
+v_mov_b32_e32 v17, 0
+v_mov_b32_e32 v18, 0
+v_mov_b32_e32 v19, 0
+v_mov_b32_e32 v20, 0
+v_mov_b32_e32 v21, 0
+v_mov_b32_e32 v22, 0
+v_mov_b32_e32 v23, 0
+v_mov_b32_e32 v24, 0
+v_mov_b32_e32 v25, 0
+v_mov_b32_e32 v26, 0
+v_mov_b32_e32 v27, 0
+v_mov_b32_e32 v28, 0
+v_mov_b32_e32 v29, 0
+v_mov_b32_e32 v30, 0
+v_mov_b32_e32 v31, 0
+v_mov_b32_e32 v32, 0
+v_mov_b32_e32 v33, 0
+s_xor_b32 s18, s18, 0x200000
+s_mul_i32 s94, s60, s61
+s_mul_i32 s94, s94, s13
+s_add_u32 s52, s93, s92
+s_cmp_lt_i32 s52, 0
+s_cbranch_scc0 104
+v_and_b32_e32 v86, 0x7f, v0
+v_lshrrev_b32_e32 v86, 1, v86
+v_bfi_b32 v86, 1, v0, v86
+v_and_b32_e64 v87, v0, 2
+v_mad_u32_u24 v86, v87, 16, v86
+v_lshlrev_b32_e32 v86, 2, v86
+v_add_co_u32_e64 v86, vcc, v86, s97
+v_and_b32_e32 v87, 3, v0
+v_lshlrev_b32_e32 v87, 2, v87
+v_add_co_u32_e64 v87, vcc, v87, s97
+ds_read_b32 v108, v87 offset:256
+ds_read_b32 v86, v86
+s_add_u32 s97, s97, 0x18c
+s_cmp_eq_u32 s97, 0xffc0
+s_cselect_b32 s97, 0xc1e0, s97
+s_waitcnt lgkmcnt(0)
+v_readfirstlane_b32 s95, v86
+v_readlane_b32 s54, v108, 0
+s_bitcmp1_b32 s54, 18
+s_cbranch_scc1 80
+v_readlane_b32 s52, v108, 1
+v_readlane_b32 s53, v108, 2
+s_add_u32 s93, s92, s53
+s_lshr_b32 s55, -1, 16
+s_and_b32 s55, s55, s66
+s_lshr_b32 s56, s66, 16
+s_mul_i32 s56, s56, s95
+s_mul_i32 s44, s55, s95
+s_lshl_b32 s55, s56, 16
+s_lshr_b32 s56, s56, 16
+s_add_u32 s44, s55, s44
+s_addc_u32 s45, s56, 0
+s_add_u32 s44, s44, s24
+s_addc_u32 s45, s45, s25
+s_mul_i32 s55, s67, s93
+s_add_u32 s44, s44, s55
+s_addc_u32 s45, s45, 0
+s_mov_b32 s47, 0x20000
+s_bitcmp1_b32 s18, 7
+s_cselect_b32 s51, 0x20000, 0
+s_lshl_b32 s55, s93, 2
+s_add_u32 s48, s34, s55
+s_addc_u32 s49, s35, 0
+s_lshl_b32 s56, s52, 2
+s_sub_u32 s50, s56, s55
+s_cselect_b32 s51, 0, s51
+s_sub_u32 s93, s52, s53
+s_sub_u32 s93, s93, 1
+s_sub_u32 s93, s93, s92
+s_cselect_b32 s47, 0, s47
+v_bfe_u32 v106, v86, 16, 16
+v_bfe_u32 v107, v86, 0, 16
+v_and_b32_e64 v108, v0, 7
+v_sub_co_u32_e32 v109, vcc, 7, v108
+v_min_u32_e32 v108, v108, v109
+v_bfe_u32 v109, v108, 1, 1
+v_bfe_u32 v108, v108, 0, 1
+v_mov_b32_dpp v106, v106  quad_perm:[1,1,1,1] row_mask:0xf bank_mask:0xf
+v_mov_b32_dpp v107, v107  quad_perm:[1,1,1,1] row_mask:0xf bank_mask:0xf
+v_add_co_u32_e32 v106, vcc, v106, v109
+v_add_co_u32_e32 v107, vcc, v107, v108
+v_mov_b32_dpp v108, v86  quad_perm:[0,0,0,0] row_mask:0xf bank_mask:0xf
+v_cmp_ge_u32_e64 s[52:53], v108, s12
+v_sub_co_u32_e64 v108, vcc, v108, s95
+v_mul_lo_u32 v108, v108, s66
+v_mad_i32_i24 v86, v106, s33, v107
+v_lshlrev_b32_e32 v86, 2, v86
+v_add_co_u32_e32 v86, vcc, v86, v108
+v_cmp_ge_u32_e64 s[58:59], v107, s33
+s_or_b64 s[56:57], s[58:59], s[52:53]
+v_cmp_ge_u32_e64 s[54:55], v106, s32
+s_or_b64 s[52:53], s[56:57], s[54:55]
+v_cndmask_b32_e64 v86, v86, -1, s[52:53]
+v_and_b32_e64 v104, v0, 63
+v_lshlrev_b32_e32 v104, 2, v104
+s_barrier
+buffer_load_dword v104, v104, s[48:51], 0 offen
+s_mov_b64 vcc, s[10:11]
+s_branch 64461
+s_endpgm
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0

--- a/src/kernels/Conv_Winograd_v21_1_3_gfx9_fp32_f3x2_stride1.inc
+++ b/src/kernels/Conv_Winograd_v21_1_3_gfx9_fp32_f3x2_stride1.inc
@@ -1,0 +1,3064 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2021 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+v_mov_b32_e32 v0, v0
+s_mov_b32 s0, 0
+s_mov_b32 s1, 0
+s_mov_b32 s2, 0
+s_mov_b32 s3, 0
+v_mov_b32_e32 v104, 0
+s_mov_b32 m0, 0x1ffff
+s_mov_b32 s97, 0xc1e0
+s_mov_b32 s96, 0xc1e0
+s_mov_b32 s91, 0
+v_lshlrev_b32_e32 v107, 2, v0
+v_add_co_u32_e32 v107, vcc, 0xffc0, v107
+v_cmp_ge_u32_e32 vcc, 12, v0
+s_cbranch_vccz 5
+v_mov_b32_e32 v106, 0
+v_cndmask_b32_e32 v107, -1, v107, vcc
+ds_write_b32 v107, v106
+s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
+s_barrier
+v_readfirstlane_b32 s52, v0
+s_lshr_b32 s52, s52, 5
+s_add_u32 s52, s52, 8
+s_and_b32 s92, s52, 20
+s_mov_b64 s[40:41], s[6:7]
+s_load_dwordx16 s[12:27], s[40:41], 0x0
+s_load_dwordx4 s[28:31], s[40:41], 0x40
+s_load_dwordx2 s[32:33], s[40:41], 0x50
+s_waitcnt lgkmcnt(0)
+s_and_b32 s18, s18, 0xffff
+s_bitcmp1_b32 s18, 6
+s_cbranch_scc0 16
+s_and_b32 s21, s21, 0xffff
+s_and_b32 s23, s23, 0xffff
+s_and_b32 s25, s25, 0xffff
+s_and_b32 s27, s27, 0xffff
+s_load_dwordx2 s[20:21], s[20:21], 0x0
+s_load_dwordx2 s[22:23], s[22:23], 0x0
+s_load_dwordx2 s[24:25], s[24:25], 0x0
+s_load_dwordx2 s[26:27], s[26:27], 0x0
+s_bitcmp1_b32 s18, 7
+s_cbranch_scc0 2
+s_load_dwordx2 s[34:35], s[40:41], 0x58
+s_mov_b32 s36, 1.0
+s_bitcmp1_b32 s18, 8
+s_cbranch_scc0 2
+s_load_dword s36, s[40:41], 0x60
+s_bitcmp1_b32 s18, 7
+s_cbranch_scc0 7
+s_bitcmp1_b32 s18, 6
+s_cbranch_scc0 5
+s_waitcnt lgkmcnt(0)
+s_and_b32 s35, s35, 0xffff
+s_load_dwordx2 s[34:35], s[34:35], 0x0
+s_bitcmp1_b32 s18, 9
+s_cbranch_scc0 72
+s_mov_b32 s42, 0x8c
+s_mov_b32 s43, 0x9c
+v_cmp_le_u32_e32 vcc, 0x100, v0
+s_cmp_eq_u32 1, src_vccz
+s_cselect_b32 s42, s43, s42
+s_load_dword s65, s[40:41], 0x88
+s_load_dword s90, s[40:41], 0x98
+s_load_dword s68, s[40:41], s42
+s_load_dwordx2 s[66:67], s[40:41], 0xa8
+s_bitcmp1_b32 s18, 10
+s_cbranch_scc0 103
+s_load_dwordx4 s[44:47], s[40:41], 0xb8
+v_ffbh_u32_e32 v4, s17
+v_lshlrev_b32_e64 v5, v4, s17
+v_and_b32_e32 v6, 0xffffff00, v5
+v_cmp_eq_u32_e32 vcc, 0x80000000, v5
+v_cvt_f32_u32_e32 v6, v6
+v_rcp_f32_e32 v2, v6
+v_subb_co_u32_e32 v3, vcc, 32, v4, vcc
+v_cvt_f32_ubyte0_e32 v4, v5
+v_fma_f32 v6, v6, v2, -1.0
+v_fma_f32 v6, v4, v2, v6
+v_madak_f32 v6, v6, v2, 0x9f000000
+v_mul_f32_e32 v6, 0x5f800000, v6
+v_mov_b32_e32 v4, 0
+v_cvt_flr_i32_f32_e64 v6, -v6
+v_lshl_add_u32 v2, v2, 9, v6
+v_mad_u64_u32 v[4:5], vcc, v5, v2, v[4:5]
+v_subb_co_u32_e64 v2, vcc, v2, -1, vcc
+v_mul_hi_u32 v4, s8, v2
+v_add_co_u32_e64 v2, vcc, v4, s8
+v_addc_co_u32_e64 v4, vcc, 0, 0, vcc
+v_cmp_eq_u32_e32 vcc, 32, v3
+v_cndmask_b32_e32 v2, v2, v4, vcc
+v_alignbit_b32 v2, v4, v2, v3
+s_waitcnt lgkmcnt(0)
+v_readfirstlane_b32 s48, v2
+s_mul_i32 s49, s48, s17
+s_sub_u32 s8, s8, s49
+s_mul_i32 s49, s45, s48
+s_add_u32 s20, s20, s49
+s_addc_u32 s21, s21, 0
+s_mul_i32 s49, s46, s48
+s_add_u32 s22, s22, s49
+s_addc_u32 s23, s23, 0
+s_mul_i32 s49, s47, s48
+s_add_u32 s24, s24, s49
+s_addc_u32 s25, s25, 0
+s_branch 49
+s_mul_i32 s42, s14, s15
+s_lshr_b32 s46, -1, 16
+s_and_b32 s46, s46, s42
+s_lshr_b32 s47, s42, 16
+s_mul_i32 s47, s47, s13
+s_mul_i32 s44, s46, s13
+s_lshl_b32 s46, s47, 16
+s_lshr_b32 s47, s47, 16
+s_add_u32 s44, s46, s44
+s_addc_u32 s45, s47, 0
+s_lshl_b32 s65, s44, 2
+s_lshl_b32 s68, s42, 2
+s_mul_i32 s43, s32, s33
+s_lshr_b32 s46, -1, 16
+s_and_b32 s46, s46, s43
+s_lshr_b32 s47, s43, 16
+s_mul_i32 s47, s47, s16
+s_mul_i32 s44, s46, s16
+s_lshl_b32 s46, s47, 16
+s_lshr_b32 s47, s47, 16
+s_add_u32 s44, s46, s44
+s_addc_u32 s45, s47, 0
+s_lshl_b32 s66, s44, 2
+s_lshl_b32 s67, s43, 2
+s_bitcmp1_b32 s18, 13
+s_cbranch_scc0 2
+s_load_dwordx8 s[48:55], s[40:41], 0x68
+s_mul_i32 s42, s28, s29
+s_lshl_b32 s42, s42, 2
+s_bitcmp1_b32 s18, 2
+s_cselect_b32 s43, s16, s13
+s_lshr_b32 s44, -1, 16
+s_and_b32 s44, s44, s42
+s_lshr_b32 s45, s42, 16
+s_mul_i32 s45, s45, s43
+s_mul_i32 s56, s44, s43
+s_lshl_b32 s44, s45, 16
+s_lshr_b32 s45, s45, 16
+s_add_u32 s56, s44, s56
+s_addc_u32 s57, s45, 0
+s_mov_b32 s43, s56
+s_bitcmp1_b32 s18, 2
+s_cselect_b32 s44, s43, s42
+s_cselect_b32 s90, s42, s43
+v_cmp_le_u32_e32 vcc, 0x100, v0
+s_cmp_eq_u32 1, src_vccz
+s_cselect_b32 s68, s44, s68
+s_waitcnt lgkmcnt(0)
+s_and_b32 s21, s21, 0xffff
+s_and_b32 s23, s23, 0xffff
+s_and_b32 s25, s25, 0xffff
+s_and_b32 s27, s27, 0xffff
+s_and_b32 s35, s35, 0xffff
+s_bitcmp1_b32 s18, 13
+s_cbranch_scc0 8
+s_add_u32 s20, s20, s48
+s_addc_u32 s21, s21, s49
+s_add_u32 s22, s22, s50
+s_addc_u32 s23, s23, s51
+s_add_u32 s24, s24, s52
+s_addc_u32 s25, s25, s53
+s_add_u32 s34, s34, s54
+s_addc_u32 s35, s35, s55
+s_and_b32 s44, 0, s30
+s_addc_u32 s44, s32, 0
+s_ashr_i32 s44, s44, 0
+s_add_u32 s42, s44, 2
+v_mov_b32_e32 v2, 0x55555556
+v_mul_hi_u32 v2, v2, s42
+v_readfirstlane_b32 s42, v2
+s_andn2_b32 s44, 0, s31
+s_addc_u32 s44, s33, 0
+s_ashr_i32 s44, s44, 0
+s_add_u32 s43, s44, 2
+v_mov_b32_e32 v2, 0x55555556
+v_mul_hi_u32 v2, v2, s43
+v_readfirstlane_b32 s43, v2
+s_sub_u32 s75, 0, s43
+s_sub_u32 s74, 0, s42
+s_add_u32 s60, s28, 1
+v_mov_b32_e32 v2, 0x80000000
+v_mul_hi_u32 v2, v2, s60
+v_readfirstlane_b32 s60, v2
+s_add_u32 s61, s29, 1
+v_mov_b32_e32 v2, 0x80000000
+v_mul_hi_u32 v2, v2, s61
+v_readfirstlane_b32 s61, v2
+v_mad_i32_i24 v2, 2, s60, -1
+v_sub_co_u32_e64 v2, vcc, v2, s28
+v_addc_co_u32_e64 v2, vcc, 0, 0, vcc
+v_readfirstlane_b32 s44, v2
+s_and_b32 s44, s44, 0
+s_and_b32 s44, s44, s60
+s_add_u32 s60, s60, s44
+v_readfirstlane_b32 s45, v0
+s_and_b32 s48, s45, 64
+s_cselect_b32 s48, 0x80000, 0
+s_or_b32 s18, s18, s48
+s_lshl_b32 s69, s68, 1
+s_mov_b64 s[70:71], 0
+s_bitcmp1_b32 s18, 12
+s_cselect_b32 s44, 0, -1
+s_bitcmp1_b32 s18, 11
+s_cselect_b32 s44, s44, 1
+s_cmp_gt_u32 s61, s44
+s_cbranch_scc0 8
+s_bitset1_b32 s18, 23
+s_bitset1_b32 s18, 20
+s_bitset0_b32 s18, 19
+s_ashr_i32 s69, s69, 1
+s_ashr_i64 s[70:71], s[70:71], 1
+s_add_u32 s61, s61, 1
+s_and_b32 s61, s61, -2
+s_branch 16
+s_and_b32 s48, s13, 1
+s_cselect_b32 s48, 0, 0x1000000
+s_bitcmp1_b32 s18, 2
+s_cselect_b32 s48, 0, s48
+s_or_b32 s18, s18, s48
+s_cmp_eq_u32 s48, 0
+s_cselect_b32 s69, s68, s69
+s_cselect_b32 s70, s68, s70
+s_cselect_b32 s71, 0, s71
+s_bitcmp0_b32 s45, 8
+s_cselect_b32 s48, s48, 0
+s_cmp_eq_u32 s48, 0
+s_cselect_b32 s48, 0, 0x80000
+s_andn2_b32 s18, s18, s48
+s_add_u32 s70, s70, s69
+s_addc_u32 s71, s71, 0
+v_bfe_u32 v3, v0, 2, 6
+v_lshrrev_b32_e32 v99, 1, v3
+s_bitcmp0_b32 s45, 8
+s_cselect_b32 s48, 0x1000000, 0
+s_or_b32 s48, s48, 0x100000
+s_and_b32 s48, s18, s48
+s_cselect_b32 s48, 0, 15
+v_bfi_b32 v99, s48, v3, v99
+s_mul_i32 s88, s12, s42
+s_sub_u32 s88, s88, 1
+s_lshr_b32 s88, s88, 0
+s_add_u32 s88, s88, 1
+s_lshr_b32 s46, -1, 16
+s_and_b32 s46, s46, s88
+s_lshr_b32 s47, s88, 16
+s_mul_i32 s47, s47, s43
+s_mul_i32 s88, s46, s43
+s_lshl_b32 s46, s47, 16
+s_lshr_b32 s47, s47, 16
+s_add_u32 s88, s46, s88
+s_addc_u32 s89, s47, 0
+s_sub_u32 s88, s88, 1
+s_subb_u32 s89, s89, 0
+s_lshr_b64 s[88:89], s[88:89], 5
+s_add_u32 s88, s88, 1
+s_addc_u32 s89, s89, 0
+v_mov_b32_e32 v4, s8
+v_mov_b32_e32 v5, s17
+v_and_b32_e32 v6, 3, v0
+v_cmp_eq_u32_e32 vcc, 2, v6
+v_cndmask_b32_e32 v4, v4, v5, vcc
+v_cmp_eq_u32_e32 vcc, 1, v6
+v_cndmask_b32_e32 v7, 0, v99, vcc
+s_bitcmp1_b32 s18, 20
+s_cbranch_scc0 4
+v_add_co_u32_e64 v5, vcc, v99, 8
+v_cmp_eq_u32_e32 vcc, 0, v6
+v_cndmask_b32_e32 v7, v7, v5, vcc
+v_cmp_eq_u32_e64 s[46:47], 3, v6
+v_bfe_u32 v97, v7, 0, 5
+v_mad_u32_u24 v97, v4, 32, v97
+v_ffbh_u32_e32 v9, s43
+v_lshlrev_b32_e64 v10, v9, s43
+v_and_b32_e32 v11, 0xffffff00, v10
+v_cmp_eq_u32_e32 vcc, 0x80000000, v10
+v_cvt_f32_u32_e32 v11, v11
+v_rcp_f32_e32 v98, v11
+v_subb_co_u32_e32 v8, vcc, 32, v9, vcc
+v_cvt_f32_ubyte0_e32 v9, v10
+v_fma_f32 v11, v11, v98, -1.0
+v_fma_f32 v11, v9, v98, v11
+v_madak_f32 v11, v11, v98, 0x9f000000
+v_mul_f32_e32 v11, 0x5f800000, v11
+v_mov_b32_e32 v9, 0
+v_cvt_flr_i32_f32_e64 v11, -v11
+v_lshl_add_u32 v98, v98, 9, v11
+v_mad_u64_u32 v[9:10], vcc, v10, v98, v[9:10]
+v_subb_co_u32_e64 v98, vcc, v98, -1, vcc
+v_mul_hi_u32 v9, v97, v98
+v_add_co_u32_e32 v98, vcc, v9, v97
+v_addc_co_u32_e64 v9, vcc, 0, 0, vcc
+v_cmp_eq_u32_e32 vcc, 32, v8
+v_cndmask_b32_e32 v98, v98, v9, vcc
+v_alignbit_b32 v98, v9, v98, v8
+v_mad_i32_i24 v96, v98, s75, v97
+v_lshrrev_b32_e32 v97, 5, v7
+v_mad_u32_u24 v97, v98, 1, v97
+v_cndmask_b32_e64 v97, v97, 1, s[46:47]
+v_ffbh_u32_e32 v9, s42
+v_lshlrev_b32_e64 v10, v9, s42
+v_and_b32_e32 v11, 0xffffff00, v10
+v_cmp_eq_u32_e32 vcc, 0x80000000, v10
+v_cvt_f32_u32_e32 v11, v11
+v_rcp_f32_e32 v98, v11
+v_subb_co_u32_e32 v8, vcc, 32, v9, vcc
+v_cvt_f32_ubyte0_e32 v9, v10
+v_fma_f32 v11, v11, v98, -1.0
+v_fma_f32 v11, v9, v98, v11
+v_madak_f32 v11, v11, v98, 0x9f000000
+v_mul_f32_e32 v11, 0x5f800000, v11
+v_mov_b32_e32 v9, 0
+v_cvt_flr_i32_f32_e64 v11, -v11
+v_lshl_add_u32 v98, v98, 9, v11
+v_mad_u64_u32 v[9:10], vcc, v10, v98, v[9:10]
+v_subb_co_u32_e64 v98, vcc, v98, -1, vcc
+v_mul_hi_u32 v9, v97, v98
+v_add_co_u32_e32 v98, vcc, v9, v97
+v_addc_co_u32_e64 v9, vcc, 0, 0, vcc
+v_cmp_eq_u32_e32 vcc, 32, v8
+v_cndmask_b32_e32 v98, v98, v9, vcc
+v_alignbit_b32 v98, v9, v98, v8
+v_mad_i32_i24 v97, v98, s74, v97
+v_readlane_b32 s76, v96, 2
+v_readlane_b32 s77, v97, 2
+v_readlane_b32 s78, v98, 2
+v_readlane_b32 s79, v97, 3
+v_readlane_b32 s80, v98, 3
+v_add_co_u32_e64 v96, vcc, v96, s75
+v_add_co_u32_e64 v97, vcc, v97, s74
+v_mov_b32_dpp v98, v98  quad_perm:[1,1,0,0] row_mask:0xf bank_mask:0xf
+v_mov_b32_dpp v96, v96  quad_perm:[1,1,0,0] row_mask:0xf bank_mask:0xf
+v_mov_b32_dpp v97, v97  quad_perm:[1,1,0,0] row_mask:0xf bank_mask:0xf
+s_mov_b32 s42, 0x80000000
+s_mov_b32 s43, 0x20000
+s_mov_b32 s46, 0x80000000
+s_mov_b32 s47, 0x20000
+v_cmp_le_u32_e32 vcc, 0x100, v0
+s_cbranch_vccnz 5
+v_xor_b32_dpp v100, v0, v0  quad_perm:[2,3,2,1] row_mask:0xf bank_mask:0xf
+v_subrev_co_u32_e32 v100, vcc, 1, v100
+v_cvt_f32_i32_e32 v100, v100
+s_branch 4
+v_xor_b32_dpp v100, v0, v0  quad_perm:[2,1,0,1] row_mask:0xf bank_mask:0xf
+v_sub_co_u32_e32 v100, vcc, 1, v100
+v_cvt_f32_i32_e32 v100, v100
+v_mov_b32_e32 v101, 1
+v_xor_b32_dpp v101, v0, v0  quad_perm:[2,3,2,3] row_mask:0xf bank_mask:0x4
+v_xor_b32_dpp v101, v0, v0  quad_perm:[0,1,0,1] row_mask:0xf bank_mask:0x8
+v_subrev_co_u32_e32 v101, vcc, 1, v101
+v_mov_b32_e32 v102, 1
+v_xor_b32_dpp v102, v0, v0  quad_perm:[0,3,2,1] row_mask:0xf bank_mask:0x2
+v_xor_b32_dpp v102, v0, v0  quad_perm:[2,1,0,3] row_mask:0xf bank_mask:0x4
+v_subrev_co_u32_e32 v102, vcc, 1, v102
+v_cvt_f32_i32_e32 v101, v101
+v_cvt_f32_i32_e32 v102, v102
+v_lshrrev_b32_e64 v106, 2, s92
+v_and_b32_e32 v107, 3, v0
+v_bfe_u32 v108, v0, 4, 3
+v_mad_u32_u24 v95, v108, 4, v107
+v_lshlrev_b32_e32 v95, 4, v95
+v_mad_u32_u24 v90, v106, 4, v107
+v_lshlrev_b32_e32 v90, 4, v90
+v_bfe_u32 v106, v0, 2, 2
+v_and_b32_e32 v107, 1, v106
+v_mad_u32_u24 v109, v106, 16, v107
+v_lshlrev_b32_e32 v109, 6, v109
+v_xor_b32_e32 v90, v90, v109
+v_mul_u32_u24_e32 v109, 0x400, v106
+v_xor_b32_e32 v95, v95, v109
+s_lshr_b32 s92, s92, 0
+v_cmp_le_u32_e32 vcc, 0x100, v0
+s_cbranch_vccnz 47
+s_and_b32 s53, s18, 0x1100000
+s_addc_u32 s53, 0, 0
+v_lshrrev_b32_e32 v109, 1, v0
+s_mul_i32 s52, 60, s53
+s_sub_u32 s52, 63, s52
+v_bfi_b32 v109, s52, v0, v109
+v_and_b32_e32 v106, 1, v109
+v_bfe_u32 v107, v109, 1, 1
+v_xor_b32_e32 v106, v106, v107
+v_bfe_u32 v108, v109, 3, 1
+v_mad_u32_u24 v107, v107, 2, v108
+v_mul_u32_u24_e32 v106, 0x118, v106
+v_bfe_u32 v108, v109, 2, 1
+v_mad_u32_u24 v107, v107, 2, v106
+v_xor_b32_e32 v107, v107, v108
+v_and_b32_e32 v108, 0xf0, v109
+v_xor_b32_e32 v107, v107, v108
+s_mul_i32 s52, 4, s53
+s_sub_u32 s52, 6, s52
+v_bfe_u32 v109, v0, s52, 1
+v_mul_u32_u24_e32 v109, 0x1040, v109
+v_xor_b32_e32 v92, 0x314, v107
+v_xor_b32_e32 v93, 0x31c, v107
+v_xor_b32_e32 v94, 8, v107
+v_mov_b32_e32 v91, v107
+v_mad_u32_u24 v91, 4, v91, v109
+v_mad_u32_u24 v92, 4, v92, v109
+v_mad_u32_u24 v93, 4, v93, v109
+v_mad_u32_u24 v94, 4, v94, v109
+s_branch 44
+s_bfe_u32 s53, s18, 0x10014
+v_lshrrev_b32_e32 v109, 1, v0
+s_mul_i32 s52, 60, s53
+s_sub_u32 s52, 63, s52
+v_bfi_b32 v109, s52, v0, v109
+v_and_b32_e32 v106, 1, v109
+v_bfe_u32 v107, v109, 1, 1
+v_bfe_u32 v108, v109, 3, 1
+v_xor_b32_e32 v106, v106, v107
+v_mad_u32_u24 v107, v107, 2, v108
+v_mul_u32_u24_e32 v106, 0x109, v106
+v_bfe_u32 v108, v109, 2, 1
+v_mad_u32_u24 v107, v107, 2, v106
+v_xor_b32_e32 v107, v107, v108
+v_and_b32_e32 v108, 0xf0, v109
+v_or_b32_e32 v107, v107, v108
+s_mul_i32 s52, 4, s53
+s_sub_u32 s52, 6, s52
+v_bfe_u32 v109, v0, s52, 1
+v_mul_u32_u24_e32 v109, 0x1040, v109
+v_mad_u32_u24 v91, 4, v107, v109
+v_xor_b32_e32 v92, 0x307, v107
+v_mad_u32_u24 v92, 4, v92, v109
+v_xor_b32_e32 v93, 0x30f, v107
+v_mad_u32_u24 v93, 4, v93, v109
+v_xor_b32_e32 v94, 8, v107
+v_mad_u32_u24 v94, 4, v94, v109
+v_subrev_co_u32_e32 v96, vcc, s76, v96
+v_mov_b32_e32 v107, s75
+v_cmp_lt_i32_e32 vcc, v96, v107
+v_subb_co_u32_e64 v106, vcc, 0, 0, vcc
+v_mad_i32_i24 v96, v106, s75, v96
+v_mad_i32_i24 v98, v106, s80, v98
+v_mad_i32_i24 v97, v106, s79, v97
+v_mov_b32_e32 v107, s74
+v_cmp_lt_i32_e32 vcc, v97, v107
+v_subb_co_u32_e64 v106, vcc, 0, 0, vcc
+v_add_co_u32_e32 v98, vcc, v98, v106
+v_mad_i32_i24 v97, v106, v107, v97
+v_subrev_co_u32_e32 v97, vcc, s77, v97
+v_cmp_lt_i32_e32 vcc, v97, v107
+v_subb_co_u32_e64 v106, vcc, 0, 0, vcc
+v_add_co_u32_e32 v98, vcc, v98, v106
+v_mad_i32_i24 v97, v106, s74, v97
+v_subrev_co_u32_e32 v98, vcc, s78, v98
+s_mov_b32 s62, 0
+s_mov_b32 s63, s28
+s_mov_b32 s64, 1
+s_mov_b32 s84, 0
+s_mov_b32 s85, s16
+s_mov_b32 s83, s85
+s_sub_u32 s93, -1, s92
+s_sub_u32 s93, s93, 32
+s_bitset1_b32 s18, 21
+s_mov_b32 s47, 0
+s_mov_b32 s51, 0
+s_mov_b32 s94, 17
+s_mov_b32 s82, 0
+s_bitset1_b32 s18, 26
+s_call_b64 s[38:39], 1678
+v_cmp_le_u32_e32 vcc, 0x100, v0
+s_cbranch_vccnz 65
+s_branch 900
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_mac_f32_e32 v2, v34, v42
+v_mac_f32_e32 v3, v35, v42
+v_mac_f32_e32 v4, v36, v42
+v_mac_f32_e32 v5, v37, v42
+v_mac_f32_e32 v6, v34, v43
+v_mac_f32_e32 v7, v35, v43
+v_mac_f32_e32 v8, v36, v43
+v_mac_f32_e32 v9, v37, v43
+v_mac_f32_e32 v10, v34, v44
+v_mac_f32_e32 v11, v35, v44
+v_mac_f32_e32 v12, v36, v44
+v_mac_f32_e32 v13, v37, v44
+v_mac_f32_e32 v14, v34, v45
+v_mac_f32_e32 v15, v35, v45
+v_mac_f32_e32 v16, v36, v45
+v_mac_f32_e32 v17, v37, v45
+v_mac_f32_e32 v18, v34, v46
+v_mac_f32_e32 v19, v35, v46
+v_mac_f32_e32 v20, v36, v46
+v_mac_f32_e32 v21, v37, v46
+v_mac_f32_e32 v22, v34, v47
+v_mac_f32_e32 v23, v35, v47
+v_mac_f32_e32 v24, v36, v47
+v_mac_f32_e32 v25, v37, v47
+v_mac_f32_e32 v26, v34, v48
+v_mac_f32_e32 v27, v35, v48
+v_mac_f32_e32 v28, v36, v48
+v_mac_f32_e32 v29, v37, v48
+v_mac_f32_e32 v30, v34, v49
+v_mac_f32_e32 v31, v35, v49
+v_subrev_f32_e64 v66, v68, v66 div:2
+v_subrev_f32_e64 v69, v67, v69 div:2
+v_add_f32_e64 v67, v68, v67 div:2
+v_mad_f32 v68, v68, 1.0, -v67
+s_setprio 0
+s_nop 0
+v_mac_f32_e32 v32, v36, v49
+v_mac_f32_e32 v33, v37, v49
+s_nop 0
+ds_read_b128 v[34:37], v95 offset:29440
+ds_read_b128 v[42:45], v90 offset:28928
+ds_read_b128 v[46:49], v90 offset:29056
+ds_write_b32 v91, v62
+ds_write_b32 v92, v63
+s_setprio 1
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+buffer_load_dword v58, v82, s[40:43], 0 offen
+buffer_load_dword v60, v84, s[40:43], 0 offen
+buffer_load_dword v59, v83, s[40:43], 0 offen
+buffer_load_dword v61, v85, s[40:43], 0 offen
+s_add_u32 s91, s91, 0x200
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 1
+s_call_b64 s[38:39], 1536
+v_mac_f32_e32 v2, v38, v50
+v_mac_f32_e32 v3, v39, v50
+v_mac_f32_e32 v4, v40, v50
+v_mac_f32_e32 v5, v41, v50
+v_mac_f32_e32 v6, v38, v51
+v_mac_f32_e32 v7, v39, v51
+v_mac_f32_e32 v8, v40, v51
+v_mac_f32_e32 v9, v41, v51
+v_mac_f32_e32 v10, v38, v52
+v_mac_f32_e32 v11, v39, v52
+v_mac_f32_e32 v12, v40, v52
+v_mac_f32_e32 v13, v41, v52
+v_mac_f32_e32 v14, v38, v53
+v_mac_f32_e32 v15, v39, v53
+v_mac_f32_e32 v16, v40, v53
+v_mac_f32_e32 v17, v41, v53
+v_mac_f32_e32 v18, v38, v54
+v_mac_f32_e32 v19, v39, v54
+v_mac_f32_e32 v20, v40, v54
+v_mac_f32_e32 v21, v41, v54
+v_mac_f32_e32 v22, v38, v55
+v_mac_f32_e32 v23, v39, v55
+v_mac_f32_e32 v24, v40, v55
+v_mac_f32_e32 v25, v41, v55
+v_mac_f32_e32 v26, v38, v56
+v_mac_f32_e32 v27, v39, v56
+v_mac_f32_e32 v28, v40, v56
+v_mac_f32_e32 v29, v41, v56
+v_mac_f32_e32 v30, v38, v57
+v_mac_f32_e32 v31, v39, v57
+v_mac_f32_dpp v66, v66, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v67, v67, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v68, v68, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v69, v69, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+s_setprio 0
+s_nop 0
+v_mac_f32_e32 v32, v40, v57
+v_mac_f32_e32 v33, v41, v57
+s_nop 0
+ds_read_b128 v[38:41], v95 offset:33536
+ds_read_b128 v[50:53], v90 offset:33024
+ds_read_b128 v[54:57], v90 offset:33152
+ds_write_b32 v93, v68 offset:8256
+ds_write_b32 v94, v69 offset:8256
+s_setprio 1
+s_nop 0
+s_waitcnt vmcnt(12) lgkmcnt(5)
+ds_append v105 offset:65472
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 3
+s_call_b64 s[38:39], 1474
+s_nop 0
+s_nop 0
+v_mac_f32_e32 v2, v34, v42
+v_mac_f32_e32 v3, v35, v42
+v_mac_f32_e32 v4, v36, v42
+v_mac_f32_e32 v5, v37, v42
+v_mac_f32_e32 v6, v34, v43
+v_mac_f32_e32 v7, v35, v43
+v_mac_f32_e32 v8, v36, v43
+v_mac_f32_e32 v9, v37, v43
+v_mac_f32_e32 v10, v34, v44
+v_mac_f32_e32 v11, v35, v44
+v_mac_f32_e32 v12, v36, v44
+v_mac_f32_e32 v13, v37, v44
+v_mac_f32_e32 v14, v34, v45
+v_mac_f32_e32 v15, v35, v45
+v_mac_f32_e32 v16, v36, v45
+v_mac_f32_e32 v17, v37, v45
+v_mac_f32_e32 v18, v34, v46
+v_mac_f32_e32 v19, v35, v46
+v_mac_f32_e32 v20, v36, v46
+v_mac_f32_e32 v21, v37, v46
+v_mac_f32_e32 v22, v34, v47
+v_mac_f32_e32 v23, v35, v47
+v_mac_f32_e32 v24, v36, v47
+v_mac_f32_e32 v25, v37, v47
+v_mac_f32_e32 v26, v34, v48
+v_mac_f32_e32 v27, v35, v48
+v_mac_f32_e32 v28, v36, v48
+v_mac_f32_e32 v29, v37, v48
+v_mac_f32_e32 v30, v34, v49
+v_mac_f32_e32 v31, v35, v49
+v_subrev_f32_e64 v70, v72, v70 div:2
+v_subrev_f32_e64 v73, v71, v73 div:2
+v_add_f32_e64 v71, v72, v71 div:2
+v_mad_f32 v72, v72, 1.0, -v71
+s_setprio 0
+s_nop 0
+v_mac_f32_e32 v32, v36, v49
+v_mac_f32_e32 v33, v37, v49
+s_nop 0
+ds_read_b128 v[34:37], v95 offset:37696
+ds_read_b128 v[42:45], v90 offset:37184
+ds_read_b128 v[46:49], v90 offset:37312
+ds_write_b32 v91, v66 offset:8256
+ds_write_b32 v92, v67 offset:8256
+s_setprio 1
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+buffer_load_dword v62, v82, s[40:43], 0 offen
+buffer_load_dword v64, v84, s[40:43], 0 offen
+buffer_load_dword v63, v83, s[40:43], 0 offen
+buffer_load_dword v65, v85, s[40:43], 0 offen
+s_mov_b32 m0, 0x2ffc0
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 1
+s_call_b64 s[38:39], 1400
+v_mac_f32_e32 v2, v38, v50
+v_mac_f32_e32 v3, v39, v50
+v_mac_f32_e32 v4, v40, v50
+v_mac_f32_e32 v5, v41, v50
+v_mac_f32_e32 v6, v38, v51
+v_mac_f32_e32 v7, v39, v51
+v_mac_f32_e32 v8, v40, v51
+v_mac_f32_e32 v9, v41, v51
+v_mac_f32_e32 v10, v38, v52
+v_mac_f32_e32 v11, v39, v52
+v_mac_f32_e32 v12, v40, v52
+v_mac_f32_e32 v13, v41, v52
+v_mac_f32_e32 v14, v38, v53
+v_mac_f32_e32 v15, v39, v53
+v_mac_f32_e32 v16, v40, v53
+v_mac_f32_e32 v17, v41, v53
+v_mac_f32_e32 v18, v38, v54
+v_mac_f32_e32 v19, v39, v54
+v_mac_f32_e32 v20, v40, v54
+v_mac_f32_e32 v21, v41, v54
+v_mac_f32_e32 v22, v38, v55
+v_mac_f32_e32 v23, v39, v55
+v_mac_f32_e32 v24, v40, v55
+v_mac_f32_e32 v25, v41, v55
+v_mac_f32_e32 v26, v38, v56
+v_mac_f32_e32 v27, v39, v56
+v_mac_f32_e32 v28, v40, v56
+v_mac_f32_e32 v29, v41, v56
+v_mac_f32_e32 v30, v38, v57
+v_mac_f32_e32 v31, v39, v57
+v_mac_f32_e32 v32, v40, v57
+v_mac_f32_dpp v70, v70, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v71, v71, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v72, v72, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v73, v73, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+s_setprio 0
+s_nop 0
+v_mac_f32_e32 v33, v41, v57
+v_cmp_eq_u32_e64 vcc, src_lds_direct, s91
+s_nop 0
+s_nop 0
+s_cbranch_vccz 65531
+s_nop 0
+ds_read_b128 v[38:41], v95 offset:41792
+ds_read_b128 v[50:53], v90 offset:41280
+ds_read_b128 v[54:57], v90 offset:41408
+ds_write_b32 v93, v72 offset:16512
+ds_write_b32 v94, v73 offset:16512
+s_setprio 1
+s_nop 0
+s_waitcnt vmcnt(12) lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 8
+s_call_b64 s[38:39], 1335
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_mac_f32_e32 v2, v34, v42
+v_mac_f32_e32 v3, v35, v42
+v_mac_f32_e32 v4, v36, v42
+v_mac_f32_e32 v5, v37, v42
+v_mac_f32_e32 v6, v34, v43
+v_mac_f32_e32 v7, v35, v43
+v_mac_f32_e32 v8, v36, v43
+v_mac_f32_e32 v9, v37, v43
+v_mac_f32_e32 v10, v34, v44
+v_mac_f32_e32 v11, v35, v44
+v_mac_f32_e32 v12, v36, v44
+v_mac_f32_e32 v13, v37, v44
+v_mac_f32_e32 v14, v34, v45
+v_mac_f32_e32 v15, v35, v45
+v_mac_f32_e32 v16, v36, v45
+v_mac_f32_e32 v17, v37, v45
+v_mac_f32_e32 v18, v34, v46
+v_mac_f32_e32 v19, v35, v46
+v_mac_f32_e32 v20, v36, v46
+v_mac_f32_e32 v21, v37, v46
+v_mac_f32_e32 v22, v34, v47
+v_mac_f32_e32 v23, v35, v47
+v_mac_f32_e32 v24, v36, v47
+v_mac_f32_e32 v25, v37, v47
+v_mac_f32_e32 v26, v34, v48
+v_mac_f32_e32 v27, v35, v48
+v_mac_f32_e32 v28, v36, v48
+v_mac_f32_e32 v29, v37, v48
+v_mac_f32_e32 v30, v34, v49
+v_mac_f32_e32 v31, v35, v49
+v_subrev_f32_e64 v74, v76, v74 div:2
+v_subrev_f32_e64 v77, v75, v77 div:2
+v_add_f32_e64 v75, v76, v75 div:2
+v_mad_f32 v76, v76, 1.0, -v75
+s_setprio 0
+s_nop 0
+v_mac_f32_e32 v32, v36, v49
+v_mac_f32_e32 v33, v37, v49
+s_nop 0
+ds_read_b128 v[34:37], v95 offset:45952
+ds_read_b128 v[42:45], v90 offset:45440
+ds_read_b128 v[46:49], v90 offset:45568
+ds_write_b32 v91, v70 offset:16512
+ds_write_b32 v92, v71 offset:16512
+s_setprio 1
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+buffer_load_dword v66, v82, s[40:43], 0 offen
+buffer_load_dword v68, v84, s[40:43], 0 offen
+buffer_load_dword v67, v83, s[40:43], 0 offen
+buffer_load_dword v69, v85, s[40:43], 0 offen
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 3
+s_call_b64 s[38:39], 1258
+s_nop 0
+s_nop 0
+v_mac_f32_e32 v2, v38, v50
+v_mac_f32_e32 v3, v39, v50
+v_mac_f32_e32 v4, v40, v50
+v_mac_f32_e32 v5, v41, v50
+v_mac_f32_e32 v6, v38, v51
+v_mac_f32_e32 v7, v39, v51
+v_mac_f32_e32 v8, v40, v51
+v_mac_f32_e32 v9, v41, v51
+v_mac_f32_e32 v10, v38, v52
+v_mac_f32_e32 v11, v39, v52
+v_mac_f32_e32 v12, v40, v52
+v_mac_f32_e32 v13, v41, v52
+v_mac_f32_e32 v14, v38, v53
+v_mac_f32_e32 v15, v39, v53
+v_mac_f32_e32 v16, v40, v53
+v_mac_f32_e32 v17, v41, v53
+v_mac_f32_e32 v18, v38, v54
+v_mac_f32_e32 v19, v39, v54
+v_mac_f32_e32 v20, v40, v54
+v_mac_f32_e32 v21, v41, v54
+v_mac_f32_e32 v22, v38, v55
+v_mac_f32_e32 v23, v39, v55
+v_mac_f32_e32 v24, v40, v55
+v_mac_f32_e32 v25, v41, v55
+v_mac_f32_e32 v26, v38, v56
+v_mac_f32_e32 v27, v39, v56
+v_mac_f32_e32 v28, v40, v56
+v_mac_f32_e32 v29, v41, v56
+v_mac_f32_e32 v30, v38, v57
+v_mac_f32_e32 v31, v39, v57
+v_mac_f32_dpp v74, v74, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v75, v75, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v76, v76, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v77, v77, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+s_setprio 0
+s_nop 0
+v_mac_f32_e32 v32, v40, v57
+v_mac_f32_e32 v33, v41, v57
+s_nop 0
+ds_read_b128 v[38:41], v95 offset:512
+ds_read_b128 v[50:53], v90
+ds_read_b128 v[54:57], v90 offset:128
+ds_write_b32 v93, v76 offset:24768
+ds_write_b32 v94, v77 offset:24768
+s_setprio 1
+s_nop 0
+s_waitcnt vmcnt(12) lgkmcnt(5)
+ds_append v105 offset:65476
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 3
+s_call_b64 s[38:39], 1194
+s_nop 0
+s_nop 0
+v_mac_f32_e32 v2, v34, v42
+v_mac_f32_e32 v3, v35, v42
+v_mac_f32_e32 v4, v36, v42
+v_mac_f32_e32 v5, v37, v42
+v_mac_f32_e32 v6, v34, v43
+v_mac_f32_e32 v7, v35, v43
+v_mac_f32_e32 v8, v36, v43
+v_mac_f32_e32 v9, v37, v43
+v_mac_f32_e32 v10, v34, v44
+v_mac_f32_e32 v11, v35, v44
+v_mac_f32_e32 v12, v36, v44
+v_mac_f32_e32 v13, v37, v44
+v_mac_f32_e32 v14, v34, v45
+v_mac_f32_e32 v15, v35, v45
+v_mac_f32_e32 v16, v36, v45
+v_mac_f32_e32 v17, v37, v45
+v_mac_f32_e32 v18, v34, v46
+v_mac_f32_e32 v19, v35, v46
+v_mac_f32_e32 v20, v36, v46
+v_mac_f32_e32 v21, v37, v46
+v_mac_f32_e32 v22, v34, v47
+v_mac_f32_e32 v23, v35, v47
+v_mac_f32_e32 v24, v36, v47
+v_mac_f32_e32 v25, v37, v47
+v_mac_f32_e32 v26, v34, v48
+v_mac_f32_e32 v27, v35, v48
+v_mac_f32_e32 v28, v36, v48
+v_mac_f32_e32 v29, v37, v48
+v_mac_f32_e32 v30, v34, v49
+v_mac_f32_e32 v31, v35, v49
+v_subrev_f32_e64 v78, v80, v78 div:2
+v_subrev_f32_e64 v81, v79, v81 div:2
+v_add_f32_e64 v79, v80, v79 div:2
+v_mad_f32 v80, v80, 1.0, -v79
+s_setprio 0
+s_nop 0
+v_mac_f32_e32 v32, v36, v49
+v_mac_f32_e32 v33, v37, v49
+s_nop 0
+ds_read_b128 v[34:37], v95 offset:4672
+ds_read_b128 v[42:45], v90 offset:4160
+ds_read_b128 v[46:49], v90 offset:4288
+ds_write_b32 v91, v74 offset:24768
+ds_write_b32 v92, v75 offset:24768
+s_setprio 1
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+buffer_load_dword v70, v82, s[40:43], 0 offen
+buffer_load_dword v72, v84, s[40:43], 0 offen
+buffer_load_dword v71, v83, s[40:43], 0 offen
+buffer_load_dword v73, v85, s[40:43], 0 offen
+s_mov_b32 m0, 0x2ffc4
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 1
+s_call_b64 s[38:39], 1120
+v_mac_f32_e32 v2, v38, v50
+v_mac_f32_e32 v3, v39, v50
+v_mac_f32_e32 v4, v40, v50
+v_mac_f32_e32 v5, v41, v50
+v_mac_f32_e32 v6, v38, v51
+v_mac_f32_e32 v7, v39, v51
+v_mac_f32_e32 v8, v40, v51
+v_mac_f32_e32 v9, v41, v51
+v_mac_f32_e32 v10, v38, v52
+v_mac_f32_e32 v11, v39, v52
+v_mac_f32_e32 v12, v40, v52
+v_mac_f32_e32 v13, v41, v52
+v_mac_f32_e32 v14, v38, v53
+v_mac_f32_e32 v15, v39, v53
+v_mac_f32_e32 v16, v40, v53
+v_mac_f32_e32 v17, v41, v53
+v_mac_f32_e32 v18, v38, v54
+v_mac_f32_e32 v19, v39, v54
+v_mac_f32_e32 v20, v40, v54
+v_mac_f32_e32 v21, v41, v54
+v_mac_f32_e32 v22, v38, v55
+v_mac_f32_e32 v23, v39, v55
+v_mac_f32_e32 v24, v40, v55
+v_mac_f32_e32 v25, v41, v55
+v_mac_f32_e32 v26, v38, v56
+v_mac_f32_e32 v27, v39, v56
+v_mac_f32_e32 v28, v40, v56
+v_mac_f32_e32 v29, v41, v56
+v_mac_f32_e32 v30, v38, v57
+v_mac_f32_e32 v31, v39, v57
+v_mac_f32_e32 v32, v40, v57
+v_mac_f32_dpp v78, v78, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v79, v79, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v80, v80, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v81, v81, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+s_setprio 0
+s_nop 0
+v_mac_f32_e32 v33, v41, v57
+v_cmp_eq_u32_e64 vcc, src_lds_direct, s91
+s_nop 0
+s_nop 0
+s_cbranch_vccz 65531
+s_nop 0
+ds_read_b128 v[38:41], v95 offset:8768
+ds_read_b128 v[50:53], v90 offset:8256
+ds_read_b128 v[54:57], v90 offset:8384
+ds_write_b32 v93, v80 offset:33024
+ds_write_b32 v94, v81 offset:33024
+s_setprio 1
+s_nop 0
+s_waitcnt vmcnt(12) lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 8
+s_call_b64 s[38:39], 1055
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_mac_f32_e32 v2, v34, v42
+v_mac_f32_e32 v3, v35, v42
+v_mac_f32_e32 v4, v36, v42
+v_mac_f32_e32 v5, v37, v42
+v_mac_f32_e32 v6, v34, v43
+v_mac_f32_e32 v7, v35, v43
+v_mac_f32_e32 v8, v36, v43
+v_mac_f32_e32 v9, v37, v43
+v_mac_f32_e32 v10, v34, v44
+v_mac_f32_e32 v11, v35, v44
+v_mac_f32_e32 v12, v36, v44
+v_mac_f32_e32 v13, v37, v44
+v_mac_f32_e32 v14, v34, v45
+v_mac_f32_e32 v15, v35, v45
+v_mac_f32_e32 v16, v36, v45
+v_mac_f32_e32 v17, v37, v45
+v_mac_f32_e32 v18, v34, v46
+v_mac_f32_e32 v19, v35, v46
+v_mac_f32_e32 v20, v36, v46
+v_mac_f32_e32 v21, v37, v46
+v_mac_f32_e32 v22, v34, v47
+v_mac_f32_e32 v23, v35, v47
+v_mac_f32_e32 v24, v36, v47
+v_mac_f32_e32 v25, v37, v47
+v_mac_f32_e32 v26, v34, v48
+v_mac_f32_e32 v27, v35, v48
+v_mac_f32_e32 v28, v36, v48
+v_mac_f32_e32 v29, v37, v48
+v_mac_f32_e32 v30, v34, v49
+v_mac_f32_e32 v31, v35, v49
+v_subrev_f32_e64 v58, v60, v58 div:2
+v_subrev_f32_e64 v61, v59, v61 div:2
+v_add_f32_e64 v59, v60, v59 div:2
+v_mad_f32 v60, v60, 1.0, -v59
+s_setprio 0
+s_nop 0
+v_mac_f32_e32 v32, v36, v49
+v_mac_f32_e32 v33, v37, v49
+s_nop 0
+ds_read_b128 v[34:37], v95 offset:12928
+ds_read_b128 v[42:45], v90 offset:12416
+ds_read_b128 v[46:49], v90 offset:12544
+ds_write_b32 v91, v78 offset:33024
+ds_write_b32 v92, v79 offset:33024
+s_setprio 1
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+buffer_load_dword v74, v82, s[40:43], 0 offen
+buffer_load_dword v76, v84, s[40:43], 0 offen
+buffer_load_dword v75, v83, s[40:43], 0 offen
+buffer_load_dword v77, v85, s[40:43], 0 offen
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 3
+s_call_b64 s[38:39], 978
+s_nop 0
+s_nop 0
+v_mac_f32_e32 v2, v38, v50
+v_mac_f32_e32 v3, v39, v50
+v_mac_f32_e32 v4, v40, v50
+v_mac_f32_e32 v5, v41, v50
+v_mac_f32_e32 v6, v38, v51
+v_mac_f32_e32 v7, v39, v51
+v_mac_f32_e32 v8, v40, v51
+v_mac_f32_e32 v9, v41, v51
+v_mac_f32_e32 v10, v38, v52
+v_mac_f32_e32 v11, v39, v52
+v_mac_f32_e32 v12, v40, v52
+v_mac_f32_e32 v13, v41, v52
+v_mac_f32_e32 v14, v38, v53
+v_mac_f32_e32 v15, v39, v53
+v_mac_f32_e32 v16, v40, v53
+v_mac_f32_e32 v17, v41, v53
+v_mac_f32_e32 v18, v38, v54
+v_mac_f32_e32 v19, v39, v54
+v_mac_f32_e32 v20, v40, v54
+v_mac_f32_e32 v21, v41, v54
+v_mac_f32_e32 v22, v38, v55
+v_mac_f32_e32 v23, v39, v55
+v_mac_f32_e32 v24, v40, v55
+v_mac_f32_e32 v25, v41, v55
+v_mac_f32_e32 v26, v38, v56
+v_mac_f32_e32 v27, v39, v56
+v_mac_f32_e32 v28, v40, v56
+v_mac_f32_e32 v29, v41, v56
+v_mac_f32_e32 v30, v38, v57
+v_mac_f32_e32 v31, v39, v57
+v_mac_f32_dpp v58, v58, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v59, v59, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v60, v60, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v61, v61, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+s_setprio 0
+s_nop 0
+v_mac_f32_e32 v32, v40, v57
+v_mac_f32_e32 v33, v41, v57
+s_nop 0
+ds_read_b128 v[38:41], v95 offset:17024
+ds_read_b128 v[50:53], v90 offset:16512
+ds_read_b128 v[54:57], v90 offset:16640
+ds_write_b32 v93, v60 offset:41280
+ds_write_b32 v94, v61 offset:41280
+s_setprio 1
+s_nop 0
+s_waitcnt vmcnt(12) lgkmcnt(5)
+ds_append v105 offset:65480
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 3
+s_call_b64 s[38:39], 914
+s_nop 0
+s_nop 0
+v_mac_f32_e32 v2, v34, v42
+v_mac_f32_e32 v3, v35, v42
+v_mac_f32_e32 v4, v36, v42
+v_mac_f32_e32 v5, v37, v42
+v_mac_f32_e32 v6, v34, v43
+v_mac_f32_e32 v7, v35, v43
+v_mac_f32_e32 v8, v36, v43
+v_mac_f32_e32 v9, v37, v43
+v_mac_f32_e32 v10, v34, v44
+v_mac_f32_e32 v11, v35, v44
+v_mac_f32_e32 v12, v36, v44
+v_mac_f32_e32 v13, v37, v44
+v_mac_f32_e32 v14, v34, v45
+v_mac_f32_e32 v15, v35, v45
+v_mac_f32_e32 v16, v36, v45
+v_mac_f32_e32 v17, v37, v45
+v_mac_f32_e32 v18, v34, v46
+v_mac_f32_e32 v19, v35, v46
+v_mac_f32_e32 v20, v36, v46
+v_mac_f32_e32 v21, v37, v46
+v_mac_f32_e32 v22, v34, v47
+v_mac_f32_e32 v23, v35, v47
+v_mac_f32_e32 v24, v36, v47
+v_mac_f32_e32 v25, v37, v47
+v_mac_f32_e32 v26, v34, v48
+v_mac_f32_e32 v27, v35, v48
+v_mac_f32_e32 v28, v36, v48
+v_mac_f32_e32 v29, v37, v48
+v_mac_f32_e32 v30, v34, v49
+v_mac_f32_e32 v31, v35, v49
+v_subrev_f32_e64 v62, v64, v62 div:2
+v_subrev_f32_e64 v65, v63, v65 div:2
+v_add_f32_e64 v63, v64, v63 div:2
+v_mad_f32 v64, v64, 1.0, -v63
+s_setprio 0
+s_nop 0
+v_mac_f32_e32 v32, v36, v49
+v_mac_f32_e32 v33, v37, v49
+s_nop 0
+ds_read_b128 v[34:37], v95 offset:21184
+ds_read_b128 v[42:45], v90 offset:20672
+ds_read_b128 v[46:49], v90 offset:20800
+ds_write_b32 v91, v58 offset:41280
+ds_write_b32 v92, v59 offset:41280
+s_setprio 1
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+buffer_load_dword v78, v82, s[40:43], 0 offen
+buffer_load_dword v80, v84, s[40:43], 0 offen
+buffer_load_dword v79, v83, s[40:43], 0 offen
+buffer_load_dword v81, v85, s[40:43], 0 offen
+s_mov_b32 m0, 0x2ffc8
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 1
+s_call_b64 s[38:39], 840
+v_mac_f32_e32 v2, v38, v50
+v_mac_f32_e32 v3, v39, v50
+v_mac_f32_e32 v4, v40, v50
+v_mac_f32_e32 v5, v41, v50
+v_mac_f32_e32 v6, v38, v51
+v_mac_f32_e32 v7, v39, v51
+v_mac_f32_e32 v8, v40, v51
+v_mac_f32_e32 v9, v41, v51
+v_mac_f32_e32 v10, v38, v52
+v_mac_f32_e32 v11, v39, v52
+v_mac_f32_e32 v12, v40, v52
+v_mac_f32_e32 v13, v41, v52
+v_mac_f32_e32 v14, v38, v53
+v_mac_f32_e32 v15, v39, v53
+v_mac_f32_e32 v16, v40, v53
+v_mac_f32_e32 v17, v41, v53
+v_mac_f32_e32 v18, v38, v54
+v_mac_f32_e32 v19, v39, v54
+v_mac_f32_e32 v20, v40, v54
+v_mac_f32_e32 v21, v41, v54
+v_mac_f32_e32 v22, v38, v55
+v_mac_f32_e32 v23, v39, v55
+v_mac_f32_e32 v24, v40, v55
+v_mac_f32_e32 v25, v41, v55
+v_mac_f32_e32 v26, v38, v56
+v_mac_f32_e32 v27, v39, v56
+v_mac_f32_e32 v28, v40, v56
+v_mac_f32_e32 v29, v41, v56
+v_mac_f32_e32 v30, v38, v57
+v_mac_f32_e32 v31, v39, v57
+v_mac_f32_e32 v32, v40, v57
+v_mac_f32_dpp v62, v62, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v63, v63, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v64, v64, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v65, v65, v100  quad_perm:[2,2,1,1] row_mask:0xf bank_mask:0xf
+s_setprio 0
+s_nop 0
+v_mac_f32_e32 v33, v41, v57
+v_cmp_eq_u32_e64 vcc, src_lds_direct, s91
+s_nop 0
+s_nop 0
+s_cbranch_vccz 65531
+s_nop 0
+ds_read_b128 v[38:41], v95 offset:25280
+ds_read_b128 v[50:53], v90 offset:24768
+ds_read_b128 v[54:57], v90 offset:24896
+ds_write_b32 v93, v64
+ds_write_b32 v94, v65
+s_setprio 1
+s_nop 0
+s_waitcnt vmcnt(12) lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 64704
+s_call_b64 s[38:39], 775
+s_branch 64702
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_mac_f32_e32 v2, v34, v42
+v_mac_f32_e32 v3, v35, v42
+v_mac_f32_e32 v4, v36, v42
+s_setprio 1
+s_nop 0
+v_mac_f32_e32 v5, v37, v42
+v_mac_f32_e32 v6, v34, v43
+v_mac_f32_e32 v7, v35, v43
+v_mac_f32_e32 v8, v36, v43
+v_mac_f32_e32 v9, v37, v43
+v_mac_f32_e32 v10, v34, v44
+v_mac_f32_e32 v11, v35, v44
+v_mac_f32_e32 v12, v36, v44
+v_mac_f32_e32 v13, v37, v44
+v_mac_f32_e32 v14, v34, v45
+v_mac_f32_e32 v15, v35, v45
+v_mac_f32_e32 v16, v36, v45
+v_mac_f32_e32 v17, v37, v45
+v_mac_f32_e32 v18, v34, v46
+v_mac_f32_e32 v19, v35, v46
+v_mac_f32_e32 v20, v36, v46
+v_mac_f32_e32 v21, v37, v46
+v_mac_f32_e32 v22, v34, v47
+v_mac_f32_e32 v23, v35, v47
+v_mac_f32_e32 v24, v36, v47
+v_mac_f32_e32 v25, v37, v47
+v_mac_f32_e32 v26, v34, v48
+v_mac_f32_e32 v27, v35, v48
+v_mac_f32_e32 v28, v36, v48
+v_mac_f32_e32 v29, v37, v48
+v_mac_f32_e32 v30, v34, v49
+v_mac_f32_e32 v31, v35, v49
+v_mac_f32_dpp v66, v66, v100  quad_perm:[0,0,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v69, v69, v100  quad_perm:[0,0,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_e32 v32, v36, v49
+v_mac_f32_e32 v33, v37, v49
+s_nop 0
+ds_read_b128 v[34:37], v95 offset:29440
+ds_read_b128 v[42:45], v90 offset:28928
+ds_read_b128 v[46:49], v90 offset:29056
+ds_write_b32 v91, v62
+ds_write_b32 v92, v63
+s_setprio 0
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+buffer_load_dword v58, v82, s[40:43], 0 offen
+buffer_load_dword v61, v85, s[40:43], 0 offen
+s_add_u32 s91, s91, 0x200
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 1
+s_call_b64 s[38:39], 704
+v_mac_f32_e32 v2, v38, v50
+v_mac_f32_e32 v3, v39, v50
+v_mac_f32_e32 v4, v40, v50
+s_setprio 1
+s_nop 0
+v_mac_f32_e32 v5, v41, v50
+v_mac_f32_e32 v6, v38, v51
+v_mac_f32_e32 v7, v39, v51
+v_mac_f32_e32 v8, v40, v51
+v_mac_f32_e32 v9, v41, v51
+v_mac_f32_e32 v10, v38, v52
+v_mac_f32_e32 v11, v39, v52
+v_mac_f32_e32 v12, v40, v52
+v_mac_f32_e32 v13, v41, v52
+v_mac_f32_e32 v14, v38, v53
+v_mac_f32_e32 v15, v39, v53
+v_mac_f32_e32 v16, v40, v53
+v_mac_f32_e32 v17, v41, v53
+v_mac_f32_e32 v18, v38, v54
+v_mac_f32_e32 v19, v39, v54
+v_mac_f32_e32 v20, v40, v54
+v_mac_f32_e32 v21, v41, v54
+v_mac_f32_e32 v22, v38, v55
+v_mac_f32_e32 v23, v39, v55
+v_mac_f32_e32 v24, v40, v55
+v_mac_f32_e32 v25, v41, v55
+v_mac_f32_e32 v26, v38, v56
+v_mac_f32_e32 v27, v39, v56
+v_mac_f32_e32 v28, v40, v56
+v_mac_f32_e32 v29, v41, v56
+v_mac_f32_e32 v30, v38, v57
+v_mac_f32_e32 v31, v39, v57
+v_add_f32_e64 v67, v66, v69 div:2
+v_add_f32_e64 v68, v66, -v69 div:2
+v_mac_f32_e32 v32, v40, v57
+v_mac_f32_e32 v33, v41, v57
+s_nop 0
+ds_read_b128 v[38:41], v95 offset:33536
+ds_read_b128 v[50:53], v90 offset:33024
+ds_read_b128 v[54:57], v90 offset:33152
+ds_write_b32 v93, v68 offset:8256
+ds_write_b32 v94, v69 offset:8256
+s_setprio 0
+s_nop 0
+s_waitcnt vmcnt(6) lgkmcnt(5)
+ds_append v105 offset:65472
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 7
+s_call_b64 s[38:39], 646
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_mac_f32_e32 v2, v34, v42
+v_mac_f32_e32 v3, v35, v42
+v_mac_f32_e32 v4, v36, v42
+s_setprio 1
+s_nop 0
+v_mac_f32_e32 v5, v37, v42
+v_mac_f32_e32 v6, v34, v43
+v_mac_f32_e32 v7, v35, v43
+v_mac_f32_e32 v8, v36, v43
+v_mac_f32_e32 v9, v37, v43
+v_mac_f32_e32 v10, v34, v44
+v_mac_f32_e32 v11, v35, v44
+v_mac_f32_e32 v12, v36, v44
+v_mac_f32_e32 v13, v37, v44
+v_mac_f32_e32 v14, v34, v45
+v_mac_f32_e32 v15, v35, v45
+v_mac_f32_e32 v16, v36, v45
+v_mac_f32_e32 v17, v37, v45
+v_mac_f32_e32 v18, v34, v46
+v_mac_f32_e32 v19, v35, v46
+v_mac_f32_e32 v20, v36, v46
+v_mac_f32_e32 v21, v37, v46
+v_mac_f32_e32 v22, v34, v47
+v_mac_f32_e32 v23, v35, v47
+v_mac_f32_e32 v24, v36, v47
+v_mac_f32_e32 v25, v37, v47
+v_mac_f32_e32 v26, v34, v48
+v_mac_f32_e32 v27, v35, v48
+v_mac_f32_e32 v28, v36, v48
+v_mac_f32_e32 v29, v37, v48
+v_mac_f32_e32 v30, v34, v49
+v_mac_f32_e32 v31, v35, v49
+v_mac_f32_dpp v70, v70, v100  quad_perm:[0,0,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v73, v73, v100  quad_perm:[0,0,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_e32 v32, v36, v49
+v_mac_f32_e32 v33, v37, v49
+s_nop 0
+ds_read_b128 v[34:37], v95 offset:37696
+ds_read_b128 v[42:45], v90 offset:37184
+ds_read_b128 v[46:49], v90 offset:37312
+ds_write_b32 v91, v66 offset:8256
+ds_write_b32 v92, v67 offset:8256
+s_setprio 0
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+buffer_load_dword v62, v82, s[40:43], 0 offen
+buffer_load_dword v65, v85, s[40:43], 0 offen
+s_mov_b32 m0, 0x2ffc0
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 1
+s_call_b64 s[38:39], 576
+v_mac_f32_e32 v2, v38, v50
+v_mac_f32_e32 v3, v39, v50
+v_mac_f32_e32 v4, v40, v50
+s_setprio 1
+s_nop 0
+v_mac_f32_e32 v5, v41, v50
+v_mac_f32_e32 v6, v38, v51
+v_mac_f32_e32 v7, v39, v51
+v_mac_f32_e32 v8, v40, v51
+v_mac_f32_e32 v9, v41, v51
+v_mac_f32_e32 v10, v38, v52
+v_mac_f32_e32 v11, v39, v52
+v_mac_f32_e32 v12, v40, v52
+v_mac_f32_e32 v13, v41, v52
+v_mac_f32_e32 v14, v38, v53
+v_mac_f32_e32 v15, v39, v53
+v_mac_f32_e32 v16, v40, v53
+v_mac_f32_e32 v17, v41, v53
+v_mac_f32_e32 v18, v38, v54
+v_mac_f32_e32 v19, v39, v54
+v_mac_f32_e32 v20, v40, v54
+v_mac_f32_e32 v21, v41, v54
+v_mac_f32_e32 v22, v38, v55
+v_mac_f32_e32 v23, v39, v55
+v_mac_f32_e32 v24, v40, v55
+v_mac_f32_e32 v25, v41, v55
+v_mac_f32_e32 v26, v38, v56
+v_mac_f32_e32 v27, v39, v56
+v_mac_f32_e32 v28, v40, v56
+v_mac_f32_e32 v29, v41, v56
+v_mac_f32_e32 v30, v38, v57
+v_mac_f32_e32 v31, v39, v57
+v_mac_f32_e32 v32, v40, v57
+v_add_f32_e64 v71, v70, v73 div:2
+v_add_f32_e64 v72, v70, -v73 div:2
+v_mac_f32_e32 v33, v41, v57
+v_cmp_eq_u32_e64 vcc, src_lds_direct, s91
+s_nop 0
+s_nop 0
+s_cbranch_vccz 65531
+s_nop 0
+ds_read_b128 v[38:41], v95 offset:41792
+ds_read_b128 v[50:53], v90 offset:41280
+ds_read_b128 v[54:57], v90 offset:41408
+ds_write_b32 v93, v72 offset:16512
+ds_write_b32 v94, v73 offset:16512
+s_setprio 0
+s_nop 0
+s_waitcnt vmcnt(6) lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 4
+s_call_b64 s[38:39], 515
+s_nop 0
+s_nop 0
+s_nop 0
+v_mac_f32_e32 v2, v34, v42
+v_mac_f32_e32 v3, v35, v42
+v_mac_f32_e32 v4, v36, v42
+s_setprio 1
+s_nop 0
+v_mac_f32_e32 v5, v37, v42
+v_mac_f32_e32 v6, v34, v43
+v_mac_f32_e32 v7, v35, v43
+v_mac_f32_e32 v8, v36, v43
+v_mac_f32_e32 v9, v37, v43
+v_mac_f32_e32 v10, v34, v44
+v_mac_f32_e32 v11, v35, v44
+v_mac_f32_e32 v12, v36, v44
+v_mac_f32_e32 v13, v37, v44
+v_mac_f32_e32 v14, v34, v45
+v_mac_f32_e32 v15, v35, v45
+v_mac_f32_e32 v16, v36, v45
+v_mac_f32_e32 v17, v37, v45
+v_mac_f32_e32 v18, v34, v46
+v_mac_f32_e32 v19, v35, v46
+v_mac_f32_e32 v20, v36, v46
+v_mac_f32_e32 v21, v37, v46
+v_mac_f32_e32 v22, v34, v47
+v_mac_f32_e32 v23, v35, v47
+v_mac_f32_e32 v24, v36, v47
+v_mac_f32_e32 v25, v37, v47
+v_mac_f32_e32 v26, v34, v48
+v_mac_f32_e32 v27, v35, v48
+v_mac_f32_e32 v28, v36, v48
+v_mac_f32_e32 v29, v37, v48
+v_mac_f32_e32 v30, v34, v49
+v_mac_f32_e32 v31, v35, v49
+v_mac_f32_dpp v74, v74, v100  quad_perm:[0,0,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v77, v77, v100  quad_perm:[0,0,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_e32 v32, v36, v49
+v_mac_f32_e32 v33, v37, v49
+s_nop 0
+ds_read_b128 v[34:37], v95 offset:45952
+ds_read_b128 v[42:45], v90 offset:45440
+ds_read_b128 v[46:49], v90 offset:45568
+ds_write_b32 v91, v70 offset:16512
+ds_write_b32 v92, v71 offset:16512
+s_setprio 0
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+buffer_load_dword v66, v82, s[40:43], 0 offen
+buffer_load_dword v69, v85, s[40:43], 0 offen
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 3
+s_call_b64 s[38:39], 450
+s_nop 0
+s_nop 0
+v_mac_f32_e32 v2, v38, v50
+v_mac_f32_e32 v3, v39, v50
+v_mac_f32_e32 v4, v40, v50
+s_setprio 1
+s_nop 0
+v_mac_f32_e32 v5, v41, v50
+v_mac_f32_e32 v6, v38, v51
+v_mac_f32_e32 v7, v39, v51
+v_mac_f32_e32 v8, v40, v51
+v_mac_f32_e32 v9, v41, v51
+v_mac_f32_e32 v10, v38, v52
+v_mac_f32_e32 v11, v39, v52
+v_mac_f32_e32 v12, v40, v52
+v_mac_f32_e32 v13, v41, v52
+v_mac_f32_e32 v14, v38, v53
+v_mac_f32_e32 v15, v39, v53
+v_mac_f32_e32 v16, v40, v53
+v_mac_f32_e32 v17, v41, v53
+v_mac_f32_e32 v18, v38, v54
+v_mac_f32_e32 v19, v39, v54
+v_mac_f32_e32 v20, v40, v54
+v_mac_f32_e32 v21, v41, v54
+v_mac_f32_e32 v22, v38, v55
+v_mac_f32_e32 v23, v39, v55
+v_mac_f32_e32 v24, v40, v55
+v_mac_f32_e32 v25, v41, v55
+v_mac_f32_e32 v26, v38, v56
+v_mac_f32_e32 v27, v39, v56
+v_mac_f32_e32 v28, v40, v56
+v_mac_f32_e32 v29, v41, v56
+v_mac_f32_e32 v30, v38, v57
+v_mac_f32_e32 v31, v39, v57
+v_add_f32_e64 v75, v74, v77 div:2
+v_add_f32_e64 v76, v74, -v77 div:2
+v_mac_f32_e32 v32, v40, v57
+v_mac_f32_e32 v33, v41, v57
+s_nop 0
+ds_read_b128 v[38:41], v95 offset:512
+ds_read_b128 v[50:53], v90
+ds_read_b128 v[54:57], v90 offset:128
+ds_write_b32 v93, v76 offset:24768
+ds_write_b32 v94, v77 offset:24768
+s_setprio 0
+s_nop 0
+s_waitcnt vmcnt(6) lgkmcnt(5)
+ds_append v105 offset:65476
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 7
+s_call_b64 s[38:39], 390
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_mac_f32_e32 v2, v34, v42
+v_mac_f32_e32 v3, v35, v42
+v_mac_f32_e32 v4, v36, v42
+s_setprio 1
+s_nop 0
+v_mac_f32_e32 v5, v37, v42
+v_mac_f32_e32 v6, v34, v43
+v_mac_f32_e32 v7, v35, v43
+v_mac_f32_e32 v8, v36, v43
+v_mac_f32_e32 v9, v37, v43
+v_mac_f32_e32 v10, v34, v44
+v_mac_f32_e32 v11, v35, v44
+v_mac_f32_e32 v12, v36, v44
+v_mac_f32_e32 v13, v37, v44
+v_mac_f32_e32 v14, v34, v45
+v_mac_f32_e32 v15, v35, v45
+v_mac_f32_e32 v16, v36, v45
+v_mac_f32_e32 v17, v37, v45
+v_mac_f32_e32 v18, v34, v46
+v_mac_f32_e32 v19, v35, v46
+v_mac_f32_e32 v20, v36, v46
+v_mac_f32_e32 v21, v37, v46
+v_mac_f32_e32 v22, v34, v47
+v_mac_f32_e32 v23, v35, v47
+v_mac_f32_e32 v24, v36, v47
+v_mac_f32_e32 v25, v37, v47
+v_mac_f32_e32 v26, v34, v48
+v_mac_f32_e32 v27, v35, v48
+v_mac_f32_e32 v28, v36, v48
+v_mac_f32_e32 v29, v37, v48
+v_mac_f32_e32 v30, v34, v49
+v_mac_f32_e32 v31, v35, v49
+v_mac_f32_dpp v78, v78, v100  quad_perm:[0,0,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v81, v81, v100  quad_perm:[0,0,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_e32 v32, v36, v49
+v_mac_f32_e32 v33, v37, v49
+s_nop 0
+ds_read_b128 v[34:37], v95 offset:4672
+ds_read_b128 v[42:45], v90 offset:4160
+ds_read_b128 v[46:49], v90 offset:4288
+ds_write_b32 v91, v74 offset:24768
+ds_write_b32 v92, v75 offset:24768
+s_setprio 0
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+buffer_load_dword v70, v82, s[40:43], 0 offen
+buffer_load_dword v73, v85, s[40:43], 0 offen
+s_mov_b32 m0, 0x2ffc4
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 1
+s_call_b64 s[38:39], 320
+v_mac_f32_e32 v2, v38, v50
+v_mac_f32_e32 v3, v39, v50
+v_mac_f32_e32 v4, v40, v50
+s_setprio 1
+s_nop 0
+v_mac_f32_e32 v5, v41, v50
+v_mac_f32_e32 v6, v38, v51
+v_mac_f32_e32 v7, v39, v51
+v_mac_f32_e32 v8, v40, v51
+v_mac_f32_e32 v9, v41, v51
+v_mac_f32_e32 v10, v38, v52
+v_mac_f32_e32 v11, v39, v52
+v_mac_f32_e32 v12, v40, v52
+v_mac_f32_e32 v13, v41, v52
+v_mac_f32_e32 v14, v38, v53
+v_mac_f32_e32 v15, v39, v53
+v_mac_f32_e32 v16, v40, v53
+v_mac_f32_e32 v17, v41, v53
+v_mac_f32_e32 v18, v38, v54
+v_mac_f32_e32 v19, v39, v54
+v_mac_f32_e32 v20, v40, v54
+v_mac_f32_e32 v21, v41, v54
+v_mac_f32_e32 v22, v38, v55
+v_mac_f32_e32 v23, v39, v55
+v_mac_f32_e32 v24, v40, v55
+v_mac_f32_e32 v25, v41, v55
+v_mac_f32_e32 v26, v38, v56
+v_mac_f32_e32 v27, v39, v56
+v_mac_f32_e32 v28, v40, v56
+v_mac_f32_e32 v29, v41, v56
+v_mac_f32_e32 v30, v38, v57
+v_mac_f32_e32 v31, v39, v57
+v_mac_f32_e32 v32, v40, v57
+v_add_f32_e64 v79, v78, v81 div:2
+v_add_f32_e64 v80, v78, -v81 div:2
+v_mac_f32_e32 v33, v41, v57
+v_cmp_eq_u32_e64 vcc, src_lds_direct, s91
+s_nop 0
+s_nop 0
+s_cbranch_vccz 65531
+s_nop 0
+ds_read_b128 v[38:41], v95 offset:8768
+ds_read_b128 v[50:53], v90 offset:8256
+ds_read_b128 v[54:57], v90 offset:8384
+ds_write_b32 v93, v80 offset:33024
+ds_write_b32 v94, v81 offset:33024
+s_setprio 0
+s_nop 0
+s_waitcnt vmcnt(6) lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 4
+s_call_b64 s[38:39], 259
+s_nop 0
+s_nop 0
+s_nop 0
+v_mac_f32_e32 v2, v34, v42
+v_mac_f32_e32 v3, v35, v42
+v_mac_f32_e32 v4, v36, v42
+s_setprio 1
+s_nop 0
+v_mac_f32_e32 v5, v37, v42
+v_mac_f32_e32 v6, v34, v43
+v_mac_f32_e32 v7, v35, v43
+v_mac_f32_e32 v8, v36, v43
+v_mac_f32_e32 v9, v37, v43
+v_mac_f32_e32 v10, v34, v44
+v_mac_f32_e32 v11, v35, v44
+v_mac_f32_e32 v12, v36, v44
+v_mac_f32_e32 v13, v37, v44
+v_mac_f32_e32 v14, v34, v45
+v_mac_f32_e32 v15, v35, v45
+v_mac_f32_e32 v16, v36, v45
+v_mac_f32_e32 v17, v37, v45
+v_mac_f32_e32 v18, v34, v46
+v_mac_f32_e32 v19, v35, v46
+v_mac_f32_e32 v20, v36, v46
+v_mac_f32_e32 v21, v37, v46
+v_mac_f32_e32 v22, v34, v47
+v_mac_f32_e32 v23, v35, v47
+v_mac_f32_e32 v24, v36, v47
+v_mac_f32_e32 v25, v37, v47
+v_mac_f32_e32 v26, v34, v48
+v_mac_f32_e32 v27, v35, v48
+v_mac_f32_e32 v28, v36, v48
+v_mac_f32_e32 v29, v37, v48
+v_mac_f32_e32 v30, v34, v49
+v_mac_f32_e32 v31, v35, v49
+v_mac_f32_dpp v58, v58, v100  quad_perm:[0,0,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v61, v61, v100  quad_perm:[0,0,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_e32 v32, v36, v49
+v_mac_f32_e32 v33, v37, v49
+s_nop 0
+ds_read_b128 v[34:37], v95 offset:12928
+ds_read_b128 v[42:45], v90 offset:12416
+ds_read_b128 v[46:49], v90 offset:12544
+ds_write_b32 v91, v78 offset:33024
+ds_write_b32 v92, v79 offset:33024
+s_setprio 0
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+buffer_load_dword v74, v82, s[40:43], 0 offen
+buffer_load_dword v77, v85, s[40:43], 0 offen
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 3
+s_call_b64 s[38:39], 194
+s_nop 0
+s_nop 0
+v_mac_f32_e32 v2, v38, v50
+v_mac_f32_e32 v3, v39, v50
+v_mac_f32_e32 v4, v40, v50
+s_setprio 1
+s_nop 0
+v_mac_f32_e32 v5, v41, v50
+v_mac_f32_e32 v6, v38, v51
+v_mac_f32_e32 v7, v39, v51
+v_mac_f32_e32 v8, v40, v51
+v_mac_f32_e32 v9, v41, v51
+v_mac_f32_e32 v10, v38, v52
+v_mac_f32_e32 v11, v39, v52
+v_mac_f32_e32 v12, v40, v52
+v_mac_f32_e32 v13, v41, v52
+v_mac_f32_e32 v14, v38, v53
+v_mac_f32_e32 v15, v39, v53
+v_mac_f32_e32 v16, v40, v53
+v_mac_f32_e32 v17, v41, v53
+v_mac_f32_e32 v18, v38, v54
+v_mac_f32_e32 v19, v39, v54
+v_mac_f32_e32 v20, v40, v54
+v_mac_f32_e32 v21, v41, v54
+v_mac_f32_e32 v22, v38, v55
+v_mac_f32_e32 v23, v39, v55
+v_mac_f32_e32 v24, v40, v55
+v_mac_f32_e32 v25, v41, v55
+v_mac_f32_e32 v26, v38, v56
+v_mac_f32_e32 v27, v39, v56
+v_mac_f32_e32 v28, v40, v56
+v_mac_f32_e32 v29, v41, v56
+v_mac_f32_e32 v30, v38, v57
+v_mac_f32_e32 v31, v39, v57
+v_add_f32_e64 v59, v58, v61 div:2
+v_add_f32_e64 v60, v58, -v61 div:2
+v_mac_f32_e32 v32, v40, v57
+v_mac_f32_e32 v33, v41, v57
+s_nop 0
+ds_read_b128 v[38:41], v95 offset:17024
+ds_read_b128 v[50:53], v90 offset:16512
+ds_read_b128 v[54:57], v90 offset:16640
+ds_write_b32 v93, v60 offset:41280
+ds_write_b32 v94, v61 offset:41280
+s_setprio 0
+s_nop 0
+s_waitcnt vmcnt(6) lgkmcnt(5)
+ds_append v105 offset:65480
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 7
+s_call_b64 s[38:39], 134
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+v_mac_f32_e32 v2, v34, v42
+v_mac_f32_e32 v3, v35, v42
+v_mac_f32_e32 v4, v36, v42
+s_setprio 1
+s_nop 0
+v_mac_f32_e32 v5, v37, v42
+v_mac_f32_e32 v6, v34, v43
+v_mac_f32_e32 v7, v35, v43
+v_mac_f32_e32 v8, v36, v43
+v_mac_f32_e32 v9, v37, v43
+v_mac_f32_e32 v10, v34, v44
+v_mac_f32_e32 v11, v35, v44
+v_mac_f32_e32 v12, v36, v44
+v_mac_f32_e32 v13, v37, v44
+v_mac_f32_e32 v14, v34, v45
+v_mac_f32_e32 v15, v35, v45
+v_mac_f32_e32 v16, v36, v45
+v_mac_f32_e32 v17, v37, v45
+v_mac_f32_e32 v18, v34, v46
+v_mac_f32_e32 v19, v35, v46
+v_mac_f32_e32 v20, v36, v46
+v_mac_f32_e32 v21, v37, v46
+v_mac_f32_e32 v22, v34, v47
+v_mac_f32_e32 v23, v35, v47
+v_mac_f32_e32 v24, v36, v47
+v_mac_f32_e32 v25, v37, v47
+v_mac_f32_e32 v26, v34, v48
+v_mac_f32_e32 v27, v35, v48
+v_mac_f32_e32 v28, v36, v48
+v_mac_f32_e32 v29, v37, v48
+v_mac_f32_e32 v30, v34, v49
+v_mac_f32_e32 v31, v35, v49
+v_mac_f32_dpp v62, v62, v100  quad_perm:[0,0,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_dpp v65, v65, v100  quad_perm:[0,0,1,1] row_mask:0xf bank_mask:0xf
+v_mac_f32_e32 v32, v36, v49
+v_mac_f32_e32 v33, v37, v49
+s_nop 0
+ds_read_b128 v[34:37], v95 offset:21184
+ds_read_b128 v[42:45], v90 offset:20672
+ds_read_b128 v[46:49], v90 offset:20800
+ds_write_b32 v91, v58 offset:41280
+ds_write_b32 v92, v59 offset:41280
+s_setprio 0
+s_add_u32 s40, s40, s70
+s_addc_u32 s41, s41, s71
+buffer_load_dword v78, v82, s[40:43], 0 offen
+buffer_load_dword v81, v85, s[40:43], 0 offen
+s_mov_b32 m0, 0x2ffc8
+s_nop 0
+s_waitcnt lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 1
+s_call_b64 s[38:39], 64
+v_mac_f32_e32 v2, v38, v50
+v_mac_f32_e32 v3, v39, v50
+v_mac_f32_e32 v4, v40, v50
+s_setprio 1
+s_nop 0
+v_mac_f32_e32 v5, v41, v50
+v_mac_f32_e32 v6, v38, v51
+v_mac_f32_e32 v7, v39, v51
+v_mac_f32_e32 v8, v40, v51
+v_mac_f32_e32 v9, v41, v51
+v_mac_f32_e32 v10, v38, v52
+v_mac_f32_e32 v11, v39, v52
+v_mac_f32_e32 v12, v40, v52
+v_mac_f32_e32 v13, v41, v52
+v_mac_f32_e32 v14, v38, v53
+v_mac_f32_e32 v15, v39, v53
+v_mac_f32_e32 v16, v40, v53
+v_mac_f32_e32 v17, v41, v53
+v_mac_f32_e32 v18, v38, v54
+v_mac_f32_e32 v19, v39, v54
+v_mac_f32_e32 v20, v40, v54
+v_mac_f32_e32 v21, v41, v54
+v_mac_f32_e32 v22, v38, v55
+v_mac_f32_e32 v23, v39, v55
+v_mac_f32_e32 v24, v40, v55
+v_mac_f32_e32 v25, v41, v55
+v_mac_f32_e32 v26, v38, v56
+v_mac_f32_e32 v27, v39, v56
+v_mac_f32_e32 v28, v40, v56
+v_mac_f32_e32 v29, v41, v56
+v_mac_f32_e32 v30, v38, v57
+v_mac_f32_e32 v31, v39, v57
+v_mac_f32_e32 v32, v40, v57
+v_add_f32_e64 v63, v62, v65 div:2
+v_add_f32_e64 v64, v62, -v65 div:2
+v_mac_f32_e32 v33, v41, v57
+v_cmp_eq_u32_e64 vcc, src_lds_direct, s91
+s_nop 0
+s_nop 0
+s_cbranch_vccz 65531
+s_nop 0
+ds_read_b128 v[38:41], v95 offset:25280
+ds_read_b128 v[50:53], v90 offset:24768
+ds_read_b128 v[54:57], v90 offset:24896
+ds_write_b32 v93, v64
+ds_write_b32 v94, v65
+s_setprio 0
+s_nop 0
+s_waitcnt vmcnt(6) lgkmcnt(5)
+s_bitset0_b32 s18, 26
+s_add_u32 s72, s72, -1
+s_cbranch_scc1 64772
+s_call_b64 s[38:39], 3
+s_branch 64770
+s_nop 0
+s_nop 0
+v_nop
+s_cmp_eq_u32 s82, 0
+s_cbranch_scc0 8
+s_branch 588
+s_add_u32 s82, s82, 1
+s_andn2_b32 s82, s82, 1
+s_bitcmp1_b32 0, 26
+s_cselect_b32 s52, s69, s70
+s_cselect_b32 s53, 0, s71
+s_sub_u32 s40, s40, s52
+s_subb_u32 s41, s41, s53
+s_cmp_eq_u32 s94, 0
+s_cbranch_scc0 3
+s_cbranch_scc1 610
+s_nop 0
+s_nop 0
+s_min_u32 s72, s82, s94
+s_sub_u32 s82, s82, s72
+s_sub_u32 s94, s94, s72
+s_sub_u32 s72, s72, 1
+s_setpc_b64 s[38:39]
+s_nop 0
+s_nop 0
+s_nop 0
+s_bitcmp1_b32 s18, 17
+s_cbranch_scc1 241
+s_add_u32 s88, s88, s17
+s_cmp_eq_u32 s88, 0
+s_cbranch_scc1 238
+s_mov_b32 s89, 0
+s_bitcmp1_b32 s18, 16
+s_cbranch_scc1 227
+s_add_u32 s87, s16, 31
+s_lshr_b32 s87, s87, 5
+v_mov_b32_e32 v107, s88
+v_mul_u32_u24_e32 v107, s87, v107
+v_add_co_u32_e32 v107, vcc, s17, v107
+v_sub_co_u32_e64 v107, vcc, v107, 1
+v_ffbh_u32_e32 v110, s17
+v_lshlrev_b32_e64 v111, v110, s17
+v_and_b32_e32 v112, 0xffffff00, v111
+v_cmp_eq_u32_e32 vcc, 0x80000000, v111
+v_cvt_f32_u32_e32 v112, v112
+v_rcp_f32_e32 v106, v112
+v_subb_co_u32_e32 v109, vcc, 32, v110, vcc
+v_cvt_f32_ubyte0_e32 v110, v111
+v_fma_f32 v112, v112, v106, -1.0
+v_fma_f32 v112, v110, v106, v112
+v_madak_f32 v112, v112, v106, 0x9f000000
+v_mul_f32_e32 v112, 0x5f800000, v112
+v_mov_b32_e32 v110, 0
+v_cvt_flr_i32_f32_e64 v112, -v112
+v_lshl_add_u32 v106, v106, 9, v112
+v_mad_u64_u32 v[110:111], vcc, v111, v106, v[110:111]
+v_subb_co_u32_e64 v106, vcc, v106, -1, vcc
+v_mul_hi_u32 v110, v107, v106
+v_add_co_u32_e32 v106, vcc, v110, v107
+v_addc_co_u32_e64 v110, vcc, 0, 0, vcc
+v_cmp_eq_u32_e32 vcc, 32, v109
+v_cndmask_b32_e32 v106, v106, v110, vcc
+v_alignbit_b32 v106, v110, v106, v109
+v_readfirstlane_b32 s86, v106
+v_mul_u32_u24_e64 v106, v106, s8
+v_ffbh_u32_e32 v110, s87
+v_lshlrev_b32_e64 v111, v110, s87
+v_and_b32_e32 v112, 0xffffff00, v111
+v_cmp_eq_u32_e32 vcc, 0x80000000, v111
+v_cvt_f32_u32_e32 v112, v112
+v_rcp_f32_e32 v107, v112
+v_subb_co_u32_e32 v109, vcc, 32, v110, vcc
+v_cvt_f32_ubyte0_e32 v110, v111
+v_fma_f32 v112, v112, v107, -1.0
+v_fma_f32 v112, v110, v107, v112
+v_madak_f32 v112, v112, v107, 0x9f000000
+v_mul_f32_e32 v112, 0x5f800000, v112
+v_mov_b32_e32 v110, 0
+v_cvt_flr_i32_f32_e64 v112, -v112
+v_lshl_add_u32 v107, v107, 9, v112
+v_mad_u64_u32 v[110:111], vcc, v111, v107, v[110:111]
+v_subb_co_u32_e64 v107, vcc, v107, -1, vcc
+v_mul_hi_u32 v110, v106, v107
+v_add_co_u32_e32 v107, vcc, v110, v106
+v_addc_co_u32_e64 v110, vcc, 0, 0, vcc
+v_cmp_eq_u32_e32 vcc, 32, v109
+v_cndmask_b32_e32 v107, v107, v110, vcc
+v_alignbit_b32 v107, v110, v107, v109
+v_readfirstlane_b32 s52, v106
+v_readfirstlane_b32 s84, v107
+s_mul_i32 s84, s84, s87
+s_sub_u32 s84, s52, s84
+v_sub_co_u32_e32 v107, vcc, s8, v107
+v_sub_co_u32_e32 v107, vcc, s17, v107
+v_and_b32_e64 v109, v0, 63
+v_cmp_eq_u32_e64 vcc, v109, 0
+v_cndmask_b32_e32 v107, 1, v107, vcc
+s_sub_u32 s58, 0, s75
+s_sub_u32 s59, 0, s74
+v_mul_u32_u24_e64 v111, v107, 32
+v_ffbh_u32_e32 v113, s58
+v_lshlrev_b32_e64 v114, v113, s58
+v_and_b32_e32 v115, 0xffffff00, v114
+v_cmp_eq_u32_e32 vcc, 0x80000000, v114
+v_cvt_f32_u32_e32 v115, v115
+v_rcp_f32_e32 v109, v115
+v_subb_co_u32_e32 v112, vcc, 32, v113, vcc
+v_cvt_f32_ubyte0_e32 v113, v114
+v_fma_f32 v115, v115, v109, -1.0
+v_fma_f32 v115, v113, v109, v115
+v_madak_f32 v115, v115, v109, 0x9f000000
+v_mul_f32_e32 v115, 0x5f800000, v115
+v_mov_b32_e32 v113, 0
+v_cvt_flr_i32_f32_e64 v115, -v115
+v_lshl_add_u32 v109, v109, 9, v115
+v_mad_u64_u32 v[113:114], vcc, v114, v109, v[113:114]
+v_subb_co_u32_e64 v109, vcc, v109, -1, vcc
+v_mul_hi_u32 v113, v111, v109
+v_add_co_u32_e32 v109, vcc, v113, v111
+v_addc_co_u32_e64 v113, vcc, 0, 0, vcc
+v_cmp_eq_u32_e32 vcc, 32, v112
+v_cndmask_b32_e32 v109, v109, v113, vcc
+v_alignbit_b32 v109, v113, v109, v112
+v_mad_i32_i24 v110, v109, s75, v111
+v_mul_u32_u24_e64 v111, v109, 1
+v_ffbh_u32_e32 v113, s59
+v_lshlrev_b32_e64 v114, v113, s59
+v_and_b32_e32 v115, 0xffffff00, v114
+v_cmp_eq_u32_e32 vcc, 0x80000000, v114
+v_cvt_f32_u32_e32 v115, v115
+v_rcp_f32_e32 v109, v115
+v_subb_co_u32_e32 v112, vcc, 32, v113, vcc
+v_cvt_f32_ubyte0_e32 v113, v114
+v_fma_f32 v115, v115, v109, -1.0
+v_fma_f32 v115, v113, v109, v115
+v_madak_f32 v115, v115, v109, 0x9f000000
+v_mul_f32_e32 v115, 0x5f800000, v115
+v_mov_b32_e32 v113, 0
+v_cvt_flr_i32_f32_e64 v115, -v115
+v_lshl_add_u32 v109, v109, 9, v115
+v_mad_u64_u32 v[113:114], vcc, v114, v109, v[113:114]
+v_subb_co_u32_e64 v109, vcc, v109, -1, vcc
+v_mul_hi_u32 v113, v111, v109
+v_add_co_u32_e32 v109, vcc, v113, v111
+v_addc_co_u32_e64 v113, vcc, 0, 0, vcc
+v_cmp_eq_u32_e32 vcc, 32, v112
+v_cndmask_b32_e32 v109, v109, v113, vcc
+v_alignbit_b32 v109, v113, v109, v112
+v_mad_i32_i24 v111, v109, s74, v111
+v_readfirstlane_b32 s76, v110
+v_readfirstlane_b32 s77, v111
+v_readfirstlane_b32 s78, v109
+v_add_co_u32_e32 v96, vcc, s76, v96
+v_addc_co_u32_e64 v112, vcc, 0, 0, vcc
+v_mad_i32_i24 v96, v112, s75, v96
+v_mad_i32_i24 v98, v112, s80, v98
+v_mad_i32_i24 v97, v112, s79, v97
+v_cmp_ge_i32_e64 vcc, v97, 0
+v_addc_co_u32_e64 v112, vcc, 0, 0, vcc
+v_add_co_u32_e32 v98, vcc, v98, v112
+v_mad_i32_i24 v97, v112, s74, v97
+v_add_co_u32_e32 v97, vcc, s77, v97
+v_addc_co_u32_e64 v112, vcc, 0, 0, vcc
+v_add_co_u32_e32 v98, vcc, v98, v112
+v_mad_i32_i24 v97, v112, s74, v97
+v_add_co_u32_e32 v98, vcc, s78, v98
+v_readlane_b32 s76, v110, 1
+v_readlane_b32 s77, v111, 1
+v_readlane_b32 s78, v109, 1
+s_add_u32 s85, s84, s86
+s_cmp_le_u32 s85, s87
+s_cselect_b32 s52, 0x20000, 0
+s_cselect_b32 s85, s85, s87
+s_or_b32 s18, s18, s52
+s_lshl_b32 s84, s84, 5
+s_lshl_b32 s85, s85, 5
+s_min_u32 s85, s85, s16
+s_cmp_eq_u32 s8, s17
+s_cselect_b32 s52, 0x20000, 0
+s_or_b32 s18, s18, s52
+s_or_b32 s18, s18, s52
+s_bitset1_b32 s18, 16
+s_branch 43
+s_lshr_b32 s84, s84, 5
+s_add_u32 s85, s84, s86
+s_sub_u32 s85, s85, s87
+s_mov_b32 s84, 0
+s_lshl_b32 s85, s85, 5
+s_min_u32 s85, s85, s16
+s_bitset1_b32 s18, 17
+s_branch 12
+s_bitset1_b32 s18, 18
+s_mov_b32 s43, 0
+s_mov_b32 s73, -1
+s_mov_b32 s82, 40
+s_branch 31
+s_add_u32 s83, s83, 32
+s_cmp_ge_u32 s83, s85
+s_cbranch_scc0 28
+s_bitset1_b32 s18, 22
+s_sub_u32 s88, s88, s17
+s_subb_u32 s89, s89, 0
+s_cbranch_scc1 65281
+v_add_co_u32_e32 v96, vcc, s76, v96
+v_addc_co_u32_e64 v106, vcc, 0, 0, vcc
+v_mad_i32_i24 v96, v106, s75, v96
+v_mad_i32_i24 v98, v106, s80, v98
+v_mad_i32_i24 v97, v106, s79, v97
+v_cmp_ge_i32_e64 vcc, v97, 0
+v_addc_co_u32_e64 v106, vcc, 0, 0, vcc
+v_add_co_u32_e32 v98, vcc, v98, v106
+v_mad_i32_i24 v97, v106, s74, v97
+v_add_co_u32_e32 v97, vcc, s77, v97
+v_addc_co_u32_e64 v106, vcc, 0, 0, vcc
+v_add_co_u32_e32 v98, vcc, v98, v106
+v_mad_i32_i24 v97, v106, s74, v97
+v_add_co_u32_e32 v98, vcc, s78, v98
+s_mov_b32 s83, s84
+v_cmp_le_u32_e32 vcc, 0x100, v0
+s_cbranch_vccz 166
+v_subrev_co_u32_e32 v106, vcc, s75, v96
+v_subrev_co_u32_e32 v107, vcc, s74, v97
+s_bitcmp1_b32 s18, 22
+s_cbranch_scc0 64
+s_bitset0_b32 s18, 22
+s_bfe_u32 s52, s18, 0x10014
+v_mul_u32_u24_e32 v111, 3, v106
+v_mul_u32_u24_e32 v112, 3, v107
+v_cvt_pk_u16_u32 v114, v111, v112
+v_and_b32_e64 v111, v0, 1
+v_cmp_eq_u32_e64 vcc, v111, 1
+v_cndmask_b32_e32 v114, v98, v114, vcc
+v_lshrrev_b32_e32 v110, 1, v0
+v_bfe_u32 v115, v110, s52, 1
+v_lshrrev_b32_e32 v110, 1, v0
+v_bfi_b32 v110, 1, v0, v110
+v_lshrrev_b32_e32 v111, 2, v0
+v_bfi_b32 v111, 1, v0, v111
+v_cmp_eq_u32_e64 vcc, s52, 0
+v_cndmask_b32_e32 v110, v111, v110, vcc
+s_sub_u32 s52, 1, s52
+v_lshrrev_b32_e32 v111, s52, v110
+v_bfi_b32 v110, 32, v111, v110
+v_and_b32_e32 v110, 63, v110
+v_add_co_u32_e32 v111, vcc, 16, v110
+v_and_b32_e64 v112, v0, 2
+v_cmp_eq_u32_e64 vcc, v112, 0
+v_cndmask_b32_e32 v111, v111, v110, vcc
+v_lshlrev_b32_e32 v112, 14, v115
+v_mad_u32_u24 v111, 4, v111, v112
+v_add_co_u32_e32 v110, vcc, s96, v111
+ds_write_b32 v110, v114
+v_writelane_b32 v112, s18, 0
+v_writelane_b32 v112, s85, 1
+v_writelane_b32 v112, s84, 2
+v_and_b32_e64 v110, v0, 63
+v_cmp_ge_u32_e64 vcc, v110, 3
+v_mov_b32_e32 v113, 0x4000
+v_cndmask_b32_e32 v110, v110, v113, vcc
+v_mad_i32_i24 v110, v110, 4, s96
+ds_write_b32 v110, v112 offset:256
+s_add_u32 s96, s96, 0x18c
+s_cmp_eq_u32 s96, 0xffc0
+s_cselect_b32 s96, 0xc1e0, s96
+v_mov_b32_dpp v108, v98  quad_perm:[0,0,0,0] row_mask:0xf bank_mask:0xf
+v_mov_b32_dpp v106, v106  quad_perm:[0,0,0,0] row_mask:0xf bank_mask:0xf
+v_mov_b32_dpp v107, v107  quad_perm:[0,0,0,0] row_mask:0xf bank_mask:0xf
+v_readfirstlane_b32 s81, v108
+v_sub_co_u32_e64 v109, vcc, v108, s81
+v_mul_lo_u32 v109, v109, s65
+v_and_b32_e64 v113, v0, 3
+v_ashrrev_i32_e64 v114, 0, s31
+v_subrev_co_u32_e32 v113, vcc, v114, v113
+v_ashrrev_i32_e64 v114, 0, s62
+v_mad_i32_i24 v110, v114, 2, v113
+s_bfe_u32 s52, s18, 0x10014
+v_lshrrev_b32_e32 v112, 2, v0
+v_and_b32_e32 v112, s52, v112
+v_mad_i32_i24 v110, v112, 2, v110
+v_add_co_u32_e64 v111, vcc, 0, s63
+v_ashrrev_i32_e32 v111, 0, v111
+v_add_co_u32_e64 v112, vcc, 0, s30
+v_ashrrev_i32_e32 v112, 0, v112
+v_sub_i32 v111, v111, v112
+s_lshl_b32 s54, s15, 2
+v_cmp_ge_u32_e64 s[52:53], v108, s12
+v_mad_i32_i24 v106, v106, 3, v110
+v_cmp_ge_u32_e64 s[56:57], v106, s15
+v_mad_i32_i24 v106, 4, v106, v109
+s_or_b64 s[56:57], s[56:57], s[52:53]
+v_mad_i32_i24 v107, v107, 3, v111
+v_cmp_ge_u32_e64 s[58:59], v107, s14
+s_or_b64 s[58:59], s[56:57], s[58:59]
+v_mad_u32_u24 v82, v107, s54, v106
+v_cndmask_b32_e64 v82, v82, -1, s[58:59]
+v_add_co_u32_e32 v107, vcc, 1, v107
+v_cmp_ge_u32_e64 s[58:59], v107, s14
+s_or_b64 s[58:59], s[56:57], s[58:59]
+v_mad_u32_u24 v83, v107, s54, v106
+v_cndmask_b32_e64 v83, v83, -1, s[58:59]
+v_add_co_u32_e32 v107, vcc, 1, v107
+v_cmp_ge_u32_e64 s[58:59], v107, s14
+s_or_b64 s[58:59], s[56:57], s[58:59]
+v_mad_u32_u24 v84, v107, s54, v106
+v_cndmask_b32_e64 v84, v84, -1, s[58:59]
+v_add_co_u32_e32 v107, vcc, 1, v107
+v_cmp_ge_u32_e64 s[58:59], v107, s14
+s_or_b64 s[58:59], s[56:57], s[58:59]
+v_mad_u32_u24 v85, v107, s54, v106
+v_cndmask_b32_e64 v85, v85, -1, s[58:59]
+s_bitcmp1_b32 s18, 18
+s_cbranch_scc1 138
+s_lshr_b32 s52, -1, 16
+s_and_b32 s52, s52, s65
+s_lshr_b32 s53, s65, 16
+s_mul_i32 s53, s53, s81
+s_mul_i32 s40, s52, s81
+s_lshl_b32 s52, s53, 16
+s_lshr_b32 s53, s53, 16
+s_add_u32 s40, s52, s40
+s_addc_u32 s41, s53, 0
+s_add_u32 s40, s40, s20
+s_addc_u32 s41, s41, s21
+s_lshr_b32 s52, s18, 6
+s_xor_b32 s52, s52, s18
+s_and_b32 s52, s52, 0x80000
+s_cselect_b32 s52, s68, 0
+s_add_u32 s40, s40, s52
+s_addc_u32 s41, s41, 0
+s_branch 95
+s_bitcmp1_b32 s18, 18
+s_cbranch_scc1 117
+s_bfe_u32 s52, s18, 0x10014
+v_xor_b32_dpp v106, v0, v0  quad_perm:[0,0,2,2] row_mask:0xf bank_mask:0xf
+v_bfe_u32 v108, v0, 2, s52
+v_mad_u32_u24 v106, v108, 2, v106
+v_mad_u32_u24 v106, s62, 2, v106
+v_sub_co_u32_e32 v108, vcc, s29, v106
+v_sub_co_u32_e64 v108, vcc, v108, 1
+s_bfe_u32 s54, s18, 0x10001
+v_cmp_eq_u32_e64 vcc, s54, 1
+v_cndmask_b32_e32 v106, v106, v108, vcc
+v_cmp_ge_u32_e64 s[52:53], v106, s29
+v_lshlrev_b32_e32 v106, 2, v106
+s_bfe_u32 s54, s18, 0x10018
+v_bfe_u32 v109, v0, 2, s54
+v_mul_lo_u32 v109, s68, v109
+v_add_co_u32_e32 v106, vcc, v106, v109
+v_mul_lo_u32 v107, s90, v99
+v_add_co_u32_e32 v107, vcc, v107, v106
+s_sub_u32 s54, s28, s63
+s_sub_u32 s54, s54, 2
+s_bitcmp1_b32 s18, 0
+s_cselect_b32 s54, s54, s63
+v_mov_b32_e32 v109, s54
+s_lshl_b32 s57, s29, 2
+v_cmp_ge_u32_e64 s[54:55], v109, s28
+v_mad_i32_i24 v82, v109, s57, v107
+s_or_b64 s[54:55], s[54:55], s[52:53]
+v_cndmask_b32_e64 v82, v82, -1, s[54:55]
+v_mov_b32_e32 v83, v82
+v_add_co_u32_e64 v109, vcc, v109, 1
+v_cmp_ge_u32_e64 s[54:55], v109, s28
+v_mad_i32_i24 v85, v109, s57, v107
+s_or_b64 s[54:55], s[54:55], s[52:53]
+v_cndmask_b32_e64 v85, v85, -1, s[54:55]
+v_add_co_u32_e64 v109, vcc, v109, 1
+v_cmp_ge_u32_e64 s[54:55], v109, s28
+v_mad_i32_i24 v84, v109, s57, v107
+s_or_b64 s[54:55], s[54:55], s[52:53]
+v_cndmask_b32_e64 v84, v84, -1, s[54:55]
+s_bitcmp1_b32 s18, 0
+s_cselect_b64 vcc, -1, 0
+v_cndmask_b32_e32 v82, v83, v85, vcc
+v_cndmask_b32_e32 v85, v85, v83, vcc
+v_add_co_u32_e64 v106, vcc, v99, s83
+v_cmp_lt_u32_e64 vcc, v106, s16
+v_cndmask_b32_e32 v82, -1, v82, vcc
+v_cndmask_b32_e32 v83, -1, v83, vcc
+v_cndmask_b32_e32 v84, -1, v84, vcc
+v_cndmask_b32_e32 v85, -1, v85, vcc
+s_lshr_b32 s52, -1, 16
+s_and_b32 s52, s52, s90
+s_lshr_b32 s53, s90, 16
+s_mul_i32 s53, s53, s83
+s_mul_i32 s40, s52, s83
+s_lshl_b32 s52, s53, 16
+s_lshr_b32 s53, s53, 16
+s_add_u32 s40, s52, s40
+s_addc_u32 s41, s53, 0
+s_add_u32 s40, s40, s22
+s_addc_u32 s41, s41, s23
+s_lshr_b32 s52, s18, 6
+s_xor_b32 s52, s52, s18
+s_and_b32 s52, s52, 0x80000
+s_cselect_b32 s52, s68, 0
+s_add_u32 s40, s40, s52
+s_addc_u32 s41, s41, 0
+s_mov_b32 s43, 0x20000
+s_mov_b32 s73, -1
+s_bfe_u32 s52, s18, 0x10014
+s_lshl_b32 s82, s13, s52
+s_bfe_u32 s52, s18, 0x10013
+s_bfe_u32 s54, s18, 0x10019
+s_xor_b32 s52, s52, s54
+s_cselect_b32 s52, 1, 0
+s_cselect_b32 s43, 0x20000, s43
+s_and_b32 s52, s52, s82
+s_sub_u32 s82, s82, s52
+s_bitcmp1_b32 s18, 20
+s_cselect_b32 s52, 0, 0x2000000
+s_bitcmp1_b32 s13, 0
+s_cselect_b32 s52, s52, 0
+s_xor_b32 s18, s18, s52
+s_cmp_eq_u32 s82, 0
+s_cbranch_scc1 1
+s_branch 64948
+s_and_b32 s52, 0x900000, s18
+s_subb_u32 s62, s62, 1
+s_cbranch_scc0 65243
+s_and_b32 s52, 0x900000, s18
+s_subb_u32 s62, s61, 1
+s_add_u32 s63, s63, 2
+s_cmp_ge_u32 s63, s28
+s_cbranch_scc0 65237
+s_mov_b32 s63, 0
+s_branch 65204
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_mov_b32 s52, 0x3c3c3c3c
+s_mov_b32 s53, s52
+v_mov_b32_e32 v107, v3
+v_mov_b32_e32 v108, v4
+v_mov_b32_e32 v109, v5
+s_waitcnt lgkmcnt(0)
+v_mov_b32_e32 v106, v2
+v_add_f32_dpp v106, v2, v2  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v107, v3, v3  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v108, v4, v4  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v109, v5, v5  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v4, v4, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v5, v5, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v2, v2, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v3, v3, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mov_b32_dpp v3, v4  row_mirror row_mask:0xf bank_mask:0x3
+v_mov_b32_dpp v2, v5  row_mirror row_mask:0xf bank_mask:0x3
+v_add_f32_dpp v107, v108, v107  row_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v106, v109, v106  row_mirror row_mask:0xf bank_mask:0xf
+v_sub_f32_dpp v109, v3, v3  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_add_f32_dpp v3, v3, v3  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_sub_f32_dpp v108, v2, v2  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_add_f32_dpp v2, v2, v2  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mov_b32_e32 v5, v107
+v_add_f32_dpp v5, v107, v107  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mov_b32_dpp v108, v109  row_ror:12 row_mask:0xf bank_mask:0x1
+v_mov_b32_dpp v108, v109  row_ror:4 row_mask:0xf bank_mask:0x8
+v_mov_b32_e32 v4, v106
+v_add_f32_dpp v4, v106, v106  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mov_b32_dpp v108, v108  quad_perm:[1,1,1,1] row_mask:0xf bank_mask:0x3
+v_sub_f32_dpp v109, v107, v107  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_add_f32_dpp v3, v3, v2  row_half_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v2, v5, v4  row_half_mirror row_mask:0xf bank_mask:0xf
+v_sub_f32_dpp v4, v106, v106  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mov_b32_dpp v4, v109  row_half_mirror row_mask:0xf bank_mask:0x9
+v_mov_b32_dpp v108, v108  quad_perm:[2,2,2,2] row_mask:0xf bank_mask:0xc
+v_cndmask_b32_e64 v3, v108, v3, s[52:53]
+v_mov_b32_dpp v4, v4  quad_perm:[0,0,2,2] row_mask:0xf bank_mask:0x5
+s_nop 1
+v_mov_b32_dpp v4, v4  quad_perm:[1,1,3,3] row_mask:0xf bank_mask:0xa
+v_mov_b32_e32 v107, v7
+v_mov_b32_e32 v108, v8
+v_mov_b32_e32 v109, v9
+s_waitcnt lgkmcnt(0)
+v_mov_b32_e32 v106, v6
+v_add_f32_dpp v106, v6, v6  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v107, v7, v7  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v108, v8, v8  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v109, v9, v9  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v8, v8, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v9, v9, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v6, v6, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v7, v7, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mov_b32_dpp v7, v8  row_mirror row_mask:0xf bank_mask:0x3
+v_mov_b32_dpp v6, v9  row_mirror row_mask:0xf bank_mask:0x3
+v_add_f32_dpp v107, v108, v107  row_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v106, v109, v106  row_mirror row_mask:0xf bank_mask:0xf
+v_sub_f32_dpp v109, v7, v7  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_add_f32_dpp v7, v7, v7  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_sub_f32_dpp v108, v6, v6  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_add_f32_dpp v6, v6, v6  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mov_b32_e32 v9, v107
+v_add_f32_dpp v9, v107, v107  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mov_b32_dpp v108, v109  row_ror:12 row_mask:0xf bank_mask:0x1
+v_mov_b32_dpp v108, v109  row_ror:4 row_mask:0xf bank_mask:0x8
+v_mov_b32_e32 v8, v106
+v_add_f32_dpp v8, v106, v106  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mov_b32_dpp v108, v108  quad_perm:[1,1,1,1] row_mask:0xf bank_mask:0x3
+v_sub_f32_dpp v109, v107, v107  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_add_f32_dpp v7, v7, v6  row_half_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v5, v9, v8  row_half_mirror row_mask:0xf bank_mask:0xf
+v_sub_f32_dpp v8, v106, v106  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mov_b32_dpp v8, v109  row_half_mirror row_mask:0xf bank_mask:0x9
+v_mov_b32_dpp v108, v108  quad_perm:[2,2,2,2] row_mask:0xf bank_mask:0xc
+v_cndmask_b32_e64 v6, v108, v7, s[52:53]
+v_mov_b32_dpp v7, v8  quad_perm:[0,0,2,2] row_mask:0xf bank_mask:0x5
+s_nop 1
+v_mov_b32_dpp v7, v8  quad_perm:[1,1,3,3] row_mask:0xf bank_mask:0xa
+v_mov_b32_e32 v107, v11
+v_mov_b32_e32 v108, v12
+v_mov_b32_e32 v109, v13
+s_waitcnt lgkmcnt(0)
+v_mov_b32_e32 v106, v10
+v_add_f32_dpp v106, v10, v10  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v107, v11, v11  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v108, v12, v12  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v109, v13, v13  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v12, v12, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v13, v13, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v10, v10, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v11, v11, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mov_b32_dpp v11, v12  row_mirror row_mask:0xf bank_mask:0x3
+v_mov_b32_dpp v10, v13  row_mirror row_mask:0xf bank_mask:0x3
+v_add_f32_dpp v107, v108, v107  row_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v106, v109, v106  row_mirror row_mask:0xf bank_mask:0xf
+v_sub_f32_dpp v109, v11, v11  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_add_f32_dpp v11, v11, v11  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_sub_f32_dpp v108, v10, v10  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_add_f32_dpp v10, v10, v10  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mov_b32_e32 v13, v107
+v_add_f32_dpp v13, v107, v107  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mov_b32_dpp v108, v109  row_ror:12 row_mask:0xf bank_mask:0x1
+v_mov_b32_dpp v108, v109  row_ror:4 row_mask:0xf bank_mask:0x8
+v_mov_b32_e32 v12, v106
+v_add_f32_dpp v12, v106, v106  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mov_b32_dpp v108, v108  quad_perm:[1,1,1,1] row_mask:0xf bank_mask:0x3
+v_sub_f32_dpp v109, v107, v107  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_add_f32_dpp v11, v11, v10  row_half_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v8, v13, v12  row_half_mirror row_mask:0xf bank_mask:0xf
+v_sub_f32_dpp v12, v106, v106  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mov_b32_dpp v12, v109  row_half_mirror row_mask:0xf bank_mask:0x9
+v_mov_b32_dpp v108, v108  quad_perm:[2,2,2,2] row_mask:0xf bank_mask:0xc
+v_cndmask_b32_e64 v9, v108, v11, s[52:53]
+v_mov_b32_dpp v10, v12  quad_perm:[0,0,2,2] row_mask:0xf bank_mask:0x5
+s_nop 1
+v_mov_b32_dpp v10, v12  quad_perm:[1,1,3,3] row_mask:0xf bank_mask:0xa
+v_mov_b32_e32 v107, v15
+v_mov_b32_e32 v108, v16
+v_mov_b32_e32 v109, v17
+s_waitcnt lgkmcnt(0)
+v_mov_b32_e32 v106, v14
+v_add_f32_dpp v106, v14, v14  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v107, v15, v15  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v108, v16, v16  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v109, v17, v17  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v16, v16, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v17, v17, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v14, v14, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v15, v15, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mov_b32_dpp v15, v16  row_mirror row_mask:0xf bank_mask:0x3
+v_mov_b32_dpp v14, v17  row_mirror row_mask:0xf bank_mask:0x3
+v_add_f32_dpp v107, v108, v107  row_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v106, v109, v106  row_mirror row_mask:0xf bank_mask:0xf
+v_sub_f32_dpp v109, v15, v15  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_add_f32_dpp v15, v15, v15  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_sub_f32_dpp v108, v14, v14  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_add_f32_dpp v14, v14, v14  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mov_b32_e32 v17, v107
+v_add_f32_dpp v17, v107, v107  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mov_b32_dpp v108, v109  row_ror:12 row_mask:0xf bank_mask:0x1
+v_mov_b32_dpp v108, v109  row_ror:4 row_mask:0xf bank_mask:0x8
+v_mov_b32_e32 v16, v106
+v_add_f32_dpp v16, v106, v106  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mov_b32_dpp v108, v108  quad_perm:[1,1,1,1] row_mask:0xf bank_mask:0x3
+v_sub_f32_dpp v109, v107, v107  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_add_f32_dpp v15, v15, v14  row_half_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v11, v17, v16  row_half_mirror row_mask:0xf bank_mask:0xf
+v_sub_f32_dpp v16, v106, v106  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mov_b32_dpp v16, v109  row_half_mirror row_mask:0xf bank_mask:0x9
+v_mov_b32_dpp v108, v108  quad_perm:[2,2,2,2] row_mask:0xf bank_mask:0xc
+v_cndmask_b32_e64 v12, v108, v15, s[52:53]
+v_mov_b32_dpp v13, v16  quad_perm:[0,0,2,2] row_mask:0xf bank_mask:0x5
+s_nop 1
+v_mov_b32_dpp v13, v16  quad_perm:[1,1,3,3] row_mask:0xf bank_mask:0xa
+v_mov_b32_e32 v107, v19
+v_mov_b32_e32 v108, v20
+v_mov_b32_e32 v109, v21
+s_waitcnt lgkmcnt(0)
+v_mov_b32_e32 v106, v18
+v_add_f32_dpp v106, v18, v18  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v107, v19, v19  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v108, v20, v20  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v109, v21, v21  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v20, v20, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v21, v21, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v18, v18, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v19, v19, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mov_b32_dpp v19, v20  row_mirror row_mask:0xf bank_mask:0x3
+v_mov_b32_dpp v18, v21  row_mirror row_mask:0xf bank_mask:0x3
+v_add_f32_dpp v107, v108, v107  row_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v106, v109, v106  row_mirror row_mask:0xf bank_mask:0xf
+v_sub_f32_dpp v109, v19, v19  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_add_f32_dpp v19, v19, v19  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_sub_f32_dpp v108, v18, v18  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_add_f32_dpp v18, v18, v18  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mov_b32_e32 v21, v107
+v_add_f32_dpp v21, v107, v107  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mov_b32_dpp v108, v109  row_ror:12 row_mask:0xf bank_mask:0x1
+v_mov_b32_dpp v108, v109  row_ror:4 row_mask:0xf bank_mask:0x8
+v_mov_b32_e32 v20, v106
+v_add_f32_dpp v20, v106, v106  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mov_b32_dpp v108, v108  quad_perm:[1,1,1,1] row_mask:0xf bank_mask:0x3
+v_sub_f32_dpp v109, v107, v107  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_add_f32_dpp v19, v19, v18  row_half_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v14, v21, v20  row_half_mirror row_mask:0xf bank_mask:0xf
+v_sub_f32_dpp v20, v106, v106  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mov_b32_dpp v20, v109  row_half_mirror row_mask:0xf bank_mask:0x9
+v_mov_b32_dpp v108, v108  quad_perm:[2,2,2,2] row_mask:0xf bank_mask:0xc
+v_cndmask_b32_e64 v15, v108, v19, s[52:53]
+v_mov_b32_dpp v16, v20  quad_perm:[0,0,2,2] row_mask:0xf bank_mask:0x5
+s_nop 1
+v_mov_b32_dpp v16, v20  quad_perm:[1,1,3,3] row_mask:0xf bank_mask:0xa
+v_mov_b32_e32 v107, v23
+v_mov_b32_e32 v108, v24
+v_mov_b32_e32 v109, v25
+s_waitcnt lgkmcnt(0)
+v_mov_b32_e32 v106, v22
+v_add_f32_dpp v106, v22, v22  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v107, v23, v23  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v108, v24, v24  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v109, v25, v25  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v24, v24, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v25, v25, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v22, v22, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v23, v23, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mov_b32_dpp v23, v24  row_mirror row_mask:0xf bank_mask:0x3
+v_mov_b32_dpp v22, v25  row_mirror row_mask:0xf bank_mask:0x3
+v_add_f32_dpp v107, v108, v107  row_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v106, v109, v106  row_mirror row_mask:0xf bank_mask:0xf
+v_sub_f32_dpp v109, v23, v23  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_add_f32_dpp v23, v23, v23  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_sub_f32_dpp v108, v22, v22  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_add_f32_dpp v22, v22, v22  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mov_b32_e32 v25, v107
+v_add_f32_dpp v25, v107, v107  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mov_b32_dpp v108, v109  row_ror:12 row_mask:0xf bank_mask:0x1
+v_mov_b32_dpp v108, v109  row_ror:4 row_mask:0xf bank_mask:0x8
+v_mov_b32_e32 v24, v106
+v_add_f32_dpp v24, v106, v106  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mov_b32_dpp v108, v108  quad_perm:[1,1,1,1] row_mask:0xf bank_mask:0x3
+v_sub_f32_dpp v109, v107, v107  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_add_f32_dpp v23, v23, v22  row_half_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v17, v25, v24  row_half_mirror row_mask:0xf bank_mask:0xf
+v_sub_f32_dpp v24, v106, v106  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mov_b32_dpp v24, v109  row_half_mirror row_mask:0xf bank_mask:0x9
+v_mov_b32_dpp v108, v108  quad_perm:[2,2,2,2] row_mask:0xf bank_mask:0xc
+v_cndmask_b32_e64 v18, v108, v23, s[52:53]
+v_mov_b32_dpp v19, v24  quad_perm:[0,0,2,2] row_mask:0xf bank_mask:0x5
+s_nop 1
+v_mov_b32_dpp v19, v24  quad_perm:[1,1,3,3] row_mask:0xf bank_mask:0xa
+v_mov_b32_e32 v107, v27
+v_mov_b32_e32 v108, v28
+v_mov_b32_e32 v109, v29
+s_waitcnt lgkmcnt(0)
+v_mov_b32_e32 v106, v26
+v_add_f32_dpp v106, v26, v26  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v107, v27, v27  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v108, v28, v28  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v109, v29, v29  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v28, v28, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v29, v29, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v26, v26, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v27, v27, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mov_b32_dpp v27, v28  row_mirror row_mask:0xf bank_mask:0x3
+v_mov_b32_dpp v26, v29  row_mirror row_mask:0xf bank_mask:0x3
+v_add_f32_dpp v107, v108, v107  row_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v106, v109, v106  row_mirror row_mask:0xf bank_mask:0xf
+v_sub_f32_dpp v109, v27, v27  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_add_f32_dpp v27, v27, v27  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_sub_f32_dpp v108, v26, v26  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_add_f32_dpp v26, v26, v26  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mov_b32_e32 v29, v107
+v_add_f32_dpp v29, v107, v107  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mov_b32_dpp v108, v109  row_ror:12 row_mask:0xf bank_mask:0x1
+v_mov_b32_dpp v108, v109  row_ror:4 row_mask:0xf bank_mask:0x8
+v_mov_b32_e32 v28, v106
+v_add_f32_dpp v28, v106, v106  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mov_b32_dpp v108, v108  quad_perm:[1,1,1,1] row_mask:0xf bank_mask:0x3
+v_sub_f32_dpp v109, v107, v107  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_add_f32_dpp v27, v27, v26  row_half_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v20, v29, v28  row_half_mirror row_mask:0xf bank_mask:0xf
+v_sub_f32_dpp v28, v106, v106  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mov_b32_dpp v28, v109  row_half_mirror row_mask:0xf bank_mask:0x9
+v_mov_b32_dpp v108, v108  quad_perm:[2,2,2,2] row_mask:0xf bank_mask:0xc
+v_cndmask_b32_e64 v21, v108, v27, s[52:53]
+v_mov_b32_dpp v22, v28  quad_perm:[0,0,2,2] row_mask:0xf bank_mask:0x5
+s_nop 1
+v_mov_b32_dpp v22, v28  quad_perm:[1,1,3,3] row_mask:0xf bank_mask:0xa
+v_mov_b32_e32 v107, v31
+v_mov_b32_e32 v108, v32
+v_mov_b32_e32 v109, v33
+s_waitcnt lgkmcnt(0)
+v_mov_b32_e32 v106, v30
+v_add_f32_dpp v106, v30, v30  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v107, v31, v31  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v108, v32, v32  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_add_f32_dpp v109, v33, v33  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v32, v32, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v33, v33, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v30, v30, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mac_f32_dpp v31, v31, v101  quad_perm:[2,3,0,1] row_mask:0xf bank_mask:0xc
+v_mov_b32_dpp v31, v32  row_mirror row_mask:0xf bank_mask:0x3
+v_mov_b32_dpp v30, v33  row_mirror row_mask:0xf bank_mask:0x3
+v_add_f32_dpp v107, v108, v107  row_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v106, v109, v106  row_mirror row_mask:0xf bank_mask:0xf
+v_sub_f32_dpp v109, v31, v31  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_add_f32_dpp v31, v31, v31  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_sub_f32_dpp v108, v30, v30  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_add_f32_dpp v30, v30, v30  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mov_b32_e32 v33, v107
+v_add_f32_dpp v33, v107, v107  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mov_b32_dpp v108, v109  row_ror:12 row_mask:0xf bank_mask:0x1
+v_mov_b32_dpp v108, v109  row_ror:4 row_mask:0xf bank_mask:0x8
+v_mov_b32_e32 v32, v106
+v_add_f32_dpp v32, v106, v106  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mov_b32_dpp v108, v108  quad_perm:[1,1,1,1] row_mask:0xf bank_mask:0x3
+v_sub_f32_dpp v109, v107, v107  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_add_f32_dpp v31, v31, v30  row_half_mirror row_mask:0xf bank_mask:0xf
+v_add_f32_dpp v23, v33, v32  row_half_mirror row_mask:0xf bank_mask:0xf
+v_sub_f32_dpp v32, v106, v106  quad_perm:[1,0,3,2] row_mask:0xf bank_mask:0x6
+v_mov_b32_dpp v32, v109  row_half_mirror row_mask:0xf bank_mask:0x9
+v_mov_b32_dpp v108, v108  quad_perm:[2,2,2,2] row_mask:0xf bank_mask:0xc
+v_cndmask_b32_e64 v24, v108, v31, s[52:53]
+v_mov_b32_dpp v25, v32  quad_perm:[0,0,2,2] row_mask:0xf bank_mask:0x5
+s_nop 1
+v_mov_b32_dpp v25, v32  quad_perm:[1,1,3,3] row_mask:0xf bank_mask:0xa
+s_waitcnt vmcnt(0)
+v_readlane_b32 s55, v104, 0
+v_add_f32_e64 v2, v2, s55
+v_mul_f32_e64 v106, v2, s36
+v_cmp_lt_f32_e64 vcc, v2, 0
+v_cndmask_b32_e32 v2, v2, v106, vcc
+v_add_f32_e64 v3, v3, s55
+v_mul_f32_e64 v106, v3, s36
+v_cmp_lt_f32_e64 vcc, v3, 0
+v_cndmask_b32_e32 v3, v3, v106, vcc
+v_add_f32_e64 v4, v4, s55
+v_mul_f32_e64 v106, v4, s36
+v_cmp_lt_f32_e64 vcc, v4, 0
+v_cndmask_b32_e32 v4, v4, v106, vcc
+buffer_store_dword v2, v86, s[44:47], 0 offen
+buffer_store_dword v3, v87, s[44:47], 0 offen
+buffer_store_dword v4, v88, s[44:47], 0 offen
+s_add_u32 s44, s44, s67
+s_addc_u32 s45, s45, 0
+s_sub_u32 s93, s93, 1
+s_cselect_b32 s47, 0, s47
+v_readlane_b32 s55, v104, 1
+v_add_f32_e64 v5, v5, s55
+v_mul_f32_e64 v106, v5, s36
+v_cmp_lt_f32_e64 vcc, v5, 0
+v_cndmask_b32_e32 v5, v5, v106, vcc
+v_add_f32_e64 v6, v6, s55
+v_mul_f32_e64 v106, v6, s36
+v_cmp_lt_f32_e64 vcc, v6, 0
+v_cndmask_b32_e32 v6, v6, v106, vcc
+v_add_f32_e64 v7, v7, s55
+v_mul_f32_e64 v106, v7, s36
+v_cmp_lt_f32_e64 vcc, v7, 0
+v_cndmask_b32_e32 v7, v7, v106, vcc
+buffer_store_dword v5, v86, s[44:47], 0 offen
+buffer_store_dword v6, v87, s[44:47], 0 offen
+buffer_store_dword v7, v88, s[44:47], 0 offen
+s_add_u32 s44, s44, s67
+s_addc_u32 s45, s45, 0
+s_sub_u32 s93, s93, 1
+s_cselect_b32 s47, 0, s47
+v_readlane_b32 s55, v104, 2
+v_add_f32_e64 v8, v8, s55
+v_mul_f32_e64 v106, v8, s36
+v_cmp_lt_f32_e64 vcc, v8, 0
+v_cndmask_b32_e32 v8, v8, v106, vcc
+v_add_f32_e64 v9, v9, s55
+v_mul_f32_e64 v106, v9, s36
+v_cmp_lt_f32_e64 vcc, v9, 0
+v_cndmask_b32_e32 v9, v9, v106, vcc
+v_add_f32_e64 v10, v10, s55
+v_mul_f32_e64 v106, v10, s36
+v_cmp_lt_f32_e64 vcc, v10, 0
+v_cndmask_b32_e32 v10, v10, v106, vcc
+buffer_store_dword v8, v86, s[44:47], 0 offen
+buffer_store_dword v9, v87, s[44:47], 0 offen
+buffer_store_dword v10, v88, s[44:47], 0 offen
+s_add_u32 s44, s44, s67
+s_addc_u32 s45, s45, 0
+s_sub_u32 s93, s93, 1
+s_cselect_b32 s47, 0, s47
+v_readlane_b32 s55, v104, 3
+v_add_f32_e64 v11, v11, s55
+v_mul_f32_e64 v106, v11, s36
+v_cmp_lt_f32_e64 vcc, v11, 0
+v_cndmask_b32_e32 v11, v11, v106, vcc
+v_add_f32_e64 v12, v12, s55
+v_mul_f32_e64 v106, v12, s36
+v_cmp_lt_f32_e64 vcc, v12, 0
+v_cndmask_b32_e32 v12, v12, v106, vcc
+v_add_f32_e64 v13, v13, s55
+v_mul_f32_e64 v106, v13, s36
+v_cmp_lt_f32_e64 vcc, v13, 0
+v_cndmask_b32_e32 v13, v13, v106, vcc
+buffer_store_dword v11, v86, s[44:47], 0 offen
+buffer_store_dword v12, v87, s[44:47], 0 offen
+buffer_store_dword v13, v88, s[44:47], 0 offen
+s_add_u32 s44, s44, s67
+s_addc_u32 s45, s45, 0
+s_sub_u32 s93, s93, 1
+s_cselect_b32 s47, 0, s47
+s_lshl_b32 s52, s67, 2
+s_add_u32 s44, s44, s52
+s_addc_u32 s45, s45, 0
+s_sub_u32 s93, s93, 4
+s_cselect_b32 s47, 0, s47
+v_readlane_b32 s55, v104, 8
+v_add_f32_e64 v14, v14, s55
+v_mul_f32_e64 v106, v14, s36
+v_cmp_lt_f32_e64 vcc, v14, 0
+v_cndmask_b32_e32 v14, v14, v106, vcc
+v_add_f32_e64 v15, v15, s55
+v_mul_f32_e64 v106, v15, s36
+v_cmp_lt_f32_e64 vcc, v15, 0
+v_cndmask_b32_e32 v15, v15, v106, vcc
+v_add_f32_e64 v16, v16, s55
+v_mul_f32_e64 v106, v16, s36
+v_cmp_lt_f32_e64 vcc, v16, 0
+v_cndmask_b32_e32 v16, v16, v106, vcc
+buffer_store_dword v14, v86, s[44:47], 0 offen
+buffer_store_dword v15, v87, s[44:47], 0 offen
+buffer_store_dword v16, v88, s[44:47], 0 offen
+s_add_u32 s44, s44, s67
+s_addc_u32 s45, s45, 0
+s_sub_u32 s93, s93, 1
+s_cselect_b32 s47, 0, s47
+v_readlane_b32 s55, v104, 9
+v_add_f32_e64 v17, v17, s55
+v_mul_f32_e64 v106, v17, s36
+v_cmp_lt_f32_e64 vcc, v17, 0
+v_cndmask_b32_e32 v17, v17, v106, vcc
+v_add_f32_e64 v18, v18, s55
+v_mul_f32_e64 v106, v18, s36
+v_cmp_lt_f32_e64 vcc, v18, 0
+v_cndmask_b32_e32 v18, v18, v106, vcc
+v_add_f32_e64 v19, v19, s55
+v_mul_f32_e64 v106, v19, s36
+v_cmp_lt_f32_e64 vcc, v19, 0
+v_cndmask_b32_e32 v19, v19, v106, vcc
+buffer_store_dword v17, v86, s[44:47], 0 offen
+buffer_store_dword v18, v87, s[44:47], 0 offen
+buffer_store_dword v19, v88, s[44:47], 0 offen
+s_add_u32 s44, s44, s67
+s_addc_u32 s45, s45, 0
+s_sub_u32 s93, s93, 1
+s_cselect_b32 s47, 0, s47
+v_readlane_b32 s55, v104, 10
+v_add_f32_e64 v20, v20, s55
+v_mul_f32_e64 v106, v20, s36
+v_cmp_lt_f32_e64 vcc, v20, 0
+v_cndmask_b32_e32 v20, v20, v106, vcc
+v_add_f32_e64 v21, v21, s55
+v_mul_f32_e64 v106, v21, s36
+v_cmp_lt_f32_e64 vcc, v21, 0
+v_cndmask_b32_e32 v21, v21, v106, vcc
+v_add_f32_e64 v22, v22, s55
+v_mul_f32_e64 v106, v22, s36
+v_cmp_lt_f32_e64 vcc, v22, 0
+v_cndmask_b32_e32 v22, v22, v106, vcc
+buffer_store_dword v20, v86, s[44:47], 0 offen
+buffer_store_dword v21, v87, s[44:47], 0 offen
+buffer_store_dword v22, v88, s[44:47], 0 offen
+s_add_u32 s44, s44, s67
+s_addc_u32 s45, s45, 0
+s_sub_u32 s93, s93, 1
+s_cselect_b32 s47, 0, s47
+v_readlane_b32 s55, v104, 11
+v_add_f32_e64 v23, v23, s55
+v_mul_f32_e64 v106, v23, s36
+v_cmp_lt_f32_e64 vcc, v23, 0
+v_cndmask_b32_e32 v23, v23, v106, vcc
+v_add_f32_e64 v24, v24, s55
+v_mul_f32_e64 v106, v24, s36
+v_cmp_lt_f32_e64 vcc, v24, 0
+v_cndmask_b32_e32 v24, v24, v106, vcc
+v_add_f32_e64 v25, v25, s55
+v_mul_f32_e64 v106, v25, s36
+v_cmp_lt_f32_e64 vcc, v25, 0
+v_cndmask_b32_e32 v25, v25, v106, vcc
+buffer_store_dword v23, v86, s[44:47], 0 offen
+buffer_store_dword v24, v87, s[44:47], 0 offen
+buffer_store_dword v25, v88, s[44:47], 0 offen
+s_add_u32 s44, s44, s67
+s_addc_u32 s45, s45, 0
+s_sub_u32 s93, s93, 1
+s_cselect_b32 s47, 0, s47
+s_add_u32 s44, s44, s52
+s_addc_u32 s45, s45, 0
+s_lshl_b32 s52, s52, 2
+s_add_u32 s44, s44, s52
+s_addc_u32 s45, s45, 0
+s_sub_u32 s93, s93, 20
+s_cselect_b32 s47, 0, s47
+s_cselect_b32 s51, 0, s51
+s_add_u32 s48, s48, 0x80
+s_addc_u32 s49, s49, 0
+s_sub_u32 s50, s50, 0x80
+s_cselect_b32 s51, 0, s51
+v_mov_b32_e32 v2, 0
+v_mov_b32_e32 v3, 0
+v_mov_b32_e32 v4, 0
+v_mov_b32_e32 v5, 0
+v_mov_b32_e32 v6, 0
+v_mov_b32_e32 v7, 0
+v_mov_b32_e32 v8, 0
+v_mov_b32_e32 v9, 0
+v_mov_b32_e32 v10, 0
+v_mov_b32_e32 v11, 0
+v_mov_b32_e32 v12, 0
+v_mov_b32_e32 v13, 0
+v_mov_b32_e32 v14, 0
+v_mov_b32_e32 v15, 0
+v_mov_b32_e32 v16, 0
+v_mov_b32_e32 v17, 0
+v_mov_b32_e32 v18, 0
+v_mov_b32_e32 v19, 0
+v_mov_b32_e32 v20, 0
+v_mov_b32_e32 v21, 0
+v_mov_b32_e32 v22, 0
+v_mov_b32_e32 v23, 0
+v_mov_b32_e32 v24, 0
+v_mov_b32_e32 v25, 0
+v_mov_b32_e32 v26, 0
+v_mov_b32_e32 v27, 0
+v_mov_b32_e32 v28, 0
+v_mov_b32_e32 v29, 0
+v_mov_b32_e32 v30, 0
+v_mov_b32_e32 v31, 0
+v_mov_b32_e32 v32, 0
+v_mov_b32_e32 v33, 0
+s_xor_b32 s18, s18, 0x200000
+s_mul_i32 s94, s60, s61
+s_mul_i32 s94, s94, s13
+s_add_u32 s52, s93, s92
+s_cmp_lt_i32 s52, 0
+s_cbranch_scc0 156
+v_and_b32_e32 v86, 0x7f, v0
+v_lshrrev_b32_e32 v86, 1, v86
+v_bfi_b32 v86, 1, v0, v86
+v_and_b32_e64 v87, v0, 2
+v_mad_u32_u24 v86, v87, 16, v86
+v_lshlrev_b32_e32 v86, 2, v86
+v_add_co_u32_e64 v86, vcc, v86, s97
+v_and_b32_e32 v87, 3, v0
+v_lshlrev_b32_e32 v87, 2, v87
+v_add_co_u32_e64 v87, vcc, v87, s97
+ds_read_b32 v108, v87 offset:256
+ds_read_b32 v86, v86
+s_add_u32 s97, s97, 0x18c
+s_cmp_eq_u32 s97, 0xffc0
+s_cselect_b32 s97, 0xc1e0, s97
+s_waitcnt lgkmcnt(0)
+v_readfirstlane_b32 s95, v86
+v_readlane_b32 s54, v108, 0
+s_bitcmp1_b32 s54, 18
+s_cbranch_scc1 131
+v_readlane_b32 s52, v108, 1
+v_readlane_b32 s53, v108, 2
+s_add_u32 s93, s92, s53
+s_lshr_b32 s55, -1, 16
+s_and_b32 s55, s55, s66
+s_lshr_b32 s56, s66, 16
+s_mul_i32 s56, s56, s95
+s_mul_i32 s44, s55, s95
+s_lshl_b32 s55, s56, 16
+s_lshr_b32 s56, s56, 16
+s_add_u32 s44, s55, s44
+s_addc_u32 s45, s56, 0
+s_add_u32 s44, s44, s24
+s_addc_u32 s45, s45, s25
+s_mul_i32 s55, s67, s93
+s_add_u32 s44, s44, s55
+s_addc_u32 s45, s45, 0
+s_mov_b32 s47, 0x20000
+s_bitcmp1_b32 s18, 7
+s_cselect_b32 s51, 0x20000, 0
+s_lshl_b32 s55, s93, 2
+s_add_u32 s48, s34, s55
+s_addc_u32 s49, s35, 0
+s_lshl_b32 s56, s52, 2
+s_sub_u32 s50, s56, s55
+s_cselect_b32 s51, 0, s51
+s_sub_u32 s93, s52, s53
+s_sub_u32 s93, s93, 1
+s_sub_u32 s93, s93, s92
+s_cselect_b32 s47, 0, s47
+v_bfe_u32 v106, v86, 16, 16
+v_bfe_u32 v107, v86, 0, 16
+v_and_b32_e64 v108, v0, 7
+v_sub_co_u32_e32 v109, vcc, 7, v108
+v_min_u32_e32 v108, v108, v109
+v_bfe_u32 v109, v108, 1, 1
+v_bfe_u32 v108, v108, 0, 1
+v_mov_b32_dpp v106, v106  quad_perm:[1,1,1,1] row_mask:0xf bank_mask:0xf
+v_mov_b32_dpp v107, v107  quad_perm:[1,1,1,1] row_mask:0xf bank_mask:0xf
+v_add_co_u32_e32 v106, vcc, v106, v109
+v_add_co_u32_e32 v107, vcc, v107, v108
+v_mov_b32_dpp v108, v86  quad_perm:[0,0,0,0] row_mask:0xf bank_mask:0xf
+v_cmp_ge_u32_e64 s[52:53], v108, s12
+v_sub_co_u32_e64 v108, vcc, v108, s95
+v_mul_lo_u32 v108, v108, s66
+v_xor_b32_dpp v109, v0, v0  quad_perm:[0,1,3,2] row_mask:0xf bank_mask:0xf
+v_xor_b32_dpp v109, v0, v0  quad_perm:[1,0,2,3] row_mask:0xf bank_mask:0xa
+v_xor_b32_dpp v89, v0, v0  quad_perm:[0,0,2,2] row_mask:0xf bank_mask:0xf
+v_xor_b32_dpp v89, v0, v0  quad_perm:[1,1,3,3] row_mask:0xf bank_mask:0xa
+v_add_co_u32_e32 v89, vcc, v107, v89
+v_add_co_u32_e32 v109, vcc, v106, v109
+v_mad_i32_i24 v86, v109, s33, v89
+v_lshlrev_b32_e32 v86, 2, v86
+v_add_co_u32_e32 v86, vcc, v86, v108
+v_cmp_ge_u32_e64 s[56:57], v89, s33
+s_or_b64 s[56:57], s[56:57], s[52:53]
+v_cmp_ge_u32_e64 s[54:55], v109, s32
+s_or_b64 s[56:57], s[56:57], s[54:55]
+v_cndmask_b32_e64 v86, v86, -1, s[56:57]
+v_xor_b32_dpp v109, v0, v0  quad_perm:[1,0,2,3] row_mask:0xf bank_mask:0xf
+v_xor_b32_dpp v109, v0, v0  quad_perm:[0,1,3,2] row_mask:0xf bank_mask:0xa
+v_xor_b32_dpp v89, v0, v0  quad_perm:[1,1,2,2] row_mask:0xf bank_mask:0xf
+v_add_co_u32_e32 v89, vcc, v107, v89
+v_add_co_u32_e32 v109, vcc, v106, v109
+v_mad_i32_i24 v87, v109, s33, v89
+v_lshlrev_b32_e32 v87, 2, v87
+v_add_co_u32_e32 v87, vcc, v87, v108
+v_cmp_ge_u32_e64 s[56:57], v89, s33
+s_or_b64 s[56:57], s[56:57], s[52:53]
+v_cmp_ge_u32_e64 s[54:55], v109, s32
+s_or_b64 s[56:57], s[56:57], s[54:55]
+v_cndmask_b32_e64 v87, v87, -1, s[56:57]
+v_xor_b32_dpp v109, v0, v0  quad_perm:[0,1,3,2] row_mask:0xf bank_mask:0xf
+v_xor_b32_dpp v109, v0, v0  quad_perm:[1,0,2,3] row_mask:0xf bank_mask:0xa
+v_xor_b32_dpp v89, v0, v0  quad_perm:[1,1,3,3] row_mask:0xf bank_mask:0xf
+v_xor_b32_dpp v89, v0, v0  quad_perm:[0,0,2,2] row_mask:0xf bank_mask:0xa
+v_add_co_u32_e32 v89, vcc, v107, v89
+v_add_co_u32_e32 v109, vcc, v106, v109
+v_mad_i32_i24 v88, v109, s33, v89
+v_lshlrev_b32_e32 v88, 2, v88
+v_add_co_u32_e32 v88, vcc, v88, v108
+v_cmp_ge_u32_e64 s[56:57], v89, s33
+s_or_b64 s[56:57], s[56:57], s[52:53]
+v_cmp_ge_u32_e64 s[54:55], v109, s32
+s_or_b64 s[56:57], s[56:57], s[54:55]
+v_cndmask_b32_e64 v88, v88, -1, s[56:57]
+v_and_b32_e64 v104, v0, 63
+v_lshlrev_b32_e32 v104, 2, v104
+s_barrier
+buffer_load_dword v104, v104, s[48:51], 0 offen
+s_branch 63895
+s_endpgm
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0
+s_nop 0

--- a/src/kernels/Conv_Winograd_v21_1_3_metadata.inc
+++ b/src/kernels/Conv_Winograd_v21_1_3_metadata.inc
@@ -1,0 +1,192 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2023 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+.macro PROLOG_KERNEL_DESCRIPTOR kernel_name
+.text
+.globl \kernel_name
+.p2align 8
+.type \kernel_name,@function
+\kernel_name:
+.endm
+
+.macro METADATA sc,wc,wg_x, kernel_name
+.amdgpu_metadata
+---
+amdhsa.version: [ 1, 0 ]
+amdhsa.kernels:
+  - .name: \kernel_name
+    .symbol: \kernel_name\().kd
+    .language: "OpenCL C"
+    .language_version: [ 1, 2 ]
+    .sgpr_count: \sc
+    .vgpr_count: \wc
+    .group_segment_fixed_size: 65536
+    .private_segment_fixed_size: 0
+    .kernarg_segment_size: 248
+    .kernarg_segment_align: 8
+    .reqd_workgroup_size: [ \wg_x, 1, 1 ]
+    .max_flat_workgroup_size: \wg_x
+    .wavefront_size: 64
+    .args:
+    - { .size: 4, .offset:   0, .value_kind: by_value, .value_type: i32, .name: BATCHSIZE }
+    - { .size: 4, .offset:   4, .value_kind: by_value, .value_type: i32, .name: C }
+    - { .size: 4, .offset:   8, .value_kind: by_value, .value_type: i32, .name: H }
+    - { .size: 4, .offset:  12, .value_kind: by_value, .value_type: i32, .name: W }
+    - { .size: 4, .offset:  16, .value_kind: by_value, .value_type: i32, .name: K }
+    - { .size: 4, .offset:  20, .value_kind: by_value, .value_type: i32, .name: n_groups }
+    - { .size: 4, .offset:  24, .value_kind: by_value, .value_type: i32, .name: flags }
+    - { .size: 4, .offset:  28, .value_kind: by_value, .value_type: i32, .name: reserved  }
+    - { .size: 8, .offset:  32, .value_kind: global_buffer, .value_type: f32, .name: in,   .address_space: global, .is_const: true }
+    - { .size: 8, .offset:  40, .value_kind: global_buffer, .value_type: f32, .name: weights,    .address_space: global, .is_const: true }
+    - { .size: 8, .offset:  48, .value_kind: global_buffer, .value_type: f32, .name: out, .address_space: global, .is_const: false }
+    - { .size: 8, .offset:  56, .value_kind: global_buffer, .value_type: f32, .name: rsv_ptr,     .address_space: global, .is_const: false }
+    - { .size: 4, .offset:  64, .value_kind: by_value, .value_type: i32, .name: R }
+    - { .size: 4, .offset:  68, .value_kind: by_value, .value_type: i32, .name: S }
+    - { .size: 4, .offset:  72, .value_kind: by_value, .value_type: i32, .name: pad_h }
+    - { .size: 4, .offset:  76, .value_kind: by_value, .value_type: i32, .name: pad_w }
+    - { .size: 4, .offset:  80, .value_kind: by_value, .value_type: i32, .name: out_h }
+    - { .size: 4, .offset:  84, .value_kind: by_value, .value_type: i32, .name: out_w }
+    - { .size: 8, .offset:  88, .value_kind: global_buffer, .value_type: f32, .name: bias_addr,    .address_space: global, .is_const: true }
+    - { .size: 4, .offset:  96, .value_kind: by_value, .value_type: f32, .name: RELU_alpha }
+    - { .size: 4, .offset: 100, .value_kind: by_value, .value_type: i32, .name: reserved2 }
+    - { .size: 8, .offset: 104, .value_kind: by_value, .value_type: i64, .name: d_offset }
+    - { .size: 8, .offset: 112, .value_kind: by_value, .value_type: i64, .name: f_offset }
+    - { .size: 8, .offset: 120, .value_kind: by_value, .value_type: i64, .name: o_offset }
+    - { .size: 8, .offset: 128, .value_kind: by_value, .value_type: i64, .name: b_offset }
+    - { .size: 4, .offset: 136, .value_kind: by_value, .value_type: i32, .name: d_N_stride }
+    - { .size: 4, .offset: 140, .value_kind: by_value, .value_type: i32, .name: d_C_stride }
+    - { .size: 4, .offset: 144, .value_kind: by_value, .value_type: i32, .name: d_H_stride }
+    - { .size: 4, .offset: 148, .value_kind: by_value, .value_type: i32, .name: d_W_stride }
+    - { .size: 4, .offset: 152, .value_kind: by_value, .value_type: i32, .name: f_K_stride }
+    - { .size: 4, .offset: 156, .value_kind: by_value, .value_type: i32, .name: f_C_stride }
+    - { .size: 4, .offset: 160, .value_kind: by_value, .value_type: i32, .name: f_R_stride }
+    - { .size: 4, .offset: 164, .value_kind: by_value, .value_type: i32, .name: f_S_stride }
+    - { .size: 4, .offset: 168, .value_kind: by_value, .value_type: i32, .name: o_N_stride }
+    - { .size: 4, .offset: 172, .value_kind: by_value, .value_type: i32, .name: o_K_stride }
+    - { .size: 4, .offset: 176, .value_kind: by_value, .value_type: i32, .name: o_H_stride }
+    - { .size: 4, .offset: 180, .value_kind: by_value, .value_type: i32, .name: o_W_stride }
+    - { .size: 4, .offset: 184, .value_kind: by_value, .value_type: i32, .name: G }
+    - { .size: 4, .offset: 188, .value_kind: by_value, .value_type: i32, .name: d_G_stride }
+    - { .size: 4, .offset: 192, .value_kind: by_value, .value_type: i32, .name: f_G_stride }
+    - { .size: 4, .offset: 196, .value_kind: by_value, .value_type: i32, .name: o_G_stride }
+    - { .size: 8, .offset: 200, .value_kind: hidden_global_offset_x, .value_type: i64 }
+    - { .size: 8, .offset: 208, .value_kind: hidden_global_offset_y, .value_type: i64 }
+    - { .size: 8, .offset: 216, .value_kind: hidden_global_offset_z, .value_type: i64 }
+    - { .size: 8, .offset: 224, .value_kind: hidden_none,   .value_type: i8 }
+    - { .size: 8, .offset: 232, .value_kind: hidden_none,   .value_type: i8 }
+    - { .size: 8, .offset: 240, .value_kind: hidden_none,   .value_type: i8 }
+...
+.end_amdgpu_metadata
+.endm // METADATA
+
+.altmacro
+.macro METADATA_WRAPPER sc,wc,wg_x, kernel_name
+    METADATA %\sc, %\wc, %\wg_x, \kernel_name
+.endm
+
+.macro kernel_end kernel_name
+s_endpgm
+.Lfunc_end0:
+   .size \kernel_name, .Lfunc_end0 - \kernel_name
+.endm
+
+.macro EPILOG_KERNEL_DESCRIPTOR kernel_name
+
+kernel_end \kernel_name
+
+.if (.amdgcn.gfx_generation_number == 9)
+    vgpr_size = 128
+    workgroup_size_x = 512
+.elseif (.amdgcn.gfx_generation_number == 10 || .amdgcn.gfx_generation_number == 11)
+    vgpr_size = 256
+    workgroup_size_x = 256
+.endif
+
+.amdgcn.next_free_sgpr = 101
+.amdgcn.next_free_vgpr = vgpr_size
+
+//xnack disabled by default for asm kernels
+__sgpr_reserve_vcc_default = 1
+__sgpr_reserve_xnack_default = 0
+__sgpr_reserve_flatscr_default = 0
+
+__group_segment_fixed_size = 65536
+__sgpr_private_segment_buffer = 1
+__sgpr_dispatch_ptr = 1
+__sgpr_kernarg_segment_ptr = 1
+__sgpr_workgroup_id_x = 1
+__sgpr_workgroup_id_y = 0
+__sgpr_workgroup_id_z = 0
+__vgpr_workitem_id = 0
+__ieee_mode = 0
+__dx10_clamp = 0
+
+.rodata
+.p2align 6
+.amdhsa_kernel \kernel_name
+    .amdhsa_group_segment_fixed_size         __group_segment_fixed_size
+    .amdhsa_user_sgpr_private_segment_buffer __sgpr_private_segment_buffer
+    .amdhsa_user_sgpr_dispatch_ptr           __sgpr_dispatch_ptr // s[6:7]
+    .amdhsa_user_sgpr_kernarg_segment_ptr    __sgpr_kernarg_segment_ptr
+    .amdhsa_system_sgpr_workgroup_id_x       __sgpr_workgroup_id_x
+    .amdhsa_system_sgpr_workgroup_id_y       __sgpr_workgroup_id_y
+    .amdhsa_system_sgpr_workgroup_id_z       __sgpr_workgroup_id_y
+    .amdhsa_system_vgpr_workitem_id          __vgpr_workitem_id
+    .amdhsa_next_free_vgpr                   .amdgcn.next_free_vgpr
+    .amdhsa_next_free_sgpr                   .amdgcn.next_free_sgpr
+    .amdhsa_reserve_vcc                      __sgpr_reserve_vcc_default
+    .amdhsa_reserve_xnack_mask               __sgpr_reserve_xnack_default
+    .amdhsa_reserve_flat_scratch             __sgpr_reserve_flatscr_default
+    .amdhsa_ieee_mode                        __ieee_mode
+    .amdhsa_dx10_clamp                       __dx10_clamp
+.end_amdhsa_kernel
+
+total_sgpr_count = .amdgcn.next_free_sgpr + 4 // vcc, xnack
+
+METADATA_WRAPPER total_sgpr_count,.amdgcn.next_free_vgpr,workgroup_size_x, <\kernel_name>
+
+.endm
+
+.macro PROLOG_KERNEL_DESCRIPTOR_WRAPPER machine_version, kernel_name_postfix
+    PROLOG_KERNEL_DESCRIPTOR miopenSp3AsmConv_v21_1_3_gfx\machine_version\()_\kernel_name_postfix
+.endm
+
+.macro EPILOG_KERNEL_DESCRIPTOR_WRAPPER machine_version, kernel_name_postfix
+    EPILOG_KERNEL_DESCRIPTOR miopenSp3AsmConv_v21_1_3_gfx\machine_version\()_\kernel_name_postfix
+.endm
+
+.macro KERNEL_PROLOG kernel_name_postfix
+	PROLOG_KERNEL_DESCRIPTOR_WRAPPER %.amdgcn.gfx_generation_number, \kernel_name_postfix
+.endm
+
+.macro KERNEL_EPILOG kernel_name_postfix
+	EPILOG_KERNEL_DESCRIPTOR_WRAPPER %.amdgcn.gfx_generation_number, \kernel_name_postfix
+.endm
+
+.if (.amdgcn.gfx_generation_number != 9)
+    .error "Unsupported gfx generation"
+    .end
+.endif

--- a/src/solver/conv_winoRxS.cpp
+++ b/src/solver/conv_winoRxS.cpp
@@ -185,16 +185,16 @@ inline bool IsWinogradV21Preferred(const std::string& asic, const ProblemDescrip
            !(IS3X2 && problem.kernel_stride_w == 2);
 }
 
-inline bool IsShaderContraintsMetV21(const ProblemDescription& problem,
-                                     const int R,
-                                     const int S,
-                                     const int C,
-                                     const int K,
-                                     const int H,
-                                     const int W,
-                                     const int OH,
-                                     const int OW,
-                                     const int N)
+inline bool IsShaderConstraintsMetV21(const ProblemDescription& problem,
+                                      const int R,
+                                      const int S,
+                                      const int C,
+                                      const int K,
+                                      const int H,
+                                      const int W,
+                                      const int OH,
+                                      const int OW,
+                                      const int N)
 {
     uint64_t o_K_stride      = static_cast<uint64_t>(OH) * OW;
     uint64_t o_N_stride      = o_K_stride * K;
@@ -229,16 +229,16 @@ inline bool IsShaderContraintsMetV21(const ProblemDescription& problem,
     // clang-format on
 }
 
-inline bool IsShaderContraintsMetV30(const ProblemDescription& problem,
-                                     const int R,
-                                     const int S,
-                                     const int C,
-                                     const int K,
-                                     const int H,
-                                     const int W,
-                                     const int OH,
-                                     const int OW,
-                                     const int N)
+inline bool IsShaderConstraintsMetV30(const ProblemDescription& problem,
+                                      const int R,
+                                      const int S,
+                                      const int C,
+                                      const int K,
+                                      const int H,
+                                      const int W,
+                                      const int OH,
+                                      const int OW,
+                                      const int N)
 {
     // clang-format off
     // Check implementation limits.
@@ -262,17 +262,17 @@ inline bool IsShaderContraintsMetV30(const ProblemDescription& problem,
 }
 
 template <int Winodata, int Winofilter>
-inline bool IsShaderContraintsMet(const ProblemDescription& problem,
-                                  const int R,
-                                  const int S,
-                                  const int C,
-                                  const int K,
-                                  const int H,
-                                  const int W,
-                                  const int OH,
-                                  const int OW,
-                                  const int N,
-                                  const std::string& asic)
+inline bool IsShaderConstraintsMet(const ProblemDescription& problem,
+                                   const int R,
+                                   const int S,
+                                   const int C,
+                                   const int K,
+                                   const int H,
+                                   const int W,
+                                   const int OH,
+                                   const int OW,
+                                   const int N,
+                                   const std::string& asic)
 {
     // Padding for bwd data shall not be negative.
     /// \todo Either remove WrW related code or re-use function from RxS
@@ -290,8 +290,8 @@ inline bool IsShaderContraintsMet(const ProblemDescription& problem,
     }
 
     return IsWinogradV21Preferred<Winodata, Winofilter>(asic, problem)
-               ? IsShaderContraintsMetV21(problem, R, S, C, K, H, W, OH, OW, N)
-               : IsShaderContraintsMetV30(problem, R, S, C, K, H, W, OH, OW, N);
+               ? IsShaderConstraintsMetV21(problem, R, S, C, K, H, W, OH, OW, N)
+               : IsShaderConstraintsMetV30(problem, R, S, C, K, H, W, OH, OW, N);
 }
 
 } // namespace
@@ -577,31 +577,31 @@ static bool IsApplicableBase(const ConvolutionContext& ctx, const ProblemDescrip
     {
         if(problem.kernel_stride_w == 2)
             return false;
-        return IsShaderContraintsMet<Winodata, Winofilter>(problem,
-                                                           problem.in_height,
-                                                           problem.in_width,
-                                                           problem.batch_sz,   // N
-                                                           n_inputs_per_group, // K
-                                                           problem.out_height,
-                                                           problem.out_width,
-                                                           problem.kernel_size_h,
-                                                           problem.kernel_size_w,
-                                                           n_outputs_per_group, // C
-                                                           name);
+        return IsShaderConstraintsMet<Winodata, Winofilter>(problem,
+                                                            problem.in_height,
+                                                            problem.in_width,
+                                                            problem.batch_sz,   // N
+                                                            n_inputs_per_group, // K
+                                                            problem.out_height,
+                                                            problem.out_width,
+                                                            problem.kernel_size_h,
+                                                            problem.kernel_size_w,
+                                                            n_outputs_per_group, // C
+                                                            name);
     }
     else
     {
-        return IsShaderContraintsMet<Winodata, Winofilter>(problem,
-                                                           problem.kernel_size_h, // RxS
-                                                           problem.kernel_size_w,
-                                                           n_inputs_per_group,  // C
-                                                           n_outputs_per_group, // K
-                                                           problem.in_height,   // HxW
-                                                           problem.in_width,
-                                                           problem.out_height, // OHxOW
-                                                           problem.out_width,
-                                                           problem.batch_sz, // N
-                                                           name);
+        return IsShaderConstraintsMet<Winodata, Winofilter>(problem,
+                                                            problem.kernel_size_h, // RxS
+                                                            problem.kernel_size_w,
+                                                            n_inputs_per_group,  // C
+                                                            n_outputs_per_group, // K
+                                                            problem.in_height,   // HxW
+                                                            problem.in_width,
+                                                            problem.out_height, // OHxOW
+                                                            problem.out_width,
+                                                            problem.batch_sz, // N
+                                                            name);
     }
 }
 

--- a/src/solver/conv_winoRxS_fused.cpp
+++ b/src/solver/conv_winoRxS_fused.cpp
@@ -68,16 +68,16 @@ inline bool IsWinogradV21Preferred(const std::string& asic, const ProblemDescrip
            !(IS3X2 && problem.kernel_stride_w == 2);
 }
 
-inline bool IsShaderContraintsMetV21(const ProblemDescription& problem,
-                                     const int R,
-                                     const int S,
-                                     const int C,
-                                     const int K,
-                                     const int H,
-                                     const int W,
-                                     const int OH,
-                                     const int OW,
-                                     const int N)
+inline bool IsShaderConstraintsMetV21(const ProblemDescription& problem,
+                                      const int R,
+                                      const int S,
+                                      const int C,
+                                      const int K,
+                                      const int H,
+                                      const int W,
+                                      const int OH,
+                                      const int OW,
+                                      const int N)
 {
     uint64_t o_K_stride      = static_cast<uint64_t>(OH) * OW;
     uint64_t o_N_stride      = o_K_stride * K;
@@ -112,16 +112,16 @@ inline bool IsShaderContraintsMetV21(const ProblemDescription& problem,
     // clang-format on
 }
 
-inline bool IsShaderContraintsMetV30(const ProblemDescription& problem,
-                                     const int R,
-                                     const int S,
-                                     const int C,
-                                     const int K,
-                                     const int H,
-                                     const int W,
-                                     const int OH,
-                                     const int OW,
-                                     const int N)
+inline bool IsShaderConstraintsMetV30(const ProblemDescription& problem,
+                                      const int R,
+                                      const int S,
+                                      const int C,
+                                      const int K,
+                                      const int H,
+                                      const int W,
+                                      const int OH,
+                                      const int OW,
+                                      const int N)
 {
     // clang-format off
     // Check implementation limits.
@@ -191,8 +191,8 @@ bool ConvBinWinogradRxSf2x3g1Fused::IsApplicable(const FusionContext& context,
     const auto OW = conv_ctx.problem.conv_problem.GetOutWidth();
 
     return IsWinogradV21Preferred<2, 3>(name, conv_ctx.problem)
-               ? IsShaderContraintsMetV21(conv_ctx.problem, R, S, C, K, H, W, OH, OW, N)
-               : IsShaderContraintsMetV30(conv_ctx.problem, R, S, C, K, H, W, OH, OW, N);
+               ? IsShaderConstraintsMetV21(conv_ctx.problem, R, S, C, K, H, W, OH, OW, N)
+               : IsShaderConstraintsMetV30(conv_ctx.problem, R, S, C, K, H, W, OH, OW, N);
 }
 
 ConvSolution ConvBinWinogradRxSf2x3g1Fused::GetSolution(const FusionContext& context,

--- a/src/solver/conv_winoRxS_fused.cpp
+++ b/src/solver/conv_winoRxS_fused.cpp
@@ -45,6 +45,8 @@
 
 MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEBUG_AMD_WINOGRAD_RXS_F2X3_G1)
 
+#define IS3X2 (Winodata == 3 && Winofilter == 2)
+
 static inline size_t Ceil(const size_t v, const size_t m)
 {
     assert(m > 0);
@@ -59,9 +61,11 @@ namespace {
 // Winograd v30 is functionally supported on Vega10/Vega20 ASICs, but performance regression is
 // expected to be ~25%. Use Winograd v21 instead.
 // Details: https://github.com/ROCmSoftwarePlatform/MIOpen/pull/1927#issuecomment-1412741130
-inline bool IsWinogradV30Supported(const std::string& asic)
+template <int Winodata, int Winofilter>
+inline bool IsWinogradV30Supported(const std::string& asic, const ProblemDescription& problem)
 {
-    return !StartsWith(asic, "gfx900") && !StartsWith(asic, "gfx906");
+    return (!StartsWith(asic, "gfx900") && !StartsWith(asic, "gfx906")) ||
+           (IS3X2 && problem.kernel_stride_w == 2);
 }
 
 inline bool IsShaderContraintsMetV21(const ProblemDescription& problem,
@@ -186,7 +190,7 @@ bool ConvBinWinogradRxSf2x3g1Fused::IsApplicable(const FusionContext& context,
     const auto OH = conv_ctx.problem.conv_problem.GetOutHeight();
     const auto OW = conv_ctx.problem.conv_problem.GetOutWidth();
 
-    return IsWinogradV30Supported(name)
+    return IsWinogradV30Supported<2, 3>(name, conv_ctx.problem)
                ? IsShaderContraintsMetV30(conv_ctx.problem, R, S, C, K, H, W, OH, OW, N)
                : IsShaderContraintsMetV21(conv_ctx.problem, R, S, C, K, H, W, OH, OW, N);
 }
@@ -203,7 +207,7 @@ ConvSolution ConvBinWinogradRxSf2x3g1Fused::GetSolution(const FusionContext& con
     const auto name     = conv_ctx.GetStream().GetDeviceName();
     const auto is_gfx9  = StartsWith(name, "gfx9");
     const auto is_gfx10 = StartsWith(name, "gfx10");
-    const auto is_v30   = IsWinogradV30Supported(name);
+    const auto is_v30   = IsWinogradV30Supported<2, 3>(name, conv_ctx.problem);
     size_t wg_size      = is_gfx9 ? 512 : 256;
     kernel.g_wk.push_back(wg_size * n_groups);
     kernel.g_wk.push_back(1);

--- a/src/solver/conv_winoRxS_fused.cpp
+++ b/src/solver/conv_winoRxS_fused.cpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (c) 2022 Advanced Micro Devices, Inc.
+ * Copyright (c) 2023 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -45,8 +45,103 @@
 
 MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEBUG_AMD_WINOGRAD_RXS_F2X3_G1)
 
+static inline size_t Ceil(const size_t v, const size_t m)
+{
+    assert(m > 0);
+    return (v + m - 1) / m;
+}
+
 namespace miopen {
 namespace solver {
+
+namespace {
+
+// Winograd v30 is functionally supported on Vega10/Vega20 ASICs, but performance regression is
+// expected to be ~25%. Use Winograd v21 instead.
+// Details: https://github.com/ROCmSoftwarePlatform/MIOpen/pull/1927#issuecomment-1412741130
+inline bool IsWinogradV30Supported(const std::string& asic)
+{
+    return !StartsWith(asic, "gfx900") && !StartsWith(asic, "gfx906");
+}
+
+inline bool IsShaderContraintsMetV21(const ProblemDescription& problem,
+                                     const int R,
+                                     const int S,
+                                     const int C,
+                                     const int K,
+                                     const int H,
+                                     const int W,
+                                     const int OH,
+                                     const int OW,
+                                     const int N)
+{
+    uint64_t o_K_stride      = static_cast<uint64_t>(OH) * OW;
+    uint64_t o_N_stride      = o_K_stride * K;
+    uint64_t o_N_stride_OHOW = o_N_stride + o_K_stride;
+
+    uint64_t d_C_stride    = static_cast<uint64_t>(H) * W;
+    uint64_t d_N_stride    = d_C_stride * C;
+    uint64_t d_N_stride_HW = d_N_stride + d_C_stride;
+
+    auto num_tiles  = Ceil(OH, 2) * Ceil(OW, 2);
+    auto stride_one = problem.kernel_stride_h == 1 && problem.kernel_stride_w == 1 &&
+                      problem.kernel_dilation_h == 1 && problem.kernel_dilation_w == 1;
+
+    // clang-format off
+    // Check implementation limits.
+    return N < std::pow(2, 16)
+        && C < std::pow(2, 16)
+        && H < std::pow(2, 16)
+        && W < std::pow(2, 16)
+        && K < std::pow(2, 16)
+        && S < std::pow(2, 16)
+        && R < std::pow(2, 16)
+        && OH < std::pow(2, 16)
+        && OW < std::pow(2, 16)
+        && problem.pad_w < std::pow(2, 16)
+        && problem.pad_h < std::pow(2, 16)
+        && C * R * S < std::pow(2, 22)
+        && K * R * S < std::pow(2, 28)
+        && ((o_N_stride_OHOW < std::pow(2, 29) && d_N_stride_HW < std::pow(2, 29))
+           || (stride_one && o_N_stride < std::pow(2, 30) && d_N_stride < std::pow(2, 30)
+           && (N == 1 || num_tiles % 16 == 0)));
+    // clang-format on
+}
+
+inline bool IsShaderContraintsMetV30(const ProblemDescription& problem,
+                                     const int R,
+                                     const int S,
+                                     const int C,
+                                     const int K,
+                                     const int H,
+                                     const int W,
+                                     const int OH,
+                                     const int OW,
+                                     const int N)
+{
+    // clang-format off
+    // Check implementation limits.
+    return N < std::pow(2, 16)
+        && C < std::pow(2, 16)
+        && H < std::pow(2, 16)
+        && W < std::pow(2, 16)
+        && K < std::pow(2, 16)
+        && S < std::pow(2, 16)
+        && R < std::pow(2, 16)
+        && OH < std::pow(2, 16)
+        && OW < std::pow(2, 16)
+        && problem.pad_w < std::pow(2, 16)
+        && problem.pad_h < std::pow(2, 16)
+        && H * W < std::pow(2, 29)
+        && K * R * S < std::pow(2, 28)
+        && (C + 1) * H * W < std::pow(2, 30)
+        && (C + 1) * R * S < std::pow(2, 22)
+        && (K + 1) * OH * OW < std::pow(2, 30);
+    // clang-format on
+}
+
+} // namespace
+
 namespace fusion {
 
 bool ConvBinWinogradRxSf2x3g1Fused::IsApplicable(const FusionContext& context,
@@ -77,38 +172,23 @@ bool ConvBinWinogradRxSf2x3g1Fused::IsApplicable(const FusionContext& context,
         return false;
     // clang-format on
 
-    const auto W           = conv_ctx.problem.conv_problem.GetInWidth();
-    const auto H           = conv_ctx.problem.conv_problem.GetInHeight();
-    const auto C           = conv_ctx.problem.conv_problem.GetInChannels();
-    const auto N           = conv_ctx.problem.conv_problem.GetInBatchSize();
-    const auto K           = conv_ctx.problem.conv_problem.GetOutChannels();
-    const auto R           = conv_ctx.problem.conv_problem.GetWeightsHeight();
-    const auto S           = conv_ctx.problem.conv_problem.GetWeightsWidth();
-    const auto OH          = conv_ctx.problem.conv_problem.GetOutHeight();
-    const auto OW          = conv_ctx.problem.conv_problem.GetOutWidth();
-    const auto pad_h       = conv_ctx.problem.conv_problem.GetPadH();
-    const auto pad_w       = conv_ctx.problem.conv_problem.GetPadW();
     const auto group_count = conv_ctx.problem.conv_problem.GetGroupCount();
+    if(group_count != 1)
+        return false;
 
-    // clang-format off
-    return N < std::pow(2, 16)
-        && C < std::pow(2, 16)
-        && H < std::pow(2, 16)
-        && W < std::pow(2, 16)
-        && K < std::pow(2, 16)
-        && R < std::pow(2, 16)
-        && S < std::pow(2, 16)
-        && OH < std::pow(2, 16)
-        && OW < std::pow(2, 16)
-        && pad_h < std::pow(2, 16)
-        && pad_w < std::pow(2, 16)
-        && H * W < std::pow(2, 29)
-        && K * R * S < std::pow(2, 28)
-        && (C + 1) *  H *  W < std::pow(2, 30)
-        && (C + 1) *  R *  S < std::pow(2, 22)
-        && (K + 1) * OH * OW < std::pow(2, 30)
-        && group_count == 1;
-    // clang-format on
+    const auto W  = conv_ctx.problem.conv_problem.GetInWidth();
+    const auto H  = conv_ctx.problem.conv_problem.GetInHeight();
+    const auto C  = conv_ctx.problem.conv_problem.GetInChannels();
+    const auto N  = conv_ctx.problem.conv_problem.GetInBatchSize();
+    const auto K  = conv_ctx.problem.conv_problem.GetOutChannels();
+    const auto R  = conv_ctx.problem.conv_problem.GetWeightsHeight();
+    const auto S  = conv_ctx.problem.conv_problem.GetWeightsWidth();
+    const auto OH = conv_ctx.problem.conv_problem.GetOutHeight();
+    const auto OW = conv_ctx.problem.conv_problem.GetOutWidth();
+
+    return IsWinogradV30Supported(name)
+               ? IsShaderContraintsMetV30(conv_ctx.problem, R, S, C, K, H, W, OH, OW, N)
+               : IsShaderContraintsMetV21(conv_ctx.problem, R, S, C, K, H, W, OH, OW, N);
 }
 
 ConvSolution ConvBinWinogradRxSf2x3g1Fused::GetSolution(const FusionContext& context,
@@ -123,6 +203,7 @@ ConvSolution ConvBinWinogradRxSf2x3g1Fused::GetSolution(const FusionContext& con
     const auto name     = conv_ctx.GetStream().GetDeviceName();
     const auto is_gfx9  = StartsWith(name, "gfx9");
     const auto is_gfx10 = StartsWith(name, "gfx10");
+    const auto is_v30   = IsWinogradV30Supported(name);
     size_t wg_size      = is_gfx9 ? 512 : 256;
     kernel.g_wk.push_back(wg_size * n_groups);
     kernel.g_wk.push_back(1);
@@ -138,8 +219,9 @@ ConvSolution ConvBinWinogradRxSf2x3g1Fused::GetSolution(const FusionContext& con
     kernel.comp_options = options.GenerateFor(kbp::GcnAsm{});
     kernel.comp_options += std::string(" -mcumode -mwavefrontsize64");
 
-    kernel.kernel_file = "Conv_Winograd_v30_2_6";
-    kernel.kernel_name = "miopenSp3AsmConv_v30_2_6";
+    const std::string kernel_version = is_v30 ? "_v30_2_6" : "_v21_1_3";
+    kernel.kernel_file               = "Conv_Winograd" + kernel_version;
+    kernel.kernel_name               = "miopenSp3AsmConv" + kernel_version;
     const auto kernel_postfix =
         "_fp32_f2x3_stride" + std::to_string(conv_ctx.problem.kernel_stride_h);
 


### PR DESCRIPTION
Continuation of #1927. This PR rolls back Winograd v21 for Vega ASICs due to a ~25% performance drop, see details in https://github.com/ROCmSoftwarePlatform/MIOpen/pull/1927#issuecomment-1412741130.

## Local verification
- gfx906, ROCm 5.4.2