### PR TITLE
[COMGR] Use OpenCL 2.0. [HIPRTC] Provide min/max limits for int. Fix build errors related to min/max limits for BF16.

### DIFF
--- a/src/comgr.cpp
+++ b/src/comgr.cpp
@@ -206,7 +206,7 @@ namespace ocl {
 
 #define OCL_EARLY_INLINE 1
 
-#define OCL_STANDARD 120 // For experiments.
+#define OCL_STANDARD 200
 
 #if !(OCL_STANDARD == 200 || OCL_STANDARD == 120)
 #error "Wrong OCL_STANDARD"
@@ -214,6 +214,9 @@ namespace ocl {
 
 static void AddCompilerOptions(OptionList& list, const miopen::TargetProperties& target)
 {
+#if OCL_STANDARD == 200
+    list.push_back("-cl-std=CL2.0");
+#endif
     list.push_back("-cl-kernel-arg-info");
 #if 0 // For experimients.
     list.push_back("-cl-denorms-are-zero");

--- a/src/kernels/miopen_limits.hpp
+++ b/src/kernels/miopen_limits.hpp
@@ -79,6 +79,16 @@ public:
     }
 };
 
+#if HIP_PACKAGE_VERSION_FLAT >= 6001024024ULL
+template <>
+class numeric_limits<int>
+{
+public:
+    static constexpr __device__ int max() noexcept { return 2147483647; }
+    static constexpr __device__ int min() noexcept { return -2147483648; }
+};
+#endif
+
 } // namespace std
 
 #else

--- a/src/kernels/miopen_limits.hpp
+++ b/src/kernels/miopen_limits.hpp
@@ -66,23 +66,13 @@ template <>
 class numeric_limits<hip_bfloat16>
 {
 public:
-    static
-#if HIP_PACKAGE_VERSION_FLAT >= 6000000000ULL
-        constexpr
-#endif
-        __device__ hip_bfloat16
-        max() noexcept
+    static __device__ hip_bfloat16 max() noexcept
     {
         // data = 0x7F7F
         return static_cast<hip_bfloat16>(0x1.FEp+127f);
     }
 
-    static
-#if HIP_PACKAGE_VERSION_FLAT >= 6000000000ULL
-        constexpr
-#endif
-        __device__ hip_bfloat16
-        min() noexcept
+    static __device__ hip_bfloat16 min() noexcept
     {
         // data = 0x0080
         return static_cast<hip_bfloat16>(0x1p-14f);


### PR DESCRIPTION
This is a companion PR for #2691 that resolves the remaining issues with mainline HIP runtime. Details:

- Fixed runtime issues:
  - [COMGR] Use OpenCL 2.0 for all kernels. Allows non-uniform grids for OCL kernels with RC HIP runtime.
- Fixed errors during kernel builds:
  - [HIPRTC] Provide min/max limits for int
  - Removed `constexpr` from numeric_limits<hip_bfloat16>::min()/max() as BF16 ctor provided by HIP can't be used in const expressions.

## :cyclone: Performance testing results

Preconditions:
- Navi21 (gfx1030/36) with ROCm 6.0 release docker
- BUILD_DEV=On, Release build
- 93 known FP32 convolution configs
- 93 known FP16 convolution configs
- NORMAL Find mode, only OpenCL convolutions enabled

Bottom line: :green_circle:  No performance or correctness regressions. Detailed logs & csv files are available upon request.

----
[Attribution] @junliume @JehandadKhan
- https://github.com/ROCm/MIOpen/labels/urgency_blocker
- Proposed reviewers: @JehandadKhan, @junliume