### PR TITLE
[HotFix] fix failed error bugs in conv backward weight solvers

### DIFF
--- a/src/include/miopen/solver/implicitgemm_ck_util.hpp
+++ b/src/include/miopen/solver/implicitgemm_ck_util.hpp
@@ -644,8 +644,6 @@ ConvSolution InitInvokerFactoryNCHW(const ExecutionContext& ctx,
 
             output_init_tr_inst.ConvertFrom(handle, kernels, conv_tensors);
 
-            /// \todo: Fix NHWC Wrw invokers to also issue a zero-out kernel. Will
-            /// need SetTensor() to properly zero out non-packed tensors
             if(output_tr_inst.GetConvOperandTag() == internal::ConvOperandTag::Weights)
             {
                 output_tr_inst.ZeroOutBuffer();

--- a/src/include/miopen/solver/implicitgemm_ck_util.hpp
+++ b/src/include/miopen/solver/implicitgemm_ck_util.hpp
@@ -97,22 +97,31 @@ bool IsCKApplicable(const ProblemDescriptionType& problem)
         ptrs.begin(), ptrs.end(), [&args](auto& ptr) { return args.IsSupportedBy(ptr); });
 }
 
-inline void ProfilingRecordStart(const Handle& handle, HipEventPtr& start, HipEventPtr& stop)
+#define WORKAROUND_CK_ISSUE_1184 1
+#ifdef WORKAROUND_CK_ISSUE_1184
+struct HipEventProfiler
 {
-    start = make_hip_event();
-    stop  = make_hip_event();
-    hipEventRecord(start.get(), handle.GetStream());
-}
+    const Handle& handle;
+    float event_time;
+    HipEventPtr start;
+    HipEventPtr stop;
 
-inline void ProfilingRecordStop(const Handle& handle, HipEventPtr& start, HipEventPtr& stop)
-{
-    hipEventRecord(stop.get(), handle.GetStream());
-    hipEventSynchronize(stop.get());
-    float mS = 0.0f;
-    hipEventElapsedTime(&mS, start.get(), stop.get());
-    handle.ResetKernelTime();
-    handle.AccumKernelTime(mS);
-}
+    HipEventProfiler(const Handle& handle_) : handle(std::move(handle_)), event_time(0.0f)
+    {
+        start = make_hip_event();
+        stop  = make_hip_event();
+        hipEventRecord(start.get(), handle.GetStream());
+    }
+    ~HipEventProfiler()
+    {
+        hipEventRecord(stop.get(), handle.GetStream());
+        hipEventSynchronize(stop.get());
+        hipEventElapsedTime(&event_time, start.get(), stop.get());
+        handle.ResetKernelTime();
+        handle.AccumKernelTime(event_time);
+    }
+};
+#endif
 
 template <typename DeviceOpType,
           typename CKArgsType,
@@ -132,44 +141,28 @@ ConvSolution InitInvokerFactoryNHWC(const ExecutionContext&,
     }
 
     ConvSolution result;
-    result.invoker_factory = [ck_args     = CKArgsType{problem},
-                              sh_conv_ptr = std::shared_ptr{std::move(*ptr_iter)}](
-                                 const std::vector<Kernel>&) mutable {
-        return [ck_args = std::move(ck_args), sh_conv_ptr = std::move(sh_conv_ptr)](
-                   const Handle& handle, const AnyInvokeParams& primitive_parameters) {
-            const auto& data_ctx = primitive_parameters.CastTo<CastType>();
-            auto argument_ptr    = ck_args.MakeArgPtr(sh_conv_ptr, data_ctx.tensors);
-            auto invoker_ptr     = sh_conv_ptr->MakeInvokerPointer();
-
-            if constexpr(std::is_same<CastType, miopen::conv::WrWInvokeParams>::value)
-            {
-                auto zero           = 0.0f;
-                const auto& tensors = data_ctx.tensors;
-                SetTensor(handle, tensors.dwDesc, tensors.dw, &zero);
-
-                HipEventPtr start = nullptr;
-                HipEventPtr stop  = nullptr;
-                if(handle.IsProfilingEnabled())
+    result.invoker_factory =
+        [ck_args     = CKArgsType{problem},
+         sh_conv_ptr = std::shared_ptr{std::move(*ptr_iter)}](const std::vector<Kernel>&) mutable {
+            return [ck_args = std::move(ck_args), sh_conv_ptr = std::move(sh_conv_ptr)](
+                       const Handle& handle, const AnyInvokeParams& primitive_parameters) {
+                const auto& data_ctx = primitive_parameters.CastTo<CastType>();
+                auto argument_ptr    = ck_args.MakeArgPtr(sh_conv_ptr, data_ctx.tensors);
+                auto invoker_ptr     = sh_conv_ptr->MakeInvokerPointer();
                 {
-                    ProfilingRecordStart(handle, start, stop);
+#ifdef WORKAROUND_CK_ISSUE_1184
+                    HipEventProfiler pfr(handle);
+#endif
+                    if constexpr(std::is_same<CastType, miopen::conv::WrWInvokeParams>::value)
+                    {
+                        auto zero           = 0.0f;
+                        const auto& tensors = data_ctx.tensors;
+                        SetTensor(handle, tensors.dwDesc, tensors.dw, &zero);
+                    }
+                    invoker_ptr->Run(argument_ptr.get(), {handle.GetStream(), false});
                 }
-                invoker_ptr->Run(argument_ptr.get(), {handle.GetStream(), false});
-                if(handle.IsProfilingEnabled())
-                    ProfilingRecordStop(handle, start, stop);
-            }
-            else
-            {
-                const auto enable_profiling = handle.IsProfilingEnabled();
-                float elapsed_time =
-                    invoker_ptr->Run(argument_ptr.get(), {handle.GetStream(), enable_profiling});
-                if(enable_profiling)
-                {
-                    handle.ResetKernelTime();
-                    handle.AccumKernelTime(elapsed_time);
-                }
-            }
+            };
         };
-    };
     return result;
 }
 
@@ -642,13 +635,9 @@ ConvSolution InitInvokerFactoryNCHW(const ExecutionContext& ctx,
                 std::swap(conv_tensors.x, conv_tensors.y);
                 std::swap(conv_tensors.xDesc, conv_tensors.yDesc);
             }
-
-            HipEventPtr start = nullptr;
-            HipEventPtr stop  = nullptr;
-            if(handle.IsProfilingEnabled())
-            {
-                ProfilingRecordStart(handle, start, stop);
-            }
+#ifdef WORKAROUND_CK_ISSUE_1184
+            HipEventProfiler pfr(handle);
+#endif
             input1_tr_inst.ConvertFrom(handle, kernels, conv_tensors);
 
             input2_tr_inst.ConvertFrom(handle, kernels, conv_tensors);
@@ -677,8 +666,6 @@ ConvSolution InitInvokerFactoryNCHW(const ExecutionContext& ctx,
                                                    tr_ptrs[2]->GetBufferPtr());
             invoker_ptr->Run(argument_ptr.get(), {handle.GetStream(), false});
             output_tr_inst.ConvertTo(handle, kernels, conv_tensors);
-            if(handle.IsProfilingEnabled())
-                ProfilingRecordStop(handle, start, stop);
         };
     };
 

--- a/src/include/miopen/solver/implicitgemm_ck_util.hpp
+++ b/src/include/miopen/solver/implicitgemm_ck_util.hpp
@@ -106,10 +106,12 @@ struct HipEventProfiler
     HipEventPtr start;
     HipEventPtr stop;
 
-    HipEventProfiler(const Handle& handle_) : handle(std::move(handle_)), event_time(0.0f)
+    HipEventProfiler(const Handle& handle_)
+        : handle(std::move(handle_)),
+          event_time(0.0f),
+          start(make_hip_event()),
+          stop(make_hip_event())
     {
-        start = make_hip_event();
-        stop  = make_hip_event();
         hipEventRecord(start.get(), handle.GetStream());
     }
     ~HipEventProfiler()


### PR DESCRIPTION
Fix the bug: the numerical error is larger than threshold in the ck-based backward weight convolution. 

MIOpen/build# ./bin/MIOpenDriver conv -n 1 -c 64 -H 130 -W 130 -k 3 -y 3 -x 3 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -t 1 -F 4
MIOpenDriver conv -n 1 -c 64 -H 130 -W 130 -k 3 -y 3 -x 3 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m conv -g 1 -t 1 -F 4
PRNG seed: 12345678
MIOpen Backward Weights Conv. Algorithm: 5, Solution: 156/ConvHipImplicitGemmGroupWrwXdlops
GPU Kernel Time Backward Weights Conv. Elapsed: 0.005003 ms (average)
stats: name, n, c, ho, wo, x, y, k, flopCnt, bytesRead, bytesWritten, GFLOPs, GB/s, timeMs
stats: bwdw-conv3x3u1, 1, 64, 128, 128, 3, 3, 3,  56623104, 0, 0, 11319, 0, 0.005003
Backward Convolution Weights FAILED: 0.892519 > 0.01