### PR TITLE
Adapt logging functionality to Windows

### DIFF
--- a/src/include/miopen/lock_file.hpp
+++ b/src/include/miopen/lock_file.hpp
@@ -94,9 +94,8 @@ public:
 
     bool try_lock()
     {
-        return TryLockOperation("lock", MIOPEN_GET_FN_NAME, [&]() {
-            return std::try_lock(access_mutex, flock) != 0;
-        });
+        return TryLockOperation(
+            "lock", MIOPEN_GET_FN_NAME, [&]() { return std::try_lock(access_mutex, flock) != 0; });
     }
 
     bool try_lock_shared()
@@ -197,8 +196,9 @@ private:
         // clang-format on
     }
 
-    void
-    LockOperation(const std::string& op_name, const std::string_view from, std::function<void()>&& op)
+    void LockOperation(const std::string& op_name,
+                       const std::string_view from,
+                       std::function<void()>&& op)
     {
         try
         {

--- a/src/include/miopen/logger.hpp
+++ b/src/include/miopen/logger.hpp
@@ -347,8 +347,8 @@ LogParam(std::ostream& os, std::string name, const std::vector<T>& vec, bool ind
 #define MIOPEN_LOG_FUNCTION(...)
 #endif
 
-constexpr std::string_view LoggingParseFunction(
-    const std::string_view func, const std::string_view pretty_func)
+constexpr std::string_view LoggingParseFunction(const std::string_view func,
+                                                const std::string_view pretty_func)
 {
     if(func != "operator()")
         return func;
@@ -399,15 +399,14 @@ constexpr std::string_view LoggingParseFunction(
 // Warnings in installable builds, errors otherwise.
 #define MIOPEN_LOG_WE(...) MIOPEN_LOG(LogWELevel, __VA_ARGS__)
 
-#define MIOPEN_LOG_DRIVER_CMD(...)                                                             \
-    do                                                                                         \
-    {                                                                                          \
-        std::ostringstream miopen_driver_cmd_ss;                                               \
-        miopen_driver_cmd_ss << miopen::LoggingPrefix() << "Command"                           \
-                             << " ["                                                           \
-                             << MIOPEN_GET_FN_NAME                                             \
-                             << "] ./bin/MIOpenDriver " << __VA_ARGS__ << std::endl;           \
-        std::cerr << miopen_driver_cmd_ss.str();                                               \
+#define MIOPEN_LOG_DRIVER_CMD(...)                                                    \
+    do                                                                                \
+    {                                                                                 \
+        std::ostringstream miopen_driver_cmd_ss;                                      \
+        miopen_driver_cmd_ss << miopen::LoggingPrefix() << "Command"                  \
+                             << " [" << MIOPEN_GET_FN_NAME << "] ./bin/MIOpenDriver " \
+                             << __VA_ARGS__ << std::endl;                             \
+        std::cerr << miopen_driver_cmd_ss.str();                                      \
     } while(false)
 
 #if MIOPEN_LOG_FUNC_TIME_ENABLE

--- a/src/include/miopen/logger.hpp
+++ b/src/include/miopen/logger.hpp
@@ -399,15 +399,21 @@ constexpr std::string_view LoggingParseFunction(const std::string_view func,
 // Warnings in installable builds, errors otherwise.
 #define MIOPEN_LOG_WE(...) MIOPEN_LOG(LogWELevel, __VA_ARGS__)
 
-#define MIOPEN_LOG_DRIVER_CMD(...)                                                    \
-    do                                                                                \
-    {                                                                                 \
-        std::ostringstream miopen_driver_cmd_ss;                                      \
-        miopen_driver_cmd_ss << miopen::LoggingPrefix() << "Command"                  \
-                             << " [" << MIOPEN_GET_FN_NAME << "] ./bin/MIOpenDriver " \
-                             << __VA_ARGS__ << std::endl;                             \
-        std::cerr << miopen_driver_cmd_ss.str();                                      \
+#define MIOPEN_LOG_DRIVER_COMMAND(driver, ...)                                               \
+    do                                                                                       \
+    {                                                                                        \
+        std::ostringstream miopen_driver_cmd_ss;                                             \
+        miopen_driver_cmd_ss << miopen::LoggingPrefix() << "Command"                         \
+                             << " [" << MIOPEN_GET_FN_NAME << "] " driver " " << __VA_ARGS__ \
+                             << std::endl;                                                   \
+        std::cerr << miopen_driver_cmd_ss.str();                                             \
     } while(false)
+
+#ifdef _WIN32
+#define MIOPEN_LOG_DRIVER_CMD(...) MIOPEN_LOG_DRIVER_COMMAND("MIOpenDriver.exe", __VA_ARGS__)
+#else
+#define MIOPEN_LOG_DRIVER_CMD(...) MIOPEN_LOG_DRIVER_COMMAND("./bin/MIOpenDriver", __VA_ARGS__)
+#endif
 
 #if MIOPEN_LOG_FUNC_TIME_ENABLE
 class LogScopeTime

--- a/src/lock_file.cpp
+++ b/src/lock_file.cpp
@@ -31,7 +31,7 @@
 
 namespace miopen {
 
-inline void LogFsError(const fs::filesystem_error& ex, const std::string& from)
+inline void LogFsError(const fs::filesystem_error& ex, const std::string_view from)
 {
     // clang-format off
     MIOPEN_LOG_E_FROM(from, "File system operation error in LockFile. "
@@ -58,7 +58,7 @@ std::string LockFilePath(const fs::path& filename_)
     }
     catch(const fs::filesystem_error& ex)
     {
-        LogFsError(ex, MIOPEN_GET_FN_NAME());
+        LogFsError(ex, MIOPEN_GET_FN_NAME);
         throw;
     }
 }
@@ -77,12 +77,12 @@ LockFile::LockFile(const char* path_, PassKey) : path(path_)
     }
     catch(const fs::filesystem_error& ex)
     {
-        LogFsError(ex, MIOPEN_GET_FN_NAME());
+        LogFsError(ex, MIOPEN_GET_FN_NAME);
         throw;
     }
     catch(const boost::interprocess::interprocess_exception& ex)
     {
-        LogFlockError(ex, "lock initialization", MIOPEN_GET_FN_NAME());
+        LogFlockError(ex, "lock initialization", MIOPEN_GET_FN_NAME);
         throw;
     }
 }

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -191,16 +191,4 @@ std::string LoggingPrefix()
     return ss.str();
 }
 
-/// Expected to be invoked with __func__ and __PRETTY_FUNCTION__.
-std::string LoggingParseFunction(const char* func, const char* pretty_func)
-{
-    std::string fname{func};
-    if(fname != "operator()")
-        return fname;
-    // lambda
-    const std::string pf{pretty_func};
-    const std::string pf_tail{pf.substr(0, pf.find_first_of('('))};
-    return pf_tail.substr(1 + pf_tail.find_last_of(':'));
-}
-
 } // namespace miopen

--- a/src/solver/conv_asm_implicit_gemm_gtc_bwd.cpp
+++ b/src/solver/conv_asm_implicit_gemm_gtc_bwd.cpp
@@ -1057,7 +1057,7 @@ ConvAsmImplicitGemmGTCDynamicBwdXdlops::GetSolution(const ExecutionContext& ctx,
 
     kernel.comp_options = options.str();
 
-    MIOPEN_LOG_I2(kernel.kernel_file + ":" + kernel.kernel_name);
+    MIOPEN_LOG_I2(kernel.kernel_file << ":" << kernel.kernel_name);
 
     result.invoker_factory =
         miopen::conv::MakeImplGemmDynamicBackwardDataInvokerFactory(problem, cfg);

--- a/src/solver/conv_asm_implicit_gemm_gtc_fwd.cpp
+++ b/src/solver/conv_asm_implicit_gemm_gtc_fwd.cpp
@@ -1594,7 +1594,7 @@ ConvAsmImplicitGemmGTCDynamicFwdXdlops::GetSolution(const ExecutionContext& ctx,
 
     kernel.comp_options = options.str();
 
-    MIOPEN_LOG_I2(kernel.kernel_file + ":" + kernel.kernel_name);
+    MIOPEN_LOG_I2(kernel.kernel_file << ":" << kernel.kernel_name);
 
     result.invoker_factory =
         miopen::conv::MakeImplGemmDynamicForwardInvokerFactory<TunableImplicitGemmGTCDynamic_t>(

--- a/src/solver/conv_asm_implicit_gemm_v4r1_dynamic.cpp
+++ b/src/solver/conv_asm_implicit_gemm_v4r1_dynamic.cpp
@@ -410,7 +410,7 @@ static inline ConvSolution GetSolutionBase(const ExecutionContext& ctx,
 
     kernel.comp_options = options.str();
 
-    MIOPEN_LOG_I2(kernel.kernel_file + ":" + kernel.kernel_name);
+    MIOPEN_LOG_I2(kernel.kernel_file << ":" << kernel.kernel_name);
 
     if(kernel_is_1x1)
     {

--- a/src/solver/conv_asm_implicit_gemm_wrw_gtc_dynamic_xdlops.cpp
+++ b/src/solver/conv_asm_implicit_gemm_wrw_gtc_dynamic_xdlops.cpp
@@ -930,7 +930,7 @@ ConvAsmImplicitGemmGTCDynamicWrwXdlops::GetSolution(const ExecutionContext& ctx,
 
     kernel.comp_options = options.str();
 
-    MIOPEN_LOG_I2(kernel.kernel_file + ":" + kernel.kernel_name);
+    MIOPEN_LOG_I2(kernel.kernel_file << ":" << kernel.kernel_name);
 
     result.construction_params.push_back(kernel);
 

--- a/src/solver/conv_asm_implicit_gemm_wrw_v4r1_dynamic.cpp
+++ b/src/solver/conv_asm_implicit_gemm_wrw_v4r1_dynamic.cpp
@@ -388,7 +388,7 @@ ConvSolution ConvAsmImplicitGemmV4R1DynamicWrw::GetSolution(const ExecutionConte
 
     kernel.comp_options = options.str();
 
-    MIOPEN_LOG_I2(kernel.kernel_file + ":" + kernel.kernel_name);
+    MIOPEN_LOG_I2(kernel.kernel_file << ":" << kernel.kernel_name);
 
     result.construction_params.push_back(kernel);
 


### PR DESCRIPTION
The clang compiler on Windows and MSVC does not recognize the GCC-specific `__PRETTY_FUNCTION__` preprocessor macro. The closest similar macro is `__FUNCSIG__`. Additionally, we use `std::string_view` for literals, which is 25% faster than `const char*` and requires no memory allocation. It also seamlessly supports `std::string`, `char*`, and `char[]`.