### PR TITLE
Find 2.0 must not autoreset buffers

### DIFF
--- a/src/problem.cpp
+++ b/src/problem.cpp
@@ -129,11 +129,6 @@ static Data_t AllocateTensor(Handle& handle,
     const auto element_size = get_data_size(descriptor.GetType());
     auto buffer             = handle.Create(descriptor.GetElementSpace() * element_size);
 
-    visit_float(descriptor.GetType(), [&](auto as_float) {
-        const auto zero = as_float(0.f);
-        SetTensor(handle, descriptor, buffer.get(), &zero);
-    });
-
     const auto allocated = buffer.get();
     owned.emplace_back(std::move(buffer));
     return allocated;


### PR DESCRIPTION
Byproduct of https://github.com/ROCm/MIOpen/pull/2819
Find 2.0 api must not autoreset automatically allocated buffers.
If the solver requires some buffers to be zeroed - the solver must do it by itself.
Otherwise API call is not reentrant (all the consecutive call will not have the buffer reset) and we hit some perf issues because we intentionally reset all the buffers even if the solver does not care about the buffer state or the user will initialize the buffer lately.

As far as I know, all the current solvers are adapted to this behavior.

Also it blocks MHA implementation since it requires `uint64_t` tensors, but `SetTensor` does not support 64bit type, it is an old OpenCL kernel and won't be fixed especially when we don't actually need it.

@atamazov 