### PR TITLE
upgrade cmake so that MIOpen docker can compile Composable Kernel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -105,8 +105,9 @@ RUN ccache -s
 # Install doc requirements
 ADD docs/.sphinx/requirements.txt /doc-requirements.txt
 RUN pip3 install -r /doc-requirements.txt
-# Composable Kernel requires upgraded cmake
-RUN pip3 install --upgrade cmake
+
+# Composable Kernel requires this version cmake
+RUN pip3 install --upgrade cmake==3.27.5
 
 # Use parallel job to accelerate tensile build
 # Workaround for Tensile with TargetID feature

--- a/Dockerfile
+++ b/Dockerfile
@@ -105,6 +105,8 @@ RUN ccache -s
 # Install doc requirements
 ADD docs/.sphinx/requirements.txt /doc-requirements.txt
 RUN pip3 install -r /doc-requirements.txt
+# Composable Kernel requires upgraded cmake
+RUN pip3 install --upgrade cmake
 
 # Use parallel job to accelerate tensile build
 # Workaround for Tensile with TargetID feature


### PR DESCRIPTION
* Currently if you build Composable Kernel (CK) in MIOpen's docker it fails to compile. This is because the CMake version of MIOpen's docker is old. This PR will upgrade the CMake in Dockerfile. 