### PR TITLE
fix ASM iGEMM applicability with datalayout

### DIFF
--- a/src/solver/conv_asm_implicit_gemm_gtc_bwd_nhwc.cpp
+++ b/src/solver/conv_asm_implicit_gemm_gtc_bwd_nhwc.cpp
@@ -945,6 +945,9 @@ bool ConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWC::IsApplicable(
     if(!ctx.rmv.IsV3())
         return false;
 
+    if(!problem.IsLayoutNHWC())
+        return false;
+
     const auto target = ctx.GetStream().GetTargetProperties();
     if(target.Xnack() && *target.Xnack())
         return false; // NOLINT (readability-simplify-boolean-expr)

--- a/src/solver/conv_asm_implicit_gemm_gtc_fwd_nhwc.cpp
+++ b/src/solver/conv_asm_implicit_gemm_gtc_fwd_nhwc.cpp
@@ -883,6 +883,9 @@ bool ConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWC::IsApplicable(
     if(!ctx.rmv.IsV3())
         return false;
 
+    if(!problem.IsLayoutNHWC())
+        return false;
+
     const auto target = ctx.GetStream().GetTargetProperties();
     if(target.Xnack() && *target.Xnack())
         return false; // NOLINT (readability-simplify-boolean-expr)

--- a/src/solver/conv_asm_implicit_gemm_gtc_wrw_nhwc.cpp
+++ b/src/solver/conv_asm_implicit_gemm_gtc_wrw_nhwc.cpp
@@ -876,6 +876,9 @@ bool ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC::IsApplicable(
     if(!ctx.rmv.IsV3())
         return false;
 
+    if(!problem.IsLayoutNHWC())
+        return false;
+
     const auto target = ctx.GetStream().GetTargetProperties();
     if(target.Xnack() && *target.Xnack())
         return false; // NOLINT (readability-simplify-boolean-expr)


### PR DESCRIPTION
https://ontrack-internal.amd.com/browse/SWDEV-404404
https://ontrack-internal.amd.com/browse/SWDEV-404537

Somhow in Find 2.0 ConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWC is picked when exaustive search is enforced, even though the datalayout is not NHWC
