### PR TITLE
[OCL] Use OpenCL 2.0 while compiling kernels

### DIFF
--- a/src/hipoc/hipoc_program.cpp
+++ b/src/hipoc/hipoc_program.cpp
@@ -260,7 +260,7 @@ void HIPOCProgramImpl::BuildCodeObjectInFile(std::string& params,
         WriteFile(src, dir->path / filename);
         params += " -target amdgcn-amd-amdhsa -x cl -D__AMD__=1  -O3";
         params += " -cl-kernel-arg-info -cl-denorms-are-zero";
-        params += " -cl-std=CL1.2 -mllvm -amdgpu-early-inline-all";
+        params += " -cl-std=CL2.0 -mllvm -amdgpu-early-inline-all";
         params += " -mllvm -amdgpu-internalize-symbols ";
         params += " " + filename + " -o " + hsaco_file.string();
         dir->Execute(HIP_OC_COMPILER, params);

--- a/src/ocl/clhelper.cpp
+++ b/src/ocl/clhelper.cpp
@@ -210,7 +210,7 @@ ClProgramPtr LoadProgram(cl_context ctx,
         params += OclKernelWarningsString();
 #endif
 #endif
-        params += " -cl-std=CL1.2";
+        params += " -cl-std=CL2.0";
         MIOPEN_LOG_I2("Building OpenCL program: '" << program_name << "', options: '" << params);
         BuildProgram(result.get(), device, params);
         return result;


### PR DESCRIPTION
if opencl 1.2 kernels are launched with non-uniform block, it needs either MIOpen use -cl-std=2.0, or https://github.com/llvm/llvm-project/pull/79026