### PR TITLE
[ROCm 6.0.1] Fix merge error in #2652 that affects #2644.

### DIFF
--- a/src/kernels/miopen_type_traits.hpp
+++ b/src/kernels/miopen_type_traits.hpp
@@ -76,7 +76,7 @@ struct remove_cv
     typedef typename remove_volatile<typename remove_const<T>::type>::type type;
 };
 
-#if HIP_PACKAGE_VERSION_FLAT >= 6001000000ULL && HIP_PACKAGE_VERSION_FLAT < 6001024000ULL
+#if HIP_PACKAGE_VERSION_FLAT >= 6000024000ULL && HIP_PACKAGE_VERSION_FLAT < 6001024000ULL
 template <class T, T v>
 struct integral_constant
 {


### PR DESCRIPTION
Fixes merge error in #2652 that affects the functionality added by #2644. Resolves https://github.com/ROCm/MIOpen/pull/2652#discussion_r1442577220.

----
[Attribution] @junliume
- https://github.com/ROCm/MIOpen/labels/bug
- https://github.com/ROCm/MIOpen/labels/urgency_normal
- Proposed reviewers: @junliume