### PR TITLE
fix for end of line issue on Windows

### DIFF
--- a/src/db.cpp
+++ b/src/db.cpp
@@ -149,7 +149,7 @@ boost::optional<DbRecord> PlainTextDb::FindRecordUnsafe(const std::string& key,
 
     MIOPEN_LOG_I2("Looking for key " << key << " in file " << filename);
 
-    std::ifstream file(filename);
+    std::ifstream file(filename, std::ios::binary);
 
     if(!file)
     {
@@ -242,7 +242,7 @@ bool PlainTextDb::FlushUnsafe(const DbRecord& record, const RecordPositions* pos
     if(pos->begin < 0 || pos->end < 0)
     {
         {
-            std::ofstream file(filename, std::ios::app);
+            std::ofstream file(filename, std::ios::app | std::ios::binary);
 
             if(!file)
             {
@@ -258,7 +258,7 @@ bool PlainTextDb::FlushUnsafe(const DbRecord& record, const RecordPositions* pos
     }
     else
     {
-        std::ifstream from(filename, std::ios::ate);
+        std::ifstream from(filename, std::ios::ate | std::ios::binary);
 
         if(!from)
         {
@@ -267,7 +267,7 @@ bool PlainTextDb::FlushUnsafe(const DbRecord& record, const RecordPositions* pos
         }
 
         const auto temp_name = filename + ".temp";
-        std::ofstream to(temp_name);
+        std::ofstream to(temp_name, std::ios::binary);
 
         if(!to)
         {


### PR DESCRIPTION
When reading from a text file on Windows line ending is CRLF, unlike on Linux whish is LF.
The code did not properly handle the line ending on Windows due to discrepancy in the interpretation of line endings between the tellg() function and the C++ runtime.
tellg() function considers CRLF (Carriage Return + Line Feed) as two characters, but when filling the buffer, C++ runtime interprets CRLF as a single character. As a result, the buffer contained incorrect data at the end of the buffer.
To address this issue, files are opened in binary mode to ensure that line ending is LF in both Windows and Linux.