### PR TITLE
Properly failing FindSoluions on exceptions

### DIFF
--- a/src/include/miopen/find_solution.hpp
+++ b/src/include/miopen/find_solution.hpp
@@ -126,6 +126,7 @@ auto FindSolutionImpl(rank<1>,
             catch(const miopen::Exception& ex)
             {
                 MIOPEN_LOG_E("Search failed for: " << s.SolverDbId() << ": " << ex.what());
+                return ConvSolution(miopenStatusInternalError);
             }
         }
     }

--- a/src/include/miopen/generic_search.hpp
+++ b/src/include/miopen/generic_search.hpp
@@ -373,7 +373,7 @@ auto GenericSearch(const Solver s,
     auto& profile_h = context.GetStream();
     const AutoEnableProfiling enableProfiling{profile_h};
 
-    auto tmp_all_configs = GetAllConfigs(s, context, problem);
+    auto tmp_all_configs = GetAllConfigs(s, context, problem); 
     // For random access
     std::vector<PerformanceConfig> all_configs;
     std::copy(tmp_all_configs.begin(), tmp_all_configs.end(), std::back_inserter(all_configs));

--- a/src/include/miopen/generic_search.hpp
+++ b/src/include/miopen/generic_search.hpp
@@ -384,6 +384,9 @@ auto GenericSearch(const Solver s,
     const std::size_t n_runs_total = std::min(all_configs.size(), GetTuningIterationsMax());
     all_configs.resize(n_runs_total);
 
+    if(all_configs.empty())
+        all_configs.emplace_back(s.GetDefaultPerformanceConfig(context, problem));
+
     bool is_passed  = false; // left false only if all iterations failed.
     float best_time = std::numeric_limits<float>::max();
     size_t n_failed = 0;

--- a/src/include/miopen/generic_search.hpp
+++ b/src/include/miopen/generic_search.hpp
@@ -373,7 +373,7 @@ auto GenericSearch(const Solver s,
     auto& profile_h = context.GetStream();
     const AutoEnableProfiling enableProfiling{profile_h};
 
-    auto tmp_all_configs = GetAllConfigs(s, context, problem); 
+    auto tmp_all_configs = GetAllConfigs(s, context, problem);
     // For random access
     std::vector<PerformanceConfig> all_configs;
     std::copy(tmp_all_configs.begin(), tmp_all_configs.end(), std::back_inserter(all_configs));

--- a/src/include/miopen/generic_search.hpp
+++ b/src/include/miopen/generic_search.hpp
@@ -381,11 +381,25 @@ auto GenericSearch(const Solver s,
     std::random_device rd{};
     auto rng = std::default_random_engine{rd()};
     std::shuffle(all_configs.begin(), all_configs.end(), rng);
-    const std::size_t n_runs_total = std::min(all_configs.size(), GetTuningIterationsMax());
+    std::size_t n_runs_total = std::min(all_configs.size(), GetTuningIterationsMax());
     all_configs.resize(n_runs_total);
 
     if(all_configs.empty())
-        all_configs.emplace_back(s.GetDefaultPerformanceConfig(context, problem));
+    {
+        const auto default_config = s.GetDefaultPerformanceConfig(context, problem);
+
+        if(default_config.IsValid(context, problem))
+        {
+            all_configs.emplace_back(default_config);
+            n_runs_total += 1;
+        }
+        else
+        {
+            const auto id = s.SolverDbId();
+            MIOPEN_THROW("Generic search has failed. Solver " + id +
+                         " cannot produce any valid configuration.");
+        }
+    }
 
     bool is_passed  = false; // left false only if all iterations failed.
     float best_time = std::numeric_limits<float>::max();


### PR DESCRIPTION
Recreated #2278
Removed the word failed from the branch name so file paths would not fail the tests.

This does two things:

Exhaustive search adds default perf config to the search space when the virtual container is empty. This is done to report the solver as failed when exiting the search. Another solver would be attempted by find rather than going on with an untested perf config.
When an error is catched from search-getsolution pair we return an empty ConvSolution with miopenStatusInternalError rather than GetSolution(..., solver.GetDefaultPerfConfig(...)). This way rest of find knows that this solver is bugged and we cannot use it for this netconfig.
This way when something like this happens again, user would be informed, but the result of operation should still be correct unless it's a GPU segfault in the solver.

To reiterate: completely empty generic search container indicates one of two things:

a recoverable bug in the solver as it shows itself as applicable, but cannot produce a valid perfconfig. This is not fine and we should fix it, but should be manageable unless segaults.
an incorrect usage of API. We check what we can check, but if the API is internal (including calls from inside library) it is hard to have both performance and lack of unchecked parameters.