### PR TITLE
Dont add librt to the MIOpen's interface

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -836,7 +836,7 @@ if(NOT WIN32 AND NOT APPLE)
     find_library(LIBRT rt)
     if(LIBRT)
         MESSAGE(STATUS "Librt: " ${LIBRT})
-        target_link_libraries(MIOpen PUBLIC ${LIBRT})
+        target_internal_library(MIOpen ${LIBRT})
     endif()
 endif()
 


### PR DESCRIPTION
librt is not used in miopen's public header so it should only be linked privately and for the tests. 

This causes an issue when using miopen on ubuntu 22.04, because it is named librt.so.1 instead of librt.so. We really shouldn't ever use absolute paths in the target interface since libraries can be located in other locations.