### PR TITLE
[SWDEV-385188] Guard HIP tests to enable building on OpenCL 

### DIFF
--- a/test/gtest/api_convbiasactiv.cpp
+++ b/test/gtest/api_convbiasactiv.cpp
@@ -23,6 +23,9 @@
  * SOFTWARE.
  *
  *******************************************************************************/
+#include <miopen/miopen.h>
+
+#if MIOPEN_BACKEND_HIP
 #include <gtest/gtest.h>
 #include <miopen/miopen.h>
 #include <miopen/solver_id.hpp>
@@ -194,3 +197,4 @@ INSTANTIATE_TEST_SUITE_P(CBAFwdAPITest,
                          testing::Combine(testing::Values(miopenConvolutionFwdAlgoDirect,
                                                           miopenConvolutionFwdAlgoWinograd),
                                           testing::ValuesIn(GetTestValues())));
+#endif

--- a/test/gtest/log_test.cpp
+++ b/test/gtest/log_test.cpp
@@ -23,6 +23,9 @@
  * SOFTWARE.
  *
  *******************************************************************************/
+#include <miopen/miopen.h>
+
+#if MIOPEN_BACKEND_HIP
 #include "log_test_helper.hpp"
 
 TEST(LOG_TEST, AssertLogCmdOutput)
@@ -34,3 +37,4 @@ TEST(LOG_TEST, AssertLogFindCmdOutput)
 {
     TestLogFun(miopen::debug::LogCmdFindConvolution, envConv, logFindConv, true);
 }
+#endif

--- a/test/gtest/log_test_neg.cpp
+++ b/test/gtest/log_test_neg.cpp
@@ -23,6 +23,9 @@
  * SOFTWARE.
  *
  *******************************************************************************/
+#include <miopen/config.h>
+
+#if MIOPEN_BACKEND_HIP
 #include "log_test_helper.hpp"
 
 TEST(LOG_TEST, AssertLogCmdOutput_Neg)
@@ -34,3 +37,4 @@ TEST(LOG_TEST, AssertLogFindCmdOutput_Neg)
 {
     TestLogFun(miopen::debug::LogCmdFindConvolution, envConv, logFindConv, false);
 }
+#endif


### PR DESCRIPTION
These tests link with hip libraries such as `rocblas` which should not happen in the OpenCL backend. Therefore, we disable these tests on the OpenCL backend.