### PR TITLE
    correct parameter which prints unused flag in log fusion cmd

### DIFF
--- a/src/fusion.cpp
+++ b/src/fusion.cpp
@@ -366,7 +366,7 @@ std::string LogCmdConvolutionFusion(const miopenFusionPlanDescriptor_t fusePlanD
                                    miopen::deref(convDesc),
                                    miopen::deref(yDesc),
                                    miopenProblemDirection_t::miopenProblemDirectionForward,
-                                   false,
+                                   std::nullopt,
                                    false);
 
     return str;


### PR DESCRIPTION
Original parameter "false" would be casted to a 0 value std::optional and make unused flag "-S" be printed in fusion cmd logs.
