### PR TITLE
Improve GET_RAND() performance

### DIFF
--- a/driver/random.hpp
+++ b/driver/random.hpp
@@ -5,19 +5,25 @@
 #include <ctime>
 #include <cstdint>
 #include <random>
-#include <chrono>
+
+std::minstd_rand& get_minstd_gen()
+{
+    static std::random_device rd;
+    static std::minstd_rand minstd_gen(rd());
+
+    return minstd_gen;
+}
 
 template <typename T>
 inline T FRAND()
 {
-    std::minstd_rand minstd_gen(std::chrono::system_clock::now().time_since_epoch().count());
-    auto d = std::generate_canonical<double, 5>(minstd_gen);
+    double d = std::generate_canonical<double, 1>(get_minstd_gen());
     return static_cast<T>(d);
 }
 
 inline int GET_RAND()
 {
-    std::minstd_rand minstd_gen(std::chrono::system_clock::now().time_since_epoch().count());
+    auto minstd_gen = get_minstd_gen();
     return minstd_gen();
 }
 

--- a/driver/random.hpp
+++ b/driver/random.hpp
@@ -2,15 +2,18 @@
 #define GUARD_RANDOM_GEN_
 
 #include <cstdlib>
+#include <ctime>
+#include <cstdint>
 
 template <typename T>
 inline T FRAND()
 {
-    double d = static_cast<double>(rand() / (static_cast<double>(RAND_MAX)));
+    std::uint32_t seed = time(nullptr);
+    double d = static_cast<double>(rand_r(&seed) / (static_cast<double>(RAND_MAX)));
     return static_cast<T>(d);
 }
 
-inline int GET_RAND() { return rand(); }
+inline int GET_RAND() {std::uint32_t seed = time(nullptr); return rand_r(&seed); }
 
 template <typename T>
 inline T RAN_GEN(T A, T B)

--- a/driver/random.hpp
+++ b/driver/random.hpp
@@ -9,11 +9,15 @@ template <typename T>
 inline T FRAND()
 {
     std::uint32_t seed = time(nullptr);
-    double d = static_cast<double>(rand_r(&seed) / (static_cast<double>(RAND_MAX)));
+    double d           = static_cast<double>(rand_r(&seed) / (static_cast<double>(RAND_MAX)));
     return static_cast<T>(d);
 }
 
-inline int GET_RAND() {std::uint32_t seed = time(nullptr); return rand_r(&seed); }
+inline int GET_RAND()
+{
+    std::uint32_t seed = time(nullptr);
+    return rand_r(&seed);
+}
 
 template <typename T>
 inline T RAN_GEN(T A, T B)

--- a/driver/random.hpp
+++ b/driver/random.hpp
@@ -5,9 +5,7 @@
 
 std::minstd_rand& get_minstd_gen()
 {
-    static std::random_device rd;
-    static std::minstd_rand minstd_gen(rd());
-
+    static thread_local std::minstd_rand minstd_gen(std::random_device{}());
     return minstd_gen;
 }
 
@@ -20,7 +18,7 @@ inline T FRAND()
 
 inline int GET_RAND()
 {
-    auto minstd_gen = get_minstd_gen();
+    decltype(auto) minstd_gen = get_minstd_gen();
     return minstd_gen();
 }
 

--- a/driver/random.hpp
+++ b/driver/random.hpp
@@ -1,9 +1,6 @@
 #ifndef GUARD_RANDOM_GEN_
 #define GUARD_RANDOM_GEN_
 
-#include <cstdlib>
-#include <ctime>
-#include <cstdint>
 #include <random>
 
 std::minstd_rand& get_minstd_gen()

--- a/driver/random.hpp
+++ b/driver/random.hpp
@@ -4,18 +4,21 @@
 #include <cstdlib>
 #include <ctime>
 #include <cstdint>
+#include <chrono>
 
 template <typename T>
 inline T FRAND()
 {
-    std::uint32_t seed = time(nullptr);
-    double d           = static_cast<double>(rand_r(&seed) / (static_cast<double>(RAND_MAX)));
+    auto const clk    = std::chrono::system_clock::now().time_since_epoch().count();
+    unsigned int seed = static_cast<unsigned int>(clk);
+    double d          = static_cast<double>(rand_r(&seed) / (static_cast<double>(RAND_MAX)));
     return static_cast<T>(d);
 }
 
 inline int GET_RAND()
 {
-    std::uint32_t seed = time(nullptr);
+    auto const clk    = std::chrono::system_clock::now().time_since_epoch().count();
+    unsigned int seed = static_cast<unsigned int>(clk);
     return rand_r(&seed);
 }
 

--- a/driver/random.hpp
+++ b/driver/random.hpp
@@ -4,22 +4,21 @@
 #include <cstdlib>
 #include <ctime>
 #include <cstdint>
+#include <random>
 #include <chrono>
 
 template <typename T>
 inline T FRAND()
 {
-    auto const clk    = std::chrono::system_clock::now().time_since_epoch().count();
-    unsigned int seed = static_cast<unsigned int>(clk);
-    double d          = static_cast<double>(rand_r(&seed) / (static_cast<double>(RAND_MAX)));
+    std::minstd_rand minstd_gen(std::chrono::system_clock::now().time_since_epoch().count());
+    double d = static_cast<double>(minstd_gen() / (static_cast<double>(RAND_MAX)));
     return static_cast<T>(d);
 }
 
 inline int GET_RAND()
 {
-    auto const clk    = std::chrono::system_clock::now().time_since_epoch().count();
-    unsigned int seed = static_cast<unsigned int>(clk);
-    return rand_r(&seed);
+    std::minstd_rand minstd_gen(std::chrono::system_clock::now().time_since_epoch().count());
+    return minstd_gen();
 }
 
 template <typename T>

--- a/driver/random.hpp
+++ b/driver/random.hpp
@@ -11,7 +11,7 @@ template <typename T>
 inline T FRAND()
 {
     std::minstd_rand minstd_gen(std::chrono::system_clock::now().time_since_epoch().count());
-    double d = static_cast<double>(minstd_gen() / (static_cast<double>(RAND_MAX)));
+    auto d = std::generate_canonical<double, 5>(minstd_gen);
     return static_cast<T>(d);
 }
 


### PR DESCRIPTION
Using `rand()` is considered harmful. Replace `rand()` with `rand_r()` instead on the driver code side.