### PR TITLE
Rename transpose* kernels (leftover of #2613)

### DIFF
--- a/src/kernels/MIOpenUtilKernels4.cl
+++ b/src/kernels/MIOpenUtilKernels4.cl
@@ -526,12 +526,12 @@ __kernel void transpose_CNHW2NCHW_V2_3D_WG_off64(const global data_t* in,
     cout[C * hw_in * n_i] = cin[hw_out * n_i];
 }
 
-__kernel void transpose_packed_MN2NM(const global data_t* in,
-                                     global data_t* out,
-                                     const int N,
-                                     const int M,
-                                     const arg_size_t in_off,
-                                     const arg_size_t out_off)
+__kernel void transpose_packed_MN2NM_off64(const global data_t* in,
+                                           global data_t* out,
+                                           const int N,
+                                           const int M,
+                                           const arg_size_t in_off,
+                                           const arg_size_t out_off)
 {
     uint i = get_global_id(0);
 

--- a/src/kernels/MIOpenUtilKernels4.cl
+++ b/src/kernels/MIOpenUtilKernels4.cl
@@ -304,16 +304,16 @@ __kernel void transpose_NCHW2CNHW_V2_3D_WG(const global data_t* in,
     cout[hw_out * n_i] = cin[C * hw_in * n_i];
 }
 
-__kernel void transpose_CNHW2NCHW_V1_1D_WG_float(const global data_t* in,
-                                                 global data_t* out,
-                                                 const arg_size_t in_off,
-                                                 const arg_size_t out_off,
-                                                 const int rd_blck,
-                                                 const int hw_rd,
-                                                 const int N,
-                                                 const int C,
-                                                 const int H,
-                                                 const int W)
+__kernel void transpose_CNHW2NCHW_V1_1D_WG_float_off64(const global data_t* in,
+                                                       global data_t* out,
+                                                       const arg_size_t in_off,
+                                                       const arg_size_t out_off,
+                                                       const int rd_blck,
+                                                       const int hw_rd,
+                                                       const int N,
+                                                       const int C,
+                                                       const int H,
+                                                       const int W)
 {
     // to reduce granularity loss
     uint c_p_blck = get_global_id(0);
@@ -332,16 +332,16 @@ __kernel void transpose_CNHW2NCHW_V1_1D_WG_float(const global data_t* in,
     }
 }
 
-__kernel void transpose_CNHW2NCHW_V1_1D_WG_float2(const global data_t* in,
-                                                  global data_t* out,
-                                                  const arg_size_t in_off,
-                                                  const arg_size_t out_off,
-                                                  const int rd_blck,
-                                                  const int hw_rd,
-                                                  const int N,
-                                                  const int C,
-                                                  const int H,
-                                                  const int W)
+__kernel void transpose_CNHW2NCHW_V1_1D_WG_float2_off64(const global data_t* in,
+                                                        global data_t* out,
+                                                        const arg_size_t in_off,
+                                                        const arg_size_t out_off,
+                                                        const int rd_blck,
+                                                        const int hw_rd,
+                                                        const int N,
+                                                        const int C,
+                                                        const int H,
+                                                        const int W)
 {
     // to reduce granularity loss
     uint c_p_blck = get_global_id(0);
@@ -360,16 +360,16 @@ __kernel void transpose_CNHW2NCHW_V1_1D_WG_float2(const global data_t* in,
     }
 }
 
-__kernel void transpose_CNHW2NCHW_V1_1D_WG_float4(const global data_t* in,
-                                                  global data_t* out,
-                                                  const arg_size_t in_off,
-                                                  const arg_size_t out_off,
-                                                  const int rd_blck,
-                                                  const int hw_rd,
-                                                  const int N,
-                                                  const int C,
-                                                  const int H,
-                                                  const int W)
+__kernel void transpose_CNHW2NCHW_V1_1D_WG_float4_off64(const global data_t* in,
+                                                        global data_t* out,
+                                                        const arg_size_t in_off,
+                                                        const arg_size_t out_off,
+                                                        const int rd_blck,
+                                                        const int hw_rd,
+                                                        const int N,
+                                                        const int C,
+                                                        const int H,
+                                                        const int W)
 {
     // to reduce granularity loss
     uint c_p_blck = get_global_id(0);
@@ -388,16 +388,16 @@ __kernel void transpose_CNHW2NCHW_V1_1D_WG_float4(const global data_t* in,
     }
 }
 
-__kernel void transpose_CNHW2NCHW_V1_2D_WG_float(const global data_t* in,
-                                                 global data_t* out,
-                                                 const arg_size_t in_off,
-                                                 const arg_size_t out_off,
-                                                 const int rd_blck,
-                                                 const int hw_rd,
-                                                 const int N,
-                                                 const int C,
-                                                 const int H,
-                                                 const int W)
+__kernel void transpose_CNHW2NCHW_V1_2D_WG_float_off64(const global data_t* in,
+                                                       global data_t* out,
+                                                       const arg_size_t in_off,
+                                                       const arg_size_t out_off,
+                                                       const int rd_blck,
+                                                       const int hw_rd,
+                                                       const int N,
+                                                       const int C,
+                                                       const int H,
+                                                       const int W)
 {
     // to reduce granularity loss
     uint c_p_blck = get_global_id(0);
@@ -414,16 +414,16 @@ __kernel void transpose_CNHW2NCHW_V1_2D_WG_float(const global data_t* in,
     cout[b * C * hw_rd] = cin[b * hw_rd];
 }
 
-__kernel void transpose_CNHW2NCHW_V1_2D_WG_float2(const global data_t* in,
-                                                  global data_t* out,
-                                                  const arg_size_t in_off,
-                                                  const arg_size_t out_off,
-                                                  const int rd_blck,
-                                                  const int hw_rd,
-                                                  const int N,
-                                                  const int C,
-                                                  const int H,
-                                                  const int W)
+__kernel void transpose_CNHW2NCHW_V1_2D_WG_float2_off64(const global data_t* in,
+                                                        global data_t* out,
+                                                        const arg_size_t in_off,
+                                                        const arg_size_t out_off,
+                                                        const int rd_blck,
+                                                        const int hw_rd,
+                                                        const int N,
+                                                        const int C,
+                                                        const int H,
+                                                        const int W)
 {
     // to reduce granularity loss
     uint c_p_blck = get_global_id(0);
@@ -440,16 +440,16 @@ __kernel void transpose_CNHW2NCHW_V1_2D_WG_float2(const global data_t* in,
     cout[b * C * hw_rd] = cin[b * hw_rd];
 }
 
-__kernel void transpose_CNHW2NCHW_V1_2D_WG_float4(const global data_t* in,
-                                                  global data_t* out,
-                                                  const arg_size_t in_off,
-                                                  const arg_size_t out_off,
-                                                  const int rd_blck,
-                                                  const int hw_rd,
-                                                  const int N,
-                                                  const int C,
-                                                  const int H,
-                                                  const int W)
+__kernel void transpose_CNHW2NCHW_V1_2D_WG_float4_off64(const global data_t* in,
+                                                        global data_t* out,
+                                                        const arg_size_t in_off,
+                                                        const arg_size_t out_off,
+                                                        const int rd_blck,
+                                                        const int hw_rd,
+                                                        const int N,
+                                                        const int C,
+                                                        const int H,
+                                                        const int W)
 {
     // to reduce granularity loss
     uint c_p_blck = get_global_id(0);
@@ -466,18 +466,18 @@ __kernel void transpose_CNHW2NCHW_V1_2D_WG_float4(const global data_t* in,
     cout[b * C * hw_rd] = cin[b * hw_rd];
 }
 
-__kernel void transpose_CNHW2NCHW_V2_2D_WG(const global data_t* in,
-                                           global data_t* out,
-                                           const arg_size_t in_off,
-                                           const arg_size_t out_off,
-                                           const int w_in,
-                                           const int w_out,
-                                           const int N,
-                                           const int C,
-                                           const int h_stride,
-                                           const int w_stride,
-                                           const int hw_in,
-                                           const int hw_out)
+__kernel void transpose_CNHW2NCHW_V2_2D_WG_off64(const global data_t* in,
+                                                 global data_t* out,
+                                                 const arg_size_t in_off,
+                                                 const arg_size_t out_off,
+                                                 const int w_in,
+                                                 const int w_out,
+                                                 const int N,
+                                                 const int C,
+                                                 const int h_stride,
+                                                 const int w_stride,
+                                                 const int hw_in,
+                                                 const int hw_out)
 {
     uint hw_i = get_global_id(0);
     uint c_i  = get_global_id(2);
@@ -497,18 +497,18 @@ __kernel void transpose_CNHW2NCHW_V2_2D_WG(const global data_t* in,
     }
 }
 
-__kernel void transpose_CNHW2NCHW_V2_3D_WG(const global data_t* in,
-                                           global data_t* out,
-                                           const arg_size_t in_off,
-                                           const arg_size_t out_off,
-                                           const int w_in,
-                                           const int w_out,
-                                           const int N,
-                                           const int C,
-                                           const int h_stride,
-                                           const int w_stride,
-                                           const int hw_in,
-                                           const int hw_out)
+__kernel void transpose_CNHW2NCHW_V2_3D_WG_off64(const global data_t* in,
+                                                 global data_t* out,
+                                                 const arg_size_t in_off,
+                                                 const arg_size_t out_off,
+                                                 const int w_in,
+                                                 const int w_out,
+                                                 const int N,
+                                                 const int C,
+                                                 const int h_stride,
+                                                 const int w_stride,
+                                                 const int hw_in,
+                                                 const int hw_out)
 {
     uint hw_i = get_global_id(0);
     uint c_i  = get_global_id(2);

--- a/src/kernels/MIOpenUtilKernels4.cl
+++ b/src/kernels/MIOpenUtilKernels4.cl
@@ -98,6 +98,7 @@ __kernel void transpose_NCHW2CNHW_V1_1D_WG_float(const global data_t* in,
     uint c_i      = iDiv(c_p_blck, hw_rd);
     uint p_blck   = iMod(c_p_blck, c_i, hw_rd);
 
+    /// \ref multiply_dims_overflow_assumption
     size_t in_offset        = c_p_blck * rd_blck + in_off;
     size_t out_offset       = c_i * N * H * W + p_blck * rd_blck + out_off;
     const global float* cin = (const global float*)(in + in_offset);
@@ -125,6 +126,7 @@ __kernel void transpose_NCHW2CNHW_V1_1D_WG_float2(const global data_t* in,
     uint c_i      = iDiv(c_p_blck, hw_rd);
     uint p_blck   = iMod(c_p_blck, c_i, hw_rd);
 
+    /// \ref multiply_dims_overflow_assumption
     size_t in_offset         = c_p_blck * rd_blck + in_off;
     size_t out_offset        = c_i * N * H * W + p_blck * rd_blck + out_off;
     const global float2* cin = (const global float2*)(in + in_offset);
@@ -152,6 +154,7 @@ __kernel void transpose_NCHW2CNHW_V1_1D_WG_float4(const global data_t* in,
     uint c_i      = iDiv(c_p_blck, hw_rd);
     uint p_blck   = iMod(c_p_blck, c_i, hw_rd);
 
+    /// \ref multiply_dims_overflow_assumption
     size_t in_offset         = c_p_blck * rd_blck + in_off;
     size_t out_offset        = c_i * N * H * W + p_blck * rd_blck + out_off;
     const global float4* cin = (const global float4*)(in + in_offset);
@@ -179,6 +182,7 @@ __kernel void transpose_NCHW2CNHW_V1_2D_WG_float(const global data_t* in,
     uint c_i      = iDiv(c_p_blck, hw_rd);
     uint p_blck   = iMod(c_p_blck, c_i, hw_rd);
 
+    /// \ref multiply_dims_overflow_assumption
     size_t in_offset        = c_p_blck * rd_blck + in_off;
     size_t out_offset       = c_i * N * H * W + p_blck * rd_blck + out_off;
     const global float* cin = (const global float*)(in + in_offset);
@@ -204,6 +208,7 @@ __kernel void transpose_NCHW2CNHW_V1_2D_WG_float2(const global data_t* in,
     uint c_i      = iDiv(c_p_blck, hw_rd);
     uint p_blck   = iMod(c_p_blck, c_i, hw_rd);
 
+    /// \ref multiply_dims_overflow_assumption
     size_t in_offset         = c_p_blck * rd_blck + in_off;
     size_t out_offset        = c_i * N * H * W + p_blck * rd_blck + out_off;
     const global float2* cin = (const global float2*)(in + in_offset);
@@ -229,6 +234,7 @@ __kernel void transpose_NCHW2CNHW_V1_2D_WG_float4(const global data_t* in,
     uint c_i      = iDiv(c_p_blck, hw_rd);
     uint p_blck   = iMod(c_p_blck, c_i, hw_rd);
 
+    /// \ref multiply_dims_overflow_assumption
     size_t in_offset         = c_p_blck * rd_blck + in_off;
     size_t out_offset        = c_i * N * H * W + p_blck * rd_blck + out_off;
     const global float4* cin = (const global float4*)(in + in_offset);
@@ -257,6 +263,7 @@ __kernel void transpose_NCHW2CNHW_V2_2D_WG(const global data_t* in,
     uint h_i = iDiv(hw_i, w_out);
     uint w_i = iMod(hw_i, h_i, w_out);
 
+    /// \ref multiply_dims_overflow_assumption
     size_t in_offset         = c_i * hw_in + h_i * h_stride * w_in + w_i * w_stride + in_off;
     size_t out_offset        = c_i * N * hw_out + hw_i + out_off;
     const global data_t* cin = (const global data_t*)(in + in_offset);
@@ -287,6 +294,7 @@ __kernel void transpose_NCHW2CNHW_V2_3D_WG(const global data_t* in,
     uint h_i = iDiv(hw_i, w_out);
     uint w_i = iMod(hw_i, h_i, w_out);
 
+    /// \ref multiply_dims_overflow_assumption
     size_t in_offset         = c_i * hw_in + h_i * h_stride * w_in + w_i * w_stride + in_off;
     size_t out_offset        = c_i * N * hw_out + hw_i + out_off;
     const global data_t* cin = (const global data_t*)(in + in_offset);
@@ -312,6 +320,7 @@ __kernel void transpose_CNHW2NCHW_V1_1D_WG_float(const global data_t* in,
     uint c_i      = iDiv(c_p_blck, hw_rd);
     uint p_blck   = iMod(c_p_blck, c_i, hw_rd);
 
+    /// \ref multiply_dims_overflow_assumption
     size_t in_offset        = c_i * N * H * W + p_blck * rd_blck + in_off;
     size_t out_offset       = c_p_blck * rd_blck + out_off;
     const global float* cin = (const global float*)(in + in_offset);
@@ -339,6 +348,7 @@ __kernel void transpose_CNHW2NCHW_V1_1D_WG_float2(const global data_t* in,
     uint c_i      = iDiv(c_p_blck, hw_rd);
     uint p_blck   = iMod(c_p_blck, c_i, hw_rd);
 
+    /// \ref multiply_dims_overflow_assumption
     size_t in_offset         = c_i * N * H * W + p_blck * rd_blck + in_off;
     size_t out_offset        = c_p_blck * rd_blck + out_off;
     const global float2* cin = (const global float2*)(in + in_offset);
@@ -366,6 +376,7 @@ __kernel void transpose_CNHW2NCHW_V1_1D_WG_float4(const global data_t* in,
     uint c_i      = iDiv(c_p_blck, hw_rd);
     uint p_blck   = iMod(c_p_blck, c_i, hw_rd);
 
+    /// \ref multiply_dims_overflow_assumption
     size_t in_offset         = c_i * N * H * W + p_blck * rd_blck + in_off;
     size_t out_offset        = c_p_blck * rd_blck + out_off;
     const global float4* cin = (const global float4*)(in + in_offset);
@@ -393,6 +404,7 @@ __kernel void transpose_CNHW2NCHW_V1_2D_WG_float(const global data_t* in,
     uint c_i      = iDiv(c_p_blck, hw_rd);
     uint p_blck   = iMod(c_p_blck, c_i, hw_rd);
 
+    /// \ref multiply_dims_overflow_assumption
     size_t in_offset        = c_i * N * H * W + p_blck * rd_blck + in_off;
     size_t out_offset       = c_p_blck * rd_blck + out_off;
     const global float* cin = (const global float*)(in + in_offset);
@@ -418,6 +430,7 @@ __kernel void transpose_CNHW2NCHW_V1_2D_WG_float2(const global data_t* in,
     uint c_i      = iDiv(c_p_blck, hw_rd);
     uint p_blck   = iMod(c_p_blck, c_i, hw_rd);
 
+    /// \ref multiply_dims_overflow_assumption
     size_t in_offset         = c_i * N * H * W + p_blck * rd_blck + in_off;
     size_t out_offset        = c_p_blck * rd_blck + out_off;
     const global float2* cin = (const global float2*)(in + in_offset);
@@ -443,6 +456,7 @@ __kernel void transpose_CNHW2NCHW_V1_2D_WG_float4(const global data_t* in,
     uint c_i      = iDiv(c_p_blck, hw_rd);
     uint p_blck   = iMod(c_p_blck, c_i, hw_rd);
 
+    /// \ref multiply_dims_overflow_assumption
     size_t in_offset         = c_i * N * H * W + p_blck * rd_blck + in_off;
     size_t out_offset        = c_p_blck * rd_blck + out_off;
     const global float4* cin = (const global float4*)(in + in_offset);
@@ -471,6 +485,7 @@ __kernel void transpose_CNHW2NCHW_V2_2D_WG(const global data_t* in,
     uint h_i = iDiv(hw_i, w_out);
     uint w_i = iMod(hw_i, h_i, w_out);
 
+    /// \ref multiply_dims_overflow_assumption
     size_t in_offset         = c_i * N * hw_out + hw_i + in_off;
     size_t out_offset        = c_i * hw_in + h_i * h_stride * w_in + w_i * w_stride + out_off;
     const global data_t* cin = (const global data_t*)(in + in_offset);
@@ -501,6 +516,7 @@ __kernel void transpose_CNHW2NCHW_V2_3D_WG(const global data_t* in,
     uint h_i = iDiv(hw_i, w_out);
     uint w_i = iMod(hw_i, h_i, w_out);
 
+    /// \ref multiply_dims_overflow_assumption
     size_t in_offset         = c_i * N * hw_out + hw_i + in_off;
     size_t out_offset        = c_i * hw_in + h_i * h_stride * w_in + w_i * w_stride + out_off;
     const global data_t* cin = (const global data_t*)(in + in_offset);
@@ -524,6 +540,11 @@ __kernel void transpose_packed_MN2NM(const global data_t* in,
         const uint m_i = iDiv(i, N);
         const uint n_i = iMod(i, m_i, N);
 
+        /// \ref multiply_dims_overflow_assumption
+        /// Computations in 32-bit domain save a bit of performance.
+        /// We assume that up to 3 dimensions can me multiplied in
+        /// 32-bit domain without overflow. See discussion at:
+        /// https://github.com/ROCm/MIOpen/pull/2613/files#r1429241306
         const size_t in_offset  = m_i * N + n_i + in_off;
         const size_t out_offset = n_i * M + m_i + out_off;
 

--- a/src/kernels/MIOpenUtilKernels4.cl
+++ b/src/kernels/MIOpenUtilKernels4.cl
@@ -82,16 +82,16 @@ typedef unsigned long arg_size_t;
 // local size = (lcl size0, 1, 1)
 // global size = (MAP_RD, N, 1)
 
-__kernel void transpose_NCHW2CNHW_V1_1D_WG_float(const global data_t* in,
-                                                 global data_t* out,
-                                                 const arg_size_t in_off,
-                                                 const arg_size_t out_off,
-                                                 const int rd_blck,
-                                                 const int hw_rd,
-                                                 const int N,
-                                                 const int C,
-                                                 const int H,
-                                                 const int W)
+__kernel void transpose_NCHW2CNHW_V1_1D_WG_float_off64(const global data_t* in,
+                                                       global data_t* out,
+                                                       const arg_size_t in_off,
+                                                       const arg_size_t out_off,
+                                                       const int rd_blck,
+                                                       const int hw_rd,
+                                                       const int N,
+                                                       const int C,
+                                                       const int H,
+                                                       const int W)
 {
     // to reduce granularity loss
     uint c_p_blck = get_global_id(0);
@@ -110,16 +110,16 @@ __kernel void transpose_NCHW2CNHW_V1_1D_WG_float(const global data_t* in,
     }
 }
 
-__kernel void transpose_NCHW2CNHW_V1_1D_WG_float2(const global data_t* in,
-                                                  global data_t* out,
-                                                  const arg_size_t in_off,
-                                                  const arg_size_t out_off,
-                                                  const int rd_blck,
-                                                  const int hw_rd,
-                                                  const int N,
-                                                  const int C,
-                                                  const int H,
-                                                  const int W)
+__kernel void transpose_NCHW2CNHW_V1_1D_WG_float2_off64(const global data_t* in,
+                                                        global data_t* out,
+                                                        const arg_size_t in_off,
+                                                        const arg_size_t out_off,
+                                                        const int rd_blck,
+                                                        const int hw_rd,
+                                                        const int N,
+                                                        const int C,
+                                                        const int H,
+                                                        const int W)
 {
     // to reduce granularity loss
     uint c_p_blck = get_global_id(0);
@@ -138,16 +138,16 @@ __kernel void transpose_NCHW2CNHW_V1_1D_WG_float2(const global data_t* in,
     }
 }
 
-__kernel void transpose_NCHW2CNHW_V1_1D_WG_float4(const global data_t* in,
-                                                  global data_t* out,
-                                                  const arg_size_t in_off,
-                                                  const arg_size_t out_off,
-                                                  const int rd_blck,
-                                                  const int hw_rd,
-                                                  const int N,
-                                                  const int C,
-                                                  const int H,
-                                                  const int W)
+__kernel void transpose_NCHW2CNHW_V1_1D_WG_float4_off64(const global data_t* in,
+                                                        global data_t* out,
+                                                        const arg_size_t in_off,
+                                                        const arg_size_t out_off,
+                                                        const int rd_blck,
+                                                        const int hw_rd,
+                                                        const int N,
+                                                        const int C,
+                                                        const int H,
+                                                        const int W)
 {
     // to reduce granularity loss
     uint c_p_blck = get_global_id(0);
@@ -166,16 +166,16 @@ __kernel void transpose_NCHW2CNHW_V1_1D_WG_float4(const global data_t* in,
     }
 }
 
-__kernel void transpose_NCHW2CNHW_V1_2D_WG_float(const global data_t* in,
-                                                 global data_t* out,
-                                                 const arg_size_t in_off,
-                                                 const arg_size_t out_off,
-                                                 const int rd_blck,
-                                                 const int hw_rd,
-                                                 const int N,
-                                                 const int C,
-                                                 const int H,
-                                                 const int W)
+__kernel void transpose_NCHW2CNHW_V1_2D_WG_float_off64(const global data_t* in,
+                                                       global data_t* out,
+                                                       const arg_size_t in_off,
+                                                       const arg_size_t out_off,
+                                                       const int rd_blck,
+                                                       const int hw_rd,
+                                                       const int N,
+                                                       const int C,
+                                                       const int H,
+                                                       const int W)
 {
     // to reduce granularity loss
     uint c_p_blck = get_global_id(0);
@@ -192,16 +192,16 @@ __kernel void transpose_NCHW2CNHW_V1_2D_WG_float(const global data_t* in,
     cout[b * hw_rd] = cin[b * C * hw_rd];
 }
 
-__kernel void transpose_NCHW2CNHW_V1_2D_WG_float2(const global data_t* in,
-                                                  global data_t* out,
-                                                  const arg_size_t in_off,
-                                                  const arg_size_t out_off,
-                                                  const int rd_blck,
-                                                  const int hw_rd,
-                                                  const int N,
-                                                  const int C,
-                                                  const int H,
-                                                  const int W)
+__kernel void transpose_NCHW2CNHW_V1_2D_WG_float2_off64(const global data_t* in,
+                                                        global data_t* out,
+                                                        const arg_size_t in_off,
+                                                        const arg_size_t out_off,
+                                                        const int rd_blck,
+                                                        const int hw_rd,
+                                                        const int N,
+                                                        const int C,
+                                                        const int H,
+                                                        const int W)
 {
     // to reduce granularity loss
     uint c_p_blck = get_global_id(0);
@@ -218,16 +218,16 @@ __kernel void transpose_NCHW2CNHW_V1_2D_WG_float2(const global data_t* in,
     cout[b * hw_rd] = cin[b * C * hw_rd];
 }
 
-__kernel void transpose_NCHW2CNHW_V1_2D_WG_float4(const global data_t* in,
-                                                  global data_t* out,
-                                                  const arg_size_t in_off,
-                                                  const arg_size_t out_off,
-                                                  const int rd_blck,
-                                                  const int hw_rd,
-                                                  const int N,
-                                                  const int C,
-                                                  const int H,
-                                                  const int W)
+__kernel void transpose_NCHW2CNHW_V1_2D_WG_float4_off64(const global data_t* in,
+                                                        global data_t* out,
+                                                        const arg_size_t in_off,
+                                                        const arg_size_t out_off,
+                                                        const int rd_blck,
+                                                        const int hw_rd,
+                                                        const int N,
+                                                        const int C,
+                                                        const int H,
+                                                        const int W)
 {
     // to reduce granularity loss
     uint c_p_blck = get_global_id(0);
@@ -244,18 +244,18 @@ __kernel void transpose_NCHW2CNHW_V1_2D_WG_float4(const global data_t* in,
     cout[b * hw_rd] = cin[b * C * hw_rd];
 }
 
-__kernel void transpose_NCHW2CNHW_V2_2D_WG(const global data_t* in,
-                                           global data_t* out,
-                                           const arg_size_t in_off,
-                                           const arg_size_t out_off,
-                                           const int w_in,
-                                           const int w_out,
-                                           const int N,
-                                           const int C,
-                                           const int h_stride,
-                                           const int w_stride,
-                                           const int hw_in,
-                                           const int hw_out)
+__kernel void transpose_NCHW2CNHW_V2_2D_WG_off64(const global data_t* in,
+                                                 global data_t* out,
+                                                 const arg_size_t in_off,
+                                                 const arg_size_t out_off,
+                                                 const int w_in,
+                                                 const int w_out,
+                                                 const int N,
+                                                 const int C,
+                                                 const int h_stride,
+                                                 const int w_stride,
+                                                 const int hw_in,
+                                                 const int hw_out)
 {
     uint hw_i = get_global_id(0);
     uint c_i  = get_global_id(2);
@@ -273,18 +273,18 @@ __kernel void transpose_NCHW2CNHW_V2_2D_WG(const global data_t* in,
         cout[hw_out * n_i] = cin[C * hw_in * n_i];
 }
 
-__kernel void transpose_NCHW2CNHW_V2_3D_WG(const global data_t* in,
-                                           global data_t* out,
-                                           const arg_size_t in_off,
-                                           const arg_size_t out_off,
-                                           const int w_in,
-                                           const int w_out,
-                                           const int N,
-                                           const int C,
-                                           const int h_stride,
-                                           const int w_stride,
-                                           const int hw_in,
-                                           const int hw_out)
+__kernel void transpose_NCHW2CNHW_V2_3D_WG_off64(const global data_t* in,
+                                                 global data_t* out,
+                                                 const arg_size_t in_off,
+                                                 const arg_size_t out_off,
+                                                 const int w_in,
+                                                 const int w_out,
+                                                 const int N,
+                                                 const int C,
+                                                 const int h_stride,
+                                                 const int w_stride,
+                                                 const int hw_in,
+                                                 const int hw_out)
 {
     uint hw_i = get_global_id(0);
     uint c_i  = get_global_id(2);

--- a/src/ocl/utilocl.cpp
+++ b/src/ocl/utilocl.cpp
@@ -837,6 +837,8 @@ float transpose_NCHW2CNHW(const Handle& handle,
             kernel_name += "_2D_WG";
         }
 
+        kernel_name += "_off64";
+
         auto&& kernels = handle.GetKernels(kernel_name, network_config);
         if(!kernels.empty())
         {

--- a/src/ocl/utilocl.cpp
+++ b/src/ocl/utilocl.cpp
@@ -1158,7 +1158,7 @@ float transpose_packed_MN2NM(const Handle& handle,
 
     std::string network_config = "t" + std::to_string(type);
 
-    std::string kernel_name = "transpose_packed_MN2NM";
+    std::string kernel_name = "transpose_packed_MN2NM_off64";
 
     auto&& kernels = handle.GetKernels(kernel_name, network_config);
 

--- a/src/ocl/utilocl.cpp
+++ b/src/ocl/utilocl.cpp
@@ -797,6 +797,7 @@ float transpose_NCHW2CNHW(const Handle& handle,
         }
 
         kernel_name += "_" + READ_TYPE;
+        kernel_name += "_off64";
 
         auto&& kernels = handle.GetKernels(kernel_name, network_config);
         if(!kernels.empty())
@@ -929,6 +930,7 @@ float transpose_CNHW2NCHW(const Handle& handle,
         }
 
         kernel_name += "_" + READ_TYPE;
+        kernel_name += "_off64";
 
         auto&& kernels = handle.GetKernels(kernel_name, network_config);
         if(!kernels.empty())

--- a/src/ocl/utilocl.cpp
+++ b/src/ocl/utilocl.cpp
@@ -964,6 +964,12 @@ float transpose_CNHW2NCHW(const Handle& handle,
             kernel_name += "_2D_WG";
         }
 
+        /// After switching to 64-bit offsets, do not use old kernels
+        /// from the binary cache that use 32-bit offsets.
+        /// See https://github.com/ROCm/MIOpen/pull/2613#issuecomment-1864781888
+        /// for details.
+        kernel_name += "_off64";
+
         const int hw_in  = h_in * w_in;
         const int hw_out = h_out * w_out;
 


### PR DESCRIPTION
- Added "_off64" to transpose* kernels.
  - Implements https://github.com/ROCm/MIOpen/pull/2613#issuecomment-1864781888
- Added comment about mixed 32/64-bit address calculations (`\ref multiply_dims_overflow_assumption`).
  - Finally addresses https://github.com/ROCm/MIOpen/pull/2613#discussion_r1429241306.

----
[Attribution] @junliume @JehandadKhan
- https://github.com/ROCm/MIOpen/labels/quality
- https://github.com/ROCm/MIOpen/labels/urgency_high
- Proposed reviewers: @JehandadKhan @CAHEK7 