### PR TITLE
Patch necessary to make FP8 convolution compile with hiprtc

### DIFF
--- a/src/kernels/MIOpenCheckNumerics.cpp
+++ b/src/kernels/MIOpenCheckNumerics.cpp
@@ -68,9 +68,9 @@ using conditional_t = typename conditional<predicate, X, Y>::type;
 #include <cstdint> // int8_t, int16_t
 #include <cmath>   // float_t
 #endif
-#endif // __HIPCC_RTC__
-
+#else              // __HIPCC_RTC__
 #include <limits> // std::numeric_limits
+#endif // __HIPCC_RTC__
 
 #define MIOPEN_ENABLE_F8_DEVICE_CODE 1
 #include "hip_float8.hpp"

--- a/src/kernels/MIOpenCheckNumerics.cpp
+++ b/src/kernels/MIOpenCheckNumerics.cpp
@@ -68,9 +68,9 @@ using conditional_t = typename conditional<predicate, X, Y>::type;
 #include <cstdint> // int8_t, int16_t
 #include <cmath>   // float_t
 #endif
-#else              // __HIPCC_RTC__
-#include <limits> // std::numeric_limits
 #endif // __HIPCC_RTC__
+
+#include <limits> // std::numeric_limits
 
 #define MIOPEN_ENABLE_F8_DEVICE_CODE 1
 #include "hip_float8.hpp"

--- a/src/kernels/gpu_reference_kernel/fp8_naive_conv.cpp
+++ b/src/kernels/gpu_reference_kernel/fp8_naive_conv.cpp
@@ -63,14 +63,35 @@ struct conditional<false, X, Y>
 
 template <bool predicate, typename X, typename Y>
 using conditional_t = typename conditional<predicate, X, Y>::type;
+
+template <class T, T V>
+struct integral_constant
+{
+    static constexpr T value = V;
+    using value_type         = T;
+    using type               = integral_constant;
+    constexpr operator value_type() const noexcept { return value; }
+    constexpr value_type operator()() const noexcept { return value; }
+    static constexpr type to() { return {}; }
+};
+
+template <bool B>
+using bool_constant = integral_constant<bool, B>;
+
+template <class T, class U>
+struct is_same : bool_constant<__is_same(T, U)>
+{
+}
+
 } // namespace std
+
 #else
 #include <cstdint> // int8_t, int16_t
 #include <cmath>   // float_t
 #endif
+#else              // __HIPCC_RTC__
+#include <limits>
 #endif // __HIPCC_RTC__
-
-#include <limits> // std::numeric_limits
 
 #define MIOPEN_ENABLE_F8_DEVICE_CODE 1
 #include "hip_float8.hpp"

--- a/src/kernels/gpu_reference_kernel/fp8_naive_conv.cpp
+++ b/src/kernels/gpu_reference_kernel/fp8_naive_conv.cpp
@@ -70,7 +70,7 @@ using conditional_t = typename conditional<predicate, X, Y>::type;
 #include <cstdint> // int8_t, int16_t
 #include <cmath>   // float_t
 #endif
-#else              // __HIPCC_RTC__
+#else // __HIPCC_RTC__
 #include <limits>
 #endif // __HIPCC_RTC__
 

--- a/src/kernels/gpu_reference_kernel/fp8_naive_conv.cpp
+++ b/src/kernels/gpu_reference_kernel/fp8_naive_conv.cpp
@@ -64,25 +64,6 @@ struct conditional<false, X, Y>
 template <bool predicate, typename X, typename Y>
 using conditional_t = typename conditional<predicate, X, Y>::type;
 
-template <class T, T V>
-struct integral_constant
-{
-    static constexpr T value = V;
-    using value_type         = T;
-    using type               = integral_constant;
-    constexpr operator value_type() const noexcept { return value; }
-    constexpr value_type operator()() const noexcept { return value; }
-    static constexpr type to() { return {}; }
-};
-
-template <bool B>
-using bool_constant = integral_constant<bool, B>;
-
-template <class T, class U>
-struct is_same : bool_constant<__is_same(T, U)>
-{
-}
-
 } // namespace std
 
 #else

--- a/src/kernels/hip_f8_impl.hpp
+++ b/src/kernels/hip_f8_impl.hpp
@@ -87,8 +87,8 @@ MIOPEN_HIP_HOST_DEVICE uint8_t cast_to_f8_no_range_reduce(T _x,
 template <int wm, int we, typename T, bool negative_zero_nan, bool clip>
 MIOPEN_HIP_HOST_DEVICE uint8_t cast_to_f8(T _x, bool stoch, uint32_t rng)
 {
-    constexpr bool is_half  = std::is_same<T, half>::value;
-    constexpr bool is_float = std::is_same<T, float>::value;
+    constexpr bool is_half  = __is_same_as(T, half);
+    constexpr bool is_float = __is_same_as(T, float);
     static_assert(wm + we == 7, "wm+we==7");
     static_assert(is_half || is_float, "Only half and float can be cast to f8");
 
@@ -272,8 +272,8 @@ MIOPEN_HIP_HOST_DEVICE uint8_t cast_to_f8(T _x, bool stoch, uint32_t rng)
 template <int wm, int we, typename T, bool negative_zero_nan>
 MIOPEN_HIP_HOST_DEVICE T cast_from_f8(uint8_t x)
 {
-    constexpr bool is_half  = std::is_same<T, half>::value;
-    constexpr bool is_float = std::is_same<T, float>::value;
+    constexpr bool is_half  = __is_same_as(T, half);
+    constexpr bool is_float = __is_same_as(T, float);
     static_assert(is_half || is_float, "only half and float are supported");
 
     constexpr int weo = is_half ? 5 : 8;

--- a/src/kernels/hip_float8.hpp
+++ b/src/kernels/hip_float8.hpp
@@ -83,6 +83,9 @@ inline MIOPEN_HIP_HOST_DEVICE bool get_hip_f8_bias_mode()
 #endif
 }
 
+template <typename T>
+class numeric_limits;
+
 template <hip_f8_type T>
 struct hip_f8
 {
@@ -262,8 +265,7 @@ struct hip_f8
 
     inline MIOPEN_HIP_HOST_DEVICE bool operator==(const hip_f8& rhs) const
     {
-        if((rhs.is_zero() && this->is_zero()) ||
-           (fabs(rhs - *this) < std::numeric_limits<hip_f8<T>>::epsilon()))
+        if((rhs.is_zero() && this->is_zero()) || (this->data == rhs.data))
         {
             return true;
         }
@@ -487,19 +489,6 @@ MIOPEN_HIP_HOST_DEVICE T F8_Max()
     x.bits = 0x7F;
     return x.value;
 }
-} // namespace miopen_f8
-
-// define numeric limits for the new data type
-namespace std {
-inline bool isfinite(miopen_f8::hip_f8<miopen_f8::hip_f8_type::fp8> x) // NOLINT
-{
-    return x.is_inf();
-}
-
-inline bool isfinite(miopen_f8::hip_f8<miopen_f8::hip_f8_type::bf8> x) // NOLINT
-{
-    return x.is_inf();
-}
 
 template <>
 class numeric_limits<miopen_f8::hip_f8<miopen_f8::hip_f8_type::fp8>>
@@ -555,7 +544,44 @@ public:
     }
 };
 
+} // namespace miopen_f8
+
+#ifndef __HIPCC_RTC__
+namespace std {
+inline bool isfinite(miopen_f8::hip_f8<miopen_f8::hip_f8_type::fp8> x) // NOLINT
+{
+    return x.is_inf();
+}
+
+inline bool isfinite(miopen_f8::hip_f8<miopen_f8::hip_f8_type::bf8> x) // NOLINT
+{
+    return x.is_inf();
+}
+
+inline bool isnan(miopen_f8::hip_f8<miopen_f8::hip_f8_type::fp8> x) // NOLINT
+{
+    return x.is_nan();
+}
+
+inline bool isnan(miopen_f8::hip_f8<miopen_f8::hip_f8_type::bf8> x) // NOLINT
+{
+    return x.is_nan();
+}
+
+template <>
+class numeric_limits<miopen_f8::hip_f8<miopen_f8::hip_f8_type::fp8>>
+    : public miopen_f8::numeric_limits<miopen_f8::hip_f8<miopen_f8::hip_f8_type::fp8>>
+{
+};
+
+template <>
+class numeric_limits<miopen_f8::hip_f8<miopen_f8::hip_f8_type::bf8>>
+    : public miopen_f8::numeric_limits<miopen_f8::hip_f8<miopen_f8::hip_f8_type::bf8>>
+{
+};
+
 } // namespace std
+#endif
 
 template <miopen_f8::hip_f8_type T>
 struct hip_f8x4


### PR DESCRIPTION
With this set of minimal changes, compilation succeeds without running into `__ptrdiff_t` problem when using hiprtc. 

Testing:
Ran  fp8e4m3fnuz (F8 with FNUZ) convoltion verification tests inside MIGraphX that calls into MIOpen for convolution on MI300., with mainline builds.
 
It passes verification tests. Two of the verification tests are flaky though. They sometime pass, sometime don't.  Those tests always pass with rocMLIR so there could potentially be a bug in MIOpen. Identifying problem and putting fix for it is not motive of this PR though.  This PR is mainly to fix compilation problem. 

Running `make check` on MIOpen fails some tests with same `__ptrdiff_t` problem though because some other testing files are still including `limits`.  Failed tests are same as failed tests on `develop` branch on MI300. 

for example : https://github.com/ROCmSoftwarePlatform/MIOpen/blob/762ae81872fa06f925860bce7158fa912e0b0e3b/src/kernels/MIOpenCheckNumerics.cpp#L73 

https://github.com/ROCmSoftwarePlatform/MIOpen/blob/762ae81872fa06f925860bce7158fa912e0b0e3b/src/composable_kernel/composable_kernel/include/utility/data_type.hpp#L14


```
	The following tests FAILED:
	          9 - test_check_numerics_test (Failed)
	         42 - test_reduce_test (Failed)
	        796 - ConvBwdTest/ConvBwdSolverTestF8.CKConvF8Bwd/(5,  G:1 N:16 C:16 D:1 H:14 W:14 k:16 z:1 y:3 x:3 pad_z:0 pad_y:1 pad_x:1 stride_z:1 stride_y:1 stride_x:1 dilation_z:1 dilation_y:1 dilation_x:1 conv_mode:0, 8) (Failed)
	        808 - DUMP_TENSOR_TEST.testDump_NAN_float (Failed)
	        810 - DUMP_TENSOR_TEST.testDump_NAN_half_float (Failed)
        812 - DUMP_TENSOR_TEST.testDump_NAN_bfloat16 (Failed)
```

Fixes for those should come later as some other PR.
