### PR TITLE
bg/LWMIOPEN-189 : use DataInvokeParams for non-fused solver - fix tuning of legacy OCL solvers

### DIFF
--- a/src/solver/conv_ocl_dir2Dfwd_exhaustive_search.cpp
+++ b/src/solver/conv_ocl_dir2Dfwd_exhaustive_search.cpp
@@ -293,12 +293,10 @@ ConvOclDirectFwdLegacyExhaustiveSearch::SearchImpl(const ConvolutionContext& ctx
     auto bias_ocl_ptr = bias_ocl_buf.get();
 #else
     auto& profile_h           = ctx.GetStream();
-    const auto& invoke_params = invoke_ctx.CastTo<miopen::fusion::FusionInvokeParams>();
-    const auto bot_ocl_ptr    = invoke_params.in;
-    const auto top_ocl_ptr    = invoke_params.out;
-    const auto wei_ocl_ptr =
-        dynamic_cast<miopen::fusion::ConvolutionOpInvokeParam&>(*invoke_params.op_args.params[0])
-            .weights;
+    const auto& invoke_params = invoke_ctx.CastTo<conv::DataInvokeParams>();
+    const auto bot_ocl_ptr    = invoke_params.tensors.in;
+    const auto top_ocl_ptr    = invoke_params.tensors.out;
+    const auto wei_ocl_ptr    = invoke_params.tensors.w;
     // There was no place in the source, where it has been actually set to something other than
     // nullptr.
     const auto bias_ocl_ptr = static_cast<Data_t>(nullptr);

--- a/src/solver/conv_ocl_dir2Dfwd_fused.cpp
+++ b/src/solver/conv_ocl_dir2Dfwd_fused.cpp
@@ -27,6 +27,8 @@
 #include <miopen/handle.hpp>
 #include <miopen/legacy_exhaustive_search.hpp>
 #include <miopen/env.hpp>
+#include <miopen/conv/tensors.hpp>
+#include <miopen/conv/data_invoke_params.hpp>
 #include <miopen/fusion/solvers.hpp>
 #include <miopen/conv/invokers/gen_x_w_y_pad.hpp>
 #include <miopen/fusion/fusion_invoke_params.hpp>
@@ -45,10 +47,22 @@ ConvOclDirectFwdFused::Search(const FusionContext& context,
                               const FusionDescription& problem,
                               const AnyInvokeParams& invoke_params) const
 {
-    const auto conv_problem = problem.GetConvProblem(0, conv::Direction::Forward);
-    const auto conv_ctx     = context.GetConvContext(conv_problem);
-    const auto legacy       = ConvOclDirectFwd{};
-    return legacy.Search(conv_ctx, conv_problem, invoke_params);
+    const auto conv_problem          = problem.GetConvProblem(0, conv::Direction::Forward);
+    const auto conv_ctx              = context.GetConvContext(conv_problem);
+    const auto legacy                = ConvOclDirectFwd{};
+    const auto& fusion_invoke_params = invoke_params.CastTo<miopen::fusion::FusionInvokeParams>();
+    const auto wei_ocl_ptr           = dynamic_cast<miopen::fusion::ConvolutionOpInvokeParam&>(
+                                 *fusion_invoke_params.op_args.params[0])
+                                 .weights;
+    const auto& tensors = miopen::ConvFwdTensors{fusion_invoke_params.inDesc,
+                                                 fusion_invoke_params.in,
+                                                 conv_problem.conv_problem.GetWeights(),
+                                                 wei_ocl_ptr,
+                                                 fusion_invoke_params.outDesc,
+                                                 fusion_invoke_params.out};
+    const auto data_invoke_params =
+        miopen::conv::DataInvokeParams{tensors, nullptr, 0, fusion_invoke_params.gfx90aFp16alt};
+    return legacy.Search(conv_ctx, conv_problem, data_invoke_params);
 }
 
 bool ConvOclDirectFwdFused::IsApplicable(const FusionContext& context,


### PR DESCRIPTION
Address https://github.com/ROCmSoftwarePlatform/MIOpen/issues/2239