### PR TITLE
[ROCm 5.6] Bump CK version to suppress gtest warning

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ boost@1.79 -DCMAKE_POSITION_INDEPENDENT_CODE=On --build -DCMAKE_CXX_FLAGS=" -std
 half,https://github.com/pfultz2/half/archive/1.12.0.tar.gz -X header -H sha256:0a08660b68abb176ebc2a0cdf8de46e3182a7f46c66443bb80dbfaaec98cf969 --build
 ROCmSoftwarePlatform/rocMLIR@rocm-5.5.0 -H sha256:a5f62769d28a73e60bc8d61022820f050e97c977c8f6f6275488db31512e1f42 -DBUILD_FAT_LIBROCKCOMPILER=1
 nlohmann/json@v3.9.1 -DJSON_MultipleHeaders=ON -DJSON_BuildTests=Off
-ROCmSoftwarePlatform/composable_kernel@5f28614222bd590bc31d98838bc019e9c3a7ad45 -DGPU_TARGETS="gfx900;gfx906;gfx908;gfx90a;gfx1030;gfx1100;gfx1101;gfx1102"
+ROCmSoftwarePlatform/composable_kernel@0f98035df1cc5ba3e90ab03187e672b426a25b00 -DGPU_TARGETS="gfx900;gfx906;gfx908;gfx90a;gfx1030;gfx1100;gfx1101;gfx1102"


### PR DESCRIPTION
This PR only cherry pick this commit https://github.com/ROCmSoftwarePlatform/composable_kernel/pull/670 to the branch `ck_final_for_miopen_5.6_release`

Currenly ths is blocking a compiler patch:
"patch 785694: [SafeBufferUsage] restore safe buffer usage warnings for MIOpen GTest | http://gerrit-git.amd.com/c/lightning/ec/llvm-project/+/785694"

Similar to https://github.com/ROCmSoftwarePlatform/MIOpen/pull/1912

Not a hard blocker since it could be overridden by setting `GTEST_CMAKE_CXX_FLAGS` globally