### PR TITLE
add parenthesis to node name labels

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 def rocmnode(name) {
-    return 'rocmtest && miopen && ' + name
+    return 'rocmtest && miopen && (' + name + ')'
 }
 
 def miopenCheckout()


### PR DESCRIPTION
Currently the node labels specified as a combination of  `||` (injunctions) are able to short circuit all the labels injunction labels. This PR would fix this issue.