### PR TITLE
[ROCm 6.0.1] Automatically activate the new HIPRTC PCH adaptations starting from the 6.0.24000 version. Fix some build errors.

### DIFF
--- a/src/kernels/MIOpenLayerNorm.cpp
+++ b/src/kernels/MIOpenLayerNorm.cpp
@@ -28,6 +28,12 @@
 #include <hip/hip_runtime.h>
 #endif
 
+#ifndef MIOPEN_DONT_USE_HIP_RUNTIME_HEADERS
+#include <hip/hip_fp16.h>
+#include <hip/hip_runtime.h>
+#endif
+
+#include "miopen_cstdint.hpp"
 #include "float_types.h"
 
 #if MIOPEN_USE_BFP16 == 1

--- a/src/kernels/MIOpenLayerNorm.cpp
+++ b/src/kernels/MIOpenLayerNorm.cpp
@@ -28,11 +28,6 @@
 #include <hip/hip_runtime.h>
 #endif
 
-#ifndef MIOPEN_DONT_USE_HIP_RUNTIME_HEADERS
-#include <hip/hip_fp16.h>
-#include <hip/hip_runtime.h>
-#endif
-
 #include "miopen_cstdint.hpp"
 #include "float_types.h"
 

--- a/src/kernels/miopen_cstdint.hpp
+++ b/src/kernels/miopen_cstdint.hpp
@@ -30,7 +30,7 @@ typedef signed char int8_t;
 typedef unsigned char uint8_t;
 typedef signed short int16_t;
 typedef unsigned short uint16_t;
-#if HIP_PACKAGE_VERSION_FLAT >= 6001000000ULL
+#if HIP_PACKAGE_VERSION_FLAT >= 6000024000ULL
 typedef signed int int32_t;
 typedef unsigned int uint32_t;
 typedef __hip_internal::uint64_t uint64_t;

--- a/src/kernels/miopen_type_traits.hpp
+++ b/src/kernels/miopen_type_traits.hpp
@@ -76,7 +76,7 @@ struct remove_cv
     typedef typename remove_volatile<typename remove_const<T>::type>::type type;
 };
 
-#if HIP_PACKAGE_VERSION_FLAT >= 6001000000ULL
+#if HIP_PACKAGE_VERSION_FLAT >= 6000024000ULL
 template <class T, T v>
 struct integral_constant
 {

--- a/src/kernels/static_composable_kernel/include/utility/static_kernel_config.hpp
+++ b/src/kernels/static_composable_kernel/include/utility/static_kernel_config.hpp
@@ -5,6 +5,7 @@
 #include "hip/hip_runtime.h"
 #include "hip/hip_fp16.h"
 #endif
+#include "miopen_cstdint.hpp"
 #include "bfloat16_dev.hpp"
 
 // index type: unsigned or signed


### PR DESCRIPTION
_Cherry picked from commit 4f695d975a2a6de2f167fc2925f3bad79fbaaf98 (see PR #2641)._

Expected to maintain compatibility with ROCm 6.0.1 (which is important for Staging/Mainline testing and future releases)

## :cyclone: Testing

- Navi21 (gfx1030/36), Ubuntu 20.04.5 LTS
- Docker images:
  - `rocm/miopen:hiprtc` (6.1 RC) with `-DMIOPEN_OVERRIDE_HIP_VERSION_PATCH=2400`
  - `rocm/miopen:ci_d868bf` (6.0)
- `-DMIOPEN_TEST_ALL=Off -DBUILD_DEV=On` (Smoke testing)
- Release builds, offline compiler.
- Tested datatypes: FLOAT, HALF, BFLOAT16, INT8

🟢 NO FAILURES