### PR TITLE
Remove legacy prng leftover

### DIFF
--- a/test/gtest/conv_tensor_gen.hpp
+++ b/test/gtest/conv_tensor_gen.hpp
@@ -26,43 +26,26 @@
 #pragma once
 
 #include <gtest/gtest.h>
-
-#include <random>
-
 #include <hip_float8.hpp>
 
-// Copied from conv_driver.hpp
+#include "../random.hpp"
 
-template <typename T>
-inline T FRAND()
-{
-    double d = static_cast<double>(rand() / (static_cast<double>(RAND_MAX)));
-    return static_cast<T>(d);
-}
-
-template <typename T>
-inline T RAN_GEN(T A, T B)
-{
-    T r = (FRAND<T>() * (B - A)) + A;
-    return r;
-}
 template <typename T>
 inline T RanGenData()
 {
-    return RAN_GEN<T>(static_cast<T>(0.0f), static_cast<T>(1.0f));
+    return prng::gen_canonical<T>();
 }
 
 template <>
 inline float8 RanGenData()
 {
-    return RAN_GEN<float8>(static_cast<float8>(-1.0f), static_cast<float8>(1.0f));
+    return prng::gen_A_to_B(static_cast<float8>(-1.0f), static_cast<float8>(1.0f));
 }
 
 template <>
 inline bfloat8 RanGenData()
 {
-    const auto tmp = RAN_GEN<float>(static_cast<float>(-1.0f), static_cast<float>(1.0f));
-    return static_cast<bfloat8>(tmp);
+    return prng::gen_A_to_B(static_cast<bfloat8>(-1.0f), static_cast<bfloat8>(1.0f));
 }
 
 template <typename T>
@@ -78,7 +61,7 @@ struct GenData
 template <typename T>
 T RanGenWeights()
 {
-    return RAN_GEN<T>(static_cast<T>(-0.5), static_cast<T>(0.5));
+    return prng::gen_A_to_B(static_cast<T>(-0.5), static_cast<T>(0.5));
 }
 
 // Shift FP16 distribution towards positive numbers,
@@ -86,34 +69,28 @@ T RanGenWeights()
 template <>
 inline half_float::half RanGenWeights()
 {
-    return RAN_GEN<half_float::half>(static_cast<half_float::half>(-1.0 / 3.0),
-                                     static_cast<half_float::half>(0.5));
+    return prng::gen_A_to_B(static_cast<half_float::half>(-1.0 / 3.0),
+                            static_cast<half_float::half>(0.5));
 }
 
 template <>
 inline float8 RanGenWeights()
 {
-    const auto tmp =
-        RAN_GEN<float>(0.0, 1.0) > 0.5 ? static_cast<float>(0.0) : static_cast<float>(1.0);
+    const auto tmp = prng::gen_canonical<float>() > 0.5f ? 0.0f : 2.0f;
     // 1 in 2 chance of number being positive
-    const float sign =
-        (RAN_GEN<float>(0.0, 1.0) > 0.5) ? static_cast<float>(-1) : static_cast<float>(1);
-    const auto tmp2 = static_cast<float>(std::numeric_limits<float8>::epsilon()) *
-                      static_cast<float>(2) * sign * static_cast<float>(tmp);
-    return static_cast<float8>(tmp2);
+    const auto sign = prng::gen_canonical<float>() > 0.5f ? -1.0f : 1.0f;
+    return static_cast<float8>(static_cast<float>(std::numeric_limits<float8>::epsilon()) * sign *
+                               tmp);
 }
 
 template <>
 inline bfloat8 RanGenWeights()
 {
-    const auto tmp =
-        RAN_GEN<float>(0.0, 1.0) > 0.5 ? static_cast<float>(0.0) : static_cast<float>(1.0);
+    const auto tmp = prng::gen_canonical<float>() > 0.5f ? 0.0f : 2.0f;
     // 1 in 2 chance of number being positive
-    const float sign =
-        (RAN_GEN<float>(0.0, 1.0) > 0.5) ? static_cast<float>(-1) : static_cast<float>(1);
-    const auto tmp2 = static_cast<float>(std::numeric_limits<float8>::epsilon()) *
-                      static_cast<float>(2) * sign * static_cast<float>(tmp);
-    return static_cast<bfloat8>(tmp2);
+    const auto sign = prng::gen_canonical<float>() > 0.5f ? -1.0f : 1.0f;
+    return static_cast<bfloat8>(static_cast<float>(std::numeric_limits<bfloat8>::epsilon()) * sign *
+                                tmp);
 }
 
 template <typename T>

--- a/test/gtest/solver_f8.hpp
+++ b/test/gtest/solver_f8.hpp
@@ -26,7 +26,6 @@
 #pragma once
 
 #include <gtest/gtest.h>
-#include <random>
 #include "cpu_conv.hpp"
 #include "get_handle.hpp"
 #include "tensor_util.hpp"
@@ -35,15 +34,10 @@
 #include "conv_common.hpp"
 #include "hip_float8.hpp"
 #include "verify.hpp"
+#include "../random.hpp"
 
 #include "conv_test_base.hpp"
 #include "f8_cast_util.hpp"
-
-float scalar_gen_random_float(float low, float high)
-{
-    float r = static_cast<float>(rand()) / static_cast<float>(RAND_MAX) * (high + low) - low;
-    return r;
-}
 
 struct ConvTestCaseF8
 {
@@ -91,8 +85,7 @@ protected:
         weights = tensor<T>{conv_config.k, conv_config.C, conv_config.y, conv_config.x};
 
         auto gen_fp8_value = [=](auto...) {
-            const auto tmp = float8(scalar_gen_random_float(-0.5, 0.5));
-            return tmp;
+            return prng::gen_A_to_B(static_cast<float8>(-0.5), static_cast<float8>(0.5));
         };
 
         input.generate(gen_fp8_value);


### PR DESCRIPTION
While I was hunting and removing legacy prng in #2234, #2319, #2327, #2337, #2397 and #2400 it flighted under the radar and has been resurrected in
https://github.com/ROCm/MIOpen/pull/2251/files#diff-587b620579d1a278e9f11a54cd17547a0699be92e8bfa26fe665f083b4e62a0d
and
https://github.com/ROCm/MIOpen/pull/2599/files#diff-5b5e77162543d83c47a6dcfc6606255b96d1d1e2659fa96bbdf5216e75a2a719

Not it's gone.