### PR TITLE
Added driver command logging for Find 2.0

### DIFF
--- a/src/api/find2_0_commons.cpp
+++ b/src/api/find2_0_commons.cpp
@@ -148,6 +148,9 @@ miopenStatus_t miopenFindSolutions(miopenHandle_t handle,
     return miopen::try_([&] {
         auto& handle_deref        = miopen::deref(handle);
         const auto& problem_deref = miopen::deref(problem);
+
+        problem_deref.LogDriverCommand();
+
         const auto& options_deref =
             options == nullptr ? miopen::FindOptions{} : miopen::deref(options);
 
@@ -197,6 +200,8 @@ miopenStatus_t miopenRunSolution(miopenHandle_t handle,
     return miopen::try_([&] {
         auto& handle_deref   = miopen::deref(handle);
         auto& solution_deref = miopen::deref(solution);
+
+        solution_deref.LogDriverCommand();
 
         const auto inputs_deref = [&]() {
             auto ret = std::unordered_map<miopenTensorArgumentId_t, miopen::Solution::RunInput>{};

--- a/src/convolution_api.cpp
+++ b/src/convolution_api.cpp
@@ -410,7 +410,7 @@ static std::string ConvArgsForMIOpenDriver(const miopen::TensorDescriptor& xDesc
                                            const miopen::ConvolutionDescriptor& convDesc,
                                            const miopen::TensorDescriptor& yDesc,
                                            const miopenProblemDirection_t& conv_dir,
-                                           std::optional<std::size_t> immediate_mode_solver_id)
+                                           std::optional<uint64_t> immediate_mode_solver_id)
 {
     std::stringstream ss;
     if(xDesc.GetType() == miopenHalf)
@@ -519,7 +519,7 @@ void LogCmdConvolution(const miopen::TensorDescriptor& x,
                        const miopen::ConvolutionDescriptor& conv,
                        const miopen::TensorDescriptor& y,
                        const miopenProblemDirection_t& dir,
-                       std::optional<std::size_t> solver_id)
+                       std::optional<uint64_t> solver_id)
 {
     if(miopen::IsLoggingCmd())
     {
@@ -547,7 +547,7 @@ void LogCmdConvolution(const miopenTensorDescriptor_t& xDesc,
         }();
 
         const auto& [x, w, conv, y] = miopen::tie_deref(xDesc, wDesc, convDesc, yDesc);
-        const auto solver_id        = is_immediate ? std::optional(0ull) : std::nullopt;
+        const auto solver_id        = is_immediate ? std::optional(0) : std::nullopt;
         LogCmdConvolution(x, w, conv, y, dir, solver_id);
     }
 }

--- a/src/convolution_api.cpp
+++ b/src/convolution_api.cpp
@@ -404,14 +404,24 @@ enum class ConvDirection
     WrW = 4
 };
 
-// not static because Find 2.0 uses it until a separate driver command is implemented
+// Not static because Find 2.0 uses it until a separate driver command is implemented
+// We use API type in the declaration so that usages won't have to convert to commandline values
 static std::string ConvArgsForMIOpenDriver(const miopen::TensorDescriptor& xDesc,
                                            const miopen::TensorDescriptor& wDesc,
                                            const miopen::ConvolutionDescriptor& convDesc,
                                            const miopen::TensorDescriptor& yDesc,
-                                           const miopenProblemDirection_t& conv_dir,
+                                           miopenProblemDirection_t dir,
                                            std::optional<uint64_t> immediate_mode_solver_id)
 {
+    const auto conv_dir = [&]() {
+        switch(dir)
+        {
+        case miopenProblemDirectionForward: return ConvDirection::Fwd;
+        case miopenProblemDirectionBackward: return ConvDirection::Bwd;
+        case miopenProblemDirectionBackwardWeights: return ConvDirection::WrW;
+        }
+    }();
+
     std::stringstream ss;
     if(xDesc.GetType() == miopenHalf)
     {
@@ -518,7 +528,7 @@ void LogCmdConvolution(const miopen::TensorDescriptor& x,
                        const miopen::TensorDescriptor& w,
                        const miopen::ConvolutionDescriptor& conv,
                        const miopen::TensorDescriptor& y,
-                       const miopenProblemDirection_t& dir,
+                       miopenProblemDirection_t dir,
                        std::optional<uint64_t> solver_id)
 {
     if(miopen::IsLoggingCmd())
@@ -532,7 +542,7 @@ void LogCmdConvolution(const miopenTensorDescriptor_t& xDesc,
                        const miopenTensorDescriptor_t& wDesc,
                        const miopenConvolutionDescriptor_t& convDesc,
                        const miopenTensorDescriptor_t& yDesc,
-                       const ConvDirection& conv_dir,
+                       ConvDirection conv_dir,
                        bool is_immediate)
 {
     if(miopen::IsLoggingCmd())
@@ -556,7 +566,7 @@ void LogCmdFindConvolution(const miopenTensorDescriptor_t& xDesc,
                            const miopenTensorDescriptor_t& wDesc,
                            const miopenConvolutionDescriptor_t& convDesc,
                            const miopenTensorDescriptor_t& yDesc,
-                           const ConvDirection& conv_dir,
+                           ConvDirection conv_dir,
                            bool is_immediate)
 {
     LogCmdConvolution(xDesc, wDesc, convDesc, yDesc, conv_dir, is_immediate);

--- a/src/convolution_api.cpp
+++ b/src/convolution_api.cpp
@@ -552,9 +552,9 @@ void LogCmdFindConvolution(const miopen::TensorDescriptor& x,
     }
 }
 
-static ConvDirection DirectionToCmdArg(miopenProblemDirection_t direction)
+static miopenProblemDirection_t CmdArgToDirection(ConvDirection direction)
 {
-    switch(conv_dir)
+    switch(direction)
     {
     case ConvDirection::Fwd: return miopenProblemDirectionForward;
     case ConvDirection::Bwd: return miopenProblemDirectionBackward;
@@ -572,7 +572,7 @@ void LogCmdConvolution(const miopenTensorDescriptor_t& xDesc,
 {
     if(miopen::IsLoggingCmd())
     {
-        const auto dir              = DirectionToCmdArg(conv_dir);
+        const auto dir              = CmdArgToDirection(conv_dir);
         const auto& [x, w, conv, y] = miopen::tie_deref(xDesc, wDesc, convDesc, yDesc);
         const auto solver_id        = is_immediate ? std::optional(0) : std::nullopt;
         LogCmdConvolution(x, w, conv, y, dir, solver_id);
@@ -588,7 +588,7 @@ void LogCmdFindConvolution(const miopenTensorDescriptor_t& xDesc,
 {
     if(miopen::IsLoggingCmd())
     {
-        const auto dir              = DirectionToCmdArg(conv_dir);
+        const auto dir              = CmdArgToDirection(conv_dir);
         const auto& [x, w, conv, y] = miopen::tie_deref(xDesc, wDesc, convDesc, yDesc);
         const auto solver_id        = is_immediate ? std::optional(0) : std::nullopt;
         LogCmdFindConvolution(x, w, conv, y, dir, solver_id);

--- a/src/convolution_api.cpp
+++ b/src/convolution_api.cpp
@@ -36,6 +36,7 @@
 #include <miopen/tensor_ops.hpp>
 
 #include <algorithm>
+#include <optional>
 
 using ExecutionContext   = miopen::ExecutionContext;
 using Direction          = miopen::conv::Direction;
@@ -403,24 +404,24 @@ enum class ConvDirection
     WrW = 4
 };
 
-static std::string ConvArgsForMIOpenDriver(const miopenTensorDescriptor_t& xDesc,
-                                           const miopenTensorDescriptor_t& wDesc,
-                                           const miopenConvolutionDescriptor_t& convDesc,
-                                           const miopenTensorDescriptor_t& yDesc,
-                                           const ConvDirection& conv_dir,
-                                           bool is_immediate)
+// not static because Find 2.0 uses it until a separate driver command is implemented
+static std::string ConvArgsForMIOpenDriver(const miopen::TensorDescriptor& xDesc,
+                                           const miopen::TensorDescriptor& wDesc,
+                                           const miopen::ConvolutionDescriptor& convDesc,
+                                           const miopen::TensorDescriptor& yDesc,
+                                           const miopenProblemDirection_t& conv_dir,
+                                           std::optional<std::size_t> immediate_mode_solver_id)
 {
     std::stringstream ss;
-    if(miopen::deref(xDesc).GetType() == miopenHalf)
+    if(xDesc.GetType() == miopenHalf)
     {
         ss << "convfp16";
     }
-    else if(miopen::deref(xDesc).GetType() == miopenBFloat16)
+    else if(xDesc.GetType() == miopenBFloat16)
     {
         ss << "convbfp16";
     }
-    else if(miopen::deref(xDesc).GetType() == miopenInt8 ||
-            miopen::deref(xDesc).GetType() == miopenInt8x4)
+    else if(xDesc.GetType() == miopenInt8 || xDesc.GetType() == miopenInt8x4)
     {
         ss << "convint8";
     }
@@ -428,24 +429,24 @@ static std::string ConvArgsForMIOpenDriver(const miopenTensorDescriptor_t& xDesc
     {
         ss << "conv";
     }
-    if(miopen::deref(convDesc).GetSpatialDimension() == 2)
+    if(convDesc.GetSpatialDimension() == 2)
     {
-        ss << " -n " << miopen::deref(xDesc).GetLengths()[0] // clang-format off
-            << " -c " << miopen::deref(xDesc).GetLengths()[1]
-            << " -H " << miopen::deref(xDesc).GetLengths()[2]
-            << " -W " << miopen::deref(xDesc).GetLengths()[3]
-            << " -k " << miopen::deref(wDesc).GetLengths()[0]
-            << " -y " << miopen::deref(wDesc).GetLengths()[2]
-            << " -x " << miopen::deref(wDesc).GetLengths()[3]
-            << " -p " << miopen::deref(convDesc).GetConvPads()[0]
-            << " -q " << miopen::deref(convDesc).GetConvPads()[1]
-            << " -u " << miopen::deref(convDesc).GetConvStrides()[0]
-            << " -v " << miopen::deref(convDesc).GetConvStrides()[1]
-            << " -l " << miopen::deref(convDesc).GetConvDilations()[0]
-            << " -j " << miopen::deref(convDesc).GetConvDilations()[1]; // clang-format on
-        std::string x_layout = miopen::deref(xDesc).GetLayout("NCHW");
-        std::string w_layout = miopen::deref(wDesc).GetLayout("NCHW");
-        std::string y_layout = miopen::deref(yDesc).GetLayout("NCHW");
+        ss << " -n " << xDesc.GetLengths()[0] // clang-format off
+            << " -c " << xDesc.GetLengths()[1]
+            << " -H " << xDesc.GetLengths()[2]
+            << " -W " << xDesc.GetLengths()[3]
+            << " -k " << wDesc.GetLengths()[0]
+            << " -y " << wDesc.GetLengths()[2]
+            << " -x " << wDesc.GetLengths()[3]
+            << " -p " << convDesc.GetConvPads()[0]
+            << " -q " << convDesc.GetConvPads()[1]
+            << " -u " << convDesc.GetConvStrides()[0]
+            << " -v " << convDesc.GetConvStrides()[1]
+            << " -l " << convDesc.GetConvDilations()[0]
+            << " -j " << convDesc.GetConvDilations()[1]; // clang-format on
+        std::string x_layout = xDesc.GetLayout("NCHW");
+        std::string w_layout = wDesc.GetLayout("NCHW");
+        std::string y_layout = yDesc.GetLayout("NCHW");
         if(x_layout != "NCHW")
         {
             ss << " --in_layout " << x_layout;
@@ -459,30 +460,30 @@ static std::string ConvArgsForMIOpenDriver(const miopenTensorDescriptor_t& xDesc
             ss << " --out_layout " << y_layout;
         }
     }
-    else if(miopen::deref(convDesc).GetSpatialDimension() == 3)
+    else if(convDesc.GetSpatialDimension() == 3)
     {
-        ss << " -n " << miopen::deref(xDesc).GetLengths()[0] // clang-format off
-            << " -c " << miopen::deref(xDesc).GetLengths()[1]
-            << " --in_d " << miopen::deref(xDesc).GetLengths()[2]
-            << " -H " << miopen::deref(xDesc).GetLengths()[3]
-            << " -W " << miopen::deref(xDesc).GetLengths()[4]
-            << " -k " << miopen::deref(wDesc).GetLengths()[0]
-            << " --fil_d " << miopen::deref(wDesc).GetLengths()[2]
-            << " -y " << miopen::deref(wDesc).GetLengths()[3]
-            << " -x " << miopen::deref(wDesc).GetLengths()[4]
-            << " --pad_d " << miopen::deref(convDesc).GetConvPads()[0]
-            << " -p " << miopen::deref(convDesc).GetConvPads()[1]
-            << " -q " << miopen::deref(convDesc).GetConvPads()[2]
-            << " --conv_stride_d " << miopen::deref(convDesc).GetConvStrides()[0]
-            << " -u " << miopen::deref(convDesc).GetConvStrides()[1]
-            << " -v " << miopen::deref(convDesc).GetConvStrides()[2]
-            << " --dilation_d " << miopen::deref(convDesc).GetConvDilations()[0]
-            << " -l " << miopen::deref(convDesc).GetConvDilations()[1]
-            << " -j " << miopen::deref(convDesc).GetConvDilations()[2]
+        ss << " -n " << xDesc.GetLengths()[0] // clang-format off
+            << " -c " << xDesc.GetLengths()[1]
+            << " --in_d " << xDesc.GetLengths()[2]
+            << " -H " << xDesc.GetLengths()[3]
+            << " -W " << xDesc.GetLengths()[4]
+            << " -k " << wDesc.GetLengths()[0]
+            << " --fil_d " << wDesc.GetLengths()[2]
+            << " -y " << wDesc.GetLengths()[3]
+            << " -x " << wDesc.GetLengths()[4]
+            << " --pad_d " << convDesc.GetConvPads()[0]
+            << " -p " << convDesc.GetConvPads()[1]
+            << " -q " << convDesc.GetConvPads()[2]
+            << " --conv_stride_d " << convDesc.GetConvStrides()[0]
+            << " -u " << convDesc.GetConvStrides()[1]
+            << " -v " << convDesc.GetConvStrides()[2]
+            << " --dilation_d " << convDesc.GetConvDilations()[0]
+            << " -l " << convDesc.GetConvDilations()[1]
+            << " -j " << convDesc.GetConvDilations()[2]
             << " --spatial_dim 3"; // clang-format on
-        std::string x_layout = miopen::deref(xDesc).GetLayout("NCDHW");
-        std::string w_layout = miopen::deref(wDesc).GetLayout("NCDHW");
-        std::string y_layout = miopen::deref(yDesc).GetLayout("NCDHW");
+        std::string x_layout = xDesc.GetLayout("NCDHW");
+        std::string w_layout = wDesc.GetLayout("NCDHW");
+        std::string y_layout = yDesc.GetLayout("NCDHW");
         if(x_layout != "NCDHW")
         {
             ss << " --in_layout " << x_layout;
@@ -496,15 +497,15 @@ static std::string ConvArgsForMIOpenDriver(const miopenTensorDescriptor_t& xDesc
             ss << " --out_layout " << y_layout;
         }
     }
-    ss << " -m " << (miopen::deref(convDesc).mode == 1 ? "trans" : "conv") // clang-format off
-        << " -g " << miopen::deref(convDesc).group_count
+    ss << " -m " << (convDesc.mode == 1 ? "trans" : "conv") // clang-format off
+        << " -g " << convDesc.group_count
         << " -F " << std::to_string(static_cast<int>(conv_dir))
         << " -t 1"; // clang-format on
-    if(miopen::deref(xDesc).GetType() == miopenInt8x4)
+    if(xDesc.GetType() == miopenInt8x4)
         ss << " -Z 1";
-    if(is_immediate)
+    if(immediate_mode_solver_id.has_value())
     {
-        ss << " -S 0";
+        ss << " -S " << *immediate_mode_solver_id;
     }
 
     return ss.str();
@@ -512,6 +513,20 @@ static std::string ConvArgsForMIOpenDriver(const miopenTensorDescriptor_t& xDesc
 
 namespace miopen {
 namespace debug {
+
+void LogCmdConvolution(const miopen::TensorDescriptor& x,
+                       const miopen::TensorDescriptor& w,
+                       const miopen::ConvolutionDescriptor& conv,
+                       const miopen::TensorDescriptor& y,
+                       const miopenProblemDirection_t& dir,
+                       std::optional<std::size_t> solver_id)
+{
+    if(miopen::IsLoggingCmd())
+    {
+        const std::string& str = ConvArgsForMIOpenDriver(x, w, conv, y, dir, solver_id);
+        MIOPEN_LOG_DRIVER_CMD(str);
+    }
+}
 
 void LogCmdConvolution(const miopenTensorDescriptor_t& xDesc,
                        const miopenTensorDescriptor_t& wDesc,
@@ -522,9 +537,18 @@ void LogCmdConvolution(const miopenTensorDescriptor_t& xDesc,
 {
     if(miopen::IsLoggingCmd())
     {
-        const std::string& str =
-            ConvArgsForMIOpenDriver(xDesc, wDesc, convDesc, yDesc, conv_dir, is_immediate);
-        MIOPEN_LOG_DRIVER_CMD(str);
+        const auto dir = [&]() {
+            switch(conv_dir)
+            {
+            case ConvDirection::Fwd: return miopenProblemDirectionForward;
+            case ConvDirection::Bwd: return miopenProblemDirectionBackward;
+            case ConvDirection::WrW: return miopenProblemDirectionBackwardWeights;
+            };
+        }();
+
+        const auto& [x, w, conv, y] = miopen::tie_deref(xDesc, wDesc, convDesc, yDesc);
+        const auto solver_id        = is_immediate ? std::optional(0ull) : std::nullopt;
+        LogCmdConvolution(x, w, conv, y, dir, solver_id);
     }
 }
 
@@ -535,12 +559,7 @@ void LogCmdFindConvolution(const miopenTensorDescriptor_t& xDesc,
                            const ConvDirection& conv_dir,
                            bool is_immediate)
 {
-    if(miopen::IsLoggingCmd())
-    {
-        const std::string& str =
-            ConvArgsForMIOpenDriver(xDesc, wDesc, convDesc, yDesc, conv_dir, is_immediate);
-        MIOPEN_LOG_DRIVER_CMD(str);
-    }
+    LogCmdConvolution(xDesc, wDesc, convDesc, yDesc, conv_dir, is_immediate);
 }
 
 } // namespace debug

--- a/src/include/miopen/problem.hpp
+++ b/src/include/miopen/problem.hpp
@@ -92,6 +92,8 @@ struct Problem : miopenProblem
                                    const TensorDescriptor& wDesc,
                                    const ConvolutionDescriptor& conv);
 
+    void LogDriverCommand() const;
+
     friend void to_json(nlohmann::json& j, const Problem& problem);
     friend void from_json(const nlohmann::json& j, Problem& problem);
 
@@ -109,6 +111,7 @@ private:
                                             const ConvolutionDescriptor& conv_desc) const;
 
     void TransposeImpl(const ConvolutionDescriptor& conv_desc);
+    void LogDriverCommand(const ConvolutionDescriptor& conv_desc) const;
 };
 
 } // namespace miopen

--- a/src/include/miopen/solution.hpp
+++ b/src/include/miopen/solution.hpp
@@ -91,6 +91,8 @@ struct Solution : miopenSolution
              Data_t workspace,
              size_t workspace_size);
 
+    void LogDriverCommand() const;
+
     friend void to_json(nlohmann::json& json, const Solution& solution);
     friend void from_json(const nlohmann::json& json, Solution& solution);
 
@@ -108,6 +110,7 @@ private:
                  const ConvolutionDescriptor& conv_desc);
 
     static Problem Transpose(const Problem& problem, RunInput* x, const RunInput& w, RunInput* y);
+    void LogDriverCommand(const ConvolutionDescriptor& conv_desc) const;
 };
 
 } // namespace miopen

--- a/src/problem.cpp
+++ b/src/problem.cpp
@@ -45,12 +45,12 @@
 
 namespace miopen::debug {
 // Todo: This should be updated when a separate driver command is implemented
-void LogCmdConvolution(const miopen::TensorDescriptor& x,
-                       const miopen::TensorDescriptor& w,
-                       const miopen::ConvolutionDescriptor& conv,
-                       const miopen::TensorDescriptor& y,
-                       miopenProblemDirection_t dir,
-                       std::optional<uint64_t> solver_id);
+void LogCmdFindConvolution(const miopen::TensorDescriptor& x,
+                           const miopen::TensorDescriptor& w,
+                           const miopen::ConvolutionDescriptor& conv,
+                           const miopen::TensorDescriptor& y,
+                           miopenProblemDirection_t dir,
+                           std::optional<uint64_t> solver_id);
 } // namespace miopen::debug
 
 namespace miopen {
@@ -409,7 +409,7 @@ void Problem::LogDriverCommand(const ConvolutionDescriptor& conv_desc) const
         GetTensorDescriptorChecked(miopenTensorConvolutionW, "miopenTensorConvolutionW");
     const auto& y_desc =
         GetTensorDescriptorChecked(miopenTensorConvolutionY, "miopenTensorConvolutionY");
-    miopen::debug::LogCmdConvolution(x_desc, w_desc, conv_desc, y_desc, direction, 0);
+    miopen::debug::LogCmdFindConvolution(x_desc, w_desc, conv_desc, y_desc, direction, 0);
 }
 
 void to_json(nlohmann::json& json, const Problem& problem)

--- a/src/problem.cpp
+++ b/src/problem.cpp
@@ -49,7 +49,7 @@ void LogCmdConvolution(const miopen::TensorDescriptor& x,
                        const miopen::TensorDescriptor& w,
                        const miopen::ConvolutionDescriptor& conv,
                        const miopen::TensorDescriptor& y,
-                       const miopenProblemDirection_t& dir,
+                       miopenProblemDirection_t dir,
                        std::optional<uint64_t> solver_id);
 } // namespace miopen::debug
 

--- a/src/problem.cpp
+++ b/src/problem.cpp
@@ -50,7 +50,7 @@ void LogCmdConvolution(const miopen::TensorDescriptor& x,
                        const miopen::ConvolutionDescriptor& conv,
                        const miopen::TensorDescriptor& y,
                        const miopenProblemDirection_t& dir,
-                       std::optional<std::size_t> solver_id);
+                       std::optional<uint64_t> solver_id);
 } // namespace miopen::debug
 
 namespace miopen {

--- a/src/problem.cpp
+++ b/src/problem.cpp
@@ -43,6 +43,16 @@
 #include <boost/variant/apply_visitor.hpp>
 #include <boost/hof/match.hpp>
 
+namespace miopen::debug {
+// Todo: This should be updated when a separate driver command is implemented
+void LogCmdConvolution(const miopen::TensorDescriptor& x,
+                       const miopen::TensorDescriptor& w,
+                       const miopen::ConvolutionDescriptor& conv,
+                       const miopen::TensorDescriptor& y,
+                       const miopenProblemDirection_t& dir,
+                       std::optional<std::size_t> solver_id);
+} // namespace miopen::debug
+
 namespace miopen {
 
 namespace detail {
@@ -381,6 +391,25 @@ void Problem::ValidateGroupCount(const TensorDescriptor& xDesc,
         if(xDesc.GetLengths()[1] / conv.group_count != wDesc.GetLengths()[1])
             MIOPEN_THROW(miopenStatusBadParm, "Invalid filter channel number");
     }
+}
+
+void Problem::LogDriverCommand() const
+{
+    const auto log_function = boost::hof::match(
+        [&](const ConvolutionDescriptor& op_desc) { return LogDriverCommand(op_desc); });
+
+    boost::apply_visitor(log_function, operator_descriptor);
+}
+
+void Problem::LogDriverCommand(const ConvolutionDescriptor& conv_desc) const
+{
+    const auto& x_desc =
+        GetTensorDescriptorChecked(miopenTensorConvolutionX, "miopenTensorConvolutionX");
+    const auto& w_desc =
+        GetTensorDescriptorChecked(miopenTensorConvolutionW, "miopenTensorConvolutionW");
+    const auto& y_desc =
+        GetTensorDescriptorChecked(miopenTensorConvolutionY, "miopenTensorConvolutionY");
+    miopen::debug::LogCmdConvolution(x_desc, w_desc, conv_desc, y_desc, direction, 0);
 }
 
 void to_json(nlohmann::json& json, const Problem& problem)

--- a/src/solution.cpp
+++ b/src/solution.cpp
@@ -41,7 +41,7 @@ void LogCmdConvolution(const miopen::TensorDescriptor& x,
                        const miopen::TensorDescriptor& w,
                        const miopen::ConvolutionDescriptor& conv,
                        const miopen::TensorDescriptor& y,
-                       const miopenProblemDirection_t& dir,
+                       miopenProblemDirection_t dir,
                        std::optional<uint64_t> solver_id);
 } // namespace miopen::debug
 

--- a/src/solution.cpp
+++ b/src/solution.cpp
@@ -26,14 +26,24 @@
 
 #include <miopen/solution.hpp>
 
+#include <miopen/any_solver.hpp>
 #include <miopen/check_numerics.hpp>
 #include <miopen/conv/data_invoke_params.hpp>
 #include <miopen/conv/wrw_invoke_params.hpp>
-#include <miopen/any_solver.hpp>
 
 #include <nlohmann/json.hpp>
 
 #include <boost/hof/match.hpp>
+
+namespace miopen::debug {
+// Todo: This should be updated when a separate driver command is implemented
+void LogCmdConvolution(const miopen::TensorDescriptor& x,
+                       const miopen::TensorDescriptor& w,
+                       const miopen::ConvolutionDescriptor& conv,
+                       const miopen::TensorDescriptor& y,
+                       const miopenProblemDirection_t& dir,
+                       std::optional<std::size_t> solver_id);
+} // namespace miopen::debug
 
 namespace miopen {
 
@@ -53,6 +63,26 @@ void Solution::Run(Handle& handle,
     });
 
     boost::apply_visitor(run, problem.GetOperatorDescriptor());
+}
+
+void Solution::LogDriverCommand() const
+{
+    const auto log_function = boost::hof::match(
+        [&](const ConvolutionDescriptor& op_desc) { return LogDriverCommand(op_desc); });
+
+    boost::apply_visitor(log_function, problem.GetOperatorDescriptor());
+}
+
+void Solution::LogDriverCommand(const ConvolutionDescriptor& conv_desc) const
+{
+    const auto& x_desc =
+        problem.GetTensorDescriptorChecked(miopenTensorConvolutionX, "miopenTensorConvolutionX");
+    const auto& w_desc =
+        problem.GetTensorDescriptorChecked(miopenTensorConvolutionW, "miopenTensorConvolutionW");
+    const auto& y_desc =
+        problem.GetTensorDescriptorChecked(miopenTensorConvolutionY, "miopenTensorConvolutionY");
+    miopen::debug::LogCmdConvolution(
+        x_desc, w_desc, conv_desc, y_desc, problem.GetDirection(), solver.Value());
 }
 
 void Solution::RunImpl(Handle& handle,

--- a/src/solution.cpp
+++ b/src/solution.cpp
@@ -42,7 +42,7 @@ void LogCmdConvolution(const miopen::TensorDescriptor& x,
                        const miopen::ConvolutionDescriptor& conv,
                        const miopen::TensorDescriptor& y,
                        const miopenProblemDirection_t& dir,
-                       std::optional<std::size_t> solver_id);
+                       std::optional<uint64_t> solver_id);
 } // namespace miopen::debug
 
 namespace miopen {

--- a/test/gtest/log_test_helper.hpp
+++ b/test/gtest/log_test_helper.hpp
@@ -43,7 +43,7 @@ void LogCmdConvolution(const miopenTensorDescriptor_t& xDesc,
                        const miopenTensorDescriptor_t& wDesc,
                        const miopenConvolutionDescriptor_t& convDesc,
                        const miopenTensorDescriptor_t& yDesc,
-                       const ConvDirection& conv_dir,
+                       ConvDirection conv_dir,
                        bool is_immediate);
 // Copy of function declaration that is in miopen.
 // This is for testing purpose only.
@@ -51,7 +51,7 @@ void LogCmdFindConvolution(const miopenTensorDescriptor_t& xDesc,
                            const miopenTensorDescriptor_t& wDesc,
                            const miopenConvolutionDescriptor_t& convDesc,
                            const miopenTensorDescriptor_t& yDesc,
-                           const ConvDirection& conv_dir,
+                           ConvDirection conv_dir,
                            bool is_immediate);
 } // namespace debug
 } // namespace miopen


### PR DESCRIPTION
Implements #1937.

This extends immediate mode logging to include solver id. (Original immediate mode logging untouched in this PR, but is trivial to update.) The command should call the same internals except for find 2.0 wrapping.

An example log lines from test_find_2_conv:
```
...
Testing miopenFindSolutions with options...
MIOpen(HIP): Command [LogCmdConvolution] ./bin/MIOpenDriver conv -n 16 -c 192 -H 28 -W 28 -k 32 -y 5 -x 5 -p 1 -q 1 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 1 -t 1 -S 0
...
Running a solution...
MIOpen(HIP): Command [LogCmdConvolution] ./bin/MIOpenDriver conv -n 16 -c 192 -H 28 -W 28 -k 32 -y 5 -x 5 -p 1 -q 1 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -F 1 -t 1 -S 84
...
```

Future work:
- Update logging when there would be separate driver commands.