### PR TITLE
[MHA] Implement MIOPEN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR Builder

### DIFF
--- a/src/graphapi/pointwise.cpp
+++ b/src/graphapi/pointwise.cpp
@@ -120,6 +120,8 @@ void BackendPointwiseDescriptor::setAttribute(miopenBackendAttributeName_t attri
         setFloatOrDouble(&PointwiseBuilder::setSoftPlusBeta);
         break;
 
+    case MIOPEN_ATTR_POINTWISE_SWISH_BETA: setFloatOrDouble(&PointwiseBuilder::setSwishBeta); break;
+
     case MIOPEN_ATTR_POINTWISE_AXIS:
         if(attributeType == MIOPEN_TYPE_INT64 && elementCount == 1)
         {
@@ -229,6 +231,8 @@ void BackendPointwiseDescriptor::getAttribute(miopenBackendAttributeName_t attri
     case MIOPEN_ATTR_POINTWISE_ELU_ALPHA: getFloatOrDouble(&Pointwise::getEluAlpha); break;
 
     case MIOPEN_ATTR_POINTWISE_SOFTPLUS_BETA: getFloatOrDouble(&Pointwise::getSoftPlusBeta); break;
+
+    case MIOPEN_ATTR_POINTWISE_SWISH_BETA: getFloatOrDouble(&Pointwise::getSwishBeta); break;
 
     case MIOPEN_ATTR_POINTWISE_AXIS:
         if(attributeType == MIOPEN_TYPE_INT64 && requestedElementCount == 1)

--- a/src/graphapi/pointwise.cpp
+++ b/src/graphapi/pointwise.cpp
@@ -50,7 +50,7 @@ void BackendPointwiseDescriptor::setAttribute(miopenBackendAttributeName_t attri
         MIOPEN_THROW(miopenStatusNotInitialized);
     }
 
-    using Setter = PointwiseBuilder& (PointwiseBuilder::*)(double value);
+    using Setter = PointwiseBuilder& (PointwiseBuilder::*)(Pointwise::FpAttribute value);
 
     auto setFloatOrDouble = [=](Setter setter) {
         if(attributeType == MIOPEN_TYPE_FLOAT && elementCount == 1)
@@ -157,18 +157,18 @@ void BackendPointwiseDescriptor::getAttribute(miopenBackendAttributeName_t attri
         MIOPEN_THROW(miopenStatusNotInitialized);
     }
 
-    using Getter = double (Pointwise::*)() const;
+    using Getter = Pointwise::FpAttribute (Pointwise::*)() const;
 
     auto getFloatOrDouble = [=](Getter getter) {
         if(attributeType == MIOPEN_TYPE_FLOAT && requestedElementCount == 1)
         {
             *elementCount                         = 1;
-            *static_cast<float*>(arrayOfElements) = (mPointwise.*getter)();
+            *static_cast<float*>(arrayOfElements) = std::get<float>((mPointwise.*getter)());
         }
         else if(attributeType == MIOPEN_TYPE_DOUBLE && requestedElementCount == 1)
         {
             *elementCount                          = 1;
-            *static_cast<double*>(arrayOfElements) = (mPointwise.*getter)();
+            *static_cast<double*>(arrayOfElements) = std::get<double>((mPointwise.*getter)());
         }
         else
         {

--- a/src/graphapi/pointwise.cpp
+++ b/src/graphapi/pointwise.cpp
@@ -27,6 +27,8 @@
 #include <miopen/errors.hpp>
 #include <miopen/graphapi/pointwise.hpp>
 
+#include <algorithm>
+
 namespace miopen {
 
 namespace graphapi {
@@ -248,6 +250,416 @@ void BackendPointwiseDescriptor::getAttribute(miopenBackendAttributeName_t attri
 
     default: MIOPEN_THROW(miopenStatusBadParm);
     }
+}
+
+std::vector<Tensor*> OperationPointwise::getInTensors() const
+{
+    switch(mPointwise->getMode())
+    {
+    /* 2-inputs operations
+     * x input
+     * b input
+     * y output
+     */
+    case MIOPEN_POINTWISE_ADD:
+    case MIOPEN_POINTWISE_ADD_SQUARE:
+    case MIOPEN_POINTWISE_DIV:
+    case MIOPEN_POINTWISE_MAX:
+    case MIOPEN_POINTWISE_MIN:
+    case MIOPEN_POINTWISE_MOD:
+    case MIOPEN_POINTWISE_MUL:
+    case MIOPEN_POINTWISE_POW:
+    case MIOPEN_POINTWISE_SUB:
+    case MIOPEN_POINTWISE_CMP_EQ:
+    case MIOPEN_POINTWISE_CMP_NEQ:
+    case MIOPEN_POINTWISE_CMP_GT:
+    case MIOPEN_POINTWISE_CMP_GE:
+    case MIOPEN_POINTWISE_CMP_LT:
+    case MIOPEN_POINTWISE_CMP_LE:
+    case MIOPEN_POINTWISE_LOGICAL_AND:
+    case MIOPEN_POINTWISE_LOGICAL_OR: return {mX, mB};
+
+    /* Single input operations
+     * x input
+     * y output
+     */
+    case MIOPEN_POINTWISE_ABS:
+    case MIOPEN_POINTWISE_CEIL:
+    case MIOPEN_POINTWISE_COS:
+    case MIOPEN_POINTWISE_EXP:
+    case MIOPEN_POINTWISE_FLOOR:
+    case MIOPEN_POINTWISE_LOG:
+    case MIOPEN_POINTWISE_NEG:
+    case MIOPEN_POINTWISE_RSQRT:
+    case MIOPEN_POINTWISE_SIN:
+    case MIOPEN_POINTWISE_SQRT:
+    case MIOPEN_POINTWISE_TAN:
+    case MIOPEN_POINTWISE_IDENTITY:
+    case MIOPEN_POINTWISE_RELU_FWD:
+    case MIOPEN_POINTWISE_TANH_FWD:
+    case MIOPEN_POINTWISE_SIGMOID_FWD:
+    case MIOPEN_POINTWISE_ELU_FWD:
+    case MIOPEN_POINTWISE_GELU_FWD:
+    case MIOPEN_POINTWISE_SOFTPLUS_FWD:
+    case MIOPEN_POINTWISE_SWISH_FWD:
+    case MIOPEN_POINTWISE_GELU_APPROX_TANH_FWD:
+    case MIOPEN_POINTWISE_LOGICAL_NOT:
+    case MIOPEN_POINTWISE_RECIPROCAL: return {mX};
+
+    /* 3-inputs operations
+     * x input
+     * b input
+     * t input
+     * y output
+     */
+    case MIOPEN_POINTWISE_BINARY_SELECT: return {mX, mB, mT};
+
+    /* 2-inputs backward operations
+     * y input
+     * dy input
+     * dx output
+     */
+    case MIOPEN_POINTWISE_RELU_BWD:
+    case MIOPEN_POINTWISE_TANH_BWD:
+    case MIOPEN_POINTWISE_SIGMOID_BWD:
+    case MIOPEN_POINTWISE_ELU_BWD:
+    case MIOPEN_POINTWISE_GELU_BWD:
+    case MIOPEN_POINTWISE_SOFTPLUS_BWD:
+    case MIOPEN_POINTWISE_SWISH_BWD:
+    case MIOPEN_POINTWISE_GELU_APPROX_TANH_BWD: return {mY, mDy};
+
+    /* TODO: Implement the remaining cases
+     */
+    case MIOPEN_POINTWISE_ERF:
+    case MIOPEN_POINTWISE_GEN_INDEX: return {};
+
+    default: MIOPEN_THROW(miopenStatusNotImplemented);
+    }
+}
+
+std::vector<Tensor*> OperationPointwise::getOutTensors() const
+{
+    switch(mPointwise->getMode())
+    {
+    /* 2-inputs operations
+     * x input
+     * b input
+     * y output
+     */
+    case MIOPEN_POINTWISE_ADD:
+    case MIOPEN_POINTWISE_ADD_SQUARE:
+    case MIOPEN_POINTWISE_DIV:
+    case MIOPEN_POINTWISE_MAX:
+    case MIOPEN_POINTWISE_MIN:
+    case MIOPEN_POINTWISE_MOD:
+    case MIOPEN_POINTWISE_MUL:
+    case MIOPEN_POINTWISE_POW:
+    case MIOPEN_POINTWISE_SUB:
+    case MIOPEN_POINTWISE_CMP_EQ:
+    case MIOPEN_POINTWISE_CMP_NEQ:
+    case MIOPEN_POINTWISE_CMP_GT:
+    case MIOPEN_POINTWISE_CMP_GE:
+    case MIOPEN_POINTWISE_CMP_LT:
+    case MIOPEN_POINTWISE_CMP_LE:
+    case MIOPEN_POINTWISE_LOGICAL_AND:
+    case MIOPEN_POINTWISE_LOGICAL_OR:
+    /* Single input operations
+     * x input
+     * y output
+     */
+    case MIOPEN_POINTWISE_ABS:
+    case MIOPEN_POINTWISE_CEIL:
+    case MIOPEN_POINTWISE_COS:
+    case MIOPEN_POINTWISE_EXP:
+    case MIOPEN_POINTWISE_FLOOR:
+    case MIOPEN_POINTWISE_LOG:
+    case MIOPEN_POINTWISE_NEG:
+    case MIOPEN_POINTWISE_RSQRT:
+    case MIOPEN_POINTWISE_SIN:
+    case MIOPEN_POINTWISE_SQRT:
+    case MIOPEN_POINTWISE_TAN:
+    case MIOPEN_POINTWISE_IDENTITY:
+    case MIOPEN_POINTWISE_RELU_FWD:
+    case MIOPEN_POINTWISE_TANH_FWD:
+    case MIOPEN_POINTWISE_SIGMOID_FWD:
+    case MIOPEN_POINTWISE_ELU_FWD:
+    case MIOPEN_POINTWISE_GELU_FWD:
+    case MIOPEN_POINTWISE_SOFTPLUS_FWD:
+    case MIOPEN_POINTWISE_SWISH_FWD:
+    case MIOPEN_POINTWISE_GELU_APPROX_TANH_FWD:
+    case MIOPEN_POINTWISE_LOGICAL_NOT:
+    case MIOPEN_POINTWISE_RECIPROCAL:
+        /* 3-inputs operations
+         * x input
+         * b input
+         * t input
+         * y output
+         */
+    case MIOPEN_POINTWISE_BINARY_SELECT: return {mY};
+
+    /* 2-inputs backward operations
+     * y input
+     * dy input
+     * dx output
+     */
+    case MIOPEN_POINTWISE_RELU_BWD:
+    case MIOPEN_POINTWISE_TANH_BWD:
+    case MIOPEN_POINTWISE_SIGMOID_BWD:
+    case MIOPEN_POINTWISE_ELU_BWD:
+    case MIOPEN_POINTWISE_GELU_BWD:
+    case MIOPEN_POINTWISE_SOFTPLUS_BWD:
+    case MIOPEN_POINTWISE_SWISH_BWD:
+    case MIOPEN_POINTWISE_GELU_APPROX_TANH_BWD: return {mDx};
+
+    /* TODO: Implement the remaining cases
+     */
+    case MIOPEN_POINTWISE_ERF:
+    case MIOPEN_POINTWISE_GEN_INDEX: return {};
+
+    default: MIOPEN_THROW(miopenStatusNotImplemented);
+    }
+}
+
+namespace {
+
+template <typename Ptr>
+void assignPtr(Ptr src, Ptr& dst)
+{
+    if(src != nullptr)
+    {
+        dst = src;
+    }
+    else
+    {
+        MIOPEN_THROW(miopenStatusBadParm);
+    }
+}
+
+} // namespace
+
+OperationPointwiseBuilder& OperationPointwiseBuilder::setPointwise(Pointwise* pointwise)
+{
+    assignPtr(pointwise, mOperationPointwise.mPointwise);
+    return *this;
+}
+
+OperationPointwiseBuilder& OperationPointwiseBuilder::setX(Tensor* x)
+{
+    assignPtr(x, mOperationPointwise.mX);
+    return *this;
+}
+
+OperationPointwiseBuilder& OperationPointwiseBuilder::setB(Tensor* b)
+{
+    assignPtr(b, mOperationPointwise.mB);
+    return *this;
+}
+
+OperationPointwiseBuilder& OperationPointwiseBuilder::setY(Tensor* y)
+{
+    assignPtr(y, mOperationPointwise.mY);
+    return *this;
+}
+
+OperationPointwiseBuilder& OperationPointwiseBuilder::setT(Tensor* t)
+{
+    assignPtr(t, mOperationPointwise.mT);
+    return *this;
+}
+
+OperationPointwiseBuilder& OperationPointwiseBuilder::setDx(Tensor* dX)
+{
+    assignPtr(dX, mOperationPointwise.mDx);
+    return *this;
+}
+
+OperationPointwiseBuilder& OperationPointwiseBuilder::setDy(Tensor* dY)
+{
+    assignPtr(dY, mOperationPointwise.mDy);
+    return *this;
+}
+
+OperationPointwiseBuilder& OperationPointwiseBuilder::setAlpha1(OperationPointwise::Alpha alpha1)
+{
+    mOperationPointwise.mAlpha1 = alpha1;
+    return *this;
+}
+
+OperationPointwiseBuilder& OperationPointwiseBuilder::setAlpha2(OperationPointwise::Alpha alpha2)
+{
+    mOperationPointwise.mAlpha2 = alpha2;
+    mAlpha2Set                  = true;
+    return *this;
+}
+
+namespace {
+
+template <typename Range1, typename Range2, typename Range3>
+bool checkDimsWithPossibleBroadcasting(Range1 input1, Range2 input2, Range3 output)
+{
+    auto input1it   = input1.cbegin();
+    auto input1Last = input1.cend();
+    auto input2it   = input2.cbegin();
+    auto input2Last = input2.cend();
+    auto outputit   = output.cbegin();
+    auto outputLast = output.cend();
+
+    bool OK = true;
+
+    for(; OK && input1it != input1Last && input2it != input2Last && outputit != outputLast;
+        ++input1it, ++input2it, ++outputit)
+    {
+        OK = (*input1it == *input2it && *input1it == *outputit) ||
+             (*input1it == 1 && *input2it > 1 && *input2it == *outputit) ||
+             (*input2it == 1 && *input1it > 1 && *input1it == *outputit);
+    }
+    OK = OK && input1it == input1Last && input2it == input2Last && outputit == outputLast;
+
+    return OK;
+}
+
+} // namespace
+
+OperationPointwise OperationPointwiseBuilder::build()
+{
+    if(mOperationPointwise.mPointwise == nullptr)
+    {
+        MIOPEN_THROW(miopenStatusBadParm);
+    }
+
+    switch(mOperationPointwise.mPointwise->getMode())
+    {
+    /* 2-inputs operations
+     * x input
+     * b input
+     * y output
+     */
+    case MIOPEN_POINTWISE_ADD:
+    case MIOPEN_POINTWISE_ADD_SQUARE:
+    case MIOPEN_POINTWISE_DIV:
+    case MIOPEN_POINTWISE_MAX:
+    case MIOPEN_POINTWISE_MIN:
+    case MIOPEN_POINTWISE_MOD:
+    case MIOPEN_POINTWISE_MUL:
+    case MIOPEN_POINTWISE_POW:
+    case MIOPEN_POINTWISE_SUB:
+    case MIOPEN_POINTWISE_CMP_EQ:
+    case MIOPEN_POINTWISE_CMP_NEQ:
+    case MIOPEN_POINTWISE_CMP_GT:
+    case MIOPEN_POINTWISE_CMP_GE:
+    case MIOPEN_POINTWISE_CMP_LT:
+    case MIOPEN_POINTWISE_CMP_LE:
+    case MIOPEN_POINTWISE_LOGICAL_AND:
+    case MIOPEN_POINTWISE_LOGICAL_OR:
+        if(mOperationPointwise.mX == nullptr || mOperationPointwise.mB == nullptr ||
+           mOperationPointwise.mY == nullptr || mOperationPointwise.mT != nullptr ||
+           mOperationPointwise.mDx != nullptr || mOperationPointwise.mDy != nullptr ||
+           !checkDimsWithPossibleBroadcasting(mOperationPointwise.mX->getDimensions(),
+                                              mOperationPointwise.mB->getDimensions(),
+                                              mOperationPointwise.mY->getDimensions()))
+        {
+            MIOPEN_THROW(miopenStatusBadParm);
+        }
+        break;
+
+    /* Single input operations
+     * x input
+     * y output
+     */
+    case MIOPEN_POINTWISE_ABS:
+    case MIOPEN_POINTWISE_CEIL:
+    case MIOPEN_POINTWISE_COS:
+    case MIOPEN_POINTWISE_EXP:
+    case MIOPEN_POINTWISE_FLOOR:
+    case MIOPEN_POINTWISE_LOG:
+    case MIOPEN_POINTWISE_NEG:
+    case MIOPEN_POINTWISE_RSQRT:
+    case MIOPEN_POINTWISE_SIN:
+    case MIOPEN_POINTWISE_SQRT:
+    case MIOPEN_POINTWISE_TAN:
+    case MIOPEN_POINTWISE_IDENTITY:
+    case MIOPEN_POINTWISE_RELU_FWD:
+    case MIOPEN_POINTWISE_TANH_FWD:
+    case MIOPEN_POINTWISE_SIGMOID_FWD:
+    case MIOPEN_POINTWISE_ELU_FWD:
+    case MIOPEN_POINTWISE_GELU_FWD:
+    case MIOPEN_POINTWISE_SOFTPLUS_FWD:
+    case MIOPEN_POINTWISE_SWISH_FWD:
+    case MIOPEN_POINTWISE_GELU_APPROX_TANH_FWD:
+    case MIOPEN_POINTWISE_LOGICAL_NOT:
+    case MIOPEN_POINTWISE_RECIPROCAL:
+        if(mOperationPointwise.mX == nullptr || mOperationPointwise.mY == nullptr ||
+           mOperationPointwise.mB != nullptr || mOperationPointwise.mT != nullptr ||
+           mOperationPointwise.mDx != nullptr || mOperationPointwise.mDy != nullptr || mAlpha2Set ||
+           !std::equal(mOperationPointwise.mX->getDimensions().cbegin(),
+                       mOperationPointwise.mX->getDimensions().cend(),
+                       mOperationPointwise.mY->getDimensions().cbegin(),
+                       mOperationPointwise.mY->getDimensions().cend()))
+        {
+            MIOPEN_THROW(miopenStatusBadParm);
+        }
+        break;
+
+    /* 3-inputs operations
+     * x input
+     * b input
+     * t input
+     * y output
+     */
+    case MIOPEN_POINTWISE_BINARY_SELECT:
+        if(mOperationPointwise.mX == nullptr || mOperationPointwise.mB == nullptr ||
+           mOperationPointwise.mT == nullptr || mOperationPointwise.mY == nullptr ||
+           mOperationPointwise.mDx != nullptr || mOperationPointwise.mDy != nullptr ||
+           !std::equal(mOperationPointwise.mX->getDimensions().cbegin(),
+                       mOperationPointwise.mX->getDimensions().cend(),
+                       mOperationPointwise.mB->getDimensions().cbegin(),
+                       mOperationPointwise.mB->getDimensions().cend()) ||
+           !std::equal(mOperationPointwise.mX->getDimensions().cbegin(),
+                       mOperationPointwise.mX->getDimensions().cend(),
+                       mOperationPointwise.mT->getDimensions().cbegin(),
+                       mOperationPointwise.mT->getDimensions().cend()) ||
+           !std::equal(mOperationPointwise.mX->getDimensions().cbegin(),
+                       mOperationPointwise.mX->getDimensions().cend(),
+                       mOperationPointwise.mY->getDimensions().cbegin(),
+                       mOperationPointwise.mY->getDimensions().cend()))
+        {
+            MIOPEN_THROW(miopenStatusBadParm);
+        }
+        break;
+
+    /* 2-inputs backward operations
+     * y input
+     * dy input
+     * dx output
+     */
+    case MIOPEN_POINTWISE_RELU_BWD:
+    case MIOPEN_POINTWISE_TANH_BWD:
+    case MIOPEN_POINTWISE_SIGMOID_BWD:
+    case MIOPEN_POINTWISE_ELU_BWD:
+    case MIOPEN_POINTWISE_GELU_BWD:
+    case MIOPEN_POINTWISE_SOFTPLUS_BWD:
+    case MIOPEN_POINTWISE_SWISH_BWD:
+    case MIOPEN_POINTWISE_GELU_APPROX_TANH_BWD:
+        if(mOperationPointwise.mY == nullptr || mOperationPointwise.mDy == nullptr ||
+           mOperationPointwise.mDx == nullptr || mOperationPointwise.mX != nullptr ||
+           mOperationPointwise.mB != nullptr || mOperationPointwise.mT != nullptr ||
+           !checkDimsWithPossibleBroadcasting(mOperationPointwise.mY->getDimensions(),
+                                              mOperationPointwise.mDy->getDimensions(),
+                                              mOperationPointwise.mDx->getDimensions()))
+        {
+            MIOPEN_THROW(miopenStatusBadParm);
+        }
+        break;
+
+    /* TODO: Implement the remaining cases
+     */
+    case MIOPEN_POINTWISE_ERF:
+    case MIOPEN_POINTWISE_GEN_INDEX: MIOPEN_THROW(miopenStatusNotImplemented);
+
+    default: MIOPEN_THROW(miopenStatusNotImplemented);
+    }
+
+    return mOperationPointwise;
 }
 
 } // namespace graphapi

--- a/src/include/miopen/graphapi/pointwise.hpp
+++ b/src/include/miopen/graphapi/pointwise.hpp
@@ -30,6 +30,7 @@
 
 #include <cstdint>
 #include <limits>
+#include <variant>
 #include <vector>
 
 namespace miopen {
@@ -38,13 +39,16 @@ namespace graphapi {
 
 class Pointwise
 {
+public:
+    using FpAttribute = std::variant<float, double>;
+
 private:
-    double mReluLowerClip      = 0.0;
-    double mReluUpperClip      = std::numeric_limits<double>::max();
-    double mReluLowerClipSlope = 0.0;
-    double mEluAlpha           = 1.0;
-    double mSoftPlusBeta       = 1.0;
-    int64_t mAxis              = -1;
+    FpAttribute mReluLowerClip      = 0.0f;
+    FpAttribute mReluUpperClip      = std::numeric_limits<float>::max();
+    FpAttribute mReluLowerClipSlope = 0.0f;
+    FpAttribute mEluAlpha           = 1.0f;
+    FpAttribute mSoftPlusBeta       = 1.0f;
+    int64_t mAxis                   = -1;
     miopenPointwiseMode_t mMode;
     miopenDataType_t mMathPrecision;
     miopenNanPropagation_t mNanPropagation = MIOPEN_NOT_PROPAGATE_NAN;
@@ -54,11 +58,11 @@ public:
     Pointwise(miopenPointwiseMode_t mode,
               miopenDataType_t mathPrecision,
               miopenNanPropagation_t nanPropagation = MIOPEN_NOT_PROPAGATE_NAN,
-              double reluLowerClip                  = 0.0,
-              double reluUpperClip                  = std::numeric_limits<double>::max(),
-              double reluLowerClipSlope             = 0.0,
-              double eluAlpha                       = 1.0,
-              double softPlusBeta                   = 1.0,
+              FpAttribute reluLowerClip             = 0.0f,
+              FpAttribute reluUpperClip             = std::numeric_limits<float>::max(),
+              FpAttribute reluLowerClipSlope        = 0.0f,
+              FpAttribute eluAlpha                  = 1.0f,
+              FpAttribute softPlusBeta              = 1.0f,
               int64_t axis                          = -1)
         : mReluLowerClip(reluLowerClip),
           mReluUpperClip(reluUpperClip),
@@ -75,11 +79,11 @@ public:
     miopenPointwiseMode_t getMode() const noexcept { return mMode; }
     miopenDataType_t getMathPrecision() const noexcept { return mMathPrecision; }
     miopenNanPropagation_t getNanPropagation() const noexcept { return mNanPropagation; }
-    double getReluLowerClip() const noexcept { return mReluLowerClip; }
-    double getReluUpperClip() const noexcept { return mReluUpperClip; }
-    double getReluLowerClipSlope() const noexcept { return mReluLowerClipSlope; }
-    double getEluAlpha() const noexcept { return mEluAlpha; }
-    double getSoftPlusBeta() const noexcept { return mSoftPlusBeta; }
+    FpAttribute getReluLowerClip() const noexcept { return mReluLowerClip; }
+    FpAttribute getReluUpperClip() const noexcept { return mReluUpperClip; }
+    FpAttribute getReluLowerClipSlope() const noexcept { return mReluLowerClipSlope; }
+    FpAttribute getEluAlpha() const noexcept { return mEluAlpha; }
+    FpAttribute getSoftPlusBeta() const noexcept { return mSoftPlusBeta; }
     int64_t getAxis() const noexcept { return mAxis; }
 
 private:
@@ -111,27 +115,27 @@ public:
         mPointwise.mNanPropagation = nanPropagation;
         return *this;
     }
-    PointwiseBuilder& setReluLowerClip(double reluLowerClip) noexcept
+    PointwiseBuilder& setReluLowerClip(Pointwise::FpAttribute reluLowerClip) noexcept
     {
         mPointwise.mReluLowerClip = reluLowerClip;
         return *this;
     }
-    PointwiseBuilder& setReluUpperClip(double reluUpperClip) noexcept
+    PointwiseBuilder& setReluUpperClip(Pointwise::FpAttribute reluUpperClip) noexcept
     {
         mPointwise.mReluUpperClip = reluUpperClip;
         return *this;
     }
-    PointwiseBuilder& setReluLowerClipSlope(double reluLowerClipSlope) noexcept
+    PointwiseBuilder& setReluLowerClipSlope(Pointwise::FpAttribute reluLowerClipSlope) noexcept
     {
         mPointwise.mReluLowerClipSlope = reluLowerClipSlope;
         return *this;
     }
-    PointwiseBuilder& setEluAlpha(double eluAlpha) noexcept
+    PointwiseBuilder& setEluAlpha(Pointwise::FpAttribute eluAlpha) noexcept
     {
         mPointwise.mEluAlpha = eluAlpha;
         return *this;
     }
-    PointwiseBuilder& setSoftPlusBeta(double softPlusBeta) noexcept
+    PointwiseBuilder& setSoftPlusBeta(Pointwise::FpAttribute softPlusBeta) noexcept
     {
         mPointwise.mSoftPlusBeta = softPlusBeta;
         return *this;

--- a/src/include/miopen/graphapi/pointwise.hpp
+++ b/src/include/miopen/graphapi/pointwise.hpp
@@ -48,6 +48,7 @@ private:
     FpAttribute mReluLowerClipSlope = 0.0f;
     FpAttribute mEluAlpha           = 1.0f;
     FpAttribute mSoftPlusBeta       = 1.0f;
+    FpAttribute mSwishBeta          = 1.0f;
     int64_t mAxis                   = -1;
     miopenPointwiseMode_t mMode;
     miopenDataType_t mMathPrecision;
@@ -63,12 +64,14 @@ public:
               FpAttribute reluLowerClipSlope        = 0.0f,
               FpAttribute eluAlpha                  = 1.0f,
               FpAttribute softPlusBeta              = 1.0f,
-              int64_t axis                          = -1)
+              FpAttribute swishBeta                 = 1.0f,
+              int64_t axis                          = -1) noexcept
         : mReluLowerClip(reluLowerClip),
           mReluUpperClip(reluUpperClip),
           mReluLowerClipSlope(reluLowerClipSlope),
           mEluAlpha(eluAlpha),
           mSoftPlusBeta(softPlusBeta),
+          mSwishBeta(swishBeta),
           mAxis(axis),
           mMode(mode),
           mMathPrecision(mathPrecision),
@@ -84,6 +87,7 @@ public:
     FpAttribute getReluLowerClipSlope() const noexcept { return mReluLowerClipSlope; }
     FpAttribute getEluAlpha() const noexcept { return mEluAlpha; }
     FpAttribute getSoftPlusBeta() const noexcept { return mSoftPlusBeta; }
+    FpAttribute getSwishBeta() const noexcept { return mSwishBeta; }
     int64_t getAxis() const noexcept { return mAxis; }
 
 private:
@@ -138,6 +142,11 @@ public:
     PointwiseBuilder& setSoftPlusBeta(Pointwise::FpAttribute softPlusBeta) noexcept
     {
         mPointwise.mSoftPlusBeta = softPlusBeta;
+        return *this;
+    }
+    PointwiseBuilder& setSwishBeta(Pointwise::FpAttribute swishBeta) noexcept
+    {
+        mPointwise.mSwishBeta = swishBeta;
         return *this;
     }
     PointwiseBuilder& setAxis(int64_t axis) noexcept

--- a/test/gtest/graphapi_operation_pointwise.cpp
+++ b/test/gtest/graphapi_operation_pointwise.cpp
@@ -1,0 +1,544 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2024 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <miopen/graphapi/pointwise.hpp>
+
+#include <tuple>
+#include <variant>
+
+#include <gtest/gtest.h>
+
+#include "graphapi_gtest_common.hpp"
+
+namespace {
+
+using miopen::graphapi::OperationPointwise;
+using miopen::graphapi::OperationPointwiseBuilder;
+using miopen::graphapi::Pointwise;
+using miopen::graphapi::Tensor;
+
+using OneInputTuple   = std::tuple<bool, Pointwise*, Tensor*, Tensor*>;
+using TwoInputTuple   = std::tuple<bool, Pointwise*, Tensor*, Tensor*, Tensor*>;
+using ThreeInputTuple = std::tuple<bool, Pointwise*, Tensor*, Tensor*, Tensor*, Tensor*>;
+
+} // namespace
+
+TEST(GraphApiOperationPointwiseBuilderSingleSetter, AnyAttribute)
+{
+    EXPECT_ANY_THROW({ OperationPointwiseBuilder().setPointwise(nullptr); })
+        << "OperationPointwiseBuilder::setPointwise failed on an invalid attribute";
+    EXPECT_ANY_THROW({ OperationPointwiseBuilder().setX(nullptr); })
+        << "OperationPointwiseBuilder::setX failed on an invalid attribute";
+    EXPECT_ANY_THROW({ OperationPointwiseBuilder().setB(nullptr); })
+        << "OperationPointwiseBuilder::setB failed on an invalid attribute";
+    EXPECT_ANY_THROW({ OperationPointwiseBuilder().setY(nullptr); })
+        << "OperationPointwiseBuilder::setY failed on an invalid attribute";
+    EXPECT_ANY_THROW({ OperationPointwiseBuilder().setT(nullptr); })
+        << "OperationPointwiseBuilder::setT failed on an invalid attribute";
+    EXPECT_ANY_THROW({ OperationPointwiseBuilder().setDx(nullptr); })
+        << "OperationPointwiseBuilder::setDx failed on an invalid attribute";
+    EXPECT_ANY_THROW({ OperationPointwiseBuilder().setDy(nullptr); })
+        << "OperationPointwiseBuilder::setDy failed on an invalid attribute";
+
+    Pointwise pointwise{MIOPEN_POINTWISE_ADD, miopenFloat};
+    EXPECT_NO_THROW({ OperationPointwiseBuilder().setPointwise(&pointwise); })
+        << "OperationPointwiseBuilder::setPointwise failed on a valid attribute";
+
+    Tensor tensor{miopenFloat, {8, 64, 64}, {64 * 64, 64, 1}, 1, false};
+    EXPECT_NO_THROW({ OperationPointwiseBuilder().setX(&tensor); })
+        << "OperationPointwiseBuilder::setX failed on a valid attribute";
+    EXPECT_NO_THROW({ OperationPointwiseBuilder().setB(&tensor); })
+        << "OperationPointwiseBuilder::setB failed on a ivalid attribute";
+    EXPECT_NO_THROW({ OperationPointwiseBuilder().setY(&tensor); })
+        << "OperationPointwiseBuilder::setY failed on a ivalid attribute";
+    EXPECT_NO_THROW({ OperationPointwiseBuilder().setT(&tensor); })
+        << "OperationPointwiseBuilder::setT failed on a valid attribute";
+    EXPECT_NO_THROW({ OperationPointwiseBuilder().setDx(&tensor); })
+        << "OperationPointwiseBuilder::setDx failed on a valid attribute";
+    EXPECT_NO_THROW({ OperationPointwiseBuilder().setDy(&tensor); })
+        << "OperationPointwiseBuilder::setDy failed on a valid attribute";
+}
+
+class GraphApiOperationPointwiseBuilderOneInput : public testing::TestWithParam<OneInputTuple>
+{
+protected:
+    bool mValid;
+    Pointwise* mPointwise;
+    Tensor* mX;
+    Tensor* mY;
+
+    void SetUp() override { std::tie(mValid, mPointwise, mX, mY) = GetParam(); }
+};
+
+TEST_P(GraphApiOperationPointwiseBuilderOneInput, Test)
+{
+    if(mValid)
+    {
+        EXPECT_NO_THROW({
+            OperationPointwiseBuilder().setPointwise(mPointwise).setX(mX).setY(mY).build();
+        }) << "Builder failed on valid attributes";
+        EXPECT_NO_THROW({
+            OperationPointwiseBuilder()
+                .setPointwise(mPointwise)
+                .setX(mX)
+                .setY(mY)
+                .setAlpha1(0.4f)
+                .build();
+        }) << "Builder failed on valid attributes with alpha1";
+    }
+    else
+    {
+        EXPECT_ANY_THROW({
+            OperationPointwiseBuilder().setPointwise(mPointwise).setX(mX).setY(mY).build();
+        }) << "Builder failed on invalid attributes";
+    }
+    EXPECT_ANY_THROW({ OperationPointwiseBuilder().setX(mX).setY(mY).build(); })
+        << "Builder failed to detect missing setPointwise call";
+    EXPECT_ANY_THROW({ OperationPointwiseBuilder().setPointwise(mPointwise).setY(mY).build(); })
+        << "Builder failed to detect missing setX call";
+    EXPECT_ANY_THROW({ OperationPointwiseBuilder().setPointwise(mPointwise).setX(mX).build(); })
+        << "Builder failed to detect missing setY call";
+    EXPECT_ANY_THROW({
+        OperationPointwiseBuilder().setPointwise(mPointwise).setX(mX).setY(mY).setB(mX).build();
+    }) << "Builder failed to detect unwanted setB call";
+    EXPECT_ANY_THROW({
+        OperationPointwiseBuilder().setPointwise(mPointwise).setX(mX).setY(mY).setT(mX).build();
+    }) << "Builder failed to detect unwanted setT call";
+    EXPECT_ANY_THROW({
+        OperationPointwiseBuilder().setPointwise(mPointwise).setX(mX).setY(mY).setDx(mX).build();
+    }) << "Builder failed to detect unwanted setDx call";
+    EXPECT_ANY_THROW({
+        OperationPointwiseBuilder().setPointwise(mPointwise).setX(mX).setY(mY).setDy(mX).build();
+    }) << "Builder failed to detect unwanted setDy call";
+    EXPECT_ANY_THROW({
+        OperationPointwiseBuilder()
+            .setPointwise(mPointwise)
+            .setX(mX)
+            .setY(mY)
+            .setAlpha2(0.5f)
+            .build();
+    }) << "Builder failed to detect unwanted setAlpha2 call";
+}
+
+class GraphApiOperationPointwiseBuilderTwoInput : public testing::TestWithParam<TwoInputTuple>
+{
+protected:
+    bool mValid;
+    Pointwise* mPointwise;
+    Tensor* mX;
+    Tensor* mB;
+    Tensor* mY;
+
+    void SetUp() override { std::tie(mValid, mPointwise, mX, mB, mY) = GetParam(); }
+};
+
+TEST_P(GraphApiOperationPointwiseBuilderTwoInput, Test)
+{
+    if(mValid)
+    {
+        EXPECT_NO_THROW({
+            OperationPointwiseBuilder().setPointwise(mPointwise).setX(mX).setB(mB).setY(mY).build();
+        }) << "Builder failed on valid attributes";
+        EXPECT_NO_THROW({
+            OperationPointwiseBuilder()
+                .setPointwise(mPointwise)
+                .setX(mX)
+                .setB(mB)
+                .setY(mY)
+                .setAlpha1(0.4f)
+                .build();
+        }) << "Builder failed on valid attributes with alpha1";
+        EXPECT_NO_THROW({
+            OperationPointwiseBuilder()
+                .setPointwise(mPointwise)
+                .setX(mX)
+                .setB(mB)
+                .setY(mY)
+                .setAlpha2(0.7f)
+                .build();
+        }) << "Builder failed on valid attributes with alpha2";
+        EXPECT_NO_THROW({
+            OperationPointwiseBuilder()
+                .setPointwise(mPointwise)
+                .setX(mX)
+                .setB(mB)
+                .setY(mY)
+                .setAlpha1(0.3f)
+                .setAlpha2(0.8f)
+                .build();
+        }) << "Builder failed on valid attributes with alpha1 and alpha2";
+    }
+    else
+    {
+        EXPECT_ANY_THROW({
+            OperationPointwiseBuilder().setPointwise(mPointwise).setX(mX).setB(mB).setY(mY).build();
+        }) << "Builder failed on invalid attributes";
+    }
+    EXPECT_ANY_THROW({ OperationPointwiseBuilder().setX(mX).setB(mB).setY(mY).build(); })
+        << "Builder failed to detect missing setPointwise call";
+    EXPECT_ANY_THROW({
+        OperationPointwiseBuilder().setPointwise(mPointwise).setB(mB).setY(mY).build();
+    }) << "Builder failed to detect missing setX call";
+    EXPECT_ANY_THROW({
+        OperationPointwiseBuilder().setPointwise(mPointwise).setX(mX).setY(mY).build();
+    }) << "Builder failed to detect missing setB call";
+    EXPECT_ANY_THROW({
+        OperationPointwiseBuilder().setPointwise(mPointwise).setX(mX).setB(mB).build();
+    }) << "Builder failed to detect missing setY call";
+    EXPECT_ANY_THROW({
+        OperationPointwiseBuilder()
+            .setPointwise(mPointwise)
+            .setX(mX)
+            .setB(mB)
+            .setY(mY)
+            .setT(mX)
+            .build();
+    }) << "Builder failed to detect unwanted setT call";
+    EXPECT_ANY_THROW({
+        OperationPointwiseBuilder()
+            .setPointwise(mPointwise)
+            .setX(mX)
+            .setB(mB)
+            .setY(mY)
+            .setDx(mX)
+            .build();
+    }) << "Builder failed to detect unwanted setDx call";
+    EXPECT_ANY_THROW({
+        OperationPointwiseBuilder()
+            .setPointwise(mPointwise)
+            .setX(mX)
+            .setB(mB)
+            .setY(mY)
+            .setDy(mX)
+            .build();
+    }) << "Builder failed to detect unwanted setDy call";
+}
+
+class GraphApiOperationPointwiseBuilderBwd : public testing::TestWithParam<TwoInputTuple>
+{
+protected:
+    bool mValid;
+    Pointwise* mPointwise;
+    Tensor* mY;
+    Tensor* mDy;
+    Tensor* mDx;
+
+    void SetUp() override { std::tie(mValid, mPointwise, mY, mDy, mDx) = GetParam(); }
+};
+
+TEST_P(GraphApiOperationPointwiseBuilderBwd, Test)
+{
+    if(mValid)
+    {
+        EXPECT_NO_THROW({
+            OperationPointwiseBuilder()
+                .setPointwise(mPointwise)
+                .setY(mY)
+                .setDy(mDy)
+                .setDx(mDx)
+                .build();
+        }) << "Builder failed on valid attributes";
+        EXPECT_NO_THROW({
+            OperationPointwiseBuilder()
+                .setPointwise(mPointwise)
+                .setY(mY)
+                .setDy(mDy)
+                .setDx(mDx)
+                .setAlpha1(0.4f)
+                .build();
+        }) << "Builder failed on valid attributes with alpha1";
+        EXPECT_NO_THROW({
+            OperationPointwiseBuilder()
+                .setPointwise(mPointwise)
+                .setY(mY)
+                .setDy(mDy)
+                .setDx(mDx)
+                .setAlpha2(0.7f)
+                .build();
+        }) << "Builder failed on valid attributes with alpha2";
+        EXPECT_NO_THROW({
+            OperationPointwiseBuilder()
+                .setPointwise(mPointwise)
+                .setY(mY)
+                .setDy(mDy)
+                .setDx(mDx)
+                .setAlpha1(0.3f)
+                .setAlpha2(0.8f)
+                .build();
+        }) << "Builder failed on valid attributes with alpha1 and alpha2";
+    }
+    else
+    {
+        EXPECT_ANY_THROW({
+            OperationPointwiseBuilder()
+                .setPointwise(mPointwise)
+                .setY(mY)
+                .setDy(mDy)
+                .setDx(mDx)
+                .build();
+        }) << "Builder failed on invalid attributes";
+    }
+    EXPECT_ANY_THROW({ OperationPointwiseBuilder().setY(mY).setDy(mDy).setDx(mDx).build(); })
+        << "Builder failed to detect missing setPointwise call";
+    EXPECT_ANY_THROW({
+        OperationPointwiseBuilder().setPointwise(mPointwise).setDy(mDy).setDx(mDx).build();
+    }) << "Builder failed to detect missing setY call";
+    EXPECT_ANY_THROW({
+        OperationPointwiseBuilder().setPointwise(mPointwise).setY(mY).setDx(mDx).build();
+    }) << "Builder failed to detect missing setDy call";
+    EXPECT_ANY_THROW({
+        OperationPointwiseBuilder().setPointwise(mPointwise).setY(mY).setDy(mDy).build();
+    }) << "Builder failed to detect missing setDx call";
+    EXPECT_ANY_THROW({
+        OperationPointwiseBuilder()
+            .setPointwise(mPointwise)
+            .setY(mY)
+            .setDy(mDy)
+            .setDx(mDx)
+            .setX(mY)
+            .build();
+    }) << "Builder failed to detect unwanted setX call";
+    EXPECT_ANY_THROW({
+        OperationPointwiseBuilder()
+            .setPointwise(mPointwise)
+            .setY(mY)
+            .setDy(mDy)
+            .setDx(mDx)
+            .setB(mY)
+            .build();
+    }) << "Builder failed to detect unwanted setB call";
+    EXPECT_ANY_THROW({
+        OperationPointwiseBuilder()
+            .setPointwise(mPointwise)
+            .setY(mY)
+            .setDy(mDy)
+            .setDx(mDx)
+            .setT(mY)
+            .build();
+    }) << "Builder failed to detect unwanted setT call";
+}
+
+class GraphApiOperationPointwiseBuilderThreeInput : public testing::TestWithParam<ThreeInputTuple>
+{
+protected:
+    bool mValid;
+    Pointwise* mPointwise;
+    Tensor* mX;
+    Tensor* mB;
+    Tensor* mY;
+    Tensor* mT;
+
+    void SetUp() override { std::tie(mValid, mPointwise, mX, mB, mY, mT) = GetParam(); }
+};
+
+TEST_P(GraphApiOperationPointwiseBuilderThreeInput, Test)
+{
+    if(mValid)
+    {
+        EXPECT_NO_THROW({
+            OperationPointwiseBuilder()
+                .setPointwise(mPointwise)
+                .setX(mX)
+                .setB(mB)
+                .setY(mY)
+                .setT(mT)
+                .build();
+        }) << "Builder failed on valid attributes";
+        EXPECT_NO_THROW({
+            OperationPointwiseBuilder()
+                .setPointwise(mPointwise)
+                .setX(mX)
+                .setB(mB)
+                .setY(mY)
+                .setT(mT)
+                .setAlpha1(0.4f)
+                .build();
+        }) << "Builder failed on valid attributes with alpha1";
+        EXPECT_NO_THROW({
+            OperationPointwiseBuilder()
+                .setPointwise(mPointwise)
+                .setX(mX)
+                .setB(mB)
+                .setY(mY)
+                .setT(mT)
+                .setAlpha2(0.6f)
+                .build();
+        }) << "Builder failed on valid attributes with alpha2";
+        EXPECT_NO_THROW({
+            OperationPointwiseBuilder()
+                .setPointwise(mPointwise)
+                .setX(mX)
+                .setB(mB)
+                .setY(mY)
+                .setT(mT)
+                .setAlpha1(0.3f)
+                .setAlpha1(0.7f)
+                .build();
+        }) << "Builder failed on valid attributes with alpha1 and alpha2";
+    }
+    else
+    {
+        EXPECT_ANY_THROW({
+            OperationPointwiseBuilder()
+                .setPointwise(mPointwise)
+                .setX(mX)
+                .setB(mB)
+                .setY(mY)
+                .setT(mT)
+                .build();
+        }) << "Builder failed on invalid attributes";
+    }
+    EXPECT_ANY_THROW({ OperationPointwiseBuilder().setX(mX).setB(mB).setY(mY).setT(mT).build(); })
+        << "Builder failed to detect missing setPointwise call";
+    EXPECT_ANY_THROW({
+        OperationPointwiseBuilder().setPointwise(mPointwise).setB(mB).setY(mY).setT(mT).build();
+    }) << "Builder failed to detect missing setX call";
+    EXPECT_ANY_THROW({
+        OperationPointwiseBuilder().setPointwise(mPointwise).setX(mX).setY(mY).setT(mT).build();
+    }) << "Builder failed to detect missing setB call";
+    EXPECT_ANY_THROW({
+        OperationPointwiseBuilder().setPointwise(mPointwise).setX(mX).setB(mB).setT(mT).build();
+    }) << "Builder failed to detect missing setY call";
+    EXPECT_ANY_THROW({
+        OperationPointwiseBuilder().setPointwise(mPointwise).setX(mX).setB(mB).setY(mY).build();
+    }) << "Builder failed to detect missing setT call";
+    EXPECT_ANY_THROW({
+        OperationPointwiseBuilder()
+            .setPointwise(mPointwise)
+            .setX(mX)
+            .setB(mB)
+            .setY(mY)
+            .setT(mT)
+            .setDx(mX)
+            .build();
+    }) << "Builder failed to detect unwanted setDx call";
+    EXPECT_ANY_THROW({
+        OperationPointwiseBuilder()
+            .setPointwise(mPointwise)
+            .setX(mX)
+            .setB(mB)
+            .setY(mY)
+            .setT(mT)
+            .setDy(mX)
+            .build();
+    }) << "Builder failed to detect unwanted setDy call";
+}
+
+static Tensor x{miopenFloat, {8, 64, 64}, {64 * 64, 64, 1}, 1, false};
+static Tensor x2{miopenFloat, {8, 1, 64}, {64 * 1, 64, 1}, 2, false};
+static Tensor x3{miopenFloat, {8, 64, 1}, {64 * 1, 1, 1}, 3, false};
+static Tensor b{miopenFloat, {8, 64, 64}, {64 * 64, 64, 1}, 4, false};
+static Tensor b2{miopenFloat, {8, 1, 64}, {64 * 1, 64, 1}, 5, false};
+static Tensor b3{miopenFloat, {8, 64, 1}, {64 * 1, 1, 1}, 6, false};
+static Tensor y{miopenFloat, {8, 64, 64}, {64 * 64, 64, 1}, 7, false};
+static Tensor y2{miopenFloat, {8, 1, 64}, {64 * 1, 64, 1}, 8, false};
+static Tensor t{miopenFloat, {8, 64, 64}, {64 * 64, 64, 1}, 9, false};
+static Pointwise pointwiseAdd{MIOPEN_POINTWISE_ADD, miopenFloat};
+static Pointwise pointwiseAbs{MIOPEN_POINTWISE_ABS, miopenFloat};
+static Pointwise pointwiseReluBwd{MIOPEN_POINTWISE_RELU_BWD, miopenFloat};
+static Pointwise pointwiseBinSel{MIOPEN_POINTWISE_BINARY_SELECT, miopenFloat};
+
+static auto oneInputValid   = testing::Combine(testing::Values(true),
+                                             testing::Values(&pointwiseAbs),
+                                             testing::Values(&x),
+                                             testing::Values(&y));
+static auto oneInputInvalid = testing::Combine(testing::Values(false),
+                                               testing::Values(&pointwiseAbs),
+                                               testing::Values(&x2, &x3),
+                                               testing::Values(&y));
+
+static auto twoInputValid1  = testing::Combine(testing::Values(true),
+                                              testing::Values(&pointwiseAdd),
+                                              testing::Values(&x, &x2, &x3),
+                                              testing::Values(&b),
+                                              testing::Values(&y));
+static auto twoInputValid2  = testing::Combine(testing::Values(true),
+                                              testing::Values(&pointwiseAdd),
+                                              testing::Values(&x),
+                                              testing::Values(&b, &b2, &b3),
+                                              testing::Values(&y));
+static auto twoInputInvalid = testing::Combine(testing::Values(false),
+                                               testing::Values(&pointwiseAdd),
+                                               testing::Values(&x, &x2, &x3),
+                                               testing::Values(&b),
+                                               testing::Values(&y2));
+
+static auto twoInputValidBwd1  = testing::Combine(testing::Values(true),
+                                                 testing::Values(&pointwiseReluBwd),
+                                                 testing::Values(&x, &x2, &x3),
+                                                 testing::Values(&b),
+                                                 testing::Values(&y));
+static auto twoInputValidBwd2  = testing::Combine(testing::Values(true),
+                                                 testing::Values(&pointwiseReluBwd),
+                                                 testing::Values(&x),
+                                                 testing::Values(&b, &b2, &b3),
+                                                 testing::Values(&y));
+static auto twoInputInvalidBwd = testing::Combine(testing::Values(false),
+                                                  testing::Values(&pointwiseReluBwd),
+                                                  testing::Values(&x, &x2, &x3),
+                                                  testing::Values(&b),
+                                                  testing::Values(&y2));
+
+static auto threeInputValid   = testing::Combine(testing::Values(true),
+                                               testing::Values(&pointwiseBinSel),
+                                               testing::Values(&x),
+                                               testing::Values(&b),
+                                               testing::Values(&y),
+                                               testing::Values(&t));
+static auto threeInputInvalid = testing::Combine(testing::Values(false),
+                                                 testing::Values(&pointwiseBinSel),
+                                                 testing::Values(&x2, &x3),
+                                                 testing::Values(&b, &b2, &b3),
+                                                 testing::Values(&y, &y2),
+                                                 testing::Values(&t));
+
+INSTANTIATE_TEST_SUITE_P(OneInputValid, GraphApiOperationPointwiseBuilderOneInput, oneInputValid);
+INSTANTIATE_TEST_SUITE_P(OneInputInvalid,
+                         GraphApiOperationPointwiseBuilderOneInput,
+                         oneInputInvalid);
+
+INSTANTIATE_TEST_SUITE_P(TwoInputValid1, GraphApiOperationPointwiseBuilderTwoInput, twoInputValid1);
+INSTANTIATE_TEST_SUITE_P(TwoInputValid2, GraphApiOperationPointwiseBuilderTwoInput, twoInputValid2);
+INSTANTIATE_TEST_SUITE_P(TwoInputInvalid,
+                         GraphApiOperationPointwiseBuilderTwoInput,
+                         twoInputInvalid);
+
+INSTANTIATE_TEST_SUITE_P(TwoInputValidBwd1,
+                         GraphApiOperationPointwiseBuilderBwd,
+                         twoInputValidBwd1);
+INSTANTIATE_TEST_SUITE_P(TwoInputValidBwd2,
+                         GraphApiOperationPointwiseBuilderBwd,
+                         twoInputValidBwd2);
+INSTANTIATE_TEST_SUITE_P(TwoInputInvalidBwd,
+                         GraphApiOperationPointwiseBuilderBwd,
+                         twoInputInvalidBwd);
+
+INSTANTIATE_TEST_SUITE_P(ThreeInputValid,
+                         GraphApiOperationPointwiseBuilderThreeInput,
+                         threeInputValid);
+INSTANTIATE_TEST_SUITE_P(ThreeInputInvalid,
+                         GraphApiOperationPointwiseBuilderThreeInput,
+                         threeInputInvalid);

--- a/test/gtest/graphapi_pointwise.cpp
+++ b/test/gtest/graphapi_pointwise.cpp
@@ -187,6 +187,7 @@ using TestCaseType = std::tuple<miopenPointwiseMode_t,
                                 bool,
                                 bool,
                                 bool,
+                                bool,
                                 int64_t>;
 
 void PrintTo(const TestCaseType& v, std::ostream* os)
@@ -198,7 +199,8 @@ void PrintTo(const TestCaseType& v, std::ostream* os)
         << ", relu_lower_clip_slope: " << (std::get<5>(v) ? "double" : "float")
         << ", elu_alpha: " << (std::get<6>(v) ? "double" : "float")
         << ", softplus_beta: " << (std::get<7>(v) ? "double" : "float")
-        << ", axis: " << std::get<8>(v);
+        << ", swish_beta: " << (std::get<8>(v) ? "double" : "float")
+        << ", axis: " << std::get<9>(v);
 }
 
 class GraphApiPointwise : public testing::TestWithParam<TestCaseType>
@@ -214,6 +216,7 @@ protected:
     DoubleOrFloatAttribute mReluLowerClipSlope;
     DoubleOrFloatAttribute mEluAlpha;
     DoubleOrFloatAttribute mSoftPlusBeta;
+    DoubleOrFloatAttribute mSwishBeta;
     Axis mAxis;
 
     void SetUp() override
@@ -225,7 +228,8 @@ protected:
               isReluUpperClipDouble,
               isReluLowerClipSlopeDouble,
               isEluAlphaDouble,
-              IsSoftPlusBetaDouble,
+              isSoftPlusBetaDouble,
+              isSwishBetaDouble,
               axis] = GetParam();
 
         mMode           = {mode};
@@ -248,9 +252,13 @@ protected:
         mEluAlpha.set(
             isEluAlphaDouble, "MIOPEN_ATTR_POINTWISE_ELU_ALPHA", MIOPEN_ATTR_POINTWISE_ELU_ALPHA);
 
-        mSoftPlusBeta.set(IsSoftPlusBetaDouble,
+        mSoftPlusBeta.set(isSoftPlusBetaDouble,
                           "MIOPEN_ATTR_POINTWISE_SOFTPLUS_BETA",
                           MIOPEN_ATTR_POINTWISE_SOFTPLUS_BETA);
+
+        mSwishBeta.set(isSwishBetaDouble,
+                       "MIOPEN_ATTR_POINTWISE_SWISH_BETA",
+                       MIOPEN_ATTR_POINTWISE_SWISH_BETA);
 
         execute.descriptor.attributes = {&mMode,
                                          &mPrecision,
@@ -260,6 +268,7 @@ protected:
                                          mReluLowerClipSlope.get(),
                                          mEluAlpha.get(),
                                          mSoftPlusBeta.get(),
+                                         mSwishBeta.get(),
                                          &mAxis};
 
         execute.descriptor.attrsValid = true;
@@ -276,6 +285,7 @@ INSTANTIATE_TEST_SUITE_P(
     testing::Combine(testing::Values(MIOPEN_POINTWISE_ADD, MIOPEN_POINTWISE_MUL),
                      testing::Values(miopenFloat, miopenHalf),
                      testing::Values(MIOPEN_NOT_PROPAGATE_NAN, MIOPEN_PROPAGATE_NAN),
+                     testing::Values(true, false),
                      testing::Values(true, false),
                      testing::Values(true, false),
                      testing::Values(true, false),

--- a/test/gtest/graphapi_pointwise.cpp
+++ b/test/gtest/graphapi_pointwise.cpp
@@ -205,9 +205,7 @@ void PrintTo(const TestCaseType& v, std::ostream* os)
 
 class GraphApiPointwise : public testing::TestWithParam<TestCaseType>
 {
-protected:
-    GTestGraphApiExecute<GTestDescriptorAttribute*> execute;
-
+private:
     Mode mMode;
     Precision mPrecision;
     NanPropagation mNanPropagation;
@@ -218,6 +216,9 @@ protected:
     DoubleOrFloatAttribute mSoftPlusBeta;
     DoubleOrFloatAttribute mSwishBeta;
     Axis mAxis;
+
+protected:
+    GTestGraphApiExecute<GTestDescriptorAttribute*> mExecute;
 
     void SetUp() override
     {
@@ -260,27 +261,27 @@ protected:
                        "MIOPEN_ATTR_POINTWISE_SWISH_BETA",
                        MIOPEN_ATTR_POINTWISE_SWISH_BETA);
 
-        execute.descriptor.attributes = {&mMode,
-                                         &mPrecision,
-                                         &mNanPropagation,
-                                         mReluLowerClip.get(),
-                                         mReluUpperClip.get(),
-                                         mReluLowerClipSlope.get(),
-                                         mEluAlpha.get(),
-                                         mSoftPlusBeta.get(),
-                                         mSwishBeta.get(),
-                                         &mAxis};
+        mExecute.descriptor.attributes = {&mMode,
+                                          &mPrecision,
+                                          &mNanPropagation,
+                                          mReluLowerClip.get(),
+                                          mReluUpperClip.get(),
+                                          mReluLowerClipSlope.get(),
+                                          mEluAlpha.get(),
+                                          mSoftPlusBeta.get(),
+                                          mSwishBeta.get(),
+                                          &mAxis};
 
-        execute.descriptor.attrsValid = true;
-        execute.descriptor.textName   = "MIOPEN_BACKEND_POINTWISE_DESCRIPTOR";
-        execute.descriptor.type       = MIOPEN_BACKEND_POINTWISE_DESCRIPTOR;
+        mExecute.descriptor.attrsValid = true;
+        mExecute.descriptor.textName   = "MIOPEN_BACKEND_POINTWISE_DESCRIPTOR";
+        mExecute.descriptor.type       = MIOPEN_BACKEND_POINTWISE_DESCRIPTOR;
     }
 };
 
-TEST_P(GraphApiPointwise, CFuncions) { execute(); }
+TEST_P(GraphApiPointwise, CFunctions) { mExecute(); }
 
 INSTANTIATE_TEST_SUITE_P(
-    CFuncionsTest,
+    ValidAttributes,
     GraphApiPointwise,
     testing::Combine(testing::Values(MIOPEN_POINTWISE_ADD, MIOPEN_POINTWISE_MUL),
                      testing::Values(miopenFloat, miopenHalf),


### PR DESCRIPTION
Issue #2839

Tasks:

MIOPEN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR
- [x] Builder and tests

C API -> BackendOperationPointwiseDescriptor (polymorphic) -> OperationPointwiseBuilder -> OperationPointwise

BackendOperationPointwiseDescriptor, a polymorphic descriptor class, is utilized by C-API functions to handle create/set/finalize/get/execute requests.

Builder pattern is used for set and finalize API requests.

OperationPointwise class represents a pointwise node in an operation graph.