### PR TITLE
Remove extra db path quotes introduced in #2823

### DIFF
--- a/src/find_db.cpp
+++ b/src/find_db.cpp
@@ -219,7 +219,7 @@ std::string FindDbRecord_t<TDb>::GetUserPath(Handle& handle, const std::string& 
 {
 #if !MIOPEN_DISABLE_USERDB
     std::ostringstream ss;
-    ss << GetUserDbPath() << '/';
+    ss << GetUserDbPath().string() << '/';
     ss << handle.GetDbBasename();
     ss << '.' << GetUserDbSuffix();
     if(!path_suffix.empty())


### PR DESCRIPTION
Fixes #2881 

#2823 removed `.string()` from `fs::path` redirected to `std::stingstream` and it introduced extra quotes to that path which caused #2881.
This is the most obvious and noticeable place, but since we mixing `std::string`, `fs::path`, and streams that but may reappear in different places.
Probably some logs can be broken, since #2823 removed `.string()` from lots of logging functions, but logs are not so critical and sometimes that's a good change, since it will quote a full path.

But reverting #2823 may not help - there are some other PRs where that sort of changes can be done. Looks like all the `fs::path` PRs should be revisited.

@atamazov  @junliume 