### PR TITLE
[API] Solver id getter from a solution and solver id to algo converter

### DIFF
--- a/include/miopen/miopen.h
+++ b/include/miopen/miopen.h
@@ -4985,7 +4985,7 @@ miopenStatus_t miopenGetSolutionWorkspaceSize(miopenSolution_t solution, size_t*
  */
 miopenStatus_t miopenGetSolutionTime(miopenSolution_t solution, float* time);
 
-/*! @brief Reads id of the solver referred to by the solution.
+/*! @brief Reads id of the solver referred by the solution.
  *
  * @param solution Solution to get solver id from
  * @param solverId Pointer to a location where to write the solver id
@@ -4993,7 +4993,7 @@ miopenStatus_t miopenGetSolutionTime(miopenSolution_t solution, float* time);
  */
 miopenStatus_t miopenGetSolutionSolverId(miopenSolution_t solution, uint64_t* solverId);
 
-/*! @brief Reads the time spent to execute the solution the last it was run.
+/*! @brief Gets the convolution algorithm implemented by a solver.
  *
  * @param solverId Solver id to get convolution algorithm of
  * @param result   Pointer to a location where to write the algorithm

--- a/include/miopen/miopen.h
+++ b/include/miopen/miopen.h
@@ -4985,6 +4985,14 @@ miopenStatus_t miopenGetSolutionWorkspaceSize(miopenSolution_t solution, size_t*
  */
 miopenStatus_t miopenGetSolutionTime(miopenSolution_t solution, float* time);
 
+/*! @brief Reads id of the solver referred to by the solution.
+ *
+ * @param solution Solution to get solver id from
+ * @param solverId Pointer to a location where to write the solver id
+ * @return         miopenStatus_t
+ */
+miopenStatus_t miopenGetSolutionSolverId(miopenSolution_t solution, uint64_t* solverId);
+
 /** @} */
 // CLOSEOUT find2 DOXYGEN GROUP
 

--- a/include/miopen/miopen.h
+++ b/include/miopen/miopen.h
@@ -4993,6 +4993,14 @@ miopenStatus_t miopenGetSolutionTime(miopenSolution_t solution, float* time);
  */
 miopenStatus_t miopenGetSolutionSolverId(miopenSolution_t solution, uint64_t* solverId);
 
+/*! @brief Reads the time spent to execute the solution the last it was run.
+ *
+ * @param solverId Solver id to get convolution algorithm of
+ * @param result   Pointer to a location where to write the algorithm
+ * @return         miopenStatus_t
+ */
+miopenStatus_t miopenGetSolverIdConvAlgorithm(uint64_t solverId, miopenConvAlgorithm_t* result);
+
 /** @} */
 // CLOSEOUT find2 DOXYGEN GROUP
 

--- a/src/api/find2_0_commons.cpp
+++ b/src/api/find2_0_commons.cpp
@@ -294,4 +294,15 @@ miopenStatus_t miopenGetSolutionTime(miopenSolution_t solution, float* time)
         *time                      = solution_deref.GetTime();
     });
 }
+
+miopenStatus_t miopenGetSolutionSolverId(miopenSolution_t solution, uint64_t* solverId)
+{
+    MIOPEN_LOG_FUNCTION(solution, solverId);
+
+    return miopen::try_([&] {
+        const auto& solution_deref = miopen::deref(solution);
+        *solverId                  = solution_deref.GetSolver().Value();
+    });
+}
+
 }

--- a/src/api/find2_0_commons.cpp
+++ b/src/api/find2_0_commons.cpp
@@ -33,6 +33,7 @@
 #include <miopen/problem.hpp>
 #include <miopen/search_options.hpp>
 #include <miopen/solution.hpp>
+#include <miopen/solver_id.hpp>
 #include <miopen/type_name.hpp>
 
 #include <nlohmann/json.hpp>
@@ -305,4 +306,17 @@ miopenStatus_t miopenGetSolutionSolverId(miopenSolution_t solution, uint64_t* so
     });
 }
 
+miopenStatus_t miopenGetSolverIdConvAlgorithm(uint64_t solverId, miopenConvAlgorithm_t* result)
+{
+    MIOPEN_LOG_FUNCTION(solverId, result);
+
+    return miopen::try_([&] {
+        const auto id_deref = miopen::solver::Id{solverId};
+
+        if(!id_deref.IsValid() || id_deref.GetPrimitive() != miopen::solver::Primitive::Convolution)
+            MIOPEN_THROW(miopenStatusInvalidValue);
+
+        *result = id_deref.GetAlgo();
+    });
+}
 }

--- a/test/find_2_conv.cpp
+++ b/test/find_2_conv.cpp
@@ -254,11 +254,13 @@ private:
             float time;
             std::size_t workspace_size;
             uint64_t solver_id;
+            miopenConvAlgorithm_t algo;
 
             EXPECT_EQUAL(miopenGetSolutionTime(solution, &time), miopenStatusSuccess);
             EXPECT_EQUAL(miopenGetSolutionWorkspaceSize(solution, &workspace_size),
                          miopenStatusSuccess);
             EXPECT_EQUAL(miopenGetSolutionSolverId(solution, &solver_id), miopenStatusSuccess);
+            EXPECT_EQUAL(miopenGetSolverIdConvAlgorithm(solver_id, &algo), miopenStatusSuccess);
         }
 
         std::cerr << "Finished testing miopenGetSolution<Attribute>." << std::endl;

--- a/test/find_2_conv.cpp
+++ b/test/find_2_conv.cpp
@@ -253,10 +253,12 @@ private:
         {
             float time;
             std::size_t workspace_size;
+            uint64_t solver_id;
 
             EXPECT_EQUAL(miopenGetSolutionTime(solution, &time), miopenStatusSuccess);
             EXPECT_EQUAL(miopenGetSolutionWorkspaceSize(solution, &workspace_size),
                          miopenStatusSuccess);
+            EXPECT_EQUAL(miopenGetSolutionSolverId(solution, &solver_id), miopenStatusSuccess);
         }
 
         std::cerr << "Finished testing miopenGetSolution<Attribute>." << std::endl;


### PR DESCRIPTION
Simply adds one solution getter and one value converter to the API. Allows people using Find 2.0 to filter found solutions by solver and algorithm.

This implements (100.10) from https://github.com/ROCmSoftwarePlatform/MIOpen/issues/374 and now we have a one-way interoperability between Find 2.0 and Immediate Modes. And the results of Find 2.0 can be "fully" examined now (for whatever purposes, e.g. filtering out unwanted algorithms or solvers, as said in the description of the PR).

Should resolve the immediate problem from #2082.