### PR TITLE
[HotFix] Changed text perfdbs to be actually installed when enabled #2722

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -520,7 +520,7 @@ else()
     set(PERFDB_SUFFIX ".txt")
 endif()
 
-function(unpack_db db_bzip2_file)
+function(unpack_db db_bzip2_file suffix_var)
     get_filename_component(__fname ${db_bzip2_file} NAME_WLE)
     add_custom_command(OUTPUT ${KERNELS_BINARY_DIR}/${__fname}
                        COMMAND ${UNZIPPER} -k ${db_bzip2_file} > ${KERNELS_BINARY_DIR}/${__fname})
@@ -536,8 +536,10 @@ function(unpack_db db_bzip2_file)
         )
         add_custom_target(generate_${__tname}_txt ALL DEPENDS ${KERNELS_BINARY_DIR}/${__fname}.txt)
         add_dependencies(generate_kernels generate_${__tname}_txt)
+        set("${suffix_var}" ".txt" PARENT_SCOPE)
     else()
         add_dependencies(generate_kernels generate_${__tname})
+        set("${suffix_var}" "" PARENT_SCOPE)
     endif()
 endfunction()
 
@@ -545,10 +547,10 @@ file(GLOB PERF_DB_BZIP_FILES CONFIGURE_DEPENDS "${KERNELS_SOURCE_DIR}/*.db.bz2")
 file(GLOB FIND_DB_BZIP_FILES CONFIGURE_DEPENDS "${KERNELS_SOURCE_DIR}/*.fdb.txt.bz2")
 
 foreach(DB_BZIP_FILE ${PERF_DB_BZIP_FILES} ${FIND_DB_BZIP_FILES})
-    unpack_db(${DB_BZIP_FILE})
+    unpack_db(${DB_BZIP_FILE} FILE_SUFFIX)
     get_filename_component(__fname ${DB_BZIP_FILE} NAME_WLE)
     if(MIOPEN_EMBED_DB STREQUAL "" AND NOT MIOPEN_DISABLE_SYSDB AND NOT ENABLE_ASAN_PACKAGING)
-        install(FILES ${KERNELS_BINARY_DIR}/${__fname}
+        install(FILES ${KERNELS_BINARY_DIR}/${__fname}${FILE_SUFFIX}
                 DESTINATION ${DATABASE_INSTALL_DIR})
     endif()
 endforeach()


### PR DESCRIPTION
Sqlite perfdb files were installed instead of txt files even when not enabled
