### PR TITLE
fix compilation of math functions on Windows

### DIFF
--- a/src/include/miopen/float_equal.hpp
+++ b/src/include/miopen/float_equal.hpp
@@ -41,7 +41,11 @@ struct float_equal_fn
     template <class T>
     static bool apply(T x, T y)
     {
-        return std::isfinite(x) and std::isfinite(y) and
+        // The standard library from MSVC does not implement std::isfinite() for integer
+        // types - no additional overloads are provided. According to the documentation,
+        // integer types should be treaded as doubles.
+        // Refer to https://en.cppreference.com/w/cpp/numeric/math/isfinite for more information.
+        return std::isfinite(static_cast<double>(x)) and std::isfinite(static_cast<double>(y)) and
                std::nextafter(x, std::numeric_limits<T>::lowest()) <= y and
                std::nextafter(x, std::numeric_limits<T>::max()) >= y;
     }

--- a/test/rnn_vanilla_common.hpp
+++ b/test/rnn_vanilla_common.hpp
@@ -540,8 +540,15 @@ void RNNFwdTrainCPUVerify(miopen::Handle& handle,
     {
         for(int h = 0; h < out_h; h++)
         {
-            assert(!std::isnan(rsvspace.at(prelayer_shift + bs * hy_stride + h)));
-            assert(!std::isinf(rsvspace.at(prelayer_shift + bs * hy_stride + h)));
+            // The standard library from MSVC does not implement std::fpclassify() for integer
+            // types - no additional overloads are provided. According to the documentation,
+            // integer types should be treaded as doubles.
+            // Refer to https://en.cppreference.com/w/cpp/numeric/math/fpclassify for more details.
+            // The functions std::isnan() and std::isinf() are using stg::fpclassify() internally.
+            assert(
+                !std::isnan(static_cast<double>(rsvspace.at(prelayer_shift + bs * hy_stride + h))));
+            assert(
+                !std::isinf(static_cast<double>(rsvspace.at(prelayer_shift + bs * hy_stride + h))));
             out_host.at(bs * out_stride + h) = rsvspace.at(prelayer_shift + bs * hy_stride + h);
             //  printf("out_host[%d]: %f\n", bs * out_stride + h, out_host.at(bs * out_stride + h));
         }

--- a/test/verify.hpp
+++ b/test/verify.hpp
@@ -82,8 +82,11 @@ struct not_finite_fn
     template <class T>
     bool operator()(T x) const
     {
-        using std::isfinite;
-        return not isfinite(x);
+        // The standard library from MSVC does not implement std::isfinite() for integer
+        // types - no additional overloads are provided. According to the documentation,
+        // integer types should be treaded as doubles.
+        // Refer to https://en.cppreference.com/w/cpp/numeric/math/isfinite for more information.
+        return not std::isfinite(static_cast<double>(x));
     }
 };
 static constexpr not_finite_fn not_finite{};


### PR DESCRIPTION
A few more fixes because MSVC does not implement `std::infinite()` and `std::fpclassify()` for integer types.