### PR TITLE
[Find 2.0] Bias for Find 2.0 fusion

### DIFF
--- a/include/miopen/miopen.h
+++ b/include/miopen/miopen.h
@@ -5233,6 +5233,9 @@ typedef enum
     miopenTensorActivationY  = 5,
     miopenTensorActivationDX = 6,
     miopenTensorActivationDY = 7,
+    miopenTensorBiasX        = 8,
+    miopenTensorBiasY        = 9,
+    miopenTensorBias         = 10,
 #endif
 } miopenTensorArgumentId_t;
 
@@ -5505,6 +5508,16 @@ miopenCreateActivationProblem(miopenProblem_t* problem,
  * @return             miopenStatus_t
  */
 MIOPEN_EXPORT miopenStatus_t miopenFuseProblems(miopenProblem_t problem1, miopenProblem_t problem2);
+
+/*! @brief Initializes a problem object describing an bias operation.
+ * @note As of now there is no way to actually get any solution for this kind of problems.
+ *
+ * @param problem        Pointer to the problem to initialize
+ * @param direction      Direction of the operation
+ * @return               miopenStatus_t
+ */
+MIOPEN_EXPORT miopenStatus_t miopenCreateBiasProblem(miopenProblem_t* problem,
+                                                     miopenProblemDirection_t direction);
 
 #endif
 

--- a/src/api/find2_0_commons.cpp
+++ b/src/api/find2_0_commons.cpp
@@ -28,7 +28,6 @@
 
 #include <miopen/common.hpp>
 #include <miopen/errors.hpp>
-#include <miopen/handle.hpp>
 #include <miopen/logger.hpp>
 #include <miopen/problem.hpp>
 #include <miopen/search_options.hpp>
@@ -62,7 +61,7 @@ miopenStatus_t miopenCreateConvProblem(miopenProblem_t* problem,
                                        miopenConvolutionDescriptor_t operatorDesc,
                                        miopenProblemDirection_t direction)
 {
-    MIOPEN_LOG_FUNCTION(problem);
+    MIOPEN_LOG_FUNCTION(problem, operatorDesc, direction);
     return MakeProblem(problem, operatorDesc, direction);
 }
 
@@ -70,8 +69,24 @@ miopenStatus_t miopenCreateActivationProblem(miopenProblem_t* problem,
                                              miopenActivationDescriptor_t operatorDesc,
                                              miopenProblemDirection_t direction)
 {
-    MIOPEN_LOG_FUNCTION(problem);
+    MIOPEN_LOG_FUNCTION(problem, operatorDesc, direction);
     return MakeProblem(problem, operatorDesc, direction);
+}
+
+miopenStatus_t miopenCreateBiasProblem(miopenProblem_t* problem, miopenProblemDirection_t direction)
+{
+    MIOPEN_LOG_FUNCTION(problem, direction);
+
+    return miopen::try_([&] {
+        miopen::deref(problem) = new miopen::ProblemContainer();
+        auto& container_deref  = miopen::deref(*problem);
+
+        container_deref.item = miopen::Problem();
+        auto& problem_deref  = boost::get<miopen::Problem>(container_deref.item);
+
+        problem_deref.SetOperatorDescriptor(miopen::BiasDescriptor{});
+        problem_deref.SetDirection(direction);
+    });
 }
 
 miopenStatus_t miopenFuseProblems(miopenProblem_t problem1, miopenProblem_t problem2)
@@ -245,6 +260,9 @@ inline std::ostream& operator<<(std::ostream& stream, const miopenTensorArgument
     case miopenTensorActivationDX: stream << "ActivDX"; break;
     case miopenTensorActivationY: stream << "ActivY"; break;
     case miopenTensorActivationDY: stream << "ActivDY"; break;
+    case miopenTensorBias: stream << "Bias"; break;
+    case miopenTensorBiasX: stream << "BiasX"; break;
+    case miopenTensorBiasY: stream << "BiasY"; break;
     case miopenTensorArgumentIdInvalid: stream << "Invalid"; break;
     }
 

--- a/src/include/miopen/problem.hpp
+++ b/src/include/miopen/problem.hpp
@@ -59,7 +59,13 @@ namespace conv {
 struct ProblemDescription;
 } // namespace conv
 
-using OperatorDescriptor = boost::variant<ConvolutionDescriptor, ActivationDescriptor>;
+struct BiasDescriptor
+{
+};
+
+// The order of types is important for deserialization and should be preserved between releases.
+using OperatorDescriptor =
+    boost::variant<ConvolutionDescriptor, ActivationDescriptor, BiasDescriptor>;
 
 struct Problem
 {
@@ -196,7 +202,9 @@ private:
 
 struct ProblemContainer : miopenProblem
 {
+    // The order of types is important for deserialization and should be preserved between releases.
     using Item = boost::variant<Problem, FusedProblem>;
+
     Item item;
 
     ProblemContainer() = default;

--- a/src/solution.cpp
+++ b/src/solution.cpp
@@ -72,6 +72,9 @@ void Solution::Run(Handle& handle,
                         },
                         [&](const ActivationDescriptor& /*op_desc*/) {
                             MIOPEN_THROW(miopenStatusNotImplemented);
+                        },
+                        [&](const BiasDescriptor& /*op_desc*/) {
+                            MIOPEN_THROW(miopenStatusNotImplemented);
                         }),
                     problem_.GetOperatorDescriptor());
             },
@@ -109,8 +112,10 @@ void Solution::LogDriverCommand(const ActivationDescriptor& desc) const
 
 void Solution::LogDriverCommand(const Problem& problem_) const
 {
-    boost::apply_visitor([&](const auto& op_desc) { LogDriverCommand(op_desc); },
-                         problem_.GetOperatorDescriptor());
+    boost::apply_visitor(
+        boost::hof::match([&](const BiasDescriptor&) { /* \todo: think on how to log bias */ },
+                          [&](const auto& op_desc) { LogDriverCommand(op_desc); }),
+        problem_.GetOperatorDescriptor());
 }
 
 void Solution::LogDriverCommand(const FusedProblem& problem_) const

--- a/test/gtest/cba_find2.hpp
+++ b/test/gtest/cba_find2.hpp
@@ -87,7 +87,7 @@ protected:
         // Setup the fusion problem
         fused_problem = miopen::FusedProblem{{
             MakeConvProblem(),
-            // MakeBiasProblem(),
+            MakeBiasProblem(),
             MakeActivationProblem(),
         }};
 
@@ -121,6 +121,14 @@ private:
         return problem;
     }
 
+    [[nodiscard]] miopen::Problem MakeBiasProblem() const
+    {
+        auto problem = miopen::Problem{};
+        problem.SetOperatorDescriptor(miopen::BiasDescriptor{});
+        problem.RegisterTensorDescriptor(miopenTensorBias, bias.desc);
+        return problem;
+    }
+
     [[nodiscard]] miopen::Problem MakeActivationProblem() const
     {
         auto problem = miopen::Problem{};
@@ -147,6 +155,11 @@ private:
                     EXPECT_EQ(desc, cfsb::output.desc);
                     return cfsb::out_dev.get();
                 }
+                if(id == miopenTensorBias)
+                {
+                    EXPECT_EQ(desc, bias.desc);
+                    return bias_dev.get();
+                }
                 MIOPEN_THROW(miopenStatusInternalError);
             },
             params);
@@ -159,7 +172,7 @@ private:
 
         cpu_values_calculated = true;
         cfsb::TearDownConv();
-        // cpu_bias_forward(cfsb::ref_out, bias);
+        cpu_bias_forward(cfsb::ref_out, bias);
 
         activationHostInfer(activ_mode,
                             activ_gamma,

--- a/test/gtest/cba_find2_infer.cpp
+++ b/test/gtest/cba_find2_infer.cpp
@@ -143,6 +143,7 @@ TEST_P(ConvBiasActivFind2InferTestFloatFusionFind, ConvBiasActivFind2Float_testF
         {miopenTensorConvolutionX, in_dev.get()},
         {miopenTensorConvolutionW, wei_dev.get()},
         {miopenTensorActivationY, out_dev.get()},
+        {miopenTensorBias, bias_dev.get()},
     };
 
     for(auto& solution : solutions)


### PR DESCRIPTION
This adds:
- an API method to create a Find 2.0 bias problem
- support for fused bias in miopenFindSolutions
- support for fused bias in miopenRunSolution
- support for fused bias in miopenSave/LoadSolution
- test_cba_find2_infer now actually checks cba rather than conv+activ with no bias

This does not add:
- any kind of standalone bias for Find 2.0

Blocked by https://github.com/ROCmSoftwarePlatform/MIOpen/pull/2486
This is actually just a [single commit](https://github.com/ROCmSoftwarePlatform/MIOpen/pull/2525/commits/46304472233c9e7d0d58d2e19da60387ddeed92c), I would rebase as soon as #2486 is merged
