### PR TITLE
[HotFix][CI] fix HIP tidy issue from #2277

### DIFF
--- a/src/ocl/dropoutocl.cpp
+++ b/src/ocl/dropoutocl.cpp
@@ -133,7 +133,8 @@ void DropoutDescriptor::InitPRNGState(Handle& handle,
     }
 
     unsigned long long states_num = prng_stateSizeInBytes / sizeof(prngStates);
-    size_t wk_grp_num             = std::min(MAX_PRNG_STATE / 256ULL, (states_num + 255) / 256);
+    size_t wk_grp_num =
+        std::min(static_cast<unsigned long long>(MAX_PRNG_STATE / 256), (states_num + 255) / 256);
 
     std::string network_config = "initprngs-" + std::to_string(sizeof(prngStates)) + "x" +
                                  std::to_string(rng_mode) + "x" + std::to_string(wk_grp_num);


### PR DESCRIPTION
HIP Tidy is failing because of:
```
[2023-08-20T03:39:18.257Z] /var/jenkins/workspace/MLLibs_MIOpen_develop/src/ocl/dropoutocl.cpp:136:46: error: performing an implicit widening conversion to type 'unsigned long long' of a multiplication performed in type 'int' [bugprone-implicit-widening-of-multiplication-result,-warnings-as-errors]

[2023-08-20T03:39:18.257Z]     size_t wk_grp_num             = std::min(MAX_PRNG_STATE / 256ULL, (states_num + 255) / 256);

[2023-08-20T03:39:18.257Z]                                              ^
```