### PR TITLE
replace [[gnu::noreturn]] with [[noreturn]]

### DIFF
--- a/addkernels/addkernels.cpp
+++ b/addkernels/addkernels.cpp
@@ -108,7 +108,7 @@ void PrintHelp()
               << std::endl;
 }
 
-[[gnu::noreturn]] void WrongUsage(const std::string& error)
+[[noreturn]] void WrongUsage(const std::string& error)
 {
     std::cout << "Wrong usage: " << error << std::endl;
     std::cout << std::endl;
@@ -117,7 +117,7 @@ void PrintHelp()
     std::exit(1);
 }
 
-[[gnu::noreturn]] void UnknownArgument(const std::string& arg)
+[[noreturn]] void UnknownArgument(const std::string& arg)
 {
     std::ostringstream ss;
     ss << "unknown argument - " << arg;

--- a/driver/InputFlags.cpp
+++ b/driver/InputFlags.cpp
@@ -101,7 +101,7 @@ void InputFlags::AddTensorFlag(const std::string& name,
     AddInputFlag(name, short_name, default_value, desc.str(), "tensor descriptor");
 }
 
-[[gnu::noreturn]] void InputFlags::Print() const
+void InputFlags::Print() const
 {
     printf("MIOpen Driver Input Flags: \n\n");
 

--- a/driver/InputFlags.hpp
+++ b/driver/InputFlags.hpp
@@ -83,7 +83,7 @@ public:
 
     void Parse(int argc, char* argv[]);
     char FindShortName(const std::string& _long_name) const;
-    void Print() const;
+    [[noreturn]] void Print() const;
 
     std::string GetValueStr(const std::string& _long_name) const;
     int GetValueInt(const std::string& _long_name) const;

--- a/driver/driver.hpp
+++ b/driver/driver.hpp
@@ -144,7 +144,7 @@ inline void PadBufferSize(size_t& sz, int datatype_sz)
     }
 }
 
-[[gnu::noreturn]] inline void Usage()
+[[noreturn]] inline void Usage()
 {
     printf("Usage: ./driver *base_arg* *other_args*\n");
     printf("Supported Base Arguments: conv[fp16|int8|bfp16|fp8|bfp8], CBAInfer[fp16], "

--- a/test/test.hpp
+++ b/test/test.hpp
@@ -39,7 +39,7 @@ inline void failed(const char* msg, const char* file, int line)
     std::cout << ss.str();
 }
 
-[[gnu::noreturn]] inline void failed_abort(const char* msg, const char* file, int line)
+[[noreturn]] inline void failed_abort(const char* msg, const char* file, int line)
 {
     failed(msg, file, line);
     std::abort();


### PR DESCRIPTION
The attribute [[noreturn]] is officially supported in the C++17 standard used in MIOpen— we don't need any more compiler-specific attributes that are less portable across platforms.