### PR TITLE
Remove SetTensorLayout 

### DIFF
--- a/test/gtest/cat.hpp
+++ b/test/gtest/cat.hpp
@@ -100,15 +100,6 @@ std::vector<CatTestCase> CatTestConfigs()
     // clang-format on
 }
 
-inline int32_t SetTensorLayout(miopen::TensorDescriptor& desc)
-{
-    std::vector<std::size_t> lens = desc.GetLengths();
-    std::vector<int32_t> int32_t_lens(lens.begin(), lens.end());
-
-    // set the strides for the tensor
-    return SetTensorNd(&desc, int32_t_lens, desc.GetType());
-}
-
 template <typename T = float>
 struct CatTest : public ::testing::TestWithParam<CatTestCase>
 {
@@ -127,12 +118,10 @@ protected:
         for(auto in_dim : in_dims)
         {
             inputs.push_back(tensor<T>{in_dim}.generate(gen_value));
-            SetTensorLayout(inputs.back().desc);
             out_dim[dim] += in_dim[dim];
         }
 
         output = tensor<T>{out_dim};
-        SetTensorLayout(output.desc);
         std::fill(output.begin(), output.end(), std::numeric_limits<T>::quiet_NaN());
 
         ref_output = tensor<T>{out_dim};

--- a/test/gtest/groupnorm.hpp
+++ b/test/gtest/groupnorm.hpp
@@ -145,15 +145,6 @@ std::vector<GroupNormTestCase> GroupNormTestConfigs()
             {64, 1, 0, 0, 256, 1, 1e-5, MIOPEN_WEIGHT_BIAS}};
 }
 
-inline int32_t SetTensorLayout(miopen::TensorDescriptor& desc)
-{
-    const std::vector<std::size_t> lens = desc.GetLengths();
-    std::vector<int32_t> int32_t_lens(lens.begin(), lens.end());
-
-    // set the strides for the tensor
-    return SetTensorNd(&desc, int32_t_lens, desc.GetType());
-}
-
 template <typename T = float>
 struct GroupNormTest : public ::testing::TestWithParam<GroupNormTestCase>
 {
@@ -189,13 +180,6 @@ protected:
         output = tensor<T>{inout_dim};
         mean   = tensor<T>{mean_rstd_dim};
         rstd   = tensor<T>{mean_rstd_dim};
-
-        SetTensorLayout(weight.desc);
-        SetTensorLayout(bias.desc);
-        SetTensorLayout(input.desc);
-        SetTensorLayout(output.desc);
-        SetTensorLayout(mean.desc);
-        SetTensorLayout(rstd.desc);
 
         std::fill(output.begin(), output.end(), std::numeric_limits<T>::quiet_NaN());
         std::fill(mean.begin(), mean.end(), std::numeric_limits<T>::quiet_NaN());

--- a/test/gtest/layernorm.hpp
+++ b/test/gtest/layernorm.hpp
@@ -151,15 +151,6 @@ std::vector<LayerNormTestCase> LayerNormTestConfigs()
     // clang-format on
 }
 
-static int32_t SetTensorLayout(miopen::TensorDescriptor& desc)
-{
-    const std::vector<std::size_t>& lens = desc.GetLengths();
-    std::vector<int32_t> int32_t_lens(lens.begin(), lens.end());
-
-    // set the strides for the tensor
-    return SetTensorNd(&desc, int32_t_lens, desc.GetType());
-}
-
 template <typename T = float>
 struct LayerNormTest : public ::testing::TestWithParam<LayerNormTestCase>
 {
@@ -190,15 +181,11 @@ protected:
             auto gen_zero = [&](auto...) { return 0; };
             weight        = tensor<T>{inner_dim}.generate(gen_one);
             bias          = tensor<T>{inner_dim}.generate(gen_zero);
-            SetTensorLayout(weight.desc);
-            SetTensorLayout(bias.desc);
         }
         else
         {
             weight = tensor<T>{inner_dim}.generate(gen_value);
             bias   = tensor<T>{inner_dim}.generate(gen_value);
-            SetTensorLayout(weight.desc);
-            SetTensorLayout(bias.desc);
         }
 
         std::vector<size_t> outer_dim;
@@ -207,14 +194,9 @@ protected:
         else
             outer_dim = {in_dim.begin(), in_dim.end() - (in_dim.size() - nomalized_dim)};
 
-        SetTensorLayout(input.desc);
-
         output = tensor<T>{in_dim};
         mean   = tensor<T>{outer_dim};
         rstd   = tensor<T>{outer_dim};
-        SetTensorLayout(output.desc);
-        SetTensorLayout(mean.desc);
-        SetTensorLayout(rstd.desc);
         std::fill(output.begin(), output.end(), std::numeric_limits<T>::quiet_NaN());
         std::fill(mean.begin(), mean.end(), std::numeric_limits<T>::quiet_NaN());
         std::fill(rstd.begin(), rstd.end(), std::numeric_limits<T>::quiet_NaN());

--- a/test/gtest/sum.hpp
+++ b/test/gtest/sum.hpp
@@ -99,15 +99,6 @@ std::vector<SumTestCase> SumTestConfigs()
     // clang-format on
 }
 
-static int32_t SetTensorLayout(miopen::TensorDescriptor& desc)
-{
-    const std::vector<std::size_t>& lens = desc.GetLengths();
-    std::vector<int32_t> int32_t_lens(lens.begin(), lens.end());
-
-    // set the strides for the tensor
-    return SetTensorNd(&desc, int32_t_lens, desc.GetType());
-}
-
 template <typename T = float>
 struct SumTest : public ::testing::TestWithParam<SumTestCase>
 {
@@ -135,10 +126,7 @@ protected:
             }
         }
 
-        SetTensorLayout(input.desc);
-
         output = tensor<T>{out_dims};
-        SetTensorLayout(output.desc);
         std::fill(output.begin(), output.end(), std::numeric_limits<T>::quiet_NaN());
 
         ref_output = tensor<T>{out_dims};


### PR DESCRIPTION
SetTensorLayout is being used in some places in MIOpen. This function is not necessary since tensor class's constructor takes care of this functionality.