### PR TITLE
[Bugfix] Layernorm Test: add missing hip_runtime.h include

### DIFF
--- a/src/kernels/MIOpenLayerNorm.cpp
+++ b/src/kernels/MIOpenLayerNorm.cpp
@@ -25,6 +25,11 @@
  *******************************************************************************/
 #ifdef MIOPEN_BETA_API
 
+#ifndef MIOPEN_DONT_USE_HIP_RUNTIME_HEADERS
+#include <hip/hip_fp16.h>
+#include <hip/hip_runtime.h>
+#endif
+
 #include "float_types.h"
 
 //#if MIOPEN_USE_BFP16 == 1


### PR DESCRIPTION
Test fails under `MIOPEN_USE_COMGR=Off` build because of missing `hip_runtime.h` include. 