### PR TITLE
HIP kernels may launch with non-uniform block size for backward compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,8 +253,7 @@ math(EXPR MIOPEN_hip_VERSION_FLAT "(${MIOPEN_hip_VERSION_MAJOR} * 1000 + ${MIOPE
 set_var_to_condition(MIOPEN_USE_HIPRTC_DEFAULT ${MIOPEN_USE_COMGR} AND (${MIOPEN_hip_VERSION_FLAT} GREATER 500000000))
 option(MIOPEN_USE_HIPRTC "Use HIPRTC to build HIP kernels instead of COMGR" ${MIOPEN_USE_HIPRTC_DEFAULT})
 
-# No assumption that HIP kernels are launched with uniform block size for backward compatibility
-# SWDEV-413293 and https://reviews.llvm.org/D155213, effective HIP_FLAT_VERSION 500723302
+# WORKAROUND_SWDEV_413293
 if(${MIOPEN_hip_VERSION_FLAT} GREATER_EQUAL 500723302)
     string(APPEND HIP_COMPILER_FLAGS " -fno-offload-uniform-block ")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,6 +253,12 @@ math(EXPR MIOPEN_hip_VERSION_FLAT "(${MIOPEN_hip_VERSION_MAJOR} * 1000 + ${MIOPE
 set_var_to_condition(MIOPEN_USE_HIPRTC_DEFAULT ${MIOPEN_USE_COMGR} AND (${MIOPEN_hip_VERSION_FLAT} GREATER 500000000))
 option(MIOPEN_USE_HIPRTC "Use HIPRTC to build HIP kernels instead of COMGR" ${MIOPEN_USE_HIPRTC_DEFAULT})
 
+# No assumption that HIP kernels are launched with uniform block size for backward compatibility
+# SWDEV-413293 and https://reviews.llvm.org/D155213
+if(${MIOPEN_hip_VERSION_FLAT} GREATER 500700000)
+    string(APPEND HIP_COMPILER_FLAGS " -fno-offload-uniform-block ")
+endif()
+
 message(STATUS "Hip compiler flags: ${HIP_COMPILER_FLAGS}")
 
 add_definitions("-DHIP_COMPILER_FLAGS=${HIP_COMPILER_FLAGS}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -255,7 +255,7 @@ option(MIOPEN_USE_HIPRTC "Use HIPRTC to build HIP kernels instead of COMGR" ${MI
 
 # No assumption that HIP kernels are launched with uniform block size for backward compatibility
 # SWDEV-413293 and https://reviews.llvm.org/D155213, effective HIP_FLAT_VERSION 500723302
-if(${MIOPEN_hip_VERSION_FLAT} GREATER 500723300)
+if(${MIOPEN_hip_VERSION_FLAT} GREATER_EQUAL 500723302)
     string(APPEND HIP_COMPILER_FLAGS " -fno-offload-uniform-block ")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -254,8 +254,8 @@ set_var_to_condition(MIOPEN_USE_HIPRTC_DEFAULT ${MIOPEN_USE_COMGR} AND (${MIOPEN
 option(MIOPEN_USE_HIPRTC "Use HIPRTC to build HIP kernels instead of COMGR" ${MIOPEN_USE_HIPRTC_DEFAULT})
 
 # No assumption that HIP kernels are launched with uniform block size for backward compatibility
-# SWDEV-413293 and https://reviews.llvm.org/D155213
-if(${MIOPEN_hip_VERSION_FLAT} GREATER 500700000)
+# SWDEV-413293 and https://reviews.llvm.org/D155213, effective HIP_FLAT_VERSION 500723302
+if(${MIOPEN_hip_VERSION_FLAT} GREATER 500723300)
     string(APPEND HIP_COMPILER_FLAGS " -fno-offload-uniform-block ")
 endif()
 

--- a/src/comgr.cpp
+++ b/src/comgr.cpp
@@ -1043,6 +1043,9 @@ void BuildAsm(const std::string& name,
 
 #define WORKAROUND_ISSUE_HIPRTC_HIPRTC_HEADER_H 1 // See SWDEV-307838, issue #1648.
 #define WORKAROUND_ISSUE_1674 (HIP_PACKAGE_VERSION_FLAT >= 5003022305ULL)
+/// No assumption that HIP kernels are launched with uniform block size for backward compatibility
+/// SWDEV-413293 and https://reviews.llvm.org/D155213
+#define WORKAROUND_SWDEV -413293(HIP_PACKAGE_VERSION_FLAT >= 5007000000ULL)
 
 namespace hiprtc {
 
@@ -1314,6 +1317,9 @@ void BuildHip(const std::string& name,
         opts.push_back("-Wno-cuda-compat");
         opts.push_back("-fno-gpu-rdc");
         opts.push_back("-O3");
+#if WORKAROUND_SWDEV - 413293
+        opts.push_back("-fno-offload-uniform-block");
+#endif
         if(std::none_of(opts.begin(), opts.end(), [](const std::string& s) {
                return StartsWith(s, "--std=") || StartsWith(s, "-std=");
            }))

--- a/src/comgr.cpp
+++ b/src/comgr.cpp
@@ -1045,7 +1045,7 @@ void BuildAsm(const std::string& name,
 #define WORKAROUND_ISSUE_1674 (HIP_PACKAGE_VERSION_FLAT >= 5003022305ULL)
 /// No assumption that HIP kernels are launched with uniform block size for backward compatibility
 /// SWDEV-413293 and https://reviews.llvm.org/D155213
-#define WORKAROUND_SWDEV -413293(HIP_PACKAGE_VERSION_FLAT >= 5007000000ULL)
+#define WORKAROUND_SWDEV_413293 (HIP_PACKAGE_VERSION_FLAT >= 5007000000ULL)
 
 namespace hiprtc {
 
@@ -1317,7 +1317,7 @@ void BuildHip(const std::string& name,
         opts.push_back("-Wno-cuda-compat");
         opts.push_back("-fno-gpu-rdc");
         opts.push_back("-O3");
-#if WORKAROUND_SWDEV - 413293
+#if WORKAROUND_SWDEV_413293
         opts.push_back("-fno-offload-uniform-block");
 #endif
         if(std::none_of(opts.begin(), opts.end(), [](const std::string& s) {

--- a/src/comgr.cpp
+++ b/src/comgr.cpp
@@ -1044,8 +1044,8 @@ void BuildAsm(const std::string& name,
 #define WORKAROUND_ISSUE_HIPRTC_HIPRTC_HEADER_H 1 // See SWDEV-307838, issue #1648.
 #define WORKAROUND_ISSUE_1674 (HIP_PACKAGE_VERSION_FLAT >= 5003022305ULL)
 /// No assumption that HIP kernels are launched with uniform block size for backward compatibility
-/// SWDEV-413293 and https://reviews.llvm.org/D155213
-#define WORKAROUND_SWDEV_413293 (HIP_PACKAGE_VERSION_FLAT >= 5007000000ULL)
+/// SWDEV-413293 and https://reviews.llvm.org/D155213 effective HIP_FLAT_VERSION 500723302
+#define WORKAROUND_SWDEV_413293 (HIP_PACKAGE_VERSION_FLAT >= 5007023302ULL)
 
 namespace hiprtc {
 


### PR DESCRIPTION
https://ontrack-internal.amd.com/browse/SWDEV-413293
https://reviews.llvm.org/D155213

From ROCm 5.7 the compiler patch above will assume uniform block sizes; however, for backward compatibility we need to add this flag in MIOpen.

Or else we will observe:
Error log :

MIOpen Error: /long_pathname_so_that_rpms_can_package_the_debug_info/data/driver/MLOpen/src/hipoc/hipoc_kernel.cpp:104: Failed to launch kernel: invalid argument
