### PR TITLE
[BF16][FP8][BF8] Fixed some specializations from `<limits>` and `<cmath>`

### DIFF
--- a/src/include/miopen/bfloat16.hpp
+++ b/src/include/miopen/bfloat16.hpp
@@ -158,14 +158,20 @@ class numeric_limits<bfloat16>
 {
 public:
     static constexpr bool is_specialized = true;
-    static constexpr bfloat16 min() noexcept { return bfloat16::generate(0x007F); }
+    static constexpr bfloat16 min() noexcept { return bfloat16::generate(0x0080); } // 0x1.00p-126
     static constexpr bfloat16 max() noexcept { return bfloat16::generate(0x7F7F); }
     static constexpr bfloat16 lowest() noexcept { return bfloat16::generate(0xFF7F); }
     static constexpr bfloat16 epsilon() noexcept { return bfloat16::generate(0x3C00); }
     static constexpr bfloat16 infinity() noexcept { return bfloat16::generate(0x7F80); }
-    static constexpr bfloat16 quiet_NaN() noexcept { return bfloat16::generate(0x7FC0); }
-    static constexpr bfloat16 signaling_NaN() noexcept { return bfloat16::generate(0x7FC0); }
-    static constexpr bfloat16 denorm_min() noexcept { return bfloat16::generate(0); }
+    static constexpr bfloat16 quiet_NaN() noexcept { return bfloat16::generate(0x7FC0); } // qnan(0)
+    static constexpr bfloat16 signaling_NaN() noexcept
+    {
+        return bfloat16::generate(0x7F81); // snan(1)
+    }
+    static constexpr bfloat16 denorm_min() noexcept
+    {
+        return bfloat16::generate(0x0001); // 0x0.02p-126
+    }
 };
 } // namespace std
 #endif

--- a/src/kernels/hip_float8.hpp
+++ b/src/kernels/hip_float8.hpp
@@ -507,8 +507,8 @@ public:
 
     static MIOPEN_HIP_HOST_DEVICE miopen_f8::hip_f8<miopen_f8::hip_f8_type::fp8> quiet_NaN()
     {
-        return static_cast<miopen_f8::hip_f8<miopen_f8::hip_f8_type::fp8>>(
-            static_cast<uint8_t>(miopen_f8::get_hip_f8_bias_mode() ? 0X80 : 0x79));
+        return miopen_f8::Generate<miopen_f8::hip_f8<miopen_f8::hip_f8_type::fp8>>(
+            MIOPEN_FP8_IEEE_EXPONENT_BIAS ? 0x7c : 0x80);
     }
 
     static MIOPEN_HIP_HOST_DEVICE miopen_f8::hip_f8<miopen_f8::hip_f8_type::fp8> max()
@@ -536,8 +536,8 @@ public:
 
     static MIOPEN_HIP_HOST_DEVICE miopen_f8::hip_f8<miopen_f8::hip_f8_type::bf8> quiet_NaN()
     {
-        return static_cast<miopen_f8::hip_f8<miopen_f8::hip_f8_type::bf8>>(
-            static_cast<uint8_t>(miopen_f8::get_hip_f8_bias_mode() ? 0X80 : 0x7d));
+        return miopen_f8::Generate<miopen_f8::hip_f8<miopen_f8::hip_f8_type::bf8>>(
+            MIOPEN_FP8_IEEE_EXPONENT_BIAS ? 0x7e : 0x80);
     }
 
     static MIOPEN_HIP_HOST_DEVICE miopen_f8::hip_f8<miopen_f8::hip_f8_type::bf8> max()

--- a/src/kernels/hip_float8.hpp
+++ b/src/kernels/hip_float8.hpp
@@ -542,9 +542,8 @@ public:
 
     static MIOPEN_HIP_HOST_DEVICE miopen_f8::hip_f8<miopen_f8::hip_f8_type::bf8> max()
     {
-        return static_cast<miopen_f8::hip_f8<miopen_f8::hip_f8_type::bf8>>(
-            miopen_f8::Generate<miopen_f8::hip_f8<miopen_f8::hip_f8_type::bf8>>(
-                MIOPEN_FP8_IEEE_EXPONENT_BIAS ? 0x7b : 0x7f));
+        return miopen_f8::Generate<miopen_f8::hip_f8<miopen_f8::hip_f8_type::bf8>>(
+            MIOPEN_FP8_IEEE_EXPONENT_BIAS ? 0x7b : 0x7f);
     }
 
     static MIOPEN_HIP_HOST_DEVICE miopen_f8::hip_f8<miopen_f8::hip_f8_type::bf8> min()

--- a/src/kernels/hip_float8.hpp
+++ b/src/kernels/hip_float8.hpp
@@ -521,12 +521,17 @@ public:
     static MIOPEN_HIP_HOST_DEVICE miopen_f8::hip_f8<miopen_f8::hip_f8_type::fp8> max()
     {
         return miopen_f8::Generate<miopen_f8::hip_f8<miopen_f8::hip_f8_type::fp8>>(
-            MIOPEN_FP8_IEEE_EXPONENT_BIAS ? 0x77 : 0x7f);
+            MIOPEN_FP8_IEEE_EXPONENT_BIAS ? 0x77 : 0x7f); // 240
     }
 
     static MIOPEN_HIP_HOST_DEVICE miopen_f8::hip_f8<miopen_f8::hip_f8_type::fp8> min()
     {
         return miopen_f8::Generate<miopen_f8::hip_f8<miopen_f8::hip_f8_type::fp8>>(0x08);
+    }
+
+    static MIOPEN_HIP_HOST_DEVICE miopen_f8::hip_f8<miopen_f8::hip_f8_type::fp8> denorm_min()
+    {
+        return miopen_f8::Generate<miopen_f8::hip_f8<miopen_f8::hip_f8_type::fp8>>(0x01);
     }
 
     static constexpr int digits = 4;
@@ -557,7 +562,7 @@ public:
     static MIOPEN_HIP_HOST_DEVICE miopen_f8::hip_f8<miopen_f8::hip_f8_type::bf8> max()
     {
         return miopen_f8::Generate<miopen_f8::hip_f8<miopen_f8::hip_f8_type::bf8>>(
-            MIOPEN_FP8_IEEE_EXPONENT_BIAS ? 0x7b : 0x7f);
+            MIOPEN_FP8_IEEE_EXPONENT_BIAS ? 0x7b : 0x7f); // 57344
     }
 
     static MIOPEN_HIP_HOST_DEVICE miopen_f8::hip_f8<miopen_f8::hip_f8_type::bf8> min()
@@ -565,7 +570,12 @@ public:
         return miopen_f8::Generate<miopen_f8::hip_f8<miopen_f8::hip_f8_type::bf8>>(0x04);
     }
 
-    static constexpr int digits = 3;
+    static MIOPEN_HIP_HOST_DEVICE miopen_f8::hip_f8<miopen_f8::hip_f8_type::bf8> denorm_min()
+    {
+        return miopen_f8::Generate<miopen_f8::hip_f8<miopen_f8::hip_f8_type::bf8>>(0x01);
+    }
+
+   static constexpr int digits = 3;
 };
 
 } // namespace miopen_f8

--- a/src/kernels/hip_float8.hpp
+++ b/src/kernels/hip_float8.hpp
@@ -511,6 +511,12 @@ public:
             MIOPEN_FP8_IEEE_EXPONENT_BIAS ? 0x7c : 0x80);
     }
 
+    static MIOPEN_HIP_HOST_DEVICE miopen_f8::hip_f8<miopen_f8::hip_f8_type::fp8> signaling_NaN()
+    {
+        return miopen_f8::Generate<miopen_f8::hip_f8<miopen_f8::hip_f8_type::fp8>>(
+            MIOPEN_FP8_IEEE_EXPONENT_BIAS ? 0x79 : 0x80);
+    }
+
     static MIOPEN_HIP_HOST_DEVICE miopen_f8::hip_f8<miopen_f8::hip_f8_type::fp8> max()
     {
         return miopen_f8::Generate<miopen_f8::hip_f8<miopen_f8::hip_f8_type::fp8>>(
@@ -538,6 +544,12 @@ public:
     {
         return miopen_f8::Generate<miopen_f8::hip_f8<miopen_f8::hip_f8_type::bf8>>(
             MIOPEN_FP8_IEEE_EXPONENT_BIAS ? 0x7e : 0x80);
+    }
+
+    static MIOPEN_HIP_HOST_DEVICE miopen_f8::hip_f8<miopen_f8::hip_f8_type::bf8> signaling_NaN()
+    {
+        return miopen_f8::Generate<miopen_f8::hip_f8<miopen_f8::hip_f8_type::bf8>>(
+            MIOPEN_FP8_IEEE_EXPONENT_BIAS ? 0x7d : 0x80);
     }
 
     static MIOPEN_HIP_HOST_DEVICE miopen_f8::hip_f8<miopen_f8::hip_f8_type::bf8> max()

--- a/src/kernels/hip_float8.hpp
+++ b/src/kernels/hip_float8.hpp
@@ -588,12 +588,12 @@ public:
 namespace std {
 inline bool isfinite(miopen_f8::hip_f8<miopen_f8::hip_f8_type::fp8> x) // NOLINT
 {
-    return x.is_inf();
+    return !(x.is_inf() || x.is_nan());
 }
 
 inline bool isfinite(miopen_f8::hip_f8<miopen_f8::hip_f8_type::bf8> x) // NOLINT
 {
-    return x.is_inf();
+    return !(x.is_inf() || x.is_nan());
 }
 
 inline bool isnan(miopen_f8::hip_f8<miopen_f8::hip_f8_type::fp8> x) // NOLINT

--- a/src/kernels/hip_float8.hpp
+++ b/src/kernels/hip_float8.hpp
@@ -484,19 +484,6 @@ inline MIOPEN_HIP_HOST_DEVICE miopen_f8::hip_f8<T> fabs(miopen_f8::hip_f8<T> v)
 }
 
 template <class T>
-MIOPEN_HIP_HOST_DEVICE T F8_Max()
-{
-    union
-    {
-        uint8_t bits;
-        T value;
-    } x;
-
-    x.bits = 0x7F;
-    return x.value;
-}
-
-template <class T>
 MIOPEN_HIP_HOST_DEVICE T Generate(uint8_t bits)
 {
     union
@@ -530,11 +517,9 @@ public:
             MIOPEN_FP8_IEEE_EXPONENT_BIAS ? 0x77 : 0x7f);
     }
 
-    /// \todo This is wrong. min() should minimum normalized positive value.
     static MIOPEN_HIP_HOST_DEVICE miopen_f8::hip_f8<miopen_f8::hip_f8_type::fp8> min()
     {
-        return static_cast<miopen_f8::hip_f8<miopen_f8::hip_f8_type::fp8>>(-1.0f) *
-               miopen_f8::F8_Max<miopen_f8::hip_f8<miopen_f8::hip_f8_type::fp8>>();
+        return miopen_f8::Generate<miopen_f8::hip_f8<miopen_f8::hip_f8_type::fp8>>(0x08);
     }
 
     static constexpr int digits = 4;
@@ -562,11 +547,9 @@ public:
                 MIOPEN_FP8_IEEE_EXPONENT_BIAS ? 0x7b : 0x7f));
     }
 
-    /// \todo This is wrong. min() should minimum normalized positive value.
     static MIOPEN_HIP_HOST_DEVICE miopen_f8::hip_f8<miopen_f8::hip_f8_type::bf8> min()
     {
-        return static_cast<miopen_f8::hip_f8<miopen_f8::hip_f8_type::bf8>>(-1.0f) *
-               miopen_f8::F8_Max<miopen_f8::hip_f8<miopen_f8::hip_f8_type::bf8>>();
+        return miopen_f8::Generate<miopen_f8::hip_f8<miopen_f8::hip_f8_type::bf8>>(0x04);
     }
 
     static constexpr int digits = 3;

--- a/src/kernels/hip_float8.hpp
+++ b/src/kernels/hip_float8.hpp
@@ -502,7 +502,8 @@ class numeric_limits<miopen_f8::hip_f8<miopen_f8::hip_f8_type::fp8>>
 public:
     static MIOPEN_HIP_HOST_DEVICE miopen_f8::hip_f8<miopen_f8::hip_f8_type::fp8> epsilon()
     {
-        return static_cast<miopen_f8::hip_f8<miopen_f8::hip_f8_type::fp8>>(float(0.0625));
+        return miopen_f8::Generate<miopen_f8::hip_f8<miopen_f8::hip_f8_type::fp8>>(
+            MIOPEN_FP8_IEEE_EXPONENT_BIAS ? 0x20 : 0x28); // 0.125
     }
 
     static MIOPEN_HIP_HOST_DEVICE miopen_f8::hip_f8<miopen_f8::hip_f8_type::fp8> quiet_NaN()
@@ -537,7 +538,8 @@ class numeric_limits<miopen_f8::hip_f8<miopen_f8::hip_f8_type::bf8>>
 public:
     static MIOPEN_HIP_HOST_DEVICE miopen_f8::hip_f8<miopen_f8::hip_f8_type::bf8> epsilon()
     {
-        return static_cast<miopen_f8::hip_f8<miopen_f8::hip_f8_type::bf8>>(float(0.125));
+        return miopen_f8::Generate<miopen_f8::hip_f8<miopen_f8::hip_f8_type::bf8>>(
+            MIOPEN_FP8_IEEE_EXPONENT_BIAS ? 0x34 : 0x38); // 0.25
     }
 
     static MIOPEN_HIP_HOST_DEVICE miopen_f8::hip_f8<miopen_f8::hip_f8_type::bf8> quiet_NaN()

--- a/src/kernels/hip_float8.hpp
+++ b/src/kernels/hip_float8.hpp
@@ -475,10 +475,15 @@ inline MIOPEN_HIP_HOST_DEVICE bool operator>(const miopen_f8::hip_f8<T>& lhs,
     return static_cast<float>(lhs) > static_cast<float>(rhs);
 }
 
-/// \todo Do not convert nan to 0 in Nan_0x80 mode (MIOPEN_FP8_IEEE_EXPONENT_BIAS=0)
 template <miopen_f8::hip_f8_type T>
 inline MIOPEN_HIP_HOST_DEVICE miopen_f8::hip_f8<T> fabs(miopen_f8::hip_f8<T> v)
 {
+#if !MIOPEN_FP8_IEEE_EXPONENT_BIAS
+    // Preserve "universal" nan.
+    // Otherwise it will be converted to valid 0.
+    if(v.data == 0x80)
+        return v;
+#endif
     v.data = v.data & 0x7f;
     return v;
 }
@@ -575,7 +580,7 @@ public:
         return miopen_f8::Generate<miopen_f8::hip_f8<miopen_f8::hip_f8_type::bf8>>(0x01);
     }
 
-   static constexpr int digits = 3;
+    static constexpr int digits = 3;
 };
 
 } // namespace miopen_f8


### PR DESCRIPTION
- For BF16
  - Fixed `numeric_limits<T>::min()`, `denorm_min()`, `quiet_NaN()`, `signaling_NaN()`
- For FP8, BF8
  - Fixed `numeric_limits<T>::min()`, `max()`, `epsilon()`, `quiet_NaN()`
  - Added `numeric_limits<T>::denorm_min()`, , `signaling_NaN()`
  - Fixed `fabs()` for non-IEEE mode
  - Fixed `isfinite()`. This resolves:
    - https://github.com/ROCm/MIOpen/pull/2584#discussion_r1419714785
    - https://github.com/ROCm/MIOpen/pull/2584#discussion_r1419715130

## ⚠️ Other action points

@xinlipn @junliume I think this should be discussed with HIP compiler/library developers who provided the initial version of https://github.com/ROCm/MIOpen/blob/e125c5316516c452be406301f5da9f0f84017ef0/src/kernels/hip_float8.h. Ours and theirs versions must be in sync _and_ of course we do not want the bugs fixed here just to re-appear from the HIP compiler later. Please either discuss the fixes with them or or refer them to me to talk. This AP is https://github.com/ROCm/MIOpen/labels/value_high

----
[Attribution] @junliume @JehandadKhan
- https://github.com/ROCm/MIOpen/labels/bug
- https://github.com/ROCm/MIOpen/labels/correctness
- https://github.com/ROCm/MIOpen/labels/urgency_high - as I am not aware of any related issues, otherwise it would be blocker.
- https://github.com/ROCm/MIOpen/labels/value_unknown
- Proposed reviewers:
  - @TejashShah for BF16 fixes
  - @xinlipn for F8 fixes
  - @JehandadKhan for general awareness
  - @junliume for general awareness
  - @CAHEK7  for general awareness
