### PR TITLE
fix a bug in legacy fwd/bwd hip igemm solver. They didn't support group conv at all

### DIFF
--- a/src/solver/conv_hip_implicit_gemm_bwd_data_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_bwd_data_xdlops.cpp
@@ -374,6 +374,8 @@ bool ConvHipImplicitGemmBwdXdlops::IsApplicable(const ConvolutionContext& ctx,
         return false;
     if(!IsIndexRangeLargeEnough(problem))
         return false;
+    if(problem.GetGroupCount() > 1)
+        return false;
     switch(problem.conv_problem.GetInDataType())
     {
     case miopenHalf: return CheckCKApplicability<ck::half_t>(problem);

--- a/src/solver/conv_hip_implicit_gemm_fwd_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_fwd_xdlops.cpp
@@ -350,6 +350,8 @@ bool ConvHipImplicitGemmFwdXdlops::IsApplicable(const ConvolutionContext& ctx,
         return false;
     if(!problem.IsLayoutNHWC())
         return false;
+    if(problem.GetGroupCount() > 1)
+        return false;
     switch(problem.conv_problem.GetInDataType())
     {
     case miopenInt8: return CheckCKApplicability<int8_t>(problem);


### PR DESCRIPTION
This fix SWDEV-414016

the solver `ConvHipImplicitGemmGroupFwdXdlops` and `ConvHipImplicitGemmBwdXdlops` does not support group conv at the first place, but not filtered out in `isApplicable()`.
This PR fix this problem