### PR TITLE
fix missing DetectRocm() in FindSolutionsImpl(), where options = nullptr

### DIFF
--- a/src/problem.cpp
+++ b/src/problem.cpp
@@ -258,7 +258,9 @@ std::vector<Solution> Problem::FindSolutionsImpl(Handle& handle,
     }
     else
     {
-        const auto workspace_max = conv_desc.GetWorkSpaceSize({&handle}, conv_problem);
+        auto tmp_ctx = ExecutionContext{&handle};
+        tmp_ctx.DetectRocm();
+        const auto workspace_max = conv_desc.GetWorkSpaceSize(tmp_ctx, conv_problem);
         workspace_size           = std::min(options.workspace_limit, workspace_max);
         owned_workspace          = workspace_size != 0 ? handle.Create(workspace_size) : nullptr;
         workspace                = owned_workspace.get();


### PR DESCRIPTION
This will fix [SWDEV-404537](https://ontrack-internal.amd.com/browse/SWDEV-404537)

We people use `miopenFindSolutoins()` API with `options = nullptr`, will have GPU crash if `MIOPEN_FIND_ENFORCE=4`

The root cause is there is no workspace allocated while tuning, since when call `GetWorkspace()` every asm solver will return not applicable, but when launching the kernel they will return applicable, and run the kernel with nullptr workspace.
This PR fix this issue.

![image](https://github.com/ROCmSoftwarePlatform/MIOpen/assets/8322173/aade19ff-5db4-4435-9d04-1cf527ae1add)
