### PR TITLE
[pooling] Fix FP16 precision issues (averaging mode) plus more

### DIFF
--- a/driver/calcerr.hpp
+++ b/driver/calcerr.hpp
@@ -1,8 +1,42 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2023 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
 #ifndef GUARD_CALC_ERR_
 #define GUARD_CALC_ERR_
 
+#include <cmath>
+#include <cstdint>
+
+// This works well when difference is small. When one value
+// is 0 and another is not, result is incorrect (very big)
+// due to zero exponent in one number and non-zero exponent
+// in another, because exponent resides in MSBs of a floating
+// point number.
 template <typename T_>
-double CalcErr(T_ c_val, T_ g_val)
+float ApproxUlps(T_ c_val, T_ g_val)
 {
     double err = -1.0;
     if(sizeof(T_) == 2)
@@ -24,10 +58,10 @@ double CalcErr(T_ c_val, T_ g_val)
         err             = static_cast<double>(std::abs(*c_uval - *g_uval));
     }
 
-    //		double delta = abs(c_val - g_val);
-    //	double nextafter_delta = nextafterf(min(abs(c_val), abs(g_val)), (T_)INFINITY) -
+    // double delta = abs(c_val - g_val);
+    // double nextafter_delta = nextafterf(min(abs(c_val), abs(g_val)), (T_)INFINITY) -
     // min(abs(c_val), abs(g_val));
-    //		err = delta / nextafter_delta;
+    // err = delta / nextafter_delta;
     return err;
 }
 

--- a/driver/pool_driver.hpp
+++ b/driver/pool_driver.hpp
@@ -647,7 +647,11 @@ int PoolDriver_impl<Tgpu, Tref, Index>::VerifyForward()
             ? MLO_POOLING_OP_MAX
             : ((mode == miopenPoolingAverage) ? MLO_POOLING_OP_AVE : MLO_POOLING_OP_AVE_INCLUSIVE);
 
-    const Tref tolerance = (sizeof(Tgpu) == 4 || sizeof(Tgpu) == 8) ? 1e-6 : 5e-3;
+    const Tref tolerance =          //
+        sizeof(Tgpu) == 8   ? 1e-6  // double
+        : sizeof(Tgpu) == 4 ? 1e-5  // float
+                            : 5e-3; // half
+
     pooling_math_stats stats;
     bool match = mloPoolingForwardRunHostAndVerify<Tgpu, Tref, Index>(
         pooling_method,

--- a/driver/pool_driver.hpp
+++ b/driver/pool_driver.hpp
@@ -325,6 +325,40 @@ std::vector<int> PoolDriver_impl<Tgpu, Tref, Index>::GetOutputTensorLengths()
     return out_dim;
 }
 
+namespace detail {
+template <typename T>
+T RanGenInput()
+{
+    return RAN_GEN<T>(static_cast<T>(0.0), static_cast<T>(1.0));
+}
+
+#define FP16IN_NORMAL 1
+#define FP16IN_CONST_SMALLEST_NORMALIZED 0
+#define FP16IN_5VALUES_0_TO_1 0
+#define FP16IN_SPARSE_X 0 // non-zero value defines "sparsity"
+
+template <>
+float16 RanGenInput()
+{
+    using T = float16;
+#if FP16IN_NORMAL
+    return RAN_GEN<T>(static_cast<T>(0.0), static_cast<T>(1.0));
+#endif
+#if FP16IN_CONST_SMALLEST_NORMALIZED
+    return static_cast<T>(+1.0p-eh) // (6.103515625E-05);
+#endif
+#if FP16IN_5VALUES_0_TO_1
+           const int r = GET_RAND() % 5; // values from 0 to 4
+    return static_cast<T>(r * 0.25);     // { 0.0, 0.25, 0.5, 0.75, 1.0 }
+#endif
+#if FP16IN_SPARSE_X
+    if(GET_RAND() % (FP16IN_SPARSE_X) != 0) // produce 9 zeros in ~ each 10 values
+        return static_cast<T>(0.0);
+    return RAN_GEN<T>(static_cast<T>(0.0), static_cast<T>(1.0));
+#endif
+}
+} // namespace detail
+
 template <typename Tgpu, typename Tref, typename Index>
 int PoolDriver_impl<Tgpu, Tref, Index>::AllocateBuffersAndCopy()
 {
@@ -366,7 +400,7 @@ int PoolDriver_impl<Tgpu, Tref, Index>::AllocateBuffersAndCopy()
     {
         for(int i = 0; i < in_sz; i++)
         {
-            in[i] = RAN_GEN<Tgpu>(static_cast<Tgpu>(0.0), static_cast<Tgpu>(1.0));
+            in[i] = detail::RanGenInput<Tgpu>();
         }
 
         if(!dump_root.empty())
@@ -614,7 +648,8 @@ int PoolDriver_impl<Tgpu, Tref, Index>::VerifyForward()
             : ((mode == miopenPoolingAverage) ? MLO_POOLING_OP_AVE : MLO_POOLING_OP_AVE_INCLUSIVE);
 
     const Tref tolerance = (sizeof(Tgpu) == 4 || sizeof(Tgpu) == 8) ? 1e-6 : 5e-3;
-    bool match           = mloPoolingForwardRunHostAndVerify<Tgpu, Tref, Index>(
+    pooling_math_stats stats;
+    bool match = mloPoolingForwardRunHostAndVerify<Tgpu, Tref, Index>(
         pooling_method,
         pad_d,
         stride_d,
@@ -633,11 +668,14 @@ int PoolDriver_impl<Tgpu, Tref, Index>::VerifyForward()
         maskhost.data(),
         mask.data(),
         tolerance,
+        stats,
         spatial_dim == 3 ? 1 : inflags.GetValueInt("index_position"));
 
-    printf(match ? "Forward Pooling Verifies on CPU and GPU\n"
-                 : "Forward Pooling verification FAILED !!\n");
-
+    if(match)
+        std::cout << "Forward Pooling Verifies on CPU and GPU (" << stats.max_error << ", "
+                  << stats.max_num_flops_per_res << ')' << std::endl;
+    else
+        std::cout << "Forward Pooling verification FAILED !!" << std::endl;
     return 0;
 }
 

--- a/src/include/miopen/pooling/solvers.hpp
+++ b/src/include/miopen/pooling/solvers.hpp
@@ -46,12 +46,12 @@ struct PoolingForward2d final : PoolingSolver
 {
     const std::string& SolverDbId() const override { return GetSolverDbId<PoolingForward2d>(); }
 
-    bool IsApplicable(const ExecutionContext&,
-                      const miopen::pooling::ProblemDescription&) const override;
-    ConvSolution GetSolution(const ExecutionContext&,
-                             const miopen::pooling::ProblemDescription&) const override;
-    std::size_t GetWorkspaceSize(const ExecutionContext&,
-                                 const miopen::pooling::ProblemDescription&) const override;
+    bool IsApplicable(const ExecutionContext& context,
+                      const miopen::pooling::ProblemDescription& problem) const override;
+    ConvSolution GetSolution(const ExecutionContext& context,
+                             const miopen::pooling::ProblemDescription& problem) const override;
+    std::size_t GetWorkspaceSize(const ExecutionContext& context,
+                                 const miopen::pooling::ProblemDescription& problem) const override;
 };
 
 struct PoolingForwardNd final : PoolingSolver

--- a/src/include/miopen/pooling/solvers.hpp
+++ b/src/include/miopen/pooling/solvers.hpp
@@ -46,12 +46,12 @@ struct PoolingForward2d final : PoolingSolver
 {
     const std::string& SolverDbId() const override { return GetSolverDbId<PoolingForward2d>(); }
 
-    bool IsApplicable(const ExecutionContext& context,
-                      const miopen::pooling::ProblemDescription& problem) const override;
-    ConvSolution GetSolution(const ExecutionContext& context,
-                             const miopen::pooling::ProblemDescription& problem) const override;
-    std::size_t GetWorkspaceSize(const ExecutionContext& context,
-                                 const miopen::pooling::ProblemDescription& problem) const override;
+    bool IsApplicable(const ExecutionContext&,
+                      const miopen::pooling::ProblemDescription&) const override;
+    ConvSolution GetSolution(const ExecutionContext&,
+                             const miopen::pooling::ProblemDescription&) const override;
+    std::size_t GetWorkspaceSize(const ExecutionContext&,
+                                 const miopen::pooling::ProblemDescription&) const override;
 };
 
 struct PoolingForwardNd final : PoolingSolver

--- a/src/include/miopen/target_properties.hpp
+++ b/src/include/miopen/target_properties.hpp
@@ -40,6 +40,7 @@ struct TargetProperties
     boost::optional<bool> Xnack() const { return xnack; }
     boost::optional<bool> Sramecc() const { return sramecc; }
     boost::optional<bool> SrameccReported() const { return sramecc_reported; }
+    static std::size_t GetMaxWaveScratchSize() { return MaxWaveScratchSize; }
     void Init(const Handle*);
 
 private:
@@ -49,6 +50,8 @@ private:
     boost::optional<bool> xnack            = boost::none;
     boost::optional<bool> sramecc          = boost::none;
     boost::optional<bool> sramecc_reported = boost::none;
+    // https://github.com/llvm/llvm-project/commit/1ed4caff1d5cd49233c1ae7b9f6483a946ed5eea
+    static const std::size_t MaxWaveScratchSize;
 };
 
 } // namespace miopen

--- a/src/include/miopen/target_properties.hpp
+++ b/src/include/miopen/target_properties.hpp
@@ -50,7 +50,6 @@ private:
     boost::optional<bool> xnack            = boost::none;
     boost::optional<bool> sramecc          = boost::none;
     boost::optional<bool> sramecc_reported = boost::none;
-    // https://github.com/llvm/llvm-project/commit/1ed4caff1d5cd49233c1ae7b9f6483a946ed5eea
     static const std::size_t MaxWaveScratchSize;
 };
 

--- a/src/kernels/MIOpenPoolingBwd.cl
+++ b/src/kernels/MIOpenPoolingBwd.cl
@@ -24,9 +24,14 @@
  *
  *******************************************************************************/
 
+#include "float_types.h"
 #include "pooling_functions.h"
 
-#ifndef USE_IMG_INDEX
+#ifdef USE_IMG_INDEX
+#if !(USE_IMG_INDEX == 0 || USE_IMG_INDEX == 1)
+#error "Bad value of USE_IMG_INDEX"
+#endif
+#else
 #define USE_IMG_INDEX 1
 #endif
 
@@ -319,7 +324,7 @@ mloPoolingMaxBwd(const __global _FLOAT* top_df,
                 {
                     int lcl_th = th - top_y;
                     int lcl_tw = tw - top_x;
-#if USE_IMG_INDEX == 1
+#if USE_IMG_INDEX
                     index_t img_idx = b_x + b_y * mlo_bot_width;
 #else
                     int filter_x   = b_x - tw * MLO_POOLING_STRIDE0 + mlo_pad0;
@@ -331,7 +336,7 @@ mloPoolingMaxBwd(const __global _FLOAT* top_df,
                     int lcl_idx = visible ? (lcl_th * MLO_POOLBWD_LCL_DATA_WIDTH + lcl_tw) : 0;
 
                     bool match = visible &&
-#if USE_IMG_INDEX == 1
+#if USE_IMG_INDEX
                                  (img_idx == lcl_mask[lcl_idx])
 #else
                                  (filter_idx == lcl_mask[lcl_idx]) && (filter_x >= 0) &&

--- a/src/kernels/MIOpenPoolingBwd.cl
+++ b/src/kernels/MIOpenPoolingBwd.cl
@@ -39,6 +39,12 @@
 #error "MLO_POOLING_INDEX_MAX not defined"
 #endif
 
+#if(MLO_POOLING_OP_ID == MLO_POOLING_OP_AVE) || (MLO_POOLING_OP_ID == MLO_POOLING_OP_AVE_INCLUSIVE)
+#define AVERAGE_OPS 1
+#else
+#define AVERAGE_OPS 0
+#endif
+
 #define MLO_POOLBWD_GROUP_SZ2 1
 
 #define MLO_POOLBWD_LCL_DATA_WIDTH                                                   \
@@ -50,6 +56,7 @@
       MLO_POOLING_STRIDE1 - 2) /                                                    \
      MLO_POOLING_STRIDE1)
 
+#if AVERAGE_OPS
 __attribute__((reqd_work_group_size(MLO_POOLBWD_GROUP_SZ0,
                                     MLO_POOLBWD_GROUP_SZ1,
                                     MLO_POOLBWD_GROUP_SZ2))) __kernel void
@@ -210,7 +217,9 @@ mloPoolingAveBwd(const __global _FLOAT* top_diff,
         }
     }
 }
+#endif // AVERAGE_OPS
 
+#if MLO_POOLING_OP_ID == MLO_POOLING_OP_MAX
 __attribute__((reqd_work_group_size(MLO_POOLBWD_GROUP_SZ0,
                                     MLO_POOLBWD_GROUP_SZ1,
                                     MLO_POOLBWD_GROUP_SZ2))) __kernel void
@@ -369,3 +378,4 @@ mloPoolingMaxBwd(const __global _FLOAT* top_df,
         }
     }
 }
+#endif // MLO_POOLING_OP_ID == MLO_POOLING_OP_MAX

--- a/src/kernels/MIOpenPoolingBwdND.cl
+++ b/src/kernels/MIOpenPoolingBwdND.cl
@@ -24,6 +24,7 @@
  *
  *******************************************************************************/
 
+#include "float_types.h"
 #include "pooling_functions.h"
 
 #ifndef MLO_POOLING_INDEX_MAX

--- a/src/kernels/MIOpenPoolingND.cl
+++ b/src/kernels/MIOpenPoolingND.cl
@@ -24,10 +24,17 @@
  *
  *******************************************************************************/
 
+#include "float_types.h"
 #include "pooling_functions.h"
 
 #ifndef USE_GLOBAL_INDEX
 #define USE_GLOBAL_INDEX 1
+#endif
+
+#if defined(MLO_POOLING_SAVE_INDEX) && (MLO_POOLING_OP_ID == MLO_POOLING_OP_MAX)
+#define USE_MASK 1
+#else
+#define USE_MASK 0
 #endif
 
 #ifndef MLO_POOLING_OP_ID
@@ -48,7 +55,7 @@
 __attribute__((reqd_work_group_size(MLO_POOLING_GROUP_SZ0, 1, 1))) __kernel void
 mloPoolingNDFwd(const __global _FLOAT* bot,
                 __global _FLOAT* top,
-#if !defined(MLO_POOLING_SAVE_INDEX) || MLO_POOLING_OP_ID != MLO_POOLING_OP_MAX
+#if !USE_MASK
                 UNUSED
 #endif
                     __global index_t* mask,
@@ -163,7 +170,7 @@ mloPoolingNDFwd(const __global _FLOAT* bot,
 #endif
                         ;
 
-#if defined(MLO_POOLING_SAVE_INDEX) && MLO_POOLING_OP_ID == MLO_POOLING_OP_MAX
+#if USE_MASK
                     index_t mask_idx = 0;
 #endif
 
@@ -177,7 +184,7 @@ mloPoolingNDFwd(const __global _FLOAT* bot,
                                 _FLOAT bot_val =
                                     bot_data[h + m * STRIDE_D][j + k * STRIDE_H][i + l * STRIDE_W];
 
-#if defined(MLO_POOLING_SAVE_INDEX) && MLO_POOLING_OP_ID == MLO_POOLING_OP_MAX
+#if USE_MASK
                                 if(bot_val > top_val)
                                 {
                                     top_val = bot_val;
@@ -210,7 +217,7 @@ mloPoolingNDFwd(const __global _FLOAT* bot,
                                        top_w_id + l;
 
                         top[top_idx] = top_val;
-#if defined(MLO_POOLING_SAVE_INDEX) && MLO_POOLING_OP_ID == MLO_POOLING_OP_MAX
+#if USE_MASK
                         mask[top_idx] = mask_idx;
 #endif
                     }

--- a/src/kernels/MIOpenPoolingND.cl
+++ b/src/kernels/MIOpenPoolingND.cl
@@ -41,10 +41,15 @@
 #define MLO_POOLING_OP_ID 0
 #endif
 
+#if(MLO_POOLING_OP_ID == MLO_POOLING_OP_AVE) || (MLO_POOLING_OP_ID == MLO_POOLING_OP_AVE_INCLUSIVE)
+#define AVERAGE_OPS 1
+#else
+#define AVERAGE_OPS 0
+#endif
+
 #if MLO_POOLING_OP_ID == MLO_POOLING_OP_MAX
 #define MLO_POOLING_OP(A, B) (fmax((A), (B)))
-#elif(MLO_POOLING_OP_ID == MLO_POOLING_OP_AVE) || \
-    (MLO_POOLING_OP_ID == MLO_POOLING_OP_AVE_INCLUSIVE)
+#elif AVERAGE_OPS
 #define MLO_POOLING_OP(A, B) ((A) + (B))
 #endif
 
@@ -117,12 +122,10 @@ mloPoolingNDFwd(const __global _FLOAT* bot,
 
                     bot_data[h][j][i] = (vis) ? bot[bot_gbl_off] :
 #if MLO_POOLING_OP_ID == MLO_POOLING_OP_MAX
-                                              (_FLOAT)(-MAX_VAL)
-#elif(MLO_POOLING_OP_ID == MLO_POOLING_OP_AVE) || \
-    (MLO_POOLING_OP_ID == MLO_POOLING_OP_AVE_INCLUSIVE)
-                                              (_FLOAT)(0)
+                                              (_FLOAT)(-MAX_VAL);
+#elif AVERAGE_OPS
+                                              (_FLOAT)(0);
 #endif
-                        ;
                 }
             }
         }
@@ -130,14 +133,14 @@ mloPoolingNDFwd(const __global _FLOAT* bot,
 #pragma unroll
         for(uint m = 0; m < TOP_D_PER_WORK; m++)
         {
-#if(MLO_POOLING_OP_ID == MLO_POOLING_OP_AVE) || (MLO_POOLING_OP_ID == MLO_POOLING_OP_AVE_INCLUSIVE)
+#if AVERAGE_OPS
             int dstart = (top_d_id + m) * STRIDE_D - pad_d;
             int dend   = min((dstart + KERNEL_SZ_D), (int)bot_d);
             dstart     = max(dstart, 0);
 #endif
             for(uint k = 0; k < TOP_H_PER_WORK; k++)
             {
-#if(MLO_POOLING_OP_ID == MLO_POOLING_OP_AVE) || (MLO_POOLING_OP_ID == MLO_POOLING_OP_AVE_INCLUSIVE)
+#if AVERAGE_OPS
                 int hstart = (top_h_id + k) * STRIDE_H - pad_h;
                 int hend   = min((hstart + KERNEL_SZ_H), (int)bot_h);
                 hstart     = max(hstart, 0);
@@ -145,7 +148,7 @@ mloPoolingNDFwd(const __global _FLOAT* bot,
                 for(uint l = 0; l < TOP_W_PER_WORK; l++)
                 {
 
-#if(MLO_POOLING_OP_ID == MLO_POOLING_OP_AVE) || (MLO_POOLING_OP_ID == MLO_POOLING_OP_AVE_INCLUSIVE)
+#if AVERAGE_OPS
                     int wstart = (top_w_id + l) * STRIDE_W - pad_w;
                     int wend   = min((wstart + KERNEL_SZ_W), (int)bot_w);
                     wstart     = max(wstart, 0);
@@ -163,12 +166,10 @@ mloPoolingNDFwd(const __global _FLOAT* bot,
 
                     _FLOAT top_val =
 #if MLO_POOLING_OP_ID == MLO_POOLING_OP_MAX
-                        (_FLOAT)(-MAX_VAL)
-#elif(MLO_POOLING_OP_ID == MLO_POOLING_OP_AVE) || \
-    (MLO_POOLING_OP_ID == MLO_POOLING_OP_AVE_INCLUSIVE)
-                        0
+                        (_FLOAT)(-MAX_VAL);
+#elif AVERAGE_OPS
+                        0;
 #endif
-                        ;
 
 #if USE_MASK
                     index_t mask_idx = 0;
@@ -205,7 +206,7 @@ mloPoolingNDFwd(const __global _FLOAT* bot,
                         }
                     }
 
-#if(MLO_POOLING_OP_ID == MLO_POOLING_OP_AVE) || (MLO_POOLING_OP_ID == MLO_POOLING_OP_AVE_INCLUSIVE)
+#if AVERAGE_OPS
                     top_val *= ((_FLOAT)1.f / (_FLOAT)pool_size);
 #endif
 

--- a/src/kernels/float_types.h
+++ b/src/kernels/float_types.h
@@ -34,6 +34,12 @@
 #define FOUR 4
 #define EIGHT 8
 
+#ifndef __HIP_PLATFORM_HCC__
+#define _FLOAT2 PPCAT(_FLOAT, TWO)
+#define _FLOAT4 PPCAT(_FLOAT, FOUR)
+#define _FLOAT8 PPCAT(_FLOAT, EIGHT)
+#endif
+
 #if MIOPEN_USE_FP16 == 1
 #ifdef __HIP_PLATFORM_HCC__
 #define FLOAT _Float16
@@ -42,13 +48,20 @@
 #pragma OPENCL EXTENSION cl_khr_fp16 : enable
 #define _FLOAT half
 #define _FLOAT_ACCUM float
-#endif                 // __HIP_PLATFORM_HCC__
-#define SIZEOF_FLOAT 2 /* sizeof is unavailable for preprocessor */
+#endif // __HIP_PLATFORM_HCC__
+#define SIZEOF_FLOAT 2
+// Max value for the main datatype
 #ifndef HALF_MAX
-#define MAX_VAL 65504 /* max value */
+#define MAX_VAL 65504
 #else
 #define MAX_VAL HALF_MAX
-#endif // HALF_MAX
+#endif
+// Max value for accumulator
+#ifndef FLT_MAX
+#define MAX_VAL_ACCUM 3.402823466e+38F
+#else
+#define MAX_VAL_ACCUM FLT_MAX
+#endif
 #endif // MIOPEN_USE_FP16
 
 #if MIOPEN_USE_FP32 == 1
@@ -58,13 +71,16 @@
 #else
 #define _FLOAT float
 #define _FLOAT_ACCUM float
-#endif                 // __HIP_PLATFORM_HCC__
-#define SIZEOF_FLOAT 4 /* sizeof is unavailable for preprocessor */
+#endif // __HIP_PLATFORM_HCC__
+#define SIZEOF_FLOAT 4
+// Max value for the main datatype
 #ifndef FLT_MAX
-#define MAX_VAL 3.402823466e+38F /* max value */
+#define MAX_VAL 3.402823466e+38F
 #else
 #define MAX_VAL FLT_MAX
-#endif // FLT_MAX
+#endif
+// Max value for accumulator
+#define MAX_VAL_ACCUM MAX_VAL
 #endif // MIOPEN_USE_FP32
 
 #if MIOPEN_USE_BFP16 == 1
@@ -74,10 +90,17 @@
 #else
 #define _FLOAT ushort
 #define _FLOAT_ACCUM float
-#endif                 //
-#define SIZEOF_FLOAT 2 /* sizeof is unavailable for preprocessor */
-#define MAX_VAL 0x7F7F /* max value */
-#endif                 // MIOPEN_USE_BFP16
+#endif //
+#define SIZEOF_FLOAT 2
+// Max value for the main datatype
+#define MAX_VAL 0x7F7F
+// Max value for accumulator
+#ifndef FLT_MAX
+#define MAX_VAL_ACCUM 3.402823466e+38F
+#else
+#define MAX_VAL_ACCUM FLT_MAX
+#endif
+#endif // MIOPEN_USE_BFP16
 
 #if MIOPEN_USE_FP16 == 1
 #ifdef __HIP_PLATFORM_HCC__
@@ -86,7 +109,14 @@
 #else
 #define CVT_FLOAT2ACCUM(x) ((_FLOAT_ACCUM)(x))
 #define CVT_ACCUM2FLOAT(x) ((_FLOAT)(x))
-#endif // MIOPEN_BACKEND_HIP
+#endif
+// These two are required to uniformly initialize
+// variables with non-zero literal constants of FP32 type
+// regardless of the actual type of the variable.
+// This is especially complicated for BF16, because
+// the compiler lacks the support of BF16 literals.
+#define CVT_FP32_2FLOAT(x) (CVT_ACCUM2FLOAT(x))
+#define CVT_FP32_2ACCUM(x) (x)
 #endif // MIOPEN_USE_FP16
 
 #if MIOPEN_USE_FP32 == 1
@@ -97,17 +127,41 @@
 #define CVT_FLOAT2ACCUM(x) ((_FLOAT_ACCUM)(x))
 #define CVT_ACCUM2FLOAT(x) ((_FLOAT)(x))
 #endif
+#define CVT_FP32_2FLOAT(x) (CVT_ACCUM2FLOAT(x))
+#define CVT_FP32_2ACCUM(x) (x)
 #endif // MIOPEN_USE_FP32
 
 #if MIOPEN_USE_BFP16 == 1
 #define CVT_FLOAT2ACCUM(x) bfloat16_to_float(x)
 #define CVT_ACCUM2FLOAT(x) float_to_bfloat16(x)
+#define CVT_FP32_2FLOAT(x) (CVT_ACCUM2FLOAT(x))
+#define CVT_FP32_2ACCUM(x) (x)
 #endif
 
-#ifndef __HIP_PLATFORM_HCC__
-#define _FLOAT2 PPCAT(_FLOAT, TWO)
-#define _FLOAT4 PPCAT(_FLOAT, FOUR)
-#define _FLOAT8 PPCAT(_FLOAT, EIGHT)
+/// If MIOPEN_USE_NATIVE_DATATYPE_ACCUM is defined as 1 when "float_types.h" is included,
+/// then all the ACCUM macros (the represent operations and types) will use the native
+/// datatype (BF16 or FP16) instead of FP32. In other words, the computations will be
+/// performed using the native datatype even if ACCUM macros are used. This allows for
+/// building both mixed-precision and "pure" kernels from the single source.
+#ifdef MIOPEN_USE_NATIVE_DATATYPE_ACCUM
+#if !(MIOPEN_USE_NATIVE_DATATYPE_ACCUM == 0 || MIOPEN_USE_NATIVE_DATATYPE_ACCUM == 1)
+#error "Invalid value of MIOPEN_USE_NATIVE_DATATYPE_ACCUM"
 #endif
+#else
+#define MIOPEN_USE_NATIVE_DATATYPE_ACCUM 0
+#endif
+
+#if MIOPEN_USE_NATIVE_DATATYPE_ACCUM
+#undef _FLOAT_ACCUM
+#define _FLOAT_ACCUM _FLOAT
+#undef MAX_VAL_ACCUM
+#define MAX_VAL_ACCUM MAX_VAL
+#undef CVT_FLOAT2ACCUM
+#define CVT_FLOAT2ACCUM(x) (x)
+#undef CVT_ACCUM2FLOAT
+#define CVT_ACCUM2FLOAT(x) (x)
+#undef CVT_FP32_2ACCUM
+#define CVT_FP32_2ACCUM(x) (CVT_FP32_2FLOAT(x))
+#endif // !(AVERAGE_OPS && MIOPEN_USE_FP16)
 
 #endif // GUARD_FLOAT_TYPES_H

--- a/src/kernels/float_types.h
+++ b/src/kernels/float_types.h
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (c) 2019 Advanced Micro Devices, Inc.
+ * Copyright (c) 2023 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +23,8 @@
  * SOFTWARE.
  *
  *******************************************************************************/
-#ifndef FLOAT_TYPES_HPP
-#define FLOAT_TYPES_HPP
+#ifndef GUARD_FLOAT_TYPES_H
+#define GUARD_FLOAT_TYPES_H
 
 #include "bfloat16_dev.hpp"
 
@@ -106,6 +106,8 @@
 
 #ifndef __HIP_PLATFORM_HCC__
 #define _FLOAT2 PPCAT(_FLOAT, TWO)
+#define _FLOAT4 PPCAT(_FLOAT, FOUR)
+#define _FLOAT8 PPCAT(_FLOAT, EIGHT)
 #endif
 
-#endif // FLOAT_TYPES_HPP
+#endif // GUARD_FLOAT_TYPES_H

--- a/src/kernels/pooling_functions.h
+++ b/src/kernels/pooling_functions.h
@@ -1,33 +1,30 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2023 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
 #ifndef GUARD_POOLING_FUNCTIONS_H
 #define GUARD_POOLING_FUNCTIONS_H
-
-#define PPCAT_NX(A, B) A##B
-#define PPCAT(A, B) PPCAT_NX(A, B)
-#define TWO 2
-#define FOUR 4
-#define EIGHT 8
-
-#if MIOPEN_USE_FP16 == 1
-#pragma OPENCL EXTENSION cl_khr_fp16 : enable
-#define _FLOAT half
-#ifndef HALF_MAX
-#define MAX_VAL 65504 /* max value */
-#else
-#define MAX_VAL HALF_MAX
-#endif
-#endif
-#if MIOPEN_USE_FP32 == 1
-#define _FLOAT float
-#ifndef FLT_MAX
-#define MAX_VAL 3.402823466e+38F /* max value */
-#else
-#define MAX_VAL FLT_MAX
-#endif
-#endif
-
-#define _FLOAT2 PPCAT(_FLOAT, TWO)
-#define _FLOAT4 PPCAT(_FLOAT, FOUR)
-#define _FLOAT8 PPCAT(_FLOAT, EIGHT)
 
 #define UNUSED __attribute__((__unused__))
 

--- a/src/solver/pooling/forward2d.cpp
+++ b/src/solver/pooling/forward2d.cpp
@@ -92,9 +92,10 @@ inline std::size_t RoundUpToMultiple(std::size_t v, std::size_t m)
 // Compute amount of private memory required for holding the arrays defined
 // in the "mloPoolingG" kernel:
 //
-// #define MLO_BOT_DATA_SZ0 \
-//    ((MLO_POOLING_N_HORIZ_OUT_PIX - 1) * MLO_POOLING_STRIDE0 + MLO_POOLING_KERNEL_SZ0)
-// #define MLO_BOT_DATA_SZ1 \
+// #define MLO_BOT_DATA_SZ0
+//     ((MLO_POOLING_N_HORIZ_OUT_PIX - 1) * MLO_POOLING_STRIDE0 + MLO_POOLING_KERNEL_SZ0)
+//
+// #define MLO_BOT_DATA_SZ1
 //    ((MLO_POOLING_N_VERT_OUT_PIX - 1) * MLO_POOLING_STRIDE1 + MLO_POOLING_KERNEL_SZ1)
 //
 // _FLOAT bot_data[MLO_BOT_DATA_SZ1][MLO_BOT_DATA_SZ0];

--- a/src/solver/pooling/forward2d.cpp
+++ b/src/solver/pooling/forward2d.cpp
@@ -131,7 +131,7 @@ std::size_t sizeof_private_memory(const miopen::pooling::ProblemDescription& pro
 
 } // namespace
 
-bool PoolingForward2d::IsApplicable(const ExecutionContext& ec,
+bool PoolingForward2d::IsApplicable(const ExecutionContext& context,
                                     const miopen::pooling::ProblemDescription& problem) const
 {
     return problem.GetDirection() == miopen::pooling::Direction::Forward &&
@@ -142,7 +142,7 @@ bool PoolingForward2d::IsApplicable(const ExecutionContext& ec,
            problem.GetXDesc().GetLayout("NCHW") == "NCHW" &&
            problem.GetYDesc().GetLayout("NCHW") == "NCHW" &&
            sizeof_private_memory(problem) <=
-               TargetProperties::GetMaxWaveScratchSize() / ec.GetStream().GetWavefrontWidth();
+               TargetProperties::GetMaxWaveScratchSize() / context.GetStream().GetWavefrontWidth();
 }
 
 ConvSolution PoolingForward2d::GetSolution(const ExecutionContext&,

--- a/src/target_properties.cpp
+++ b/src/target_properties.cpp
@@ -67,6 +67,8 @@ static std::string GetDeviceNameFromMap(const std::string& in)
     return name; // NOLINT (performance-no-automatic-move)
 }
 
+const std::size_t TargetProperties::MaxWaveScratchSize = (256 * 4) * ((1 << 13) - 1);
+
 void TargetProperties::Init(const Handle* const handle)
 {
     const auto rawName = [&]() -> std::string {

--- a/src/target_properties.cpp
+++ b/src/target_properties.cpp
@@ -67,7 +67,9 @@ static std::string GetDeviceNameFromMap(const std::string& in)
     return name; // NOLINT (performance-no-automatic-move)
 }
 
-const std::size_t TargetProperties::MaxWaveScratchSize = (256 * 4) * ((1 << 13) - 1);
+// See https://github.com/llvm/llvm-project/commit/1ed4caff1d5cd49233c1ae7b9f6483a946ed5eea.
+const std::size_t TargetProperties::MaxWaveScratchSize =
+    (static_cast<const std::size_t>(256) * 4) * ((1 << 13) - 1);
 
 void TargetProperties::Init(const Handle* const handle)
 {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -193,10 +193,12 @@ if(MIOPEN_TEST_HALF)
     set(MIOPEN_TEST_FLOAT_ARG --half)
     set(MIOPENDRIVER_MODE_CONV convfp16)
     set(MIOPENDRIVER_MODE_BN bnormfp16)
+    set(MIOPENDRIVER_MODE_POOL poolfp16)
 elseif(MIOPEN_TEST_INT8)
     set(MIOPEN_TEST_FLOAT_ARG --int8)
     set(MIOPENDRIVER_MODE_CONV convint8)
     set(MIOPENDRIVER_MODE_BN NOT_SUPPORTED)
+    set(MIOPENDRIVER_MODE_POOL NOT_SUPPORTED)
     set(MIOPEN_TEST_CONV_INT8_OUTPUT_TYPE_INT8 --output_type int8)
     set(MIOPEN_TEST_CONV_INT8_OUTPUT_TYPE_INT32 --output_type int32)
     set(MIOPEN_TEST_CONV_INT8_OUTPUT_TYPE_FLOAT --output_type float)
@@ -204,11 +206,13 @@ elseif(MIOPEN_TEST_BFLOAT16)
     set(MIOPEN_TEST_FLOAT_ARG --bfloat16)
     set(MIOPENDRIVER_MODE_CONV convbfp16)
     set(MIOPENDRIVER_MODE_BN NOT_SUPPORTED)
+    set(MIOPENDRIVER_MODE_POOL NOT_SUPPORTED)
 else()
     set(MIOPEN_TEST_FLOAT_ARG --float)
     set(MIOPEN_TEST_FLOAT TRUE)
     set(MIOPENDRIVER_MODE_CONV conv)
     set(MIOPENDRIVER_MODE_BN bnorm)
+    set(MIOPENDRIVER_MODE_POOL pool)
 endif()
 
 message(STATUS "MIOPEN_TEST_FLOAT ${MIOPEN_TEST_FLOAT}")
@@ -670,6 +674,16 @@ if(${MIOPEN_TEST_WITH_MIOPENDRIVER})
     add_custom_test(test_miopendriver_regression_half SKIP_UNLESS_ALL GFX103X_ENABLED GFX110X_ENABLED FLOAT_DISABLED HALF_ENABLED
         # Regression test for https://github.com/ROCmSoftwarePlatform/MIOpen/issues/1576
         COMMAND MIOPEN_FIND_MODE=1 MIOPEN_DRIVER_USE_GPU_REFERENCE=1 MIOPEN_DEBUG_FIND_ONLY_SOLVER=ConvDirectNaiveConvBwd $<TARGET_FILE:MIOpenDriver> ${MIOPENDRIVER_MODE_CONV} --forw 2 --in_layout NCHW --out_layout NCHW --fil_layout NCHW -n 256 -c 1024 -H 14 -W 14 -k 256 -y 1 -x 1 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -t 1
+        # Regression test for https://github.com/ROCmSoftwarePlatform/MIOpen/issues/2109
+        $<TARGET_FILE:MIOpenDriver> ${MIOPENDRIVER_MODE_POOL} -M 0 --input 1x3x255x255,195075x65025x255x1 -y 255 -x 255 -p 0 -q 0 -v 1 -u 1 -m avg -F 1 -t 1 -i 1
+        $<TARGET_FILE:MIOpenDriver> ${MIOPENDRIVER_MODE_POOL} -M 0 --input 1x3x227x227,154587x51529x227x1 -y 100 -x 100 -p 0 -q 0 -v 1 -u 1 -m avg -F 0 -t 1 -i 1
+    )
+
+    add_custom_test(test_miopendriver_regression_float SKIP_UNLESS_ALL GFX103X_ENABLED GFX110X_ENABLED
+        # Regression test for https://github.com/ROCmSoftwarePlatform/MIOpen/issues/2109
+        $<TARGET_FILE:MIOpenDriver> ${MIOPENDRIVER_MODE_POOL} -M 0 --input 1x3x255x255,195075x65025x255x1 -y 255 -x 255 -p 0 -q 0 -v 1 -u 1 -m avg -F 1 -t 1 -i 1
+        $<TARGET_FILE:MIOpenDriver> ${MIOPENDRIVER_MODE_POOL} -M 0 --input 1x3x227x227,154587x51529x227x1 -y 100 -x 100 -p 0 -q 0 -v 1 -u 1 -m avg -F 0 -t 1 -i 1
+        $<TARGET_FILE:MIOpenDriver> ${MIOPENDRIVER_MODE_POOL} -M 0 --input 1x3x227x63,42903x14301x63x1 -y 30 -x 30 -p 0 -q 0 -v 1 -u 1 -m avg -F 0 -t 1 -i 1
     )
 
     add_custom_test(test_miopendriver_regression_int8 SKIP_UNLESS_ALL GFX103X_ENABLED GFX110X_ENABLED FLOAT_DISABLED INT8_ENABLED


### PR DESCRIPTION
The main goal if resolving issue #2109. This is done by switching to mixed precision for FP16 average pooling. Other changes include adjustments of verification tolerance for FP32 inference and for FP16 training (to avoid false failures) and observing available amount of scratch memory in order to avoid building of kernels that would fail anyway. Plus lots of refactoring. Details:

- [pooling kernels] 
  - [Forward] 🔴 Fix: Engage mixed-precision in FP16 average pooling
    - Implemented in e939b336076c138b675102a693d7e35521d04d53
  - [Backward] 🟡 Fix: Build only necessary kernels. This allows POOLING_OP_AVE to handle larger configs.
    - Implemented in 75ed210ed337f773c9276775e86c59957b4a0d2a
- [pooling solver] 🔴 Fix: Make PoolingForward2d not applicable when scratch limit is exceeded.
  - Implemented in b451c210fc88dcc9d79889b1d31820d7630a64e4
- [tests][pooling] 🟡 Added regression tests for issue #2109
- [driver][pooling]
  - [Backward][FP16] 🟡 Fix: Raised verification tolerance to avoid false failures (1e-6 -> 5e-3)
  - [Forward][FP32] 🟡 Fix: Raised verification tolerance to avoid false failures (1e-6 -> 1e-5).
  - [NFC][Debugging]
    - Improved verification and printing of its results.
    - Added different initialization modes on input for Forward FP16 pooling.
    - Added emulation of validation errors for Forward pooling.
- Other by-products that may be useful in all solvers/kernels
  - 🟢 Added MaxWaveScratchSize to TargetProperties
    - Implemented in 1527854a404936081ad85495f6f42939a7d2f630
  - [NFC][float_types.h] This can be used in any kernel:
    - Support for for building both mixed-precision and "pure" kernels from the single source.
    - Support for uniform initialization of BF16 variables.
    - Both features implemented in 643a8d668aa2ea9c8ff3f46d4f0c76b4d7ea6774

### ℹ️ Note for reviewers

All significant commits (which change the behavior of the library OR may be useful) are listed above. I recommend looking at them first. Other commits are just refactorings.

----
[Attribution] @junliume @johnny-keker
- https://github.com/ROCmSoftwarePlatform/MIOpen/labels/bug
- https://github.com/ROCmSoftwarePlatform/MIOpen/labels/correctness
- https://github.com/ROCmSoftwarePlatform/MIOpen/labels/urgency_blocker
- Proposed assignees:
  - @JehandadKhan
  - @ce1adon 
  - @carlushuang
  - @asroy