### PR TITLE
RNN back weights update

### DIFF
--- a/driver/lstm_verify_gemm.hpp
+++ b/driver/lstm_verify_gemm.hpp
@@ -493,7 +493,7 @@ void RunLSTMForwardGEMMCPUVerify(miopenHandle_t handle,
                     else
                     {
                         size_t prec_shift = li * batch_n * hy_stride +
-                                         (bacc - in_n.at(ti - 1)) * hy_stride + bi * 4 * hy_h;
+                                            (bacc - in_n.at(ti - 1)) * hy_stride + bi * 4 * hy_h;
 
                         hid_state.at(hid_shift + (bacc + bs) * hy_stride + bi * 4 * hy_h + h) +=
                             activfunc(hid_state.at(hid_shift + (bacc + bs) * hy_stride + hy_h + h),
@@ -1069,7 +1069,7 @@ void RunLSTMBackwardDataGEMMCPUVerify(
                         if(ti < seqLength - 1)
                         {
                             size_t pretime_shift = li * batch_n * hy_stride +
-                                                (baccbi - in_n[seqLength - 2 - ti]) * hy_stride;
+                                                   (baccbi - in_n[seqLength - 2 - ti]) * hy_stride;
 
                             dh_state[hid_shift + (baccbi + bs) * hy_stride + bi * 4 * hy_h + hy_h +
                                      h] +=
@@ -1124,7 +1124,7 @@ void RunLSTMBackwardDataGEMMCPUVerify(
                             {
                                 size_t pretime_shift =
                                     li * batch_n * hy_stride +
-                                                    (baccbi + in_n[seqLength - 1 - ti]) * hy_stride;
+                                    (baccbi + in_n[seqLength - 1 - ti]) * hy_stride;
 
                                 dh_state[hid_shift + (baccbi + bs) * hy_stride + 5 * hy_h + h] +=
                                     dh_state[hid_shift + (baccbi + bs) * hy_stride + bi * 4 * hy_h +
@@ -1338,7 +1338,7 @@ void RunLSTMBackwardWeightGEMMCPUVerify(std::vector<Tgpu>& in,
                                         bool hx_is_null = false)
 {
     size_t batch_n = sumvc(in_n);
-    int numlayer = bidirection ? hy_d / 2 : hy_d;
+    int numlayer   = bidirection ? hy_d / 2 : hy_d;
     size_t bacc; // accumulation of batch
     int bi = bidirection ? 2 : 1;
 
@@ -1401,7 +1401,7 @@ void RunLSTMBackwardWeightGEMMCPUVerify(std::vector<Tgpu>& in,
     }
 
     size_t wei_shift_bias = (in_h + hy_h + (bi * hy_h + hy_h) * (numlayer - 1)) * wei_stride;
-    int wei_len        = wei_shift_bias;
+    int wei_len           = wei_shift_bias;
     if(biased)
     {
         int in_bias = 2;

--- a/driver/lstm_verify_gemm.hpp
+++ b/driver/lstm_verify_gemm.hpp
@@ -38,10 +38,10 @@ void RunLSTMForwardGEMMCPUVerify(miopenHandle_t handle,
                                  bool hx_is_null = false,
                                  bool cx_is_null = false)
 {
-    int batch_n = sumvc(in_n);
+    size_t batch_n = sumvc(in_n);
 
     int numlayer = bidirection ? hy_d / 2 : hy_d;
-    int bacc, baccbi; // accumulation of batch
+    size_t bacc, baccbi; // accumulation of batch
     int bi = bidirection ? 2 : 1;
 
     int in_stride  = in_h;
@@ -141,8 +141,8 @@ void RunLSTMForwardGEMMCPUVerify(miopenHandle_t handle,
     // forward emulator
     for(int li = 0; li < numlayer; li++)
     {
-        int hid_shift = li * batch_n * hy_stride;
-        int hx_shift  = li * in_n.at(0) * h_stride;
+        size_t hid_shift = li * batch_n * hy_stride;
+        size_t hx_shift  = li * in_n.at(0) * h_stride;
 
         // from input
         if(li == 0)
@@ -215,8 +215,9 @@ void RunLSTMForwardGEMMCPUVerify(miopenHandle_t handle,
         }
         else
         {
-            int wei_shift = (in_h + hy_h) * wei_stride + (li - 1) * (bi * hy_h + hy_h) * wei_stride;
-            int prelayer_shift = (li - 1) * batch_n * hy_stride + bi * 5 * hy_h;
+            size_t wei_shift =
+                (in_h + hy_h) * wei_stride + (li - 1) * (bi * hy_h + hy_h) * wei_stride;
+            size_t prelayer_shift = (li - 1) * batch_n * hy_stride + bi * 5 * hy_h;
             if(use_dropout)
             {
                 auto dropout_states_tmp = dropout_states_host;
@@ -260,7 +261,7 @@ void RunLSTMForwardGEMMCPUVerify(miopenHandle_t handle,
             // from bias
             if(biased)
             {
-                int wei_shift_bias_temp = wei_shift_bias + li * 2 * wei_stride;
+                size_t wei_shift_bias_temp = wei_shift_bias + li * 2 * wei_stride;
 
                 for(int bs = 0; bs < batch_n; bs++)
                 {
@@ -279,7 +280,7 @@ void RunLSTMForwardGEMMCPUVerify(miopenHandle_t handle,
         for(int ti = 0; ti < seqLength; ti++)
         {
             baccbi -= in_n.at(seqLength - 1 - ti);
-            int wei_shift = in_h * wei_stride + li * (bi * hy_h + hy_h) * wei_stride;
+            size_t wei_shift = in_h * wei_stride + li * (bi * hy_h + hy_h) * wei_stride;
 
             if(ti == 0)
             {
@@ -306,7 +307,7 @@ void RunLSTMForwardGEMMCPUVerify(miopenHandle_t handle,
                     // from bias
                     if(biased)
                     {
-                        int wei_shift_bias_temp = wei_shift_bias + (li * 2 + 1) * wei_stride;
+                        size_t wei_shift_bias_temp = wei_shift_bias + (li * 2 + 1) * wei_stride;
 
                         for(int bs = 0; bs < in_n[ti]; bs++)
                         {
@@ -379,7 +380,7 @@ void RunLSTMForwardGEMMCPUVerify(miopenHandle_t handle,
                 // from bias
                 if(biased)
                 {
-                    int wei_shift_bias_temp = wei_shift_bias + (li * 2 + 1) * wei_stride;
+                    size_t wei_shift_bias_temp = wei_shift_bias + (li * 2 + 1) * wei_stride;
 
                     for(int bs = 0; bs < in_n[ti]; bs++)
                     {
@@ -419,7 +420,7 @@ void RunLSTMForwardGEMMCPUVerify(miopenHandle_t handle,
                         // from bias
                         if(biased)
                         {
-                            int wei_shift_bias_temp = wei_shift_bias + (li * 2 + 1) * wei_stride;
+                            size_t wei_shift_bias_temp = wei_shift_bias + (li * 2 + 1) * wei_stride;
 
                             for(int bs = in_n.at(seqLength - ti); bs < in_n.at(seqLength - 1 - ti);
                                 bs++)
@@ -455,7 +456,7 @@ void RunLSTMForwardGEMMCPUVerify(miopenHandle_t handle,
                     // from bias
                     if(biased)
                     {
-                        int wei_shift_bias_temp = wei_shift_bias + (li * 2 + 1) * wei_stride;
+                        size_t wei_shift_bias_temp = wei_shift_bias + (li * 2 + 1) * wei_stride;
 
                         for(int bs = 0; bs < in_n.at(seqLength - ti); bs++)
                         {
@@ -491,7 +492,7 @@ void RunLSTMForwardGEMMCPUVerify(miopenHandle_t handle,
                     }
                     else
                     {
-                        int prec_shift = li * batch_n * hy_stride +
+                        size_t prec_shift = li * batch_n * hy_stride +
                                          (bacc - in_n.at(ti - 1)) * hy_stride + bi * 4 * hy_h;
 
                         hid_state.at(hid_shift + (bacc + bs) * hy_stride + bi * 4 * hy_h + h) +=
@@ -579,7 +580,7 @@ void RunLSTMForwardGEMMCPUVerify(miopenHandle_t handle,
 
                             if(bs < in_n.at(seqLength - ti))
                             {
-                                int prec_shift =
+                                size_t prec_shift =
                                     li * batch_n * hy_stride +
                                     (baccbi + in_n.at(seqLength - 1 - ti)) * hy_stride +
                                     bi * 4 * hy_h + hy_h;
@@ -641,7 +642,7 @@ void RunLSTMForwardGEMMCPUVerify(miopenHandle_t handle,
     }
 
     // output
-    int prelayer_shift = (numlayer - 1) * batch_n * hy_stride + bi * 5 * hy_h;
+    size_t prelayer_shift = (numlayer - 1) * batch_n * hy_stride + bi * 5 * hy_h;
 
     for(int i = 0; i < numlayer * batch_n * hy_stride * 2; i++)
     {
@@ -711,10 +712,10 @@ void RunLSTMBackwardDataGEMMCPUVerify(
     bool dhy_is_null = false,
     bool dcy_is_null = false)
 {
-    int batch_n = sumvc(in_n);
+    size_t batch_n = sumvc(in_n);
 
     int numlayer = bidirection ? hy_d / 2 : hy_d;
-    int bacc, baccbi; // accumulation of batch
+    size_t bacc, baccbi; // accumulation of batch
     int bi = bidirection ? 2 : 1;
 
     int in_stride  = in_h;
@@ -816,9 +817,9 @@ void RunLSTMBackwardDataGEMMCPUVerify(
     // bwd data emulator
     for(int li = numlayer - 1; li >= 0; li--)
     {
-        int wei_shift = (in_h + hy_h) * wei_stride + li * (bi * hy_h + hy_h) * wei_stride;
-        int hid_shift = li * batch_n * hy_stride;
-        int hx_shift  = li * in_n[0] * h_stride;
+        size_t wei_shift = (in_h + hy_h) * wei_stride + li * (bi * hy_h + hy_h) * wei_stride;
+        size_t hid_shift = li * batch_n * hy_stride;
+        size_t hx_shift  = li * in_n[0] * h_stride;
 
         if(li == numlayer - 1)
         {
@@ -833,7 +834,7 @@ void RunLSTMBackwardDataGEMMCPUVerify(
         }
         else
         {
-            int prelayer_shift = (li + 1) * batch_n * hy_stride;
+            size_t prelayer_shift = (li + 1) * batch_n * hy_stride;
 
             ADNN_mm_cpu<Tref>(&dh_state[prelayer_shift],
                               hy_h * bi * 4,
@@ -942,8 +943,8 @@ void RunLSTMBackwardDataGEMMCPUVerify(
                     }
                 }
 
-                int pretime_shift = li * batch_n * hy_stride + (bacc + in_n[ti]) * hy_stride;
-                int weitime_shift = in_h * wei_stride + li * (bi * hy_h + hy_h) * wei_stride;
+                size_t pretime_shift = li * batch_n * hy_stride + (bacc + in_n[ti]) * hy_stride;
+                size_t weitime_shift = in_h * wei_stride + li * (bi * hy_h + hy_h) * wei_stride;
 
                 ADNN_mm_cpu<Tref>(&dh_state[pretime_shift],
                                   hy_h * 4,
@@ -999,7 +1000,7 @@ void RunLSTMBackwardDataGEMMCPUVerify(
                     {
                         if(bs < in_n[ti + 1])
                         {
-                            int pretime_shift =
+                            size_t pretime_shift =
                                 li * batch_n * hy_stride + (bacc + in_n[ti]) * hy_stride;
 
                             dh_state[hid_shift + (bacc + bs) * hy_stride + bi * 4 * hy_h + h] +=
@@ -1030,7 +1031,7 @@ void RunLSTMBackwardDataGEMMCPUVerify(
                     }
                     else
                     {
-                        int pretime_shift =
+                        size_t pretime_shift =
                             li * batch_n * hy_stride + (bacc - in_n[ti - 1]) * hy_stride;
 
                         dh_state[hid_shift + (bacc + bs) * hy_stride + hy_h + h] +=
@@ -1067,7 +1068,7 @@ void RunLSTMBackwardDataGEMMCPUVerify(
                     {
                         if(ti < seqLength - 1)
                         {
-                            int pretime_shift = li * batch_n * hy_stride +
+                            size_t pretime_shift = li * batch_n * hy_stride +
                                                 (baccbi - in_n[seqLength - 2 - ti]) * hy_stride;
 
                             dh_state[hid_shift + (baccbi + bs) * hy_stride + bi * 4 * hy_h + hy_h +
@@ -1121,7 +1122,8 @@ void RunLSTMBackwardDataGEMMCPUVerify(
 
                             if(bs < in_n[seqLength - ti])
                             {
-                                int pretime_shift = li * batch_n * hy_stride +
+                                size_t pretime_shift =
+                                    li * batch_n * hy_stride +
                                                     (baccbi + in_n[seqLength - 1 - ti]) * hy_stride;
 
                                 dh_state[hid_shift + (baccbi + bs) * hy_stride + 5 * hy_h + h] +=
@@ -1170,8 +1172,8 @@ void RunLSTMBackwardDataGEMMCPUVerify(
         }
 
         // dcx, dhx
-        int pretime_shift = li * batch_n * hy_stride;
-        int weitime_shift = in_h * wei_stride + li * (bi * hy_h + hy_h) * wei_stride;
+        size_t pretime_shift = li * batch_n * hy_stride;
+        size_t weitime_shift = in_h * wei_stride + li * (bi * hy_h + hy_h) * wei_stride;
 
         ADNN_mm_cpu<Tref>(&dh_state[pretime_shift],
                           hy_h * 4,
@@ -1335,9 +1337,9 @@ void RunLSTMBackwardWeightGEMMCPUVerify(std::vector<Tgpu>& in,
                                         bool use_dropout,
                                         bool hx_is_null = false)
 {
-    int batch_n  = sumvc(in_n);
+    size_t batch_n = sumvc(in_n);
     int numlayer = bidirection ? hy_d / 2 : hy_d;
-    int bacc; // accumulation of batch
+    size_t bacc; // accumulation of batch
     int bi = bidirection ? 2 : 1;
 
     int in_stride  = in_h;
@@ -1398,7 +1400,7 @@ void RunLSTMBackwardWeightGEMMCPUVerify(std::vector<Tgpu>& in,
         in_h = 0;
     }
 
-    int wei_shift_bias = (in_h + hy_h + (bi * hy_h + hy_h) * (numlayer - 1)) * wei_stride;
+    size_t wei_shift_bias = (in_h + hy_h + (bi * hy_h + hy_h) * (numlayer - 1)) * wei_stride;
     int wei_len        = wei_shift_bias;
     if(biased)
     {
@@ -1449,11 +1451,12 @@ void RunLSTMBackwardWeightGEMMCPUVerify(std::vector<Tgpu>& in,
         }
         else
         {
-            int prelayer_shift =
+            size_t prelayer_shift =
                 use_dropout ? 2 * numlayer * batch_n * hy_stride + (li - 1) * batch_n * hy_h * bi
                             : (li - 1) * batch_n * hy_stride + bi * hy_h * 5;
-            int hid_shift = li * batch_n * hy_stride;
-            int wei_shift = (in_h + hy_h) * wei_stride + (li - 1) * (bi * hy_h + hy_h) * wei_stride;
+            size_t hid_shift = li * batch_n * hy_stride;
+            size_t wei_shift =
+                (in_h + hy_h) * wei_stride + (li - 1) * (bi * hy_h + hy_h) * wei_stride;
 
             ADNN_mm_cpu<Tref>(&wkspace_state[hid_shift],
                               hy_h * bi * 4,
@@ -1491,9 +1494,9 @@ void RunLSTMBackwardWeightGEMMCPUVerify(std::vector<Tgpu>& in,
         bacc = 0;
         for(int ti = 0; ti < seqLength; ti++)
         {
-            int hid_shift = li * batch_n * hy_stride + bacc * hy_stride;
-            int hx_shift  = li * in_n[0] * h_stride;
-            int wei_shift = in_h * wei_stride + li * (bi * hy_h + hy_h) * wei_stride;
+            size_t hid_shift = li * batch_n * hy_stride + bacc * hy_stride;
+            size_t hx_shift  = li * in_n[0] * h_stride;
+            size_t wei_shift = in_h * wei_stride + li * (bi * hy_h + hy_h) * wei_stride;
             int pretime_shift;
 
             // between time
@@ -1521,7 +1524,7 @@ void RunLSTMBackwardWeightGEMMCPUVerify(std::vector<Tgpu>& in,
 
                     if(biased)
                     {
-                        int bias_shift = wei_shift_bias + li * 2 * wei_stride + wei_stride;
+                        size_t bias_shift = wei_shift_bias + li * 2 * wei_stride + wei_stride;
 
                         for(int h = 0; h < hy_h * 4; h++)
                         {
@@ -1559,7 +1562,7 @@ void RunLSTMBackwardWeightGEMMCPUVerify(std::vector<Tgpu>& in,
 
                 if(biased)
                 {
-                    int bias_shift = wei_shift_bias + li * 2 * wei_stride + wei_stride;
+                    size_t bias_shift = wei_shift_bias + li * 2 * wei_stride + wei_stride;
 
                     for(int h = 0; h < hy_h * 4; h++)
                     {
@@ -1598,7 +1601,7 @@ void RunLSTMBackwardWeightGEMMCPUVerify(std::vector<Tgpu>& in,
 
                         if(biased)
                         {
-                            int bias_shift = wei_shift_bias + li * 2 * wei_stride + wei_stride;
+                            size_t bias_shift = wei_shift_bias + li * 2 * wei_stride + wei_stride;
 
                             for(int h = 0; h < hy_h * 4; h++)
                             {
@@ -1636,7 +1639,7 @@ void RunLSTMBackwardWeightGEMMCPUVerify(std::vector<Tgpu>& in,
 
                         if(biased)
                         {
-                            int bias_shift = wei_shift_bias + li * 2 * wei_stride + wei_stride;
+                            size_t bias_shift = wei_shift_bias + li * 2 * wei_stride + wei_stride;
 
                             for(int h = 0; h < hy_h * 4; h++)
                             {
@@ -1672,7 +1675,7 @@ void RunLSTMBackwardWeightGEMMCPUVerify(std::vector<Tgpu>& in,
 
                     if(biased)
                     {
-                        int bias_shift = wei_shift_bias + li * 2 * wei_stride + wei_stride;
+                        size_t bias_shift = wei_shift_bias + li * 2 * wei_stride + wei_stride;
 
                         for(int h = 0; h < hy_h * 4; h++)
                         {

--- a/src/include/miopen/rnn_util.hpp
+++ b/src/include/miopen/rnn_util.hpp
@@ -340,7 +340,7 @@ inline size_t ReductionWorkspaceSize(const Handle& handle,
     {
         miopen::ReduceTensorDescriptor red_add{
             miopenReduceTensorOp_t::MIOPEN_REDUCE_TENSOR_ADD,
-            rnn_data_t,
+            miopenDataType_t::miopenFloat,                   // compute in float for fp16
             miopenNanPropagation_t::MIOPEN_PROPAGATE_NAN,
             miopenReduceTensorIndices_t::MIOPEN_REDUCE_TENSOR_NO_INDICES,
             miopenIndicesType_t::MIOPEN_32BIT_INDICES};
@@ -359,9 +359,9 @@ inline size_t ReductionWorkspaceSize(const Handle& handle,
 
         const std::vector<size_t> dw_bias_strides{bias_total_cnt, bias_total_cnt, 1};
         const miopen::TensorDescriptor dw_desc{rnn_data_t, {1, 1, bias_total_cnt}, dw_bias_strides};
-        
-        
-        reduction_ws = red_add.GetWorkspaceSize(handle, ws_desc, dw_desc);
+                
+        reduction_ws = red_add.GetWorkspaceSize(handle, ws_desc, dw_desc) + // WA CK bug
+                       (rnn_data_t == miopenDataType_t::miopenHalf ? 4 : 0);
     }
     else
     {

--- a/src/include/miopen/rnn_util.hpp
+++ b/src/include/miopen/rnn_util.hpp
@@ -321,12 +321,12 @@ void FillSeqTensorByPaddingMarker(const Handle& handle,
 int getReductionAlgo();
 
 inline size_t ReductionWorkspaceSize(const Handle& handle,
-                              size_t batchLenSum,
-                              size_t nHiddenTensorsPerLayer,
-                              size_t workspaceScale,
-                              size_t hsize,
-                              bool is_bidirect,
-                              miopenDataType_t rnn_data_t)
+                                     size_t batchLenSum,
+                                     size_t nHiddenTensorsPerLayer,
+                                     size_t workspaceScale,
+                                     size_t hsize,
+                                     bool is_bidirect,
+                                     miopenDataType_t rnn_data_t)
 {
     int red_algo = getReductionAlgo();
 
@@ -339,9 +339,9 @@ inline size_t ReductionWorkspaceSize(const Handle& handle,
             miopenNanPropagation_t::MIOPEN_PROPAGATE_NAN,
             miopenReduceTensorIndices_t::MIOPEN_REDUCE_TENSOR_NO_INDICES,
             miopenIndicesType_t::MIOPEN_32BIT_INDICES};
-        
+
         int bidirect_mp = is_bidirect ? 2 : 1;
-        
+
         size_t hy_stride = hsize * bidirect_mp * workspaceScale;
 
         size_t bias_total_cnt = hsize * bidirect_mp * nHiddenTensorsPerLayer;
@@ -357,7 +357,8 @@ inline size_t ReductionWorkspaceSize(const Handle& handle,
 
         reduction_ws = red_add.GetWorkspaceSize(handle, ws_desc, dw_desc);
     }
-    else {
+    else
+    {
         if(red_algo == 2 || red_algo == 3)
         {
             reduction_ws = batchLenSum * GetTypeSize(rnn_data_t);

--- a/src/include/miopen/rnn_util.hpp
+++ b/src/include/miopen/rnn_util.hpp
@@ -331,6 +331,11 @@ inline size_t ReductionWorkspaceSize(const Handle& handle,
     int red_algo = getReductionAlgo();
 
     size_t reduction_ws = 0;
+
+    // nothing to reduce,
+    if(batchLenSum == 1)
+        return 0;
+
     if(red_algo == 1)
     {
         miopen::ReduceTensorDescriptor red_add{
@@ -354,7 +359,8 @@ inline size_t ReductionWorkspaceSize(const Handle& handle,
 
         const std::vector<size_t> dw_bias_strides{bias_total_cnt, bias_total_cnt, 1};
         const miopen::TensorDescriptor dw_desc{rnn_data_t, {1, 1, bias_total_cnt}, dw_bias_strides};
-
+        
+        
         reduction_ws = red_add.GetWorkspaceSize(handle, ws_desc, dw_desc);
     }
     else

--- a/src/include/miopen/rnn_util.hpp
+++ b/src/include/miopen/rnn_util.hpp
@@ -32,6 +32,7 @@
 #include <miopen/common.hpp>
 #include <miopen/handle.hpp>
 #include <miopen/seq_tensor.hpp>
+#include <miopen/reducetensor.hpp>
 
 namespace miopen {
 
@@ -316,6 +317,54 @@ private:
 void FillSeqTensorByPaddingMarker(const Handle& handle,
                                   const SeqTensorDescriptor& desc,
                                   Data_t data);
+
+int getReductionAlgo();
+
+inline size_t ReductionWorkspaceSize(const Handle& handle,
+                              size_t batchLenSum,
+                              size_t nHiddenTensorsPerLayer,
+                              size_t workspaceScale,
+                              size_t hsize,
+                              bool is_bidirect,
+                              miopenDataType_t rnn_data_t)
+{
+    int red_algo = getReductionAlgo();
+
+    size_t reduction_ws = 0;
+    if(red_algo == 1)
+    {
+        miopen::ReduceTensorDescriptor red_add{
+            miopenReduceTensorOp_t::MIOPEN_REDUCE_TENSOR_ADD,
+            rnn_data_t,
+            miopenNanPropagation_t::MIOPEN_PROPAGATE_NAN,
+            miopenReduceTensorIndices_t::MIOPEN_REDUCE_TENSOR_NO_INDICES,
+            miopenIndicesType_t::MIOPEN_32BIT_INDICES};
+        
+        int bidirect_mp = is_bidirect ? 2 : 1;
+        
+        size_t hy_stride = hsize * bidirect_mp * workspaceScale;
+
+        size_t bias_total_cnt = hsize * bidirect_mp * nHiddenTensorsPerLayer;
+
+        const std::vector<size_t> ws_bias_strides{
+            batchLenSum * workspaceScale * hsize * bidirect_mp, hy_stride, 1};
+
+        const miopen::TensorDescriptor ws_desc{
+            rnn_data_t, {1, batchLenSum, bias_total_cnt}, ws_bias_strides};
+
+        const std::vector<size_t> dw_bias_strides{bias_total_cnt, bias_total_cnt, 1};
+        const miopen::TensorDescriptor dw_desc{rnn_data_t, {1, 1, bias_total_cnt}, dw_bias_strides};
+
+        reduction_ws = red_add.GetWorkspaceSize(handle, ws_desc, dw_desc);
+    }
+    else {
+        if(red_algo == 2 || red_algo == 3)
+        {
+            reduction_ws = batchLenSum * GetTypeSize(rnn_data_t);
+        }
+    }
+    return reduction_ws;
+}
 
 } // namespace miopen
 

--- a/src/include/miopen/rnn_util.hpp
+++ b/src/include/miopen/rnn_util.hpp
@@ -340,7 +340,7 @@ inline size_t ReductionWorkspaceSize(const Handle& handle,
     {
         miopen::ReduceTensorDescriptor red_add{
             miopenReduceTensorOp_t::MIOPEN_REDUCE_TENSOR_ADD,
-            miopenDataType_t::miopenFloat,                   // compute in float for fp16
+            miopenDataType_t::miopenFloat, // compute in float for fp16
             miopenNanPropagation_t::MIOPEN_PROPAGATE_NAN,
             miopenReduceTensorIndices_t::MIOPEN_REDUCE_TENSOR_NO_INDICES,
             miopenIndicesType_t::MIOPEN_32BIT_INDICES};
@@ -359,7 +359,7 @@ inline size_t ReductionWorkspaceSize(const Handle& handle,
 
         const std::vector<size_t> dw_bias_strides{bias_total_cnt, bias_total_cnt, 1};
         const miopen::TensorDescriptor dw_desc{rnn_data_t, {1, 1, bias_total_cnt}, dw_bias_strides};
-                
+
         reduction_ws = red_add.GetWorkspaceSize(handle, ws_desc, dw_desc) + // WA CK bug
                        (rnn_data_t == miopenDataType_t::miopenHalf ? 4 : 0);
     }

--- a/src/ocl/rnnocl.cpp
+++ b/src/ocl/rnnocl.cpp
@@ -70,6 +70,146 @@ void checkGemmStatusAndLog(miopenStatus_t gemm_status) {
     }
 }
 
+miopenStatus_t ReducAddBias(miopen::Handle& handle,
+                            Data_t dw,
+                            const Data_t workSpace,
+                            const miopen::TensorDescriptor& dw_desc,
+                            const miopen::TensorDescriptor& ws_desc,
+                            size_t dw_bias_offset,
+                            size_t ws_bias_offset,
+                            Data_t red_workSpace,
+                            size_t red_workSpace_size)
+{
+    int algo = getReductionAlgo;
+
+    switch(algo)
+    {
+    case 0: {
+        float alpha0 = 0;
+        float alpha1 = 1;
+        float beta_t = 1;
+
+        OpTensor(handle,
+                 miopenTensorOpAdd,
+                 &alpha0,
+                 dw_desc,
+                 dw,
+                 &alpha1,
+                 ws_desc,
+                 workSpace,
+                 &beta_t,
+                 dw_desc,
+                 dw,
+                 dw_bias_offset,
+                 ws_bias_offset,
+                 dw_bias_offset,
+                 true);
+    }
+    break;
+    case 1: {
+        float alpha1 = 1;
+        float beta1  = 1;
+
+        miopen::ReduceTensorDescriptor red_add{
+            miopenReduceTensorOp_t::MIOPEN_REDUCE_TENSOR_ADD,
+            dw_desc.GetType(),
+            miopenNanPropagation_t::MIOPEN_PROPAGATE_NAN,
+            miopenReduceTensorIndices_t::MIOPEN_REDUCE_TENSOR_NO_INDICES,
+            miopenIndicesType_t::MIOPEN_32BIT_INDICES};
+
+        Data_t srcA_with_offset =
+            static_cast<char*>(workSpace) + ws_bias_offset * GetTypeSize(dw_desc.GetType());
+
+        Data_t dstC_with_offset =
+            static_cast<char*>(dw) + dw_bias_offset * GetTypeSize(dw_desc.GetType());
+
+        red_add.ReduceTensor(handle,
+                             nullptr,
+                             0,
+                             red_workSpace,
+                             red_workSpace_size,
+                             &alpha1,
+                             ws_desc,
+                             srcA_with_offset,
+                             &beta1,
+                             dw_desc,
+                             dstC_with_offset);
+    }
+    break;
+    case 2: 
+    case 3: {
+        float alpha1  = 1.;
+        auto red_type = ws_desc.GetType();
+        int m = 1, n = ws_desc.GetLengths()[2], k = ws_desc.GetLengths()[1];
+        int lda = k, ldb = ws_desc.GetStrides()[1], ldc = n;
+
+        const miopen::TensorDescriptor red_matrix{
+            red_type, std::vector<int>{1, 1, k}, std::vector<int>{k, k, 1}};
+
+        SetTensor(handle, red_matrix, red_workSpace, &alpha1);
+
+        float alpha = 1, beta = 1;
+        if(algo == 2)
+        {
+            miopen::GemmDescriptor gemm_desc = GemmDescriptor{false,
+                                                              false,
+                                                              false,
+                                                              m,
+                                                              n,
+                                                              k,
+                                                              lda,
+                                                              ldb,
+                                                              ldc,
+                                                              1, // batch count
+                                                              0, // Stride A
+                                                              0, // Stride B
+                                                              0, // Stride C
+                                                              alpha, // alpha
+                                                              beta,  // beta
+                                                              red_type,
+                                                              false};
+
+            miopenStatus_t gemm_status = CallGemm(handle,
+                                                  gemm_desc,
+                                                  red_workSpace,
+                                                  0,
+                                                  workSpace,
+                                                  ws_bias_offset,
+                                                  dw,
+                                                  dw_bias_offset,
+                                                  GemmBackend_t::rocblas);
+            checkGemmStatusAndLog(gemm_status);
+}
+        else
+        {
+            if(dw_desc.GetType() != miopenDataType_t::miopenFloat)
+                MIOPEN_THROW(miopenStatusInternalError , "rocblas_sgemv wrong Type");
+
+            Data_t srcA_with_offset =
+                static_cast<char*>(workSpace) + ws_bias_offset * GetTypeSize(dw_desc.GetType());
+
+            Data_t dstY_with_offset =
+                static_cast<char*>(dw) + dw_bias_offset * GetTypeSize(dw_desc.GetType());
+
+            rocblas_sgemv(handle.rhandle().get(),
+                          rocblas_operation::rocblas_operation_none,
+                          n,
+                          k,
+                          &alpha,
+                          static_cast<float*> (srcA_with_offset),
+                          ldb,
+                          static_cast<float*> (red_workSpace),
+                          1,
+                          &beta,
+                          static_cast<float*> (dstY_with_offset),
+                          1);
+        }
+    }
+    break;
+    default: break;
+    }
+    return miopenStatusSuccess;
+}
 
 } // namespace
 
@@ -5801,34 +5941,31 @@ void RNNDescriptor::RNNBackwardWeightsPackedTensors(
 
         if(biasMode != 0u)
         {
-            wei_shift = static_cast<int>(wei_shift_bias) + li * 2 * wei_stride;
+            size_t dw_bias_offset = wei_shift_bias + li * 2 * wei_stride;
 
-            sp_size[1] = batch_n;
-            sp_size[2] = wei_stride;
-            w_size[1]  = 1;
-            w_size[2]  = wei_stride;
-            w_desc     = miopen::TensorDescriptor(dwDesc.GetType(), w_size, w_stride);
-            sp_desc    = miopen::TensorDescriptor(dwDesc.GetType(), sp_size, sp_stride);
+            const std::vector<size_t> ws_bias_strides{batch_n * hy_stride, hy_stride, 1};
+            const miopen::TensorDescriptor ws_desc{
+                rnn_data_t, {1, batch_n, wei_stride}, ws_bias_strides};
 
-            alpha0 = 0;
-            alpha1 = 1;
-            beta_t = 1;
+            const std::vector<size_t> dw_bias_strides{wei_stride, wei_stride, 1};
+            const miopen::TensorDescriptor dw_desc{rnn_data_t, {1, 1, wei_stride}, dw_bias_strides};
 
-            OpTensor(handle,
-                     miopenTensorOpAdd,
-                     &alpha0,
-                     w_desc,
+            size_t main_ws_size =
+                GetMainSolWorkspaceSize(batch_n, miopenRNNTraining, miopenRNNDataSeqMajorNotPadded);
+            
+            size_t reduction_ws_size = workSpaceSize - main_ws_size;
+
+            Data_t reduction_workSpace = static_cast<char*>(workSpace) + main_ws_size;
+
+            ReducAddBias(handle,
                      dw,
-                     &alpha1,
-                     sp_desc,
                      workSpace,
-                     &beta_t,
-                     w_desc,
-                     dw,
-                     wei_shift,
+                         dw_desc,
+                         ws_desc,
+                         dw_bias_offset,
                      hid_shift,
-                     wei_shift,
-                     true);
+                         reduction_workSpace,
+                         reduction_ws_size);
 
             // Update time
             profileRNNkernels(handle, 1, ctime);
@@ -5897,7 +6034,11 @@ void RNNDescriptor::RNNBackwardWeightsPackedTensors(
                 }
                 else
                 {
-                    CopyTensor(handle, w_desc, dw, w_desc, dw, wei_shift - wei_stride, wei_shift);
+                    const std::vector<int> dw_bias_strides{wei_stride, wei_stride, 1};
+                    const miopen::TensorDescriptor dw_desc{
+                        rnn_data_t, {1, 1, wei_stride}, dw_bias_strides};
+
+                    CopyTensor(handle, dw_desc, dw, dw_desc, dw, wei_shift - wei_stride, wei_shift);
                     // Update time
                     profileRNNkernels(handle, 1, ctime);
                 }
@@ -6247,7 +6388,7 @@ void RNNDescriptor::RNNBackwardWeightsPackedTensors(
                                                    0, // Stride C
                                                    1, // alpha
                                                    1, // beta
-                                                   xDesc[0].GetType(),
+                                                   rnn_data_t,
                                                    false};
 
                                 miopenStatus_t gemm_status =

--- a/src/ocl/rnnocl.cpp
+++ b/src/ocl/rnnocl.cpp
@@ -56,7 +56,8 @@ bool RNNForwardMSIsSupported([[maybe_unused]] const RNNDescriptor& desctiptor,
     return false;
 }
 
-void checkGemmStatusAndLog(miopenStatus_t gemm_status) {
+void checkGemmStatusAndLog(miopenStatus_t gemm_status)
+{
     if(gemm_status != miopenStatusSuccess)
     {
         if(gemm_status == miopenStatusNotImplemented)
@@ -140,7 +141,7 @@ miopenStatus_t ReducAddBias(miopen::Handle& handle,
                              dstC_with_offset);
     }
     break;
-    case 2: 
+    case 2:
     case 3: {
         float alpha1  = 1.;
         auto red_type = ws_desc.GetType();
@@ -164,10 +165,10 @@ miopenStatus_t ReducAddBias(miopen::Handle& handle,
                                                               lda,
                                                               ldb,
                                                               ldc,
-                                                              1, // batch count
-                                                              0, // Stride A
-                                                              0, // Stride B
-                                                              0, // Stride C
+                                                              1,     // batch count
+                                                              0,     // Stride A
+                                                              0,     // Stride B
+                                                              0,     // Stride C
                                                               alpha, // alpha
                                                               beta,  // beta
                                                               red_type,
@@ -183,11 +184,11 @@ miopenStatus_t ReducAddBias(miopen::Handle& handle,
                                                   dw_bias_offset,
                                                   GemmBackend_t::rocblas);
             checkGemmStatusAndLog(gemm_status);
-}
+        }
         else
         {
             if(dw_desc.GetType() != miopenDataType_t::miopenFloat)
-                MIOPEN_THROW(miopenStatusInternalError , "rocblas_sgemv wrong Type");
+                MIOPEN_THROW(miopenStatusInternalError, "rocblas_sgemv wrong Type");
 
             Data_t srcA_with_offset =
                 static_cast<char*>(workSpace) + ws_bias_offset * GetTypeSize(dw_desc.GetType());
@@ -200,12 +201,12 @@ miopenStatus_t ReducAddBias(miopen::Handle& handle,
                           n,
                           k,
                           &alpha,
-                          static_cast<float*> (srcA_with_offset),
+                          static_cast<float*>(srcA_with_offset),
                           ldb,
-                          static_cast<float*> (red_workSpace),
+                          static_cast<float*>(red_workSpace),
                           1,
                           &beta,
-                          static_cast<float*> (dstY_with_offset),
+                          static_cast<float*>(dstY_with_offset),
                           1);
         }
     }
@@ -5940,19 +5941,19 @@ void RNNDescriptor::RNNBackwardWeightsPackedTensors(
                                                   wei_shift,
                                                   GemmBackend_t::rocblas);
 
-            checkGemmStatusAndLog(gemm_status);            
+            checkGemmStatusAndLog(gemm_status);
             // Update time
             profileRNNkernels(handle, 1, ctime);
         }
 
         if(biasMode != 0u)
-        {           
+        {
             size_t dw_bias_offset = wei_shift_bias + li * 2 * wei_stride;
 
             const std::vector<size_t> ws_bias_strides{batch_n * hy_stride, hy_stride, 1};
             const miopen::TensorDescriptor ws_desc{
                 rnn_data_t, {1, batch_n, wei_stride}, ws_bias_strides};
-            
+
             const std::vector<size_t> dw_bias_strides{wei_stride, wei_stride, 1};
             const miopen::TensorDescriptor dw_desc{rnn_data_t, {1, 1, wei_stride}, dw_bias_strides};
 
@@ -6222,7 +6223,7 @@ void RNNDescriptor::RNNBackwardWeightsPackedTensors(
                                      GemmBackend_t::rocblas);
 
                         checkGemmStatusAndLog(gemm_status);
-                        
+
                         // Update time
                         profileRNNkernels(handle, 1, ctime);
                     }
@@ -6301,24 +6302,23 @@ void RNNDescriptor::RNNBackwardWeightsPackedTensors(
                         {
                             if(hx != nullptr)
                             {
-                                miopen::GemmDescriptor gemm_desc =
-                                    GemmDescriptor{false,
-                                                   true,
-                                                   false,
-                                                   wei_len,
-                                                   hy_h,
-                                                   in_n.at(cur_time),
-                                                   hy_stride,
-                                                   uni_stride,
-                                                   uni_stride,
-                                                   1, // batch count
-                                                   0, // Stride A
-                                                   0, // Stride B
-                                                   0, // Stride C
-                                                   1, // alpha
-                                                   1, // beta
-                                                   rnn_data_t,
-                                                   false};
+                                miopen::GemmDescriptor gemm_desc = GemmDescriptor{false,
+                                                                                  true,
+                                                                                  false,
+                                                                                  wei_len,
+                                                                                  hy_h,
+                                                                                  in_n.at(cur_time),
+                                                                                  hy_stride,
+                                                                                  uni_stride,
+                                                                                  uni_stride,
+                                                                                  1, // batch count
+                                                                                  0, // Stride A
+                                                                                  0, // Stride B
+                                                                                  0, // Stride C
+                                                                                  1, // alpha
+                                                                                  1, // beta
+                                                                                  rnn_data_t,
+                                                                                  false};
 
                                 miopenStatus_t gemm_status =
                                     CallGemm(handle,
@@ -6383,24 +6383,23 @@ void RNNDescriptor::RNNBackwardWeightsPackedTensors(
 
                             if(in_n.at(use_time) > 0)
                             {
-                                miopen::GemmDescriptor gemm_desc =
-                                    GemmDescriptor{false,
-                                                   true,
-                                                   false,
-                                                   wei_len,
-                                                   hy_h,
-                                                   in_n.at(use_time),
-                                                   hy_stride,
-                                                   hy_stride,
-                                                   uni_stride,
-                                                   1, // batch count
-                                                   0, // Stride A
-                                                   0, // Stride B
-                                                   0, // Stride C
-                                                   1, // alpha
-                                                   1, // beta
-                                                   rnn_data_t,
-                                                   false};
+                                miopen::GemmDescriptor gemm_desc = GemmDescriptor{false,
+                                                                                  true,
+                                                                                  false,
+                                                                                  wei_len,
+                                                                                  hy_h,
+                                                                                  in_n.at(use_time),
+                                                                                  hy_stride,
+                                                                                  hy_stride,
+                                                                                  uni_stride,
+                                                                                  1, // batch count
+                                                                                  0, // Stride A
+                                                                                  0, // Stride B
+                                                                                  0, // Stride C
+                                                                                  1, // alpha
+                                                                                  1, // beta
+                                                                                  rnn_data_t,
+                                                                                  false};
 
                                 miopenStatus_t gemm_status =
                                     CallGemm(handle,

--- a/src/ocl/rnnocl.cpp
+++ b/src/ocl/rnnocl.cpp
@@ -5948,8 +5948,6 @@ void RNNDescriptor::RNNBackwardWeightsPackedTensors(
 
         if(biasMode != 0u)
         {
-            size_t dw_bias_offset = wei_shift_bias + li * 2 * wei_stride;
-
             const std::vector<size_t> ws_bias_strides{batch_n * hy_stride, hy_stride, 1};
             const miopen::TensorDescriptor ws_desc{
                 rnn_data_t, {1, batch_n, wei_stride}, ws_bias_strides};

--- a/src/ocl/rnnocl.cpp
+++ b/src/ocl/rnnocl.cpp
@@ -81,8 +81,9 @@ miopenStatus_t ReducAddBias(miopen::Handle& handle,
                             Data_t red_workSpace,
                             size_t red_workSpace_size)
 {
-    if (ws_desc.GetLengths()[1] != 1) {
-        
+    if(ws_desc.GetLengths()[1] != 1)
+    {
+
         int algo = getReductionAlgo();
 
         switch(algo)
@@ -130,7 +131,8 @@ miopenStatus_t ReducAddBias(miopen::Handle& handle,
             Data_t red_workSpace_bugfix = red_workSpace;
             if(dw_desc.GetType() == miopenDataType_t::miopenHalf)
             {
-                if(std::align(4, red_workSpace_size-4, red_workSpace_bugfix, red_workSpace_size) == 0)
+                if(std::align(
+                       4, red_workSpace_size - 4, red_workSpace_bugfix, red_workSpace_size) == 0)
                     MIOPEN_THROW(miopenStatusInternalError, "failed alignment.");
             }
 
@@ -6055,7 +6057,7 @@ void RNNDescriptor::RNNBackwardWeightsPackedTensors(
                     // Update time
                     profileRNNkernels(handle, 1, ctime);
                 }
-                else         
+                else
                 {
                     // second dw bias equal to the first, so just copy reduction result
                     const std::vector<int> dw_bias_strides{wei_stride, wei_stride, 1};

--- a/src/ocl/rnnocl.cpp
+++ b/src/ocl/rnnocl.cpp
@@ -80,7 +80,11 @@ miopenStatus_t ReducAddBias(miopen::Handle& handle,
                             Data_t red_workSpace,
                             size_t red_workSpace_size)
 {
-    int algo = getReductionAlgo;
+    // nothing to reduce,
+    if(dw_desc.GetLengths()[1] == 1)
+        return miopenStatusSuccess;
+
+    int algo = getReductionAlgo();
 
     switch(algo)
     {

--- a/src/ocl/rnnocl.cpp
+++ b/src/ocl/rnnocl.cpp
@@ -132,7 +132,8 @@ miopenStatus_t ReducAddBias(miopen::Handle& handle,
             if(dw_desc.GetType() == miopenDataType_t::miopenHalf)
             {
                 if(std::align(
-                       4, red_workSpace_size - 4, red_workSpace_bugfix, red_workSpace_size) == 0)
+                       4, red_workSpace_size - 4, red_workSpace_bugfix, red_workSpace_size) ==
+                   nullptr)
                     MIOPEN_THROW(miopenStatusInternalError, "failed alignment.");
             }
 

--- a/src/ocl/rnnocl.cpp
+++ b/src/ocl/rnnocl.cpp
@@ -81,9 +81,7 @@ miopenStatus_t ReducAddBias(miopen::Handle& handle,
                             Data_t red_workSpace,
                             size_t red_workSpace_size)
 {
-    // nothing to reduce,
-    if(ws_desc.GetLengths()[1] == 1)
-        return miopenStatusSuccess;
+    if (ws_desc.GetLengths()[1] != 1) {
 
     int algo = getReductionAlgo();
 
@@ -213,6 +211,14 @@ miopenStatus_t ReducAddBias(miopen::Handle& handle,
     break;
     default: break;
     }
+    }
+    else
+    {
+        // nothing to reduce
+        // just copy data from workspace to dw
+        CopyTensor(handle, ws_desc, workSpace, dw_desc, dw, ws_bias_offset, dw_bias_offset);
+    }
+
     return miopenStatusSuccess;
 }
 
@@ -6043,6 +6049,7 @@ void RNNDescriptor::RNNBackwardWeightsPackedTensors(
                 }
                 else
                 {
+                    // second dw bias equal to the first, so just copy reduction result
                     const std::vector<int> dw_bias_strides{wei_stride, wei_stride, 1};
                     const miopen::TensorDescriptor dw_desc{
                         rnn_data_t, {1, 1, wei_stride}, dw_bias_strides};

--- a/src/ocl/rnnocl.cpp
+++ b/src/ocl/rnnocl.cpp
@@ -5870,7 +5870,7 @@ void RNNDescriptor::RNNBackwardWeightsPackedTensors(
         int hid_shift = li * batch_n * hy_stride;
         int wei_shift = (in_h + hy_h) * wei_stride + (li - 1) * (bi * hy_h + hy_h) * wei_stride;
 
-        size_t dw_bias_offset = wei_shift_bias + li * 2 * wei_stride;
+        size_t dw_bias_offset = wei_shift_bias + static_cast<size_t>(li) * 2 * wei_stride;
 
         // between layers
         if(li == 0)
@@ -5948,12 +5948,17 @@ void RNNDescriptor::RNNBackwardWeightsPackedTensors(
 
         if(biasMode != 0u)
         {
-            const std::vector<size_t> ws_bias_strides{batch_n * hy_stride, hy_stride, 1};
+            const std::vector<size_t> ws_bias_strides{
+                static_cast<size_t>(batch_n) * hy_stride, static_cast<size_t>(hy_stride), 1};
             const miopen::TensorDescriptor ws_desc{
-                rnn_data_t, {1, batch_n, wei_stride}, ws_bias_strides};
+                rnn_data_t,
+                {1, static_cast<size_t>(batch_n), static_cast<size_t>(wei_stride)},
+                ws_bias_strides};
 
-            const std::vector<size_t> dw_bias_strides{wei_stride, wei_stride, 1};
-            const miopen::TensorDescriptor dw_desc{rnn_data_t, {1, 1, wei_stride}, dw_bias_strides};
+            const std::vector<size_t> dw_bias_strides{
+                static_cast<size_t>(wei_stride), static_cast<size_t>(wei_stride), 1};
+            const miopen::TensorDescriptor dw_desc{
+                rnn_data_t, {1, 1, static_cast<size_t>(wei_stride)}, dw_bias_strides};
 
             size_t main_ws_size =
                 GetMainSolWorkspaceSize(batch_n, miopenRNNTraining, miopenRNNDataSeqMajorNotPadded);

--- a/src/rnn.cpp
+++ b/src/rnn.cpp
@@ -458,7 +458,7 @@ size_t RNNDescriptor::GetMainSolWorkspaceSize(size_t batchLenSum,
     return (workspaceScale * nLayers * batchLenSum * hsize * typeSize) * (is_bidirect ? 2 : 1);
 }
 
-size_t RNNDescriptor::GetWorkspaceSize(Handle& handle ,
+size_t RNNDescriptor::GetWorkspaceSize(Handle& handle,
                                        const SeqTensorDescriptor& xDesc,
                                        miopenRNNFWDMode_t fwdMode) const
 {

--- a/src/rnn.cpp
+++ b/src/rnn.cpp
@@ -458,7 +458,7 @@ size_t RNNDescriptor::GetMainSolWorkspaceSize(size_t batchLenSum,
     return (workspaceScale * nLayers * batchLenSum * hsize * typeSize) * (is_bidirect ? 2 : 1);
 }
 
-size_t RNNDescriptor::GetWorkspaceSize(Handle& /* handle */,
+size_t RNNDescriptor::GetWorkspaceSize(Handle& handle ,
                                        const SeqTensorDescriptor& xDesc,
                                        miopenRNNFWDMode_t fwdMode) const
 {
@@ -478,7 +478,15 @@ size_t RNNDescriptor::GetWorkspaceSize(Handle& /* handle */,
 
     const std::size_t total_sequence_len = xDesc.GetTotalSequenceLen();
 
-    return transformer_tmp_space +
+    size_t reduction_ws = ReductionWorkspaceSize(handle,
+                                                 total_sequence_len,
+                                                 nHiddenTensorsPerLayer,
+                                                 workspaceScale,
+                                                 hsize,
+                                                 dirMode == miopenRNNbidirection,
+                                                 dataType);
+
+    return transformer_tmp_space + reduction_ws +
            GetMainSolWorkspaceSize(total_sequence_len, fwdMode, miopenRNNDataSeqMajorNotPadded);
 }
 
@@ -499,7 +507,7 @@ size_t RNNDescriptor::GetMaxWorkspaceSize(Handle& handle,
 }
 
 // legacy
-size_t RNNDescriptor::GetWorkspaceSize(Handle& /* handle */,
+size_t RNNDescriptor::GetWorkspaceSize(Handle& handle,
                                        const int seqLength,
                                        c_array_view<const miopenTensorDescriptor_t> xDesc) const
 {
@@ -523,9 +531,17 @@ size_t RNNDescriptor::GetWorkspaceSize(Handle& /* handle */,
             return x + deref(y).GetLengths()[0];
         });
 
-    return padding_converter_tmp_space + GetMainSolWorkspaceSize(total_sequence_len,
-                                                                 miopenRNNInference,
-                                                                 miopenRNNDataSeqMajorNotPadded);
+    size_t reduction_ws = ReductionWorkspaceSize(handle,
+                                                 total_sequence_len,
+                                                 nHiddenTensorsPerLayer,
+                                                 workspaceScale,
+                                                 hsize,
+                                                 dirMode == miopenRNNbidirection,
+                                                 dataType);
+
+    return padding_converter_tmp_space + reduction_ws +
+           GetMainSolWorkspaceSize(
+               total_sequence_len, miopenRNNInference, miopenRNNDataSeqMajorNotPadded);
 }
 
 /////////////////////////////////

--- a/src/rnn/rnn_util.cpp
+++ b/src/rnn/rnn_util.cpp
@@ -27,8 +27,18 @@
 #include <miopen/rnn.hpp>
 #include <miopen/rnn_util.hpp>
 #include <algorithm>
+#include <miopen/env.hpp>
+
+MIOPEN_DECLARE_ENV_VAR_UINT64(MIOPEN_RNNWRW_REDUCTION)
 
 namespace miopen {
+
+int getReductionAlgo()
+{
+    return miopen::IsUnset(ENV(MIOPEN_RNNWRW_REDUCTION))
+               ? 0
+               : miopen::Value(ENV(MIOPEN_RNNWRW_REDUCTION));
+}
 
 void RNNTensorPaddingConverter::ConvertTensorData(const Handle& handle,
                                                   const TensorDescriptor& padded_tensor_desc,

--- a/src/rnn/rnn_util.cpp
+++ b/src/rnn/rnn_util.cpp
@@ -36,7 +36,7 @@ namespace miopen {
 int getReductionAlgo()
 {
     return miopen::IsUnset(ENV(MIOPEN_RNNWRW_REDUCTION))
-               ? 0
+               ? 1
                : miopen::Value(ENV(MIOPEN_RNNWRW_REDUCTION));
 }
 


### PR DESCRIPTION
Changed reduction kernel to CK.

Backward Weights time table

![image](https://github.com/ROCm/MIOpen/assets/37591772/80e5bd8c-88ec-466e-89d4-23ca058b9342)


40-50% less time