### PR TITLE
bg/LWPMIOPEN-191: Gracefully exit if search mode is not supported during fusion's compile stage.

### DIFF
--- a/src/fusion.cpp
+++ b/src/fusion.cpp
@@ -497,8 +497,13 @@ static auto MakeFusionInvokeParams(const FusionContext& fusion_ctx,
         //     Convolution + Activation
         //     GEMM + Activation
         //
-        MIOPEN_LOG_I2("Allocating buffers for given fusion operators is not supported yet.");
-        MIOPEN_THROW(miopenStatusNotImplemented);
+        MIOPEN_LOG_W("Allocating buffers for given fusion operators is not supported yet.");
+        return miopen::fusion::FusionInvokeParams(OperatorArgs(),
+                                                  miopen::TensorDescriptor(),
+                                                  nullptr,
+                                                  miopen::TensorDescriptor(),
+                                                  nullptr,
+                                                  false);
     }
 }
 
@@ -516,6 +521,14 @@ miopenStatus_t FusionPlanDescriptor::Compile(Handle& handle)
     // If we are tuning, then we need to allocate buffers.
     if(enforce.IsSearch(fusion_ctx))
         invoke_params = MakeFusionInvokeParams(fusion_ctx, fusion_problem, invoke_bufs, params);
+    // During search mode, miopen invokes kernel to find the best config.
+    // If memory allocation of the invoke params for the given fusion plan
+    // is not supported we return early.
+    // if(enforce.IsSearch(fusion_ctx) && invoke_bufs.empty())
+    // {
+    //     MIOPEN_LOG_I("No supported fusion solvers found during Search Mode.");
+    //     return miopenStatusUnsupportedOp;
+    // }
     // tmp_sols is a collection of ConvSolutions that isApplicable for the fusion_problem.
     // These ConvSolutions stores instructions on how to build. It also stores invoker.
     const auto tmp_sols = solvers.SearchForAllSolutions(

--- a/src/fusion.cpp
+++ b/src/fusion.cpp
@@ -524,11 +524,11 @@ miopenStatus_t FusionPlanDescriptor::Compile(Handle& handle)
     // During search mode, miopen invokes kernel to find the best config.
     // If memory allocation of the invoke params for the given fusion plan
     // is not supported we return early.
-    // if(enforce.IsSearch(fusion_ctx) && invoke_bufs.empty())
-    // {
-    //     MIOPEN_LOG_I("No supported fusion solvers found during Search Mode.");
-    //     return miopenStatusUnsupportedOp;
-    // }
+    if(enforce.IsSearch(fusion_ctx) && invoke_bufs.empty())
+    {
+        MIOPEN_LOG_I("No supported fusion solvers found during Search Mode.");
+        return miopenStatusUnsupportedOp;
+    }
     // tmp_sols is a collection of ConvSolutions that isApplicable for the fusion_problem.
     // These ConvSolutions stores instructions on how to build. It also stores invoker.
     const auto tmp_sols = solvers.SearchForAllSolutions(


### PR DESCRIPTION
Gracefully exit when search mode is not supported during fusion's compile state. Currently we only support (conv + bias + activ ) some fusion operation during search mode. Any other fusion operation during search mode should gracefully exit. 