### PR TITLE
[tuning] Do not insert default perf-config into empty tuning container

### DIFF
--- a/src/include/miopen/generic_search.hpp
+++ b/src/include/miopen/generic_search.hpp
@@ -381,24 +381,17 @@ auto GenericSearch(const Solver s,
     std::random_device rd{};
     auto rng = std::default_random_engine{rd()};
     std::shuffle(all_configs.begin(), all_configs.end(), rng);
-    std::size_t n_runs_total = std::min(all_configs.size(), GetTuningIterationsMax());
+    const std::size_t n_runs_total = std::min(all_configs.size(), GetTuningIterationsMax());
     all_configs.resize(n_runs_total);
 
+    // If a Solver produces none performanceConfigs for tuning (container is empty),
+    // then something is definitely wrong and needs to be fixed (e.g. applicability
+    // of the solver needs to be corrected or so).
     if(all_configs.empty())
     {
-        const auto default_config = s.GetDefaultPerformanceConfig(context, problem);
-
-        if(default_config.IsValid(context, problem))
-        {
-            all_configs.emplace_back(default_config);
-            n_runs_total += 1;
-        }
-        else
-        {
-            const auto id = s.SolverDbId();
-            MIOPEN_THROW("Generic search has failed. Solver " + id +
-                         " cannot produce any valid configuration.");
-        }
+        const auto id = s.SolverDbId();
+        MIOPEN_THROW("Generic search has failed. Solver " + id +
+                     " cannot produce any valid configuration.");
     }
 
     bool is_passed  = false; // left false only if all iterations failed.


### PR DESCRIPTION
An addition to #2279, a partial fix for #2270. Resolves https://github.com/ROCmSoftwarePlatform/MIOpen/pull/2279#discussion_r1283080654. 

----
[Attribution] @junliume @JehandadKhan
- https://github.com/ROCmSoftwarePlatform/MIOpen/labels/quality
- https://github.com/ROCmSoftwarePlatform/MIOpen/labels/urgency_normal
- https://github.com/ROCmSoftwarePlatform/MIOpen/labels/value_high - It is important to not camouflage problem in the tunable Solvers.
- Proposed reviewers:
  - @JehandadKhan
  - @junliume
  - @shurale-nkn 
  - @DrizztDoUrden
