### PR TITLE
Search-proofed PrepareInvoker

### DIFF
--- a/src/ocl/convolutionocl.cpp
+++ b/src/ocl/convolutionocl.cpp
@@ -150,6 +150,7 @@ static Invoker PrepareInvoker(ExecutionContext ctx,
 {
     problem.SetupFloats(ctx);
     ctx.do_search = false;
+    ctx.disable_search_enforce = true;
 
     const auto solver = solver_id.GetSolver();
     auto db           = GetDb(ctx);


### PR DESCRIPTION
This makes calling immediate mode functions with forced tuning safe by ignoring enforce when it is not possible to tune.

This PR fixes SWDEV-433582