### PR TITLE
[Tests] split teardown to runtest and verify in layernorm gtest

### DIFF
--- a/test/gtest/layernorm.cpp
+++ b/test/gtest/layernorm.cpp
@@ -42,10 +42,15 @@ struct LayerNormTestFloat : LayerNormTest<float>
 TEST_P(LayerNormTestFloat, LayerNormTestFw)
 {
     const auto& handle = get_handle();
-    if(!(miopen::IsEnvvarValueEnabled("MIOPEN_TEST_ALL") && (GetFloatArg() == "--float")) ||
-       !(miopen::StartsWith(handle.GetDeviceName(), "gfx908") ||
-         miopen::StartsWith(handle.GetDeviceName(), "gfx90a") ||
-         miopen::StartsWith(handle.GetDeviceName(), "gfx94")))
+    if((miopen::StartsWith(handle.GetDeviceName(), "gfx908") ||
+        miopen::StartsWith(handle.GetDeviceName(), "gfx90a") ||
+        miopen::StartsWith(handle.GetDeviceName(), "gfx94")) &&
+       miopen::IsEnvvarValueEnabled("MIOPEN_TEST_ALL") && (GetFloatArg() == "--float"))
+    {
+        RunTest();
+        Verify();
+    }
+    else
     {
         GTEST_SKIP();
     }

--- a/test/gtest/layernorm.hpp
+++ b/test/gtest/layernorm.hpp
@@ -236,7 +236,7 @@ protected:
         mean_dev   = handle.Write(mean.data);
         rstd_dev   = handle.Write(rstd.data);
     }
-    void TearDown() override
+    void RunTest()
     {
         auto&& handle = get_handle();
 
@@ -266,7 +266,10 @@ protected:
         output.data = handle.Read<T>(output_dev, output.data.size());
         mean.data   = handle.Read<T>(mean_dev, mean.data.size());
         rstd.data   = handle.Read<T>(rstd_dev, rstd.data.size());
+    }
 
+    void Verify()
+    {
         double threshold = std::numeric_limits<T>::epsilon();
         auto error       = miopen::rms_range(ref_output, output);
 


### PR DESCRIPTION
When used teardown as main part, gtest was skipped after the kernel was called.
Changed to not use teardown by split teardown to runtest and verify.
Follow-up #2528
Related to #2527