### PR TITLE
[W/A] Suppress safe-buffer-usage deprecated-declarations shadow-uncaptured-local with new compiler update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,10 @@
 ################################################################################
 cmake_minimum_required( VERSION 3.11 )
 
+if (POLICY CMP0074)
+  cmake_policy(SET CMP0074 NEW)
+endif()
+
 macro(set_var_to_condition var)
     if(${ARGN})
         set(${var} TRUE)

--- a/cmake/EnableCompilerWarnings.cmake
+++ b/cmake/EnableCompilerWarnings.cmake
@@ -93,6 +93,7 @@ else()
                 -Wno-weak-vtables
                 -Wno-covered-switch-default
                 -Wno-unused-result
+                -Wno-unsafe-buffer-usage
             )
         else()
             if (CMAKE_${COMPILER}_COMPILER_ID MATCHES "GNU" AND ${COMPILER} MATCHES "CXX")

--- a/cmake/EnableCompilerWarnings.cmake
+++ b/cmake/EnableCompilerWarnings.cmake
@@ -94,6 +94,8 @@ else()
                 -Wno-covered-switch-default
                 -Wno-unused-result
                 -Wno-unsafe-buffer-usage
+                -Wno-deprecated-declarations
+                -Wno-shadow-uncaptured-local
             )
         else()
             if (CMAKE_${COMPILER}_COMPILER_ID MATCHES "GNU" AND ${COMPILER} MATCHES "CXX")

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ nlohmann/json@v3.9.1 -DJSON_MultipleHeaders=ON -DJSON_BuildTests=Off
 ROCmSoftwarePlatform/FunctionalPlus@v0.2.18-p0
 ROCmSoftwarePlatform/eigen@3.4.0
 ROCmSoftwarePlatform/frugally-deep@9683d557eb672ee2304f80f6682c51242d748a50
-ROCmSoftwarePlatform/composable_kernel@0f98035df1cc5ba3e90ab03187e672b426a25b00 -DGPU_TARGETS="gfx900;gfx906;gfx908;gfx90a;gfx1030;gfx1100;gfx1101;gfx1102"
+ROCmSoftwarePlatform/composable_kernel@0a8dac4ef1a232abd8f6896a5b016f9e76192ddd -DGPU_TARGETS="gfx900;gfx906;gfx908;gfx90a;gfx940;gfx1030;gfx1100;gfx1101;gfx1102"

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ nlohmann/json@v3.9.1 -DJSON_MultipleHeaders=ON -DJSON_BuildTests=Off
 ROCmSoftwarePlatform/FunctionalPlus@v0.2.18-p0
 ROCmSoftwarePlatform/eigen@3.4.0
 ROCmSoftwarePlatform/frugally-deep@9683d557eb672ee2304f80f6682c51242d748a50
-ROCmSoftwarePlatform/composable_kernel@0a8dac4ef1a232abd8f6896a5b016f9e76192ddd -DGPU_TARGETS="gfx900;gfx906;gfx908;gfx90a;gfx940;gfx1030;gfx1100;gfx1101;gfx1102"
+ROCmSoftwarePlatform/composable_kernel@0a8dac4ef1a232abd8f6896a5b016f9e76192ddd -DGPU_TARGETS="gfx900;gfx906;gfx908;gfx90a;gfx1030;gfx1100;gfx1101;gfx1102"


### PR DESCRIPTION
These are workaround with Compiler Updates:
```
HOST:~/MIOpen# /opt/rocm/llvm/bin/clang++ --version
AMD clang version 17.0.0 (ssh://gerritgit/lightning/ec/llvm-project  23173 991d7848b74064014482e2a47b19a4e534a58fd5)
Target: x86_64-unknown-linux-gnu
Thread model: posix
InstalledDir: /opt/rocm/llvm/bin
```