### PR TITLE
[Tests] tensor operations tests improvements.

### DIFF
--- a/test/tensor_ops.cpp
+++ b/test/tensor_ops.cpp
@@ -324,8 +324,14 @@ struct tensor_ops_driver : test_driver
 
     void run()
     {
-        if(tensorlens_ac.size() == tensorlens_b.size() && tensorlens_ac >= tensorlens_b)
+        if(tensorlens_ac.size() == tensorlens_b.size())
         {
+            for(size_t idx = 0; idx < tensorlens_b.size(); ++idx)
+            {
+                if((tensorlens_b[idx] != 1) && (tensorlens_ac[idx] != tensorlens_b[idx]))
+                    return;
+            }
+
             tensor<T> aTensor = get_subtensors(super_a, tensorlens_ac, packed);
             tensor<T> bTensor = get_subtensors(super_b, tensorlens_b, packed);
             tensor<T> cTensor = get_subtensors(super_c, tensorlens_ac, packed);

--- a/test/tensor_ops.cpp
+++ b/test/tensor_ops.cpp
@@ -197,17 +197,21 @@ struct verify_tensor_ops
                          Boffset,
                          Coffset);
 
-        auto r = c;
-        r.data = handle.Read<T>(c_dev, r.data.size());
-
+        if(not no_validate)
+        {
+            auto r = c;
+            r.data = handle.Read<T>(c_dev, r.data.size());
 #if(MIO_OPS_DEBUG)
-        handle.Finish();
-        auto clens    = r.desc.GetLengths();
-        auto cstrides = r.desc.GetStrides();
-        for(int i = 0; i < r.desc.GetElementSize(); i++)
-            printf("GPU_C[%d]: %f\n", i, c.data[i + Coffset]);
+            handle.Finish();
+            auto clens    = r.desc.GetLengths();
+            auto cstrides = r.desc.GetStrides();
+            for(int i = 0; i < r.desc.GetElementSize(); i++)
+                printf("GPU_C[%d]: %f\n", i, c.data[i + Coffset]);
 #endif
-        return r;
+            return r;
+        }
+
+        return c;
     }
 
     void fail(int = 0) const

--- a/test/tensor_ops.cpp
+++ b/test/tensor_ops.cpp
@@ -130,8 +130,8 @@ struct verify_tensor_ops
                        cten[cindex + CtenOffset],
                        aindex + AtenOffset,
                        aten[aindex + AtenOffset],
-                       bindex + Btenoffset,
-                       bten[bindex + Btenoffset]);
+                       bindex + BtenOffset,
+                       bten[bindex + BtenOffset]);
 #endif
                 cten[cindex + CtenOffset] =
                     // add_elem(aten[aindex + AtenOffset] * palpha0, bten[bindex + BtenOffset] *


### PR DESCRIPTION
Fixes and improvements related to issue #2222 

Added strides configuration for each tensor.
Improved checks for incompatible combinations of strides and tensors.
Added ability to set any reasonable tensor sizes (they must fit into GPU memory).
Fixed offset configuration reset after `packed` tests.
Improved tests performance (currently 3x, but can be 10x+, it heavily depends on tensor sizes):
Current PR
```
time ./bin/test_tensor_ops --all
real    0m1,482s
user    0m1,330s
sys     0m0,252s
```

Previous version
```
time ./bin/test_tensor_ops --all
real    0m4,535s
user    0m4,608s
sys     0m0,309s
```

@junliume, @atamazov who can review that kind of PR?