### PR TITLE
OpTensor1d improvement

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -439,6 +439,7 @@ if( MIOPEN_BACKEND MATCHES "OpenCL" OR MIOPEN_BACKEND STREQUAL "HIPOC" OR MIOPEN
         kernels/xform_out.s
         kernels/gcnAsmBNBwdTrainSpatial.s
         kernels/MIOpenTensorKernels.cl
+        kernels/MIOpenTensorKernelsHip.cpp
         kernels/MIOpenSubTensorOpWithScalarKernel.cl
         kernels/MIOpenSubTensorOpWithSubTensorKernel.cl
         kernels/MIOpenSubTensorOpWithCastTensorKernel.cl

--- a/src/kernels/MIOpenTensorKernels.cl
+++ b/src/kernels/MIOpenTensorKernels.cl
@@ -1185,67 +1185,6 @@ __kernel void Op2dTensorGeneric(global MIOPEN_TYPE* a,
 
 #endif
 
-#ifdef USE_1D_TENSOR_GENERIC
-// N
-__kernel void Op1dTensorGeneric(global MIOPEN_TYPE* a,
-                                global MIOPEN_TYPE* b,
-                                const int b_n,
-                                global MIOPEN_TYPE* c,
-                                const int c_n,
-                                const MIOPEN_TYPE alpha0,
-                                const MIOPEN_TYPE alpha1,
-                                const MIOPEN_TYPE beta,
-                                const unsigned int bitmap,
-                                const int work_per_wg,
-                                const long Aoffset,
-                                const long Boffset,
-                                const long Coffset,
-                                const int num_wg)
-{
-    int gid = get_group_id(0);
-
-    global MIOPEN_TYPE* a_off = a + Aoffset;
-    global MIOPEN_TYPE* b_off = b + Boffset;
-    global MIOPEN_TYPE* c_off = c + Coffset;
-
-    // num_wg: the number of workgroups should be launched
-    // MAX_NUM_WG: the maximum number of workgroups actually launched
-    if(beta == (MIOPEN_TYPE)0)
-    {
-        for(; gid < num_wg; gid += MAX_NUM_WG)
-        {
-            int lid             = get_local_id(0);
-            int o_n_gid_off     = gid % b_n;
-            int bindex          = o_n_gid_off;
-            MIOPEN_TYPE operand = b_off[bindex] * alpha1;
-            while(lid < work_per_wg)
-            {
-                int o_n    = (bitmap & (1 << 0)) ? o_n_gid_off : lid % c_n;
-                c_off[o_n] = MIOPEN_TENSOR_OP(a_off[o_n] * alpha0, operand);
-                lid += get_local_size(0);
-            }
-        }
-    }
-    else
-    {
-        for(; gid < num_wg; gid += MAX_NUM_WG)
-        {
-            int lid             = get_local_id(0);
-            int o_n_gid_off     = gid % b_n;
-            int bindex          = o_n_gid_off;
-            MIOPEN_TYPE operand = b_off[bindex] * alpha1;
-            while(lid < work_per_wg)
-            {
-                int o_n    = (bitmap & (1 << 0)) ? o_n_gid_off : lid % c_n;
-                c_off[o_n] = MIOPEN_TENSOR_OP(a_off[o_n] * alpha0, operand) + beta * c_off[o_n];
-                lid += get_local_size(0);
-            }
-        }
-    }
-}
-
-#endif
-
 #ifdef USE_4D_TENSOR_LITE
 // N - batch size
 // C - # of maps

--- a/src/kernels/MIOpenTensorKernelsHip.cpp
+++ b/src/kernels/MIOpenTensorKernelsHip.cpp
@@ -1,0 +1,94 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2023 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+template <typename T>
+__device__ T miopenAdd(T a, T b)
+{
+    return a + b;
+}
+
+template <typename T>
+__device__ T miopenMul(T a, T b)
+{
+    return a * b;
+}
+
+template <typename T>
+__device__ T miopenMax(T a, T b)
+{
+    return ((a > b) ? a : b);
+}
+
+template <typename T>
+__device__ T miopenMin(T a, T b)
+{
+    return ((a < b) ? a : b);
+}
+
+#ifdef USE_1D_TENSOR_GENERIC
+// N
+extern "C" __global__ void Op1dTensorGeneric(const MIOPEN_TYPE* __restrict__ a,
+                                             const MIOPEN_TYPE* __restrict__ b,
+                                             MIOPEN_TYPE* __restrict__ c,
+                                             const uint64_t Aoffset,
+                                             const uint64_t Boffset,
+                                             const uint64_t Coffset,
+                                             const uint32_t a_nstride,
+                                             const uint32_t b_nstride,
+                                             const uint32_t c_nstride,
+                                             const MIOPEN_TYPE alpha0,
+                                             const MIOPEN_TYPE alpha1,
+                                             const MIOPEN_TYPE beta,
+                                             const uint32_t total_work,
+                                             const bool use_beta)
+{
+    const MIOPEN_TYPE* __restrict__ a_off = a + Aoffset;
+    const MIOPEN_TYPE* __restrict__ b_off = b + Boffset;
+    MIOPEN_TYPE* __restrict__ c_off       = c + Coffset;
+
+    const auto gid = blockIdx.x * blockDim.x + threadIdx.x;
+    auto a_ptr     = a_off + gid * a_nstride;
+    auto b_ptr     = b_off + gid * b_nstride;
+    auto c_ptr     = c_off + gid * c_nstride;
+
+    const auto step   = gridDim.x * blockDim.x;
+    const auto a_step = step * a_nstride;
+    const auto b_step = step * b_nstride;
+    const auto c_step = step * c_nstride;
+
+    const auto c_end = c_off + total_work * c_nstride;
+    while(c_ptr < c_end)
+    {
+        const auto res = MIOPEN_TENSOR_OP(a_ptr[0] * alpha0, b_ptr[0] * alpha1);
+        c_ptr[0]       = use_beta ? c_ptr[0] * beta + res : res;
+
+        a_ptr += a_step;
+        b_ptr += b_step;
+        c_ptr += c_step;
+    }
+}
+
+#endif

--- a/src/ocl/tensorocl.cpp
+++ b/src/ocl/tensorocl.cpp
@@ -964,6 +964,12 @@ void OpTensorOther(const Handle& handle,
     auto bsize    = blens.size();
     auto cstrides = cTensorDesc.GetStrides();
 
+    const bool case_1d = bsize == 1;
+    const bool case_2d = bsize == 2;
+    const bool case_5d = bsize == 5;
+
+    const bool use_hip = case_1d;
+
     // first_not_one is incorrect if btensor size equal to 1
     auto first_not_one = std::find_if(blens.rbegin(), blens.rend(), [](int i) { return i != 1; });
     auto d             = std::distance(blens.begin(), first_not_one.base());
@@ -994,13 +1000,15 @@ void OpTensorOther(const Handle& handle,
 
     size_t local_threads = 256;
 
-    std::string program_name = "MIOpenTensorKernels.cl";
+    std::string program_name = use_hip ? "MIOpenTensorKernelsHip.cpp" : "MIOpenTensorKernels.cl";
 
     const std::vector<size_t> vld{local_threads, 1, 1};
 
     // Special case for adding tensors in place
     size_t global_threads;
-    global_threads = num_wg * local_threads;
+    global_threads =
+        (case_1d ? std::clamp(clens[0] / local_threads, size_t(1), size_t(max_num_wg)) : num_wg) *
+        local_threads;
 
     const std::vector<size_t> vgd{global_threads, 1, 1};
 
@@ -1014,7 +1022,7 @@ void OpTensorOther(const Handle& handle,
         auto miopen_alpha1 = as_float(*(static_cast<const float*>(alpha1)));
         auto miopen_beta   = as_float(*(static_cast<const float*>(beta)));
 
-        if(bsize == 5)
+        if(case_5d)
         {
             auto&& kernels = handle.GetKernels("Op5dTensorGeneric", network_config);
 
@@ -1056,7 +1064,7 @@ void OpTensorOther(const Handle& handle,
                 return;
             }
         }
-        else if(bsize == 2)
+        else if(case_2d)
         {
             auto&& kernels = handle.GetKernels("Op2dTensorGeneric", network_config);
 
@@ -1083,7 +1091,7 @@ void OpTensorOther(const Handle& handle,
                 return;
             }
         }
-        else if(bsize == 1)
+        else if(case_1d)
         {
             auto&& kernels = handle.GetKernels("Op1dTensorGeneric", network_config);
 
@@ -1093,18 +1101,18 @@ void OpTensorOther(const Handle& handle,
                 auto kernel = kernels.front();
                 kernel(ATensor,
                        BTensor,
-                       int(blens[0]),
                        CTensor,
-                       int(clens[0]),
+                       uint64_t(Aoffset),
+                       uint64_t(Boffset),
+                       uint64_t(Coffset),
+                       uint32_t(astrides[0]),
+                       uint32_t(blens[0] == 1 ? 0 : bstrides[0]),
+                       uint32_t(cstrides[0]),
                        miopen_alpha0,
                        miopen_alpha1,
                        miopen_beta,
-                       bitmap,
-                       work_per_wg,
-                       long(Aoffset),
-                       long(Boffset),
-                       long(Coffset),
-                       int(num_wg_orig));
+                       uint32_t(clens[0]),
+                       !float_equal(miopen_beta, 0.0));
                 return;
             }
         }
@@ -1123,7 +1131,7 @@ void OpTensorOther(const Handle& handle,
         case 3: parms += "miopenMax"; break;
         }
 
-        if(bsize == 5)
+        if(case_5d)
         {
             parms += " -DUSE_5D_TENSOR_GENERIC";
 
@@ -1166,7 +1174,7 @@ void OpTensorOther(const Handle& handle,
                                     long(Coffset),
                                     int(num_wg_orig));
         }
-        else if(bsize == 2)
+        else if(case_2d)
         {
             parms += " -DUSE_2D_TENSOR_GENERIC";
 
@@ -1194,7 +1202,7 @@ void OpTensorOther(const Handle& handle,
                                     long(Coffset),
                                     int(num_wg_orig));
         }
-        else if(bsize == 1)
+        else if(case_1d)
         {
             parms += " -DUSE_1D_TENSOR_GENERIC";
 
@@ -1206,18 +1214,18 @@ void OpTensorOther(const Handle& handle,
                              vgd,
                              parms)(ATensor,
                                     BTensor,
-                                    int(blens[0]),
                                     CTensor,
-                                    int(clens[0]),
+                                    uint64_t(Aoffset),
+                                    uint64_t(Boffset),
+                                    uint64_t(Coffset),
+                                    uint32_t(astrides[0]),
+                                    uint32_t(blens[0] == 1 ? 0 : bstrides[0]),
+                                    uint32_t(cstrides[0]),
                                     miopen_alpha0,
                                     miopen_alpha1,
                                     miopen_beta,
-                                    bitmap,
-                                    work_per_wg,
-                                    long(Aoffset),
-                                    long(Boffset),
-                                    long(Coffset),
-                                    int(num_wg_orig));
+                                    uint32_t(clens[0]),
+                                    !float_equal(miopen_beta, 0.0));
         }
     });
 }


### PR DESCRIPTION
1D case for #2221
Simplified kernel code, significantly improved performance, added strides support, rewritten to HIP.

Perf tests dataset
- tensor A size is evenly distributed 2620 values from 2 to 83927466 with explicit power of 2 +-1 values.
- tensor B size is either 1 or equal to tensor A size
- beta multiplier is 0 or 1

Summary for gfx1030:
beta = 0
|metric\B|1|n|
|-|-|-|
|min|1.13|0.93|
|median|88.53|49.31|
|max|147.51|99.78|
|mean|97.18|55.27|

beta = 1
|metric\B|1|n|
|-|-|-|
|min|0.96|0.86|
|median|60.18|37.58|
|max|108.54|79.99|
|mean|67.96|43.08|

All the gains less than 1 are for tiny tensors less than 128 elements with less than 2 us execution time and can be just random fluctuations. Also "average metrics" are a bit useless because of a complex nature of a process - there are a few regions of interests and probably graphs may show better picture there.
Linear scale for whole picture. Maximum perf gain can be achieved around 16M of elements - around 128-192Mb of accessed data, which almost perfectly fits to L3 of gfx1030. Then it stabilizes on some value depended on the case.

![gfx1030](https://github.com/ROCmSoftwarePlatform/MIOpen/assets/489073/87978607-0a9e-44d6-a5a4-3b6e61c0ded4)

Log scale is for small values. Power of 2 values show better gains due to no granularity loss. Tensors less than 1024 element show almost identical performance (gain around 1).

![gfx1030_logscale](https://github.com/ROCmSoftwarePlatform/MIOpen/assets/489073/9aaaefda-c516-46b0-abed-1a521190d5db)

Raw data:
[OpTensor1d_gfx1030.xlsx](https://github.com/ROCmSoftwarePlatform/MIOpen/files/12074336/OpTensor1d_gfx1030.xlsx)

MI200 measurement is on the way, but I don't expect any performance drops compare to old version.

NB. There are no default perf tests for any tensor operations - as far as I can see only convolutions are tested.