### PR TITLE
enable compilation on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -259,6 +259,10 @@ if(MIOPEN_hip_VERSION VERSION_GREATER_EQUAL 5.7.23302)
     string(APPEND HIP_COMPILER_FLAGS " -fno-offload-uniform-block ")
 endif()
 
+if(WIN32)
+    string(REPLACE "\\" "/" HIP_COMPILER_FLAGS "${HIP_COMPILER_FLAGS}")
+endif()
+
 message(STATUS "Hip compiler flags: ${HIP_COMPILER_FLAGS}")
 
 add_compile_definitions($<$<COMPILE_LANGUAGE:CXX>:HIP_COMPILER_FLAGS=${HIP_COMPILER_FLAGS}>)
@@ -309,7 +313,7 @@ endif()
 message( STATUS "${MIOPEN_BACKEND} backend selected." )
 
 # look for and register clang-offload-bundler
-if(MIOPEN_HIP_COMPILER MATCHES ".*clang\\+\\+$")
+if(MIOPEN_HIP_COMPILER MATCHES ".*clang\\+\\+.*")
     find_program(MIOPEN_OFFLOADBUNDLER_BIN clang-offload-bundler
         PATH_SUFFIXES bin
         PATHS
@@ -376,9 +380,11 @@ endif()
 if(MIOPEN_USE_HIPRTC)
     if(NOT MIOPEN_USE_COMGR)
         message(FATAL_ERROR "HIPRTC can be used only together with COMGR")
-    else()
-        message(STATUS "Build with HIPRTC")
     endif()
+    if(WIN32)
+        find_package(hiprtc REQUIRED)
+    endif()
+    message(STATUS "Build with HIPRTC")
 endif()
 
 option(Boost_USE_STATIC_LIBS "Use boost static libraries" ON)

--- a/driver/CMakeLists.txt
+++ b/driver/CMakeLists.txt
@@ -27,6 +27,10 @@
 find_package(Threads REQUIRED)
 
 add_executable(MIOpenDriver main.cpp InputFlags.cpp)
+if(WIN32)
+    # Refer to https://en.cppreference.com/w/cpp/language/types for details.
+    target_compile_options(MIOpenDriver PRIVATE $<BUILD_INTERFACE:$<$<CXX_COMPILER_ID:Clang>:-U__LP64__>>)
+endif()
 target_include_directories(MIOpenDriver PRIVATE ../src/kernels)
 target_link_libraries(MIOpenDriver MIOpen Threads::Threads)
 if(NOT MIOPEN_EMBED_DB STREQUAL "")

--- a/speedtests/sequences.cpp
+++ b/speedtests/sequences.cpp
@@ -174,8 +174,13 @@ struct BoostSequence
 {
     using value_type     = TValue;
     using const_iterator = const TValue*;
+#ifdef _MSC_VER
+    constexpr const_iterator begin() const { return arr.begin()._Unwrapped(); }
+    constexpr const_iterator end() const { return arr.end()._Unwrapped(); }
+#else
     constexpr const_iterator begin() const { return arr.begin(); }
     constexpr const_iterator end() const { return arr.end(); }
+#endif
 
 private:
     static constexpr std::size_t count                         = sizeof...(values);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -708,12 +708,26 @@ if(MIOPEN_USE_COMPOSABLEKERNEL)
 set(MIOPEN_CK_LINK_FLAGS composable_kernel::device_other_operations composable_kernel::device_gemm_operations composable_kernel::device_conv_operations composable_kernel::device_contraction_operations composable_kernel::device_reduction_operations hip::host)
 endif()
 
+if(WIN32)
+    # Refer to https://en.cppreference.com/w/cpp/language/types for details.
+    target_compile_options(MIOpen PRIVATE $<BUILD_INTERFACE:$<$<CXX_COMPILER_ID:Clang>:-U__LP64__>>)
+endif()
+
 target_include_directories(MIOpen SYSTEM PUBLIC $<BUILD_INTERFACE:${HALF_INCLUDE_DIR}>)
 target_include_directories(MIOpen SYSTEM PRIVATE ${BZIP2_INCLUDE_DIR})
 # Workaround : change in rocm-cmake was causing linking error so had to add ${CMAKE_DL_LIBS} 
 #               We can remove ${CMAKE_DL_LIBS} once root cause is identified.
 target_link_libraries(MIOpen PRIVATE ${CMAKE_DL_LIBS} Threads::Threads ${BZIP2_LIBRARIES} ${MIOPEN_CK_LINK_FLAGS})
 miopen_generate_export_header(MIOpen)
+
+if(BUILD_TESTING)
+    # On Windows, export all symbols only when tests are built, too.
+    # The officially released binaries must not have internals exposed
+    # because it violates threat model requirements.
+    # The property applies only to MS-compatible tools on Windows, and
+    # is ignored for the rest.
+    set_target_properties(MIOpen PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
+endif()
 
 if(MIOPEN_ENABLE_AI_KERNEL_TUNING OR MIOPEN_ENABLE_AI_IMMED_MODE_FALLBACK)
         find_path(FDEEP_INCLUDE_DIR "fdeep/fdeep.hpp")
@@ -762,6 +776,9 @@ if( MIOPEN_BACKEND STREQUAL "OpenCL")
 elseif(MIOPEN_BACKEND STREQUAL "HIPOC" OR MIOPEN_BACKEND STREQUAL "HIP")
     target_link_libraries( MIOpen PRIVATE hip::device )
     target_link_libraries( MIOpen INTERFACE hip::host )
+    if(MIOPEN_USE_HIPRTC AND WIN32)
+        target_link_libraries( MIOpen PRIVATE hiprtc::hiprtc )
+    endif()
     if(ENABLE_HIP_WORKAROUNDS)
         # Workaround hip not setting its usage requirements correctly
         target_compile_definitions( MIOpen PRIVATE -D__HIP_PLATFORM_HCC__=1 )

--- a/src/hipoc/hipoc_program.cpp
+++ b/src/hipoc/hipoc_program.cpp
@@ -45,7 +45,9 @@
 #include <mutex>
 #include <sstream>
 
+#if defined(__linux__)
 #include <unistd.h>
+#endif
 
 /// 0 or undef or wrong - auto-detect
 /// 1 - <blank> / "-Xclang -target-feature -Xclang +code-object-v3"

--- a/src/include/miopen/type_name.hpp
+++ b/src/include/miopen/type_name.hpp
@@ -35,7 +35,7 @@ template <class MIOpen_Private_TypeName_>
 const std::string& get_type_name()
 {
     static const std::string ret =
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && !defined(__clang__)
         typeid(MIOpen_Private_TypeName_).name().substr(7);
 #else
         [](std::string name) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -321,6 +321,9 @@ separate_arguments(MIOPEN_TEST_FLAGS_ARGS NATIVE_COMMAND ${MIOPEN_TEST_FLAGS})
 
 function(add_test_executable TEST_NAME)
     add_executable (${TEST_NAME} EXCLUDE_FROM_ALL ${ARGN})
+    if(WIN32)
+        target_compile_definitions(${TEST_NAME} PRIVATE NOMINMAX)
+    endif()
     clang_tidy_check(${TEST_NAME})
     target_link_libraries(${TEST_NAME} Threads::Threads)
     # Cmake does not add flags correctly for gcc
@@ -360,7 +363,11 @@ function(add_test_executable TEST_NAME)
         target_link_libraries(${TEST_NAME} MIOpen)
     endif()
     target_include_directories(${TEST_NAME} PRIVATE ../src/kernels)
-endfunction(add_test_executable)
+    if(WIN32)
+        # Refer to https://en.cppreference.com/w/cpp/language/types for details.
+        target_compile_options(${TEST_NAME} PRIVATE $<BUILD_INTERFACE:$<$<CXX_COMPILER_ID:Clang>:-U__LP64__>>)
+    endif()
+endfunction()
 
 set(MIOPEN_TEST_SANITIZERS)
 foreach(SANTIZER address thread)

--- a/test/find_db.cpp
+++ b/test/find_db.cpp
@@ -37,7 +37,12 @@
 #include <miopen/hip_build_utils.hpp>
 
 #include <chrono>
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+#else
 #include <cstdlib>
+#endif
 #include <functional>
 
 namespace miopen {
@@ -232,8 +237,14 @@ private:
 
 int main(int argc, const char* argv[])
 {
+#ifdef _WIN32
+    SetEnvironmentVariable("MIOPEN_LOG_LEVEL", "6");
+    SetEnvironmentVariable("MIOPEN_COMPILE_PARALLEL_LEVEL", "1");
+    SetEnvironmentVariable("MIOPEN_ENABLE_LOGGING_ELAPSED_TIME", "1");
+#else
     setenv("MIOPEN_LOG_LEVEL", "6", 1);                   // NOLINT (concurrency-mt-unsafe)
     setenv("MIOPEN_COMPILE_PARALLEL_LEVEL", "1", 1);      // NOLINT (concurrency-mt-unsafe)
     setenv("MIOPEN_ENABLE_LOGGING_ELAPSED_TIME", "1", 1); // NOLINT (concurrency-mt-unsafe)
+#endif
     test_drive<miopen::FindDbTest>(argc, argv);
 }

--- a/test/gtest/CMakeLists.txt
+++ b/test/gtest/CMakeLists.txt
@@ -1,10 +1,4 @@
-find_package(GTest CONFIG REQUIRED)
-if(GTest_FOUND)
-  MESSAGE(STATUS "GoogleTest: " ${GTest})
-  enable_testing()
-  include(GoogleTest)
-endif()
-
+find_package(GTest REQUIRED)
 find_package(rocblas)
 
 set(SOURCES
@@ -20,6 +14,9 @@ function(add_gtest TEST_NAME)
   if( NOT (TEST_NAME IN_LIST SKIP_TESTS))
     message("Adding Test: " ${TEST_NAME})
     add_executable(test_${TEST_NAME} ${TEST_NAME}.cpp  ${SOURCES})
+    if(WIN32)
+      target_compile_definitions(test_${TEST_NAME} PRIVATE NOMINMAX)
+    endif()
     add_dependencies(tests test_${TEST_NAME})
     add_dependencies(check test_${TEST_NAME})
     target_compile_options(test_${TEST_NAME} PRIVATE -Wno-global-constructors -Wno-undef)
@@ -32,9 +29,15 @@ function(add_gtest TEST_NAME)
     if(NOT MIOPEN_EMBED_DB STREQUAL "")
         target_link_libraries(test_${TEST_NAME} $<BUILD_INTERFACE:miopen_data>)
     endif()
-    # Enable CMake to discover the test binary
-    gtest_discover_tests(test_${TEST_NAME} PROPERTIES ENVIRONMENT "MIOPEN_USER_DB_PATH=${CMAKE_CURRENT_BINARY_DIR};MIOPEN_TEST_FLOAT_ARG=${MIOPEN_TEST_FLOAT_ARG};MIOPEN_TEST_ALL=${MIOPEN_TEST_ALL};MIOPEN_TEST_MLIR=${MIOPEN_TEST_MLIR};MIOPEN_TEST_COMPOSABLEKERNEL=${MIOPEN_TEST_COMPOSABLEKERNEL}")
+    if(NOT WIN32) # TODO: cannot run on Windows due to missing DLL dependencies
+      # Enable CMake to discover the test binary
+      gtest_discover_tests(test_${TEST_NAME} PROPERTIES ENVIRONMENT "MIOPEN_USER_DB_PATH=${CMAKE_CURRENT_BINARY_DIR};MIOPEN_TEST_FLOAT_ARG=${MIOPEN_TEST_FLOAT_ARG};MIOPEN_TEST_ALL=${MIOPEN_TEST_ALL};MIOPEN_TEST_MLIR=${MIOPEN_TEST_MLIR};MIOPEN_TEST_COMPOSABLEKERNEL=${MIOPEN_TEST_COMPOSABLEKERNEL}")
+    endif()
 
+    if(WIN32)
+      # Refer to https://en.cppreference.com/w/cpp/language/types for details.
+      target_compile_options(test_${TEST_NAME} PRIVATE $<BUILD_INTERFACE:$<$<CXX_COMPILER_ID:Clang>:-U__LP64__>>)
+    endif()
   endif()
 endfunction()
 

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -24,7 +24,7 @@
 # 
 ################################################################################
 
-if( NOT ENABLE_ASAN_PACKAGING )
+if( NOT ENABLE_ASAN_PACKAGING AND NOT WIN32 )
   install(FILES install_precompiled_kernels.sh
       PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
       DESTINATION ${CMAKE_INSTALL_BINDIR})


### PR DESCRIPTION
This is the semi-final PR enabling compilation on Windows. The prerequisites (dependency projects from requirements.txt) must be compiled and built separately. This PR also needs all the other Windows PRs submitted to be merged first.
One more PR will be submitted soon to introduce a "one-click" compilation from a single CMake file. That includes MIOpen and dependency projects, too.