### PR TITLE
[bug fix]: add 2D constraint to Winograd solver

### DIFF
--- a/src/solver/conv_wino_fury_RxS.cpp
+++ b/src/solver/conv_wino_fury_RxS.cpp
@@ -168,6 +168,9 @@ template <uint32_t Winodata, uint32_t Winofilter>
 bool ConvWinoFuryRxS<Winodata, Winofilter>::IsApplicable(const ConvolutionContext& ctx,
                                                          const ProblemDescription& problem) const
 {
+    if(!problem.Is2d())
+        return false;
+
     if(is2x3() && miopen::IsDisabled(MIOPEN_DEBUG_AMD_WINOGRAD_FURY_RXS_F2X3{}))
         return false;
 


### PR DESCRIPTION
test_conv3d & test_immed_conv3d fails on navi because `GetSolutionFallback` performs a wider search and tries `WinoGrad` solvers, one of which throws an exception: 
```
32: terminate called after throwing an instance of 'miopen::Exception'
32:   what():  /home/mhassaan/repos/MIOpen/src/include/miopen/problem_description.hpp:302: UnifiedDescriptionConv2d supports only 2D
```

Adding a check for problem being 2D fixes it. 