### PR TITLE
[NFC][Doc] Add note about local compiled kernel cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ The script `utils/install_precompiled_kernels.sh` provided as part of MIOpen aut
 
 The above script depends on the __rocminfo__ package to query the GPU architecture.
 
+More info can be found [here](https://github.com/ROCmSoftwarePlatform/MIOpen/blob/develop/doc/src/cache.md#installing-pre-compiled-kernels).
+
 ## Installing the dependencies
 
 The dependencies can be installed with the `install_deps.cmake`, script: `cmake -P install_deps.cmake`

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Currently both the backends cannot be installed on the same system simultaneousl
 
 MIOpen provides an optional pre-compiled kernels package to reduce the startup latency. These precompiled kernels comprise a select set of popular input configurations and will expand in future release to contain additional coverage.
 
+Note that all compiled kernels are locally cached in the folder `$HOME/.cache/miopen/`, so the performance impact will only apply to the first execution of a new compute kernel. There is no startup time penalty on subsequent runs.
+
 To install the kernels package for your GPU architecture, use the following command:
 
 ```

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Currently both the backends cannot be installed on the same system simultaneousl
 
 MIOpen provides an optional pre-compiled kernels package to reduce the startup latency. These precompiled kernels comprise a select set of popular input configurations and will expand in future release to contain additional coverage.
 
-Note that all compiled kernels are locally cached in the folder `$HOME/.cache/miopen/`, so the performance impact will only apply to the first execution of a new compute kernel. There is no startup time penalty on subsequent runs.
+Note that all compiled kernels are locally cached in the folder `$HOME/.cache/miopen/`, so precompiled kernels reduce the startup latency only for the first execution of a neural network. Precompiled kernels do not reduce startup time on subsequent runs.
 
 To install the kernels package for your GPU architecture, use the following command:
 


### PR DESCRIPTION
This adds a note to the readme that compiled kernels will be cached, and not installing the precompiled kernel package will only make a difference on the first run.

Closes: #1999 