### PR TITLE
[MHA] Implement MIOPEN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR API Class

### DIFF
--- a/src/graphapi/graphapi.cpp
+++ b/src/graphapi/graphapi.cpp
@@ -63,6 +63,9 @@ miopenBackendCreateDescriptor(miopenBackendDescriptorType_t descriptorType,
         case MIOPEN_BACKEND_OPERATION_CONVOLUTION_BACKWARD_DATA_DESCRIPTOR:
             outputDesciptor = new miopen::graphapi::BackendOperationConvolutionBackwardDataDescriptor(); break;
 
+        case MIOPEN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR:
+            outputDesciptor = new miopen::graphapi::BackendOperationPointwiseDescriptor(); break;
+
         case MIOPEN_BACKEND_OPERATION_RNG_DESCRIPTOR:
             outputDesciptor = new miopen::graphapi::BackendOperationRngDescriptor(); break;
 
@@ -204,6 +207,9 @@ extern "C" miopenStatus_t miopenBackendInitialize(miopenBackendDescriptor_t desc
 
         case MIOPEN_BACKEND_OPERATION_CONVOLUTION_BACKWARD_DATA_DESCRIPTOR:
             initializeBackendDescriptor<miopen::graphapi::BackendOperationConvolutionBackwardDataDescriptor>(descriptor, sizeInBytes); break;
+
+        case MIOPEN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR:
+            initializeBackendDescriptor<miopen::graphapi::BackendOperationPointwiseDescriptor>(descriptor, sizeInBytes); break;
 
         case MIOPEN_BACKEND_OPERATION_RNG_DESCRIPTOR:
             initializeBackendDescriptor<miopen::graphapi::BackendOperationRngDescriptor>(descriptor, sizeInBytes); break;

--- a/src/graphapi/pointwise.cpp
+++ b/src/graphapi/pointwise.cpp
@@ -252,6 +252,214 @@ void BackendPointwiseDescriptor::getAttribute(miopenBackendAttributeName_t attri
     }
 }
 
+const std::string& OperationPointwise::signName() const
+{
+    switch(mPointwise->getMode())
+    {
+    case MIOPEN_POINTWISE_ADD: {
+        static const std::string name = "OP_POINTWISE:ADD";
+        return name;
+    }
+    case MIOPEN_POINTWISE_ADD_SQUARE: {
+        static const std::string name = "OP_POINTWISE:ADD_SQUARE";
+        return name;
+    }
+    case MIOPEN_POINTWISE_DIV: {
+        static const std::string name = "OP_POINTWISE:DIV";
+        return name;
+    }
+    case MIOPEN_POINTWISE_MAX: {
+        static const std::string name = "OP_POINTWISE:MAX";
+        return name;
+    }
+    case MIOPEN_POINTWISE_MIN: {
+        static const std::string name = "OP_POINTWISE:MIN";
+        return name;
+    }
+    case MIOPEN_POINTWISE_MOD: {
+        static const std::string name = "OP_POINTWISE:MOD";
+        return name;
+    }
+    case MIOPEN_POINTWISE_MUL: {
+        static const std::string name = "OP_POINTWISE:MUL";
+        return name;
+    }
+    case MIOPEN_POINTWISE_POW: {
+        static const std::string name = "OP_POINTWISE:POW";
+        return name;
+    }
+    case MIOPEN_POINTWISE_SUB: {
+        static const std::string name = "OP_POINTWISE:SUB";
+        return name;
+    }
+    case MIOPEN_POINTWISE_ABS: {
+        static const std::string name = "OP_POINTWISE:ABS";
+        return name;
+    }
+    case MIOPEN_POINTWISE_CEIL: {
+        static const std::string name = "OP_POINTWISE:CEIL";
+        return name;
+    }
+    case MIOPEN_POINTWISE_COS: {
+        static const std::string name = "OP_POINTWISE:COS";
+        return name;
+    }
+    case MIOPEN_POINTWISE_EXP: {
+        static const std::string name = "OP_POINTWISE:EXP";
+        return name;
+    }
+    case MIOPEN_POINTWISE_FLOOR: {
+        static const std::string name = "OP_POINTWISE:FLOOR";
+        return name;
+    }
+    case MIOPEN_POINTWISE_LOG: {
+        static const std::string name = "OP_POINTWISE:LOG";
+        return name;
+    }
+    case MIOPEN_POINTWISE_NEG: {
+        static const std::string name = "OP_POINTWISE:NEG";
+        return name;
+    }
+    case MIOPEN_POINTWISE_RSQRT: {
+        static const std::string name = "OP_POINTWISE:RSQRT";
+        return name;
+    }
+    case MIOPEN_POINTWISE_SIN: {
+        static const std::string name = "OP_POINTWISE:SIN";
+        return name;
+    }
+    case MIOPEN_POINTWISE_SQRT: {
+        static const std::string name = "OP_POINTWISE:SQRT";
+        return name;
+    }
+    case MIOPEN_POINTWISE_TAN: {
+        static const std::string name = "OP_POINTWISE:TAN";
+        return name;
+    }
+    case MIOPEN_POINTWISE_ERF: {
+        static const std::string name = "OP_POINTWISE:ERF";
+        return name;
+    }
+    case MIOPEN_POINTWISE_IDENTITY: {
+        static const std::string name = "OP_POINTWISE:IDENTITY";
+        return name;
+    }
+    case MIOPEN_POINTWISE_RELU_FWD: {
+        static const std::string name = "OP_POINTWISE:RELU_FWD";
+        return name;
+    }
+    case MIOPEN_POINTWISE_TANH_FWD: {
+        static const std::string name = "OP_POINTWISE:TANH_FWD";
+        return name;
+    }
+    case MIOPEN_POINTWISE_SIGMOID_FWD: {
+        static const std::string name = "OP_POINTWISE:SIGMOID_FWD";
+        return name;
+    }
+    case MIOPEN_POINTWISE_ELU_FWD: {
+        static const std::string name = "OP_POINTWISE:ELU_FWD";
+        return name;
+    }
+    case MIOPEN_POINTWISE_GELU_FWD: {
+        static const std::string name = "OP_POINTWISE:GELU_FWD";
+        return name;
+    }
+    case MIOPEN_POINTWISE_SOFTPLUS_FWD: {
+        static const std::string name = "OP_POINTWISE:SOFTPLUS_FWD";
+        return name;
+    }
+    case MIOPEN_POINTWISE_SWISH_FWD: {
+        static const std::string name = "OP_POINTWISE:SWISH_FWD";
+        return name;
+    }
+    case MIOPEN_POINTWISE_GELU_APPROX_TANH_FWD: {
+        static const std::string name = "OP_POINTWISE:APPROX_TANH_FWD";
+        return name;
+    }
+    case MIOPEN_POINTWISE_RELU_BWD: {
+        static const std::string name = "OP_POINTWISE:RELU_BWD";
+        return name;
+    }
+    case MIOPEN_POINTWISE_TANH_BWD: {
+        static const std::string name = "OP_POINTWISE:TANH_BWD";
+        return name;
+    }
+    case MIOPEN_POINTWISE_SIGMOID_BWD: {
+        static const std::string name = "OP_POINTWISE:SIGMOID_BWD";
+        return name;
+    }
+    case MIOPEN_POINTWISE_ELU_BWD: {
+        static const std::string name = "OP_POINTWISE:ELU_BWD";
+        return name;
+    }
+    case MIOPEN_POINTWISE_GELU_BWD: {
+        static const std::string name = "OP_POINTWISE:GELU_BWD";
+        return name;
+    }
+    case MIOPEN_POINTWISE_SOFTPLUS_BWD: {
+        static const std::string name = "OP_POINTWISE:SOFTPLUS_BWD";
+        return name;
+    }
+    case MIOPEN_POINTWISE_SWISH_BWD: {
+        static const std::string name = "OP_POINTWISE:SWISH_BWD";
+        return name;
+    }
+    case MIOPEN_POINTWISE_GELU_APPROX_TANH_BWD: {
+        static const std::string name = "OP_POINTWISE:APPROX_TANH_BWD";
+        return name;
+    }
+    case MIOPEN_POINTWISE_CMP_EQ: {
+        static const std::string name = "OP_POINTWISE:CMP_EQ";
+        return name;
+    }
+    case MIOPEN_POINTWISE_CMP_NEQ: {
+        static const std::string name = "OP_POINTWISE:CMP_NEQ";
+        return name;
+    }
+    case MIOPEN_POINTWISE_CMP_GT: {
+        static const std::string name = "OP_POINTWISE:CMP_GT";
+        return name;
+    }
+    case MIOPEN_POINTWISE_CMP_GE: {
+        static const std::string name = "OP_POINTWISE:CMP_GE";
+        return name;
+    }
+    case MIOPEN_POINTWISE_CMP_LT: {
+        static const std::string name = "OP_POINTWISE:CMP_LT";
+        return name;
+    }
+    case MIOPEN_POINTWISE_CMP_LE: {
+        static const std::string name = "OP_POINTWISE:CMP_LE";
+        return name;
+    }
+    case MIOPEN_POINTWISE_LOGICAL_AND: {
+        static const std::string name = "OP_POINTWISE:LOGICAL_AND";
+        return name;
+    }
+    case MIOPEN_POINTWISE_LOGICAL_OR: {
+        static const std::string name = "OP_POINTWISE:LOGICAL_OR";
+        return name;
+    }
+    case MIOPEN_POINTWISE_LOGICAL_NOT: {
+        static const std::string name = "OP_POINTWISE:LOGICAL_NOT";
+        return name;
+    }
+    case MIOPEN_POINTWISE_GEN_INDEX: {
+        static const std::string name = "OP_POINTWISE:GEN_INDEX";
+        return name;
+    }
+    case MIOPEN_POINTWISE_BINARY_SELECT: {
+        static const std::string name = "OP_POINTWISE:BINARY_SELECT";
+        return name;
+    }
+    case MIOPEN_POINTWISE_RECIPROCAL: {
+        static const std::string name = "OP_POINTWISE:RECIPROCAL";
+        return name;
+    }
+    default: MIOPEN_THROW(miopenStatusNotImplemented);
+    }
+}
+
 std::vector<Tensor*> OperationPointwise::getInTensors() const
 {
     switch(mPointwise->getMode())

--- a/src/graphapi/pointwise.cpp
+++ b/src/graphapi/pointwise.cpp
@@ -420,62 +420,45 @@ std::vector<Tensor*> OperationPointwise::getOutTensors() const
     }
 }
 
-namespace {
-
-template <typename Ptr>
-void assignPtr(Ptr src, Ptr& dst)
-{
-    if(src != nullptr)
-    {
-        dst = src;
-    }
-    else
-    {
-        MIOPEN_THROW(miopenStatusBadParm);
-    }
-}
-
-} // namespace
-
 OperationPointwiseBuilder& OperationPointwiseBuilder::setPointwise(Pointwise* pointwise)
 {
-    assignPtr(pointwise, mOperationPointwise.mPointwise);
+    mOperationPointwise.mPointwise = checkPtr(pointwise);
     return *this;
 }
 
 OperationPointwiseBuilder& OperationPointwiseBuilder::setX(Tensor* x)
 {
-    assignPtr(x, mOperationPointwise.mX);
+    mOperationPointwise.mX = checkPtr(x);
     return *this;
 }
 
 OperationPointwiseBuilder& OperationPointwiseBuilder::setB(Tensor* b)
 {
-    assignPtr(b, mOperationPointwise.mB);
+    mOperationPointwise.mB = checkPtr(b);
     return *this;
 }
 
 OperationPointwiseBuilder& OperationPointwiseBuilder::setY(Tensor* y)
 {
-    assignPtr(y, mOperationPointwise.mY);
+    mOperationPointwise.mY = checkPtr(y);
     return *this;
 }
 
 OperationPointwiseBuilder& OperationPointwiseBuilder::setT(Tensor* t)
 {
-    assignPtr(t, mOperationPointwise.mT);
+    mOperationPointwise.mT = checkPtr(t);
     return *this;
 }
 
 OperationPointwiseBuilder& OperationPointwiseBuilder::setDx(Tensor* dX)
 {
-    assignPtr(dX, mOperationPointwise.mDx);
+    mOperationPointwise.mDx = checkPtr(dX);
     return *this;
 }
 
 OperationPointwiseBuilder& OperationPointwiseBuilder::setDy(Tensor* dY)
 {
-    assignPtr(dY, mOperationPointwise.mDy);
+    mOperationPointwise.mDy = checkPtr(dY);
     return *this;
 }
 

--- a/src/graphapi/reduction.cpp
+++ b/src/graphapi/reduction.cpp
@@ -136,6 +136,46 @@ void BackendReductionDescriptor::getAttribute(miopenBackendAttributeName_t attri
     }
 }
 
+const std::string& OperationReduction::signName() const
+{
+    switch(mReduction->getReductionOperator())
+    {
+    case MIOPEN_REDUCE_TENSOR_ADD: {
+        static const std::string name = "OP_REDUCTION:ADD";
+        return name;
+    }
+    case MIOPEN_REDUCE_TENSOR_MUL: {
+        static const std::string name = "OP_REDUCTION:MUK";
+        return name;
+    }
+    case MIOPEN_REDUCE_TENSOR_MIN: {
+        static const std::string name = "OP_REDUCTION:MIN";
+        return name;
+    }
+    case MIOPEN_REDUCE_TENSOR_MAX: {
+        static const std::string name = "OP_REDUCTION:MAX";
+        return name;
+    }
+    case MIOPEN_REDUCE_TENSOR_AMAX: {
+        static const std::string name = "OP_REDUCTION:AMAX";
+        return name;
+    }
+    case MIOPEN_REDUCE_TENSOR_AVG: {
+        static const std::string name = "OP_REDUCTION:AVG";
+        return name;
+    }
+    case MIOPEN_REDUCE_TENSOR_NORM1: {
+        static const std::string name = "OP_REDUCTION:NORM1";
+        return name;
+    }
+    case MIOPEN_REDUCE_TENSOR_NORM2: {
+        static const std::string name = "OP_REDUCTION:NORM2";
+        return name;
+    }
+    default: MIOPEN_THROW(miopenStatusNotImplemented);
+    }
+}
+
 std::vector<Tensor*> OperationReduction::getInTensors() const { return {mX}; }
 
 std::vector<Tensor*> OperationReduction::getOutTensors() const { return {mY}; }

--- a/src/graphapi/rng.cpp
+++ b/src/graphapi/rng.cpp
@@ -210,28 +210,14 @@ std::vector<Tensor*> OperationRng::getOutTensors() const { return {mOutput}; }
 
 OperationRngBuilder& OperationRngBuilder::setRng(Rng* rng)
 {
-    if(rng != nullptr)
-    {
-        mOperationRng.mRng = rng;
-        return *this;
-    }
-    else
-    {
-        MIOPEN_THROW(miopenStatusBadParm);
-    }
+    mOperationRng.mRng = checkPtr(rng);
+    return *this;
 }
 
 OperationRngBuilder& OperationRngBuilder::setOutput(Tensor* output)
 {
-    if(output != nullptr)
-    {
-        mOperationRng.mOutput = output;
-        return *this;
-    }
-    else
-    {
-        MIOPEN_THROW(miopenStatusBadParm);
-    }
+    mOperationRng.mOutput = checkPtr(output);
+    return *this;
 }
 
 OperationRngBuilder& OperationRngBuilder::setSeed(int64_t seed) noexcept

--- a/src/graphapi/rng.cpp
+++ b/src/graphapi/rng.cpp
@@ -194,6 +194,12 @@ void BackendRngDescriptor::getAttribute(miopenBackendAttributeName_t attributeNa
     }
 }
 
+const std::string& OperationRng::signName() const
+{
+    static const std::string name = "OP_RNG";
+    return name;
+}
+
 std::vector<Tensor*> OperationRng::getInTensors() const
 {
     if(mSeed.index() == 0)

--- a/src/include/miopen/errors.hpp
+++ b/src/include/miopen/errors.hpp
@@ -127,6 +127,19 @@ auto deref(T&& x, [[maybe_unused]] miopenStatus_t err = miopenStatusBadParm)
 template <class... Ts>
 auto tie_deref(Ts&... xs) MIOPEN_RETURNS(std::tie(miopen::deref(xs)...));
 
+template <typename Ptr>
+Ptr checkPtr(Ptr ptr, [[maybe_unused]] miopenStatus_t err = miopenStatusBadParm)
+{
+    if(ptr != nullptr)
+    {
+        return ptr;
+    }
+    else
+    {
+        MIOPEN_THROW(err, "Passing nullptr");
+    }
+}
+
 } // namespace miopen
 
 #endif

--- a/src/include/miopen/graphapi/convolution.hpp
+++ b/src/include/miopen/graphapi/convolution.hpp
@@ -26,7 +26,7 @@
 #pragma once
 
 #include <miopen/graphapi/graphapi.hpp>
-#include <miopen/graphapi/operation.hpp>
+#include <miopen/graphapi/opgraph.hpp>
 #include <miopen/graphapi/tensor.hpp>
 
 #include <cstdint>
@@ -291,6 +291,11 @@ public:
         : OperationConvolution(convolution, x, w, y, alpha, beta)
     {
     }
+    virtual const std::string& signName() const override
+    {
+        static const std::string name = "OP_CONVOLUTION_FORWARD";
+        return name;
+    }
     virtual std::vector<Tensor*> getInTensors() const override { return {getX(), getW()}; }
     virtual std::vector<Tensor*> getOutTensors() const override { return {getY()}; }
 };
@@ -479,6 +484,11 @@ public:
         : OperationConvolution(convolution, x, w, y, alpha, beta)
     {
     }
+    virtual const std::string& signName() const override
+    {
+        static const std::string name = "OP_CONVOLUTION_BACKWARD_DATA";
+        return name;
+    }
     virtual std::vector<Tensor*> getInTensors() const override { return {getW(), getY()}; }
     virtual std::vector<Tensor*> getOutTensors() const override { return {getX()}; }
 };
@@ -565,6 +575,11 @@ public:
                                        double beta) noexcept
         : OperationConvolution(convolution, x, w, y, alpha, beta)
     {
+    }
+    virtual const std::string& signName() const override
+    {
+        static const std::string name = "OP_CONVOLUTION_BACKWARD_FILTER";
+        return name;
     }
     virtual std::vector<Tensor*> getInTensors() const override { return {getX(), getY()}; }
     virtual std::vector<Tensor*> getOutTensors() const override { return {getW()}; }

--- a/src/include/miopen/graphapi/opgraph.hpp
+++ b/src/include/miopen/graphapi/opgraph.hpp
@@ -36,6 +36,8 @@ class OpNode
 public:
     virtual ~OpNode() = default;
 
+    virtual const std::string& signName() const = 0;
+
     virtual std::vector<Tensor*> getInTensors() const = 0;
 
     virtual std::vector<Tensor*> getOutTensors() const = 0;

--- a/src/include/miopen/graphapi/pointwise.hpp
+++ b/src/include/miopen/graphapi/pointwise.hpp
@@ -28,7 +28,7 @@
 
 #include <half/half.hpp>
 #include <miopen/graphapi/graphapi.hpp>
-#include <miopen/graphapi/operation.hpp>
+#include <miopen/graphapi/opgraph.hpp>
 
 #include <cstdint>
 #include <limits>
@@ -249,6 +249,7 @@ public:
     Alpha getAlpha1() const noexcept { return mAlpha1; }
     Alpha getAlpha2() const noexcept { return mAlpha2; }
 
+    const std::string& signName() const override;
     std::vector<Tensor*> getInTensors() const override;
     std::vector<Tensor*> getOutTensors() const override;
 };

--- a/src/include/miopen/graphapi/pointwise.hpp
+++ b/src/include/miopen/graphapi/pointwise.hpp
@@ -273,6 +273,37 @@ public:
     OperationPointwise build();
 };
 
+class BackendOperationPointwiseDescriptor : public BackendDescriptor
+{
+private:
+    OperationPointwiseBuilder mBuilder;
+    OperationPointwise mOperationPointwise;
+
+    miopenBackendDescriptor_t mPointwiseDescriptor = nullptr;
+    miopenBackendDescriptor_t mXDescriptor         = nullptr;
+    miopenBackendDescriptor_t mBDescriptor         = nullptr;
+    miopenBackendDescriptor_t mYDescriptor         = nullptr;
+    miopenBackendDescriptor_t mTDescriptor         = nullptr;
+    miopenBackendDescriptor_t mDxDescriptor        = nullptr;
+    miopenBackendDescriptor_t mDyDescriptor        = nullptr;
+
+public:
+    void setAttribute(miopenBackendAttributeName_t attributeName,
+                      miopenBackendAttributeType_t attributeType,
+                      int64_t elementCount,
+                      void* arrayOfElements) override;
+    void finalize() override;
+    void getAttribute(miopenBackendAttributeName_t attributeName,
+                      miopenBackendAttributeType_t attributeType,
+                      int64_t requestedElementCount,
+                      int64_t* elementCount,
+                      void* arrayOfElements) override;
+    OpNode* getOperation() override;
+
+    const OperationPointwise* getOperationPointwise() const { return &mOperationPointwise; }
+    OperationPointwise* getOperationPointwise() { return &mOperationPointwise; }
+};
+
 } // namespace graphapi
 
 } // namespace miopen

--- a/src/include/miopen/graphapi/reduction.hpp
+++ b/src/include/miopen/graphapi/reduction.hpp
@@ -27,7 +27,7 @@
 
 #include <miopen/miopen.h>
 #include <miopen/graphapi/graphapi.hpp>
-#include <miopen/graphapi/operation.hpp>
+#include <miopen/graphapi/opgraph.hpp>
 
 namespace miopen {
 
@@ -119,6 +119,7 @@ public:
     Tensor* getX() const noexcept { return mX; }
     Tensor* getY() const noexcept { return mY; }
 
+    const std::string& signName() const override;
     std::vector<Tensor*> getInTensors() const override;
     std::vector<Tensor*> getOutTensors() const override;
 };

--- a/src/include/miopen/graphapi/rng.hpp
+++ b/src/include/miopen/graphapi/rng.hpp
@@ -27,7 +27,7 @@
 
 #include <miopen/miopen.h>
 #include <miopen/graphapi/graphapi.hpp>
-#include <miopen/graphapi/operation.hpp>
+#include <miopen/graphapi/opgraph.hpp>
 #include <miopen/graphapi/tensor.hpp>
 
 #include <cstdint>
@@ -158,6 +158,7 @@ public:
     std::variant<int64_t, Tensor*> getSeed() const noexcept { return mSeed; }
     Tensor* getOffset() const noexcept { return mOffset; }
 
+    virtual const std::string& signName() const override;
     virtual std::vector<Tensor*> getInTensors() const override;
     virtual std::vector<Tensor*> getOutTensors() const override;
 };


### PR DESCRIPTION
Issue #2839

Tasks:

MIOPEN_BACKEND_OPERATION_POINTWISE_DESCRIPTOR
- [x] C functions and tests

C API -> BackendOperationPointwiseDescriptor (polymorphic) -> OperationPointwiseBuilder -> OperationPointwise

BackendOperationPointwiseDescriptor, a polymorphic descriptor class, is utilized by C-API functions to handle create/set/finalize/get/execute requests.

Builder pattern is used for set and finalize API requests.

OperationPointwise class represents a pointwise node in an operation graph.

closes #2839