### PR TITLE
[HotFix] Fix issue with MIOPEN_THROW when expanded

### DIFF
--- a/src/seq_tensor.cpp
+++ b/src/seq_tensor.cpp
@@ -208,8 +208,10 @@ SeqTensorDescriptor::SeqTensorDescriptor(miopenDataType_t t,
     else
     {
         if(padding_in.size() != dims)
+        {
             MIOPEN_THROW(miopenStatusBadParm,
                          "Lengths and padding number dimensions must be equal");
+        }
         else
             padds = padding_in;
     }


### PR DESCRIPTION
There is a problem with `MIOPEN_THROW` MACRO:

```
#define MIOPEN_THROW(__VA_ARGS__...) do { miopen::MIOpenThrow(__FILE__, __LINE__, __VA_ARGS__); } while(false);
```
Expands to:
```
do { miopen::MIOpenThrow("MIOpen/src/seq_tensor.cpp", 213, miopenStatusBadParm, "Lengths and padding number dimensions must be equal"); } while(false);
```
and when it is followed with `else` we will see the error:
```
MIOpen/src/seq_tensor.cpp:213:9: error: expected expression
        else
        ^
```

I am not sure how it get passed the CI but it is showing up on standalone desktops
