### PR TITLE
fix build after #2657 and #2690 (boost::filesystem)

### DIFF
--- a/src/hip/handlehip.cpp
+++ b/src/hip/handlehip.cpp
@@ -530,7 +530,7 @@ Program Handle::LoadProgram(const std::string& program_name,
                            program_name,
                            params);
 #else
-        auto path = miopen::GetCachePath(false) / boost::filesystem::unique_path();
+        auto path = miopen::GetCachePath(false) / boost::filesystem::unique_path().string();
         if(p.IsCodeObjectInMemory())
             miopen::WriteFile(p.GetCodeObjectBlob(), path);
         else

--- a/src/include/miopen/execution_context.hpp
+++ b/src/include/miopen/execution_context.hpp
@@ -136,7 +136,6 @@ struct ExecutionContext
                 MIOPEN_LOG_I2("inexact embedded perf database search");
                 const auto db_id        = GetStream().GetTargetProperties().DbId();
                 const int real_cu_count = GetStream().GetMaxComputeUnits();
-                namespace fs            = boost::filesystem;
                 int closest_cu          = std::numeric_limits<int>::max();
                 fs::path best_path;
                 for(auto const& entry : miopen_data())

--- a/src/nogpu/handle.cpp
+++ b/src/nogpu/handle.cpp
@@ -195,7 +195,7 @@ Program Handle::LoadProgram(const std::string& program_name,
                            program_name,
                            params);
 #else
-        auto path = miopen::GetCachePath(false) / boost::filesystem::unique_path();
+        auto path = miopen::GetCachePath(false) / boost::filesystem::unique_path().string();
         if(p.IsCodeObjectInMemory())
             miopen::WriteFile(p.GetCodeObjectBlob(), path);
         else

--- a/src/ocl/handleocl.cpp
+++ b/src/ocl/handleocl.cpp
@@ -406,7 +406,7 @@ Program Handle::LoadProgram(const std::string& program_name,
         miopen::SaveBinary(
             binary, this->GetTargetProperties(), this->GetMaxComputeUnits(), program_name, params);
 #else
-        auto path = miopen::GetCachePath(false) / boost::filesystem::unique_path();
+        auto path = miopen::GetCachePath(false) / boost::filesystem::unique_path().string();
         miopen::SaveProgramBinary(p, path.string());
         miopen::SaveBinary(path.string(), this->GetTargetProperties(), program_name, params);
 #endif


### PR DESCRIPTION
#2657 introduced `std::filesystem` and #2690 replaced most of `boost::filesystem` code with `std` but there are a few ifdefs where this replacement was missing.

It's not very critical for the releases, because most of the cases are under the `!MIOPEN_ENABLE_SQLITE_KERN_CACHE` (disabled kernel cache) define. But it may affect development environment.

@atamazov @JehandadKhan 