### PR TITLE
Patch half.hpp file location reorg

### DIFF
--- a/driver/driver.hpp
+++ b/driver/driver.hpp
@@ -26,7 +26,11 @@
 #ifndef GUARD_MIOPEN_DRIVER_HPP
 #define GUARD_MIOPEN_DRIVER_HPP
 
-#include "half.hpp"
+#if HIP_PACKAGE_VERSION_FLAT >= 5006000000ULL
+#include <half/half.hpp>
+#else
+#include <half.hpp>
+#endif
 
 #include "random.hpp"
 

--- a/driver/reduce_driver.hpp
+++ b/driver/reduce_driver.hpp
@@ -43,7 +43,11 @@
 #include <string>
 #include <cassert>
 #include <type_traits>
+#if HIP_PACKAGE_VERSION_FLAT >= 5006000000ULL
+#include <half/half.hpp>
+#else
 #include <half.hpp>
+#endif
 #include "random.hpp"
 
 #include "miopen_Reduction.hpp"

--- a/src/composable_kernel/host/driver_offline/src/conv_bwd_driver_offline.cpp
+++ b/src/composable_kernel/host/driver_offline/src/conv_bwd_driver_offline.cpp
@@ -3,7 +3,11 @@
 #include <initializer_list>
 #include <cstdlib>
 #include <stdlib.h>
+#if HIP_PACKAGE_VERSION_FLAT >= 5006000000ULL
+#include <half/half.hpp>
+#else
 #include <half.hpp>
+#endif
 #include "config.hpp"
 #include "print.hpp"
 #include "device.hpp"

--- a/src/composable_kernel/host/driver_offline/src/conv_fwd_driver_offline.cpp
+++ b/src/composable_kernel/host/driver_offline/src/conv_fwd_driver_offline.cpp
@@ -3,7 +3,11 @@
 #include <initializer_list>
 #include <cstdlib>
 #include <stdlib.h>
+#if HIP_PACKAGE_VERSION_FLAT >= 5006000000ULL
+#include <half/half.hpp>
+#else
 #include <half.hpp>
+#endif
 #include "config.hpp"
 #include "print.hpp"
 #include "device.hpp"

--- a/src/fusion.cpp
+++ b/src/fusion.cpp
@@ -39,7 +39,11 @@
 #include <ios>
 #include <algorithm>
 #include <string>
+#if HIP_PACKAGE_VERSION_FLAT >= 5006000000ULL
+#include <half/half.hpp>
+#else
 #include <half.hpp>
+#endif
 
 #define MIOPEN_CHECK(x)          \
     if(x != miopenStatusSuccess) \

--- a/src/gemm_v2.cpp
+++ b/src/gemm_v2.cpp
@@ -39,7 +39,11 @@
 #endif
 
 #if MIOPEN_USE_ROCBLAS
+#if HIP_PACKAGE_VERSION_FLAT >= 5006000000ULL
+#include <half/half.hpp>
+#else
 #include <half.hpp>
+#endif
 #if MIOPEN_ROCBLAS_VERSION_FLAT < 2045000
 #include <rocblas.h>
 #else

--- a/src/include/miopen/op_kernel_args.hpp
+++ b/src/include/miopen/op_kernel_args.hpp
@@ -3,7 +3,11 @@
 
 #include <type_traits>
 #include <cstdint>
+#if HIP_PACKAGE_VERSION_FLAT >= 5006000000ULL
+#include <half/half.hpp>
+#else
 #include <half.hpp>
+#endif
 #include <boost/container/small_vector.hpp>
 
 struct OpKernelArg

--- a/src/include/miopen/reduce_common.hpp
+++ b/src/include/miopen/reduce_common.hpp
@@ -26,7 +26,11 @@
 #ifndef GUARD_MIOPEN_REDUCE_COMMON_HPP
 #define GUARD_MIOPEN_REDUCE_COMMON_HPP
 
+#if HIP_PACKAGE_VERSION_FLAT >= 5006000000ULL
+#include <half/half.hpp>
+#else
 #include <half.hpp>
+#endif
 #include <miopen/bfloat16.hpp>
 
 namespace reduce {

--- a/src/include/miopen/visit_float.hpp
+++ b/src/include/miopen/visit_float.hpp
@@ -28,7 +28,11 @@
 #define GUARD_MLOPEN_VISIT_FLOAT_HPP
 
 #include <miopen/miopen.h>
+#if HIP_PACKAGE_VERSION_FLAT >= 5006000000ULL
+#include <half/half.hpp>
+#else
 #include <half.hpp>
+#endif
 #include <miopen/bfloat16.hpp>
 
 namespace miopen {

--- a/src/solver/conv_asm_1x1u_bias_activ_fused.cpp
+++ b/src/solver/conv_asm_1x1u_bias_activ_fused.cpp
@@ -38,7 +38,11 @@
 #include <miopen/fusion/solvers.hpp>
 #include <miopen/fusion/fusion_invoke_params.hpp>
 
-#include "half.hpp"
+#if HIP_PACKAGE_VERSION_FLAT >= 5006000000ULL
+#include <half/half.hpp>
+#else
+#include <half.hpp>
+#endif
 
 using half_float::half;
 

--- a/src/solver/conv_ocl_dir2Dfwd_exhaustive_search.cpp
+++ b/src/solver/conv_ocl_dir2Dfwd_exhaustive_search.cpp
@@ -33,7 +33,11 @@
 #include <miopen/legacy_exhaustive_search.hpp>
 #include <miopen/bfloat16.hpp>
 #include <miopen/fusion/fusion_invoke_params.hpp>
+#if HIP_PACKAGE_VERSION_FLAT >= 5006000000ULL
+#include <half/half.hpp>
+#else
 #include <half.hpp>
+#endif
 
 #ifdef max
 #undef max

--- a/test/cpu_reduce_util.hpp
+++ b/test/cpu_reduce_util.hpp
@@ -26,7 +26,11 @@
 #ifndef GUARD_CPU_REDUCE_UTIL_HPP
 #define GUARD_CPU_REDUCE_UTIL_HPP
 
+#if HIP_PACKAGE_VERSION_FLAT >= 5006000000ULL
+#include <half/half.hpp>
+#else
 #include <half.hpp>
+#endif
 #include <limits>
 #include <cmath>
 #include <cassert>

--- a/test/driver.hpp
+++ b/test/driver.hpp
@@ -37,7 +37,11 @@
 
 #include <functional>
 #include <deque>
+#if HIP_PACKAGE_VERSION_FLAT >= 5006000000ULL
+#include <half/half.hpp>
+#else
 #include <half.hpp>
+#endif
 #include <type_traits>
 #include <boost/filesystem.hpp>
 #include <miopen/functional.hpp>

--- a/test/gpu_reference_kernel.cpp
+++ b/test/gpu_reference_kernel.cpp
@@ -36,7 +36,11 @@
 #include <ctime>
 #include <tuple> // std::ignore
 #include <type_traits>
+#if HIP_PACKAGE_VERSION_FLAT >= 5006000000ULL
+#include <half/half.hpp>
+#else
 #include <half.hpp>
+#endif
 #include "test.hpp"
 #include "driver.hpp"
 #include "tensor_holder.hpp"

--- a/test/serialize.hpp
+++ b/test/serialize.hpp
@@ -29,7 +29,11 @@
 
 #include <miopen/rank.hpp>
 #include <miopen/each_args.hpp>
+#if HIP_PACKAGE_VERSION_FLAT >= 5006000000ULL
+#include <half/half.hpp>
+#else
 #include <half.hpp>
+#endif
 #include <fstream>
 #include <string>
 #include <tuple>

--- a/test/tensor_holder.hpp
+++ b/test/tensor_holder.hpp
@@ -36,7 +36,11 @@
 
 #include "serialize.hpp"
 
+#if HIP_PACKAGE_VERSION_FLAT >= 5006000000ULL
+#include <half/half.hpp>
+#else
 #include <half.hpp>
+#endif
 #include <iomanip>
 #include <fstream>
 


### PR DESCRIPTION
Patch warning messages like:
```
/opt/rocm/include/half.hpp:22:2: warning: "This file is deprecated. Use the header file from /opt/rocm-5.6.0/include/half/half.hpp by using #include <half/half.hpp>" [-W#warnings]
#warning "This file is deprecated. Use the header file from /opt/rocm-5.6.0/include/half/half.hpp by using #include <half/half.hpp>"
 ^
```
