### PR TITLE
fix compilation without CK on Windows

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -149,19 +149,16 @@ set( MIOpen_Source
     solver/activ/bwd_1.cpp
     solver/activ/fwd_0.cpp
     solver/activ/fwd_1.cpp
-    solver/batchnorm/backward_ck.cpp
     solver/batchnorm/backward_per_activation.cpp
     solver/batchnorm/backward_per_activation_fused.cpp
     solver/batchnorm/backward_spatial_multiple.cpp
     solver/batchnorm/backward_spatial_single.cpp
     solver/batchnorm/forward_inference.cpp
-    solver/batchnorm/forward_inference_ck.cpp
     solver/batchnorm/forward_inference_fused.cpp
     solver/batchnorm/forward_per_activation.cpp
     solver/batchnorm/forward_per_activation_fused.cpp
     solver/batchnorm/forward_spatial_multiple.cpp
     solver/batchnorm/forward_spatial_single.cpp
-    solver/batchnorm/forward_training_ck.cpp
     solver/conv_asm_1x1u.cpp
     solver/conv_asm_1x1u_bias_activ_fused.cpp
     solver/conv_asm_1x1u_stride2.cpp
@@ -185,8 +182,6 @@ set( MIOpen_Source
     solver/conv_bin_wino3x3U.cpp
     solver/conv_bin_winoRxS.cpp
     solver/conv_bin_winoRxS_fused.cpp
-    solver/conv_ck_igemm_fwd_v6r1_dlops_nchw.cpp
-    solver/conv_ck_igemm_fwd_bias_activ_fused.cpp
     solver/conv_direct_naive_conv.cpp
     solver/conv_direct_naive_conv_bwd.cpp
     solver/conv_direct_naive_conv_fwd.cpp
@@ -236,8 +231,6 @@ set( MIOpen_Source
     solver/gemm_common.cpp
     solver/gemm_wrw.cpp
     solver/norm/forward_layernorm.cpp
-    solver/norm/forward_layernorm2d_ck.cpp
-    solver/norm/forward_layernorm4d_ck.cpp
     solver/pooling/forward2d.cpp
     solver/pooling/forwardNaive.cpp
     solver/pooling/forwardNd.cpp
@@ -263,6 +256,18 @@ endif()
 
 if(MIOPEN_ENABLE_SQLITE AND MIOPEN_ENABLE_SQLITE_KERN_CACHE)
     list(APPEND MIOpen_Source kern_db.cpp bz2.cpp)
+endif()
+
+if(MIOPEN_USE_COMPOSABLEKERNEL)
+    list(APPEND MIOpen_Source
+        solver/batchnorm/backward_ck.cpp
+        solver/batchnorm/forward_inference_ck.cpp
+        solver/batchnorm/forward_training_ck.cpp
+        solver/conv_ck_igemm_fwd_v6r1_dlops_nchw.cpp
+        solver/conv_ck_igemm_fwd_bias_activ_fused.cpp
+        solver/norm/forward_layernorm2d_ck.cpp
+        solver/norm/forward_layernorm4d_ck.cpp
+    )
 endif()
 
 if( MIOPEN_BACKEND MATCHES "OpenCL" OR MIOPEN_BACKEND STREQUAL "HIPOC" OR MIOPEN_BACKEND STREQUAL "HIP" OR MIOPEN_BACKEND STREQUAL "HIPNOGPU")

--- a/src/fusion.cpp
+++ b/src/fusion.cpp
@@ -696,10 +696,12 @@ static auto GetFusedDirectSolvers()
                                    solver::fusion::ConvOclDirectFwdFused>{};
 }
 
+#if MIOPEN_USE_COMPOSABLEKERNEL
 static auto GetFusedIGemmSolvers()
 {
     return solver::SolverContainer<solver::fusion::ConvCKIgemmFwdBiasActivFused>{};
 }
+#endif
 
 static auto GetFusedWinogradSolvers()
 {
@@ -709,7 +711,10 @@ static auto GetFusedWinogradSolvers()
 
 static auto GetAllFusionSolvers()
 {
-    return GetFusedNonConvSolvers() + GetFusedDirectSolvers() + GetFusedIGemmSolvers() +
+    return GetFusedNonConvSolvers() + GetFusedDirectSolvers() +
+#if MIOPEN_USE_COMPOSABLEKERNEL
+           GetFusedIGemmSolvers() +
+#endif
            GetFusedWinogradSolvers();
 }
 
@@ -783,7 +788,9 @@ static const std::vector<std::unique_ptr<ISolversFinder>>& GetFusionSolverFinder
         auto tmp = std::vector<std::unique_ptr<ISolversFinder>>{};
         add(tmp, GetFusedNonConvSolvers(), "fusion");
         add(tmp, GetFusedDirectSolvers(), "miopenConvolutionFwdAlgoDirect");
+#if MIOPEN_USE_COMPOSABLEKERNEL
         add(tmp, GetFusedIGemmSolvers(), "miopenConvolutionFwdAlgoImplicitGEMM");
+#endif
         add(tmp, GetFusedWinogradSolvers(), "miopenConvolutionFwdAlgoWinograd");
         return tmp;
     }();

--- a/src/include/miopen/batchnorm/solvers.hpp
+++ b/src/include/miopen/batchnorm/solvers.hpp
@@ -132,6 +132,7 @@ struct BnFwdInference final : BatchnormSolver
                              const miopen::batchnorm::ProblemDescription& problem) const override;
 };
 
+#if MIOPEN_USE_COMPOSABLEKERNEL
 struct BnCKFwdInference final : BatchnormSolver
 {
     const std::string& SolverDbId() const override { return GetSolverDbId<BnCKFwdInference>(); }
@@ -161,6 +162,7 @@ struct BnCKFwdTraining final : BatchnormSolver
     ConvSolution GetSolution(const ExecutionContext& context,
                              const miopen::batchnorm::ProblemDescription& problem) const override;
 };
+#endif
 
 } // namespace batchnorm
 

--- a/src/include/miopen/fusion/solvers.hpp
+++ b/src/include/miopen/fusion/solvers.hpp
@@ -185,6 +185,7 @@ struct ConvOclDirectFwdFused final : FusionTunableSolver<LegacyPerformanceConfig
                                   const PerformanceConfigConvOclDirectFwdFused&) const override;
 };
 
+#if MIOPEN_USE_COMPOSABLEKERNEL
 struct PerformanceConfigConvCKIgemmFwdBiasActivFused
     : PerfConfigBase<PerformanceConfigConvCKIgemmFwdBiasActivFused>
 {
@@ -252,6 +253,7 @@ private:
     template <typename DataType>
     bool CheckCKApplicability(const miopen::conv::ProblemDescription&) const;
 };
+#endif
 
 struct ConvBinWinogradRxSFused final : FusionSolverBase
 {

--- a/src/include/miopen/norm/solvers.hpp
+++ b/src/include/miopen/norm/solvers.hpp
@@ -50,6 +50,7 @@ struct LayernormForward final : NormalizationSolver
                              const miopen::norm::ProblemDescription& problem) const override;
 };
 
+#if MIOPEN_USE_COMPOSABLEKERNEL
 struct Layernorm2DCKForward final : NormalizationSolver
 {
     const std::string& SolverDbId() const override { return GetSolverDbId<Layernorm2DCKForward>(); }
@@ -69,6 +70,7 @@ struct Layernorm4DCKForward final : NormalizationSolver
     ConvSolution GetSolution(const ExecutionContext& context,
                              const miopen::norm::ProblemDescription& problem) const override;
 };
+#endif // MIOPEN_USE_COMPOSABLEKERNEL
 
 } // namespace norm
 

--- a/src/include/miopen/solver.hpp
+++ b/src/include/miopen/solver.hpp
@@ -2844,6 +2844,7 @@ struct ConvHipImplicitGemmWrwV4R4Xdlops_Padded_Gemm final
            const AnyInvokeParams& invoke_ctx) const override;
 };
 
+#if MIOPEN_USE_COMPOSABLEKERNEL
 struct PerformanceConvCkIgemmFwdV6r1DlopsNchw
     : PerfConfigBase<PerformanceConvCkIgemmFwdV6r1DlopsNchw>
 {
@@ -2899,6 +2900,7 @@ struct ConvCkIgemmFwdV6r1DlopsNchw final : ConvTunableSolver<PerformanceConvCkIg
                              const miopen::conv::ProblemDescription&,
                              const PerformanceConvCkIgemmFwdV6r1DlopsNchw&) const override;
 };
+#endif
 
 struct ConvDirectNaiveConvFwd final : ConvSolver
 {

--- a/src/layer_norm.cpp
+++ b/src/layer_norm.cpp
@@ -72,10 +72,10 @@ miopenStatus_t LayerNormForward(Handle& handle,
     const auto algo    = AlgorithmName{"LayerNormForward"};
     const auto solvers = solver::SolverContainer<
 #if MIOPEN_USE_COMPOSABLEKERNEL
-                                                 solver::norm::Layernorm2DCKForward,
-                                                 solver::norm::Layernorm4DCKForward,
+        solver::norm::Layernorm2DCKForward,
+        solver::norm::Layernorm4DCKForward,
 #endif
-                                                 solver::norm::LayernormForward>{};
+        solver::norm::LayernormForward>{};
 
     solvers.ExecutePrimitive(handle, problem, algo, invoke_params);
 

--- a/src/layer_norm.cpp
+++ b/src/layer_norm.cpp
@@ -70,8 +70,11 @@ miopenStatus_t LayerNormForward(Handle& handle,
     }();
 
     const auto algo    = AlgorithmName{"LayerNormForward"};
-    const auto solvers = solver::SolverContainer<solver::norm::Layernorm2DCKForward,
+    const auto solvers = solver::SolverContainer<
+#if MIOPEN_USE_COMPOSABLEKERNEL
+                                                 solver::norm::Layernorm2DCKForward,
                                                  solver::norm::Layernorm4DCKForward,
+#endif
                                                  solver::norm::LayernormForward>{};
 
     solvers.ExecutePrimitive(handle, problem, algo, invoke_params);

--- a/src/mlo_dir_conv.cpp
+++ b/src/mlo_dir_conv.cpp
@@ -118,14 +118,16 @@ static auto GetImplicitGemmSolvers()
         miopen::solver::conv::ConvAsmImplicitGemmGTCDynamicBwdXdlops,
         miopen::solver::conv::ConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWC,
         miopen::solver::conv::ConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWC,
+#if MIOPEN_USE_COMPOSABLEKERNEL
         miopen::solver::conv::ConvCkIgemmFwdV6r1DlopsNchw,
-#if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
+#if MIOPEN_BACKEND_HIP
         miopen::solver::conv::ConvHipImplicitGemmFwdXdlops,
         miopen::solver::conv::ConvHipImplicitGemmBwdXdlops,
         miopen::solver::conv::ConvHipImplicitGemmGroupFwdXdlops,
         miopen::solver::conv::ConvHipImplicitGemm3DGroupFwdXdlops,
         miopen::solver::conv::ConvHipImplicitGemm3DGroupBwdXdlops,
-#endif // MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
+#endif // MIOPEN_BACKEND_HIP
+#endif // MIOPEN_USE_COMPOSABLEKERNEL
         miopen::solver::conv::ConvAsmImplicitGemmGTCDynamicFwdDlopsNCHWC>{};
 }
 

--- a/src/ocl/batchnormocl.cpp
+++ b/src/ocl/batchnormocl.cpp
@@ -131,7 +131,10 @@ void BatchNormForwardTraining(Handle& handle,
         return tmp;
     }();
 
-    const auto solvers = solver::SolverContainer<solver::batchnorm::BnCKFwdTraining,
+    const auto solvers = solver::SolverContainer<
+#if MIOPEN_USE_COMPOSABLEKERNEL
+                                                 solver::batchnorm::BnCKFwdTraining,
+#endif
                                                  solver::batchnorm::BnFwdTrainingSpatialSingle,
                                                  solver::batchnorm::BnFwdTrainingSpatialMultiple,
                                                  solver::batchnorm::BnFwdTrainingPerActivation>{};
@@ -223,8 +226,11 @@ void BatchNormForwardInference(Handle& handle,
         }();
 
         const auto algo    = AlgorithmName{"miopenBatchNormalizationForwardInference"};
-        const auto solvers = solver::SolverContainer<solver::batchnorm::BnFwdInference,
-                                                     solver::batchnorm::BnCKFwdInference>{};
+        const auto solvers = solver::SolverContainer<solver::batchnorm::BnFwdInference
+#if MIOPEN_USE_COMPOSABLEKERNEL
+                                                     , solver::batchnorm::BnCKFwdInference
+#endif
+                                                     >{};
 
         solvers.ExecutePrimitive(handle, problem, algo, invoke_params);
     }
@@ -346,7 +352,10 @@ void BatchNormBackward(Handle& handle,
         return tmp;
     }();
 
-    const auto solvers = solver::SolverContainer<solver::batchnorm::BnCKBwdBackward,
+    const auto solvers = solver::SolverContainer<
+#if MIOPEN_USE_COMPOSABLEKERNEL
+                                                 solver::batchnorm::BnCKBwdBackward,
+#endif
                                                  solver::batchnorm::BnBwdTrainingSpatialSingle,
                                                  solver::batchnorm::BnBwdTrainingSpatialMultiple,
                                                  solver::batchnorm::BnBwdTrainingPerActivation>{};

--- a/src/ocl/batchnormocl.cpp
+++ b/src/ocl/batchnormocl.cpp
@@ -133,11 +133,11 @@ void BatchNormForwardTraining(Handle& handle,
 
     const auto solvers = solver::SolverContainer<
 #if MIOPEN_USE_COMPOSABLEKERNEL
-                                                 solver::batchnorm::BnCKFwdTraining,
+        solver::batchnorm::BnCKFwdTraining,
 #endif
-                                                 solver::batchnorm::BnFwdTrainingSpatialSingle,
-                                                 solver::batchnorm::BnFwdTrainingSpatialMultiple,
-                                                 solver::batchnorm::BnFwdTrainingPerActivation>{};
+        solver::batchnorm::BnFwdTrainingSpatialSingle,
+        solver::batchnorm::BnFwdTrainingSpatialMultiple,
+        solver::batchnorm::BnFwdTrainingPerActivation>{};
 
     solvers.ExecutePrimitive(handle, problem, algo, invoke_params);
 
@@ -228,7 +228,8 @@ void BatchNormForwardInference(Handle& handle,
         const auto algo    = AlgorithmName{"miopenBatchNormalizationForwardInference"};
         const auto solvers = solver::SolverContainer<solver::batchnorm::BnFwdInference
 #if MIOPEN_USE_COMPOSABLEKERNEL
-                                                     , solver::batchnorm::BnCKFwdInference
+                                                     ,
+                                                     solver::batchnorm::BnCKFwdInference
 #endif
                                                      >{};
 
@@ -354,11 +355,11 @@ void BatchNormBackward(Handle& handle,
 
     const auto solvers = solver::SolverContainer<
 #if MIOPEN_USE_COMPOSABLEKERNEL
-                                                 solver::batchnorm::BnCKBwdBackward,
+        solver::batchnorm::BnCKBwdBackward,
 #endif
-                                                 solver::batchnorm::BnBwdTrainingSpatialSingle,
-                                                 solver::batchnorm::BnBwdTrainingSpatialMultiple,
-                                                 solver::batchnorm::BnBwdTrainingPerActivation>{};
+        solver::batchnorm::BnBwdTrainingSpatialSingle,
+        solver::batchnorm::BnBwdTrainingSpatialMultiple,
+        solver::batchnorm::BnBwdTrainingPerActivation>{};
 
     solvers.ExecutePrimitive(handle, problem, algo, invoke_params);
 

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -608,13 +608,13 @@ inline SolverRegistrar::SolverRegistrar(IdRegistryData& registry)
                        ++id,
                        conv::ConvHipImplicitGemm3DGroupBwdXdlops{},
                        miopenConvolutionAlgoImplicitGEMM);
-#if MIOPEN_USE_COMPOSABLEKERNEL					   
+#if MIOPEN_USE_COMPOSABLEKERNEL
     Register(registry, ++id, Primitive::Batchnorm, batchnorm::BnCKFwdInference{}.SolverDbId());
     Register(registry, ++id, Primitive::Batchnorm, batchnorm::BnCKBwdBackward{}.SolverDbId());
     Register(registry, ++id, Primitive::Batchnorm, batchnorm::BnCKFwdTraining{}.SolverDbId());
     Register(registry, ++id, Primitive::Normalization, norm::Layernorm2DCKForward{}.SolverDbId());
     Register(registry, ++id, Primitive::Normalization, norm::Layernorm4DCKForward{}.SolverDbId());
-#endif	
+#endif
     Register(registry, ++id, Primitive::Normalization, norm::LayernormForward{}.SolverDbId());
 
     // IMPORTANT: New solvers should be added to the end of the function!

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -528,8 +528,10 @@ inline SolverRegistrar::SolverRegistrar(IdRegistryData& registry)
     Register(
         registry, ++id, Primitive::Batchnorm, batchnorm::BnFwdTrainingSpatialSingle{}.SolverDbId());
 
+#if MIOPEN_USE_COMPOSABLEKERNEL
     RegisterWithSolver(
         registry, ++id, conv::ConvCkIgemmFwdV6r1DlopsNchw{}, miopenConvolutionAlgoImplicitGEMM);
+#endif
 
     Register(registry,
              ++id,
@@ -580,11 +582,13 @@ inline SolverRegistrar::SolverRegistrar(IdRegistryData& registry)
     Register(registry, ++id, Primitive::Fusion, fusion::BnFwdInferActivationFused{}.SolverDbId());
     Register(registry, ++id, Primitive::Fusion, fusion::BnFwdTrgActivationFused{}.SolverDbId());
     Register(registry, ++id, Primitive::Fusion, fusion::BnBwdTrgActivationFused{}.SolverDbId());
+#if MIOPEN_USE_COMPOSABLEKERNEL
     Register(registry,
              ++id,
              Primitive::Fusion,
              fusion::ConvCKIgemmFwdBiasActivFused{}.SolverDbId(),
              miopenConvolutionAlgoImplicitGEMM);
+#endif
     Register(registry, ++id, Primitive::Pooling, pooling::PoolingForwardNaive{}.SolverDbId());
     RegisterWithSolver(registry,
                        ++id,
@@ -604,11 +608,13 @@ inline SolverRegistrar::SolverRegistrar(IdRegistryData& registry)
                        ++id,
                        conv::ConvHipImplicitGemm3DGroupBwdXdlops{},
                        miopenConvolutionAlgoImplicitGEMM);
+#if MIOPEN_USE_COMPOSABLEKERNEL					   
     Register(registry, ++id, Primitive::Batchnorm, batchnorm::BnCKFwdInference{}.SolverDbId());
     Register(registry, ++id, Primitive::Batchnorm, batchnorm::BnCKBwdBackward{}.SolverDbId());
     Register(registry, ++id, Primitive::Batchnorm, batchnorm::BnCKFwdTraining{}.SolverDbId());
     Register(registry, ++id, Primitive::Normalization, norm::Layernorm2DCKForward{}.SolverDbId());
     Register(registry, ++id, Primitive::Normalization, norm::Layernorm4DCKForward{}.SolverDbId());
+#endif	
     Register(registry, ++id, Primitive::Normalization, norm::LayernormForward{}.SolverDbId());
 
     // IMPORTANT: New solvers should be added to the end of the function!

--- a/test/gtest/CMakeLists.txt
+++ b/test/gtest/CMakeLists.txt
@@ -12,10 +12,6 @@ set(SOURCES
     platform.cpp
     )
 
-if(MIOPEN_BACKEND_OPENCL)
-  set(SKIP_TESTS dumpTensorTest)
-endif()
-
 function(add_gtest TEST_NAME)
   if( NOT (TEST_NAME IN_LIST SKIP_TESTS))
     message("Adding Test: " ${TEST_NAME})
@@ -43,6 +39,11 @@ file(GLOB TESTS *.cpp)
 foreach(SOURCE ${SOURCES})
     list(REMOVE_ITEM TESTS ${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE})
 endforeach()
+
+if(NOT MIOPEN_USE_COMPOSABLEKERNEL)
+  # Remove tests when CK is disabled
+  list(REMOVE_ITEM TESTS ${CMAKE_CURRENT_SOURCE_DIR}/bad_fusion_plan.cpp)
+endif()
 
 foreach(TEST ${TESTS})
     get_filename_component(BASE_NAME ${TEST} NAME_WE)

--- a/test/gtest/cba_find2_infer.cpp
+++ b/test/gtest/cba_find2_infer.cpp
@@ -122,11 +122,13 @@ TEST_P(ConvBiasActivFind2InferTestFloat, ConvBinWinogradRxSf2x3g1Find2Fused)
         fused_problem, invoke_params, conv_config, test_skipped);
 }
 
+#if MIOPEN_USE_COMPOSABLEKERNEL
 TEST_P(ConvBiasActivFind2InferTestHalf, ConvCKIgemmFwdBiasActivFind2Fused)
 {
     RunTunableSolver<miopen::solver::fusion::ConvCKIgemmFwdBiasActivFused>(
         fused_problem, invoke_params, conv_config, test_skipped);
 }
+#endif
 
 #if MIOPEN_BACKEND_HIP
 TEST_P(ConvBiasActivFind2InferTestFloatFusionFind, ConvBiasActivFind2Float_testFind)

--- a/test/gtest/cba_infer.cpp
+++ b/test/gtest/cba_infer.cpp
@@ -138,6 +138,7 @@ TEST_P(ConvBiasActivInferTestFloat, ConvBinWinogradRxSf2x3g1Fused)
         fusePlanDesc, plan_params, conv_config, test_skipped);
 }
 
+#if MIOPEN_USE_COMPOSABLEKERNEL
 TEST_P(ConvBiasActivInferTestHalf, ConvCKIgemmFwdBiasActivFused)
 {
     const auto plan_params = std::make_unique<miopen::fusion::FusionInvokeParams>(
@@ -145,6 +146,7 @@ TEST_P(ConvBiasActivInferTestHalf, ConvCKIgemmFwdBiasActivFused)
     RunTunableSolver<miopen::solver::fusion::ConvCKIgemmFwdBiasActivFused>(
         fusePlanDesc, plan_params, conv_config, test_skipped);
 }
+#endif
 
 #if MIOPEN_BACKEND_HIP
 TEST_P(ConvBiasActivInferTestFloatFusionCompileStep, ConvBiasActivAsm1x1UFloat_testCompile)


### PR DESCRIPTION
The porting of Composable Kernels to Windows is pending. The PR fixes the compilation when `MIOPEN_USE_COMPOSABLEKERNEL` is `OFF`.