### PR TITLE
Remove MIOPEN_CONV_CONTEXT_USE_FIN_COMPAT_API

### DIFF
--- a/src/convolution.cpp
+++ b/src/convolution.cpp
@@ -291,13 +291,6 @@ TensorDescriptor ConvolutionDescriptor::GetForwardOutputTensor(const TensorDescr
 /// for some related host-side optimizations.
 ///
 /// These optimizations are kind of cutting corners, but advantages are quite high.
-#if MIOPEN_CONV_CONTEXT_USE_FIN_COMPAT_API
-bool ConvolutionDescriptor::IsWinograd3x3SupportedAndFast(
-    const miopen::ConvolutionContext& ctx) const
-{
-    return IsWinograd3x3SupportedAndFast(ctx, ctx.problem);
-}
-#endif
 bool ConvolutionDescriptor::IsWinograd3x3SupportedAndFast(const miopen::ConvolutionContext& ctx,
                                                           const ProblemDescription& problem) const
 {

--- a/src/include/miopen/any_solver.hpp
+++ b/src/include/miopen/any_solver.hpp
@@ -46,12 +46,6 @@ struct AnySolver
     AnySolver() : ptr_value(nullptr){};
     template <class U>
     AnySolver(U src) : ptr_value(new AnySolver_tmpl<U>(std::forward<U>(src))){};
-#if MIOPEN_CONV_CONTEXT_USE_FIN_COMPAT_API
-    bool IsApplicable(const ConvolutionContext& ctx) const
-    {
-        return IsApplicable(ctx, ctx.problem);
-    }
-#endif
     bool IsApplicable(const ConvolutionContext& ctx, const ProblemDescription& problem) const
     {
         assert(ptr_value != nullptr);
@@ -62,12 +56,6 @@ struct AnySolver
         assert(ptr_value != nullptr);
         return ptr_value->IsTunable();
     };
-#if MIOPEN_CONV_CONTEXT_USE_FIN_COMPAT_API
-    bool TestPerfCfgParams(const ConvolutionContext& ctx, const std::string& params) const
-    {
-        return TestPerfCfgParams(ctx, ctx.problem, params);
-    }
-#endif
     bool TestPerfCfgParams(const ConvolutionContext& ctx,
                            const ProblemDescription& problem,
                            const std::string& params) const
@@ -75,12 +63,6 @@ struct AnySolver
         assert(ptr_value != nullptr);
         return ptr_value->TestPerfCfgParams(ctx, problem, params);
     };
-#if MIOPEN_CONV_CONTEXT_USE_FIN_COMPAT_API
-    std::vector<ConvSolution> GetAllSolutions(const ConvolutionContext& ctx) const
-    {
-        return GetAllSolutions(ctx, ctx.problem);
-    }
-#endif
     std::vector<ConvSolution> GetAllSolutions(const ConvolutionContext& ctx,
                                               const ProblemDescription& problem) const
     {
@@ -103,15 +85,6 @@ struct AnySolver
         return ptr_value->Type();
     };
     bool IsEmpty() const { return ptr_value == nullptr; };
-#if MIOPEN_CONV_CONTEXT_USE_FIN_COMPAT_API
-    ConvSolution FindSolution(const ConvolutionContext& ctx,
-                              PerformanceDb& db,
-                              const miopen::AnyInvokeParams& invoke_ctx,
-                              const std::string& perf_cfg = "") const
-    {
-        return FindSolution(ctx, ctx.problem, db, invoke_ctx, perf_cfg);
-    }
-#endif
     ConvSolution FindSolution(const ConvolutionContext& ctx,
                               const ProblemDescription& problem,
                               PerformanceDb& db,
@@ -121,12 +94,6 @@ struct AnySolver
         assert(ptr_value != nullptr);
         return ptr_value->FindSolution(ctx, problem, db, invoke_ctx, perf_cfg);
     };
-#if MIOPEN_CONV_CONTEXT_USE_FIN_COMPAT_API
-    std::string GetPerfCfgParams(const ConvolutionContext& ctx, PerformanceDb& db) const
-    {
-        return GetPerfCfgParams(ctx, ctx.problem, db);
-    }
-#endif
     std::string GetPerfCfgParams(const ConvolutionContext& ctx,
                                  const ProblemDescription& problem,
                                  PerformanceDb& db) const

--- a/src/include/miopen/conv/context.hpp
+++ b/src/include/miopen/conv/context.hpp
@@ -26,7 +26,7 @@
 
 #pragma once
 
-#define MIOPEN_CONV_CONTEXT_USE_FIN_COMPAT_API 1
+#define MIOPEN_CONV_CONTEXT_USE_FIN_COMPAT_API 0
 
 #include <miopen/db_path.hpp>
 #include <miopen/execution_context.hpp>

--- a/src/include/miopen/conv/context.hpp
+++ b/src/include/miopen/conv/context.hpp
@@ -26,47 +26,28 @@
 
 #pragma once
 
-#define MIOPEN_CONV_CONTEXT_USE_FIN_COMPAT_API 0
-
-#include <miopen/db_path.hpp>
 #include <miopen/execution_context.hpp>
 #include <miopen/problem_description.hpp>
-#include <miopen/miopen.h>
 
 #include <string>
 
 namespace miopen {
-struct ConvolutionDescriptor;
-struct Handle;
-struct TensorDescriptor;
-
-/// A leftover of the legacy design, houses problem config,
+/// A leftover of the legacy design, houses
 /// environmental context (e.g. HW/SW platform) and solver-specific state.
 ///
-/// TODO: These three entities should be made separate.
+/// TODO: These two entities should be made separate.
 struct ConvolutionContext : ExecutionContext
 {
     // Solution-specific
     std::string general_compile_options;
 
     ConvolutionContext() = default;
-
-#if MIOPEN_CONV_CONTEXT_USE_FIN_COMPAT_API
-    explicit ConvolutionContext(const ProblemDescription& problem_) : problem(problem_) {}
-#endif
     explicit ConvolutionContext(const ExecutionContext& ctx) : ExecutionContext(ctx) {}
 
-#if MIOPEN_CONV_CONTEXT_USE_FIN_COMPAT_API
-    void SetupFloats() { SetupFloats(problem); }
-#endif
     void SetupFloats(const ProblemDescription& problem);
 
 public:
     bool is_for_generic_search = false;
-
-#if MIOPEN_CONV_CONTEXT_USE_FIN_COMPAT_API
-    ProblemDescription problem;
-#endif
 };
 
 } // namespace miopen

--- a/src/include/miopen/convolution.hpp
+++ b/src/include/miopen/convolution.hpp
@@ -184,7 +184,6 @@ struct ConvolutionDescriptor : miopenConvolutionDescriptor
     ForwardBackwardDataGetWorkSpaceSizeWinograd(const miopen::ConvolutionContext& ctx,
                                                 const miopen::ProblemDescription& problem) const;
 
-    bool IsWinograd3x3SupportedAndFast(const miopen::ConvolutionContext& ctx) const;
     bool IsWinograd3x3SupportedAndFast(const miopen::ConvolutionContext& ctx,
                                        const ProblemDescription& problem) const;
 

--- a/src/mlo_dir_conv.cpp
+++ b/src/mlo_dir_conv.cpp
@@ -382,18 +382,18 @@ AllFFTForwardBackwardDataWorkspaceSize(const miopen::ConvolutionContext& ctx,
     return GetFFTSolvers().GetWorkspaceSizes(ctx, problem);
 }
 
-void miopen::ConvolutionContext::SetupFloats(const miopen::ProblemDescription& problem_)
+void miopen::ConvolutionContext::SetupFloats(const miopen::ProblemDescription& problem)
 {
-    if(problem_.IsFp32() || problem_.IsFp16() || problem_.IsBfp16() || problem_.IsInt8())
+    if(problem.IsFp32() || problem.IsFp16() || problem.IsBfp16() || problem.IsInt8())
     {
-        general_compile_options += GetDataTypeKernelParams(problem_.in_data_type);
+        general_compile_options += GetDataTypeKernelParams(problem.in_data_type);
     }
     else
     {
         MIOPEN_LOG_W("Unsupported data types configuration: "
-                     << miopen::GetDataTypeName(problem_.in_data_type) << "x"
-                     << miopen::GetDataTypeName(problem_.weights_data_type) << "x"
-                     << miopen::GetDataTypeName(problem_.out_data_type));
+                     << miopen::GetDataTypeName(problem.in_data_type) << "x"
+                     << miopen::GetDataTypeName(problem.weights_data_type) << "x"
+                     << miopen::GetDataTypeName(problem.out_data_type));
     }
 }
 


### PR DESCRIPTION
This PR removes `MIOPEN_CONV_CONTEXT_USE_FIN_COMPAT_API`, since https://github.com/ROCmSoftwarePlatform/MIFin/pull/76 has been merged. This is the last stage of splitting `Context` and `ProblemDescription`.