### PR TITLE
use find_package() for SQLite3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,8 +91,7 @@ option(BUILD_SHARED_LIBS "Create shared libraries" ON)
 
 if(MIOPEN_ENABLE_SQLITE)
     # MIOpen now depends on SQLite as well
-    find_package(PkgConfig)
-    pkg_check_modules(SQLITE3 REQUIRED sqlite3)
+    find_package(SQLite3 REQUIRED)
 endif()
 find_package(BZip2)
 find_package(nlohmann_json 3.9.1 REQUIRED)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -823,12 +823,7 @@ endif()
 #######################################
 if(MIOPEN_ENABLE_SQLITE)
     # MIOpen depends on SQLite
-    target_include_directories(MIOpen SYSTEM PRIVATE ${SQLITE3_STATIC_INCLUDE_DIRS})
-    target_include_directories(MIOpen SYSTEM INTERFACE $<BUILD_INTERFACE:${SQLITE3_STATIC_INCLUDE_DIRS}>)
-    target_compile_options(MIOpen PRIVATE ${SQLITE3_STATIC_CFLAGS})
-    target_compile_options(MIOpen INTERFACE $<BUILD_INTERFACE:${SQLITE3_STATIC_CFLAGS}>)
-    target_link_libraries(MIOpen PRIVATE ${SQLITE3_STATIC_LDFLAGS})
-    target_link_libraries(MIOpen INTERFACE $<BUILD_INTERFACE:${SQLITE3_STATIC_LDFLAGS}>)
+    target_link_libraries(MIOpen PRIVATE SQLite::SQLite3)
 endif()
 ############################################################
 # MIOpen depends on librt for Boost.Interprocess

--- a/src/sqlite/CMakeLists.txt
+++ b/src/sqlite/CMakeLists.txt
@@ -34,7 +34,7 @@ target_compile_options(sqlite_memvfs PRIVATE
         $<$<CXX_COMPILER_ID:Clang>:-Wno-everything>
         $<$<CXX_COMPILER_ID:GNU>:-w>)
 
-target_include_directories(sqlite_memvfs SYSTEM PRIVATE ${SQLITE3_STATIC_INCLUDE_DIRS})
+target_link_libraries(sqlite_memvfs PRIVATE SQLite::SQLite3)
 # set_target_properties(
 #     sqlite_memvfs
 #     PROPERTIES


### PR DESCRIPTION
The utility `pkg-config` is not available on Windows. However, CMake provides a module for searching and configuring SQLite3. The PR is changing from `pkg-config` to `find_package()` for Windows and Linux.