### PR TITLE
[Windows] roctracer: disable on Windows (not supported)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -850,8 +850,10 @@ if(NOT WIN32 AND NOT APPLE)
         target_internal_library(MIOpen ${LIBRT})
     endif()
 endif()
-############################################################
-target_link_libraries(MIOpen PRIVATE "-lroctx64")
+
+if(NOT WIN32)
+    target_link_libraries(MIOpen PRIVATE roctx64)
+endif()
 
 ############################################################
 # Installation

--- a/src/include/miopen/logger.hpp
+++ b/src/include/miopen/logger.hpp
@@ -38,7 +38,9 @@
 #include <miopen/object.hpp>
 #include <miopen/config.h>
 
+#ifndef _WIN32
 #include <roctracer/roctx.h>
+#endif
 
 // See https://github.com/pfultz2/Cloak/wiki/C-Preprocessor-tricks,-tips,-and-idioms
 #define MIOPEN_PP_CAT(x, y) MIOPEN_PP_PRIMITIVE_CAT(x, y)
@@ -410,6 +412,7 @@ private:
 #define MIOPEN_LOG_SCOPE_TIME
 #endif
 
+#ifndef _WIN32
 class LogScopeRoctx
 {
 public:
@@ -434,6 +437,7 @@ public:
 private:
     bool m_active{false};
 };
+#endif
 
 } // namespace miopen
 


### PR DESCRIPTION
The rocTRACER is not currently supported on Windows (it has not been ported to Windows yet). Therefore, the PR deactivates it on Windows.