### PR TITLE
Disable Op2dTensorLite kernel for the cases with wrong results

### DIFF
--- a/src/ocl/tensorocl.cpp
+++ b/src/ocl/tensorocl.cpp
@@ -185,8 +185,18 @@ void OpTensor3d(const Handle& handle,
 
     size_t total_work = std::max(clens[2] / RD_BLCK, size_t(1));
     size_t grp_sz     = (total_work + local_threads - 1) / local_threads;
-    grp_sz            = std::min(size_t(max_num_wg), grp_sz);
-    size_t glb_sz     = local_threads * grp_sz;
+
+    // opencl kernels are no longer supported, fallback to generic case
+    bool lite_applicable = grp_sz <= size_t(max_num_wg);
+
+    bool is_lite = clens[0] == 1 && blens[0] == 1 && alens[0] == 1 &&
+                   (blens[1] == clens[1] || blens[1] == 1) && blens[2] == clens[2];
+
+    bool is_squashed =
+        !is_lite && (blens[0] == 1 && clens[0] == 1 && clens[1] == 1 && blens[2] == clens[2]);
+
+    grp_sz        = std::min(size_t(max_num_wg), grp_sz);
+    size_t glb_sz = local_threads * grp_sz;
 
     size_t local_threads2 = 64;
     size_t total_work2    = clens[1];
@@ -199,8 +209,7 @@ void OpTensor3d(const Handle& handle,
         auto miopen_alpha1 = as_float(*(static_cast<const float*>(alpha1)));
         auto miopen_beta   = as_float(*(static_cast<const float*>(beta)));
 
-        if(clens[0] == 1 && blens[0] == 1 && alens[0] == 1 &&
-           (blens[1] == clens[1] || blens[1] == 1) && blens[2] == clens[2])
+        if(lite_applicable && is_lite)
         {
 
             network_config += std::to_string(RD_BLCK) + "x" + std::to_string(local_threads) + "x" +
@@ -233,7 +242,7 @@ void OpTensor3d(const Handle& handle,
                 return;
             }
         }
-        else if(blens[0] == 1 && clens[0] == 1 && clens[1] == 1 && blens[2] == clens[2])
+        else if(is_squashed)
         {
             network_config += std::to_string(RD_BLCK) + "x" + std::to_string(local_threads) + "x" +
                               std::to_string(grp_sz);
@@ -318,8 +327,7 @@ void OpTensor3d(const Handle& handle,
 
         const std::vector<size_t> vld{local_threads, 1, 1};
 
-        if(clens[0] == 1 && blens[0] == 1 && alens[0] == 1 &&
-           (blens[1] == clens[1] || blens[1] == 1) && blens[2] == clens[2])
+        if(lite_applicable && is_lite)
         {
             parms += " -DUSE_2D_TENSOR_LITE";
             parms += " -DRD_BLCK=" + std::to_string(RD_BLCK) + " -DREAD_TYPE=" + READ_TYPE;
@@ -345,7 +353,7 @@ void OpTensor3d(const Handle& handle,
                 int(!float_equal(miopen_beta, 0.0)),
                 int(blens[1] == 1));
         }
-        else if(blens[0] == 1 && clens[0] == 1 && clens[1] == 1 && blens[2] == clens[2])
+        else if(is_squashed)
         {
             parms += " -DUSE_2D_TENSOR_SQUASH";
             parms += " -DRD_BLCK=" + std::to_string(RD_BLCK) + " -DREAD_TYPE=" + READ_TYPE;


### PR DESCRIPTION
Fix for #2314 

Since we do not support OpenCL kernel, it just disables Op2dTensorLite for the cases where it produces wrong results.
There is also a ticket (#2221) for tensor operations improvements, any further fixes or perf improvements will be done under #2221.

Potentially it may affect RNN, but as far as I know, it uses small enough tensors to fit this limitation.