### PR TITLE
[GFX94X] Disable Winograd Multipass

### DIFF
--- a/src/solver/conv_multipass_wino3x3WrW.cpp
+++ b/src/solver/conv_multipass_wino3x3WrW.cpp
@@ -453,7 +453,7 @@ bool ConvWinograd3x3MultipassWrW<WinoDataH, WinoFilterH, WinoDataW, WinoFilterW>
                                                                                        problem)))
         return false;
 
-    if(!(StartsWith(name, "gfx8") || StartsWith(name, "gfx9")))
+    if(!(StartsWith(name, "gfx8") || StartsWith(name, "gfx9")) || StartsWith(name, "gfx94"))
         return false;
     if(name == "gfx90a" && problem.conv_problem.IsGfx90aFp16altRequired())
         return false;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2308,7 +2308,7 @@ add_custom_test(smoke_solver_ConvBinWinogradRxSf3x2_f32 GFX103X_ENABLED GFX110X_
 )
 
 # FP16 ALT attribute is disabled to enable the backward solver on MI200 for HALF.
-add_custom_test(smoke_solver_ConvWinograd3x3MultipassWrW HALF_ENABLED BF16_ENABLED SKIP_XNACK_ON OCL_DISABLED
+add_custom_test(smoke_solver_ConvWinograd3x3MultipassWrW GFX94X_DISABLED HALF_ENABLED BF16_ENABLED SKIP_XNACK_ON OCL_DISABLED
     COMMAND MIOPEN_DEBUG_CONVOLUTION_ATTRIB_FP16_ALT_IMPL=0
       MIOPEN_FIND_MODE=normal MIOPEN_DEBUG_FIND_ONLY_SOLVER='ConvWinograd3x3MultipassWrW<3-2>' $<TARGET_FILE:test_conv2d>
       ${TEST_CONV_VERBOSE_W} --input 1 16 24 24 --weights 16 16 3 3 --pads_strides_dilations 1 1 2 2 1 1 ${MIOPEN_TEST_FLAGS_ARGS}


### PR DESCRIPTION
Winograd Multipass kernels don't support gfx940 ASICs for now because of the following:
- **Compilation errors.** Some instructions have been renamed in the new ISA.
- **Data hazards.** The shader may contain gfx940-specific data hazards that should be explicitly avoided.

This PR disables Winograd Multipass solver for gfx94x ASICs.