### PR TITLE
Faster batchsize split

### DIFF
--- a/src/include/miopen/conv/asm_implicit_gemm.hpp
+++ b/src/include/miopen/conv/asm_implicit_gemm.hpp
@@ -261,12 +261,22 @@ static inline int igemm_split_batch_size(const int hi,
         // find the smallest multiple k of n such that (n / k) * image_size <= max_tensor_size.
         // once k is known, (n / k) == max_n
         size_t k = std::ceil(n / max_n); // (n / k) <= max_n   =>   k >= n/max_n
-        while (n % max_n != 0)
+        size_t _sqrt_n = std::sqrt(n);
+        while(n % max_n != 0)
         {
-            if (n % k == 0)
+            if(n % k == 0)
                 max_n = n / k;
             else
+            {
                 k += 1;
+                if(k > _sqrt_n)
+                {
+                    // if k > sqrt_n, then there must exist u < sqrt_n s.t. u * k = sqrt_n, but
+                    // such a u cannot exist since k is the smallest multiple of n. Thus, the 
+                    // search is over, and we know k = max_n
+                    max_n = 1;
+                }
+            }        
         }
     }
 

--- a/src/include/miopen/conv/asm_implicit_gemm.hpp
+++ b/src/include/miopen/conv/asm_implicit_gemm.hpp
@@ -251,7 +251,7 @@ static inline int igemm_split_batch_size(const int hi,
     if(image_size >= max_tensor_size)
         return 0;
 
-    // Round up splits: we must find the largest multiple of n, max_n, s.t. 
+    // Round up splits: we must find the largest multiple of n, max_n, s.t.
     // max_n * image_size <= max_tensor_size
     size_t max_n = max_tensor_size / image_size;
     if(max_n > n)
@@ -260,7 +260,7 @@ static inline int igemm_split_batch_size(const int hi,
     {
         // find the smallest multiple m of n such that (n / m) * image_size <= max_tensor_size.
         // once m is known, max_n := (n / m)
-        size_t m = std::ceil(n / max_n); // m >= n * (image_size / max_tensor_size)
+        size_t m       = std::ceil(n / max_n); // m >= n * (image_size / max_tensor_size)
         size_t _sqrt_n = std::sqrt(n);
         while(n % max_n != 0)
         {
@@ -272,7 +272,7 @@ static inline int igemm_split_batch_size(const int hi,
                 if(m > _sqrt_n)
                 {
                     // if m > sqrt_n, then there must exist u < sqrt_n s.t. u * m = sqrt_n, but
-                    // such a u cannot exist since m is the smallest multiple of n. Thus, the 
+                    // such a u cannot exist since m is the smallest multiple of n. Thus, the
                     // search is over, and we know m = max_n
                     max_n = 1;
                 }

--- a/src/include/miopen/conv/asm_implicit_gemm.hpp
+++ b/src/include/miopen/conv/asm_implicit_gemm.hpp
@@ -258,25 +258,25 @@ static inline int igemm_split_batch_size(const int hi,
         max_n = n % max_n;
     else if(max_n < n)
     {
-        // find the smallest multiple k of n such that (n / k) * image_size <= max_tensor_size.
-        // once k is known, (n / k) == max_n
-        size_t k = std::ceil(n / max_n); // (n / k) <= max_n   =>   k >= n/max_n
+        // find the smallest multiple m of n such that (n / m) * image_size <= max_tensor_size.
+        // once m is known, max_n := (n / m)
+        size_t m = std::ceil(n / max_n); // m >= n * (image_size / max_tensor_size)
         size_t _sqrt_n = std::sqrt(n);
         while(n % max_n != 0)
         {
-            if(n % k == 0)
-                max_n = n / k;
+            if(n % m == 0)
+                max_n = n / m;
             else
             {
-                k += 1;
-                if(k > _sqrt_n)
+                m += 1;
+                if(m > _sqrt_n)
                 {
-                    // if k > sqrt_n, then there must exist u < sqrt_n s.t. u * k = sqrt_n, but
-                    // such a u cannot exist since k is the smallest multiple of n. Thus, the 
-                    // search is over, and we know k = max_n
+                    // if m > sqrt_n, then there must exist u < sqrt_n s.t. u * m = sqrt_n, but
+                    // such a u cannot exist since m is the smallest multiple of n. Thus, the 
+                    // search is over, and we know m = max_n
                     max_n = 1;
                 }
-            }        
+            }
         }
     }
 


### PR DESCRIPTION
Batchsize splitting done during the verification of igemm_kernels takes too long. This is because the calculation for max_n in https://github.com/ROCmSoftwarePlatform/MIOpen/blob/develop/src/include/miopen/conv/asm_implicit_gemm.hpp#LL253-L266C22 is slow. In theory, max_n can have a value anywhere from 4294967296 (`0xfffffffful`) to 1. The current algorithm starts with a max_n of 4294967296 / image_size, and it decrements it by 1 until max_n becomes a multiple of batch_size. For a small image_size (which is often the case for neural networks), this linear time search can be prohibitively slow, and can be improved significantly using the algorithm in this PR.

Note that KernelTuningNet for iGEMM does beam search. If there are N tuning parameters to predict, and we have a beam width of K, then constraint checking needs to happen N*K times, and  any slowdowns in constraint checking can slowdown KernelTuningNet by a lot.