### PR TITLE
Fix build with disabled CK (after #2523)

### DIFF
--- a/src/solver/conv_hip_implicit_gemm_f16f8f16_fwd_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_f16f8f16_fwd_xdlops.cpp
@@ -44,11 +44,12 @@ namespace miopen {
 namespace solver {
 namespace conv {
 
-using d_type             = ck::half_t;
-using c_type             = ck::f8_t;
 using ProblemDescription = miopen::conv::ProblemDescription;
 
 #if MIOPEN_USE_COMPOSABLEKERNEL
+using d_type = ck::half_t;
+using c_type = ck::f8_t;
+
 template <typename DataType, typename ComputeType>
 using DeviceOpF8Fwd = ck::tensor_operation::device::DeviceGroupedConvFwdMultipleABD<
     3,

--- a/src/solver/conv_hip_implicit_gemm_grouped_fwd_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_grouped_fwd_xdlops.cpp
@@ -339,7 +339,7 @@ void PerformanceConfigHipImplicitGemmGroupFwdXdlops::HeuristicInit(
 
 bool PerformanceConfigHipImplicitGemmGroupFwdXdlops::SetNextValue(const ProblemDescription& problem)
 {
-#if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
+#if MIOPEN_USE_COMPOSABLEKERNEL
     if(valid_kernels.empty())
     {
         switch(problem.GetInDataType())

--- a/src/solver/conv_hip_implicit_gemm_grouped_fwd_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_grouped_fwd_xdlops.cpp
@@ -191,7 +191,6 @@ bool ConvHipImplicitGemmGroupFwdXdlops::CheckCKApplicability(
 {
     return IsCKApplicable<DeviceOpGFwdPtrs<DataType>, CKArgs>(problem);
 }
-#endif
 
 #if MIOPEN_ENABLE_AI_KERNEL_TUNING
 static std::vector<std::string> GetKernelAsTokens(const std::string& kernel)
@@ -285,7 +284,8 @@ bool PerformanceConfigHipImplicitGemmGroupFwdXdlops::RunParameterPredictionModel
     }
     return false;
 }
-#endif
+#endif // MIOPEN_ENABLE_AI_KERNEL_TUNING
+#endif // MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
 
 bool PerformanceConfigHipImplicitGemmGroupFwdXdlops::IsModelApplicable(
     const ExecutionContext& ctx, const ProblemDescription& problem) const
@@ -339,6 +339,7 @@ void PerformanceConfigHipImplicitGemmGroupFwdXdlops::HeuristicInit(
 
 bool PerformanceConfigHipImplicitGemmGroupFwdXdlops::SetNextValue(const ProblemDescription& problem)
 {
+#if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
     if(valid_kernels.empty())
     {
         switch(problem.GetInDataType())
@@ -362,6 +363,7 @@ bool PerformanceConfigHipImplicitGemmGroupFwdXdlops::SetNextValue(const ProblemD
         return true;
     }
     else
+#endif
         return false;
 }
 


### PR DESCRIPTION
Properly guard CK usage by MIOPEN_USE_COMPOSABLEKERNEL defines.
Fixes windows build and any othe builds without CK support.  (fix for #2523)