### PR TITLE
[Solvers] Fix for #2663 ensure tensor dimensions are consumed by solvers correctly

### DIFF
--- a/src/solver/conv_hip_implicit_gemm_grouped_bwd_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_grouped_bwd_xdlops.cpp
@@ -306,6 +306,8 @@ bool ConvHipImplicitGemmGroupBwdXdlops::IsApplicable(
         return false;
     if(problem.HasNonPackedTensors())
         return false;
+    if(problem.HasAtLeastOne64BitTensor())
+        return false;
     if(problem.IsTensorsCasted())
         return false;
     if(!problem.IsDirectionBackwardData())

--- a/src/solver/conv_hip_implicit_gemm_grouped_wrw_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_grouped_wrw_xdlops.cpp
@@ -302,6 +302,8 @@ bool ConvHipImplicitGemmGroupWrwXdlops::IsApplicable(
         return false;
     if(problem.HasNonPackedTensors())
         return false;
+    if(problem.HasAtLeastOne64BitTensor())
+        return false;
     if(!problem.IsDirectionBackwardWrW())
         return false;
     if(!problem.Is2d())


### PR DESCRIPTION
`ConvHipImplicitGemmGroupBwdXdlops` and `ConvHipImplicitGemmGroupWrwXdlops`: `HasAtLeastOne64BitTensor()` check has been added.