### PR TITLE
[Documentaion] convolution API in MIOpen are restricted to alpha = 1.0 and beta 0.0

### DIFF
--- a/include/miopen/miopen.h
+++ b/include/miopen/miopen.h
@@ -1715,6 +1715,8 @@ miopenFindConvolutionForwardAlgorithm(miopenHandle_t handle,
  * Runs the forward convolution layer based on the selected algorithm. The function
  * miopenFindConvolutionForwardAlgorithm() must have been executed previously to
  * determine the required memory needed for the workspace and the best convolutional algorithm.
+ * The scaling parameter alpha (float) and shift parameter beta (float) are only supported for
+ * alpha = 1 and beta = 0.
  *
  * If using Group/Depthwise convolution mode, call miopenSetConvolutionGroupCount() before running
  * this.
@@ -1751,6 +1753,8 @@ MIOPEN_EXPORT miopenStatus_t miopenConvolutionForward(miopenHandle_t handle,
 /*! @brief Calculate element-wise scale and shift of a tensor via a bias tensor
  *
  *  This function applies an element-wise bias to a data tensor from an input bias tensor.
+ *  The scaling parameter alpha (float) and shift parameter beta (float) are only supported for
+ *  alpha = 1 and beta = 0.
  *
  * @param handle         MIOpen handle (input)
  * @param alpha          Floating point scaling factor, allocated on the host (input)
@@ -2018,6 +2022,8 @@ miopenConvolutionBackwardWeights(miopenHandle_t handle,
 /*! @brief Calculates the gradient with respect to the bias.
  *
  * Compute the convolution backwards gradient with respect to the bias tensor.
+ * The scaling parameter alpha (float) and shift parameter beta (float) are only supported for
+ * alpha = 1 and beta = 0.
  *
  * @param handle         MIOpen handle (input)
  * @param alpha          Floating point scaling factor, allocated on the host (input)


### PR DESCRIPTION
Below listed MIOpen convolution APIs only support (alpha, beta) == (1.f, 0.f). This is not in the API documentation (only in the [release notes](https://github.com/ROCmSoftwarePlatform/MIOpen/blob/develop/CHANGELOG.md#miopen-110-for-rocm-100)). This PR is to make documentation more clear to the user.

Comments were modified in APIs

`miopenConvolutionForward`
`miopenConvolutionForwardBias`
`miopenConvolutionBackwardBias`


