### PR TITLE
addkernels: fix operations on path for Windows

### DIFF
--- a/addkernels/include_inliner.hpp
+++ b/addkernels/include_inliner.hpp
@@ -24,11 +24,13 @@
  *
  *******************************************************************************/
 #ifndef SOURCE_INLINER_HPP
-
 #define SOURCE_INLINER_HPP
+
 #include "source_file_desc.hpp"
-#include <ostream>
+#include <exception>
+#include <filesystem>
 #include <memory>
+#include <ostream>
 #include <stack>
 
 class InlineException : public std::exception
@@ -118,8 +120,8 @@ public:
 
     void Process(std::istream& input,
                  std::ostream& output,
-                 const std::string& root,
-                 const std::string& file_name,
+                 const std::filesystem::path& root,
+                 const std::filesystem::path& file_name,
                  const std::string& directive,
                  bool allow_angle_brackets,
                  bool recurse);
@@ -131,8 +133,8 @@ private:
 
     void ProcessCore(std::istream& input,
                      std::ostream& output,
-                     const std::string& root,
-                     const std::string& file_name,
+                     const std::filesystem::path& root,
+                     const std::filesystem::path& file_name,
                      int line_number,
                      const std::string& directive,
                      bool allow_angle_brackets,

--- a/addkernels/source_file_desc.hpp
+++ b/addkernels/source_file_desc.hpp
@@ -24,19 +24,22 @@
  *
  *******************************************************************************/
 #ifndef SOURCE_FILE_DESC_HPP
-
 #define SOURCE_FILE_DESC_HPP
-#include <string>
+
+#include <filesystem>
 #include <memory>
+#include <string>
 
 class SourceFileDesc
 {
 public:
-    std::string path;
+    std::filesystem::path path;
     int included_line;
     std::shared_ptr<SourceFileDesc> included_from;
 
-    SourceFileDesc(const std::string& path_, std::shared_ptr<SourceFileDesc> from, int line)
+    SourceFileDesc(const std::filesystem::path& path_,
+                   std::shared_ptr<SourceFileDesc> from,
+                   int line)
         : path(path_), included_line(line), included_from(from)
     {
     }


### PR DESCRIPTION
Using `std::string` for manipulating paths is error-prone - it produces paths that do not work on Windows because MIOpen uses the Linux-specific and not portable approach. Moving to `std::filesystem::path` will make it OS-agnostic. Furthermore, we deliberately use `std::filesystem::path` and not `boost::filesystem::path` because the MSVC standard library is incompatible with Boost and requires extra conversion/translation between Boost and Std. The example is when `boost::filesystem::path` is used with `std::ofstream` - GNU has additional construction accepting Boost path, MSVC does not, and we need to convert each time to either Std path or `std::string`.
At the same time, MIOpen is using C++17 standard, and `std::filesystem` has most of the functionality Boost offers.
Later, we will submit PRs for other components in MIOpen, changing `std::string` and `boost::filesystem::path` to `std::filesystem::path`. Currently, the Linux-specific path operations block Windows MIOpen from executing specific scenarios.