### PR TITLE
Post-merge fixups: Replace environment variable check with problem config check and reduce lambda capture for Invoker obj

### DIFF
--- a/src/include/miopen/solver.hpp
+++ b/src/include/miopen/solver.hpp
@@ -4561,7 +4561,7 @@ struct PerformanceConfigHipImplicitGemmFwdXdlops
     PerformanceConfigHipImplicitGemmFwdXdlops() : PerformanceConfigHipImplicitGemmFwdXdlops(0, "")
     {
     }
-    PerformanceConfigHipImplicitGemmFwdXdlops(bool)
+    explicit PerformanceConfigHipImplicitGemmFwdXdlops(bool)
         : PerformanceConfigHipImplicitGemmFwdXdlops(0, "")
     {
     }

--- a/src/solver/conv_hip_implicit_gemm_fwd_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_fwd_xdlops.cpp
@@ -238,7 +238,7 @@ MakeInvokerFactoryHipImplGemmFwdXdlops(const ProblemDescription& problem,
     InvokerFactory ret =
         [ck_args = std::move(ck_args), data_type, config_idx](const std::vector<Kernel>& kernels) {
             std::ignore = kernels;
-            return [ck_args = std::move(ck_args), data_type, config_idx](
+            return [ck_args, data_type, config_idx](
                        const Handle& handle, const AnyInvokeParams& primitive_parameters) {
                 switch(data_type)
                 {

--- a/src/solver/conv_hip_implicit_gemm_fwd_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_fwd_xdlops.cpp
@@ -238,8 +238,8 @@ MakeInvokerFactoryHipImplGemmFwdXdlops(const ProblemDescription& problem,
     InvokerFactory ret =
         [ck_args = std::move(ck_args), data_type, config_idx](const std::vector<Kernel>& kernels) {
             std::ignore = kernels;
-            return [ck_args, data_type, config_idx](
-                       const Handle& handle, const AnyInvokeParams& primitive_parameters) {
+            return [ck_args, data_type, config_idx](const Handle& handle,
+                                                    const AnyInvokeParams& primitive_parameters) {
                 switch(data_type)
                 {
                 case miopenInt8:

--- a/src/solver/conv_hip_implicit_gemm_fwd_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_fwd_xdlops.cpp
@@ -236,15 +236,14 @@ void RunCKSolution(const Handle& handle,
 template <typename DataType>
 InvokerFactory MakeInvokerFactoryHelper(CKArgs ck_args, size_t config_idx)
 {
-    return std::move([ck_args = std::move(ck_args),
-                      config_idx](const std::vector<Kernel>& kernels) mutable {
+    return [ck_args = std::move(ck_args), config_idx](const std::vector<Kernel>& kernels) mutable {
         std::ignore = kernels;
 
-        return std::move([ck_args = std::move(ck_args), config_idx](
-                             const Handle& handle, const AnyInvokeParams& primitive_parameters) {
+        return [ck_args = std::move(ck_args),
+                config_idx](const Handle& handle, const AnyInvokeParams& primitive_parameters) {
             RunCKSolution<DataType>(handle, primitive_parameters, ck_args, config_idx);
-        });
-    });
+        };
+    };
 }
 
 InvokerFactory MakeInvokerFactoryThrowError()

--- a/src/solver/conv_hip_implicit_gemm_fwd_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_fwd_xdlops.cpp
@@ -413,7 +413,7 @@ ConvSolution ConvHipImplicitGemmFwdXdlops::GetSolution(
     return {};
 #else
     ConvSolution result;
-    result.invoker_factory = MakeInvokerFactoryHipImplGemmFwdXdlops(problem, config.index);
+    result.invoker_factory = MakeInvokerFactoryHipImplGemmFwdXdlops(problem, config);
 
     return result;
 #endif

--- a/src/solver/conv_hip_implicit_gemm_fwd_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_fwd_xdlops.cpp
@@ -246,16 +246,6 @@ InvokerFactory MakeInvokerFactoryHelper(CKArgs ck_args, size_t config_idx)
     };
 }
 
-InvokerFactory MakeInvokerFactoryThrowError()
-{
-    return [](const std::vector<Kernel>& kernels) {
-        std::ignore = kernels;
-        MIOPEN_THROW(miopenStatusNotImplemented,
-                     "Convolution operation not implemented for this data type");
-        return [](const Handle&, const AnyInvokeParams&) {};
-    };
-}
-
 InvokerFactory
 MakeInvokerFactoryHipImplGemmFwdXdlops(const ProblemDescription& problem,
                                        const PerformanceConfigHipImplicitGemmFwdXdlops& config)
@@ -272,7 +262,10 @@ MakeInvokerFactoryHipImplGemmFwdXdlops(const ProblemDescription& problem,
     case miopenInt32:
     case miopenInt8x4:
     case miopenBFloat16:
-    case miopenDouble: return MakeInvokerFactoryThrowError();
+    case miopenDouble:
+    default:
+        MIOPEN_THROW(miopenStatusInternalError,
+                     "ConvHipImplicitGemmFwdXdlops operation not implemented for this data type");
     }
 }
 

--- a/src/solver/conv_hip_implicit_gemm_grouped_fwd_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_grouped_fwd_xdlops.cpp
@@ -397,7 +397,7 @@ bool ConvHipImplicitGemmGroupFwdXdlops::IsApplicable(const ConvolutionContext& c
 #else
     if(miopen::IsDisabled(MIOPEN_DEBUG_GROUP_CONV_IMPLICIT_GEMM_HIP_FWD_XDLOPS{}))
         return false;
-    if(miopen::IsEnabled(MIOPEN_DEBUG_CONVOLUTION_DETERMINISTIC{}))
+    if(problem.conv_problem.GetConv().attribute.deterministic)
         return false;
     if(problem.conv_problem.GetInDataType() != problem.conv_problem.GetWeightsDataType() ||
        problem.conv_problem.GetWeightsDataType() != problem.conv_problem.GetOutDataType() ||


### PR DESCRIPTION
addressing comments from #2301 . 
1. Replace env variable based check with a check based on `conv_problem`. 
2. Move InvokerFactory creation into a separate function with careful attention to what is captured by `Invoker` lambda as the latter is cached for reuse and we want it to be fast and minimal in size.