### PR TITLE
[-Wdeprecated-copy-with-dtor] Fix more deprecated copy with dtor

### DIFF
--- a/src/include/miopen/execution_context.hpp
+++ b/src/include/miopen/execution_context.hpp
@@ -99,6 +99,9 @@ struct ExecutionContext
     ExecutionContext()                        = default;
     virtual ~ExecutionContext()               = default;
     ExecutionContext(const ExecutionContext&) = default;
+    ExecutionContext(ExecutionContext&&)      = default;
+    ExecutionContext& operator=(const ExecutionContext&) = default;
+    ExecutionContext& operator=(ExecutionContext&&) = default;
 
     ExecutionContext& DetectRocm();
 


### PR DESCRIPTION
relate to https://github.com/ROCmSoftwarePlatform/MIOpen/pull/2063

To fix the following issue:
```
[2023-06-16T08:48:37.973Z] /long_pathname_so_that_rpms_can_package_the_debug_info/data/driver/MLOpen/src/include/miopen/execution_context.hpp:100:13: warning: definition of implicit copy assignment operator for 'ExecutionContext' is deprecated because it has a user-declared destructor [-Wdeprecated-copy-with-dtor]

[2023-06-16T08:48:37.973Z]     virtual ~ExecutionContext()               = default;

[2023-06-16T08:48:37.973Z]             ^

[2023-06-16T08:48:37.973Z] /opt/rh/devtoolset-7/root/usr/lib/gcc/x86_64-redhat-linux/7/../../../../include/c++/7/tuple:322:19: note: in implicit copy assignment operator for 'miopen::ExecutionContext' first required here

[2023-06-16T08:48:37.973Z]           _M_head(*this) = std::forward<_UHead>

[2023-06-16T08:48:37.973Z]                          ^

[2023-06-16T08:48:37.973Z] /opt/rh/devtoolset-7/root/usr/lib/gcc/x86_64-redhat-linux/7/../../../../include/c++/7/tuple:1235:36: note: in instantiation of function template specialization 'std::_Tuple_impl<0, miopen::ExecutionContext &, miopen::conv::ProblemDescription &>::operator=<miopen::ExecutionContext, miopen::conv::ProblemDescription>' requested here

[2023-06-16T08:48:37.973Z]           static_cast<_Inherited&>(*this) = std::move(__in);

[2023-06-16T08:48:37.973Z]                                           ^

[2023-06-16T08:48:37.973Z] /long_pathname_so_that_rpms_can_package_the_debug_info/data/driver/MLOpen/src/convolution_api.cpp:392:32: note: in instantiation of function template specialization 'std::tuple<miopen::ExecutionContext &, miopen::conv::ProblemDescription &>::operator=<miopen::ExecutionContext, miopen::conv::ProblemDescription>' requested here

[2023-06-16T08:48:37.973Z]         std::tie(ctx, problem) = MakeFwdCtxAndProblem(handle, xDesc, wDesc, convDesc, yDesc);

[2023-06-16T08:48:37.973Z]                                ^

[2023-06-16T08:48:38.261Z] 1 warning generated when compiling for gfx906.