### PR TITLE
Add API to get the number of convolution groups

### DIFF
--- a/docs/convolution.rst
+++ b/docs/convolution.rst
@@ -60,6 +60,11 @@ miopenGetConvolutionNdDescriptor
 
 .. doxygenfunction::  miopenGetConvolutionNdDescriptor
 
+miopenGetConvolutionGroupCount
+------------------------------
+
+.. doxygenfunction::  miopenGetConvolutionGroupCount
+
 miopenSetConvolutionGroupCount
 ------------------------------
 

--- a/include/miopen/miopen.h
+++ b/include/miopen/miopen.h
@@ -927,6 +927,15 @@ miopenGetConvolutionNdDescriptor(miopenConvolutionDescriptor_t convDesc,
                                  int* dilationA,
                                  miopenConvolutionMode_t* c_mode);
 
+/*! @brief Get the number of groups to be used in Group/Depthwise convolution
+ *
+ * @param convDesc   Convolution layer descriptor (input)
+ * @param groupCount Pointer to number of groups in group/depthwise convolution (output)
+ * @return           miopenStatus_t
+ */
+MIOPEN_EXPORT miopenStatus_t miopenGetConvolutionGroupCount(miopenConvolutionDescriptor_t convDesc,
+                                                            int* groupCount);
+
 /*! @brief Set the number of groups to be used in Group/Depthwise convolution
  *
  * Must be called before all computational APIs of group/depthwise convolution, it is preferable to

--- a/src/convolution_api.cpp
+++ b/src/convolution_api.cpp
@@ -190,9 +190,7 @@ extern "C" miopenStatus_t miopenGetConvolutionGroupCount(miopenConvolutionDescri
                                                          int* groupCount)
 {
     MIOPEN_LOG_FUNCTION(convDesc, groupCount);
-    return miopen::try_([&] {
-        miopen::deref(groupCount) = miopen::deref(convDesc).group_count;
-    });
+    return miopen::try_([&] { miopen::deref(groupCount) = miopen::deref(convDesc).group_count; });
 }
 
 extern "C" miopenStatus_t miopenSetConvolutionGroupCount(miopenConvolutionDescriptor_t convDesc,

--- a/src/convolution_api.cpp
+++ b/src/convolution_api.cpp
@@ -186,6 +186,15 @@ extern "C" miopenStatus_t miopenInitConvolutionNdDescriptor(miopenConvolutionDes
     });
 }
 
+extern "C" miopenStatus_t miopenGetConvolutionGroupCount(miopenConvolutionDescriptor_t convDesc,
+                                                         int* groupCount)
+{
+    MIOPEN_LOG_FUNCTION(convDesc, groupCount);
+    return miopen::try_([&] {
+        miopen::deref(groupCount) = miopen::deref(convDesc).group_count;
+    });
+}
+
 extern "C" miopenStatus_t miopenSetConvolutionGroupCount(miopenConvolutionDescriptor_t convDesc,
                                                          int groupCount)
 {


### PR DESCRIPTION
This PR adds support for getting the number of groups in a convolution descriptor to the API. This is necessary for frameworks to query existing descriptors.