### PR TITLE
Adjustments for the latest assembler (e.g. latest changes in the upstream clang)

### DIFF
--- a/src/comgr.cpp
+++ b/src/comgr.cpp
@@ -970,8 +970,6 @@ void BuildAsm(const std::string& name,
         SetIsaName(action, target);
         action.SetLogging(true);
         auto optAsm = miopen::SplitSpaceSeparated(options);
-        if(target.Xnack() && !*target.Xnack())
-            optAsm.emplace_back("-mno-xnack");
         compiler::lc::gcnasm::RemoveOptionsUnwanted(optAsm);
         action.SetOptionList(optAsm);
 

--- a/src/comgr.cpp
+++ b/src/comgr.cpp
@@ -60,6 +60,9 @@
 /// More info at https://github.com/ROCm/MIOpen/issues/1257.
 #define WORKAROUND_ISSUE_1257 (HIP_PACKAGE_VERSION_FLAT >= 4003021331ULL)
 
+/// https://github.com/ROCm/ROCm-CompilerSupport/issues/67 about unused -nogpulib.
+#define WORKAROUND_ROCMCOMPILERSUPPORT_ISSUE_67 1
+
 MIOPEN_DECLARE_ENV_VAR_BOOL(MIOPEN_DEBUG_COMGR_LOG_CALLS)
 MIOPEN_DECLARE_ENV_VAR_BOOL(MIOPEN_DEBUG_COMGR_LOG_SOURCE_NAMES)
 
@@ -971,6 +974,9 @@ void BuildAsm(const std::string& name,
         action.SetLogging(true);
         auto optAsm = miopen::SplitSpaceSeparated(options);
         compiler::lc::gcnasm::RemoveOptionsUnwanted(optAsm);
+#if WORKAROUND_ROCMCOMPILERSUPPORT_ISSUE_67
+        optAsm.push_back("--rocm-path=.");
+#endif
         action.SetOptionList(optAsm);
 
         const Dataset relocatable;

--- a/src/hip/handlehip.cpp
+++ b/src/hip/handlehip.cpp
@@ -31,6 +31,7 @@
 #include <miopen/env.hpp>
 #include <miopen/errors.hpp>
 #include <miopen/handle_lock.hpp>
+#include <miopen/hip_build_utils.hpp>
 #include <miopen/invoker.hpp>
 #include <miopen/kernel_cache.hpp>
 #include <miopen/logger.hpp>
@@ -493,8 +494,17 @@ Program Handle::LoadProgram(const std::string& program_name,
 
     std::string orig_params = params; // make a copy for target ID fallback
 
-    if(!miopen::EndsWith(program_name, ".mlir"))
-        params = params + " -mcpu=" + this->GetTargetProperties().Name();
+    if(miopen::EndsWith(program_name, ".mlir"))
+    { // no -mcpu
+    }
+    else if(miopen::EndsWith(program_name, ".s"))
+    {
+        params += " -mcpu=" + LcOptionTargetStrings{this->GetTargetProperties()}.targetId;
+    }
+    else
+    {
+        params += " -mcpu=" + this->GetTargetProperties().Name();
+    }
 
     auto hsaco = miopen::LoadBinary(
         this->GetTargetProperties(), this->GetMaxComputeUnits(), program_name, params);

--- a/src/hip/hip_build_utils.cpp
+++ b/src/hip/hip_build_utils.cpp
@@ -132,7 +132,6 @@ static fs::path HipBuildImpl(boost::optional<TmpDir>& tmp_dir,
     src += "\nint main() {}\n";
     WriteFile(src, tmp_dir->path / filename);
 
-    // cppcheck-suppress unreadVariable
     const LcOptionTargetStrings lots(target);
 
     auto env = std::string("");

--- a/src/ocl/gcn_asm_utils.cpp
+++ b/src/ocl/gcn_asm_utils.cpp
@@ -182,8 +182,6 @@ std::string AmdgcnAssemble(const std::string& source,
 
     std::ostringstream options;
     options << " -x assembler -target amdgcn--amdhsa";
-    if(target.Xnack() && !*target.Xnack())
-        options << " -mno-xnack";
     /// \todo Hacky way to find out which CO version we need to assemble for.
     if(params.find("ROCM_METADATA_VERSION=5", 0) == std::string::npos) // Assume that !COv3 == COv2.
         if(GcnAssemblerSupportsNoCOv3()) // If assembling for COv2, then disable COv3.


### PR DESCRIPTION
- COMgr amdgcn assembly: Removed "-mno-xnack"
  - This resolves #2851
- Added WORKAROUND_ROCMCOMPILERSUPPORT_ISSUE_67 for https://github.com/ROCm/ROCm-CompilerSupport/issues/67
- Offline (clang) amdgcn assembly:
  - Removed "-mno-xnack".
  - Added features to "-mcpu" value (e.g. `"-mcpu=gfx908"` -> `"-mcpu=gfx908:xnack-"`,  see [here](https://llvm.org/docs/AMDGPUUsage.html#amdgpu-target-features) for more info)

### ⚠️ @junliume @JehandadKhan This introduces backward incompatibility of the offline binary cache. I do not expect any complications, because the precompiled binary cache package should be regenerated with each release. But please be aware of this if you would like to cherry-pick this into some release branch.

## :cyclone: Performance/correctness testing results `develop` vs this PR

Preconditions:
- System & build configurations:
  - Navi21/36 ROCm 6.0 docker, online gcnasm (COMgr)
  - Navi21/36 ROCm 6.0 docker, offline gcnasm (/opt/rocm/llvm/bin/clang)
  - gfx906/60 ROCm 6.0 docker, online gcnasm (COMgr)
  - gfx906/60 ROCm 6.0 docker, offline gcnasm (/opt/rocm/llvm/bin/clang)
  - gfx906/60 ROCm 5.7 docker, online gcnasm (COMgr)
  - gfx906/60 ROCm 5.7 docker, offline gcnasm (/opt/rocm/llvm/bin/clang)
- Common system & build parameters: Ubuntu 20.04.5 LTS, BUILD_DEV=On, Release build, 
- 93 known FP32 convolution configs
- Only assembly kernels enabled

No performance or correctness regressions.

Verdict: :green_circle: GO!

----
[Attribution] @junliume @JehandadKhan
- https://github.com/ROCm/MIOpen/labels/enhancement
- https://github.com/ROCm/MIOpen/labels/urgency_high
- Proposed reviewers:
  - @JehandadKhan 
  - @cderb 
  - @shurale-nkn 
  - @littlewu2508