### PR TITLE
[HOTFIX] Disable "granularity loss" W/A for #2492 and add a new, "tiny tensor" based one.

### DIFF
--- a/src/solver/conv_winoRxS.cpp
+++ b/src/solver/conv_winoRxS.cpp
@@ -64,9 +64,10 @@
 /// tests use very small convolutions and Winograd algorithm is
 /// ineffective with such small configs due to huge granularity loss,
 /// we can disable Winograd without any performance implications.
-#define WORKAROUND_ISSUE_2493 1
+#define WORKAROUND_ISSUE_2492_granularity_loss 0
+#define WORKAROUND_ISSUE_2492_tiny_tensor 1
 
-MIOPEN_DECLARE_ENV_VAR_BOOL(MIOPEN_DEBUG_WORKAROUND_ISSUE_2493)
+MIOPEN_DECLARE_ENV_VAR_BOOL(MIOPEN_DEBUG_WORKAROUND_ISSUE_2492_granularity_loss)
 
 MIOPEN_DECLARE_ENV_VAR_BOOL(MIOPEN_DEBUG_AMD_WINOGRAD_RXS_F2X3)
 MIOPEN_DECLARE_ENV_VAR_STR(MIOPEN_DEBUG_AMD_WINOGRAD_RXS_F2X3_PERF_VALS)
@@ -683,8 +684,8 @@ static bool IsApplicableBase(const ExecutionContext& ctx, const ProblemDescripti
         return false;
         // clang-format on
 
-#if WORKAROUND_ISSUE_2493
-    if(!miopen::IsDisabled(ENV(MIOPEN_DEBUG_WORKAROUND_ISSUE_2493)) &&
+#if WORKAROUND_ISSUE_2492_granularity_loss
+    if(!miopen::IsDisabled(ENV(MIOPEN_DEBUG_WORKAROUND_ISSUE_2492_granularity_loss)) &&
        !miopen::debug::IsWarmupOngoing)
     {
         constexpr double max_perf_drop_due_to_granularity = 200; // Times.
@@ -695,6 +696,11 @@ static bool IsApplicableBase(const ExecutionContext& ctx, const ProblemDescripti
             return false;
         }
     }
+#endif
+
+#if WORKAROUND_ISSUE_2492_tiny_tensor
+    if(problem.GetInHeight() <= 6 && problem.GetInHeight() <= 6)
+        return false;
 #endif
 
     const auto n_inputs_per_group  = problem.GetInChannels() / problem.GetGroupCount(),

--- a/src/solver/conv_winoRxS.cpp
+++ b/src/solver/conv_winoRxS.cpp
@@ -64,10 +64,17 @@
 /// tests use very small convolutions and Winograd algorithm is
 /// ineffective with such small configs due to huge granularity loss,
 /// we can disable Winograd without any performance implications.
-#define WORKAROUND_ISSUE_2492_granularity_loss 0
-#define WORKAROUND_ISSUE_2492_tiny_tensor 1
+#define WORKAROUND_ISSUE_2492_GRANULARITY_LOSS 0
+/// \anchor disable_winograd_with_small_tensor
+/// This is alternative W/A for the same problem, which
+/// resolves issues shown at
+/// https://github.com/ROCm/MIOpen/issues/2492#issuecomment-1910928563
+/// The idea is to disable the solver for very small tensors.
+/// PyTorch tests use sizes like 2x2x6x6 (NCHW), but let's add
+/// some spare space for N anc C and disable starting from 4x4x6x6.
+#define WORKAROUND_ISSUE_2492_TINY_TENSOR 1
 
-MIOPEN_DECLARE_ENV_VAR_BOOL(MIOPEN_DEBUG_WORKAROUND_ISSUE_2492_granularity_loss)
+MIOPEN_DECLARE_ENV_VAR_BOOL(MIOPEN_DEBUG_WORKAROUND_ISSUE_2492)
 
 MIOPEN_DECLARE_ENV_VAR_BOOL(MIOPEN_DEBUG_AMD_WINOGRAD_RXS_F2X3)
 MIOPEN_DECLARE_ENV_VAR_STR(MIOPEN_DEBUG_AMD_WINOGRAD_RXS_F2X3_PERF_VALS)
@@ -684,8 +691,8 @@ static bool IsApplicableBase(const ExecutionContext& ctx, const ProblemDescripti
         return false;
         // clang-format on
 
-#if WORKAROUND_ISSUE_2492_granularity_loss
-    if(!miopen::IsDisabled(ENV(MIOPEN_DEBUG_WORKAROUND_ISSUE_2492_granularity_loss)) &&
+#if WORKAROUND_ISSUE_2492_GRANULARITY_LOSS
+    if(!miopen::IsDisabled(ENV(MIOPEN_DEBUG_WORKAROUND_ISSUE_2492)) &&
        !miopen::debug::IsWarmupOngoing)
     {
         constexpr double max_perf_drop_due_to_granularity = 200; // Times.
@@ -698,9 +705,17 @@ static bool IsApplicableBase(const ExecutionContext& ctx, const ProblemDescripti
     }
 #endif
 
-#if WORKAROUND_ISSUE_2492_tiny_tensor
-    if(problem.GetInHeight() <= 6 && problem.GetInHeight() <= 6)
-        return false;
+#if WORKAROUND_ISSUE_2492_TINY_TENSOR
+    if(!miopen::IsDisabled(ENV(MIOPEN_DEBUG_WORKAROUND_ISSUE_2492)) &&
+       !miopen::debug::IsWarmupOngoing)
+    {
+        // Group count is not taken into account intentionally.
+        if(problem.GetInHeight() <= 6     //
+           && problem.GetInHeight() <= 6  //
+           && problem.GetBatchSize() <= 4 //
+           && problem.GetInChannels() <= 4)
+            return false;
+    }
 #endif
 
     const auto n_inputs_per_group  = problem.GetInChannels() / problem.GetGroupCount(),

--- a/src/solver/conv_winoRxS.cpp
+++ b/src/solver/conv_winoRxS.cpp
@@ -711,7 +711,7 @@ static bool IsApplicableBase(const ExecutionContext& ctx, const ProblemDescripti
     {
         // Group count is not taken into account intentionally.
         if(problem.GetInHeight() <= 6     //
-           && problem.GetInHeight() <= 6  //
+           && problem.GetInWidth() <= 6  //
            && problem.GetBatchSize() <= 4 //
            && problem.GetInChannels() <= 4)
             return false;

--- a/test/gtest/db_sync.cpp
+++ b/test/gtest/db_sync.cpp
@@ -44,9 +44,9 @@
 #include <exception>
 #include <unordered_set>
 
-#define WORKAROUND_ISSUE_2493 1
+#define WORKAROUND_ISSUE_2492_granularity_loss 0
 
-#if WORKAROUND_ISSUE_2493 && defined(_WIN32)
+#if WORKAROUND_ISSUE_2492_granularity_loss && defined(_WIN32)
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
 #endif
@@ -81,13 +81,13 @@ struct std::hash<KDBKey>
     }
 };
 
-#if WORKAROUND_ISSUE_2493 && !defined(_WIN32)
+#if WORKAROUND_ISSUE_2492_granularity_loss && !defined(_WIN32)
 static void SetEnvironmentVariable(std::string_view name, std::string_view value)
 {
     const auto ret = setenv(name.data(), value.data(), 1);
     ASSERT_TRUE(ret == 0);
 }
-#endif // WORKAROUND_ISSUE_2493
+#endif // WORKAROUND_ISSUE_2492_granularity_loss
 
 #if WORKAROUND_ISSUE_1987
 /// \todo Copied from src/db_record.cpp
@@ -444,8 +444,8 @@ TEST(DBSync, KDBTargetID)
     if(miopen::IsEnabled(ENV(MIOPEN_TEST_DBSYNC)))
     {
         fs::path fdb_file_path, pdb_file_path, kdb_file_path;
-#if WORKAROUND_ISSUE_2493
-        SetEnvironmentVariable("MIOPEN_DEBUG_WORKAROUND_ISSUE_2493", "0");
+#if WORKAROUND_ISSUE_2492_granularity_loss
+        SetEnvironmentVariable("MIOPEN_DEBUG_WORKAROUND_ISSUE_2492_granularity_loss", "0");
 #endif
         SetupPaths(fdb_file_path, pdb_file_path, kdb_file_path, get_handle());
         std::ignore = fdb_file_path;

--- a/test/gtest/db_sync.cpp
+++ b/test/gtest/db_sync.cpp
@@ -44,9 +44,13 @@
 #include <exception>
 #include <unordered_set>
 
-#define WORKAROUND_ISSUE_2492_granularity_loss 0
+/// \todo HACK
+/// This should be set to 1 if either WORKAROUND_ISSUE_2492_GRANULARITY_LOSS
+/// or WORKAROUND_ISSUE_2492_TINY_TENSOR is defined as non-zero in
+/// src/solver/conv_winoRxS.cpp
+#define WORKAROUND_ISSUE_2492 1
 
-#if WORKAROUND_ISSUE_2492_granularity_loss && defined(_WIN32)
+#if WORKAROUND_ISSUE_2492 && defined(_WIN32)
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
 #endif
@@ -81,13 +85,13 @@ struct std::hash<KDBKey>
     }
 };
 
-#if WORKAROUND_ISSUE_2492_granularity_loss && !defined(_WIN32)
+#if WORKAROUND_ISSUE_2492 && !defined(_WIN32)
 static void SetEnvironmentVariable(std::string_view name, std::string_view value)
 {
     const auto ret = setenv(name.data(), value.data(), 1);
     ASSERT_TRUE(ret == 0);
 }
-#endif // WORKAROUND_ISSUE_2492_granularity_loss
+#endif // WORKAROUND_ISSUE_2492
 
 #if WORKAROUND_ISSUE_1987
 /// \todo Copied from src/db_record.cpp
@@ -444,8 +448,8 @@ TEST(DBSync, KDBTargetID)
     if(miopen::IsEnabled(ENV(MIOPEN_TEST_DBSYNC)))
     {
         fs::path fdb_file_path, pdb_file_path, kdb_file_path;
-#if WORKAROUND_ISSUE_2492_granularity_loss
-        SetEnvironmentVariable("MIOPEN_DEBUG_WORKAROUND_ISSUE_2492_granularity_loss", "0");
+#if WORKAROUND_ISSUE_2492
+        SetEnvironmentVariable("MIOPEN_DEBUG_WORKAROUND_ISSUE_2492", "0");
 #endif
         SetupPaths(fdb_file_path, pdb_file_path, kdb_file_path, get_handle());
         std::ignore = fdb_file_path;


### PR DESCRIPTION
This is improved version of #2693, that resolves https://github.com/ROCm/MIOpen/issues/2492#issuecomment-1910928563 while keeping W/A for https://github.com/ROCm/MIOpen/issues/2492#issue-1968826021.