### PR TITLE
Fix non-optimal solver selection in the Fusion plan

### DIFF
--- a/src/fusion.cpp
+++ b/src/fusion.cpp
@@ -462,7 +462,7 @@ miopenStatus_t FusionPlanDescriptor::Compile(Handle& handle)
         std::sort(solutions.begin(),
                   solutions.end(),
                   [](const solver::ConvSolution& a, const solver::ConvSolution& b) -> bool {
-                      return a.weight < b.weight;
+                      return a.weight > b.weight;
                   });
         status = miopenStatusSuccess;
     }


### PR DESCRIPTION
This PR fixes non-optimal solution selection in the Fusion API. Previously, all solvers were sorted in non-descending order of their weights, and then the solution with the **lowest weight** was executed. This led to the selection of a suboptimal solution.

https://github.com/ROCmSoftwarePlatform/MIOpen/blob/ddc395e119e946a0be34d55d4bd63a81ddcf9749/src/fusion.cpp#L462-L466

https://github.com/ROCmSoftwarePlatform/MIOpen/blob/ddc395e119e946a0be34d55d4bd63a81ddcf9749/src/fusion.cpp#L487
