### PR TITLE
Perf Tests include setting Find Mode to 1

### DIFF
--- a/test/test_perf.py
+++ b/test/test_perf.py
@@ -126,13 +126,11 @@ def run_driver_cmds(filename, install_path, override=None):
           if override:
             cmd = f"export LD_LIBRARY_PATH={install_path}/lib && export MIOPEN_LOG_LEVEL=6 && "\
                   f"export MIOPEN_SYSTEM_DB_PATH={install_path}/share/miopen/db && "\
-                  f"export MIOPEN_FIND_MODE=1 && "\
                   f"{var_str} "\
                   f"{install_path}/bin/{driver_cmd} -V 0 -i 10 -w 1 -t 1"
           else:
             cmd = f"export LD_LIBRARY_PATH={install_path}/lib && export MIOPEN_LOG_LEVEL=6 && "\
                   f"export MIOPEN_SYSTEM_DB_PATH={install_path}/share/miopen/db && "\
-                  f"export MIOPEN_FIND_MODE=1 && "\
                   f"{install_path}/bin/{driver_cmd} -V 0 -i 10 -w 1 -t 1"
           print(f'Running cm: {cmd}')
           proc = subprocess.Popen(cmd,


### PR DESCRIPTION
The Perf test script sets the MIOpen find mode to 1 which increases the time perf tests take but would also result in incorrect performance numbers being logged.