### PR TITLE
Fix compilation on SELS/RHEL after #2657 merged

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,6 +133,11 @@ else()
     set(MIOPEN_DEFAULT_BACKEND "OpenCL")
 endif()
 
+if(NOT WIN32)
+    include(CheckCXXLinkerFlag)
+    check_cxx_linker_flag(stdc++fs HAS_LIB_STD_FILESYSTEM)
+endif()
+
 list(APPEND CMAKE_PREFIX_PATH ${CMAKE_INSTALL_PREFIX} ${CMAKE_INSTALL_PREFIX}/llvm ${CMAKE_INSTALL_PREFIX}/hip /opt/rocm /opt/rocm/llvm /opt/rocm/hip)
 
 option(ENABLE_HIP_WORKAROUNDS Off)

--- a/addkernels/CMakeLists.txt
+++ b/addkernels/CMakeLists.txt
@@ -27,5 +27,9 @@
 set(ADD_KERNELS_SOURCE include_inliner.cpp addkernels.cpp)
 
 add_executable(addkernels EXCLUDE_FROM_ALL ${ADD_KERNELS_SOURCE})
+target_include_directories(addkernels PRIVATE ${PROJECT_SOURCE_DIR}/src/include)
+if(HAS_LIB_STD_FILESYSTEM)
+    target_link_libraries(addkernels PRIVATE stdc++fs)
+endif()
 
 clang_tidy_check(addkernels)

--- a/addkernels/addkernels.cpp
+++ b/addkernels/addkernels.cpp
@@ -25,7 +25,6 @@
  *******************************************************************************/
 #include "include_inliner.hpp"
 #include <algorithm>
-#include <filesystem>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
@@ -125,7 +124,7 @@ void PrintHelp()
     WrongUsage(ss.str());
 }
 
-void Process(const std::filesystem::path& sourcePath,
+void Process(const fs::path& sourcePath,
              std::ostream& target,
              size_t bufferSize,
              size_t lineSize,
@@ -133,14 +132,14 @@ void Process(const std::filesystem::path& sourcePath,
              bool as_extern,
              bool mark_includes)
 {
-    if(!std::filesystem::exists(sourcePath))
+    if(!fs::exists(sourcePath))
     {
         std::cerr << "File not found: " << sourcePath << std::endl;
         // NOLINTNEXTLINE (concurrency-mt-unsafe)
         std::exit(1);
     }
 
-    std::filesystem::path root{sourcePath.has_parent_path() ? sourcePath.parent_path() : ""};
+    fs::path root{sourcePath.has_parent_path() ? sourcePath.parent_path() : ""};
     std::ifstream sourceFile{sourcePath, std::ios::in | std::ios::binary};
     std::istream* source = &sourceFile;
 

--- a/addkernels/include_inliner.cpp
+++ b/addkernels/include_inliner.cpp
@@ -39,8 +39,8 @@ std::string IncludeFileExceptionBase::What() const
 
 void IncludeInliner::Process(std::istream& input,
                              std::ostream& output,
-                             const std::filesystem::path& root,
-                             const std::filesystem::path& file_name,
+                             const fs::path& root,
+                             const fs::path& file_name,
                              const std::string& directive,
                              bool allow_angle_brackets,
                              bool recurse)
@@ -50,8 +50,8 @@ void IncludeInliner::Process(std::istream& input,
 
 void IncludeInliner::ProcessCore(std::istream& input,
                                  std::ostream& output,
-                                 const std::filesystem::path& root,
-                                 const std::filesystem::path& file_name,
+                                 const fs::path& root,
+                                 const fs::path& file_name,
                                  int line_number,
                                  const std::string& directive,
                                  bool allow_angle_brackets,
@@ -115,10 +115,9 @@ void IncludeInliner::ProcessCore(std::istream& input,
             const std::string include_file_path =
                 line.substr(first_quote_pos + 1, second_quote_pos - first_quote_pos - 1);
 
-            const auto abs_include_file_path{
-                std::filesystem::weakly_canonical(root / include_file_path)};
+            const auto abs_include_file_path{miopen::weakly_canonical(root / include_file_path)};
 
-            if(!std::filesystem::exists(abs_include_file_path))
+            if(!fs::exists(abs_include_file_path))
             {
                 if(include_optional)
                     continue;

--- a/addkernels/include_inliner.hpp
+++ b/addkernels/include_inliner.hpp
@@ -28,7 +28,6 @@
 
 #include "source_file_desc.hpp"
 #include <exception>
-#include <filesystem>
 #include <memory>
 #include <ostream>
 #include <stack>
@@ -120,8 +119,8 @@ public:
 
     void Process(std::istream& input,
                  std::ostream& output,
-                 const std::filesystem::path& root,
-                 const std::filesystem::path& file_name,
+                 const fs::path& root,
+                 const fs::path& file_name,
                  const std::string& directive,
                  bool allow_angle_brackets,
                  bool recurse);
@@ -133,8 +132,8 @@ private:
 
     void ProcessCore(std::istream& input,
                      std::ostream& output,
-                     const std::filesystem::path& root,
-                     const std::filesystem::path& file_name,
+                     const fs::path& root,
+                     const fs::path& file_name,
                      int line_number,
                      const std::string& directive,
                      bool allow_angle_brackets,

--- a/addkernels/source_file_desc.hpp
+++ b/addkernels/source_file_desc.hpp
@@ -26,20 +26,20 @@
 #ifndef SOURCE_FILE_DESC_HPP
 #define SOURCE_FILE_DESC_HPP
 
-#include <filesystem>
+#include <miopen/filesystem.hpp>
 #include <memory>
 #include <string>
+
+namespace fs = miopen::fs;
 
 class SourceFileDesc
 {
 public:
-    std::filesystem::path path;
+    fs::path path;
     int included_line;
     std::shared_ptr<SourceFileDesc> included_from;
 
-    SourceFileDesc(const std::filesystem::path& path_,
-                   std::shared_ptr<SourceFileDesc> from,
-                   int line)
+    SourceFileDesc(const fs::path& path_, std::shared_ptr<SourceFileDesc> from, int line)
         : path(path_), included_line(line), included_from(from)
     {
     }

--- a/cmake/CheckCXXLinkerFlag.cmake
+++ b/cmake/CheckCXXLinkerFlag.cmake
@@ -1,0 +1,60 @@
+################################################################################
+#
+# MIT License
+#
+# Copyright (c) 2024 Advanced Micro Devices, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+################################################################################
+
+set(check_cxx_linker_flag_patterns
+        FAIL_REGEX "[Uu]nrecogni[sz]ed .*option"               # GNU, NAG
+        FAIL_REGEX "switch .* is no longer supported"          # GNU
+        FAIL_REGEX "unknown .*option"                          # Clang
+        FAIL_REGEX "optimization flag .* not supported"        # Clang
+        FAIL_REGEX "unknown argument ignored"                  # Clang (cl)
+        FAIL_REGEX "ignoring unknown option"                   # MSVC, Intel
+        FAIL_REGEX "warning D9002"                             # MSVC, any lang
+        FAIL_REGEX "option.*not supported"                     # Intel
+        FAIL_REGEX "invalid argument .*option"                 # Intel
+        FAIL_REGEX "ignoring option .*argument required"       # Intel
+        FAIL_REGEX "ignoring option .*argument is of wrong type" # Intel
+        FAIL_REGEX "[Uu]nknown option"                         # HP
+        FAIL_REGEX "[Ww]arning: [Oo]ption"                     # SunPro
+        FAIL_REGEX "command option .* is not recognized"       # XL
+        FAIL_REGEX "command option .* contains an incorrect subargument" # XL
+        FAIL_REGEX "Option .* is not recognized.  Option will be ignored." # XL
+        FAIL_REGEX "not supported in this configuration. ignored"       # AIX
+        FAIL_REGEX "File with unknown suffix passed to linker" # PGI
+        FAIL_REGEX "[Uu]nknown switch"                         # PGI
+        FAIL_REGEX "WARNING: unknown flag:"                    # Open64
+        FAIL_REGEX "Incorrect command line option:"            # Borland
+        FAIL_REGEX "Warning: illegal option"                   # SunStudio 12
+        FAIL_REGEX "[Ww]arning: Invalid suboption"             # Fujitsu
+        FAIL_REGEX "An invalid option .* appears on the command line" # Cray
+)
+
+include (CheckCXXSourceCompiles)
+
+function(check_cxx_linker_flag _flag _var)
+    set (_source "int main() { return 0; }")
+    check_cxx_source_compiles("${_source}" _result ${check_cxx_linker_flag_patterns})
+    set(${_var} "${_result}" PARENT_SCOPE)
+endfunction()

--- a/src/anyramdb.cpp
+++ b/src/anyramdb.cpp
@@ -29,8 +29,7 @@
 #include <miopen/errors.hpp>
 #include <miopen/logger.hpp>
 
-#include <boost/filesystem/operations.hpp>
-#include <boost/filesystem.hpp>
+#include <miopen/filesystem.hpp>
 
 #include <chrono>
 #include <ctime>

--- a/src/binary_cache.cpp
+++ b/src/binary_cache.cpp
@@ -206,7 +206,7 @@ fs::path LoadBinary(const TargetProperties& target,
 
     (void)num_cu;
     auto f = GetCacheFile(target.DbId(), name, args);
-    if(boost::filesystem::exists(f))
+    if(fs::exists(f))
     {
         return f.string();
     }
@@ -223,13 +223,13 @@ void SaveBinary(const fs::path& binary_path,
 {
     if(miopen::IsCacheDisabled())
     {
-        boost::filesystem::remove(binary_path);
+        fs::remove(binary_path);
     }
     else
     {
         auto p = GetCacheFile(target.DbId(), name, args);
-        boost::filesystem::create_directories(p.parent_path());
-        boost::filesystem::rename(binary_path, p);
+        fs::create_directories(p.parent_path());
+        fs::rename(binary_path, p);
     }
 }
 #endif

--- a/src/binary_cache.cpp
+++ b/src/binary_cache.cpp
@@ -40,7 +40,7 @@
 #include <miopen/db.hpp>
 #include <miopen/db_path.hpp>
 #include <miopen/target_properties.hpp>
-#include <boost/filesystem.hpp>
+#include <miopen/filesystem.hpp>
 #include <fstream>
 #include <iostream>
 
@@ -49,20 +49,20 @@ MIOPEN_DECLARE_ENV_VAR_STR(MIOPEN_CUSTOM_CACHE_DIR)
 
 namespace miopen {
 
-static boost::filesystem::path ComputeSysCachePath()
+static fs::path ComputeSysCachePath()
 {
     const std::string cache_dir = GetSystemDbPath();
     auto p                      = miopen::ExpandUser(cache_dir);
-    if(!boost::filesystem::exists(p))
+    if(!fs::exists(p))
         return {};
     else
         return p;
 }
 
-static boost::filesystem::path ComputeUserCachePath()
+static fs::path ComputeUserCachePath()
 {
 #ifdef MIOPEN_CACHE_DIR
-    boost::filesystem::path p;
+    fs::path p;
     /// If MIOPEN_CUSTOM_CACHE_DIR is set in the environment, then
     /// use exactly that path.
     const auto& custom = miopen::GetStringEnv(ENV(MIOPEN_CUSTOM_CACHE_DIR));
@@ -81,21 +81,21 @@ static boost::filesystem::path ComputeUserCachePath()
 #if !MIOPEN_BUILD_DEV
         /// \ref nfs-detection
         if(IsNetworkedFilesystem(p))
-            p = boost::filesystem::temp_directory_path();
+            p = fs::temp_directory_path();
 #endif
     }
-    if(!boost::filesystem::exists(p) && !MIOPEN_DISABLE_USERDB)
-        boost::filesystem::create_directories(p);
+    if(!fs::exists(p) && !MIOPEN_DISABLE_USERDB)
+        fs::create_directories(p);
     return p;
 #else
     return {};
 #endif
 }
 
-boost::filesystem::path GetCachePath(bool is_system)
+fs::path GetCachePath(bool is_system)
 {
-    static const boost::filesystem::path user_path = ComputeUserCachePath();
-    static const boost::filesystem::path sys_path  = ComputeSysCachePath();
+    static const fs::path user_path = ComputeUserCachePath();
+    static const fs::path sys_path  = ComputeSysCachePath();
     if(is_system)
     {
         if(MIOPEN_DISABLE_SYSDB)
@@ -130,23 +130,21 @@ KDb GetDb(const TargetProperties& target, size_t num_cu)
 {
     static const auto user_dir = ComputeUserCachePath();
     static const auto sys_dir  = ComputeSysCachePath();
-    boost::filesystem::path user_path =
-        user_dir / (Handle::GetDbBasename(target, num_cu) + ".ukdb");
-    boost::filesystem::path sys_path = sys_dir / (Handle::GetDbBasename(target, num_cu) + ".kdb");
+    fs::path user_path         = user_dir / (Handle::GetDbBasename(target, num_cu) + ".ukdb");
+    fs::path sys_path          = sys_dir / (Handle::GetDbBasename(target, num_cu) + ".kdb");
     if(user_dir.empty())
         user_path = user_dir;
-    if(!boost::filesystem::exists(sys_path))
+    if(!fs::exists(sys_path))
         sys_path = sys_dir / (target.DbId() + ".kdb");
 #if !MIOPEN_EMBED_DB
-    if(!boost::filesystem::exists(sys_path))
-        sys_path = boost::filesystem::path{};
+    if(!fs::exists(sys_path))
+        sys_path = fs::path{};
 #endif
     return {sys_path.string(), user_path.string()};
 }
 #endif
 
-boost::filesystem::path
-GetCacheFile(const std::string& device, const std::string& name, const std::string& args)
+fs::path GetCacheFile(const std::string& device, const std::string& name, const std::string& args)
 {
     const std::string filename = name + ".o";
     return GetCachePath(false) / miopen::md5(device + ":" + args) / filename;
@@ -198,10 +196,10 @@ void SaveBinary(const std::string& hsaco,
     db.StoreRecord(cfg);
 }
 #else
-boost::filesystem::path LoadBinary(const TargetProperties& target,
-                                   const size_t num_cu,
-                                   const std::string& name,
-                                   const std::string& args)
+fs::path LoadBinary(const TargetProperties& target,
+                    const size_t num_cu,
+                    const std::string& name,
+                    const std::string& args)
 {
     if(miopen::IsCacheDisabled())
         return {};
@@ -218,7 +216,7 @@ boost::filesystem::path LoadBinary(const TargetProperties& target,
     }
 }
 
-void SaveBinary(const boost::filesystem::path& binary_path,
+void SaveBinary(const fs::path& binary_path,
                 const TargetProperties& target,
                 const std::string& name,
                 const std::string& args)

--- a/src/conv/heuristics/ai_heuristics.cpp
+++ b/src/conv/heuristics/ai_heuristics.cpp
@@ -27,7 +27,7 @@
 #include <miopen/conv/heuristics/ai_heuristics.hpp>
 #if MIOPEN_ENABLE_AI_IMMED_MODE_FALLBACK || MIOPEN_ENABLE_AI_KERNEL_TUNING
 #include <fdeep/fdeep.hpp>
-#include <boost/filesystem.hpp>
+#include <miopen/filesystem.hpp>
 
 namespace miopen {
 namespace ai {
@@ -35,7 +35,7 @@ namespace common {
 
 nlohmann::json LoadJSON(const std::string& path)
 {
-    if(!boost::filesystem::exists(path))
+    if(!fs::exists(path))
         MIOPEN_THROW(miopenStatusInternalError, "Unable to load file: " + path);
     return nlohmann::json::parse(std::ifstream(path));
 }
@@ -138,7 +138,7 @@ protected:
     static std::string ModelPath(const std::string& arch)
     {
         const auto file_path = GetSystemDbPath() + "/" + arch + ".tn.model";
-        if(!boost::filesystem::exists(file_path))
+        if(!fs::exists(file_path))
             MIOPEN_THROW(miopenStatusInternalError, "Unable to load AI model file:" + file_path);
         return file_path;
     }
@@ -475,7 +475,7 @@ private:
     {
         const std::string path =
             GetSystemDbPath() + "/" + arch + "_" + solver + "_encoder.ktn.model";
-        if(!boost::filesystem::exists(path))
+        if(!fs::exists(path))
             MIOPEN_THROW(miopenStatusInternalError, "Unable to load file: " + path);
         return path;
     }
@@ -483,7 +483,7 @@ private:
     {
         const std::string path =
             GetSystemDbPath() + "/" + arch + "_" + solver + "_decoder.ktn.model";
-        if(!boost::filesystem::exists(path))
+        if(!fs::exists(path))
             MIOPEN_THROW(miopenStatusInternalError, "Unable to load file: " + path);
         return path;
     }

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -30,8 +30,7 @@
 #include <miopen/logger.hpp>
 
 #include <boost/date_time/posix_time/posix_time_types.hpp>
-#include <boost/filesystem.hpp>
-#include <boost/filesystem/path.hpp>
+#include <miopen/filesystem.hpp>
 #include <boost/none.hpp>
 #include <boost/optional.hpp>
 
@@ -61,15 +60,15 @@ PlainTextDb::PlainTextDb(const std::string& filename_, bool is_system)
 
     if(!DisableUserDbFileIO)
     {
-        auto file            = boost::filesystem::path(filename_);
+        auto file            = fs::path(filename_);
         const auto directory = file.remove_filename();
 
-        if(!(boost::filesystem::exists(directory)))
+        if(!(fs::exists(directory)))
         {
-            if(!boost::filesystem::create_directories(directory))
+            if(!fs::create_directories(directory))
                 MIOPEN_LOG_W("Unable to create a directory: " << directory);
             else
-                boost::filesystem::permissions(directory, boost::filesystem::all_all);
+                fs::permissions(directory, fs::perms::all);
         }
     }
 }
@@ -253,7 +252,7 @@ bool PlainTextDb::FlushUnsafe(const DbRecord& record, const RecordPositions* pos
             record.WriteContents(file);
         }
 
-        boost::filesystem::permissions(filename, boost::filesystem::all_all);
+        fs::permissions(filename, fs::perms::all);
     }
     else
     {
@@ -285,10 +284,10 @@ bool PlainTextDb::FlushUnsafe(const DbRecord& record, const RecordPositions* pos
         from.close();
         to.close();
 
-        std::remove(filename.c_str());
-        std::rename(temp_name.c_str(), filename.c_str());
+        fs::remove(filename);
+        fs::rename(temp_name, filename);
         /// \todo What if rename fails? Thou shalt not loose the original file.
-        boost::filesystem::permissions(filename, boost::filesystem::all_all);
+        fs::permissions(filename, fs::perms::all);
     }
     return true;
 }

--- a/src/db_path.cpp.in
+++ b/src/db_path.cpp.in
@@ -29,8 +29,7 @@
 #include <miopen/stringutils.hpp>
 #include <miopen/expanduser.hpp>
 #include <miopen/logger.hpp>
-
-#include <boost/filesystem.hpp>
+#include <miopen/filesystem.hpp>
 
 #include <cstdlib>
 #ifdef __linux__
@@ -43,14 +42,14 @@ MIOPEN_DECLARE_ENV_VAR_STR(MIOPEN_USER_DB_PATH)
 namespace miopen {
 
 #ifdef __linux__
-boost::filesystem::path GetLibPath()
+fs::path GetLibPath()
 {
-    boost::filesystem::path path = {""};
+    fs::path path = {""};
     Dl_info info;
 
     if(dladdr(reinterpret_cast<void*>(miopenCreate), &info) != 0)
     {
-        path = boost::filesystem::canonical(boost::filesystem::path{info.dli_fname});
+        path = fs::canonical(fs::path{info.dli_fname});
         MIOPEN_LOG_I2(std::string("Lib Path: ") + path.string());
         if(path.empty())
             return path;
@@ -85,7 +84,7 @@ std::string GetSystemDbPath()
 }
 
 namespace {
-boost::filesystem::path PrepareUserDbPath()
+fs::path PrepareUserDbPath()
 {
     /// If MIOPEN_USER_DB_PATH is set in the environment, then assume that the user wants
     /// the library to use exactly that path.
@@ -103,7 +102,7 @@ boost::filesystem::path PrepareUserDbPath()
     const auto udb_path = ExpandUser("${MIOPEN_USER_DB_PATH}");
 #if !MIOPEN_BUILD_DEV
     if(IsNetworkedFilesystem(udb_path))
-        return boost::filesystem::temp_directory_path();
+        return fs::temp_directory_path();
 #endif
     return udb_path;
 }
@@ -113,7 +112,7 @@ std::string GetUserDbSuffix() { return "${MIOPEN_USER_DB_SUFFIX}"; }
 
 std::string GetSystemFindDbSuffix() { return "${MIOPEN_SYSTEM_FIND_DB_SUFFIX}"; }
 
-const boost::filesystem::path& GetUserDbPath()
+const fs::path& GetUserDbPath()
 {
     static const auto instance = PrepareUserDbPath();
     return instance;

--- a/src/expanduser.cpp
+++ b/src/expanduser.cpp
@@ -28,7 +28,7 @@
 #include <miopen/logger.hpp>
 #include <miopen/stringutils.hpp>
 
-#include <boost/filesystem.hpp>
+#include <miopen/filesystem.hpp>
 
 #include <string>
 #ifdef _WIN32
@@ -136,7 +136,7 @@ bool IsNetworked(unsigned long ft)
 
 #undef CASE_RET_STRING
 
-bool IsNetworkedFilesystem(const boost::filesystem::path& path_)
+bool IsNetworkedFilesystem(const fs::path& path_)
 {
     // Non-DEV builds put user databases in ~/.config/miopen by default; the binary cache is placed
     // in ~/.cache/miopen. If these directories do not exist, this is not a problem, because the
@@ -155,7 +155,7 @@ bool IsNetworkedFilesystem(const boost::filesystem::path& path_)
     auto path = path_;
     for(int i = 0; i < 32; ++i)
     {
-        if(boost::filesystem::exists(path))
+        if(fs::exists(path))
             break;
         MIOPEN_LOG_NQI2("Path does not exist: '" << path.string() << '\'');
         path = path.parent_path();
@@ -188,11 +188,11 @@ std::string GetHomeDir()
     // need to figure out what is the correct thing to do here
     // in tensoflow unit tests run via bazel, $HOME is not set, so this can happen
     // setting home_dir to the /tmp for now
-    return {boost::filesystem::temp_directory_path().string()};
+    return {fs::temp_directory_path().string()};
 }
 } // namespace
 
-boost::filesystem::path ExpandUser(const std::string& path)
+fs::path ExpandUser(const std::string& path)
 {
     static const std::string home_dir = GetHomeDir();
     return {ReplaceString(path, "~", home_dir)};
@@ -229,9 +229,9 @@ ReplaceVariable(const std::string& path, std::string_view name, std::size_t offs
             auto value{GetEnvironmentVariable(name)};
             if(!value)
             {
-                // TODO: log warning message that the name used does not
-                //       correspond to an environment variable.
-                value = boost::filesystem::temp_directory_path().string();
+                // TODO: log warning message that the name used
+                //       does not correspond to an environment variable.
+                value = fs::temp_directory_path().string();
             }
             result.replace(pos, variable.length(), *value);
             return {{pos, result}};
@@ -241,7 +241,7 @@ ReplaceVariable(const std::string& path, std::string_view name, std::size_t offs
 }
 } // namespace
 
-boost::filesystem::path ExpandUser(const std::string& path)
+fs::path ExpandUser(const std::string& path)
 {
     auto result{ReplaceVariable(path, "USERPROFILE")};
     if(!result)
@@ -261,7 +261,7 @@ boost::filesystem::path ExpandUser(const std::string& path)
     return {!result ? path : std::get<1>(*result)};
 }
 
-bool IsNetworkedFilesystem(const boost::filesystem::path&) { return false; }
+bool IsNetworkedFilesystem(const fs::path&) { return false; }
 
 #endif
 

--- a/src/find_db.cpp
+++ b/src/find_db.cpp
@@ -32,7 +32,7 @@
 #if MIOPEN_EMBED_DB
 #include <miopen_data.hpp>
 #endif
-#include <boost/filesystem.hpp>
+#include <miopen/filesystem.hpp>
 #include <string>
 #include <vector>
 
@@ -59,7 +59,6 @@ std::string FindDbRecord_t<TDb>::GetInstalledPathEmbed(Handle& handle,
                                                        const std::string& path_suffix)
 {
     static const auto embed_path = [&] {
-        namespace fs          = boost::filesystem;
         const std::string ext = ".fdb.txt";
         const auto root_path  = fs::path(GetSystemDbPath());
         const auto base_name  = handle.GetDbBasename();
@@ -127,14 +126,13 @@ std::string FindDbRecord_t<TDb>::GetInstalledPathFile(Handle& handle,
                                                       const std::string& path_suffix)
 {
     static const auto installed_path = [&] {
-        namespace fs          = boost::filesystem;
         const std::string ext = ".fdb.txt";
         const auto root_path  = fs::path(GetSystemDbPath());
         const auto base_name  = handle.GetDbBasename();
         const auto suffix =
             GetSystemFindDbSuffix() + (path_suffix.empty() ? "" : ('.' + path_suffix));
         const auto file_path = root_path / (base_name + "." + suffix + ext);
-        if(boost::filesystem::exists(file_path))
+        if(fs::exists(file_path))
         {
             MIOPEN_LOG_I2("Found exact find database file: " + file_path.string());
             return file_path.string();

--- a/src/hip/handlehip.cpp
+++ b/src/hip/handlehip.cpp
@@ -41,6 +41,7 @@
 
 #if !MIOPEN_ENABLE_SQLITE_KERN_CACHE
 #include <miopen/write_file.hpp>
+#include <boost/filesystem/operations.hpp>
 #endif
 
 #include <miopen/filesystem.hpp>
@@ -546,7 +547,7 @@ Program Handle::LoadProgram(const std::string& program_name,
         if(p.IsCodeObjectInMemory())
             miopen::WriteFile(p.GetCodeObjectBlob(), path);
         else
-            boost::filesystem::copy_file(p.GetCodeObjectPathname(), path);
+            fs::copy_file(p.GetCodeObjectPathname(), path);
         miopen::SaveBinary(path, this->GetTargetProperties(), program_name, params);
 #endif
         p.FreeCodeObjectFileStorage();

--- a/src/hip/handlehip.cpp
+++ b/src/hip/handlehip.cpp
@@ -43,7 +43,7 @@
 #include <miopen/write_file.hpp>
 #endif
 
-#include <boost/filesystem.hpp>
+#include <miopen/filesystem.hpp>
 #include <miopen/load_file.hpp>
 
 #ifndef _WIN32

--- a/src/hip/hip_build_utils.cpp
+++ b/src/hip/hip_build_utils.cpp
@@ -42,12 +42,12 @@ MIOPEN_DECLARE_ENV_VAR_BOOL(MIOPEN_DEBUG_HIP_DUMP)
 
 namespace miopen {
 
-static boost::filesystem::path HipBuildImpl(boost::optional<TmpDir>& tmp_dir,
-                                            const std::string& filename,
-                                            std::string src,
-                                            std::string params,
-                                            const TargetProperties& target,
-                                            const bool testing_mode)
+static fs::path HipBuildImpl(boost::optional<TmpDir>& tmp_dir,
+                             const std::string& filename,
+                             std::string src,
+                             std::string params,
+                             const TargetProperties& target,
+                             const bool testing_mode)
 {
 #ifdef __linux__
     // Write out the include files
@@ -56,7 +56,7 @@ static boost::filesystem::path HipBuildImpl(boost::optional<TmpDir>& tmp_dir,
     {
         auto inc_list = GetHipKernelIncList();
         auto inc_path = tmp_dir->path;
-        boost::filesystem::create_directories(inc_path);
+        fs::create_directories(inc_path);
         for(const auto& inc_file : inc_list)
         {
             auto inc_src = GetKernelInc(inc_file);
@@ -129,7 +129,7 @@ static boost::filesystem::path HipBuildImpl(boost::optional<TmpDir>& tmp_dir,
         const std::string cmd        = env + std::string(" ") + MIOPEN_HIP_COMPILER;
         const std::string args       = params + filename + " -o " + bin_file.string() + redirector;
         tmp_dir->Execute(cmd, args);
-        if(!boost::filesystem::exists(bin_file))
+        if(!fs::exists(bin_file))
             MIOPEN_THROW("Failed cmd: '" + cmd + "', args: '" + args + '\'');
     }
 
@@ -207,11 +207,11 @@ static bool DetectIfBufferAtomicFaddReturnsFloat(const TargetProperties& target)
 }
 #endif
 
-boost::filesystem::path HipBuild(boost::optional<TmpDir>& tmp_dir,
-                                 const std::string& filename,
-                                 std::string src,
-                                 std::string params,
-                                 const TargetProperties& target)
+fs::path HipBuild(boost::optional<TmpDir>& tmp_dir,
+                  const std::string& filename,
+                  std::string src,
+                  std::string params,
+                  const TargetProperties& target)
 {
 #ifndef ROCM_FEATURE_LLVM_AMDGCN_BUFFER_ATOMIC_FADD_F32_RETURNS_FLOAT
     if(miopen::solver::support_amd_buffer_atomic_fadd(target.Name()))
@@ -224,7 +224,7 @@ boost::filesystem::path HipBuild(boost::optional<TmpDir>& tmp_dir,
     return HipBuildImpl(tmp_dir, filename, src, params, target, false);
 }
 
-void bin_file_to_str(const boost::filesystem::path& file, std::string& buf)
+void bin_file_to_str(const fs::path& file, std::string& buf)
 {
     std::ifstream bin_file_ptr(file.string().c_str(), std::ios::binary);
     std::ostringstream bin_file_strm;

--- a/src/hip/hip_build_utils.cpp
+++ b/src/hip/hip_build_utils.cpp
@@ -151,11 +151,11 @@ static fs::path HipBuildImpl(boost::optional<TmpDir>& tmp_dir,
                          + " --inputs=" + bin_file.string() + " --outputs=" + bin_file.string() +
                          ".hsaco --unbundle");
 
-    auto hsaco = std::find_if(boost::filesystem::directory_iterator{tmp_dir->path},
-                              {},
-                              [](auto entry) { return (entry.path().extension() == ".hsaco"); });
+    auto hsaco = std::find_if(fs::directory_iterator{tmp_dir->path}, {}, [](auto entry) {
+        return (entry.path().extension() == ".hsaco");
+    });
 
-    if(hsaco == boost::filesystem::directory_iterator{})
+    if(hsaco == fs::directory_iterator{})
     {
         MIOPEN_LOG_E("failed to find *.hsaco in " << hsaco->path().string());
     }

--- a/src/hipoc/hipoc_program.cpp
+++ b/src/hipoc/hipoc_program.cpp
@@ -158,7 +158,7 @@ inline std::string GetCodeObjectVersionOption()
 } // namespace
 #endif
 
-static hipModulePtr CreateModule(const boost::filesystem::path& hsaco_file)
+static hipModulePtr CreateModule(const fs::path& hsaco_file)
 {
     hipModule_t raw_m;
     auto status = hipModuleLoad(&raw_m, hsaco_file.string().c_str());
@@ -185,8 +185,7 @@ hipModulePtr CreateModuleInMem(const T& blob)
 #endif
 }
 
-HIPOCProgramImpl::HIPOCProgramImpl(const std::string& program_name,
-                                   const boost::filesystem::path& filespec)
+HIPOCProgramImpl::HIPOCProgramImpl(const std::string& program_name, const fs::path& filespec)
     : program(program_name), hsaco_file(filespec)
 {
     module = CreateModule(hsaco_file);
@@ -356,7 +355,7 @@ HIPOCProgram::HIPOCProgram(const std::string& program_name,
 {
 }
 
-HIPOCProgram::HIPOCProgram(const std::string& program_name, const boost::filesystem::path& hsaco)
+HIPOCProgram::HIPOCProgram(const std::string& program_name, const fs::path& hsaco)
     : impl(std::make_shared<HIPOCProgramImpl>(program_name, hsaco))
 {
 }
@@ -368,7 +367,7 @@ HIPOCProgram::HIPOCProgram(const std::string& program_name, const std::string& h
 
 hipModule_t HIPOCProgram::GetModule() const { return impl->module.get(); }
 
-boost::filesystem::path HIPOCProgram::GetCodeObjectPathname() const
+fs::path HIPOCProgram::GetCodeObjectPathname() const
 {
     if(!impl->hsaco_file.empty())
     {

--- a/src/hipoc/hipoc_program.cpp
+++ b/src/hipoc/hipoc_program.cpp
@@ -264,7 +264,7 @@ void HIPOCProgramImpl::BuildCodeObjectInFile(std::string& params,
         params += " " + filename + " -o " + hsaco_file.string();
         dir->Execute(HIP_OC_COMPILER, params);
     }
-    if(!boost::filesystem::exists(hsaco_file))
+    if(!fs::exists(hsaco_file))
         MIOPEN_THROW("Cant find file: " + hsaco_file.string());
 }
 

--- a/src/include/miopen/binary_cache.hpp
+++ b/src/include/miopen/binary_cache.hpp
@@ -29,25 +29,24 @@
 
 #include <miopen/config.h>
 #include <miopen/target_properties.hpp>
-#include <boost/filesystem/path.hpp>
+#include <miopen/filesystem.hpp>
 #include <string>
 
 namespace miopen {
 
 bool IsCacheDisabled();
 
-boost::filesystem::path
-GetCacheFile(const std::string& device, const std::string& name, const std::string& args);
+fs::path GetCacheFile(const std::string& device, const std::string& name, const std::string& args);
 
-boost::filesystem::path GetCachePath(bool is_system);
+fs::path GetCachePath(bool is_system);
 
 #if !MIOPEN_ENABLE_SQLITE_KERN_CACHE
-boost::filesystem::path LoadBinary(const TargetProperties& target,
-                                   std::size_t num_cu,
-                                   const std::string& name,
-                                   const std::string& args);
+fs::path LoadBinary(const TargetProperties& target,
+                    std::size_t num_cu,
+                    const std::string& name,
+                    const std::string& args);
 
-void SaveBinary(const boost::filesystem::path& binary_path,
+void SaveBinary(const fs::path& binary_path,
                 const TargetProperties& target,
                 const std::string& name,
                 const std::string& args);

--- a/src/include/miopen/conv/heuristics/ai_heuristics.hpp
+++ b/src/include/miopen/conv/heuristics/ai_heuristics.hpp
@@ -41,7 +41,7 @@
 #include <nlohmann/json.hpp>
 #include <miopen/db_path.hpp>
 #include <miopen/any_solver.hpp>
-#include <boost/filesystem.hpp>
+#include <miopen/filesystem.hpp>
 #include <miopen/anyramdb.hpp>
 
 namespace miopen {

--- a/src/include/miopen/db.hpp
+++ b/src/include/miopen/db.hpp
@@ -36,12 +36,6 @@
 #include <chrono>
 #include <string>
 
-namespace boost {
-namespace filesystem {
-class path;
-} // namespace filesystem
-} // namespace boost
-
 namespace miopen {
 
 struct RecordPositions

--- a/src/include/miopen/db_path.hpp
+++ b/src/include/miopen/db_path.hpp
@@ -26,13 +26,13 @@
 #ifndef GUARD_MIOPEN_DB_PATH_HPP
 #define GUARD_MIOPEN_DB_PATH_HPP
 
-#include <boost/filesystem.hpp>
+#include <miopen/filesystem.hpp>
 #include <string>
 
 namespace miopen {
 
 std::string GetSystemDbPath();
-const boost::filesystem::path& GetUserDbPath();
+const fs::path& GetUserDbPath();
 std::string GetUserDbSuffix();
 std::string GetSystemFindDbSuffix();
 

--- a/src/include/miopen/execution_context.hpp
+++ b/src/include/miopen/execution_context.hpp
@@ -34,7 +34,7 @@
 #if MIOPEN_EMBED_DB
 #include <miopen_data.hpp>
 #endif
-#include <boost/filesystem.hpp>
+#include <miopen/filesystem.hpp>
 
 #include <string>
 
@@ -115,7 +115,7 @@ struct ExecutionContext
     std::string GetPerfDbPathEmbed() const
     {
         static const auto result = [&] {
-            boost::filesystem::path pdb_path(GetSystemDbPath());
+            fs::path pdb_path(GetSystemDbPath());
             std::ostringstream filename;
             // clang-format off
             filename << GetStream().GetDbBasename();
@@ -183,7 +183,7 @@ struct ExecutionContext
     std::string GetPerfDbPathFile() const
     {
         static const auto result = [&] {
-            const boost::filesystem::path pdb_path(GetSystemDbPath());
+            const fs::path pdb_path(GetSystemDbPath());
             std::ostringstream filename;
             // clang-format off
         filename << GetStream().GetDbBasename();
@@ -194,7 +194,7 @@ struct ExecutionContext
 #endif
         filename << ext;
             // clang-format on
-            if(boost::filesystem::exists(pdb_path / filename.str()))
+            if(fs::exists(pdb_path / filename.str()))
             {
                 MIOPEN_LOG_I("Found exact perf database file");
                 return (pdb_path / filename.str()).string();
@@ -204,7 +204,6 @@ struct ExecutionContext
                 MIOPEN_LOG_I2("inexact perf database search");
                 const auto db_id        = GetStream().GetTargetProperties().DbId();
                 const int real_cu_count = GetStream().GetMaxComputeUnits();
-                namespace fs            = boost::filesystem;
                 if(fs::exists(pdb_path) && fs::is_directory(pdb_path))
                 {
                     MIOPEN_LOG_I2("Iterating over perf db directory " << pdb_path.string());

--- a/src/include/miopen/expanduser.hpp
+++ b/src/include/miopen/expanduser.hpp
@@ -26,13 +26,13 @@
 #ifndef MIOPEN_GUARD_MLOPEN_EXPANDUSER_HPP
 #define MIOPEN_GUARD_MLOPEN_EXPANDUSER_HPP
 
-#include <boost/filesystem.hpp>
+#include <miopen/filesystem.hpp>
 #include <string>
 
 namespace miopen {
 
-boost::filesystem::path ExpandUser(const std::string& path);
-bool IsNetworkedFilesystem(const boost::filesystem::path&);
+fs::path ExpandUser(const std::string& path);
+bool IsNetworkedFilesystem(const fs::path&);
 
 } // namespace miopen
 

--- a/src/include/miopen/filesystem.hpp
+++ b/src/include/miopen/filesystem.hpp
@@ -77,7 +77,7 @@ namespace fs = ::std::experimental::filesystem;
 
 #if MIOPEN_HAS_FILESYSTEM_TS
 #ifdef __linux__
-#include<linux/limits.h>
+#include <linux/limits.h>
 namespace miopen {
 inline fs::path weakly_canonical(const fs::path& path)
 {

--- a/src/include/miopen/filesystem.hpp
+++ b/src/include/miopen/filesystem.hpp
@@ -97,4 +97,3 @@ inline fs::path weakly_canonical(const fs::path& path) { return fs::weakly_canon
 #endif
 
 #endif // GUARD_MIOPEN_FILESYSTEM_HPP_
-

--- a/src/include/miopen/filesystem.hpp
+++ b/src/include/miopen/filesystem.hpp
@@ -1,0 +1,100 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2020 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#ifndef GUARD_MIOPEN_FILESYSTEM_HPP_
+#define GUARD_MIOPEN_FILESYSTEM_HPP_
+
+#if defined(CPPCHECK)
+#define MIOPEN_HAS_FILESYSTEM 1
+#define MIOPEN_HAS_FILESYSTEM_TS 1
+#elif defined(_WIN32)
+#if _MSC_VER >= 1920
+#define MIOPEN_HAS_FILESYSTEM 1
+#define MIOPEN_HAS_FILESYSTEM_TS 0
+#elif _MSC_VER >= 1900
+#define MIOPEN_HAS_FILESYSTEM 0
+#define MIOPEN_HAS_FILESYSTEM_TS 1
+#else
+#define MIOPEN_HAS_FILESYSTEM 0
+#define MIOPEN_HAS_FILESYSTEM_TS 0
+#endif
+#elif defined(__has_include)
+#if __has_include(<filesystem>) && __cplusplus >= 201703L
+#define MIOPEN_HAS_FILESYSTEM 1
+#else
+#define MIOPEN_HAS_FILESYSTEM 0
+#endif
+#if __has_include(<experimental/filesystem>) && __cplusplus >= 201103L
+#define MIOPEN_HAS_FILESYSTEM_TS 1
+#else
+#define MIOPEN_HAS_FILESYSTEM_TS 0
+#endif
+#else
+#define MIOPEN_HAS_FILESYSTEM 0
+#define MIOPEN_HAS_FILESYSTEM_TS 0
+#endif
+
+#if MIOPEN_HAS_FILESYSTEM
+#include <filesystem>
+#elif MIOPEN_HAS_FILESYSTEM_TS
+#include <experimental/filesystem>
+#else
+#error "No filesystem include available"
+#endif
+
+namespace miopen {
+
+#if MIOPEN_HAS_FILESYSTEM
+namespace fs = ::std::filesystem;
+#elif MIOPEN_HAS_FILESYSTEM_TS
+namespace fs = ::std::experimental::filesystem;
+#endif
+
+} // namespace miopen
+
+#if MIOPEN_HAS_FILESYSTEM_TS
+#ifdef __linux__
+#include<linux/limits.h>
+namespace miopen {
+inline fs::path weakly_canonical(const fs::path& path)
+{
+    std::string result(PATH_MAX, '\0');
+    std::string p{path.is_relative() ? (fs::current_path() / path).string() : path.string()};
+    char* retval = realpath(p.c_str(), &result[0]);
+    return (retval == nullptr) ? path : fs::path{result};
+}
+} // namespace miopen
+#else
+#error "Not implmeneted!"
+#endif
+#else
+namespace miopen {
+inline fs::path weakly_canonical(const fs::path& path) { return fs::weakly_canonical(path); }
+} // namespace miopen
+#endif
+
+#endif // GUARD_MIOPEN_FILESYSTEM_HPP_
+

--- a/src/include/miopen/handle_lock.hpp
+++ b/src/include/miopen/handle_lock.hpp
@@ -60,7 +60,7 @@ inline fs::path get_handle_lock_path(const char* name)
     if(!fs::exists(p))
     {
         auto tmp = fs::current_path() / boost::filesystem::unique_path().string();
-        std::ofstream{tmp};
+        std::ofstream{tmp}; // NOLINT(bugprone-unused-raii)
         fs::rename(tmp, p);
     }
     return p;

--- a/src/include/miopen/handle_lock.hpp
+++ b/src/include/miopen/handle_lock.hpp
@@ -29,9 +29,10 @@
 
 #include <boost/interprocess/sync/file_lock.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
-#include <boost/filesystem.hpp>
-#include <boost/filesystem/fstream.hpp>
+#include <boost/filesystem/operations.hpp>
+#include <fstream>
 #include <mutex>
+#include <miopen/filesystem.hpp>
 #include <miopen/config.h>
 #include <miopen/errors.hpp>
 #include <miopen/logger.hpp>
@@ -53,14 +54,14 @@ MIOPEN_DECLARE_HANDLE_MUTEX(gpu_handle_mutex)
 #define MIOPEN_HANDLE_LOCK
 #endif
 
-inline boost::filesystem::path get_handle_lock_path(const char* name)
+inline fs::path get_handle_lock_path(const char* name)
 {
-    auto p = boost::filesystem::current_path() / name;
-    if(!boost::filesystem::exists(p))
+    auto p = fs::current_path() / name;
+    if(!fs::exists(p))
     {
-        auto tmp = boost::filesystem::current_path() / boost::filesystem::unique_path();
-        boost::filesystem::ofstream{tmp}; // NOLINT
-        boost::filesystem::rename(tmp, p);
+        auto tmp = fs::current_path() / boost::filesystem::unique_path().string();
+        std::ofstream{tmp};
+        fs::rename(tmp, p);
     }
     return p;
 }

--- a/src/include/miopen/hip_build_utils.hpp
+++ b/src/include/miopen/hip_build_utils.hpp
@@ -36,13 +36,13 @@
 
 namespace miopen {
 
-boost::filesystem::path HipBuild(boost::optional<miopen::TmpDir>& tmp_dir,
-                                 const std::string& filename,
-                                 std::string src,
-                                 std::string params,
-                                 const TargetProperties& target);
+fs::path HipBuild(boost::optional<miopen::TmpDir>& tmp_dir,
+                  const std::string& filename,
+                  std::string src,
+                  std::string params,
+                  const TargetProperties& target);
 
-void bin_file_to_str(const boost::filesystem::path& file, std::string& buf);
+void bin_file_to_str(const fs::path& file, std::string& buf);
 
 class LcOptionTargetStrings
 {

--- a/src/include/miopen/hipoc_program.hpp
+++ b/src/include/miopen/hipoc_program.hpp
@@ -29,7 +29,7 @@
 #include <miopen/target_properties.hpp>
 #include <miopen/manage_ptr.hpp>
 #include <miopen/hipoc_program_impl.hpp>
-#include <boost/filesystem/path.hpp>
+#include <miopen/filesystem.hpp>
 #include <hip/hip_runtime_api.h>
 #include <string>
 
@@ -49,13 +49,13 @@ struct HIPOCProgram
                  std::string params,
                  const TargetProperties& target,
                  const std::string& kernel_src);
-    HIPOCProgram(const std::string& program_name, const boost::filesystem::path& hsaco);
+    HIPOCProgram(const std::string& program_name, const fs::path& hsaco);
     HIPOCProgram(const std::string& program_name, const std::string& hsaco);
     std::shared_ptr<HIPOCProgramImpl> impl;
     hipModule_t GetModule() const;
     /// \return Pathname of CO file, if it resides on the filesystem.
     /// This function should not be called after FreeCodeObjectFileStorage().
-    boost::filesystem::path GetCodeObjectPathname() const;
+    fs::path GetCodeObjectPathname() const;
     /// \return Copy of in-memory CO blob.
     std::string GetCodeObjectBlob() const;
     /// \return True if CO blob resides in-memory.

--- a/src/include/miopen/hipoc_program_impl.hpp
+++ b/src/include/miopen/hipoc_program_impl.hpp
@@ -29,7 +29,7 @@
 #include <miopen/target_properties.hpp>
 #include <miopen/manage_ptr.hpp>
 #include <miopen/tmp_dir.hpp>
-#include <boost/filesystem/path.hpp>
+#include <miopen/filesystem.hpp>
 #include <boost/optional.hpp>
 #include <hip/hip_runtime_api.h>
 
@@ -39,7 +39,7 @@ using hipModulePtr = MIOPEN_MANAGE_PTR(hipModule_t, hipModuleUnload);
 struct HIPOCProgramImpl
 {
     HIPOCProgramImpl(){};
-    HIPOCProgramImpl(const std::string& program_name, const boost::filesystem::path& filespec);
+    HIPOCProgramImpl(const std::string& program_name, const fs::path& filespec);
 
     HIPOCProgramImpl(const std::string& program_name, const std::string& blob);
 
@@ -50,7 +50,7 @@ struct HIPOCProgramImpl
 
     std::string program;
     TargetProperties target;
-    boost::filesystem::path hsaco_file;
+    fs::path hsaco_file;
     hipModulePtr module;
     boost::optional<TmpDir> dir;
     std::vector<char> binary;

--- a/src/include/miopen/kern_db.hpp
+++ b/src/include/miopen/kern_db.hpp
@@ -42,12 +42,6 @@
 #include <chrono>
 #include <thread>
 
-namespace boost {
-namespace filesystem {
-class path;
-} // namespace filesystem
-} // namespace boost
-
 namespace miopen {
 struct KernelConfig
 {

--- a/src/include/miopen/load_file.hpp
+++ b/src/include/miopen/load_file.hpp
@@ -1,13 +1,13 @@
 #ifndef MIOPEN_GUARD_MLOPEN_LOAD_FILE_HPP
 #define MIOPEN_GUARD_MLOPEN_LOAD_FILE_HPP
 
-#include <boost/filesystem/path.hpp>
+#include <miopen/filesystem.hpp>
 #include <string>
 
 namespace miopen {
 
 std::string LoadFile(const std::string& s);
-std::string LoadFile(const boost::filesystem::path& p);
+std::string LoadFile(const fs::path& p);
 
 } // namespace miopen
 

--- a/src/include/miopen/lock_file.hpp
+++ b/src/include/miopen/lock_file.hpp
@@ -26,13 +26,13 @@
 #ifndef GUARD_MIOPEN_LOCK_FILE_HPP_
 #define GUARD_MIOPEN_LOCK_FILE_HPP_
 
+#include <miopen/filesystem.hpp>
 #include <miopen/logger.hpp>
 
 #include <boost/date_time/posix_time/posix_time_duration.hpp>
 #include <boost/date_time/posix_time/posix_time_types.hpp>
 #include <boost/date_time/posix_time/ptime.hpp>
 #include <boost/date_time/time.hpp>
-#include <boost/filesystem/operations.hpp>
 #include <boost/interprocess/sync/file_lock.hpp>
 
 #include <chrono>
@@ -45,7 +45,7 @@
 
 namespace miopen {
 
-std::string LockFilePath(const boost::filesystem::path& filename_);
+std::string LockFilePath(const fs::path& filename_);
 // LockFile class is a wrapper around boost::interprocess::file_lock providing MT-safety.
 // One process should never have more than one instance of this class with same path at the same
 // time. It may lead to undefined behaviour on Windows.

--- a/src/include/miopen/mlir_build.hpp
+++ b/src/include/miopen/mlir_build.hpp
@@ -31,7 +31,7 @@
 
 #include <miopen/target_properties.hpp>
 #include <miopen/tmp_dir.hpp>
-#include <boost/filesystem/path.hpp>
+#include <miopen/filesystem.hpp>
 #include <boost/optional.hpp>
 #include <string>
 

--- a/src/include/miopen/process.hpp
+++ b/src/include/miopen/process.hpp
@@ -27,7 +27,7 @@
 #ifndef MIOPEN_GUARD_MLOPEN_PROCESS_HPP
 #define MIOPEN_GUARD_MLOPEN_PROCESS_HPP
 
-#include <boost/filesystem.hpp>
+#include <miopen/filesystem.hpp>
 #include <memory>
 #include <string_view>
 
@@ -37,10 +37,10 @@ struct ProcessImpl;
 
 struct Process
 {
-    Process(const boost::filesystem::path& cmd);
+    Process(const fs::path& cmd);
     ~Process() noexcept;
 
-    int operator()(std::string_view args = "", const boost::filesystem::path& cwd = "");
+    int operator()(std::string_view args = "", const fs::path& cwd = "");
 
 private:
     std::unique_ptr<ProcessImpl> impl;
@@ -48,9 +48,7 @@ private:
 
 struct ProcessAsync
 {
-    ProcessAsync(const boost::filesystem::path& cmd,
-                 std::string_view args              = "",
-                 const boost::filesystem::path& cwd = "");
+    ProcessAsync(const fs::path& cmd, std::string_view args = "", const fs::path& cwd = "");
     ~ProcessAsync() noexcept;
 
     ProcessAsync(ProcessAsync&&) noexcept;

--- a/src/include/miopen/sqlite_db.hpp
+++ b/src/include/miopen/sqlite_db.hpp
@@ -55,12 +55,6 @@
 MIOPEN_DECLARE_ENV_VAR_BOOL(MIOPEN_DEBUG_DISABLE_SQL_WAL)
 MIOPEN_DECLARE_ENV_VAR_STR(MIOPEN_DEBUG_PERFDB_OVERRIDE)
 
-namespace boost {
-namespace filesystem {
-class path;
-} // namespace filesystem
-} // namespace boost
-
 namespace miopen {
 
 constexpr bool InMemDb = MIOPEN_EMBED_DB;

--- a/src/include/miopen/sqlite_db.hpp
+++ b/src/include/miopen/sqlite_db.hpp
@@ -233,7 +233,7 @@ public:
         }
         else if(!is_system)
         {
-            auto file            = boost::filesystem::path(filename_);
+            auto file            = fs::path(filename_);
             const auto directory = file.remove_filename();
             if(directory.string().empty())
             {
@@ -241,18 +241,18 @@ public:
                 return;
             }
 
-            if(!(boost::filesystem::exists(directory)))
+            if(!fs::exists(directory))
             {
-                if(!boost::filesystem::create_directories(directory))
+                if(!fs::create_directories(directory))
                     MIOPEN_LOG_W("Unable to create a directory: " << directory);
                 else
-                    boost::filesystem::permissions(directory, boost::filesystem::all_all);
+                    fs::permissions(directory, fs::perms::all);
             }
         }
         sql = SQLite{filename_, is_system};
         if(!sql.Valid())
         {
-            bool isKDB = boost::filesystem::path(filename).extension() == ".kdb";
+            bool isKDB = fs::path(filename).extension() == ".kdb";
             dbInvalid  = true;
             filename   = "";
             if(!is_system)

--- a/src/include/miopen/tmp_dir.hpp
+++ b/src/include/miopen/tmp_dir.hpp
@@ -2,13 +2,13 @@
 #define MIOPEN_GUARD_MLOPEN_TMP_DIR_HPP
 
 #include <string_view>
-#include <boost/filesystem/path.hpp>
+#include <miopen/filesystem.hpp>
 
 namespace miopen {
 
 struct TmpDir
 {
-    boost::filesystem::path path;
+    fs::path path;
     TmpDir(std::string prefix);
 
     TmpDir(TmpDir const&) = delete;

--- a/src/include/miopen/write_file.hpp
+++ b/src/include/miopen/write_file.hpp
@@ -1,7 +1,7 @@
 #ifndef GUARD_MLOPEN_WRITE_FILE_HPP
 #define GUARD_MLOPEN_WRITE_FILE_HPP
 
-#include <boost/filesystem.hpp>
+#include <miopen/filesystem.hpp>
 #include <miopen/manage_ptr.hpp>
 #include <fstream>
 
@@ -9,7 +9,7 @@ namespace miopen {
 
 using FilePtr = MIOPEN_MANAGE_PTR(FILE*, std::fclose);
 
-inline void WriteFile(const std::string& content, const boost::filesystem::path& name)
+inline void WriteFile(const std::string& content, const fs::path& name)
 {
     // std::cerr << "Write file: " << name << std::endl;
     const FilePtr f{std::fopen(name.string().c_str(), "w")};
@@ -17,7 +17,7 @@ inline void WriteFile(const std::string& content, const boost::filesystem::path&
         MIOPEN_THROW("Failed to write to file");
 }
 
-inline void WriteFile(const std::vector<char>& content, const boost::filesystem::path& name)
+inline void WriteFile(const std::vector<char>& content, const fs::path& name)
 {
     // std::cerr << "Write file: " << name << std::endl;
     const FilePtr f{std::fopen(name.string().c_str(), "w")};

--- a/src/load_file.cpp
+++ b/src/load_file.cpp
@@ -4,7 +4,7 @@
 
 namespace miopen {
 
-std::string LoadFile(const boost::filesystem::path& p) { return LoadFile(p.string()); }
+std::string LoadFile(const fs::path& p) { return LoadFile(p.string()); }
 
 std::string LoadFile(const std::string& s)
 {

--- a/src/lock_file.cpp
+++ b/src/lock_file.cpp
@@ -29,8 +29,6 @@
 #include <miopen/logger.hpp>
 #include <miopen/md5.hpp>
 
-namespace fs = boost::filesystem;
-
 namespace miopen {
 
 inline void LogFsError(const fs::filesystem_error& ex, const std::string& from)
@@ -51,7 +49,7 @@ std::string LockFilePath(const fs::path& filename_)
         if(!fs::exists(directory))
         {
             fs::create_directories(directory);
-            fs::permissions(directory, fs::all_all);
+            fs::permissions(directory, fs::perms::all);
         }
         const auto hash = md5(filename_.parent_path().string());
         const auto file = directory / (hash + "_" + filename_.filename().string() + ".lock");
@@ -73,7 +71,7 @@ LockFile::LockFile(const char* path_, PassKey) : path(path_)
         {
             if(!std::ofstream{path})
                 MIOPEN_THROW(std::string("Error creating file <") + path + "> for locking.");
-            fs::permissions(path, fs::all_all);
+            fs::permissions(path, fs::perms::all);
         }
         flock = path;
     }

--- a/src/nogpu/handle.cpp
+++ b/src/nogpu/handle.cpp
@@ -41,7 +41,7 @@
 #include <miopen/write_file.hpp>
 #endif
 
-#include <boost/filesystem.hpp>
+#include <miopen/filesystem.hpp>
 #include <miopen/load_file.hpp>
 
 #ifndef _WIN32

--- a/src/nogpu/handle.cpp
+++ b/src/nogpu/handle.cpp
@@ -39,6 +39,7 @@
 
 #if !MIOPEN_ENABLE_SQLITE_KERN_CACHE
 #include <miopen/write_file.hpp>
+#include <boost/filesystem/operations.hpp>
 #endif
 
 #include <miopen/filesystem.hpp>
@@ -198,7 +199,7 @@ Program Handle::LoadProgram(const std::string& program_name,
         if(p.IsCodeObjectInMemory())
             miopen::WriteFile(p.GetCodeObjectBlob(), path);
         else
-            boost::filesystem::copy_file(p.GetCodeObjectPathname(), path);
+            fs::copy_file(p.GetCodeObjectPathname(), path);
         miopen::SaveBinary(path, this->GetTargetProperties(), program_name, params);
 #endif
     }

--- a/src/ocl/convolutionocl.cpp
+++ b/src/ocl/convolutionocl.cpp
@@ -346,7 +346,6 @@ void DumpTensorToFileFromDevice(const miopen::Handle& handle,
         MIOPEN_LOG_E("Dereferencing nullptr when trying to dump tensor from gpu");
         return;
     }
-    namespace fs = boost::filesystem;
 
     fs::path file_name_with_path(filename);
     fs::path path = file_name_with_path.parent_path();

--- a/src/ocl/gcn_asm_utils.cpp
+++ b/src/ocl/gcn_asm_utils.cpp
@@ -36,6 +36,7 @@ bool ValidateGcnAssembler() { return true; }
 #include <cstdio>
 #include <cstdlib>
 #include <fstream>
+#include <miopen/filesystem.hpp>
 #include <miopen/env.hpp>
 #include <miopen/errors.hpp>
 #include <miopen/manage_ptr.hpp>
@@ -55,6 +56,9 @@ bool ValidateGcnAssembler() { return true; }
 #include <sys/wait.h>
 #include <unistd.h>
 #endif // __linux__
+
+#include <boost/filesystem/operations.hpp>
+namespace fs = miopen::fs;
 
 /// SWDEV-233338: hip-clang reports unknown target instead of amdgpu.
 /// \todo Try to assemble AMD GCN source?
@@ -265,7 +269,7 @@ static void AmdgcnAssembleQuiet(const std::string& source, const std::string& pa
 
 static bool GcnAssemblerHasBug34765Impl()
 {
-    auto p = boost::filesystem::temp_directory_path() / boost::filesystem::unique_path();
+    auto p = fs::temp_directory_path() / boost::filesystem::unique_path().string();
     miopen::WriteFile(miopen::GetKernelSrc("bugzilla_34765_detect.s"), p);
     const auto& src = p.string();
     try
@@ -288,7 +292,7 @@ static bool GcnAssemblerHasBug34765()
 
 static bool GcnAssemblerSupportsOption(const std::string& option)
 {
-    auto p = boost::filesystem::temp_directory_path() / boost::filesystem::unique_path();
+    auto p = fs::temp_directory_path() / boost::filesystem::unique_path().string();
     miopen::WriteFile(miopen::GetKernelSrc("dummy_kernel.s"), p);
     const auto& src = p.string();
     try

--- a/src/ocl/handleocl.cpp
+++ b/src/ocl/handleocl.cpp
@@ -39,7 +39,7 @@
 #include <miopen/ocldeviceinfo.hpp>
 #include <miopen/timer.hpp>
 
-#include <boost/filesystem.hpp>
+#include <miopen/filesystem.hpp>
 
 #include <string>
 

--- a/src/ocl/handleocl.cpp
+++ b/src/ocl/handleocl.cpp
@@ -40,6 +40,7 @@
 #include <miopen/timer.hpp>
 
 #include <miopen/filesystem.hpp>
+#include <boost/filesystem/operations.hpp>
 
 #include <string>
 

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -122,10 +122,7 @@ private:
 
 #endif
 
-Process::Process(const fs::path& cmd)
-    : impl{std::make_unique<ProcessImpl>(cmd.string())}
-{
-}
+Process::Process(const fs::path& cmd) : impl{std::make_unique<ProcessImpl>(cmd.string())} {}
 
 Process::~Process() noexcept = default;
 
@@ -135,9 +132,7 @@ int Process::operator()(std::string_view args, const fs::path& cwd)
     return impl->Wait();
 }
 
-ProcessAsync::ProcessAsync(const fs::path& cmd,
-                           std::string_view args,
-                           const fs::path& cwd)
+ProcessAsync::ProcessAsync(const fs::path& cmd, std::string_view args, const fs::path& cwd)
     : impl{std::make_unique<ProcessImpl>(cmd.string())}
 {
     impl->Create(args, cwd.string());

--- a/src/process.cpp
+++ b/src/process.cpp
@@ -87,7 +87,7 @@ public:
     }
 
 private:
-    boost::filesystem::path path;
+    fs::path path;
     PROCESS_INFORMATION processInfo{};
 };
 
@@ -116,28 +116,28 @@ struct ProcessImpl
     }
 
 private:
-    boost::filesystem::path path;
+    fs::path path;
     FILE* pipe = nullptr;
 };
 
 #endif
 
-Process::Process(const boost::filesystem::path& cmd)
+Process::Process(const fs::path& cmd)
     : impl{std::make_unique<ProcessImpl>(cmd.string())}
 {
 }
 
 Process::~Process() noexcept = default;
 
-int Process::operator()(std::string_view args, const boost::filesystem::path& cwd)
+int Process::operator()(std::string_view args, const fs::path& cwd)
 {
     impl->Create(args, cwd.string());
     return impl->Wait();
 }
 
-ProcessAsync::ProcessAsync(const boost::filesystem::path& cmd,
+ProcessAsync::ProcessAsync(const fs::path& cmd,
                            std::string_view args,
-                           const boost::filesystem::path& cwd)
+                           const fs::path& cwd)
     : impl{std::make_unique<ProcessImpl>(cmd.string())}
 {
     impl->Create(args, cwd.string());

--- a/src/ramdb.cpp
+++ b/src/ramdb.cpp
@@ -30,8 +30,7 @@
 #include <miopen/lock_file.hpp>
 #include <miopen/logger.hpp>
 
-#include <boost/filesystem/operations.hpp>
-#include <boost/filesystem.hpp>
+#include <miopen/filesystem.hpp>
 
 #include <chrono>
 #include <ctime>
@@ -295,7 +294,7 @@ bool RamDb::ValidateUnsafe()
 {
     if(DisableUserDbFileIO)
         return true;
-    if(!boost::filesystem::exists(GetFileName()))
+    if(!fs::exists(GetFileName()))
         return cache.empty();
     const auto file_mod_time     = GetDbModificationTime(GetFileName());
     const auto validation_result = file_mod_time < file_read_time;

--- a/src/readonlyramdb.cpp
+++ b/src/readonlyramdb.cpp
@@ -27,13 +27,11 @@
 #include <miopen/readonlyramdb.hpp>
 #include <miopen/logger.hpp>
 #include <miopen/errors.hpp>
+#include <miopen/filesystem.hpp>
 
 #if MIOPEN_EMBED_DB
 #include <miopen_data.hpp>
 #endif
-
-#include <boost/filesystem.hpp>
-#include <boost/filesystem/path.hpp>
 
 #include <fstream>
 #include <mutex>
@@ -136,7 +134,7 @@ void ReadonlyRamDb::Prefetch(bool warn_if_unreadable)
         if(!debug::rordb_embed_fs_override() && isEmbedded)
         {
 #if MIOPEN_EMBED_DB
-            boost::filesystem::path filepath(db_path);
+            fs::path filepath(db_path);
             const auto& it_p = miopen_data().find(filepath.filename().string() + ".o");
             if(it_p == miopen_data().end())
                 MIOPEN_THROW(miopenStatusInternalError,

--- a/src/sqlite_db.cpp
+++ b/src/sqlite_db.cpp
@@ -30,13 +30,12 @@
 #include <miopen/logger.hpp>
 #include <miopen/conv/problem_description.hpp>
 #include <miopen/exp_backoff.hpp>
+#include <miopen/filesystem.hpp>
 
 #if MIOPEN_EMBED_DB
 #include <miopen_data.hpp>
 #endif
 #include <boost/date_time/posix_time/posix_time_types.hpp>
-#include <boost/filesystem.hpp>
-#include <boost/filesystem/path.hpp>
 #include <boost/none.hpp>
 #include <boost/optional.hpp>
 
@@ -73,7 +72,7 @@ class SQLite::impl
     };
     using sqlite3_ptr = std::unique_ptr<sqlite3, SQLiteCloser>;
 #if MIOPEN_EMBED_DB
-    int CreateInMemDb(const boost::filesystem::path& filepath, bool is_system)
+    int CreateInMemDb(const fs::path& filepath, bool is_system)
     {
         sqlite3* ptr_tmp = nullptr;
         int rc           = 0;
@@ -145,13 +144,13 @@ class SQLite::impl
         return rc;
     }
 #endif
-    int CreateFileDb(const boost::filesystem::path& filepath, bool is_system)
+    int CreateFileDb(const fs::path& filepath, bool is_system)
     {
         sqlite3* ptr_tmp = nullptr;
         int rc           = 0;
         if(is_system)
         {
-            if(boost::filesystem::file_size(filepath) <
+            if(fs::file_size(filepath) <
                512) // size of a very small database, Empty MIOpen DBs are 20 kb
             {
                 rc = -1;
@@ -177,7 +176,7 @@ class SQLite::impl
 public:
     impl(const std::string& filename_, bool is_system)
     {
-        boost::filesystem::path filepath(filename_);
+        fs::path filepath(filename_);
         int rc = 0;
 #if MIOPEN_EMBED_DB
         rc = CreateInMemDb(filepath, is_system);

--- a/src/temp_file.cpp
+++ b/src/temp_file.cpp
@@ -1,7 +1,7 @@
 #include <miopen/temp_file.hpp>
 #include <miopen/errors.hpp>
-#include <boost/filesystem/fstream.hpp>
-#include <boost/filesystem.hpp>
+#include <miopen/filesystem.hpp>
+#include <fstream>
 
 namespace miopen {
 TempFile::TempFile(const std::string& path_infix_) : path_infix(path_infix_), dir(path_infix)

--- a/src/tmp_dir.cpp
+++ b/src/tmp_dir.cpp
@@ -26,10 +26,11 @@
 
 #include <miopen/tmp_dir.hpp>
 #include <miopen/env.hpp>
-#include <boost/filesystem.hpp>
+#include <miopen/filesystem.hpp>
 #include <miopen/errors.hpp>
 #include <miopen/logger.hpp>
 #include <miopen/process.hpp>
+#include <boost/filesystem/operations.hpp>
 
 MIOPEN_DECLARE_ENV_VAR_BOOL(MIOPEN_DEBUG_SAVE_TEMP_DIR)
 MIOPEN_DECLARE_ENV_VAR_BOOL(MIOPEN_DEBUG_EXIT_STATUS_TEMP_DIR)
@@ -37,10 +38,10 @@ MIOPEN_DECLARE_ENV_VAR_BOOL(MIOPEN_DEBUG_EXIT_STATUS_TEMP_DIR)
 namespace miopen {
 
 TmpDir::TmpDir(std::string prefix)
-    : path(boost::filesystem::temp_directory_path() /
-           boost::filesystem::unique_path("miopen-" + prefix + "-%%%%-%%%%-%%%%-%%%%"))
+    : path(fs::temp_directory_path() /
+           boost::filesystem::unique_path("miopen-" + prefix + "-%%%%-%%%%-%%%%-%%%%").string())
 {
-    boost::filesystem::create_directories(this->path);
+    fs::create_directories(this->path);
 }
 
 TmpDir& TmpDir::operator=(TmpDir&& other) noexcept
@@ -68,7 +69,7 @@ TmpDir::~TmpDir()
     if(!miopen::IsEnabled(ENV(MIOPEN_DEBUG_SAVE_TEMP_DIR)))
     {
         if(!this->path.empty())
-            boost::filesystem::remove_all(this->path);
+            fs::remove_all(this->path);
     }
 }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -377,6 +377,9 @@ function(add_test_executable TEST_NAME)
         # Refer to https://en.cppreference.com/w/cpp/language/types for details.
         target_compile_options(${TEST_NAME} PRIVATE $<BUILD_INTERFACE:$<$<CXX_COMPILER_ID:Clang>:-U__LP64__>>)
     endif()
+    if(HAS_LIB_STD_FILESYSTEM)
+        target_link_libraries(${TEST_NAME} stdc++fs)
+    endif()
 endfunction()
 
 set(MIOPEN_TEST_SANITIZERS)

--- a/test/driver.hpp
+++ b/test/driver.hpp
@@ -43,7 +43,7 @@
 #include <half.hpp>
 #endif
 #include <type_traits>
-#include <boost/filesystem.hpp>
+#include <miopen/filesystem.hpp>
 #include <miopen/functional.hpp>
 #include <miopen/expanduser.hpp>
 #include <miopen/md5.hpp>
@@ -739,7 +739,7 @@ struct test_driver
         if(disabled_cache)
             return true;
         auto p = miopen::ExpandUser(cache_path) / ".disabled";
-        return boost::filesystem::exists(p);
+        return miopen::fs::exists(p);
     }
 
     template <class V, class... Ts>
@@ -750,10 +750,10 @@ struct test_driver
             return cpu_async(v, xs...);
         auto key = miopen::get_type_name<V>() + "-" + miopen::md5(get_command_args());
         auto p   = miopen::ExpandUser(cache_path) / std::to_string(cache_version);
-        if(!boost::filesystem::exists(p))
-            boost::filesystem::create_directories(p);
+        if(!miopen::fs::exists(p))
+            miopen::fs::create_directories(p);
         auto f = p / key;
-        if(boost::filesystem::exists(f) and not retry)
+        if(miopen::fs::exists(f) and not retry)
         {
             miss = false;
             return detach_async([=] {

--- a/test/embed_sqlite.cpp
+++ b/test/embed_sqlite.cpp
@@ -37,7 +37,7 @@
 #include <miopen/sqlite_db.hpp>
 #include <miopen/find_db.hpp>
 
-#include <boost/filesystem/path.hpp>
+#include <miopen/filesystem.hpp>
 
 namespace miopen {
 
@@ -72,7 +72,7 @@ struct EmbedSQLite : test_driver
         {
             // Get filename for the sys db
             // Check it in miopen_data()
-            boost::filesystem::path pdb_path(ctx.GetPerfDbPath());
+            fs::path pdb_path(ctx.GetPerfDbPath());
             const auto& it_p = miopen_data().find(pdb_path.filename().string() + ".o");
             EXPECT(it_p != miopen_data().end());
             // find all the entries in perf db

--- a/test/gtest/CMakeLists.txt
+++ b/test/gtest/CMakeLists.txt
@@ -36,6 +36,9 @@ function(add_gtest TEST_NAME TEST_CPP)
     # Refer to https://en.cppreference.com/w/cpp/language/types for details.
     target_compile_options(${TEST_NAME} PRIVATE $<BUILD_INTERFACE:$<$<CXX_COMPILER_ID:Clang>:-U__LP64__>>)
   endif()
+  if(HAS_LIB_STD_FILESYSTEM)
+    target_link_libraries(${TEST_NAME} stdc++fs)
+  endif()
 endfunction()
 
 file(GLOB TESTS *.cpp)

--- a/test/gtest/dumpTensorTest.cpp
+++ b/test/gtest/dumpTensorTest.cpp
@@ -9,6 +9,8 @@
 #include <miopen/convolution.hpp>
 #include <gtest/gtest.h>
 
+namespace fs = miopen::fs;
+
 const std::string test_file_name_prefix = "dumptensortest_";
 const size_t tensor_size                = 20;
 const size_t nan_index                  = 5;
@@ -101,7 +103,7 @@ void testDump(const std::string& test_file_name)
     compare(host_tensor, tensor_from_file);
 
     // clean up
-    boost::filesystem::remove(test_file_name);
+    fs::remove(test_file_name);
 }
 
 template <class T>
@@ -137,7 +139,7 @@ void testDumpWithNan(const std::string& test_file_name)
             << "] = " << host_tensor.data[nan_index];
     }
     // clean up
-    boost::filesystem::remove(test_file_name);
+    fs::remove(test_file_name);
 }
 
 TEST(DUMP_TENSOR_TEST, testDump_float) { testDump<float>(test_file_name_prefix + "float.bin"); }

--- a/test/include_inliner.cpp
+++ b/test/include_inliner.cpp
@@ -27,25 +27,25 @@
 #include <string>
 #include <fstream>
 
-#include <boost/filesystem.hpp>
+#include <miopen/filesystem.hpp>
 #include <miopen/errors.hpp>
 #include <miopen/tmp_dir.hpp>
 #include <miopen/process.hpp>
 
 #include "test.hpp"
 
-static int Child(std::string_view cmd, const boost::filesystem::path& path)
+namespace miopen {
+namespace tests {
+
+static int Child(std::string_view cmd, const fs::path& path)
 {
     return miopen::Process{cmd}("-source " + path.string());
 }
 
-namespace miopen {
-namespace tests {
-
 class InlinerTest
 {
 public:
-    void Run(const boost::filesystem::path& exe_path) const
+    void Run(const fs::path& exe_path) const
     {
         const TmpDir test_srcs{"test_include_inliner"};
         const auto addkernels      = (exe_path.parent_path() / "addkernels").string();

--- a/test/perfdb.cpp
+++ b/test/perfdb.cpp
@@ -27,6 +27,7 @@
 #include "test.hpp"
 #include "driver.hpp"
 
+#include <miopen/filesystem.hpp>
 #include <miopen/db.hpp>
 #include <miopen/db_record.hpp>
 #include <miopen/lock_file.hpp>
@@ -35,8 +36,6 @@
 #include <miopen/readonlyramdb.hpp>
 #include <miopen/temp_file.hpp>
 
-#include <boost/filesystem/operations.hpp>
-#include <boost/filesystem/path.hpp>
 #include <boost/optional.hpp>
 
 #include <array>
@@ -66,10 +65,10 @@ private:
     bool cached;
 };
 
-static boost::filesystem::path& exe_path()
+static fs::path& exe_path()
 {
     // NOLINTNEXTLINE (cppcoreguidelines-avoid-non-const-global-variables)
-    static boost::filesystem::path exe_path;
+    static fs::path exe_path;
     return exe_path;
 }
 
@@ -213,7 +212,7 @@ class DbTest
 public:
     DbTest(TempFile& temp_file_) : temp_file(temp_file_) { ResetDb(); }
 
-    virtual ~DbTest() { std::remove(LockFilePath(temp_file.Path()).c_str()); }
+    virtual ~DbTest() { fs::remove(LockFilePath(temp_file.Path())); }
 
 protected:
     TempFile& temp_file;
@@ -709,8 +708,8 @@ private:
             const auto err_path = *thread_logs_root() + "/thread-" + std::to_string(id) + "_" +
                                   log_postfix + "-err.log";
 
-            std::remove(out_path.c_str());
-            std::remove(err_path.c_str());
+            fs::remove(out_path);
+            fs::remove(err_path);
 
             log.open(out_path);
             log_err.open(err_path);
@@ -1006,7 +1005,7 @@ public:
             EXPECT_EQUAL(child.Wait(), 0);
         }
 
-        std::remove(lock_file_path.c_str());
+        fs::remove(lock_file_path);
 
         const std::string p = temp_file;
         const auto c        = [&p]() MIOPEN_RETURNS(GetDbInstance<TDb>(p, false));
@@ -1091,7 +1090,7 @@ public:
             EXPECT_EQUAL(child.Wait(), 0);
         }
 
-        std::remove(lock_file_path.c_str());
+        fs::remove(lock_file_path);
     }
 
     static void WorkItem(unsigned int id, const std::string& db_path)

--- a/test/sqlite_perfdb.cpp
+++ b/test/sqlite_perfdb.cpp
@@ -34,9 +34,8 @@
 #include <miopen/lock_file.hpp>
 #include <miopen/process.hpp>
 #include <miopen/temp_file.hpp>
+#include <miopen/filesystem.hpp>
 
-#include <boost/filesystem/operations.hpp>
-#include <boost/filesystem/path.hpp>
 #include <boost/optional.hpp>
 #include <boost/thread.hpp>
 
@@ -52,10 +51,10 @@
 
 namespace miopen {
 namespace tests {
-static boost::filesystem::path& exe_path()
+static fs::path& exe_path()
 {
     // NOLINTNEXTLINE (cppcoreguidelines-avoid-non-const-global-variables)
-    static boost::filesystem::path exe_path;
+    static fs::path exe_path;
     return exe_path;
 }
 static boost::optional<std::string>& thread_logs_root()
@@ -595,8 +594,8 @@ private:
             const auto err_path = *thread_logs_root() + "/thread-" + std::to_string(id) + "_" +
                                   log_postfix + "-err.log";
 
-            std::remove(out_path.c_str());
-            std::remove(err_path.c_str());
+            fs::remove(out_path);
+            fs::remove(err_path);
 
             log.open(out_path);
             log_err.open(err_path);
@@ -869,7 +868,7 @@ public:
             EXPECT_EQUAL(child.Wait(), 0);
         }
 
-        std::remove(lock_file_path.c_str());
+        fs::remove(lock_file_path);
 
         const std::string p = temp_file;
         const auto c        = [&p]() { return SQLitePerfDb(p, false); };
@@ -948,7 +947,7 @@ public:
             EXPECT_EQUAL(child.Wait(), 0);
         }
 
-        std::remove(lock_file_path.c_str());
+        fs::remove(lock_file_path);
     }
 
     static void WorkItem(unsigned int id, const std::string& db_path)


### PR DESCRIPTION
The PR fixes compilation on SLES and RHEL, which have `std::filesystem` experimental implementation. It also changes the existing `boost::filesystem` to `std::filesystem` - the MSVC standard library is incompatible with Boost and requires extra conversion/translation between Boost and Std. The example is when `boost::filesystem::path` is used with `std::ofstream` - GNU has additional construction accepting Boost path, MSVC does not, and we need to convert each time to either Std path or `std::string`.
The PR is a prerequisite to the upcoming PRs changing path handling from `std::string` to `fs::path` for most use cases.


**Update:** fix https://github.com/ROCm/MIOpen/pull/2687