### PR TITLE
[builds] Add hash pin for rocm-recipes

### DIFF
--- a/install_deps.cmake
+++ b/install_deps.cmake
@@ -113,5 +113,5 @@ cget(init ${TOOLCHAIN_FLAG} -DCMAKE_INSTALL_RPATH=${PREFIX}/lib ${PARSE_UNPARSED
 cget(ignore pcre)
 
 # Install dependencies
-cget(install -U ROCmSoftwarePlatform/rocm-recipes)
+cget(install -U ROCmSoftwarePlatform/rocm-recipes@7c09d33ac418c31cd5fe1f6e3c2605061dd367c6)
 cget(install -U -f requirements.txt)

--- a/rbuild.ini
+++ b/rbuild.ini
@@ -1,9 +1,10 @@
+recipe_hash=7c09d33ac418c31cd5fe1f6e3c2605061dd367c6
 [main]
 cxx = ${rocm_path}/llvm/bin/clang++
 cc = ${rocm_path}/llvm/bin/clang
 ignore = pcre
 deps =
-    ROCmSoftwarePlatform/rocm-recipes
+    ROCmSoftwarePlatform/rocm-recipes@${recipe_hash}
     -f requirements.txt
 
 [develop]
@@ -20,5 +21,5 @@ cxx = ${rocm_path}/llvm/bin/clang++
 cc = ${rocm_path}/llvm/bin/clang
 ignore = pcre
 deps =
-    ROCmSoftwarePlatform/rocm-recipes
+    ROCmSoftwarePlatform/rocm-recipes@${recipe_hash}
     -f dev-requirements.txt


### PR DESCRIPTION
The hash needs to be duplicated across the ini file and install_deps.cmake, but we can fix this in the future by having install_deps.cmake to use rbuild instead of cget directly.