### PR TITLE
SWDEV-416566 - Set composablekernel as a package dependency for miopen-hip

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -466,6 +466,12 @@ elseif(MIOPEN_BACKEND STREQUAL "OpenCL")
     set(CPACK_RPM_PACKAGE_CONFLICTS miopen-hip)
 endif()
 
+if(MIOPEN_USE_COMPOSABLEKERNEL)
+    # Add composablekernel-dev/devel as package dependency
+    set(CPACK_DEBIAN_PACKAGE_DEPENDS "${CPACK_DEBIAN_PACKAGE_DEPENDS}, composablekernel-dev")
+    set(CPACK_RPM_PACKAGE_REQUIRES "${CPACK_RPM_PACKAGE_REQUIRES}, composablekernel-devel")
+endif()
+
 # Unpack DB files
 function(unpack_db db_bzip2_file)
     set(KERNELS_DIR "${CMAKE_SOURCE_DIR}/src/kernels")


### PR DESCRIPTION
miopen-hip package doesn't have a dependency to composablekernel package Added composablekernel-dev/devel as a package dependency if composablekernel is enabled