### PR TITLE
Fixed a value being checked incorrectly

### DIFF
--- a/src/solution.cpp
+++ b/src/solution.cpp
@@ -79,7 +79,8 @@ void Solution::RunImpl(Handle& handle,
     const auto problem_ =
         conv_desc.mode == miopenTranspose ? Transpose(GetProblem(), &x, w, &y) : GetProblem();
 
-    if(problem_.GetDirection() == miopenProblemDirectionBackward && y.descriptor->GetLengths()[1] != w.descriptor->GetLengths()[0])
+    if(problem_.GetDirection() == miopenProblemDirectionBackward &&
+       y.descriptor->GetLengths()[1] != w.descriptor->GetLengths()[0])
     {
         MIOPEN_THROW(miopenStatusBadParm);
     }

--- a/src/solution.cpp
+++ b/src/solution.cpp
@@ -79,7 +79,7 @@ void Solution::RunImpl(Handle& handle,
     const auto problem_ =
         conv_desc.mode == miopenTranspose ? Transpose(GetProblem(), &x, w, &y) : GetProblem();
 
-    if(y.descriptor->GetLengths()[1] != w.descriptor->GetLengths()[0])
+    if(problem_.GetDirection() == miopenProblemDirectionBackward && y.descriptor->GetLengths()[1] != w.descriptor->GetLengths()[0])
     {
         MIOPEN_THROW(miopenStatusBadParm);
     }


### PR DESCRIPTION
This fixes NHWC calls returning `miopenStatusBadParam` in Find 2.0 when it would not in Find 1.0.