### PR TITLE
[OCL] patch softmax issue

### DIFF
--- a/src/kernels/MIOpenSoftmax.cl
+++ b/src/kernels/MIOpenSoftmax.cl
@@ -271,6 +271,7 @@ __kernel void SoftmaxForward(global _FLOAT* x,
         }
 
         _FLOAT channel_max = l_helper[0];
+        barrier(CLK_LOCAL_MEM_FENCE);
 #else
         _FLOAT
 #endif
@@ -508,6 +509,7 @@ __kernel void SoftmaxForward(global _FLOAT* x,
     }
 
     _FLOAT channel_max = l_helper[batch * BATCH_SIZE];
+    barrier(CLK_LOCAL_MEM_FENCE);
 #else
     _FLOAT
 #endif


### PR DESCRIPTION
PyTorch and TensorFlow don't use MIOpen's softmax API, but MIOpen's CTCLoss API uses MIOpen’s softmax API and TensorFlow uses MIOpen's CTCLoss API. So this could impact users at abstractive layer.

**How to Reproduce**:
On gfx1030 it can be reproduced *forcefully*:
```
diff --git a/src/kernels/MIOpenSoftmax.cl b/src/kernels/MIOpenSoftmax.cl
index 4d5147189..7804b894f 100644
--- a/src/kernels/MIOpenSoftmax.cl
+++ b/src/kernels/MIOpenSoftmax.cl
@@ -115,6 +115,14 @@
 #error "Wrong values of USE_SOFTMAX_MODE_... macros -- exactly one should be 1, others shall be 0"
 #endif
 
+// apply delay by repeating memory access many times
+void apply_delay(global _FLOAT *buf)
+{
+    for(int i = 0; i < 1000*1000*10; i++) {
+        *(global _FLOAT volatile *)buf;
+    }
+}
+
 typedef union GPtr
 {
     _FLOAT* f;
@@ -270,6 +278,11 @@ __kernel void SoftmaxForward(global _FLOAT* x,
             barrier(CLK_LOCAL_MEM_FENCE);
         }
 
+        // apply delay all the thread except thread lid==0
+        if(lid != 0) {
+            apply_delay(x);
+        }
+
         _FLOAT channel_max = l_helper[0];
 #else
         _FLOAT

```

Apply the patch above and rebuild MIOpen and run test_soft_max  which is included in the MIOpen’s test suite 


**Observation**:
```
# clear the cache
$  rm -rf ~/.cache/miopen
# run softmax test
$ cd MIOpen/build
$ ./bin/test_soft_max  --float --input-dim 1 256 13 13 --algorithm 1 --mode 1 --scales 1 0 --tolerance 8000 
FAILED: 0.0638413
Iteration: 0
Forward Sofmax:
Input tensor: 1, 256, 13, 13
Max diff: 0.0469943
Mismatch at 0: 9.52534e-08 != 1.76887e-14
```