### PR TITLE
Fixes for conv_asm perf config validity check.

### DIFF
--- a/src/solver/conv_asm_implicit_gemm_gtc_bwd_nhwc.cpp
+++ b/src/solver/conv_asm_implicit_gemm_gtc_bwd_nhwc.cpp
@@ -734,9 +734,10 @@ bool PerformanceConfigAsmImplicitGemmGTCBwdXdlopsNHWC::IsValidValue() const
     if(IsDefaultConstructed())
         return true;
     const auto& config_list = GetBwdXdlopsNHWCConfigList();
-    if(index >= config_list.size())
-        return false;
-    return *this == config_list[index];
+    for(auto cfg_it = config_list.begin(); cfg_it != config_list.end(); ++cfg_it)
+        if(*this == *cfg_it)
+            return true;
+    return false;
 }
 bool PerformanceConfigAsmImplicitGemmGTCBwdXdlopsNHWC::SetNextValue(const ProblemDescription&)
 {

--- a/src/solver/conv_asm_implicit_gemm_gtc_bwd_nhwc.cpp
+++ b/src/solver/conv_asm_implicit_gemm_gtc_bwd_nhwc.cpp
@@ -734,10 +734,7 @@ bool PerformanceConfigAsmImplicitGemmGTCBwdXdlopsNHWC::IsValidValue() const
     if(IsDefaultConstructed())
         return true;
     const auto& config_list = GetBwdXdlopsNHWCConfigList();
-    for(const auto& cfg_it : config_list)
-        if(*this == cfg_it)
-            return true;
-    return false;
+    return miopen::any_of(config_list, [](auto v) { return (*this == v); })
 }
 bool PerformanceConfigAsmImplicitGemmGTCBwdXdlopsNHWC::SetNextValue(const ProblemDescription&)
 {

--- a/src/solver/conv_asm_implicit_gemm_gtc_bwd_nhwc.cpp
+++ b/src/solver/conv_asm_implicit_gemm_gtc_bwd_nhwc.cpp
@@ -734,7 +734,7 @@ bool PerformanceConfigAsmImplicitGemmGTCBwdXdlopsNHWC::IsValidValue() const
     if(IsDefaultConstructed())
         return true;
     const auto& config_list = GetBwdXdlopsNHWCConfigList();
-    for(const auto & cfg_it : config_list)
+    for(const auto& cfg_it : config_list)
         if(*this == cfg_it)
             return true;
     return false;

--- a/src/solver/conv_asm_implicit_gemm_gtc_bwd_nhwc.cpp
+++ b/src/solver/conv_asm_implicit_gemm_gtc_bwd_nhwc.cpp
@@ -734,6 +734,8 @@ bool PerformanceConfigAsmImplicitGemmGTCBwdXdlopsNHWC::IsValidValue() const
     if(IsDefaultConstructed())
         return true;
     const auto& config_list = GetBwdXdlopsNHWCConfigList();
+    if(index < config_list.size() && *this == config_list[index])
+        return true;
     return miopen::any_of(config_list, [&](auto v) { return (*this == v); });
 }
 bool PerformanceConfigAsmImplicitGemmGTCBwdXdlopsNHWC::SetNextValue(const ProblemDescription&)

--- a/src/solver/conv_asm_implicit_gemm_gtc_bwd_nhwc.cpp
+++ b/src/solver/conv_asm_implicit_gemm_gtc_bwd_nhwc.cpp
@@ -734,7 +734,7 @@ bool PerformanceConfigAsmImplicitGemmGTCBwdXdlopsNHWC::IsValidValue() const
     if(IsDefaultConstructed())
         return true;
     const auto& config_list = GetBwdXdlopsNHWCConfigList();
-    return miopen::any_of(config_list, [](auto v) { return (*this == v); })
+    return miopen::any_of(config_list, [&](auto v) { return (*this == v); });
 }
 bool PerformanceConfigAsmImplicitGemmGTCBwdXdlopsNHWC::SetNextValue(const ProblemDescription&)
 {

--- a/src/solver/conv_asm_implicit_gemm_gtc_bwd_nhwc.cpp
+++ b/src/solver/conv_asm_implicit_gemm_gtc_bwd_nhwc.cpp
@@ -734,8 +734,8 @@ bool PerformanceConfigAsmImplicitGemmGTCBwdXdlopsNHWC::IsValidValue() const
     if(IsDefaultConstructed())
         return true;
     const auto& config_list = GetBwdXdlopsNHWCConfigList();
-    for(auto cfg_it = config_list.begin(); cfg_it != config_list.end(); ++cfg_it)
-        if(*this == *cfg_it)
+    for(const auto & cfg_it : config_list)
+        if(*this == cfg_it)
             return true;
     return false;
 }

--- a/src/solver/conv_asm_implicit_gemm_gtc_fwd_nchwc.cpp
+++ b/src/solver/conv_asm_implicit_gemm_gtc_fwd_nchwc.cpp
@@ -459,7 +459,7 @@ bool PerformanceConfigAsmImplicitGemmGTCFwdDlopsNCHWC::IsValidValue() const
     if(IsDefaultConstructed())
         return true;
     const auto& config_list = GetFwdDlopsNCHWCConfigList();
-    return miopen::any_of(config_list, [](auto v) { return (*this == v); })
+    return miopen::any_of(config_list, [&](auto v) { return (*this == v); });
 }
 bool PerformanceConfigAsmImplicitGemmGTCFwdDlopsNCHWC::IsValid(
     const ProblemDescription& problem) const

--- a/src/solver/conv_asm_implicit_gemm_gtc_fwd_nchwc.cpp
+++ b/src/solver/conv_asm_implicit_gemm_gtc_fwd_nchwc.cpp
@@ -459,7 +459,7 @@ bool PerformanceConfigAsmImplicitGemmGTCFwdDlopsNCHWC::IsValidValue() const
     if(IsDefaultConstructed())
         return true;
     const auto& config_list = GetFwdDlopsNCHWCConfigList();
-    for(const auto & cfg_it : config_list)
+    for(const auto& cfg_it : config_list)
         if(*this == cfg_it)
             return true;
     return false;

--- a/src/solver/conv_asm_implicit_gemm_gtc_fwd_nchwc.cpp
+++ b/src/solver/conv_asm_implicit_gemm_gtc_fwd_nchwc.cpp
@@ -459,6 +459,8 @@ bool PerformanceConfigAsmImplicitGemmGTCFwdDlopsNCHWC::IsValidValue() const
     if(IsDefaultConstructed())
         return true;
     const auto& config_list = GetFwdDlopsNCHWCConfigList();
+    if(index < config_list.size() && *this == config_list[index])
+        return true;
     return miopen::any_of(config_list, [&](auto v) { return (*this == v); });
 }
 bool PerformanceConfigAsmImplicitGemmGTCFwdDlopsNCHWC::IsValid(

--- a/src/solver/conv_asm_implicit_gemm_gtc_fwd_nchwc.cpp
+++ b/src/solver/conv_asm_implicit_gemm_gtc_fwd_nchwc.cpp
@@ -459,9 +459,10 @@ bool PerformanceConfigAsmImplicitGemmGTCFwdDlopsNCHWC::IsValidValue() const
     if(IsDefaultConstructed())
         return true;
     const auto& config_list = GetFwdDlopsNCHWCConfigList();
-    if(index >= config_list.size())
-        return false;
-    return *this == config_list[index];
+    for(auto cfg_it = config_list.begin(); cfg_it != config_list.end(); ++cfg_it)
+        if(*this == *cfg_it)
+            return true;
+    return false;
 }
 bool PerformanceConfigAsmImplicitGemmGTCFwdDlopsNCHWC::IsValid(
     const ProblemDescription& problem) const

--- a/src/solver/conv_asm_implicit_gemm_gtc_fwd_nchwc.cpp
+++ b/src/solver/conv_asm_implicit_gemm_gtc_fwd_nchwc.cpp
@@ -459,10 +459,7 @@ bool PerformanceConfigAsmImplicitGemmGTCFwdDlopsNCHWC::IsValidValue() const
     if(IsDefaultConstructed())
         return true;
     const auto& config_list = GetFwdDlopsNCHWCConfigList();
-    for(const auto& cfg_it : config_list)
-        if(*this == cfg_it)
-            return true;
-    return false;
+    return miopen::any_of(config_list, [](auto v) { return (*this == v); })
 }
 bool PerformanceConfigAsmImplicitGemmGTCFwdDlopsNCHWC::IsValid(
     const ProblemDescription& problem) const

--- a/src/solver/conv_asm_implicit_gemm_gtc_fwd_nchwc.cpp
+++ b/src/solver/conv_asm_implicit_gemm_gtc_fwd_nchwc.cpp
@@ -459,8 +459,8 @@ bool PerformanceConfigAsmImplicitGemmGTCFwdDlopsNCHWC::IsValidValue() const
     if(IsDefaultConstructed())
         return true;
     const auto& config_list = GetFwdDlopsNCHWCConfigList();
-    for(auto cfg_it = config_list.begin(); cfg_it != config_list.end(); ++cfg_it)
-        if(*this == *cfg_it)
+    for(const auto & cfg_it : config_list)
+        if(*this == cfg_it)
             return true;
     return false;
 }

--- a/src/solver/conv_asm_implicit_gemm_gtc_fwd_nhwc.cpp
+++ b/src/solver/conv_asm_implicit_gemm_gtc_fwd_nhwc.cpp
@@ -642,10 +642,7 @@ bool PerformanceConfigAsmImplicitGemmGTCFwdXdlopsNHWC::IsValidValue() const
     if(IsDefaultConstructed())
         return true;
     const auto& config_list = GetFwdXdlopsNHWCConfigList();
-    for(const auto& cfg_it : config_list)
-        if(*this == cfg_it)
-            return true;
-    return false;
+    return miopen::any_of(config_list, [](auto v) { return (*this == v); })
 }
 
 bool PerformanceConfigAsmImplicitGemmGTCFwdXdlopsNHWC::IsValid(

--- a/src/solver/conv_asm_implicit_gemm_gtc_fwd_nhwc.cpp
+++ b/src/solver/conv_asm_implicit_gemm_gtc_fwd_nhwc.cpp
@@ -636,15 +636,18 @@ bool PerformanceConfigAsmImplicitGemmGTCFwdXdlopsNHWC::SetNextValue(const Proble
         return false;
     }
 }
+
 bool PerformanceConfigAsmImplicitGemmGTCFwdXdlopsNHWC::IsValidValue() const
 {
     if(IsDefaultConstructed())
         return true;
     const auto& config_list = GetFwdXdlopsNHWCConfigList();
-    if(index >= config_list.size())
-        return false;
-    return *this == config_list[index];
+    for(auto cfg_it = config_list.begin(); cfg_it != config_list.end(); ++cfg_it)
+        if(*this == *cfg_it)
+            return true;
+    return false;
 }
+
 bool PerformanceConfigAsmImplicitGemmGTCFwdXdlopsNHWC::IsValid(
     const ProblemDescription& problem) const
 {
@@ -697,9 +700,6 @@ bool PerformanceConfigAsmImplicitGemmGTCFwdXdlopsNHWC::IsValid(
 
     if(!(tensor_a_thread_lengths[1] == 1 && tensor_b_thread_lengths[1] == 1))
     {
-        // in case k split too large
-        if(gemm_k_global_split != 0 && (gemm_k_per_block << gemm_k_global_split) > (k / group))
-            return false;
         // if both 1, indicate padded c support
         if(((c >> gemm_k_global_split) / group) % gemm_k_per_block != 0)
             return false;

--- a/src/solver/conv_asm_implicit_gemm_gtc_fwd_nhwc.cpp
+++ b/src/solver/conv_asm_implicit_gemm_gtc_fwd_nhwc.cpp
@@ -642,7 +642,7 @@ bool PerformanceConfigAsmImplicitGemmGTCFwdXdlopsNHWC::IsValidValue() const
     if(IsDefaultConstructed())
         return true;
     const auto& config_list = GetFwdXdlopsNHWCConfigList();
-    return miopen::any_of(config_list, [](auto v) { return (*this == v); })
+    return miopen::any_of(config_list, [&](auto v) { return (*this == v); });
 }
 
 bool PerformanceConfigAsmImplicitGemmGTCFwdXdlopsNHWC::IsValid(

--- a/src/solver/conv_asm_implicit_gemm_gtc_fwd_nhwc.cpp
+++ b/src/solver/conv_asm_implicit_gemm_gtc_fwd_nhwc.cpp
@@ -642,8 +642,8 @@ bool PerformanceConfigAsmImplicitGemmGTCFwdXdlopsNHWC::IsValidValue() const
     if(IsDefaultConstructed())
         return true;
     const auto& config_list = GetFwdXdlopsNHWCConfigList();
-    for(auto cfg_it = config_list.begin(); cfg_it != config_list.end(); ++cfg_it)
-        if(*this == *cfg_it)
+    for(const auto & cfg_it : config_list)
+        if(*this == cfg_it)
             return true;
     return false;
 }

--- a/src/solver/conv_asm_implicit_gemm_gtc_fwd_nhwc.cpp
+++ b/src/solver/conv_asm_implicit_gemm_gtc_fwd_nhwc.cpp
@@ -642,6 +642,8 @@ bool PerformanceConfigAsmImplicitGemmGTCFwdXdlopsNHWC::IsValidValue() const
     if(IsDefaultConstructed())
         return true;
     const auto& config_list = GetFwdXdlopsNHWCConfigList();
+    if(index < config_list.size() && *this == config_list[index])
+        return true;
     return miopen::any_of(config_list, [&](auto v) { return (*this == v); });
 }
 

--- a/src/solver/conv_asm_implicit_gemm_gtc_fwd_nhwc.cpp
+++ b/src/solver/conv_asm_implicit_gemm_gtc_fwd_nhwc.cpp
@@ -642,7 +642,7 @@ bool PerformanceConfigAsmImplicitGemmGTCFwdXdlopsNHWC::IsValidValue() const
     if(IsDefaultConstructed())
         return true;
     const auto& config_list = GetFwdXdlopsNHWCConfigList();
-    for(const auto & cfg_it : config_list)
+    for(const auto& cfg_it : config_list)
         if(*this == cfg_it)
             return true;
     return false;

--- a/src/solver/conv_asm_implicit_gemm_gtc_wrw_nhwc.cpp
+++ b/src/solver/conv_asm_implicit_gemm_gtc_wrw_nhwc.cpp
@@ -725,6 +725,8 @@ bool PerformanceConfigAsmImplicitGemmGTCWrwXdlopsNHWC::IsValidValue() const
     if(IsDefaultConstructed())
         return true;
     const auto& config_list = GetWrwXdlopsNHWCConfigList();
+    if(index < config_list.size() && *this == config_list[index])
+        return true;
     return miopen::any_of(config_list, [&](auto v) { return (*this == v); });
 }
 

--- a/src/solver/conv_asm_implicit_gemm_gtc_wrw_nhwc.cpp
+++ b/src/solver/conv_asm_implicit_gemm_gtc_wrw_nhwc.cpp
@@ -725,9 +725,10 @@ bool PerformanceConfigAsmImplicitGemmGTCWrwXdlopsNHWC::IsValidValue() const
     if(IsDefaultConstructed())
         return true;
     const auto& config_list = GetWrwXdlopsNHWCConfigList();
-    if(index >= config_list.size())
-        return false;
-    return *this == config_list[index];
+    for(auto cfg_it = config_list.begin(); cfg_it != config_list.end(); ++cfg_it)
+        if(*this == *cfg_it)
+            return true;
+    return false;
 }
 
 bool PerformanceConfigAsmImplicitGemmGTCWrwXdlopsNHWC::IsValid(

--- a/src/solver/conv_asm_implicit_gemm_gtc_wrw_nhwc.cpp
+++ b/src/solver/conv_asm_implicit_gemm_gtc_wrw_nhwc.cpp
@@ -725,10 +725,7 @@ bool PerformanceConfigAsmImplicitGemmGTCWrwXdlopsNHWC::IsValidValue() const
     if(IsDefaultConstructed())
         return true;
     const auto& config_list = GetWrwXdlopsNHWCConfigList();
-    for(const auto& cfg_it : config_list)
-        if(*this == cfg_it)
-            return true;
-    return false;
+    return miopen::any_of(config_list, [](auto v) { return (*this == v); })
 }
 
 bool PerformanceConfigAsmImplicitGemmGTCWrwXdlopsNHWC::IsValid(

--- a/src/solver/conv_asm_implicit_gemm_gtc_wrw_nhwc.cpp
+++ b/src/solver/conv_asm_implicit_gemm_gtc_wrw_nhwc.cpp
@@ -725,8 +725,8 @@ bool PerformanceConfigAsmImplicitGemmGTCWrwXdlopsNHWC::IsValidValue() const
     if(IsDefaultConstructed())
         return true;
     const auto& config_list = GetWrwXdlopsNHWCConfigList();
-    for(auto cfg_it = config_list.begin(); cfg_it != config_list.end(); ++cfg_it)
-        if(*this == *cfg_it)
+    for(const auto & cfg_it : config_list)
+        if(*this == cfg_it)
             return true;
     return false;
 }

--- a/src/solver/conv_asm_implicit_gemm_gtc_wrw_nhwc.cpp
+++ b/src/solver/conv_asm_implicit_gemm_gtc_wrw_nhwc.cpp
@@ -725,7 +725,7 @@ bool PerformanceConfigAsmImplicitGemmGTCWrwXdlopsNHWC::IsValidValue() const
     if(IsDefaultConstructed())
         return true;
     const auto& config_list = GetWrwXdlopsNHWCConfigList();
-    for(const auto & cfg_it : config_list)
+    for(const auto& cfg_it : config_list)
         if(*this == cfg_it)
             return true;
     return false;

--- a/src/solver/conv_asm_implicit_gemm_gtc_wrw_nhwc.cpp
+++ b/src/solver/conv_asm_implicit_gemm_gtc_wrw_nhwc.cpp
@@ -725,7 +725,7 @@ bool PerformanceConfigAsmImplicitGemmGTCWrwXdlopsNHWC::IsValidValue() const
     if(IsDefaultConstructed())
         return true;
     const auto& config_list = GetWrwXdlopsNHWCConfigList();
-    return miopen::any_of(config_list, [](auto v) { return (*this == v); })
+    return miopen::any_of(config_list, [&](auto v) { return (*this == v); });
 }
 
 bool PerformanceConfigAsmImplicitGemmGTCWrwXdlopsNHWC::IsValid(


### PR DESCRIPTION
Remove k-split comparison with output size.
Update IsValidValue so that it is stateless, allows IsValidPerformanceConfig to be called without state.