### PR TITLE
Argmin enhancement in case of inner dim reduce 

### DIFF
--- a/docs/apireference.rst
+++ b/docs/apireference.rst
@@ -26,4 +26,5 @@ API Reference
     argmax
     groupnorm
     cat
+    argmin
 

--- a/docs/argmin.rst
+++ b/docs/argmin.rst
@@ -1,0 +1,14 @@
+
+Argmin Layer(experimental)
+========================
+
+The argmin functions. 
+Find the index of the minimum value of a tensor across dimensions.
+To enable this, define MIOPEN_BETA_API before including miopen.h.
+
+
+miopenArgminForward
+----------------------------------
+
+.. doxygenfunction::  miopenArgminForward
+

--- a/driver/argmin_driver.hpp
+++ b/driver/argmin_driver.hpp
@@ -1,0 +1,340 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2023 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#ifndef GUARD_MIOPEN_ARGMIN_DRIVER_HPP
+#define GUARD_MIOPEN_ARGMIN_DRIVER_HPP
+
+#include "InputFlags.hpp"
+#include "driver.hpp"
+#include "tensor_driver.hpp"
+#include "timer.hpp"
+#include "random.hpp"
+#include <algorithm>
+#include <cfloat>
+#include <cstdlib>
+#include <memory>
+#include <miopen/miopen.h>
+#include <miopen/tensor.hpp>
+#include <numeric>
+#include <vector>
+#include <../test/tensor_holder.hpp>
+#include <../test/verify.hpp>
+
+template <typename Tgpu, typename Tcheck>
+int32_t mloArgminForwardRunHost(miopenTensorDescriptor_t inputDesc,
+                                miopenTensorDescriptor_t outputDesc,
+                                Tgpu* input,
+                                int32_t* outputhost,
+                                int32_t dim)
+{
+    auto input_dims  = miopen::deref(inputDesc).GetLengths();
+    auto output_dims = miopen::deref(outputDesc).GetLengths();
+
+    int32_t reduce_size = static_cast<int32_t>(input_dims[dim]);
+    auto output_numel =
+        std::accumulate(output_dims.begin(), output_dims.end(), 1L, std::multiplies<int64_t>());
+
+    auto inner_size = std::accumulate(
+        input_dims.begin() + dim + 1, input_dims.end(), 1ULL, std::multiplies<uint64_t>());
+
+    int32_t ret = 0;
+
+    for(size_t o = 0; o < output_numel; o++)
+    {
+        size_t input_idx = (o / inner_size) * inner_size * reduce_size + o % inner_size;
+
+        int32_t min_idx = 0;
+        Tcheck min      = static_cast<Tcheck>(input[input_idx]);
+
+        for(int32_t i = 1; i < reduce_size; i++)
+        {
+            input_idx += inner_size;
+            Tcheck val = static_cast<Tcheck>(input[input_idx]);
+            if(min > val)
+            {
+                min     = val;
+                min_idx = i;
+            }
+        }
+        outputhost[o] = min_idx;
+    }
+    return ret;
+}
+
+template <typename Tgpu, typename Tref>
+class ArgminDriver : public Driver
+{
+public:
+    ArgminDriver() : Driver()
+    {
+        miopenCreateTensorDescriptor(&inputDesc);
+        miopenCreateTensorDescriptor(&outputDesc);
+
+        data_type = miopen_type<Tgpu>{};
+    }
+
+    int AddCmdLineArgs() override;
+    int ParseCmdLineArgs(int argc, char* argv[]) override;
+    InputFlags& GetInputFlags() override { return inflags; }
+
+    int GetandSetData() override;
+    std::vector<int> GetInputTensorLengthsFromCmdLine();
+
+    int AllocateBuffersAndCopy() override;
+
+    int RunForwardGPU() override;
+    int RunForwardCPU();
+
+    int RunBackwardGPU() override;
+
+    int VerifyBackward() override;
+    int VerifyForward() override;
+    ~ArgminDriver() override
+    {
+        miopenDestroyTensorDescriptor(inputDesc);
+        miopenDestroyTensorDescriptor(outputDesc);
+    }
+
+private:
+    InputFlags inflags;
+
+    int forw;
+
+    miopenTensorDescriptor_t inputDesc;
+    miopenTensorDescriptor_t outputDesc;
+
+    std::unique_ptr<GPUMem> in_dev;
+    std::unique_ptr<GPUMem> out_dev;
+
+    std::vector<Tgpu> in;
+    std::vector<int> out;
+    std::vector<int> outhost;
+
+    int dim;
+};
+
+template <typename Tgpu, typename Tref>
+int ArgminDriver<Tgpu, Tref>::ParseCmdLineArgs(int argc, char* argv[])
+{
+    inflags.Parse(argc, argv);
+
+    if(inflags.GetValueInt("time") == 1)
+    {
+        miopenEnableProfiling(GetHandle(), true);
+    }
+    return miopenStatusSuccess;
+}
+
+template <typename Tgpu, typename Tref>
+int ArgminDriver<Tgpu, Tref>::GetandSetData()
+{
+    std::vector<int> in_len = GetInputTensorLengthsFromCmdLine();
+    dim                     = inflags.GetValueInt("DimToReduce");
+
+    SetTensorNd(inputDesc, in_len, data_type);
+
+    std::vector<int> out_len;
+
+    for(int i = 0; i < in_len.size(); i++)
+    {
+        if(i != dim)
+        {
+            out_len.push_back(in_len[i]);
+        }
+    }
+
+    if(out_len.empty())
+        out_len.push_back(1);
+
+    SetTensorNd(outputDesc, out_len, miopenInt32);
+
+    return 0;
+}
+
+template <typename Tgpu, typename Tref>
+int ArgminDriver<Tgpu, Tref>::AddCmdLineArgs()
+{
+    inflags.AddInputFlag("forw", 'F', "1", "Run only Forward Argmin (Default=1)", "int");
+    inflags.AddInputFlag("batchsize", 'n', "21", "Mini-batch size (Default=100)", "int");
+    inflags.AddInputFlag("in_channels", 'c', "500", "Number of Input Channels (Default=3)", "int");
+    inflags.AddInputFlag("in_d", 'D', "0", "Input Depth (Default=0)", "int");
+    inflags.AddInputFlag("in_h", 'H', "0", "Input Height (Default=32)", "int");
+    inflags.AddInputFlag("in_w", 'W', "375", "Input Width (Default=32)", "int");
+    inflags.AddInputFlag(
+        "DimToReduce", 'R', "0", "The indice of the dimensions to be reduced(Default=1)", "int");
+    inflags.AddInputFlag("iter", 'i', "10", "Number of Iterations (Default=10)", "int");
+    inflags.AddInputFlag("verify", 'V', "1", "Verify Each Layer (Default=1)", "int");
+    inflags.AddInputFlag("time", 't', "0", "Time Each Layer (Default=0)", "int");
+    inflags.AddInputFlag(
+        "wall", 'w', "0", "Wall-clock Time Each Layer, Requires time == 1 (Default=0)", "int");
+
+    return miopenStatusSuccess;
+}
+
+template <typename Tgpu, typename Tref>
+std::vector<int> ArgminDriver<Tgpu, Tref>::GetInputTensorLengthsFromCmdLine()
+{
+    int in_n = inflags.GetValueInt("batchsize");
+    int in_c = inflags.GetValueInt("in_channels");
+    int in_w = inflags.GetValueInt("in_w");
+    int in_h = inflags.GetValueInt("in_h");
+    int in_d = inflags.GetValueInt("in_d");
+
+    if((in_n != 0) && (in_c != 0) && (in_d != 0) && (in_h != 0) && (in_w != 0))
+    {
+        return std::vector<int>({in_n, in_c, in_d, in_h, in_w});
+    }
+    else if((in_n != 0) && (in_c != 0) && (in_h != 0) && (in_w != 0))
+    {
+        return std::vector<int>({in_n, in_c, in_h, in_w});
+    }
+    else if((in_n != 0) && (in_c != 0) && (in_w != 0))
+    {
+        return std::vector<int>({in_n, in_c, in_w});
+    }
+    else if((in_n != 0) && (in_w != 0))
+    {
+        return std::vector<int>({in_n, in_w});
+    }
+    else if(in_n != 0)
+    {
+        return std::vector<int>({in_n});
+    }
+    else
+    {
+        std::cerr << "Error Input Tensor Lengths\n" << std::endl;
+        return std::vector<int>({0});
+    }
+}
+
+template <typename Tgpu, typename Tref>
+int ArgminDriver<Tgpu, Tref>::AllocateBuffersAndCopy()
+{
+    size_t in_sz  = GetTensorSize(inputDesc);
+    size_t out_sz = GetTensorSize(outputDesc);
+
+    uint32_t ctx = 0;
+
+    in_dev  = std::unique_ptr<GPUMem>(new GPUMem(ctx, in_sz, sizeof(Tgpu)));
+    out_dev = std::unique_ptr<GPUMem>(new GPUMem(ctx, out_sz, sizeof(int)));
+
+    in      = std::vector<Tgpu>(in_sz, static_cast<Tgpu>(0));
+    out     = std::vector<int>(out_sz, static_cast<int>(0));
+    outhost = std::vector<int>(out_sz, static_cast<int>(0));
+
+    for(int i = 0; i < in_sz; i++)
+    {
+        in[i] = prng::gen_A_to_B<Tgpu>(static_cast<Tgpu>(0.0), static_cast<Tgpu>(1.0));
+    }
+
+    if(in_dev->ToGPU(GetStream(), in.data()) != 0)
+        std::cerr << "Error copying (in) to GPU, size: " << in_dev->GetSize() << std::endl;
+
+    if(out_dev->ToGPU(GetStream(), out.data()) != 0)
+        std::cerr << "Error copying (out) to GPU, size: " << out_dev->GetSize() << std::endl;
+
+    return miopenStatusSuccess;
+}
+
+template <typename Tgpu, typename Tref>
+int ArgminDriver<Tgpu, Tref>::RunForwardGPU()
+{
+    float kernel_total_time = 0;
+    float kernel_first_time = 0;
+
+    Timer t;
+    START_TIME
+
+    for(int i = 0; i < inflags.GetValueInt("iter"); i++)
+    {
+        miopenArgminForward(
+            GetHandle(), inputDesc, in_dev->GetMem(), dim, outputDesc, out_dev->GetMem());
+
+        float time = 0;
+        miopenGetKernelTime(GetHandle(), &time);
+        kernel_total_time += time;
+        if(i == 0)
+            kernel_first_time = time;
+    }
+
+    if(inflags.GetValueInt("time") == 1)
+    {
+        STOP_TIME
+        int iter = inflags.GetValueInt("iter");
+        if(WALL_CLOCK)
+            std::cout << "Wall-clock Time Forward Argmin Elapsed: " << t.gettime_ms() / iter
+                      << " ms\n";
+
+        float kernel_average_time =
+            iter > 1 ? (kernel_total_time - kernel_first_time) / (iter - 1) : kernel_first_time;
+        std::cout << "GPU Kernel Time Forward Argmin Elapsed: " << kernel_average_time << " ms\n";
+    }
+
+    if(out_dev->FromGPU(GetStream(), out.data()) != 0)
+        std::cerr << "Error copying (out_dev) from GPU, size: " << out_dev->GetSize() << std::endl;
+
+    return miopenStatusSuccess;
+}
+
+template <typename Tgpu, typename Tref>
+int ArgminDriver<Tgpu, Tref>::RunForwardCPU()
+{
+    mloArgminForwardRunHost<Tgpu, Tref>(inputDesc, outputDesc, in.data(), outhost.data(), dim);
+
+    return miopenStatusSuccess;
+}
+
+template <typename Tgpu, typename Tref>
+int ArgminDriver<Tgpu, Tref>::RunBackwardGPU()
+{
+    return miopenStatusSuccess;
+}
+
+template <typename Tgpu, typename Tref>
+int ArgminDriver<Tgpu, Tref>::VerifyForward()
+{
+    RunForwardCPU();
+    auto error = miopen::rms_range(outhost, out);
+
+    if(!std::isfinite(error) || std::abs(static_cast<float>(error)) != 0.0f)
+    {
+        std::cout << "Forward Argmin FAILED: Result does not equal" << std::endl;
+        return EC_VerifyFwd;
+    }
+    else
+    {
+        std::cout << "Forward Argmin Verifies on CPU and GPU (err=" << error << ")\n";
+    }
+
+    return miopenStatusSuccess;
+}
+
+template <typename Tgpu, typename Tref>
+int ArgminDriver<Tgpu, Tref>::VerifyBackward()
+{
+    return miopenStatusSuccess;
+}
+
+#endif // GUARD_MIOPEN_ARGMIN_DRIVER_HPP

--- a/driver/driver.hpp
+++ b/driver/driver.hpp
@@ -151,7 +151,7 @@ inline void PadBufferSize(size_t& sz, int datatype_sz)
            "pool[fp16], lrn[fp16], "
            "activ[fp16], softmax[fp16], bnorm[fp16], rnn[fp16], gemm[fp16], ctc, dropout[fp16], "
            "tensorop[fp16], reduce[fp16|fp64], layernorm[bfp16|fp16], sum[bfp16|fp16], "
-           "argmax[bfp16|fp16], groupnorm[bfp16|fp16], cat[bfp16|fp16]\n");
+           "argmax[bfp16|fp16], groupnorm[bfp16|fp16], cat[bfp16|fp16], argmin[bfp16|fp16]\n");
     exit(0); // NOLINT (concurrency-mt-unsafe)
 }
 
@@ -176,7 +176,8 @@ inline std::string ParseBaseArg(int argc, char* argv[])
        arg != "layernormfp16" && arg != "layernormbfp16" && arg != "sum" && arg != "sumfp16" &&
        arg != "sumbfp16" && arg != "argmax" && arg != "argmaxfp16" && arg != "argmaxbfp16" &&
        arg != "groupnorm" && arg != "groupnormfp16" && arg != "groupnormbfp16" && arg != "cat" &&
-       arg != "catfp16" && arg != "catbfp16" && arg != "--version")
+       arg != "catfp16" && arg != "catbfp16" && arg != "argmin" && arg != "argminfp16" &&
+       arg != "argminbfp16" && arg != "--version")
     {
         printf("FAILED: Invalid Base Input Argument\n");
         Usage();

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -45,6 +45,7 @@
 #include "layernorm_driver.hpp"
 #include "sum_driver.hpp"
 #include "argmax_driver.hpp"
+#include "argmin_driver.hpp"
 #include "cat_driver.hpp"
 #include <miopen/config.h>
 #include <miopen/stringutils.hpp>
@@ -259,6 +260,18 @@ int main(int argc, char* argv[])
     else if(base_arg == "catbfp16")
     {
         drv = new CatDriver<bfloat16>();
+    }
+    else if(base_arg == "argmin")
+    {
+        drv = new ArgminDriver<float, float>();
+    }
+    else if(base_arg == "argminfp16")
+    {
+        drv = new ArgminDriver<float16, float>();
+    }
+    else if(base_arg == "argminbfp16")
+    {
+        drv = new ArgminDriver<bfloat16, float>();
     }
     else
     {

--- a/include/miopen/miopen.h
+++ b/include/miopen/miopen.h
@@ -68,6 +68,7 @@
  * @defgroup argmax
  * @defgroup groupnorm
  * @defgroup cat
+ * @defgroup argmin
  *
  */
 
@@ -5728,6 +5729,28 @@ MIOPEN_EXPORT miopenStatus_t miopenGroupNormForward(miopenHandle_t handle,
 
 /** @} */
 // CLOSEOUT groupnorm DOXYGEN GROUP
+#endif
+
+#ifdef MIOPEN_BETA_API
+
+/*! @ingroup argmin
+ * @brief Find the index of the maximum value of a tensor across dimensions.
+ *
+ * @param handle                   MIOpen handle (input)
+ * @param xDesc                    Tensor descriptor for data input tensor x (input)
+ * @param x                        Data tensor x (input)
+ * @param dim                      Dimensions to reduce argmin. (input)
+ * @param yDesc                    Tensor descriptor for output indice data tensor y (input)
+ * @param y                        Data tensor y (output)
+ * @return                         miopenStatus_t
+ */
+MIOPEN_EXPORT miopenStatus_t miopenArgminForward(miopenHandle_t handle,
+                                                 const miopenTensorDescriptor_t xDesc,
+                                                 const void* x,
+                                                 const int32_t dim,
+                                                 const miopenTensorDescriptor_t yDesc,
+                                                 void* y);
+
 #endif
 
 #ifdef __cplusplus

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -87,6 +87,7 @@ set( MIOpen_Source
     activ_api.cpp
     api/find2_0_commons.cpp
     argmax_api.cpp
+    argmin_api.cpp
     batch_norm.cpp
     batch_norm_api.cpp
     batchnorm/problem_description.cpp
@@ -260,6 +261,7 @@ set( MIOpen_Source
     solver/pooling/backward2d.cpp
     solver/pooling/backwardNd.cpp
     solver/reduce/forward_argmax.cpp
+    solver/reduce/forward_argmin.cpp
     solver/reduce/forward_sum.cpp
     solver/softmax/attn_softmax.cpp
     solver/softmax/softmax.cpp
@@ -428,6 +430,7 @@ if( MIOPEN_BACKEND MATCHES "OpenCL" OR MIOPEN_BACKEND STREQUAL "HIPOC" OR MIOPEN
         ${GPU_BATCHED_TRANSPOSE_KERNEL_HIP}
         ${GPU_GENERAL_TENSOR_REORDER_KERNEL_HIP_SOURCE}
         kernels/MIOpenArgmax.cpp
+        kernels/MIOpenArgmin.cpp
         kernels/MIOpenCat.cpp
         kernels/MIOpenCheckNumerics.cpp
         kernels/MIOpenBatchNormActivBwdPerAct.cl
@@ -566,6 +569,7 @@ if( MIOPEN_BACKEND MATCHES "OpenCL" OR MIOPEN_BACKEND STREQUAL "HIPOC" OR MIOPEN
     list(APPEND MIOpen_Source
         activ.cpp
         argmax.cpp
+        argmin.cpp
         cat.cpp
         groupnorm.cpp
         kernel_cache.cpp

--- a/src/argmin.cpp
+++ b/src/argmin.cpp
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2023 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <miopen/argmin.hpp>
+#include <miopen/datatype.hpp>
+#include <miopen/find_solution.hpp>
+#include <miopen/float_equal.hpp>
+#include <miopen/kernel_cache.hpp>
+#include <miopen/reduce/invoke_params.hpp>
+#include <miopen/reduce/solvers.hpp>
+#include <miopen/tensor.hpp>
+
+namespace miopen {
+
+miopenStatus_t ArgminForward(Handle& handle,
+                             const TensorDescriptor& xDesc,
+                             ConstData_t x,
+                             const TensorDescriptor& yDesc,
+                             Data_t y,
+                             int32_t dim)
+{
+    const auto problem = reduce::ProblemDescription{xDesc, yDesc, dim};
+
+    const auto invoke_params = [&]() {
+        auto tmp  = reduce::InvokeParams{};
+        tmp.type  = InvokeType::Run;
+        tmp.xDesc = &xDesc;
+        tmp.yDesc = &yDesc;
+        tmp.x     = x;
+        tmp.y     = y;
+        tmp.dim   = dim;
+        return tmp;
+    }();
+
+    const auto algo    = AlgorithmName{"ArgminForward"};
+    const auto solvers = solver::SolverContainer<solver::reduce::ArgminForward>{};
+
+    solvers.ExecutePrimitive(handle, problem, algo, invoke_params);
+
+    return miopenStatusSuccess;
+}
+
+} // namespace miopen

--- a/src/argmin_api.cpp
+++ b/src/argmin_api.cpp
@@ -1,0 +1,102 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2023 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <miopen/argmin.hpp>
+#include <miopen/errors.hpp>
+#include <miopen/handle.hpp>
+#include <miopen/logger.hpp>
+#include <miopen/tensor_ops.hpp>
+
+static void LogCmdArgmin(const miopenTensorDescriptor_t xDesc, bool is_fwd)
+{
+    if(miopen::IsLoggingCmd())
+    {
+        std::stringstream ss;
+        auto dtype = miopen::deref(xDesc).GetType();
+        if(dtype == miopenHalf)
+        {
+            ss << "argminfp16";
+        }
+        else if(dtype == miopenFloat)
+        {
+            ss << "argminfp32";
+        }
+        else if(dtype == miopenBFloat16)
+        {
+            ss << "argminbfp16";
+        }
+
+        int32_t size = {0};
+        miopenGetTensorDescriptorSize(xDesc, &size);
+        ss << " -n " << miopen::deref(xDesc).GetLengths()[0];
+        if(size == 5)
+        {
+            ss << " -c " << miopen::deref(xDesc).GetLengths()[1] << " -D "
+               << miopen::deref(xDesc).GetLengths()[2] << " -H "
+               << miopen::deref(xDesc).GetLengths()[3] << " -W "
+               << miopen::deref(xDesc).GetLengths()[4];
+        }
+        else if(size == 4)
+        {
+            ss << " -c " << miopen::deref(xDesc).GetLengths()[1] << " -H "
+               << miopen::deref(xDesc).GetLengths()[2] << " -W "
+               << miopen::deref(xDesc).GetLengths()[3];
+        }
+        else if(size == 3)
+        {
+            ss << " -c " << miopen::deref(xDesc).GetLengths()[1] << " -W "
+               << miopen::deref(xDesc).GetLengths()[2];
+        }
+        else if(size == 2)
+        {
+            ss << " -c " << miopen::deref(xDesc).GetLengths()[1];
+        }
+
+        ss << " -F " << ((is_fwd) ? "1" : "2");
+
+        MIOPEN_LOG_DRIVER_CMD(ss.str());
+    }
+}
+
+extern "C" miopenStatus_t miopenArgminForward(miopenHandle_t handle,
+                                              const miopenTensorDescriptor_t xDesc,
+                                              const void* x,
+                                              const int32_t dim,
+                                              const miopenTensorDescriptor_t yDesc,
+                                              void* y)
+{
+    MIOPEN_LOG_FUNCTION(handle, xDesc, x, dim, yDesc, y);
+
+    LogCmdArgmin(xDesc, true);
+    return miopen::try_([&] {
+        miopen::ArgminForward(miopen::deref(handle),
+                              miopen::deref(xDesc),
+                              DataCast(x),
+                              miopen::deref(yDesc),
+                              DataCast(y),
+                              dim);
+    });
+}

--- a/src/include/miopen/argmin.hpp
+++ b/src/include/miopen/argmin.hpp
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2023 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#ifndef MIOPEN_ARGMIN_HPP_
+#define MIOPEN_ARGMIN_HPP_
+
+#include <miopen/common.hpp>
+
+namespace miopen {
+
+struct Handle;
+struct TensorDescriptor;
+
+miopenStatus_t ArgminForward(Handle& handle,
+                             const TensorDescriptor& xDesc,
+                             ConstData_t x,
+                             const TensorDescriptor& yDesc,
+                             Data_t y,
+                             int32_t dim);
+
+} // namespace miopen
+#endif // _MIOPEN_ARGMIN_HPP_

--- a/src/include/miopen/reduce/solvers.hpp
+++ b/src/include/miopen/reduce/solvers.hpp
@@ -53,6 +53,22 @@ struct SumForward final : ReduceSolver
 struct ArgmaxForward final : ReduceSolver
 {
     const std::string& SolverDbId() const override { return GetSolverDbId<ArgmaxForward>(); }
+    size_t XGridSize(std::vector<size_t> ydims) const;
+    bool OverMaxGridSize(const ExecutionContext& context,
+                         const miopen::reduce::ProblemDescription& problem) const;
+
+    bool IsApplicable(const ExecutionContext& context,
+                      const miopen::reduce::ProblemDescription& problem) const override;
+    ConvSolution GetSolution(const ExecutionContext& context,
+                             const miopen::reduce::ProblemDescription& problem) const override;
+};
+
+struct ArgminForward final : ReduceSolver
+{
+    const std::string& SolverDbId() const override { return GetSolverDbId<ArgminForward>(); }
+    size_t XGridSize(std::vector<size_t> ydims) const;
+    bool OverMaxGridSize(const ExecutionContext& context,
+                         const miopen::reduce::ProblemDescription& problem) const;
 
     bool IsApplicable(const ExecutionContext& context,
                       const miopen::reduce::ProblemDescription& problem) const override;

--- a/src/kernels/MIOpenArgmax.cpp
+++ b/src/kernels/MIOpenArgmax.cpp
@@ -30,7 +30,7 @@
 
 #include "float_types.h"
 
-#if INPUT_TYPE == ushort
+#if MIOPEN_USE_BFP16 == 1
 #define CVT_FLOAT2ACCUM(x) (bfloat16_to_float(x))
 #define CVT_ACCUM2FLOAT(x) (float_to_bfloat16(x))
 #define CVT_INTEGRAL2ACCUM(x) ((_FLOAT_ACCUM)(x))

--- a/src/kernels/MIOpenArgmin.cpp
+++ b/src/kernels/MIOpenArgmin.cpp
@@ -30,7 +30,7 @@
 
 #include "float_types.h"
 
-#if INPUT_TYPE == ushort
+#if MIOPEN_USE_BFP16 == 1
 #define CVT_FLOAT2ACCUM(x) (bfloat16_to_float(x))
 #define CVT_ACCUM2FLOAT(x) (float_to_bfloat16(x))
 #define CVT_INTEGRAL2ACCUM(x) ((_FLOAT_ACCUM)(x))

--- a/src/kernels/MIOpenArgmin.cpp
+++ b/src/kernels/MIOpenArgmin.cpp
@@ -39,7 +39,7 @@
 #endif
 
 template <typename TI, typename TO>
-__device__ void argmaxfwdcontiguous(const TI* __restrict__ x,
+__device__ void argminfwdcontiguous(const TI* __restrict__ x,
                                     TO* __restrict__ y,
                                     uint64_t output_numel,
                                     int32_t reduce_size,
@@ -51,29 +51,29 @@ __device__ void argmaxfwdcontiguous(const TI* __restrict__ x,
 
     uint64_t input_idx = (gid / inner_size) * inner_size * reduce_size + gid % inner_size;
 
-    int32_t max_idx = 0;
-    FLOAT_ACCUM max = CVT_FLOAT2ACCUM(x[input_idx]);
+    int32_t min_idx = 0;
+    FLOAT_ACCUM min = CVT_FLOAT2ACCUM(x[input_idx]);
 
     for(int32_t k = 1; k < reduce_size; ++k)
     {
         input_idx += inner_size;
         FLOAT_ACCUM val = CVT_FLOAT2ACCUM(x[input_idx]);
-        if(max < val)
+        if(min > val)
         {
-            max     = val;
-            max_idx = k;
+            min     = val;
+            min_idx = k;
         }
     }
 
-    y[gid] = max_idx;
+    y[gid] = min_idx;
 }
 
-extern "C" __global__ void ArgmaxFwdContiguous(const INPUT_TYPE* __restrict__ x,
+extern "C" __global__ void ArgminFwdContiguous(const INPUT_TYPE* __restrict__ x,
                                                OUTPUT_TYPE* __restrict__ y,
                                                uint64_t output_numel,
                                                int32_t reduce_size,
                                                uint64_t inner_size)
 {
     // instantiate the kernel
-    argmaxfwdcontiguous<INPUT_TYPE, OUTPUT_TYPE>(x, y, output_numel, reduce_size, inner_size);
+    argminfwdcontiguous<INPUT_TYPE, OUTPUT_TYPE>(x, y, output_numel, reduce_size, inner_size);
 }

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -642,6 +642,7 @@ inline SolverRegistrar::SolverRegistrar(IdRegistryData& registry)
                        ++id,
                        conv::ConvHipImplicitGemmGroupWrwXdlops{},
                        miopenConvolutionAlgoImplicitGEMM);
+    Register(registry, ++id, Primitive::Reduce, reduce::ArgminForward{}.SolverDbId());
     // IMPORTANT: New solvers should be added to the end of the function!
 }
 

--- a/src/solver/reduce/forward_argmax.cpp
+++ b/src/solver/reduce/forward_argmax.cpp
@@ -77,6 +77,7 @@ ConvSolution ArgmaxForward::GetSolution(const ExecutionContext&,
 {
     auto result = ConvSolution{miopenStatusSuccess};
 
+    auto dtype        = problem.GetXDesc().GetType();
     auto input_dtype  = miopen::GetDataType(problem.GetXDesc().GetType());
     auto output_dtype = miopen::GetDataType(problem.GetYDesc().GetType());
     auto xdims        = problem.GetXDesc().GetLengths();
@@ -98,6 +99,9 @@ ConvSolution ArgmaxForward::GetSolution(const ExecutionContext&,
         xgridsize          = XGridSize(ydims);
 
         const auto build_params = KernelBuildParameters{
+            {"MIOPEN_USE_FP16", static_cast<int32_t>(dtype == miopenHalf)},
+            {"MIOPEN_USE_FP32", static_cast<int32_t>(dtype == miopenFloat)},
+            {"MIOPEN_USE_BFP16", static_cast<int32_t>(dtype == miopenBFloat16)},
             {"INPUT_TYPE", input_dtype == "bfloat16" ? "ushort" : input_dtype},
             {"OUTPUT_TYPE", output_dtype == "bfloat16" ? "ushort" : output_dtype},
         };

--- a/src/solver/reduce/forward_argmin.cpp
+++ b/src/solver/reduce/forward_argmin.cpp
@@ -77,6 +77,7 @@ ConvSolution ArgminForward::GetSolution(const ExecutionContext&,
 {
     auto result = ConvSolution{miopenStatusSuccess};
 
+    auto dtype        = problem.GetXDesc().GetType();
     auto input_dtype  = miopen::GetDataType(problem.GetXDesc().GetType());
     auto output_dtype = miopen::GetDataType(problem.GetYDesc().GetType());
     auto xdims        = problem.GetXDesc().GetLengths();
@@ -98,6 +99,9 @@ ConvSolution ArgminForward::GetSolution(const ExecutionContext&,
         xgridsize          = XGridSize(ydims);
 
         const auto build_params = KernelBuildParameters{
+            {"MIOPEN_USE_FP16", static_cast<int32_t>(dtype == miopenHalf)},
+            {"MIOPEN_USE_FP32", static_cast<int32_t>(dtype == miopenFloat)},
+            {"MIOPEN_USE_BFP16", static_cast<int32_t>(dtype == miopenBFloat16)},
             {"INPUT_TYPE", input_dtype == "bfloat16" ? "ushort" : input_dtype},
             {"OUTPUT_TYPE", output_dtype == "bfloat16" ? "ushort" : output_dtype},
         };

--- a/src/solver/reduce/forward_argmin.cpp
+++ b/src/solver/reduce/forward_argmin.cpp
@@ -24,7 +24,7 @@
  *
  *******************************************************************************/
 
-#include <miopen/argmax.hpp>
+#include <miopen/argmin.hpp>
 #include <miopen/datatype.hpp>
 #include <miopen/kernel_build_params.hpp>
 #include <miopen/reduce/invoke_params.hpp>
@@ -39,7 +39,7 @@ namespace solver {
 
 namespace reduce {
 
-size_t ArgmaxForward::XGridSize(std::vector<size_t> ydims) const
+size_t ArgminForward::XGridSize(std::vector<size_t> ydims) const
 {
     auto output_numel =
         std::accumulate(ydims.begin(), ydims.end(), 1ULL, std::multiplies<size_t>());
@@ -47,7 +47,7 @@ size_t ArgmaxForward::XGridSize(std::vector<size_t> ydims) const
 }
 
 /// \todo https://github.com/ROCm/MIOpen/pull/2583#discussion_r1437054128
-bool ArgmaxForward::OverMaxGridSize(const ExecutionContext& context,
+bool ArgminForward::OverMaxGridSize(const ExecutionContext& context,
                                     const miopen::reduce::ProblemDescription& problem) const
 {
     auto ydims = problem.GetYDesc().GetLengths();
@@ -56,7 +56,7 @@ bool ArgmaxForward::OverMaxGridSize(const ExecutionContext& context,
     return true;
 }
 
-bool ArgmaxForward::IsApplicable(const ExecutionContext& context,
+bool ArgminForward::IsApplicable(const ExecutionContext& context,
                                  const miopen::reduce::ProblemDescription& problem) const
 {
     if(!problem.IsRightDim())
@@ -72,7 +72,7 @@ bool ArgmaxForward::IsApplicable(const ExecutionContext& context,
     return true;
 }
 
-ConvSolution ArgmaxForward::GetSolution(const ExecutionContext&,
+ConvSolution ArgminForward::GetSolution(const ExecutionContext&,
                                         const miopen::reduce::ProblemDescription& problem) const
 {
     auto result = ConvSolution{miopenStatusSuccess};
@@ -92,8 +92,8 @@ ConvSolution ArgmaxForward::GetSolution(const ExecutionContext&,
 
         auto kernel = KernelInfo{};
 
-        kernel.kernel_file = "MIOpenArgmax.cpp";
-        kernel.kernel_name = "ArgmaxFwdContiguous";
+        kernel.kernel_file = "MIOpenArgmin.cpp";
+        kernel.kernel_name = "ArgminFwdContiguous";
         xlocalsize         = LOCAL_SIZE;
         xgridsize          = XGridSize(ydims);
 

--- a/test/cpu_argmin.hpp
+++ b/test/cpu_argmin.hpp
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2023 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#ifndef GUARD_CPU_ARGMIN_HPP
+#define GUARD_CPU_ARGMIN_HPP
+
+#include "tensor_holder.hpp"
+
+template <class T>
+void cpu_argmin_forward(tensor<T> input, tensor<int>& ref_output, int32_t dim)
+{
+    auto input_dims  = input.desc.GetLengths();
+    auto output_dims = ref_output.desc.GetLengths();
+
+    auto reduce_size = input_dims[dim];
+    auto output_numel =
+        std::accumulate(output_dims.begin(), output_dims.end(), 1L, std::multiplies<int64_t>());
+
+    auto inner_size = 1ULL;
+    for(int32_t i = dim + 1; i < input_dims.size(); i++)
+    {
+        inner_size *= input_dims[i];
+    }
+
+    par_ford(output_numel)([&](size_t o) {
+        size_t input_idx = (o / inner_size) * inner_size * reduce_size + o % inner_size;
+
+        int32_t min_idx = 0;
+        T min           = input[input_idx];
+
+        ford(reduce_size)([&](size_t i) {
+            T val = input[input_idx];
+            if(min > val)
+            {
+                min     = val;
+                min_idx = i;
+            }
+            input_idx += inner_size;
+        });
+
+        ref_output[o] = min_idx;
+    });
+}
+#endif

--- a/test/gtest/argmin.cpp
+++ b/test/gtest/argmin.cpp
@@ -1,0 +1,101 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2023 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include "argmin.hpp"
+#include <miopen/env.hpp>
+
+MIOPEN_DECLARE_ENV_VAR_STR(MIOPEN_TEST_FLOAT_ARG)
+MIOPEN_DECLARE_ENV_VAR_BOOL(MIOPEN_TEST_ALL)
+
+namespace argmin {
+
+std::string GetFloatArg()
+{
+    const auto& tmp = miopen::GetStringEnv(ENV(MIOPEN_TEST_FLOAT_ARG));
+    if(tmp.empty())
+    {
+        return "";
+    }
+    return tmp;
+}
+
+struct ArgminTestFloat : ArgminTest<float>
+{
+};
+
+struct ArgminTestHalf : ArgminTest<half_float::half>
+{
+};
+
+struct ArgminTestBFloat16 : ArgminTest<bfloat16>
+{
+};
+
+} // namespace argmin
+using namespace argmin;
+
+TEST_P(ArgminTestFloat, ArgminTestFw)
+{
+    if(miopen::IsEnabled(ENV(MIOPEN_TEST_ALL)) && (GetFloatArg() == "--float"))
+    {
+        RunTest();
+        Verify();
+    }
+    else
+    {
+        GTEST_SKIP();
+    }
+};
+
+TEST_P(ArgminTestHalf, ArgminTestFw)
+{
+    if(miopen::IsEnabled(ENV(MIOPEN_TEST_ALL)) && (GetFloatArg() == "--half"))
+    {
+        RunTest();
+        Verify();
+    }
+    else
+    {
+        GTEST_SKIP();
+    }
+};
+
+TEST_P(ArgminTestBFloat16, ArgminTestFw)
+{
+    if(miopen::IsEnabled(ENV(MIOPEN_TEST_ALL)) && (GetFloatArg() == "--bfloat16"))
+    {
+        RunTest();
+        Verify();
+    }
+    else
+    {
+        GTEST_SKIP();
+    }
+};
+
+INSTANTIATE_TEST_SUITE_P(ArgminTestSet, ArgminTestFloat, testing::ValuesIn(ArgminTestConfigs()));
+INSTANTIATE_TEST_SUITE_P(ArgminTestSet, ArgminTestHalf, testing::ValuesIn(ArgminTestConfigs()));
+INSTANTIATE_TEST_SUITE_P(ArgminTestSet, ArgminTestBFloat16, testing::ValuesIn(ArgminTestConfigs()));

--- a/test/gtest/argmin.hpp
+++ b/test/gtest/argmin.hpp
@@ -1,0 +1,168 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2023 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include "../driver/tensor_driver.hpp"
+#include "cpu_argmin.hpp"
+#include "get_handle.hpp"
+#include "random.hpp"
+#include "tensor_holder.hpp"
+#include "verify.hpp"
+#include <gtest/gtest.h>
+#include <miopen/argmin.hpp>
+#include <miopen/miopen.h>
+
+struct ArgminTestCase
+{
+    size_t N;
+    size_t C;
+    size_t D;
+    size_t H;
+    size_t W;
+    int32_t dim;
+    friend std::ostream& operator<<(std::ostream& os, const ArgminTestCase& tc)
+    {
+        return os << " N:" << tc.N << " C:" << tc.C << " D:" << tc.D << " H:" << tc.H
+                  << " W:" << tc.W << " dim:" << tc.dim;
+    }
+
+    std::vector<size_t> GetInput()
+    {
+        if((N != 0) && (C != 0) && (D != 0) && (H != 0) && (W != 0))
+        {
+            return std::vector<size_t>({N, C, D, H, W});
+        }
+        else if((N != 0) && (C != 0) && (H != 0) && (W != 0))
+        {
+            return std::vector<size_t>({N, C, H, W});
+        }
+        else if((N != 0) && (C != 0) && (W != 0))
+        {
+            return std::vector<size_t>({N, C, W});
+        }
+        else if((N != 0) && (W != 0))
+        {
+            return std::vector<size_t>({N, W});
+        }
+        else if((N != 0))
+        {
+            return std::vector<size_t>({N});
+        }
+        else
+        {
+            std::cout << "Error Input Tensor Lengths\n" << std::endl;
+            return std::vector<size_t>({0});
+        }
+    }
+};
+
+std::vector<ArgminTestCase> ArgminTestConfigs()
+{ // n c d h w dim
+    // clang-format off
+    return {
+        { 16, 21,   0, 513, 513, 1 },   //deeplabv3m
+        { 24, 21,   0, 513, 513, 1 },   //deeplabv3r
+        { 64, 21,   0, 230, 333, 1 },   //fcn_resnet_lraspp
+        { 64, 21,   0, 215, 288, 1 },
+        { 1,  21,   0, 333, 500, 1 },   //stdc
+        { 1,  21,   0, 375, 500, 1 },
+        { 15, 21,   0, 256, 256, 1 },   //unet
+        { 22, 21,   0, 256, 256, 1 },
+        { 21, 412,  0, 0,   500, 0 },
+        { 21, 333,  0, 0,   500, 0 }
+      };
+    // clang-format on
+}
+
+template <typename T = float>
+struct ArgminTest : public ::testing::TestWithParam<ArgminTestCase>
+{
+protected:
+    void SetUp() override
+    {
+        auto&& handle  = get_handle();
+        argmin_config  = GetParam();
+        auto gen_value = [](auto...) { return prng::gen_descreet_uniform_sign<T>(1e-2, 100); };
+
+        dim = argmin_config.dim;
+
+        auto in_dims = argmin_config.GetInput();
+
+        input = tensor<T>{in_dims}.generate(gen_value);
+
+        std::vector<size_t> out_dims;
+
+        for(int i = 0; i < in_dims.size(); i++)
+        {
+            if(i != dim)
+            {
+                out_dims.push_back(in_dims[i]);
+            }
+        }
+
+        output = tensor<int>{out_dims};
+        std::fill(output.begin(), output.end(), std::numeric_limits<int>::quiet_NaN());
+
+        ref_output = tensor<int>{out_dims};
+        std::fill(ref_output.begin(), ref_output.end(), std::numeric_limits<int>::quiet_NaN());
+
+        input_dev  = handle.Write(input.data);
+        output_dev = handle.Write(output.data);
+    }
+    void RunTest()
+    {
+        auto&& handle = get_handle();
+
+        cpu_argmin_forward<T>(input, ref_output, dim);
+        miopenStatus_t status;
+
+        status = miopen::ArgminForward(
+            handle, input.desc, input_dev.get(), output.desc, output_dev.get(), dim);
+
+        EXPECT_EQ(status, miopenStatusSuccess);
+
+        output.data = handle.Read<int>(output_dev, output.data.size());
+    }
+
+    void Verify()
+    {
+        auto error = miopen::rms_range(ref_output, output);
+
+        EXPECT_TRUE(miopen::range_distance(ref_output) == miopen::range_distance(output));
+        EXPECT_TRUE(std::abs(static_cast<float>(error)) == 0.0f)
+            << "Error output beyond tolerance Error:" << error;
+    }
+    ArgminTestCase argmin_config;
+
+    tensor<T> input;
+    tensor<int> output;
+
+    tensor<int> ref_output;
+
+    miopen::Allocator::ManageDataPtr input_dev;
+    miopen::Allocator::ManageDataPtr output_dev;
+
+    int32_t dim;
+};


### PR DESCRIPTION
- Fix bfloat16 error in argmax
- Added argmin operation and kernel with solver
- Added driver test and gtest for argmin
- Compared to ROCm pytorch, there is a performance improvement when argmin is performed on the inner dim rather than the last dim

<details><summary>float16</summary>

<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
.font5
	{color:windowtext;
	font-size:8.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:"맑은 고딕", monospace;
	mso-font-charset:129;}
tr
	{mso-height-source:auto;
	mso-ruby-visibility:none;}
col
	{mso-width-source:auto;
	mso-ruby-visibility:none;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:11.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:"맑은 고딕", monospace;
	mso-font-charset:129;
	mso-number-format:General;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
.xl65
	{font-size:10.0pt;
	font-weight:700;
	font-family:Arial, sans-serif;
	mso-font-charset:0;}
.xl66
	{font-size:10.0pt;
	font-family:Arial, sans-serif;
	mso-font-charset:0;
	mso-number-format:Standard;
	text-align:right;
	background:#F4C7C3;
	mso-pattern:#F4C7C3 none;}
.xl67
	{font-size:10.0pt;
	font-weight:700;
	font-family:Arial, sans-serif;
	mso-font-charset:0;
	mso-number-format:"\#\,\#\#0";}
.xl68
	{font-size:10.0pt;
	font-weight:700;
	mso-number-format:"\#\,\#\#0";}
ruby
	{ruby-align:left;}
rt
	{color:windowtext;
	font-size:8.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:"맑은 고딕", monospace;
	mso-font-charset:129;
	mso-char-type:none;
	display:none;}
-->
</head>

<body link="#467886" vlink="#96607D">


op_name | dtype | size | model | dim | direction | ROCm pytorch | MIOpen HIP | Improvement
-- | -- | -- | -- | -- | -- | -- | -- | --
Argmin | float16 | [16 21 513 513] | deeplabv3m | 1 | fwd | 835682 | 254739 | 3.28
Argmin | float16 | [24 21 513 513] | deeplabv3r | 1 | fwd | 1243250 | 378366 | 3.29
Argmin | float16 | [64 21 230 333] | fcn_resnet_lraspp | 1 | fwd | 1112466 | 291859 | 3.81
Argmin | float16 | [64 21 240 240] | fcn_resnet_lraspp | 1 | fwd | 843330 | 217423 | 3.88
Argmin | float16 | [64 21 176 174] | fcn_resnet_lraspp | 1 | fwd | 478241 | 124285 | 3.85
Argmin | float16 | [64 21 269 332] | fcn_resnet_lraspp | 1 | fwd | 1396003 | 342455 | 4.08
Argmin | float16 | [64 21 208 320] | fcn_resnet_lraspp | 1 | fwd | 968866 | 250027 | 3.88
Argmin | float16 | [64 21 213 273] | fcn_resnet_lraspp | 1 | fwd | 732369 | 226045 | 3.24
Argmin | float16 | [64 21 275 324] | fcn_resnet_lraspp | 1 | fwd | 1393987 | 341744 | 4.08
Argmin | float16 | [64 21 151 191] | fcn_resnet_lraspp | 1 | fwd | 377265 | 117992 | 3.20
Argmin | float16 | [64 21 281 255] | fcn_resnet_lraspp | 1 | fwd | 892626 | 273814 | 3.26
Argmin | float16 | [64 21 274 266] | fcn_resnet_lraspp | 1 | fwd | 1140066 | 269814 | 4.23
Argmin | float16 | [64 21 215 288] | fcn_resnet_lraspp | 1 | fwd | 954354 | 237459 | 4.02
Argmin | float16 | [1 21 366 500] | stdc | 1 | fwd | 49488 | 15804 | 3.13
Argmin | float16 | [1 21 335 500] | stdc | 1 | fwd | 47472 | 15626 | 3.04
Argmin | float16 | [1 21 333 500] | stdc | 1 | fwd | 47232 | 15786 | 2.99
Argmin | float16 | [1 21 375 500] | stdc | 1 | fwd | 51392 | 15857 | 3.24
Argmin | float16 | [1 21 500 334] | stdc | 1 | fwd | 47328 | 15893 | 2.98
Argmin | float16 | [1 21 332 500] | stdc | 1 | fwd | 47296 | 14808 | 3.19
Argmin | float16 | [32 21 256 256] | unet | 1 | fwd | 480369 | 126542 | 3.80
Argmin | float16 | [7 21 513 513] | deeplabv3r | 1 | fwd | 382241 | 114863 | 3.33
Argmin | float16 | [14 21 513 513] | deeplabv3r | 1 | fwd | 746849 | 222365 | 3.36
Argmin | float16 | [64 21 151 174] | fcn_resnet_lraspp | 1 | fwd | 385569 | 107503 | 3.59
Argmin | float16 | [64 21 200 224] | fcn_resnet_lraspp | 1 | fwd | 653905 | 172161 | 3.80
Argmin | float16 | [47 21 196 299] | fcn_resnet_lraspp | 1 | fwd | 675009 | 169192 | 3.99
Argmin | float16 | [54 21 196 299] | fcn_resnet_lraspp | 1 | fwd | 774513 | 192854 | 4.02
Argmin | float16 | [15 21 256 256] | unet | 1 | fwd | 232177 | 61280 | 3.79
Argmin | float16 | [22 21 256 256] | unet | 1 | fwd | 334976 | 89049 | 3.76
Argmin | float16 | [21 412 500] | unet | 0 | fwd | 52976 | 15680 | 3.38
Argmin | float16 | [21 230 500] | unet | 0 | fwd | 39472 | 15004 | 2.63
Argmin | float16 | [21 333 500] | unet | 0 | fwd | 46704 | 15697 | 2.98
Argmin | float16 | [21 332 500] | unet | 0 | fwd | 46480 | 15608 | 2.98
Argmin | float16 | [21 375 500] | unet | 0 | fwd | 49424 | 15804 | 3.13
Argmin | float16 | [21 370 500] | unet | 0 | fwd | 48928 | 15431 | 3.17
Argmin | float16 | [21 500 375] | unet | 0 | fwd | 49760 | 15893 | 3.13
Argmin | float16 | [21 500 486] | unet | 0 | fwd | 60160 | 22026 | 2.73
Argmin | float16 | [21 334 500] | unet | 0 | fwd | 46880 | 15911 | 2.95
Argmin | float16 | [21 281 500] | unet | 0 | fwd | 42336 | 15449 | 2.74
Argmin | float16 | [21 335 500] | unet | 0 | fwd | 46816 | 15271 | 3.07
Argmin | float16 | [21 336 500] | unet | 0 | fwd | 46288 | 15537 | 2.98
Argmin | float16 | [21 500 333] | unet | 0 | fwd | 46672 | 15840 | 2.95
Argmin | float16 | [21 331 500] | unet | 0 | fwd | 46672 | 15733 | 2.97
Argmin | float16 | [21 343 500] | unet | 0 | fwd | 47744 | 14844 | 3.22
Argmin | float16 | [21 500 334] | unet | 0 | fwd | 46464 | 16035 | 2.90
Argmin | float16 | [21 500 422] | unet | 0 | fwd | 54144 | 16391 | 3.30
Argmin | float16 | [21 366 500] | unet | 0 | fwd | 48496 | 14808 | 3.27

</body>

</html>

</details>
<details><summary>float32</summary>

<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
.font5
	{color:windowtext;
	font-size:8.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:"맑은 고딕", monospace;
	mso-font-charset:129;}
tr
	{mso-height-source:auto;
	mso-ruby-visibility:none;}
col
	{mso-width-source:auto;
	mso-ruby-visibility:none;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:11.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:"맑은 고딕", monospace;
	mso-font-charset:129;
	mso-number-format:General;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
.xl65
	{font-size:10.0pt;
	font-weight:700;
	font-family:Arial, sans-serif;
	mso-font-charset:0;}
.xl66
	{font-size:10.0pt;
	font-family:Arial, sans-serif;
	mso-font-charset:0;
	mso-number-format:Standard;
	text-align:right;
	background:#F4C7C3;
	mso-pattern:#F4C7C3 none;}
.xl67
	{font-size:10.0pt;
	font-weight:700;
	font-family:Arial, sans-serif;
	mso-font-charset:0;
	mso-number-format:"\#\,\#\#0";}
.xl68
	{font-size:10.0pt;
	font-weight:700;
	mso-number-format:"\#\,\#\#0";}
ruby
	{ruby-align:left;}
rt
	{color:windowtext;
	font-size:8.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:"맑은 고딕", monospace;
	mso-font-charset:129;
	mso-char-type:none;
	display:none;}
-->
</head>

<body link="#467886" vlink="#96607D">


op_name | dtype | size | model | dim | direction | ROCm pytorch | MIOpen HIP | Improvement
-- | -- | -- | -- | -- | -- | -- | -- | --
Argmin | float32 | [16 21 513 513] | deeplabv3m | 1 | fwd | 1088290 | 361424 | 3.01
Argmin | float32 | [24 21 513 513] | deeplabv3r | 1 | fwd | 1614915 | 546793 | 2.95
Argmin | float32 | [64 21 230 333] | fcn_resnet_lraspp | 1 | fwd | 1369826 | 406313 | 3.37
Argmin | float32 | [64 21 240 240] | fcn_resnet_lraspp | 1 | fwd | 1084050 | 272854 | 3.97
Argmin | float32 | [64 21 176 174] | fcn_resnet_lraspp | 1 | fwd | 597409 | 163663 | 3.65
Argmin | float32 | [64 21 269 332] | fcn_resnet_lraspp | 1 | fwd | 1781539 | 480127 | 3.71
Argmin | float32 | [64 21 208 320] | fcn_resnet_lraspp | 1 | fwd | 1246050 | 315255 | 3.95
Argmin | float32 | [64 21 213 273] | fcn_resnet_lraspp | 1 | fwd | 942658 | 307326 | 3.07
Argmin | float32 | [64 21 275 324] | fcn_resnet_lraspp | 1 | fwd | 1775459 | 481477 | 3.69
Argmin | float32 | [64 21 151 191] | fcn_resnet_lraspp | 1 | fwd | 477089 | 156729 | 3.04
Argmin | float32 | [64 21 281 255] | fcn_resnet_lraspp | 1 | fwd | 1154818 | 381619 | 3.03
Argmin | float32 | [64 21 274 266] | fcn_resnet_lraspp | 1 | fwd | 1450947 | 393673 | 3.69
Argmin | float32 | [64 21 215 288] | fcn_resnet_lraspp | 1 | fwd | 1213506 | 324268 | 3.74
Argmin | float32 | [1 21 366 500] | stdc | 1 | fwd | 57632 | 17475 | 3.30
Argmin | float32 | [1 21 335 500] | stdc | 1 | fwd | 54032 | 17582 | 3.07
Argmin | float32 | [1 21 333 500] | stdc | 1 | fwd | 53920 | 17351 | 3.11
Argmin | float32 | [1 21 375 500] | stdc | 1 | fwd | 59280 | 17884 | 3.31
Argmin | float32 | [1 21 500 334] | stdc | 1 | fwd | 54064 | 16906 | 3.20
Argmin | float32 | [1 21 332 500] | stdc | 1 | fwd | 54384 | 16515 | 3.29
Argmin | float32 | [32 21 256 256] | unet | 1 | fwd | 608193 | 158116 | 3.85
Argmin | float32 | [7 21 513 513] | deeplabv3r | 1 | fwd | 507889 | 156161 | 3.25
Argmin | float32 | [14 21 513 513] | deeplabv3r | 1 | fwd | 972978 | 315308 | 3.09
Argmin | float32 | [64 21 151 174] | fcn_resnet_lraspp | 1 | fwd | 465601 | 141850 | 3.28
Argmin | float32 | [64 21 200 224] | fcn_resnet_lraspp | 1 | fwd | 837698 | 210187 | 3.99
Argmin | float32 | [47 21 196 299] | fcn_resnet_lraspp | 1 | fwd | 853682 | 227948 | 3.75
Argmin | float32 | [54 21 196 299] | fcn_resnet_lraspp | 1 | fwd | 979650 | 261494 | 3.75
Argmin | float32 | [15 21 256 256] | unet | 1 | fwd | 288161 | 74667 | 3.86
Argmin | float32 | [22 21 256 256] | unet | 1 | fwd | 419857 | 106152 | 3.96
Argmin | float32 | [21 412 500] | unet | 0 | fwd | 62928 | 18275 | 3.44
Argmin | float32 | [21 230 500] | unet | 0 | fwd | 43520 | 16249 | 2.68
Argmin | float32 | [21 333 500] | unet | 0 | fwd | 53392 | 17368 | 3.07
Argmin | float32 | [21 332 500] | unet | 0 | fwd | 53056 | 17137 | 3.10
Argmin | float32 | [21 375 500] | unet | 0 | fwd | 58192 | 17511 | 3.32
Argmin | float32 | [21 370 500] | unet | 0 | fwd | 57344 | 17173 | 3.34
Argmin | float32 | [21 500 375] | unet | 0 | fwd | 58400 | 17831 | 3.28
Argmin | float32 | [21 500 486] | unet | 0 | fwd | 75776 | 26133 | 2.90
Argmin | float32 | [21 334 500] | unet | 0 | fwd | 53504 | 17333 | 3.09
Argmin | float32 | [21 281 500] | unet | 0 | fwd | 46208 | 15964 | 2.89
Argmin | float32 | [21 335 500] | unet | 0 | fwd | 53680 | 17351 | 3.09
Argmin | float32 | [21 336 500] | unet | 0 | fwd | 51568 | 16071 | 3.21
Argmin | float32 | [21 500 333] | unet | 0 | fwd | 53440 | 16995 | 3.14
Argmin | float32 | [21 331 500] | unet | 0 | fwd | 53712 | 17582 | 3.05
Argmin | float32 | [21 343 500] | unet | 0 | fwd | 55680 | 17244 | 3.23
Argmin | float32 | [21 500 334] | unet | 0 | fwd | 53520 | 17280 | 3.10
Argmin | float32 | [21 500 422] | unet | 0 | fwd | 64976 | 18364 | 3.54
Argmin | float32 | [21 366 500] | unet | 0 | fwd | 56688 | 17582 | 3.22



</body>

</html>


</details>
<details><summary>bfloat16</summary>
<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
.font5
	{color:windowtext;
	font-size:8.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:"맑은 고딕", monospace;
	mso-font-charset:129;}
tr
	{mso-height-source:auto;
	mso-ruby-visibility:none;}
col
	{mso-width-source:auto;
	mso-ruby-visibility:none;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:11.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:"맑은 고딕", monospace;
	mso-font-charset:129;
	mso-number-format:General;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
.xl65
	{font-size:10.0pt;
	font-weight:700;
	font-family:Arial, sans-serif;
	mso-font-charset:0;}
.xl66
	{font-size:10.0pt;
	font-family:Arial, sans-serif;
	mso-font-charset:0;
	mso-number-format:Standard;
	text-align:right;
	background:#F4C7C3;
	mso-pattern:#F4C7C3 none;}
.xl67
	{font-size:10.0pt;
	font-weight:700;
	font-family:Arial, sans-serif;
	mso-font-charset:0;
	mso-number-format:"\#\,\#\#0";}
.xl68
	{font-size:10.0pt;
	font-weight:700;
	mso-number-format:"\#\,\#\#0";}
ruby
	{ruby-align:left;}
rt
	{color:windowtext;
	font-size:8.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:"맑은 고딕", monospace;
	mso-font-charset:129;
	mso-char-type:none;
	display:none;}
-->
</head>

<body link="#467886" vlink="#96607D">


op_name | dtype | size | model | dim | direction | ROCm pytorch | MIOpen HIP | Improvement
-- | -- | -- | -- | -- | -- | -- | -- | --
Argmin | bfloat16 | [16 21 513 513] | deeplabv3m | 1 | fwd | 837025 | 254419 | 3.29
Argmin | bfloat16 | [24 21 513 513] | deeplabv3r | 1 | fwd | 1246786 | 378722 | 3.29
Argmin | bfloat16 | [64 21 230 333] | fcn_resnet_lraspp | 1 | fwd | 1119810 | 291681 | 3.84
Argmin | bfloat16 | [64 21 240 240] | fcn_resnet_lraspp | 1 | fwd | 848722 | 217245 | 3.91
Argmin | bfloat16 | [64 21 176 174] | fcn_resnet_lraspp | 1 | fwd | 483729 | 124321 | 3.89
Argmin | bfloat16 | [64 21 269 332] | fcn_resnet_lraspp | 1 | fwd | 1406178 | 341921 | 4.11
Argmin | bfloat16 | [64 21 208 320] | fcn_resnet_lraspp | 1 | fwd | 974866 | 249885 | 3.90
Argmin | bfloat16 | [64 21 213 273] | fcn_resnet_lraspp | 1 | fwd | 741361 | 226010 | 3.28
Argmin | bfloat16 | [64 21 275 324] | fcn_resnet_lraspp | 1 | fwd | 1409682 | 341157 | 4.13
Argmin | bfloat16 | [64 21 151 191] | fcn_resnet_lraspp | 1 | fwd | 382176 | 117903 | 3.24
Argmin | bfloat16 | [64 21 281 255] | fcn_resnet_lraspp | 1 | fwd | 899634 | 273459 | 3.29
Argmin | bfloat16 | [64 21 274 266] | fcn_resnet_lraspp | 1 | fwd | 1151154 | 269903 | 4.27
Argmin | bfloat16 | [64 21 215 288] | fcn_resnet_lraspp | 1 | fwd | 961634 | 237761 | 4.04
Argmin | bfloat16 | [1 21 366 500] | stdc | 1 | fwd | 48736 | 15964 | 3.05
Argmin | bfloat16 | [1 21 335 500] | stdc | 1 | fwd | 47152 | 15591 | 3.02
Argmin | bfloat16 | [1 21 333 500] | stdc | 1 | fwd | 47056 | 14791 | 3.18
Argmin | bfloat16 | [1 21 375 500] | stdc | 1 | fwd | 50160 | 15982 | 3.14
Argmin | bfloat16 | [1 21 500 334] | stdc | 1 | fwd | 46832 | 15360 | 3.05
Argmin | bfloat16 | [1 21 332 500] | stdc | 1 | fwd | 47088 | 15502 | 3.04
Argmin | bfloat16 | [32 21 256 256] | unet | 1 | fwd | 484257 | 125795 | 3.85
Argmin | bfloat16 | [7 21 513 513] | deeplabv3r | 1 | fwd | 382481 | 114738 | 3.33
Argmin | bfloat16 | [14 21 513 513] | deeplabv3r | 1 | fwd | 750754 | 222472 | 3.37
Argmin | bfloat16 | [64 21 151 174] | fcn_resnet_lraspp | 1 | fwd | 389105 | 107360 | 3.62
Argmin | bfloat16 | [64 21 200 224] | fcn_resnet_lraspp | 1 | fwd | 661330 | 171983 | 3.85
Argmin | bfloat16 | [47 21 196 299] | fcn_resnet_lraspp | 1 | fwd | 683825 | 169032 | 4.05
Argmin | bfloat16 | [54 21 196 299] | fcn_resnet_lraspp | 1 | fwd | 783202 | 192427 | 4.07
Argmin | bfloat16 | [15 21 256 256] | unet | 1 | fwd | 232721 | 61582 | 3.78
Argmin | bfloat16 | [22 21 256 256] | unet | 1 | fwd | 338145 | 89173 | 3.79
Argmin | bfloat16 | [21 412 500] | unet | 0 | fwd | 53872 | 15840 | 3.40
Argmin | bfloat16 | [21 230 500] | unet | 0 | fwd | 39792 | 15129 | 2.63
Argmin | bfloat16 | [21 333 500] | unet | 0 | fwd | 46464 | 15751 | 2.95
Argmin | bfloat16 | [21 332 500] | unet | 0 | fwd | 46368 | 15946 | 2.91
Argmin | bfloat16 | [21 375 500] | unet | 0 | fwd | 49328 | 15964 | 3.09
Argmin | bfloat16 | [21 370 500] | unet | 0 | fwd | 48528 | 15982 | 3.04
Argmin | bfloat16 | [21 500 375] | unet | 0 | fwd | 49120 | 15964 | 3.08
Argmin | bfloat16 | [21 500 486] | unet | 0 | fwd | 60144 | 22080 | 2.72
Argmin | bfloat16 | [21 334 500] | unet | 0 | fwd | 46496 | 15644 | 2.97
Argmin | bfloat16 | [21 281 500] | unet | 0 | fwd | 42176 | 15875 | 2.66
Argmin | bfloat16 | [21 335 500] | unet | 0 | fwd | 47904 | 15413 | 3.11
Argmin | bfloat16 | [21 336 500] | unet | 0 | fwd | 46224 | 15840 | 2.92
Argmin | bfloat16 | [21 500 333] | unet | 0 | fwd | 47888 | 15733 | 3.04
Argmin | bfloat16 | [21 331 500] | unet | 0 | fwd | 47824 | 15751 | 3.04
Argmin | bfloat16 | [21 343 500] | unet | 0 | fwd | 46992 | 15715 | 2.99
Argmin | bfloat16 | [21 500 334] | unet | 0 | fwd | 46400 | 15697 | 2.96
Argmin | bfloat16 | [21 500 422] | unet | 0 | fwd | 53472 | 15840 | 3.38
Argmin | bfloat16 | [21 366 500] | unet | 0 | fwd | 48336 | 15715 | 3.08



</body>

</html>


</details>

- Average over all cases
<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
.font5
	{color:windowtext;
	font-size:8.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:"맑은 고딕", monospace;
	mso-font-charset:129;}
tr
	{mso-height-source:auto;
	mso-ruby-visibility:none;}
col
	{mso-width-source:auto;
	mso-ruby-visibility:none;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:11.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:"맑은 고딕", monospace;
	mso-font-charset:129;
	mso-number-format:General;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
.xl65
	{mso-number-format:Fixed;}
ruby
	{ruby-align:left;}
rt
	{color:windowtext;
	font-size:8.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:"맑은 고딕", monospace;
	mso-font-charset:129;
	mso-char-type:none;
	display:none;}
-->
</head>

<body link="#467886" vlink="#96607D">


Type | average
-- | --
float16 | 3.36
float32 | 3.34
bfloat16 | 3.36



</body>

</html>

