### PR TITLE
fix test after removal of mlir from gfx908 kdb

### DIFF
--- a/test/gtest/cba_infer.cpp
+++ b/test/gtest/cba_infer.cpp
@@ -151,7 +151,8 @@ TEST_P(ConvBiasActivInferTestHalf, ConvCKIgemmFwdBiasActivFused)
 #if MIOPEN_BACKEND_HIP
 TEST_P(ConvBiasActivInferTestFloatFusionCompileStep, ConvBiasActivAsm1x1UFloat_testCompile)
 {
-    setEnvironmentVariable("MIOPEN_FIND_ENFORCE", "3");
+    setEnvironmentVariable("MIOPEN_FIND_ENFORCE", "SEARCH_DB_UPDATE");
+    setEnvironmentVariable("MIOPEN_DEBUG_TUNING_ITERATIONS_MAX", "5");
     fusePlanDesc.Compile(get_handle());
     const auto plan_params = std::make_unique<miopen::fusion::FusionInvokeParams>(
         params, input.desc, in_dev.get(), output.desc, out_dev.get(), false);


### PR DESCRIPTION
* Currently we have set `MIOPEN_FIND_ENFORCE=3` in our test. Setting value `3` means that tuning is not performed if the perf-db already contains the performance parameters. For reliability of the test, use MIOPEN_FIND_ENFORCE=SEARCH_DB_UPDATE.

* The full tuning cycle may take thousands of iterations. We use `MIOPEN_DEBUG_TUNING_ITERATIONS_MAX=5` to limit tuning time in tests.
* This PR is also to fix the current failing develop branch. 

Reference : https://github.com/ROCmSoftwarePlatform/MIOpen/pull/2154#discussion_r1252350092