### PR TITLE
Fixed incorrectly generated files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -531,7 +531,7 @@ function(unpack_db db_bzip2_file)
 
     if(NOT MIOPEN_USE_SQLITE_PERFDB AND __extension STREQUAL ".db")
         add_custom_command(OUTPUT ${KERNELS_BINARY_DIR}/${__fname}.txt
-                           DEPENDS addkernels ${KERNELS_BINARY_DIR}/${__fname}
+                           DEPENDS $<TARGET_FILE:sqlite2txt> ${KERNELS_BINARY_DIR}/${__fname}
                            COMMAND $<TARGET_FILE:sqlite2txt> ${KERNELS_BINARY_DIR}/${__fname} ${KERNELS_BINARY_DIR}/${__fname}.txt
         )
         add_custom_target(generate_${__tname}_txt ALL DEPENDS ${KERNELS_BINARY_DIR}/${__fname}.txt)

--- a/src/include/miopen/execution_context.hpp
+++ b/src/include/miopen/execution_context.hpp
@@ -105,11 +105,11 @@ struct ExecutionContext
     ExecutionContext() { DetectRocm(); }
     ExecutionContext(Handle* stream_) : stream(stream_) { DetectRocm(); }
 
-    virtual ~ExecutionContext()                          = default;
-    ExecutionContext(const ExecutionContext&)            = default;
-    ExecutionContext(ExecutionContext&&)                 = default;
+    virtual ~ExecutionContext()               = default;
+    ExecutionContext(const ExecutionContext&) = default;
+    ExecutionContext(ExecutionContext&&)      = default;
     ExecutionContext& operator=(const ExecutionContext&) = default;
-    ExecutionContext& operator=(ExecutionContext&&)      = default;
+    ExecutionContext& operator=(ExecutionContext&&) = default;
 
 #if MIOPEN_EMBED_DB
     std::string GetPerfDbPathEmbed() const

--- a/src/include/miopen/execution_context.hpp
+++ b/src/include/miopen/execution_context.hpp
@@ -105,11 +105,11 @@ struct ExecutionContext
     ExecutionContext() { DetectRocm(); }
     ExecutionContext(Handle* stream_) : stream(stream_) { DetectRocm(); }
 
-    virtual ~ExecutionContext()               = default;
-    ExecutionContext(const ExecutionContext&) = default;
-    ExecutionContext(ExecutionContext&&)      = default;
+    virtual ~ExecutionContext()                          = default;
+    ExecutionContext(const ExecutionContext&)            = default;
+    ExecutionContext(ExecutionContext&&)                 = default;
     ExecutionContext& operator=(const ExecutionContext&) = default;
-    ExecutionContext& operator=(ExecutionContext&&) = default;
+    ExecutionContext& operator=(ExecutionContext&&)      = default;
 
 #if MIOPEN_EMBED_DB
     std::string GetPerfDbPathEmbed() const
@@ -279,10 +279,10 @@ struct ExecutionContext
             return "";
         std::ostringstream filename;
         filename << GetStream().GetDbBasename();
-#if MIOPEN_ENABLE_SQLITE
+#if MIOPEN_ENABLE_SQLITE && MIOPEN_USE_SQLITE_PERFDB
         filename << "_" << SQLitePerfDb::MIOPEN_PERFDB_SCHEMA_VER << ".udb";
 #else
-        filename << "." << GetUserDbSuffix() << ".cd.updb.txt";
+        filename << "." << GetUserDbSuffix() << ".udb.txt";
 #endif
         return (udb / filename.str()).string();
     }

--- a/tools/sqlite2txt/main.cpp
+++ b/tools/sqlite2txt/main.cpp
@@ -48,7 +48,7 @@ struct ProblemConfig
     std::string layout, data_type, direction;
 
     template <class Self>
-    static void Visit(Self&& self, std::function<void(int64_t, std::string)> f)
+    static void Visit(Self&& self, std::function<void(int64_t&, std::string)> f)
     {
         // The column names match the driver command line argument names
         f(self.spatial_dim, "spatial_dim");
@@ -75,7 +75,7 @@ struct ProblemConfig
     }
 
     template <class Self>
-    static void Visit(Self&& self, std::function<void(std::string, std::string)> f)
+    static void Visit(Self&& self, std::function<void(std::string&, std::string)> f)
     {
         f(self.layout, "layout");
         f(self.data_type, "data_type");
@@ -85,9 +85,9 @@ struct ProblemConfig
     template <class Self, class Visitor>
     static void VisitAll(Self&& self, const Visitor& f)
     {
-        Visit(std::forward<Self>(self), [&](int64_t value, std::string name) { f(value, name); });
+        Visit(std::forward<Self>(self), [&](int64_t& value, std::string name) { f(value, name); });
         Visit(std::forward<Self>(self),
-              [&](std::string value, std::string name) { f(value, name); });
+              [&](std::string& value, std::string name) { f(value, name); });
     }
 
     [[nodiscard]] static const std::string& GetFieldNames()
@@ -104,10 +104,10 @@ struct ProblemConfig
         return value;
     }
 
-    [[nodiscard]] std::string Serialize() const
+    [[nodiscard]] std::string Serialize()
     {
         std::ostringstream ss;
-        ProblemConfig::VisitAll(ProblemConfig{}, [&](auto&& value, auto&&) {
+        ProblemConfig::VisitAll(*this, [&](auto&& value, auto&&) {
             if(ss.tellp() != 0)
                 ss << "x";
             ss << value;


### PR DESCRIPTION
This is a hotfix for issue described here: https://github.com/ROCm/MIOpen/pull/2722#issuecomment-1961900323

3 things are fixed:
- text db files now contain correct keys
- any updates to sqlite2txt now force regeneration of db.txt files
- text user dbs now have a separate extension