### PR TITLE
Fix COMgr dependency in MIOpen package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -375,7 +375,7 @@ message(STATUS "AMDGCN assembler: ${MIOPEN_AMDGCN_ASSEMBLER}")
 if(MIOPEN_USE_COMGR)
     find_package(amd_comgr REQUIRED CONFIG)
     message(STATUS "Build with comgr ${amd_comgr_VERSION}")
-    set(MIOPEN_PACKAGE_REQS "${MIOPEN_PACKAGE_REQS}, amd_comgr")
+    set(MIOPEN_PACKAGE_REQS "${MIOPEN_PACKAGE_REQS}, comgr")
 endif()
 
 if(MIOPEN_USE_HIPRTC)


### PR DESCRIPTION
Fix the following issue caused by #2508 :
```
Error snippet:

+ apt install -y rocblas rocblas-dev miopen-hip miopen-hip-dev
[2023-12-28T16:56:01.407Z] 
[2023-12-28T16:56:01.407Z] WARNING: apt does not have a stable CLI interface. Use with caution in scripts.
[2023-12-28T16:56:01.407Z] 
[2023-12-28T16:56:02.387Z] Reading package lists...
[2023-12-28T16:56:02.387Z] Building dependency tree...
[2023-12-28T16:56:02.387Z] Reading state information...
[2023-12-28T16:56:02.659Z] Some packages could not be installed. This may mean that you have
[2023-12-28T16:56:02.659Z] requested an impossible situation or if you are using the unstable
[2023-12-28T16:56:02.659Z] distribution that some required packages have not yet been created
[2023-12-28T16:56:02.659Z] or been moved out of Incoming.
[2023-12-28T16:56:02.659Z] The following information may help to resolve the situation:
[2023-12-28T16:56:02.659Z] 
[2023-12-28T16:56:02.659Z] The following packages have unmet dependencies:
[2023-12-28T16:56:02.659Z]  miopen-hip : Depends: amd_comgr but it is not installable
[2023-12-28T16:56:02.659Z] E: Unable to correct problems, you have held broken packages.
```

After the fix:
```
Depends: hip-rocclr, comgr, roctracer, rocblas, rocm-core
```