### PR TITLE
Fix ConvCkIgemmFwdV6r1DlopsNchw solver to reflect that its not dynamic

### DIFF
--- a/src/include/miopen/solver.hpp
+++ b/src/include/miopen/solver.hpp
@@ -2954,7 +2954,7 @@ struct ConvCkIgemmFwdV6r1DlopsNchw final : ConvTunableSolver<PerformanceConvCkIg
     bool IsApplicable(const ConvolutionContext&, const ProblemDescription&) const override;
     size_t GetWorkspaceSize(const ConvolutionContext&, const ProblemDescription&) const override;
     bool MayNeedWorkspace() const override { return true; }
-    bool IsDynamic() const override { return true; }
+    bool IsDynamic() const override { return false; }
     PerformanceConvCkIgemmFwdV6r1DlopsNchw
     GetDefaultPerformanceConfig(const ConvolutionContext&,
                                 const ProblemDescription&) const override;


### PR DESCRIPTION
`ConvCkIgemmFwdV6r1DlopsNchw` is not dynamic, however the class definition marks it as dynamic. This PR updates the definition so that `ConvCkIgemmFwdV6r1DlopsNchw ` is no longer marked as Dynamic.