### PR TITLE
[HOTFIX] Restore safe implementation of MIOPEN_THROW

### DIFF
--- a/src/include/miopen/errors.hpp
+++ b/src/include/miopen/errors.hpp
@@ -67,7 +67,7 @@ template <class... Params>
     do                                                        \
     {                                                         \
         miopen::MIOpenThrow(__FILE__, __LINE__, __VA_ARGS__); \
-    } while(false);
+    } while(false)
 
 #define MIOPEN_THROW_CL_STATUS(...) \
     MIOPEN_THROW(miopenStatusUnknownError, miopen::OpenCLErrorMessage(__VA_ARGS__))

--- a/src/seq_tensor.cpp
+++ b/src/seq_tensor.cpp
@@ -208,10 +208,8 @@ SeqTensorDescriptor::SeqTensorDescriptor(miopenDataType_t t,
     else
     {
         if(padding_in.size() != dims)
-        {
             MIOPEN_THROW(miopenStatusBadParm,
                          "Lengths and padding number dimensions must be equal");
-        }
         else
             padds = padding_in;
     }


### PR DESCRIPTION
Reverts #2367 and fixes issue introduced in https://github.com/ROCmSoftwarePlatform/MIOpen/pull/2166/files#r1314316746 that leads to https://github.com/ROCmSoftwarePlatform/MIOpen/pull/2367#issue-1876440217 and possibly more (because currently each occurence of `MIOPEN_TROW(...);` expands to two statements instead of one).

----
[Attribution] @junliume @JehandadKhan
- https://github.com/ROCmSoftwarePlatform/MIOpen/labels/bug
- https://github.com/ROCmSoftwarePlatform/MIOpen/labels/urgency_blocker
- Proposed reviewers:
  - @muralinr 
  - @junliume
  - @shurale-nkn 