### PR TITLE
[MI200] Refresh kdb using db_sync

### DIFF
--- a/src/kernels/gfx90a.kdb.bz2
+++ b/src/kernels/gfx90a.kdb.bz2
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:91eaa7412acf3e9a6f23cd70b386037434318a63e1d7be7212979a9ee50fe617
-size 592987974
+oid sha256:3d76d7c53648f4864a5cfe9267e8cb9171abab81de9d1732a9f94bafb0816b61
+size 250548882


### PR DESCRIPTION
Used db_sync gtest to regenerate MI200 kdb for each skew + merged.