### PR TITLE
Fixing the tip of develop build failure

### DIFF
--- a/src/ocl/rnnocl.cpp
+++ b/src/ocl/rnnocl.cpp
@@ -347,7 +347,6 @@ void RNNDescriptor::RNNForwardTraining_MS(Handle& handle,
                                                     wx_off,
                                                     reserveSpace,
                                                     out_offset,
-                                                    nullptr,
                                                     GemmBackend_t::miopengemm);
         if(gemm_status != miopenStatusSuccess)
             MIOPEN_THROW("GEMM execution failure");
@@ -459,7 +458,6 @@ void RNNDescriptor::RNNForwardTraining_MS(Handle& handle,
                                                     WeiBuf.get_matrix_h_off(layer),
                                                     reserveSpace,
                                                     RB_layer_save_points_off,
-                                                    nullptr,
                                                     GemmBackend_t::miopengemm);
 
         if(gemm_status != miopenStatusSuccess)


### PR DESCRIPTION
This breakage is blocking MLIR release branching. Tip of develop is broken and would yield the compile failure as below:

> /root/MIOpen/src/ocl/rnnocl.cpp:342:44: error: no matching function for call to 'CallGemm'                                                                                                                                                                                                                                                                      const miopenStatus_t gemm_status = CallGemm(handle,                                                                                                                                                                                                                                                                                                                                        ^~~~~~~~                                                                                                                                                                                                                                                                                                     
/root/MIOpen/src/include/miopen/gemm_v2.hpp:94:16: note: candidate function not viable: no known conversion from 'std::nullptr_t' to 'miopen::GemmBackend_t' for 9th argument                                                                                                                                                                           miopenStatus_t CallGemm(const Handle& handle,                                                                                                                                                                                                                                                                                                                          ^                                                                                                                                                                                                                                                                                                                                        

> /root/MIOpen/src/ocl/rnnocl.cpp:454:44: error: no matching function for call to 'CallGemm'                                                                                                                                                                                                                                                                      const miopenStatus_t gemm_status = CallGemm(handle,                                                                                                                                                                                                                                                                                                                                        ^~~~~~~~                                                                                                                                                                                                                                                                                                     /root/MIOpen/src/include/miopen/gemm_v2.hpp:94:16: note: candidate function not viable: no known conversion from 'std::nullptr_t' to 'miopen::GemmBackend_t' for 9th argument                                                                                                                                                                           miopenStatus_t CallGemm(const Handle& handle,

Looks to me that this is caused by some conflict resolution failure.