### PR TITLE
[HOTFIX] Fix build with -DMIOPEN_USE_COMPOSABLEKERNEL=Off after #2517.

### DIFF
--- a/src/solver/conv_ck_igemm_fwd_bias_res_add_activ_fused.cpp
+++ b/src/solver/conv_ck_igemm_fwd_bias_res_add_activ_fused.cpp
@@ -46,6 +46,8 @@ namespace miopen {
 namespace solver {
 namespace fusion {
 
+#if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
+
 using CK_OutLayout = ck::tensor_layout::convolution::NDHWGK;
 
 // DataType also applies to weights
@@ -67,7 +69,6 @@ using DeviceOp = ck::tensor_operation::device::instance::DeviceOperationInstance
         ck::tensor_operation::element_wise::
             ScaleAddScaleAddRelu>>; // end DeviceOperationInstanceFactory
 
-#if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
 namespace {
 
 struct CKArgs


### PR DESCRIPTION
Resolves https://github.com/ROCm/MIOpen/pull/2517#issuecomment-1865244958.

----
[Attribution] @junliume @JehandadKhan
- https://github.com/ROCm/MIOpen/labels/bug
- https://github.com/ROCm/MIOpen/labels/urgency_blocker
- Proposed reviewers:
  - @junliume
  - @amberhassaan 