### PR TITLE
Fused Winograd solver update

### DIFF
--- a/src/fusion.cpp
+++ b/src/fusion.cpp
@@ -397,7 +397,8 @@ static auto GetFusedSolvers()
     return solver::SolverContainer<solver::fusion::ConvBiasActivAsm1x1U,
                                    solver::fusion::ConvOclDirectFwdFused,
                                    solver::fusion::ConvBinWinogradRxSFused,
-                                   solver::fusion::ConvBinWinogradRxSf2x3g1Fused,
+                                   solver::fusion::ConvBinWinogradRxSg1Fused<2, 3>,
+                                   solver::fusion::ConvBinWinogradRxSg1Fused<3, 2>,
                                    solver::fusion::BnFwdInferActivationFused,
                                    solver::fusion::BnFwdTrgActivationFused,
                                    solver::fusion::BnBwdTrgActivationFused>{};

--- a/src/include/miopen/fusion/solvers.hpp
+++ b/src/include/miopen/fusion/solvers.hpp
@@ -222,13 +222,19 @@ struct ConvBinWinogradRxSFused final : FusionSolverBase
     ConvSolution GetSolution(const FusionContext& context, const FusionDescription& problem) const;
 };
 
-struct ConvBinWinogradRxSf2x3g1Fused final : FusionSolverBase
+template <int Winodata, int Winofilter>
+struct ConvBinWinogradRxSg1Fused final : FusionSolverBase
 {
     using FusionSolverBase::IsApplicable;
 
     const std::string& SolverDbId() const override
     {
-        return GetSolverDbId<ConvBinWinogradRxSf2x3g1Fused>();
+        static const std::string dbId = std::string("ConvBinWinogradRxSf")
+                                            .append(std::to_string(Winodata))
+                                            .append("x")
+                                            .append(std::to_string(Winofilter))
+                                            .append("g1Fused");
+        return dbId;
     }
 
     bool IsApplicable(const OldStyleFusionDesc& context) const override
@@ -245,6 +251,19 @@ struct ConvBinWinogradRxSf2x3g1Fused final : FusionSolverBase
 
     ConvSolution GetSolution(const FusionContext& context, const FusionDescription& problem) const;
 };
+
+// Suppress misleading clang warnings
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wweak-template-vtables"
+#endif
+
+extern template struct ConvBinWinogradRxSg1Fused<2, 3>;
+extern template struct ConvBinWinogradRxSg1Fused<3, 2>;
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 
 struct BnFwdInferActivationFused final : FusionSolverBase
 {

--- a/src/include/miopen/fusion/utils.hpp
+++ b/src/include/miopen/fusion/utils.hpp
@@ -81,8 +81,6 @@ inline bool WinoCommonIsApplicable(const FusionContext& params)
 
     if(!conv_ctx.problem.Is2d())
         return false;
-    if(!conv_ctx.problem.IsFp32())
-        return false;
     if(!conv_ctx.problem.IsLayoutDefault())
         return false;
     if(!conv_ctx.problem.direction.IsForward())

--- a/src/ocl/fusionopbiasbnactivocl.cpp
+++ b/src/ocl/fusionopbiasbnactivocl.cpp
@@ -36,7 +36,8 @@ bool IsWinograd(const std::vector<solver::AnySolver>& ss)
 {
     assert(ss.size() == 1);
     auto solverId = ss[0].GetSolverDbId();
-    return (solverId == "ConvBinWinogradRxSFused" || solverId == "ConvBinWinogradRxSf2x3g1Fused");
+    return (solverId == "ConvBinWinogradRxSFused" || solverId == "ConvBinWinogradRxSf2x3g1Fused" ||
+            solverId == "ConvBinWinogradRxSf3x2g1Fused");
 }
 
 } // namespace fusion

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -541,7 +541,7 @@ inline SolverRegistrar::SolverRegistrar(IdRegistryData& registry)
     Register(registry,
              ++id,
              Primitive::Fusion,
-             solver::fusion::ConvBinWinogradRxSf2x3g1Fused{}.SolverDbId(),
+             solver::fusion::ConvBinWinogradRxSg1Fused<2, 3>{}.SolverDbId(),
              miopenConvolutionAlgoWinograd);
     Register(registry,
              ++id,
@@ -551,6 +551,11 @@ inline SolverRegistrar::SolverRegistrar(IdRegistryData& registry)
         registry, ++id, Primitive::Fusion, solver::fusion::BnFwdTrgActivationFused{}.SolverDbId());
     Register(
         registry, ++id, Primitive::Fusion, solver::fusion::BnBwdTrgActivationFused{}.SolverDbId());
+    Register(registry,
+             ++id,
+             Primitive::Fusion,
+             solver::fusion::ConvBinWinogradRxSg1Fused<3, 2>{}.SolverDbId(),
+             miopenConvolutionAlgoWinograd);
 
     // IMPORTANT: New solvers should be added to the end of the function!
 }

--- a/src/solver/conv_bin_winoRxS_fused.cpp
+++ b/src/solver/conv_bin_winoRxS_fused.cpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (c) 2022 Advanced Micro Devices, Inc.
+ * Copyright (c) 2023 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -66,6 +66,10 @@ bool ConvBinWinogradRxSFused::IsApplicable(const FusionContext& context,
         return false;
     const miopen::ConvolutionContext conv_ctx =
         context.GetConvContext(0, miopen::conv::Direction::Forward, problem);
+
+    if(!conv_ctx.problem.IsFp32())
+        return false;
+
     const std::string name = conv_ctx.GetStream().GetDeviceName();
     if(name != "gfx803")
         return false;

--- a/src/solver/conv_winoRxS_fused.cpp
+++ b/src/solver/conv_winoRxS_fused.cpp
@@ -256,10 +256,16 @@ ConvBinWinogradRxSg1Fused<Winodata, Winofilter>::GetSolution(const FusionContext
     kernel.kernel_file += kernel_postfix + ".s";
     result.construction_params.push_back(kernel);
 
-    const auto x = conv_ctx.problem.conv_problem.GetWeightsWidth();
-    const auto y = conv_ctx.problem.conv_problem.GetWeightsHeight();
+    const auto x        = conv_ctx.problem.conv_problem.GetWeightsWidth();
+    const auto y        = conv_ctx.problem.conv_problem.GetWeightsHeight();
+    const auto stride_w = conv_ctx.problem.kernel_stride_w;
+    // assert(stride_w == stride_h)
 
-    if(x == 3 && y == 3)
+    if(IS2X3 && x == 3 && y == 3 && stride_w == 1)
+        result.weight = 100;
+    else if(IS3X2 && x == 3 && y == 3 && stride_w == 2)
+        result.weight = 100;
+    else if(IS3X2 && x == 2 && y == 2 && stride_w == 1)
         result.weight = 100;
     else
         result.weight = 5;

--- a/test/gtest/cba_infer.cpp
+++ b/test/gtest/cba_infer.cpp
@@ -113,7 +113,14 @@ TEST_P(ConvBiasActivInferTestFloat, ConvBinWinogradRxSf2x3g1Fused)
 {
     const auto plan_params = std::make_unique<miopen::fusion::FusionInvokeParams>(
         params, input.desc, in_dev.get(), output.desc, out_dev.get(), false);
-    RunSolver<miopen::solver::fusion::ConvBinWinogradRxSf2x3g1Fused>(
+    RunSolver<miopen::solver::fusion::ConvBinWinogradRxSg1Fused<2, 3>>(
+        fusePlanDesc, plan_params, conv_config, test_skipped);
+}
+TEST_P(ConvBiasActivInferTestFloat, ConvBinWinogradRxSf3x2g1Fused)
+{
+    const auto plan_params = std::make_unique<miopen::fusion::FusionInvokeParams>(
+        params, input.desc, in_dev.get(), output.desc, out_dev.get(), false);
+    RunSolver<miopen::solver::fusion::ConvBinWinogradRxSg1Fused<3, 2>>(
         fusePlanDesc, plan_params, conv_config, test_skipped);
 }
 INSTANTIATE_TEST_SUITE_P(CBAInferSolverTest,


### PR DESCRIPTION
Continuation of #1927. This PR updates the Fused Winograd solver.

## Summary of code changes
- Added FP16 data type support
- Added Fused Winograd F(3,2) support
- The `weight` heuristic used in the Fusion Plan is now calculated based on the granularity loss model

## Local verification
- gfx906, rocm 5.4.2
- gfx90a, rocm 5.4.2