### PR TITLE
[HOTFIX] Adapt to changes in HIP Mainline 417 (possibly future 6.1 RC)

### DIFF
--- a/src/comgr.cpp
+++ b/src/comgr.cpp
@@ -1302,10 +1302,9 @@ void BuildHip(const std::string& name,
 #endif
         opts.push_back("-DHIP_PACKAGE_VERSION_FLAT=" + std::to_string(HIP_PACKAGE_VERSION_FLAT));
         opts.push_back("-DMIOPEN_DONT_USE_HIP_RUNTIME_HEADERS");
-        /// For now, use only standard <limits> to avoid possibility of
-        /// correctnes or performance regressions.
-        /// \todo Test and enable "custom" local implementation.
+#if HIP_PACKAGE_VERSION_FLAT < 6001024000ULL
         opts.push_back("-DWORKAROUND_DONT_USE_CUSTOM_LIMITS=1");
+#endif
 #if WORKAROUND_ISSUE_1431
         if((StartsWith(target.Name(), "gfx10") || StartsWith(target.Name(), "gfx11")) &&
            !miopen::comgr::IsWave64Enforced(opts))

--- a/src/kernel_warnings.cpp
+++ b/src/kernel_warnings.cpp
@@ -23,10 +23,11 @@
  * SOFTWARE.
  *
  *******************************************************************************/
-#include <iterator>
 #include <miopen/config.h>
 #include <miopen/kernel_warnings.hpp>
 #include <miopen/stringutils.hpp>
+
+#include <iterator>
 #include <numeric>
 #include <sstream>
 
@@ -48,6 +49,9 @@ static std::vector<std::string> OclKernelWarnings()
         "-Wno-shorten-64-to-32",
         "-Wno-sign-compare",
         "-Wno-sign-conversion",
+#if HIP_PACKAGE_VERSION_FLAT >= 6001024000ULL
+        "-Wno-unsafe-buffer-usage",
+#endif
         "-Wno-unused-function",
         "-Wno-unused-macros",
         "-Wno-declaration-after-statement", // W/A for SWDEV-337356
@@ -58,7 +62,7 @@ static std::vector<std::string> OclKernelWarnings()
 
 static std::vector<std::string> HipKernelWarnings()
 {
-    return {
+    std::vector<std::string> rv = {
         "-Weverything",
         "-Wno-c++98-compat",
         "-Wno-c++98-compat-pedantic",
@@ -83,7 +87,12 @@ static std::vector<std::string> HipKernelWarnings()
         "-Wno-covered-switch-default",
         "-Wno-disabled-macro-expansion",
         "-Wno-undefined-reinterpret-cast",
+#if HIP_PACKAGE_VERSION_FLAT >= 6001024000ULL
+        "-Wno-unsafe-buffer-usage",
+#endif
     };
+
+    return rv;
 }
 
 static std::string MakeKernelWarningsString(const std::vector<std::string>& kernel_warnings,

--- a/src/kernels/miopen_limits.hpp
+++ b/src/kernels/miopen_limits.hpp
@@ -25,8 +25,8 @@
  *******************************************************************************/
 #pragma once
 
-#ifndef WORKAROUND_DO_NOT_USE_CUSTOM_LIMITS
-#define WORKAROUND_DO_NOT_USE_CUSTOM_LIMITS 0
+#ifndef WORKAROUND_DONT_USE_CUSTOM_LIMITS
+#define WORKAROUND_DONT_USE_CUSTOM_LIMITS 0
 #endif
 
 #if defined(MIOPEN_DONT_USE_HIP_RUNTIME_HEADERS) && !WORKAROUND_DONT_USE_CUSTOM_LIMITS

--- a/src/kernels/miopen_type_traits.hpp
+++ b/src/kernels/miopen_type_traits.hpp
@@ -76,7 +76,7 @@ struct remove_cv
     typedef typename remove_volatile<typename remove_const<T>::type>::type type;
 };
 
-#if HIP_PACKAGE_VERSION_FLAT >= 6001000000ULL
+#if HIP_PACKAGE_VERSION_FLAT >= 6001000000ULL && HIP_PACKAGE_VERSION_FLAT < 6001024000ULL
 template <class T, T v>
 struct integral_constant
 {

--- a/test/handle_test.cpp
+++ b/test/handle_test.cpp
@@ -29,12 +29,11 @@
 #define WORKAROUND_SWDEV_257056_PCH_MISSING_MACROS 1
 
 // https://gerrit-git.amd.com/c/compute/ec/clr/+/972441
-// "HIP_PACKAGE_VERSION_FLAT == 6001000000ULL" is for ROCm 6.1 RC where issue #2600 is not
-// yet fixed in the compiler. In order to test such release candidates, we have to
-// override HIP version to 6.1.0.
+// Issue #2600 is not fixed in 6.0 and still persists in 6.1 release candidates.
+// We are expecting it to be fixed in 6.1 RC after week 4 in 2024.
 #define WORKAROUND_ISSUE_2600                                                                    \
     ((HIP_PACKAGE_VERSION_FLAT >= 6000000000ULL && HIP_PACKAGE_VERSION_FLAT <= 6000999999ULL) || \
-     HIP_PACKAGE_VERSION_FLAT == 6001000000ULL)
+     (HIP_PACKAGE_VERSION_FLAT >= 6001000000ULL && HIP_PACKAGE_VERSION_FLAT <= 6001024049ULL))
 
 #include <miopen/config.h>
 #include <miopen/handle.hpp>


### PR DESCRIPTION
This PR may be considered as a continuation of #2637. We need it due to recent breaking changes in HIP mainline.

Supersedes #2650.

### In short
- Fixes build failures with HIP Mainline 417
- ⚠️ Currently, HIP Mainline builds report incorrect HIP versions.
  - Therefore, in order to properly build the library for the HIP Mainline, the user must override the HIP version in the CMake command line.
  - For Mainline 417 and similar, use `-DMIOPEN_OVERRIDE_HIP_VERSION_MINOR=1 -DMIOPEN_OVERRIDE_HIP_VERSION_PATCH=24000`.
  - For older Mainline builds, `-DMIOPEN_OVERRIDE_HIP_VERSION_MINOR=1 -DMIOPEN_OVERRIDE_HIP_VERSION_PATCH=0` may work better.

### Some details
- HIP Mainline 417 specific fixes
  - Disabled some new OCL & HIP kernel build warnings.
  - [tests] Disabled a testcase from handle_test as [#2600](https://github.com/ROCm/MIOpen/issues/2600) still persists.
    - The testcase will be automatically enabled after week 4.
  - [hipRTC] Used custom implementations instead of standard `<limits>`.
  - [hipRTC] Disabled some of the custom implementations from `<type_traits>` (like `integral_constant` etc).
  - [clang++] Removed "-mcpu" from HIP build options. 
- By-products
  - Fixed issue in `"miopen_limits.h"` that prevented the use of custom implementations.
  - Improved diagnostic messages output onto console after offline build failures.


## :cyclone: Testing

Preconditions:
- Navi21 (gfx1030/36), Ubuntu 20.04.5 LTS
- `-DMIOPEN_TEST_ALL=Off -DBUILD_DEV=On` (Smoke testing)
- `-DMIOPEN_OVERRIDE_HIP_VERSION_MINOR=1 -DMIOPEN_OVERRIDE_HIP_VERSION_PATCH=24000`
- Both online (`-DMIOPEN_USE_COMGR=On -DMIOPEN_USE_HIPRTC=On`) and offline (`-DMIOPEN_USE_COMGR=Off -DMIOPEN_USE_HIPRTC=Off`) kernel compilers were tested.
- ROCm version, docker image, build type, compiler, datatypes tested and results of testing - see table below

  |   |   |   | Results |   |   |   |
-- | -- | -- | -- | -- | -- | -- | --
ROCm version | Docker image | Build type | Compiler | FLOAT | HALF | BFLOAT16 | INT8
Mainline 417 | - | Release, -Werror | COMgr/hipRTC | OK | OK | OK | OK
Mainline 417 | - | Release, -Werror | clang++ | OK | OK | - | -

🟢 Bottom line: No failures.

----
[Attribution] @junliume @JehandadKhan
- https://github.com/ROCm/MIOpen/labels/bug
- https://github.com/ROCm/MIOpen/labels/non-miopen-bug
- https://github.com/ROCm/MIOpen/labels/urgency_blocker
- Proposed reviewers:
  - @JehandadKhan
  - @junliume
  - @CAHEK7 