### PR TITLE
Restrict CK solvers to only run on MI100, MI200 and MI300

### DIFF
--- a/src/include/miopen/solver/ck_utility_common.hpp
+++ b/src/include/miopen/solver/ck_utility_common.hpp
@@ -45,26 +45,7 @@ MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEBUG_CK_USE_AMD_BUFFER_ADDRESSING)
 namespace miopen {
 namespace solver {
 namespace ck_utility {
-
-// Disclaimer: Currently CK is only supported in MI100, MI200 and MI300.
-//             Please use is_ck_whitelist instead of this function.
-static inline bool is_ck_supported_hardware(const Handle& handle)
-{
-    return (StartsWith(handle.GetDeviceName(), "gfx803") && handle.GetMaxComputeUnits() == 64) ||
-           StartsWith(handle.GetDeviceName(), "gfx900") ||
-           StartsWith(handle.GetDeviceName(), "gfx906") ||
-           StartsWith(handle.GetDeviceName(), "gfx908") ||
-           StartsWith(handle.GetDeviceName(), "gfx90a") ||
-           StartsWith(handle.GetDeviceName(), "gfx940") ||
-           StartsWith(handle.GetDeviceName(), "gfx941") ||
-           StartsWith(handle.GetDeviceName(), "gfx942") ||
-           StartsWith(handle.GetDeviceName(), "gfx1030") ||
-           StartsWith(handle.GetDeviceName(), "gfx1031") ||
-           StartsWith(handle.GetDeviceName(), "gfx1100") ||
-           StartsWith(handle.GetDeviceName(), "gfx1101") ||
-           StartsWith(handle.GetDeviceName(), "gfx1102");
-}
-
+    
 // MI100 : gfx908
 // MI200 : gfx90a
 // MI300 : gfx940, gfx941, gfx942

--- a/src/include/miopen/solver/ck_utility_common.hpp
+++ b/src/include/miopen/solver/ck_utility_common.hpp
@@ -45,7 +45,7 @@ MIOPEN_DECLARE_ENV_VAR(MIOPEN_DEBUG_CK_USE_AMD_BUFFER_ADDRESSING)
 namespace miopen {
 namespace solver {
 namespace ck_utility {
-    
+
 // MI100 : gfx908
 // MI200 : gfx90a
 // MI300 : gfx940, gfx941, gfx942

--- a/src/solver/batchnorm/backward_ck.cpp
+++ b/src/solver/batchnorm/backward_ck.cpp
@@ -195,7 +195,7 @@ bool BnCKBwdBackward::IsApplicable(
         return false;
     if(!bn_problem.IsLayoutNHWC())
         return false;
-    if(!ck_utility::is_ck_supported_hardware(context.GetStream()))
+    if(!ck_utility::is_ck_whitelist(context.GetStream()))
         return false;
     if(bn_problem.GetXDesc().GetType() != bn_problem.GetScaleBiasDiffDesc().GetType())
         return false;

--- a/src/solver/batchnorm/forward_training_ck.cpp
+++ b/src/solver/batchnorm/forward_training_ck.cpp
@@ -187,7 +187,7 @@ bool BnCKFwdTraining::IsApplicable(
         return false;
     if(!bn_problem.IsLayoutNHWC())
         return false;
-    if(!ck_utility::is_ck_supported_hardware(context.GetStream()))
+    if(!ck_utility::is_ck_whitelist(context.GetStream()))
         return false;
 
     switch(bn_problem.GetXDesc().GetType())

--- a/src/solver/conv_ck_igemm_fwd_v6r1_dlops_nchw.cpp
+++ b/src/solver/conv_ck_igemm_fwd_v6r1_dlops_nchw.cpp
@@ -99,7 +99,7 @@ bool ConvCkIgemmFwdV6r1DlopsNchw::IsApplicable(const ExecutionContext& ctx,
         return false;
     if(!ctx.use_hip_kernels)
         return false;
-    if(!ck_utility::is_ck_supported_hardware(ctx.GetStream()))
+    if(!ck_utility::is_ck_whitelist(ctx.GetStream()))
         return false;
     if(!problem.IsLayoutDefault())
         return false;

--- a/src/solver/norm/forward_layernorm2d_ck.cpp
+++ b/src/solver/norm/forward_layernorm2d_ck.cpp
@@ -228,7 +228,7 @@ bool Layernorm2DCKForward::IsApplicable(
         return false;
     if(!problem.IsLargeSize())
         return false;
-    if(!ck_utility::is_ck_supported_hardware(context.GetStream()))
+    if(!ck_utility::is_ck_whitelist(context.GetStream()))
         return false;
 
     switch(problem.GetXDesc().GetType())

--- a/src/solver/norm/forward_layernorm4d_ck.cpp
+++ b/src/solver/norm/forward_layernorm4d_ck.cpp
@@ -236,7 +236,7 @@ bool Layernorm4DCKForward::IsApplicable(
         return false;
     if(!problem.IsLargeSize())
         return false;
-    if(!ck_utility::is_ck_supported_hardware(context.GetStream()))
+    if(!ck_utility::is_ck_whitelist(context.GetStream()))
         return false;
 
     switch(problem.GetXDesc().GetType())


### PR DESCRIPTION
Currently tests are passing when Jenkins randomly choses MI series GPU. If Jenkins chooses GPU other then MI series, the tests starts failing. The reason is the CK solvers are currently only verified(tests pass) in MI series. This PR is to restrict all the CK solvers to only run on MI100, MI200 and MI300. 

For this I replaced  `is_ck_supported_hardware` with [`is_ck_whitelist`](https://github.com/ROCmSoftwarePlatform/MIOpen/blob/bf3be47cd9f27a77bacbdb1ae4c9fde402028cfd/src/include/miopen/solver/ck_utility_common.hpp#L52). 
