### PR TITLE
Fixing linking issue for sqlite2txt on Windows

### DIFF
--- a/tools/sqlite2txt/CMakeLists.txt
+++ b/tools/sqlite2txt/CMakeLists.txt
@@ -2,5 +2,10 @@ add_executable(sqlite2txt
         main.cpp
 )
 
-target_link_libraries(sqlite2txt SQLite::SQLite3 pthread dl)
+target_link_libraries(sqlite2txt SQLite::SQLite3 Threads::Threads)
+
+if (NOT WIN32)
+    target_link_libraries(sqlite2txt dl)
+endif()
+
 clang_tidy_check(sqlite2txt)


### PR DESCRIPTION
Fixing linking issue for Windows which is related to previously merged PR #2773 .

Adding `pthread` and `dl` to target link libraries caused blockage on Windows build with linking issue because `thread.lib` and `dl.lib` are not supported on Windows. 

Replaced `pthread` with `Threads::Threads` and added support for `dl` library for Linux.