### PR TITLE
Dropout: make seed and states_num kernel arguments

### DIFF
--- a/src/kernels/MIOpenDropout.cl
+++ b/src/kernels/MIOpenDropout.cl
@@ -273,13 +273,14 @@ void xorwow_lite_init(prngStates* cur_state,
     cur_state->d += (uint)(offset)*362437;
 }
 
-__kernel void InitKernelState(__global prngStates* state)
+__kernel void InitKernelState(__global prngStates* state, uint prng_seed,
+                              uint states_num)
 {
-    for(uint gid = get_global_id(0); gid < STATES_NUM; gid += get_global_size(0))
+    for(uint gid = get_global_id(0); gid < states_num; gid += get_global_size(0))
     {
         prngStates state_gid;
         xorwow_lite_init(&state_gid,
-                         (unsigned long long)PRNG_SEED,
+                         (unsigned long long)prng_seed,
                          (unsigned long long)gid,
                          (unsigned long long)0);
 

--- a/src/kernels/MIOpenDropout.cl
+++ b/src/kernels/MIOpenDropout.cl
@@ -273,8 +273,7 @@ void xorwow_lite_init(prngStates* cur_state,
     cur_state->d += (uint)(offset)*362437;
 }
 
-__kernel void InitKernelState(__global prngStates* state, uint prng_seed,
-                              uint states_num)
+__kernel void InitKernelState(__global prngStates* state, uint prng_seed, uint states_num)
 {
     for(uint gid = get_global_id(0); gid < states_num; gid += get_global_size(0))
     {

--- a/src/kernels/MIOpenDropout.cl
+++ b/src/kernels/MIOpenDropout.cl
@@ -273,7 +273,7 @@ void xorwow_lite_init(prngStates* cur_state,
     cur_state->d += (uint)(offset)*362437;
 }
 
-__kernel void InitKernelState(__global prngStates* state, uint prng_seed, uint states_num)
+__kernel void InitKernelState(__global prngStates* state, ulong prng_seed, ulong states_num)
 {
     for(uint gid = get_global_id(0); gid < states_num; gid += get_global_size(0))
     {

--- a/src/ocl/dropoutocl.cpp
+++ b/src/ocl/dropoutocl.cpp
@@ -132,8 +132,8 @@ void DropoutDescriptor::InitPRNGState(Handle& handle,
         MIOPEN_THROW("PRNG state size should not exceed system maximum memory allocation size.");
     }
 
-    size_t states_num = prng_stateSizeInBytes / sizeof(prngStates);
-    size_t wk_grp_num = std::min(size_t(MAX_PRNG_STATE / 256), (states_num + 255) / 256);
+    unsigned long long states_num = prng_stateSizeInBytes / sizeof(prngStates);
+    size_t wk_grp_num             = std::min(MAX_PRNG_STATE / 256ULL, (states_num + 255) / 256);
 
     std::string network_config = "initprngs-" + std::to_string(sizeof(prngStates)) + "x" +
                                  std::to_string(rng_mode) + "x" + std::to_string(wk_grp_num);
@@ -141,9 +141,7 @@ void DropoutDescriptor::InitPRNGState(Handle& handle,
     auto&& kernels = handle.GetKernels(kernel_name, network_config);
     if(!kernels.empty())
     {
-        kernels.front()(prng_states,
-                        static_cast<unsigned int>(prng_seed),
-                        static_cast<unsigned int>(states_num));
+        kernels.front()(prng_states, prng_seed, states_num);
     }
     else
     {
@@ -157,9 +155,7 @@ void DropoutDescriptor::InitPRNGState(Handle& handle,
         std::cout << "Memory allocated for PRNG states: " << stateSizeInBytes << std::endl;
 #endif
         handle.AddKernel(kernel_name, network_config, program_name, kernel_name, vld, vgd, params)(
-            prng_states,
-            static_cast<unsigned int>(prng_seed),
-            static_cast<unsigned int>(states_num));
+            prng_states, prng_seed, states_num);
 #if DROPOUT_DEBUG
         std::cout << "Succeeded in launching InitPRNGState()." << stateSizeInBytes << std::endl;
 #endif

--- a/src/ocl/dropoutocl.cpp
+++ b/src/ocl/dropoutocl.cpp
@@ -135,15 +135,14 @@ void DropoutDescriptor::InitPRNGState(Handle& handle,
     size_t states_num = prng_stateSizeInBytes / sizeof(prngStates);
     size_t wk_grp_num = std::min(size_t(MAX_PRNG_STATE / 256), (states_num + 255) / 256);
 
-    std::string network_config = "initprngs-" +
-                                 std::to_string(sizeof(prngStates)) + "x" +
-                                 std::to_string(rng_mode) + "x" +
-                                 std::to_string(wk_grp_num);
+    std::string network_config = "initprngs-" + std::to_string(sizeof(prngStates)) + "x" +
+                                 std::to_string(rng_mode) + "x" + std::to_string(wk_grp_num);
 
     auto&& kernels = handle.GetKernels(kernel_name, network_config);
     if(!kernels.empty())
     {
-        kernels.front()(prng_states, static_cast<unsigned int>(prng_seed),
+        kernels.front()(prng_states,
+                        static_cast<unsigned int>(prng_seed),
                         static_cast<unsigned int>(states_num));
     }
     else
@@ -158,7 +157,8 @@ void DropoutDescriptor::InitPRNGState(Handle& handle,
         std::cout << "Memory allocated for PRNG states: " << stateSizeInBytes << std::endl;
 #endif
         handle.AddKernel(kernel_name, network_config, program_name, kernel_name, vld, vgd, params)(
-            prng_states, static_cast<unsigned int>(prng_seed),
+            prng_states,
+            static_cast<unsigned int>(prng_seed),
             static_cast<unsigned int>(states_num));
 #if DROPOUT_DEBUG
         std::cout << "Succeeded in launching InitPRNGState()." << stateSizeInBytes << std::endl;


### PR DESCRIPTION
Every time a dropout descriptor is created (even if it's with a different seed), the initialization kernel is recompiled. This PR turns the number of states to initialize and random seed into runtime parameters. There seems to be no effect on the runtime of the initialization kernel (which I'm assuming is not performance critical), but fewer JIT compilation calls.

Note: I tried setting `prng_seed` to be an `unsigned long long` parameter, but that passed a wrong value onto the kernel itself.