### PR TITLE
Unify 'include <half/half.hpp>' across Windows and Linux

### DIFF
--- a/driver/conv_common.hpp
+++ b/driver/conv_common.hpp
@@ -39,11 +39,7 @@
 #include <miopen/bfloat16.hpp>
 
 #include <cstdint>
-#if !defined(_WIN32)
 #include <half/half.hpp>
-#else
-#include <half.hpp>
-#endif
 using half         = half_float::half;
 using hip_bfloat16 = bfloat16;
 #include <hip_float8.hpp>

--- a/driver/driver.hpp
+++ b/driver/driver.hpp
@@ -26,12 +26,7 @@
 #ifndef GUARD_MIOPEN_DRIVER_HPP
 #define GUARD_MIOPEN_DRIVER_HPP
 
-#if !defined(_WIN32)
 #include <half/half.hpp>
-#else
-#include <half.hpp>
-#endif
-
 #include "random.hpp"
 
 #include "InputFlags.hpp"

--- a/driver/reduce_driver.hpp
+++ b/driver/reduce_driver.hpp
@@ -41,11 +41,7 @@
 #include <miopen/reduce_common.hpp>
 #include <miopen/tensor.hpp>
 
-#if !defined(_WIN32)
 #include <half/half.hpp>
-#else
-#include <half.hpp>
-#endif
 
 #include <algorithm>
 #include <cassert>

--- a/driver/rocrand_wrapper.hpp
+++ b/driver/rocrand_wrapper.hpp
@@ -34,11 +34,7 @@
 // definitions are different.
 
 #include <boost/core/demangle.hpp>
-#if !defined(_WIN32)
 #include <half/half.hpp>
-#else
-#include <half.hpp>
-#endif
 
 #include <iostream>
 #include <typeinfo>

--- a/src/fusion.cpp
+++ b/src/fusion.cpp
@@ -45,11 +45,7 @@
 #include <ios>
 #include <algorithm>
 #include <string>
-#if !defined(_WIN32)
 #include <half/half.hpp>
-#else
-#include <half.hpp>
-#endif
 
 #define MIOPEN_CHECK(x)          \
     if(x != miopenStatusSuccess) \

--- a/src/gemm_v2.cpp
+++ b/src/gemm_v2.cpp
@@ -40,11 +40,7 @@
 #pragma clang diagnostic ignored "-Wunused-macros"
 #define ROCBLAS_BETA_FEATURES_API 1
 #pragma clang diagnostic pop
-#if !defined(_WIN32)
 #include <half/half.hpp>
-#else
-#include <half.hpp>
-#endif
 #if MIOPEN_ROCBLAS_VERSION_FLAT < 2045000
 #include <rocblas.h>
 #else

--- a/src/include/miopen/op_kernel_args.hpp
+++ b/src/include/miopen/op_kernel_args.hpp
@@ -3,11 +3,7 @@
 
 #include <type_traits>
 #include <cstdint>
-#if !defined(_WIN32)
 #include <half/half.hpp>
-#else
-#include <half.hpp>
-#endif
 #include <boost/container/small_vector.hpp>
 
 struct OpKernelArg

--- a/src/include/miopen/reduce_common.hpp
+++ b/src/include/miopen/reduce_common.hpp
@@ -26,11 +26,7 @@
 #ifndef GUARD_MIOPEN_REDUCE_COMMON_HPP
 #define GUARD_MIOPEN_REDUCE_COMMON_HPP
 
-#if !defined(_WIN32)
 #include <half/half.hpp>
-#else
-#include <half.hpp>
-#endif
 #include <miopen/bfloat16.hpp>
 
 namespace reduce {

--- a/src/include/miopen/visit_float.hpp
+++ b/src/include/miopen/visit_float.hpp
@@ -28,11 +28,7 @@
 #define GUARD_MLOPEN_VISIT_FLOAT_HPP
 
 #include <miopen/miopen.h>
-#if !defined(_WIN32)
 #include <half/half.hpp>
-#else
-#include <half.hpp>
-#endif
 #include <miopen/bfloat16.hpp>
 
 namespace miopen {

--- a/src/solver/conv_asm_1x1u_bias_activ_fused.cpp
+++ b/src/solver/conv_asm_1x1u_bias_activ_fused.cpp
@@ -38,11 +38,7 @@
 #include <miopen/fusion/solvers.hpp>
 #include <miopen/fusion/fusion_invoke_params.hpp>
 
-#if !defined(_WIN32)
 #include <half/half.hpp>
-#else
-#include <half.hpp>
-#endif
 
 using half_float::half;
 

--- a/src/solver/conv_ocl_dir2Dfwd_exhaustive_search.cpp
+++ b/src/solver/conv_ocl_dir2Dfwd_exhaustive_search.cpp
@@ -33,11 +33,7 @@
 #include <miopen/legacy_exhaustive_search.hpp>
 #include <miopen/bfloat16.hpp>
 #include <miopen/fusion/fusion_invoke_params.hpp>
-#if !defined(_WIN32)
 #include <half/half.hpp>
-#else
-#include <half.hpp>
-#endif
 
 #ifdef max
 #undef max

--- a/test/cpu_reduce_util.hpp
+++ b/test/cpu_reduce_util.hpp
@@ -26,11 +26,7 @@
 #ifndef GUARD_CPU_REDUCE_UTIL_HPP
 #define GUARD_CPU_REDUCE_UTIL_HPP
 
-#if !defined(_WIN32)
 #include <half/half.hpp>
-#else
-#include <half.hpp>
-#endif
 #include <limits>
 #include <cmath>
 #include <cassert>

--- a/test/driver.hpp
+++ b/test/driver.hpp
@@ -37,11 +37,7 @@
 
 #include <functional>
 #include <deque>
-#if !defined(_WIN32)
 #include <half/half.hpp>
-#else
-#include <half.hpp>
-#endif
 #include <type_traits>
 #include <miopen/filesystem.hpp>
 #include <miopen/functional.hpp>

--- a/test/gpu_reference_kernel.cpp
+++ b/test/gpu_reference_kernel.cpp
@@ -36,11 +36,7 @@
 #include <cstdlib>
 #include <ctime>
 #include <type_traits>
-#if !defined(_WIN32)
 #include <half/half.hpp>
-#else
-#include <half.hpp>
-#endif
 #include "test.hpp"
 #include "driver.hpp"
 #include "tensor_holder.hpp"

--- a/test/serialize.hpp
+++ b/test/serialize.hpp
@@ -29,11 +29,7 @@
 
 #include <miopen/rank.hpp>
 #include <miopen/each_args.hpp>
-#if !defined(_WIN32)
 #include <half/half.hpp>
-#else
-#include <half.hpp>
-#endif
 #include <fstream>
 #include <string>
 #include <tuple>

--- a/test/tensor_holder.hpp
+++ b/test/tensor_holder.hpp
@@ -37,11 +37,7 @@
 
 #include "serialize.hpp"
 
-#if !defined(_WIN32)
 #include <half/half.hpp>
-#else
-#include <half.hpp>
-#endif
 using half         = half_float::half;
 using hip_bfloat16 = bfloat16;
 #include <hip_float8.hpp>


### PR DESCRIPTION
Windows MIOpen moved to HIP SDK 6.0 and no longer supports HIP SDK 5.7 out of the box. However, HIP SDK 5.7 might still be used to compile MIOpen, but with slight modifications to the source code.