### PR TITLE
guard header with MIOPEN_DONT_USE_HIP_RUNTIME_HEADERS

### DIFF
--- a/src/kernels/gpu_reference_kernel/naive_conv.cpp
+++ b/src/kernels/gpu_reference_kernel/naive_conv.cpp
@@ -36,7 +36,9 @@
 typedef signed char int8_t;
 typedef signed short int16_t;
 typedef float float_t;
+#ifndef MIOPEN_DONT_USE_HIP_RUNTIME_HEADERS
 #include <limits> // std::numeric_limits
+#endif
 
 #else
 #include <cstdint> // int8_t, int16_t


### PR DESCRIPTION
this is to fix issue https://github.com/ROCmSoftwarePlatform/MIOpen/issues/2049 by adding `MIOPEN_DONT_USE_HIP_RUNTIME_HEADERS` around headers, as suggested https://github.com/ROCmSoftwarePlatform/MIOpen/issues/2049#issuecomment-1484242502

