### PR TITLE
ConvProblemDescription: fix GetInSize(), GetOutSize() and GetWeightsSize()

### DIFF
--- a/driver/conv_driver.hpp
+++ b/driver/conv_driver.hpp
@@ -942,7 +942,7 @@ int ConvDriver<Tgpu, Tref>::GetandSetData()
             static_cast<int>(miopenConvolutionFindModeNormal)); // Repeat via hidden API.
         miopenSetConvolutionGroupCount(warmupConvDesc, group_count);
 
-        int warmup_out_len_size = miopen::deref(warmupInputTensor).GetSize();
+        int warmup_out_len_size = miopen::deref(warmupInputTensor).GetNumDims();
         std::vector<int> warmup_out_len(warmup_out_len_size);
         miopenGetConvolutionNdForwardOutputDim(warmupConvDesc,
                                                warmupInputTensor,
@@ -1297,7 +1297,7 @@ int ConvDriver<Tgpu, Tref>::SetConvDescriptorFromCmdLineArgs()
 template <typename Tgpu, typename Tref>
 std::vector<int> ConvDriver<Tgpu, Tref>::GetOutputTensorLengths()
 {
-    int ndim = miopen::deref(inputTensor).GetSize();
+    int ndim = miopen::deref(inputTensor).GetNumDims();
 
     std::vector<int> out_lens(ndim);
 
@@ -1750,7 +1750,7 @@ void ConvDriver<Tgpu, Tref>::PrintForwardTime(const float kernel_total_time,
                                     : kernel_first_time;
     printf("GPU Kernel Time Forward Conv. Elapsed: %f ms (average)\n", kernel_average_time);
 
-    const auto num_dim = miopen::deref(inputTensor).GetSize() - 2;
+    const auto num_dim = miopen::deref(inputTensor).GetNumDims() - 2;
     if(num_dim != 2 && num_dim != 3)
     {
         printf("stats: <not implemented> for conv%dd\n", num_dim);
@@ -2648,7 +2648,7 @@ void ConvDriver<Tgpu, Tref>::PrintBackwardDataTime(float kernel_total_time, floa
 
     printf("GPU Kernel Time Backward Data Conv. Elapsed: %f ms (average)\n", kernel_average_time);
 
-    const auto num_dim = miopen::deref(inputTensor).GetSize() - 2;
+    const auto num_dim = miopen::deref(inputTensor).GetNumDims() - 2;
     if(num_dim != 2 && num_dim != 3)
     {
         printf("stats: <not implemented> for conv%dd\n", num_dim);
@@ -2856,7 +2856,7 @@ void ConvDriver<Tgpu, Tref>::PrintBackwardWrwTime(float kernel_total_time, float
     printf("GPU Kernel Time Backward Weights Conv. Elapsed: %f ms (average)\n",
            kernel_average_time);
 
-    const auto num_dim = miopen::deref(inputTensor).GetSize() - 2;
+    const auto num_dim = miopen::deref(inputTensor).GetNumDims() - 2;
     if(num_dim != 2 && num_dim != 3)
     {
         printf("stats: <not implemented> for conv%dd\n", num_dim);

--- a/driver/dropout_gpu_emulator.hpp
+++ b/driver/dropout_gpu_emulator.hpp
@@ -208,8 +208,8 @@ void RunDropoutForwardEmulator(miopenHandle_t handle,
                                size_t rsvsp_offset = 0)
 {
     (void)noise_shape;
-    auto in_dim  = miopen::deref(inputTensor).GetSize();
-    auto out_dim = miopen::deref(outputTensor).GetSize();
+    auto in_dim  = miopen::deref(inputTensor).GetNumDims();
+    auto out_dim = miopen::deref(outputTensor).GetNumDims();
     if(in_dim != out_dim)
     {
         printf("CPU verification: Input/Output dimension does not match\n");
@@ -292,8 +292,8 @@ void RunDropoutBackwardEmulator(const miopenDropoutDescriptor_t dropoutDesc,
                                 size_t out_offset   = 0,
                                 size_t rsvsp_offset = 0)
 {
-    auto in_dim  = miopen::deref(inputTensor).GetSize();
-    auto out_dim = miopen::deref(outputTensor).GetSize();
+    auto in_dim  = miopen::deref(inputTensor).GetNumDims();
+    auto out_dim = miopen::deref(outputTensor).GetNumDims();
     if(in_dim != out_dim)
     {
         printf("CPU verification: Input/Output dimension does not match\n");

--- a/driver/tensor_driver.hpp
+++ b/driver/tensor_driver.hpp
@@ -101,7 +101,7 @@ inline std::vector<int> GetTensorLengths(const miopenTensorDescriptor_t& tensor)
     }
 
     std::vector<int> tensor_len;
-    tensor_len.resize(miopen::deref(tensor).GetSize());
+    tensor_len.resize(miopen::deref(tensor).GetNumDims());
     miopenGetTensorDescriptor(tensor, nullptr, tensor_len.data(), nullptr);
 
     return tensor_len;
@@ -131,7 +131,7 @@ inline std::vector<int> GetTensorStrides(const miopenTensorDescriptor_t& tensor)
     }
 
     std::vector<int> tensor_strides;
-    tensor_strides.resize(miopen::deref(tensor).GetSize());
+    tensor_strides.resize(miopen::deref(tensor).GetNumDims());
 
     miopenGetTensorDescriptor(tensor, nullptr, nullptr, tensor_strides.data());
 

--- a/src/conv/invokers/impl_gemm.cpp
+++ b/src/conv/invokers/impl_gemm.cpp
@@ -139,8 +139,8 @@ InvokerFactory MakeImplGemmDataInvokerFactory(const ProblemDescription& problem)
                     {
                         if(tensors.wDesc.GetLengths()[2] == 1 && tensors.wDesc.GetLengths()[3] == 1)
                         { // filter = 1
-                            if(tensors.wDesc.GetSize() == 4 ||
-                               (tensors.wDesc.GetSize() == 5 && tensors.wDesc.GetLengths()[4] == 1))
+                            if(tensors.wDesc.GetNumDims() == 4 ||
+                               (tensors.wDesc.GetNumDims() == 5 && tensors.wDesc.GetLengths()[4] == 1))
                             {
                                 is_1x1_s1 = true;
                             }

--- a/src/conv/invokers/impl_gemm.cpp
+++ b/src/conv/invokers/impl_gemm.cpp
@@ -140,7 +140,8 @@ InvokerFactory MakeImplGemmDataInvokerFactory(const ProblemDescription& problem)
                         if(tensors.wDesc.GetLengths()[2] == 1 && tensors.wDesc.GetLengths()[3] == 1)
                         { // filter = 1
                             if(tensors.wDesc.GetNumDims() == 4 ||
-                               (tensors.wDesc.GetNumDims() == 5 && tensors.wDesc.GetLengths()[4] == 1))
+                               (tensors.wDesc.GetNumDims() == 5 &&
+                                tensors.wDesc.GetLengths()[4] == 1))
                             {
                                 is_1x1_s1 = true;
                             }

--- a/src/convolution.cpp
+++ b/src/convolution.cpp
@@ -355,7 +355,7 @@ ConvolutionDescriptor::GetForwardOutputTensorWithLayout(const TensorDescriptor& 
     out_lens[0] = in_n;
     out_lens[1] = out_c;
 
-    const std::string default_layout = tensor_layout_get_default(xDesc.GetSize());
+    const std::string default_layout = tensor_layout_get_default(xDesc.GetNumDims());
     std::vector<std::size_t> out_strides;
     tensor_layout_to_strides(
         out_lens, default_layout, yLayout, xDesc.GetVectorLength(), out_strides);
@@ -373,7 +373,7 @@ TensorDescriptor ConvolutionDescriptor::GetForwardOutputTensor(const TensorDescr
                                                                miopenDataType_t yType) const
 {
     // output layout same as input
-    const std::string default_layout = tensor_layout_get_default(xDesc.GetSize());
+    const std::string default_layout = tensor_layout_get_default(xDesc.GetNumDims());
     const std::string in_layout      = xDesc.GetLayout(default_layout);
     return GetForwardOutputTensorWithLayout(xDesc, wDesc, in_layout, yType);
 }

--- a/src/convolution_api.cpp
+++ b/src/convolution_api.cpp
@@ -344,9 +344,9 @@ miopenGetConvolutionNdForwardOutputDim(miopenConvolutionDescriptor_t convDesc,
         auto out_desc = miopen::deref(convDesc).GetForwardOutputTensor(
             miopen::deref(inputTensorDesc), miopen::deref(filterDesc));
 
-        miopen::deref(nDim) = out_desc.GetSize();
+        miopen::deref(nDim) = out_desc.GetNumDims();
 
-        for(int i = 0; i < out_desc.GetSize(); ++i)
+        for(unsigned i = 0; i < out_desc.GetNumDims(); ++i)
         {
             outputTensorDimA[i] = out_desc.GetLengths()[i];
         }

--- a/src/fusion.cpp
+++ b/src/fusion.cpp
@@ -98,7 +98,7 @@ miopenStatus_t ConvBiasActivFusion(Handle& handle,
     float falpha1 = alpha1 != nullptr ? *(static_cast<const float*>(alpha1)) : 1.0f;
     float falpha2 = alpha2 != nullptr ? *(static_cast<const float*>(alpha2)) : 1.0f;
 
-    // if(z != nullptr || zDesc.GetSize() != 0)
+    // if(z != nullptr || zDesc.GetNumDims() != 0)
     // MIOPEN_THROW(miopenStatusNotImplemented, "The addition of z vector is not yet supported");
     FusionPlanDescriptor fusePlanDesc{miopenVerticalFusion, xDesc};
     OperatorArgs fusionArgs;

--- a/src/include/miopen/conv/problem_description.hpp
+++ b/src/include/miopen/conv/problem_description.hpp
@@ -189,19 +189,7 @@ struct ProblemDescription : ProblemDescriptionBase
     std::size_t GetInStrideH() const { return GetH5(GetSpatialDims(), in.GetStrides()); }
     std::size_t GetInStrideW() const { return GetW5(GetSpatialDims(), in.GetStrides()); }
     std::string GetInLayout() const { return in_layout; }
-    std::string ComputeInLayout() const
-    {
-        if(GetSpatialDims() == 2)
-        {
-            return in.GetLayout(in.GetLayout_str());
-        }
-        else
-        {
-            return in.GetLayout("NCDHW");
-        }
-    }
     std::size_t GetInElementSize() const { return GetTypeSize(GetInDataType()); }
-
     std::size_t GetInSize() const { return in.GetNumBytes(); }
 
     // Out getters
@@ -218,19 +206,7 @@ struct ProblemDescription : ProblemDescriptionBase
     std::size_t GetOutStrideH() const { return GetH5(GetSpatialDims(), out.GetStrides()); }
     std::size_t GetOutStrideW() const { return GetW5(GetSpatialDims(), out.GetStrides()); }
     std::string GetOutLayout() const { return out_layout; }
-    std::string ComputeOutLayout() const
-    {
-        if(GetSpatialDims() == 2)
-        {
-            return out.GetLayout(out.GetLayout_str());
-        }
-        else
-        {
-            return out.GetLayout("NCDHW");
-        }
-    }
     std::size_t GetOutElementSize() const { return GetTypeSize(GetOutDataType()); }
-
     std::size_t GetOutSize() const { return out.GetNumBytes(); }
 
     // Weights getters
@@ -258,19 +234,7 @@ struct ProblemDescription : ProblemDescriptionBase
     // std::size_t GetWeightsStrideW() const { return GetW5(GetSpatialDims(), weights.GetStrides());
     // }
     std::string GetWeightsLayout() const { return weights_layout; }
-    std::string ComputeWeightsLayout() const
-    {
-        if(GetSpatialDims() == 2)
-        {
-            return weights.GetLayout(weights.GetLayout_str());
-        }
-        else
-        {
-            return weights.GetLayout("NCDHW");
-        }
-    }
     std::size_t GetWeightsElementSize() const { return GetTypeSize(GetWeightsDataType()); }
-
     std::size_t GetWeightsSize() const { return weights.GetNumBytes(); }
 
     const TensorDescriptor& GetIn() const { return in; }
@@ -458,6 +422,42 @@ struct ProblemDescription : ProblemDescriptionBase
     void SetupFloats(ExecutionContext& ctx) const;
 
 private:
+    std::string ComputeInLayout() const
+    {
+        if(GetSpatialDims() == 2)
+        {
+            return in.GetLayout(in.GetLayout_str());
+        }
+        else
+        {
+            return in.GetLayout("NCDHW");
+        }
+    }
+
+    std::string ComputeOutLayout() const
+    {
+        if(GetSpatialDims() == 2)
+        {
+            return out.GetLayout(out.GetLayout_str());
+        }
+        else
+        {
+            return out.GetLayout("NCDHW");
+        }
+    }
+
+    std::string ComputeWeightsLayout() const
+    {
+        if(GetSpatialDims() == 2)
+        {
+            return weights.GetLayout(weights.GetLayout_str());
+        }
+        else
+        {
+            return weights.GetLayout("NCDHW");
+        }
+    }
+
     TensorDescriptor in;
     TensorDescriptor weights;
     TensorDescriptor out;

--- a/src/include/miopen/conv/problem_description.hpp
+++ b/src/include/miopen/conv/problem_description.hpp
@@ -204,8 +204,7 @@ struct ProblemDescription : ProblemDescriptionBase
 
     std::size_t GetInSize() const
     {
-        return GetInBatchSize() * GetInChannels() * GetInDepth() * GetInHeight() * GetInWidth() *
-               GetInElementSize();
+        return in.GetNumBytes();
     }
 
     // Out getters
@@ -237,8 +236,7 @@ struct ProblemDescription : ProblemDescriptionBase
 
     std::size_t GetOutSize() const
     {
-        return GetOutBatchSize() * GetOutChannels() * GetOutDepth() * GetOutHeight() *
-               GetOutWidth() * GetOutElementSize();
+        return out.GetNumBytes();
     }
 
     // Weights getters
@@ -281,8 +279,7 @@ struct ProblemDescription : ProblemDescriptionBase
 
     std::size_t GetWeightsSize() const
     {
-        return GetInChannels() * GetOutChannels() * GetWeightsDepth() * GetWeightsHeight() *
-               GetWeightsWidth() * GetWeightsElementSize();
+        return weights.GetNumBytes();
     }
 
     const TensorDescriptor& GetIn() const { return in; }

--- a/src/include/miopen/conv/problem_description.hpp
+++ b/src/include/miopen/conv/problem_description.hpp
@@ -202,10 +202,7 @@ struct ProblemDescription : ProblemDescriptionBase
     }
     std::size_t GetInElementSize() const { return GetTypeSize(GetInDataType()); }
 
-    std::size_t GetInSize() const
-    {
-        return in.GetNumBytes();
-    }
+    std::size_t GetInSize() const { return in.GetNumBytes(); }
 
     // Out getters
     miopenDataType_t GetOutDataType() const { return out.GetType(); }
@@ -234,10 +231,7 @@ struct ProblemDescription : ProblemDescriptionBase
     }
     std::size_t GetOutElementSize() const { return GetTypeSize(GetOutDataType()); }
 
-    std::size_t GetOutSize() const
-    {
-        return out.GetNumBytes();
-    }
+    std::size_t GetOutSize() const { return out.GetNumBytes(); }
 
     // Weights getters
     miopenDataType_t GetWeightsDataType() const { return weights.GetType(); }
@@ -277,10 +271,7 @@ struct ProblemDescription : ProblemDescriptionBase
     }
     std::size_t GetWeightsElementSize() const { return GetTypeSize(GetWeightsDataType()); }
 
-    std::size_t GetWeightsSize() const
-    {
-        return weights.GetNumBytes();
-    }
+    std::size_t GetWeightsSize() const { return weights.GetNumBytes(); }
 
     const TensorDescriptor& GetIn() const { return in; }
     const TensorDescriptor& GetWeights() const { return weights; }

--- a/src/include/miopen/tensor.hpp
+++ b/src/include/miopen/tensor.hpp
@@ -180,7 +180,7 @@ struct MIOPEN_EXPORT TensorDescriptor : miopenTensorDescriptor
 
     const std::vector<std::size_t>& GetLengths() const;
     const std::vector<std::size_t>& GetStrides() const;
-    // This name is misleading, all the usages shold be replaced with GetNumDims()
+    // This name is misleading, all the usages should be replaced with GetNumDims()
     int GetSize() const;
     unsigned GetNumDims() const;
 

--- a/src/include/miopen/tensor.hpp
+++ b/src/include/miopen/tensor.hpp
@@ -180,8 +180,6 @@ struct MIOPEN_EXPORT TensorDescriptor : miopenTensorDescriptor
 
     const std::vector<std::size_t>& GetLengths() const;
     const std::vector<std::size_t>& GetStrides() const;
-    // This name is misleading, all the usages should be replaced with GetNumDims()
-    int GetSize() const;
     unsigned GetNumDims() const;
 
     miopenDataType_t GetType() const;

--- a/src/include/miopen/tensor.hpp
+++ b/src/include/miopen/tensor.hpp
@@ -180,7 +180,9 @@ struct MIOPEN_EXPORT TensorDescriptor : miopenTensorDescriptor
 
     const std::vector<std::size_t>& GetLengths() const;
     const std::vector<std::size_t>& GetStrides() const;
+    // This name is misleading, all the usages shold be replaced with GetNumDims()
     int GetSize() const;
+    unsigned GetNumDims() const;
 
     miopenDataType_t GetType() const;
     miopenTensorLayout_t GetLayout_t() const;

--- a/src/include/miopen/tensor_layout.hpp
+++ b/src/include/miopen/tensor_layout.hpp
@@ -105,7 +105,7 @@ void tensor_layout_to_strides(const std::vector<T>& len,
         });
 }
 
-inline std::string tensor_layout_get_default(int size)
+inline std::string tensor_layout_get_default(unsigned size)
 {
     if(size == 4)
         return "NCHW";

--- a/src/include/miopen/utility/transposing_solver.hpp
+++ b/src/include/miopen/utility/transposing_solver.hpp
@@ -292,7 +292,7 @@ struct ProblemTensorTransposeDescriptor
 
     inline TensorDescriptor Transpose(const TensorDescriptor& in) const
     {
-        const auto labels    = tensor_layout_get_default(in.GetSize());
+        const auto labels    = tensor_layout_get_default(in.GetNumDims());
         auto derived_strides = std::vector<size_t>{};
         tensor_layout_to_strides(
             in.GetLengths(), labels, SyncLayoutDims(labels.c_str(), to), derived_strides);
@@ -441,7 +441,7 @@ struct TransposingSolver : Base
         for(auto transpose : Derived::GetTransposes())
         {
             decltype(auto) descriptor = (problem.*(transpose.cdescriptor))();
-            const auto labels         = tensor_layout_get_default(descriptor.GetSize());
+            const auto labels         = tensor_layout_get_default(descriptor.GetNumDims());
             const auto layout         = descriptor.GetLayout(labels);
             const auto to             = SyncLayoutDims(layout.c_str(), transpose.to);
 
@@ -488,7 +488,7 @@ struct TransposingSolver : Base
         for(auto transpose : Derived::GetTransposes())
         {
             const auto& descriptor = (problem.*(transpose.cdescriptor))();
-            const auto labels      = tensor_layout_get_default(descriptor.GetSize());
+            const auto labels      = tensor_layout_get_default(descriptor.GetNumDims());
             const auto layout      = descriptor.GetLayout(labels);
             const auto to          = SyncLayoutDims(labels.c_str(), transpose.to);
 

--- a/src/ocl/batchnormocl.cpp
+++ b/src/ocl/batchnormocl.cpp
@@ -68,7 +68,8 @@ void BatchNormForwardTraining(Handle& handle,
     {
         MIOPEN_THROW(miopenStatusBadParm);
     }
-    if(xDesc.GetNumDims() != yDesc.GetNumDims() || xDesc.GetNumDims() != bnScaleBiasMeanVarDesc.GetNumDims())
+    if(xDesc.GetNumDims() != yDesc.GetNumDims() ||
+       xDesc.GetNumDims() != bnScaleBiasMeanVarDesc.GetNumDims())
     {
         MIOPEN_THROW(miopenStatusBadParm);
     }
@@ -297,7 +298,8 @@ void BatchNormBackward(Handle& handle,
     {
         MIOPEN_THROW(miopenStatusBadParm);
     }
-    if(xDesc.GetNumDims() != dyDesc.GetNumDims() || xDesc.GetNumDims() != bnScaleBiasDiffDesc.GetNumDims())
+    if(xDesc.GetNumDims() != dyDesc.GetNumDims() ||
+       xDesc.GetNumDims() != bnScaleBiasDiffDesc.GetNumDims())
     {
         MIOPEN_THROW(miopenStatusBadParm);
     }

--- a/src/ocl/batchnormocl.cpp
+++ b/src/ocl/batchnormocl.cpp
@@ -68,7 +68,7 @@ void BatchNormForwardTraining(Handle& handle,
     {
         MIOPEN_THROW(miopenStatusBadParm);
     }
-    if(xDesc.GetSize() != yDesc.GetSize() || xDesc.GetSize() != bnScaleBiasMeanVarDesc.GetSize())
+    if(xDesc.GetNumDims() != yDesc.GetNumDims() || xDesc.GetNumDims() != bnScaleBiasMeanVarDesc.GetNumDims())
     {
         MIOPEN_THROW(miopenStatusBadParm);
     }
@@ -81,7 +81,7 @@ void BatchNormForwardTraining(Handle& handle,
         MIOPEN_LOG_E("Only fully packed tensors supported.");
         MIOPEN_THROW(miopenStatusBadParm);
     }
-    if(xDesc.GetSize() < 3)
+    if(xDesc.GetNumDims() < 3)
     {
         MIOPEN_THROW(miopenStatusBadParm);
     }
@@ -185,8 +185,8 @@ void BatchNormForwardInference(Handle& handle,
         {
             MIOPEN_THROW(miopenStatusBadParm);
         }
-        if(xDesc.GetSize() != yDesc.GetSize() ||
-           xDesc.GetSize() != bnScaleBiasMeanVarDesc.GetSize())
+        if(xDesc.GetNumDims() != yDesc.GetNumDims() ||
+           xDesc.GetNumDims() != bnScaleBiasMeanVarDesc.GetNumDims())
         {
             MIOPEN_THROW(miopenStatusBadParm);
         }
@@ -194,7 +194,7 @@ void BatchNormForwardInference(Handle& handle,
         {
             MIOPEN_THROW(miopenStatusBadParm);
         }
-        if(xDesc.GetSize() < 3)
+        if(xDesc.GetNumDims() < 3)
         {
             MIOPEN_THROW(miopenStatusBadParm);
         }
@@ -297,7 +297,7 @@ void BatchNormBackward(Handle& handle,
     {
         MIOPEN_THROW(miopenStatusBadParm);
     }
-    if(xDesc.GetSize() != dyDesc.GetSize() || xDesc.GetSize() != bnScaleBiasDiffDesc.GetSize())
+    if(xDesc.GetNumDims() != dyDesc.GetNumDims() || xDesc.GetNumDims() != bnScaleBiasDiffDesc.GetNumDims())
     {
         MIOPEN_THROW(miopenStatusBadParm);
     }
@@ -305,7 +305,7 @@ void BatchNormBackward(Handle& handle,
     {
         MIOPEN_THROW(miopenStatusBadParm);
     }
-    if(xDesc.GetSize() < 3)
+    if(xDesc.GetNumDims() < 3)
     {
         MIOPEN_THROW(miopenStatusBadParm);
     }

--- a/src/ocl/convolutionocl.cpp
+++ b/src/ocl/convolutionocl.cpp
@@ -453,14 +453,14 @@ void ConvolutionDescriptor::ValidateTensors(const ConvTensors& tensors) const
     }
 
     // x_tensor_invalid =
-    if(tensors.xDesc.GetSize() < 3)
+    if(tensors.xDesc.GetNumDims() < 3)
     {
         MIOPEN_THROW(miopenStatusBadParm, "input tensor's number of dimensions is wrong");
     }
 
     // tensor_sizes_not_matched =
-    if(tensors.xDesc.GetSize() != tensors.yDesc.GetSize() ||
-       tensors.xDesc.GetSize() != tensors.wDesc.GetSize())
+    if(tensors.xDesc.GetNumDims() != tensors.yDesc.GetNumDims() ||
+       tensors.xDesc.GetNumDims() != tensors.wDesc.GetNumDims())
     {
         MIOPEN_THROW(miopenStatusBadParm,
                      "number of dimensions mismatch between input, output and weights tensors");

--- a/src/ocl/dropoutocl.cpp
+++ b/src/ocl/dropoutocl.cpp
@@ -181,12 +181,12 @@ void DropoutDescriptor::DropoutForward(const Handle& handle,
         MIOPEN_THROW(miopenStatusBadParm);
     }
 
-    if(xDesc.GetSize() != yDesc.GetSize())
+    if(xDesc.GetNumDims() != yDesc.GetNumDims())
     {
         MIOPEN_THROW("Input/Output dimension does not match");
     }
 
-    if(xDesc.GetSize() > 5)
+    if(xDesc.GetNumDims() > 5)
     {
         MIOPEN_THROW("Only support 1D to 5D tensors");
     }
@@ -197,7 +197,7 @@ void DropoutDescriptor::DropoutForward(const Handle& handle,
     }
 
     if(xDesc.GetElementSize() != noise_shape.GetElementSize() ||
-       xDesc.GetSize() != noise_shape.GetSize())
+       xDesc.GetNumDims() != noise_shape.GetNumDims())
     {
         MIOPEN_THROW("Only support dropout with regular noise shape currently");
     }
@@ -277,7 +277,7 @@ void DropoutDescriptor::DropoutForward(const Handle& handle,
         std::to_string(wk_grp_num) /* + "-noise" + std::to_string(noise_shape.GetLengths()[0])*/;
 
     // TODO: Add noise shape
-    // for(int i = 1; i < noise_shape.GetSize(); i++)
+    // for(int i = 1; i < noise_shape.GetNumDims(); i++)
     //    network_config += "x" + std::to_string(noise_shape.GetLengths()[i]);
 
     auto&& kernels = handle.GetKernels(kernel_name, network_config);
@@ -385,12 +385,12 @@ void DropoutDescriptor::DropoutBackward(const Handle& handle,
         MIOPEN_THROW(miopenStatusBadParm);
     }
 
-    if(dxDesc.GetSize() != dyDesc.GetSize())
+    if(dxDesc.GetNumDims() != dyDesc.GetNumDims())
     {
         MIOPEN_THROW("Input/Output dimension does not match");
     }
 
-    if(dyDesc.GetSize() > 5)
+    if(dyDesc.GetNumDims() > 5)
     {
         MIOPEN_THROW("Only support 1D to 5D tensors");
     }
@@ -401,7 +401,7 @@ void DropoutDescriptor::DropoutBackward(const Handle& handle,
     }
 
     if(dxDesc.GetElementSize() != noise_shape.GetElementSize() ||
-       dxDesc.GetSize() != noise_shape.GetSize())
+       dxDesc.GetNumDims() != noise_shape.GetNumDims())
     {
         MIOPEN_THROW("Only support dropout with regular noise shape currently");
     }
@@ -482,7 +482,7 @@ void DropoutDescriptor::DropoutBackward(const Handle& handle,
         std::to_string(wk_grp_num) /* + "-noise" + std::to_string(noise_shape.GetLengths()[0]) */;
 
     // TODO: Add noise shape
-    // for(int i = 1; i < noise_shape.GetSize(); i++)
+    // for(int i = 1; i < noise_shape.GetNumDims(); i++)
     //    network_config += "x" + std::to_string(noise_shape.GetLengths()[i]);
 
     auto&& kernels = handle.GetKernels(kernel_name, network_config);

--- a/src/ocl/pooling_ocl.cpp
+++ b/src/ocl/pooling_ocl.cpp
@@ -80,7 +80,7 @@ miopenStatus_t PoolingDescriptor::Forward(Handle& handle,
         }
     }
 
-    int pool_dim = xDesc.GetSize();
+    unsigned pool_dim = xDesc.GetNumDims();
     if(pool_dim != 4 && pool_dim != 5)
     {
         MIOPEN_THROW("Unsupported pooling dimension");
@@ -171,7 +171,7 @@ miopenStatus_t PoolingDescriptor::Backward(Handle& handle,
     assert(yDesc.GetElementSize() == dyDesc.GetElementSize() &&
            xDesc.GetElementSize() == dxDesc.GetElementSize());
 
-    int pool_dim = dyDesc.GetSize();
+    unsigned pool_dim = dyDesc.GetNumDims();
     if(pool_dim != 4 && pool_dim != 5)
     {
         MIOPEN_THROW("Unsupported pooling dimension");

--- a/src/ocl/rnnocl.cpp
+++ b/src/ocl/rnnocl.cpp
@@ -3973,9 +3973,9 @@ void RNNDescriptor::RNNBackwardData(Handle& handle,
     {
         MIOPEN_THROW(miopenStatusBadParm);
     }
-    if(dhyDesc.GetNumDims() != dcyDesc.GetNumDims() || dhyDesc.GetNumDims() != hxDesc.GetNumDims() ||
-       dhyDesc.GetNumDims() != cxDesc.GetNumDims() || dhyDesc.GetNumDims() != dhxDesc.GetNumDims() ||
-       dhyDesc.GetNumDims() != dcxDesc.GetNumDims())
+    if(dhyDesc.GetNumDims() != dcyDesc.GetNumDims() ||
+       dhyDesc.GetNumDims() != hxDesc.GetNumDims() || dhyDesc.GetNumDims() != cxDesc.GetNumDims() ||
+       dhyDesc.GetNumDims() != dhxDesc.GetNumDims() || dhyDesc.GetNumDims() != dcxDesc.GetNumDims())
     {
         MIOPEN_THROW(miopenStatusBadParm);
     }
@@ -4108,7 +4108,8 @@ void RNNDescriptor::RNNBackwardDataPackedTensors(
 
     // if projections supported, dcxDesc.GetLengths()[2] should be used for hidden_size,
     // dhxDesc.GetLengths()[2] for proj_size.
-    if(dhxDesc.GetNumDims() != dcxDesc.GetNumDims() || dhxDesc.GetLengths()[2] != dcxDesc.GetLengths()[2])
+    if(dhxDesc.GetNumDims() != dcxDesc.GetNumDims() ||
+       dhxDesc.GetLengths()[2] != dcxDesc.GetLengths()[2])
     {
         MIOPEN_THROW(miopenStatusBadParm);
     }

--- a/src/ocl/rnnocl.cpp
+++ b/src/ocl/rnnocl.cpp
@@ -1099,8 +1099,8 @@ void RNNDescriptor::RNNForwardInference(Handle& handle,
     {
         MIOPEN_THROW(miopenStatusBadParm);
     }
-    if(hxDesc.GetSize() != cxDesc.GetSize() || hxDesc.GetSize() != hyDesc.GetSize() ||
-       hxDesc.GetSize() != cyDesc.GetSize())
+    if(hxDesc.GetNumDims() != cxDesc.GetNumDims() || hxDesc.GetNumDims() != hyDesc.GetNumDims() ||
+       hxDesc.GetNumDims() != cyDesc.GetNumDims())
     {
         MIOPEN_THROW(miopenStatusBadParm);
     }
@@ -2488,8 +2488,8 @@ void RNNDescriptor::RNNForwardTraining(Handle& handle,
     {
         MIOPEN_THROW(miopenStatusBadParm);
     }
-    if(hxDesc.GetSize() != cxDesc.GetSize() || hxDesc.GetSize() != hyDesc.GetSize() ||
-       hxDesc.GetSize() != cyDesc.GetSize())
+    if(hxDesc.GetNumDims() != cxDesc.GetNumDims() || hxDesc.GetNumDims() != hyDesc.GetNumDims() ||
+       hxDesc.GetNumDims() != cyDesc.GetNumDims())
     {
         MIOPEN_THROW(miopenStatusBadParm);
     }
@@ -3973,9 +3973,9 @@ void RNNDescriptor::RNNBackwardData(Handle& handle,
     {
         MIOPEN_THROW(miopenStatusBadParm);
     }
-    if(dhyDesc.GetSize() != dcyDesc.GetSize() || dhyDesc.GetSize() != hxDesc.GetSize() ||
-       dhyDesc.GetSize() != cxDesc.GetSize() || dhyDesc.GetSize() != dhxDesc.GetSize() ||
-       dhyDesc.GetSize() != dcxDesc.GetSize())
+    if(dhyDesc.GetNumDims() != dcyDesc.GetNumDims() || dhyDesc.GetNumDims() != hxDesc.GetNumDims() ||
+       dhyDesc.GetNumDims() != cxDesc.GetNumDims() || dhyDesc.GetNumDims() != dhxDesc.GetNumDims() ||
+       dhyDesc.GetNumDims() != dcxDesc.GetNumDims())
     {
         MIOPEN_THROW(miopenStatusBadParm);
     }
@@ -4108,7 +4108,7 @@ void RNNDescriptor::RNNBackwardDataPackedTensors(
 
     // if projections supported, dcxDesc.GetLengths()[2] should be used for hidden_size,
     // dhxDesc.GetLengths()[2] for proj_size.
-    if(dhxDesc.GetSize() != dcxDesc.GetSize() || dhxDesc.GetLengths()[2] != dcxDesc.GetLengths()[2])
+    if(dhxDesc.GetNumDims() != dcxDesc.GetNumDims() || dhxDesc.GetLengths()[2] != dcxDesc.GetLengths()[2])
     {
         MIOPEN_THROW(miopenStatusBadParm);
     }

--- a/src/ocl/tensorocl.cpp
+++ b/src/ocl/tensorocl.cpp
@@ -1430,7 +1430,7 @@ void SetTensor(const Handle& handle,
     const TensorDescriptor yDesc_flat = GetFlattenedTensorDescriptor(yDesc);
 
 #ifndef NDEBUG
-    if(yDesc.GetSize() != yDesc_flat.GetSize())
+    if(yDesc.GetNumDims() != yDesc_flat.GetNumDims())
     {
         MIOPEN_LOG_I2(__func__ << std::endl
                                << "real descriptor: " << yDesc << std::endl
@@ -1438,7 +1438,7 @@ void SetTensor(const Handle& handle,
     }
 #endif
 
-    const std::size_t yDim_flat = yDesc_flat.GetSize();
+    const std::size_t yDim_flat = yDesc_flat.GetNumDims();
 
     assert(yDim_flat > 0 && yDim_flat <= 5);
 
@@ -1584,7 +1584,7 @@ void ScaleTensor(const Handle& handle,
     const TensorDescriptor yDesc_flat = GetFlattenedTensorDescriptor(yDesc);
 
 #ifndef NDEBUG
-    if(yDesc.GetSize() != yDesc_flat.GetSize())
+    if(yDesc.GetNumDims() != yDesc_flat.GetNumDims())
     {
         MIOPEN_LOG_I2(__func__ << std::endl
                                << "real descriptor: " << yDesc << std::endl
@@ -1592,7 +1592,7 @@ void ScaleTensor(const Handle& handle,
     }
 #endif
 
-    const std::size_t yDim_flat = yDesc_flat.GetSize();
+    const std::size_t yDim_flat = yDesc_flat.GetNumDims();
 
     assert(yDim_flat > 0 && yDim_flat <= 5);
 
@@ -1763,7 +1763,7 @@ void CopyTensor(const Handle& handle,
     const TensorDescriptor& dstDesc_flat = std::get<1>(flat_descriptors);
 
 #ifndef NDEBUG
-    if(srcDesc.GetSize() != srcDesc_flat.GetSize())
+    if(srcDesc.GetNumDims() != srcDesc_flat.GetNumDims())
     {
         MIOPEN_LOG_I2(__func__ << std::endl
                                << "src real descriptor: " << srcDesc << std::endl
@@ -1773,7 +1773,7 @@ void CopyTensor(const Handle& handle,
     }
 #endif
 
-    std::size_t srcDim_flat = srcDesc_flat.GetSize();
+    std::size_t srcDim_flat = srcDesc_flat.GetNumDims();
 
     if(srcDim_flat < 1 || srcDim_flat > 5)
     {
@@ -1973,7 +1973,7 @@ void CastTensor(const Handle& handle,
     const TensorDescriptor& dstDesc_flat = std::get<1>(flat_descriptors);
 
 #ifndef NDEBUG
-    if(srcDesc.GetSize() != srcDesc_flat.GetSize())
+    if(srcDesc.GetNumDims() != srcDesc_flat.GetNumDims())
     {
         MIOPEN_LOG_I2(__func__ << std::endl
                                << "src real descriptor: " << srcDesc << std::endl
@@ -1983,7 +1983,7 @@ void CastTensor(const Handle& handle,
     }
 #endif
 
-    std::size_t srcDim_flat = srcDesc_flat.GetSize();
+    std::size_t srcDim_flat = srcDesc_flat.GetNumDims();
 
     if(srcDim_flat < 1 || srcDim_flat > 5)
     {
@@ -2257,14 +2257,14 @@ void TransformTensor(const Handle& handle,
         const TensorDescriptor& yDesc_flat = std::get<1>(flat_descriptors);
 
 #ifndef NDEBUG
-        if(xDesc.GetSize() != xDesc_flat.GetSize())
+        if(xDesc.GetNumDims() != xDesc_flat.GetNumDims())
         {
             MIOPEN_LOG_I2(__func__ << std::endl
                                    << "real descriptor: " << xDesc << std::endl
                                    << "flat descriptor: " << xDesc_flat << std::endl);
         }
 
-        if(yDesc.GetSize() != yDesc_flat.GetSize())
+        if(yDesc.GetNumDims() != yDesc_flat.GetNumDims())
         {
             MIOPEN_LOG_I2(__func__ << std::endl
                                    << "real descriptor: " << yDesc << std::endl
@@ -2272,7 +2272,7 @@ void TransformTensor(const Handle& handle,
         }
 #endif
 
-        const std::size_t yDim_flat = yDesc_flat.GetSize();
+        const std::size_t yDim_flat = yDesc_flat.GetNumDims();
 
         assert(yDim_flat > 0 && yDim_flat <= 5);
 

--- a/src/pooling.cpp
+++ b/src/pooling.cpp
@@ -215,10 +215,10 @@ void PoolingDescriptor::GetForwardOutputDimNd(const TensorDescriptor& xDesc,
 
 TensorDescriptor PoolingDescriptor::GetForwardOutputTensor(const TensorDescriptor& xDesc) const
 {
-    std::vector<int> out_dim(xDesc.GetSize());
-    GetForwardOutputDimNd(xDesc, xDesc.GetSize(), out_dim.data());
+    std::vector<int> out_dim(xDesc.GetNumDims());
+    GetForwardOutputDimNd(xDesc, xDesc.GetNumDims(), out_dim.data());
 
-    const std::string default_layout = tensor_layout_get_default(xDesc.GetSize());
+    const std::string default_layout = tensor_layout_get_default(xDesc.GetNumDims());
     const std::string in_layout      = xDesc.GetLayout(default_layout);
     std::vector<int> out_strides;
     tensor_layout_to_strides(out_dim, default_layout, in_layout, out_strides);
@@ -233,7 +233,7 @@ std::size_t PoolingDescriptor::GetWorkSpaceSize(const TensorDescriptor& yDesc) c
 
     const auto main_ws = GetMode() == miopenPoolingMax ? y_size * index_e_size : 0;
 
-    const auto labels        = tensor_layout_get_default(yDesc.GetSize());
+    const auto labels        = tensor_layout_get_default(yDesc.GetNumDims());
     std::size_t transpose_ws = 0;
 
     if(yDesc.GetLayout(labels) != labels)

--- a/src/pooling_api.cpp
+++ b/src/pooling_api.cpp
@@ -41,7 +41,7 @@ inline void Pooling_logging_cmd(const miopenPoolingDescriptor_t poolDesc,
 {
     if(miopen::IsLoggingCmd())
     {
-        auto tensor_dim = miopen::deref(tensorDesc).GetSize();
+        auto tensor_dim = miopen::deref(tensorDesc).GetNumDims();
         std::stringstream ss;
 
         switch(miopen::deref(tensorDesc).GetType())

--- a/src/rnn.cpp
+++ b/src/rnn.cpp
@@ -1300,7 +1300,7 @@ void RNNDescriptor::RNNForward(Handle& handle,
     {
         MIOPEN_THROW(miopenStatusBadParm);
     }
-    if(hDesc.GetSize() != cDesc.GetSize())
+    if(hDesc.GetNumDims() != cDesc.GetNumDims())
     {
         MIOPEN_THROW(miopenStatusBadParm);
     }
@@ -1405,7 +1405,7 @@ void RNNDescriptor::RNNBackwardData(Handle& handle,
     {
         MIOPEN_THROW(miopenStatusBadParm);
     }
-    if(hDesc.GetSize() != cDesc.GetSize())
+    if(hDesc.GetNumDims() != cDesc.GetNumDims())
     {
         MIOPEN_THROW(miopenStatusBadParm);
     }

--- a/src/solver/activ/bwd_1.cpp
+++ b/src/solver/activ/bwd_1.cpp
@@ -71,14 +71,14 @@ ConvSolution ActivBwdSolver1::GetSolution(const ExecutionContext&,
     int hdOutStride = 0;
     int wdOutStride = 0;
 
-    if(dyDesc.GetSize() == 4)
+    if(dyDesc.GetNumDims() == 4)
     {
         std::tie(ndOut, cdOut, hdOut, wdOut)                         = tien<4>(dyDesc.GetLengths());
         std::tie(ndOutStride, cdOutStride, hdOutStride, wdOutStride) = tien<4>(dyDesc.GetStrides());
     }
-    else if(dyDesc.GetSize() < 4 && dyDesc.GetSize() > 0)
+    else if(dyDesc.GetNumDims() < 4 && dyDesc.GetNumDims() > 0)
     {
-        auto tensor_size = dyDesc.GetSize();
+        auto tensor_size = dyDesc.GetNumDims();
         switch(tensor_size)
         {
         case 1:
@@ -116,14 +116,14 @@ ConvSolution ActivBwdSolver1::GetSolution(const ExecutionContext&,
     int hOutStride = 0;
     int wOutStride = 0;
 
-    if(yDesc.GetSize() == 4)
+    if(yDesc.GetNumDims() == 4)
     {
         std::tie(nOut, cOut, hOut, wOut)                         = tien<4>(yDesc.GetLengths());
         std::tie(nOutStride, cOutStride, hOutStride, wOutStride) = tien<4>(yDesc.GetStrides());
     }
-    else if(yDesc.GetSize() < 4 && yDesc.GetSize() > 0)
+    else if(yDesc.GetNumDims() < 4 && yDesc.GetNumDims() > 0)
     {
-        auto tensor_size = yDesc.GetSize();
+        auto tensor_size = yDesc.GetNumDims();
         switch(tensor_size)
         {
         case 1:
@@ -162,14 +162,14 @@ ConvSolution ActivBwdSolver1::GetSolution(const ExecutionContext&,
     int hdInStride = 0;
     int wdInStride = 0;
 
-    if(dxDesc.GetSize() == 4)
+    if(dxDesc.GetNumDims() == 4)
     {
         std::tie(ndIn, cdIn, hdIn, wdIn)                         = tien<4>(dxDesc.GetLengths());
         std::tie(ndInStride, cdInStride, hdInStride, wdInStride) = tien<4>(dxDesc.GetStrides());
     }
-    else if(dxDesc.GetSize() < 4 && dxDesc.GetSize() > 0)
+    else if(dxDesc.GetNumDims() < 4 && dxDesc.GetNumDims() > 0)
     {
-        auto tensor_size = dxDesc.GetSize();
+        auto tensor_size = dxDesc.GetNumDims();
         switch(tensor_size)
         {
         case 1:
@@ -208,14 +208,14 @@ ConvSolution ActivBwdSolver1::GetSolution(const ExecutionContext&,
     int hInStride = 0;
     int wInStride = 0;
 
-    if(xDesc.GetSize() == 4)
+    if(xDesc.GetNumDims() == 4)
     {
         std::tie(nIn, cIn, hIn, wIn)                         = tien<4>(xDesc.GetLengths());
         std::tie(nInStride, cInStride, hInStride, wInStride) = tien<4>(xDesc.GetStrides());
     }
-    else if(xDesc.GetSize() < 4 && xDesc.GetSize() > 0)
+    else if(xDesc.GetNumDims() < 4 && xDesc.GetNumDims() > 0)
     {
-        auto tensor_size = xDesc.GetSize();
+        auto tensor_size = xDesc.GetNumDims();
         switch(tensor_size)
         {
         case 1:

--- a/src/solver/activ/fwd_1.cpp
+++ b/src/solver/activ/fwd_1.cpp
@@ -67,14 +67,14 @@ ConvSolution ActivFwdSolver1::GetSolution(const ExecutionContext&,
     int hOutStride = 0;
     int wOutStride = 0;
 
-    if(yDesc.GetSize() == 4)
+    if(yDesc.GetNumDims() == 4)
     {
         std::tie(nOut, cOut, hOut, wOut)                         = tien<4>(yDesc.GetLengths());
         std::tie(nOutStride, cOutStride, hOutStride, wOutStride) = tien<4>(yDesc.GetStrides());
     }
-    else if(yDesc.GetSize() < 4 && yDesc.GetSize() > 0)
+    else if(yDesc.GetNumDims() < 4 && yDesc.GetNumDims() > 0)
     {
-        auto tensor_size = yDesc.GetSize();
+        auto tensor_size = yDesc.GetNumDims();
         switch(tensor_size)
         {
         case 1:
@@ -113,14 +113,14 @@ ConvSolution ActivFwdSolver1::GetSolution(const ExecutionContext&,
     int hInStride = 0;
     int wInStride = 0;
 
-    if(xDesc.GetSize() == 4)
+    if(xDesc.GetNumDims() == 4)
     {
         std::tie(nIn, cIn, hIn, wIn)                         = tien<4>(xDesc.GetLengths());
         std::tie(nInStride, cInStride, hInStride, wInStride) = tien<4>(xDesc.GetStrides());
     }
-    else if(xDesc.GetSize() < 4 && xDesc.GetSize() > 0)
+    else if(xDesc.GetNumDims() < 4 && xDesc.GetNumDims() > 0)
     {
-        auto tensor_size = xDesc.GetSize();
+        auto tensor_size = xDesc.GetNumDims();
         switch(tensor_size)
         {
         case 1:

--- a/src/solver/pooling/backward2d.cpp
+++ b/src/solver/pooling/backward2d.cpp
@@ -174,7 +174,7 @@ bool PoolingBackward2d::IsApplicable(const ExecutionContext&,
            (problem.GetPooling().GetMode() == miopenPoolingMax ||
             problem.GetPooling().GetMode() == miopenPoolingAverage ||
             problem.GetPooling().GetMode() == miopenPoolingAverageInclusive) &&
-           problem.GetXDesc().GetSize() == 4 && problem.GetXDesc().GetLayout("NCHW") == "NCHW" &&
+           problem.GetXDesc().GetNumDims() == 4 && problem.GetXDesc().GetLayout("NCHW") == "NCHW" &&
            problem.GetYDesc().GetLayout("NCHW") == "NCHW" &&
            sizeof_local_memory(problem) <= TargetProperties::GetMaxLocalMemorySize();
 }

--- a/src/solver/pooling/backwardNd.cpp
+++ b/src/solver/pooling/backwardNd.cpp
@@ -50,11 +50,11 @@ bool PoolingBackwardNd::IsApplicable(const ExecutionContext&,
                || problem.GetPooling().GetMode() == miopenPoolingAverage           //
                || problem.GetPooling().GetMode() == miopenPoolingAverageInclusive) //
            && (                                                                    //
-                  (problem.GetXDesc().GetNumDims() == 5                               //
+                  (problem.GetXDesc().GetNumDims() == 5                            //
                    && problem.GetXDesc().GetLayout("NCDHW") == "NCDHW"             //
                    && problem.GetYDesc().GetLayout("NCDHW") == "NCDHW")            //
                   ||                                                               //
-                  (problem.GetXDesc().GetNumDims() == 4                               //
+                  (problem.GetXDesc().GetNumDims() == 4                            //
                    && problem.GetXDesc().GetLayout("NCHW") == "NCHW"               //
                    && problem.GetYDesc().GetLayout("NCHW") == "NCHW")              //
                   )                                                                //

--- a/src/solver/pooling/backwardNd.cpp
+++ b/src/solver/pooling/backwardNd.cpp
@@ -50,11 +50,11 @@ bool PoolingBackwardNd::IsApplicable(const ExecutionContext&,
                || problem.GetPooling().GetMode() == miopenPoolingAverage           //
                || problem.GetPooling().GetMode() == miopenPoolingAverageInclusive) //
            && (                                                                    //
-                  (problem.GetXDesc().GetSize() == 5                               //
+                  (problem.GetXDesc().GetNumDims() == 5                               //
                    && problem.GetXDesc().GetLayout("NCDHW") == "NCDHW"             //
                    && problem.GetYDesc().GetLayout("NCDHW") == "NCDHW")            //
                   ||                                                               //
-                  (problem.GetXDesc().GetSize() == 4                               //
+                  (problem.GetXDesc().GetNumDims() == 4                               //
                    && problem.GetXDesc().GetLayout("NCHW") == "NCHW"               //
                    && problem.GetYDesc().GetLayout("NCHW") == "NCHW")              //
                   )                                                                //
@@ -102,7 +102,7 @@ PoolingBackwardNd::GetSolution(const ExecutionContext&,
     int batch = top.GetLengths()[0];
     int chal  = top.GetLengths()[1];
 
-    const bool is2d = (bot.GetSize() == 4);
+    const bool is2d = (bot.GetNumDims() == 4);
 
     int bot_d = is2d ? 1 : *(bot.GetLengths().rbegin() + 2);
     int bot_h = *(bot.GetLengths().rbegin() + 1);

--- a/src/solver/pooling/forward2d.cpp
+++ b/src/solver/pooling/forward2d.cpp
@@ -136,7 +136,7 @@ bool PoolingForward2d::IsApplicable(const ExecutionContext& context,
                                     const miopen::pooling::ProblemDescription& problem) const
 {
     return problem.GetDirection() == miopen::pooling::Direction::Forward &&
-           problem.GetXDesc().GetSize() == 4 &&
+           problem.GetXDesc().GetNumDims() == 4 &&
            problem.GetXDesc().GetType() == problem.GetYDesc().GetType() &&
            (problem.GetXDesc().GetType() == miopenFloat ||
             problem.GetXDesc().GetType() == miopenHalf) &&

--- a/src/solver/pooling/forwardNaive.cpp
+++ b/src/solver/pooling/forwardNaive.cpp
@@ -76,11 +76,11 @@ bool PoolingForwardNaive::IsApplicable(const ExecutionContext&,
                || problem.GetPooling().GetMode() == miopenPoolingAverage           //
                || problem.GetPooling().GetMode() == miopenPoolingAverageInclusive) //
            && (                                                                    //
-                  (problem.GetXDesc().GetSize() == 5                               //
+                  (problem.GetXDesc().GetNumDims() == 5                               //
                    && problem.GetXDesc().GetLayout("NCDHW") == "NCDHW"             //
                    && problem.GetYDesc().GetLayout("NCDHW") == "NCDHW")            //
                   ||                                                               //
-                  (problem.GetXDesc().GetSize() == 4                               //
+                  (problem.GetXDesc().GetNumDims() == 4                               //
                    && problem.GetXDesc().GetLayout("NCHW") == "NCHW"               //
                    && problem.GetYDesc().GetLayout("NCHW") == "NCHW")              //
               );
@@ -94,7 +94,7 @@ PoolingForwardNaive::GetSolution(const ExecutionContext& context,
 
     const auto bot  = problem.GetXDesc();
     const auto top  = problem.GetYDesc();
-    const bool is2d = (bot.GetSize() == 4);
+    const bool is2d = (bot.GetNumDims() == 4);
 
     // To compact code:
     const auto& pooling = problem.GetPooling();

--- a/src/solver/pooling/forwardNaive.cpp
+++ b/src/solver/pooling/forwardNaive.cpp
@@ -76,11 +76,11 @@ bool PoolingForwardNaive::IsApplicable(const ExecutionContext&,
                || problem.GetPooling().GetMode() == miopenPoolingAverage           //
                || problem.GetPooling().GetMode() == miopenPoolingAverageInclusive) //
            && (                                                                    //
-                  (problem.GetXDesc().GetNumDims() == 5                               //
+                  (problem.GetXDesc().GetNumDims() == 5                            //
                    && problem.GetXDesc().GetLayout("NCDHW") == "NCDHW"             //
                    && problem.GetYDesc().GetLayout("NCDHW") == "NCDHW")            //
                   ||                                                               //
-                  (problem.GetXDesc().GetNumDims() == 4                               //
+                  (problem.GetXDesc().GetNumDims() == 4                            //
                    && problem.GetXDesc().GetLayout("NCHW") == "NCHW"               //
                    && problem.GetYDesc().GetLayout("NCHW") == "NCHW")              //
               );

--- a/src/solver/pooling/forwardNd.cpp
+++ b/src/solver/pooling/forwardNd.cpp
@@ -108,7 +108,7 @@ bool PoolingForwardNd::IsApplicable(const ExecutionContext& context,
 {
 
     return problem.GetDirection() == miopen::pooling::Direction::Forward                      //
-           && problem.GetXDesc().GetSize() == 5                                               //
+           && problem.GetXDesc().GetNumDims() == 5                                            //
            && problem.GetXDesc().GetLayout("NCDHW") == "NCDHW"                                //
            && problem.GetYDesc().GetLayout("NCDHW") == "NCDHW"                                //
            && problem.GetXDesc().GetType() == problem.GetYDesc().GetType()                    //

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -331,9 +331,15 @@ const std::vector<std::size_t>& TensorDescriptor::GetLengths() const { return le
 
 const std::vector<std::size_t>& TensorDescriptor::GetStrides() const { return strides; }
 
-int TensorDescriptor::GetSize() const
+unsigned TensorDescriptor::GetNumDims() const
 {
     return lens.size();
+}
+
+// This name is misleading, all the usages shold be replaced with GetNumDims()
+int TensorDescriptor::GetSize() const
+{
+    return GetNumDims();
 }
 
 std::size_t TensorDescriptor::GetElementSize() const

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -333,7 +333,7 @@ const std::vector<std::size_t>& TensorDescriptor::GetStrides() const { return st
 
 unsigned TensorDescriptor::GetNumDims() const { return lens.size(); }
 
-// This name is misleading, all the usages shold be replaced with GetNumDims()
+// This name is misleading, all the usages should be replaced with GetNumDims()
 int TensorDescriptor::GetSize() const { return GetNumDims(); }
 
 std::size_t TensorDescriptor::GetElementSize() const

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -333,13 +333,11 @@ const std::vector<std::size_t>& TensorDescriptor::GetStrides() const { return st
 
 int TensorDescriptor::GetSize() const
 {
-    assert(lens.size() == strides.size());
     return lens.size();
 }
 
 std::size_t TensorDescriptor::GetElementSize() const
 {
-    assert(lens.size() == strides.size());
     return std::accumulate(lens.begin(), lens.end(), vector_length, std::multiplies<std::size_t>());
 }
 

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -333,9 +333,6 @@ const std::vector<std::size_t>& TensorDescriptor::GetStrides() const { return st
 
 unsigned TensorDescriptor::GetNumDims() const { return lens.size(); }
 
-// This name is misleading, all the usages should be replaced with GetNumDims()
-int TensorDescriptor::GetSize() const { return GetNumDims(); }
-
 std::size_t TensorDescriptor::GetElementSize() const
 {
     return std::accumulate(lens.begin(), lens.end(), vector_length, std::multiplies<std::size_t>());
@@ -376,7 +373,7 @@ std::size_t TensorDescriptor::GetIndex(std::initializer_list<int> l) const
     // l is in NCHW order (MIOpen implicit logic)
     if(this->GetLayout_str() == "CHWNc")
     {
-        assert(l.size() - 1 <= this->GetSize());
+        assert(l.size() - 1 <= this->GetNumDims());
         std::initializer_list<int> l_chwn{
             *(l.begin()), *(l.begin() + 2), *(l.begin() + 3), *(l.begin() + 4), *(l.begin() + 1)};
         return std::inner_product(l_chwn.begin() + 1,
@@ -388,12 +385,12 @@ std::size_t TensorDescriptor::GetIndex(std::initializer_list<int> l) const
     {
         if(!this->IsVectorized())
         {
-            assert(l.size() <= this->GetSize());
+            assert(l.size() <= this->GetNumDims());
             return std::inner_product(l.begin(), l.end(), strides.begin(), std::size_t{0});
         }
         else
         {
-            assert(l.size() - 1 <= this->GetSize());
+            assert(l.size() - 1 <= this->GetNumDims());
             return std::inner_product(
                 l.begin() + 1, l.end(), strides.begin(), static_cast<std::size_t>(*(l.begin())));
         }

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -331,16 +331,10 @@ const std::vector<std::size_t>& TensorDescriptor::GetLengths() const { return le
 
 const std::vector<std::size_t>& TensorDescriptor::GetStrides() const { return strides; }
 
-unsigned TensorDescriptor::GetNumDims() const
-{
-    return lens.size();
-}
+unsigned TensorDescriptor::GetNumDims() const { return lens.size(); }
 
 // This name is misleading, all the usages shold be replaced with GetNumDims()
-int TensorDescriptor::GetSize() const
-{
-    return GetNumDims();
-}
+int TensorDescriptor::GetSize() const { return GetNumDims(); }
 
 std::size_t TensorDescriptor::GetElementSize() const
 {

--- a/src/tensor_api.cpp
+++ b/src/tensor_api.cpp
@@ -248,7 +248,7 @@ extern "C" miopenStatus_t miopenGetTensorDescriptorSize(miopenTensorDescriptor_t
                                                         int* size)
 {
     MIOPEN_LOG_FUNCTION(tensorDesc);
-    return miopen::try_([&] { miopen::deref(size) = miopen::deref(tensorDesc).GetSize(); });
+    return miopen::try_([&] { miopen::deref(size) = miopen::deref(tensorDesc).GetNumDims(); });
 }
 
 extern "C" miopenStatus_t miopenGetTensorDescriptor(miopenTensorDescriptor_t tensorDesc,

--- a/test/conv_common.hpp
+++ b/test/conv_common.hpp
@@ -189,7 +189,7 @@ tensor<Tout> get_output_tensor(const miopen::ConvolutionDescriptor& filter,
 
     std::string yLayout =
         out_layout.empty()
-            ? input.desc.GetLayout(miopen::tensor_layout_get_default(input.desc.GetSize()))
+            ? input.desc.GetLayout(miopen::tensor_layout_get_default(input.desc.GetNumDims()))
             : out_layout;
     return tensor<Tout>{filter.GetForwardOutputTensorWithLayout(
         input.desc, weights.desc, yLayout, miopen_type<Tout>{})};
@@ -2062,12 +2062,12 @@ struct conv_driver : test_driver
                           .generate(tensor_elem_gen_integer{17});
         }
 
-        if(input.desc.GetSize() != in_layout.size() ||
-           weights.desc.GetSize() != fil_layout.size() || input.desc.GetSize() != out_layout.size())
+        if(input.desc.GetNumDims() != in_layout.size() ||
+           weights.desc.GetNumDims() != fil_layout.size() || input.desc.GetNumDims() != out_layout.size())
         {
-            std::cout << input.desc.GetSize() << "," << in_layout.size() << std::endl;
-            std::cout << weights.desc.GetSize() << "," << fil_layout.size() << std::endl;
-            std::cout << input.desc.GetSize() << "," << out_layout.size() << std::endl;
+            std::cout << input.desc.GetNumDims() << "," << in_layout.size() << std::endl;
+            std::cout << weights.desc.GetNumDims() << "," << fil_layout.size() << std::endl;
+            std::cout << input.desc.GetNumDims() << "," << out_layout.size() << std::endl;
             std::cerr << "FAILED: layout not match dimension size!" << std::endl;
             return;
         }
@@ -2082,7 +2082,7 @@ struct conv_driver : test_driver
             std::vector<std::size_t> dim_strides;
             miopen::tensor_layout_to_strides(
                 dim_lens,
-                miopen::tensor_layout_get_default(weights.desc.GetSize()),
+                miopen::tensor_layout_get_default(weights.desc.GetNumDims()),
                 in_layout,
                 vector_length,
                 dim_strides);
@@ -2094,14 +2094,14 @@ struct conv_driver : test_driver
             std::vector<std::size_t> dim_strides;
             miopen::tensor_layout_to_strides(
                 dim_lens,
-                miopen::tensor_layout_get_default(weights.desc.GetSize()),
+                miopen::tensor_layout_get_default(weights.desc.GetNumDims()),
                 fil_layout,
                 vector_length,
                 dim_strides);
             weights.desc = miopen::TensorDescriptor(miopen_type<T>{}, dim_lens, dim_strides);
         }
 
-        if(input.desc.GetSize() != 2 + spatial_dim || weights.desc.GetSize() != 2 + spatial_dim ||
+        if(input.desc.GetNumDims() != 2 + spatial_dim || weights.desc.GetNumDims() != 2 + spatial_dim ||
            pads_strides_dilations.size() != 3 * spatial_dim ||
            trans_output_pads.size() != spatial_dim)
         {
@@ -2501,7 +2501,7 @@ struct conv_bias_driver : test_driver
     {
         for(int i = 2; i < 4; i++)
         {
-            if(output.desc.GetSize() == i + 2)
+            if(output.desc.GetNumDims() == i + 2)
                 return i;
         }
         return -1;

--- a/test/conv_common.hpp
+++ b/test/conv_common.hpp
@@ -2063,7 +2063,8 @@ struct conv_driver : test_driver
         }
 
         if(input.desc.GetNumDims() != in_layout.size() ||
-           weights.desc.GetNumDims() != fil_layout.size() || input.desc.GetNumDims() != out_layout.size())
+           weights.desc.GetNumDims() != fil_layout.size() ||
+           input.desc.GetNumDims() != out_layout.size())
         {
             std::cout << input.desc.GetNumDims() << "," << in_layout.size() << std::endl;
             std::cout << weights.desc.GetNumDims() << "," << fil_layout.size() << std::endl;
@@ -2101,7 +2102,8 @@ struct conv_driver : test_driver
             weights.desc = miopen::TensorDescriptor(miopen_type<T>{}, dim_lens, dim_strides);
         }
 
-        if(input.desc.GetNumDims() != 2 + spatial_dim || weights.desc.GetNumDims() != 2 + spatial_dim ||
+        if(input.desc.GetNumDims() != 2 + spatial_dim ||
+           weights.desc.GetNumDims() != 2 + spatial_dim ||
            pads_strides_dilations.size() != 3 * spatial_dim ||
            trans_output_pads.size() != spatial_dim)
         {

--- a/test/cpu_bias.hpp
+++ b/test/cpu_bias.hpp
@@ -43,7 +43,7 @@
 template <std::size_t NSpatialDim, typename Tout, typename Tbias>
 void cpu_bias_forward_impl(tensor<Tout>& out, const tensor<Tbias>& bias)
 {
-    assert(out.desc.GetSize() == NSpatialDim + 2 and bias.desc.GetSize() == NSpatialDim + 2);
+    assert(out.desc.GetNumDims() == NSpatialDim + 2 and bias.desc.GetNumDims() == NSpatialDim + 2);
     assert(
         bias.desc.GetLengths()[0] == 1 && bias.desc.GetLengths()[1] == out.desc.GetLengths()[1] &&
         std::all_of(bias.desc.GetLengths().begin() + 2, bias.desc.GetLengths().end(), [](auto v) {
@@ -59,7 +59,7 @@ void cpu_bias_forward_impl(tensor<Tout>& out, const tensor<Tbias>& bias)
 template <std::size_t NSpatialDim, typename Tout, typename Tbias>
 void cpu_bias_backward_data_impl(const tensor<Tout>& out, tensor<Tbias>& bias)
 {
-    assert(out.desc.GetSize() == NSpatialDim + 2 and bias.desc.GetSize() == NSpatialDim + 2);
+    assert(out.desc.GetNumDims() == NSpatialDim + 2 and bias.desc.GetNumDims() == NSpatialDim + 2);
     assert(
         bias.desc.GetLengths()[0] == 1 && bias.desc.GetLengths()[1] == out.desc.GetLengths()[0] &&
         std::all_of(bias.desc.GetLengths().begin() + 2, bias.desc.GetLengths().end(), [](auto v) {
@@ -88,7 +88,7 @@ void cpu_bias_backward_data_impl(const tensor<Tout>& out, tensor<Tbias>& bias)
 template <typename Tout, typename Tbias>
 void cpu_bias_forward(tensor<Tout>& out, const tensor<Tbias>& bias)
 {
-    switch(out.desc.GetSize())
+    switch(out.desc.GetNumDims())
     {
     case 3: {
         cpu_bias_forward_impl<1>(out, bias);
@@ -115,7 +115,7 @@ void cpu_bias_forward(tensor<Tout>& out, const tensor<Tbias>& bias)
 template <typename Tout, typename Tbias>
 void cpu_bias_backward_data(const tensor<Tout>& out, tensor<Tbias>& bias)
 {
-    switch(out.desc.GetSize())
+    switch(out.desc.GetNumDims())
     {
     case 3: {
         cpu_bias_backward_data_impl<1>(out, bias);

--- a/test/cpu_conv.hpp
+++ b/test/cpu_conv.hpp
@@ -90,8 +90,8 @@ void cpu_convolution_forward_impl(const tensor<Tin>& in,
                                   FW fw = {})
 {
     static_assert(ConvDim > 0, "wrong! convolution dim should be larger than 0");
-    assert(in.desc.GetSize() == ConvDim + 2 and wei.desc.GetSize() == ConvDim + 2 and
-           out.desc.GetSize() == ConvDim + 2 and pads.size() == ConvDim and
+    assert(in.desc.GetNumDims() == ConvDim + 2 and wei.desc.GetNumDims() == ConvDim + 2 and
+           out.desc.GetNumDims() == ConvDim + 2 and pads.size() == ConvDim and
            strides.size() == ConvDim and dilations.size() == ConvDim);
     std::size_t out_n_len = out.desc.GetLengths()[0];
 
@@ -212,8 +212,8 @@ void cpu_convolution_backward_data_impl(tensor<Tin>& in,
                                         FO fo = {})
 {
     static_assert(ConvDim > 0, "wrong! convolution dim should be larger than 0");
-    assert(in.desc.GetSize() == ConvDim + 2 and wei.desc.GetSize() == ConvDim + 2 and
-           out.desc.GetSize() == ConvDim + 2 and pads.size() == ConvDim and
+    assert(in.desc.GetNumDims() == ConvDim + 2 and wei.desc.GetNumDims() == ConvDim + 2 and
+           out.desc.GetNumDims() == ConvDim + 2 and pads.size() == ConvDim and
            strides.size() == ConvDim and dilations.size() == ConvDim);
 
     std::size_t in_n_len = in.desc.GetLengths()[0];
@@ -306,8 +306,8 @@ void cpu_convolution_backward_weight_impl(const tensor<Tin>& in,
                                           FO fo)
 {
     static_assert(ConvDim > 0, "wrong! convolution dim should be larger than 0");
-    assert(in.desc.GetSize() == ConvDim + 2 and wei.desc.GetSize() == ConvDim + 2 and
-           out.desc.GetSize() == ConvDim + 2 and pads.size() == ConvDim and
+    assert(in.desc.GetNumDims() == ConvDim + 2 and wei.desc.GetNumDims() == ConvDim + 2 and
+           out.desc.GetNumDims() == ConvDim + 2 and pads.size() == ConvDim and
            strides.size() == ConvDim and dilations.size() == ConvDim);
 
     std::size_t out_n_len = out.desc.GetLengths()[0];

--- a/test/tensor_cast.cpp
+++ b/test/tensor_cast.cpp
@@ -184,10 +184,10 @@ struct tensor_cast_driver : test_driver
         std::vector<size_t> srcSuperStrides = srcSuper.desc.GetStrides();
         std::vector<size_t> dstSuperStrides = dstSuper.desc.GetStrides();
         std::vector<int> src_super_strides(srcSuperStrides.begin() +
-                                               (srcSuper.desc.GetSize() - castLens.size()),
+                                               (srcSuper.desc.GetNumDims() - castLens.size()),
                                            srcSuperStrides.end());
         std::vector<int> dst_super_strides(dstSuperStrides.begin() +
-                                               (dstSuper.desc.GetSize() - castLens.size()),
+                                               (dstSuper.desc.GetNumDims() - castLens.size()),
                                            dstSuperStrides.end());
 
         srcDesc = miopen::TensorDescriptor(miopenInt32, castLens, src_super_strides);

--- a/test/tensor_copy.cpp
+++ b/test/tensor_copy.cpp
@@ -163,10 +163,10 @@ struct tensor_copy_driver : test_driver
         std::vector<size_t> srcSuperStrides = srcSuper.desc.GetStrides();
         std::vector<size_t> dstSuperStrides = dstSuper.desc.GetStrides();
         std::vector<int> src_super_strides(srcSuperStrides.begin() +
-                                               (srcSuper.desc.GetSize() - copyLens.size()),
+                                               (srcSuper.desc.GetNumDims() - copyLens.size()),
                                            srcSuperStrides.end());
         std::vector<int> dst_super_strides(dstSuperStrides.begin() +
-                                               (dstSuper.desc.GetSize() - copyLens.size()),
+                                               (dstSuper.desc.GetNumDims() - copyLens.size()),
                                            dstSuperStrides.end());
 
         srcDesc = miopen::TensorDescriptor(this->type, copyLens, src_super_strides);

--- a/test/tensor_scale.cpp
+++ b/test/tensor_scale.cpp
@@ -127,7 +127,7 @@ struct tensor_scale_driver : test_driver
         super = tensor<T>{superLens}.generate(tensor_elem_gen_integer{max_value});
 
         std::vector<size_t> superStrides = super.desc.GetStrides();
-        std::vector<int> subStrides(superStrides.begin() + (super.desc.GetSize() - subLens.size()),
+        std::vector<int> subStrides(superStrides.begin() + (super.desc.GetNumDims() - subLens.size()),
                                     superStrides.end());
 
         subDesc = miopen::TensorDescriptor(this->type, subLens, subStrides);

--- a/test/tensor_scale.cpp
+++ b/test/tensor_scale.cpp
@@ -127,8 +127,8 @@ struct tensor_scale_driver : test_driver
         super = tensor<T>{superLens}.generate(tensor_elem_gen_integer{max_value});
 
         std::vector<size_t> superStrides = super.desc.GetStrides();
-        std::vector<int> subStrides(superStrides.begin() + (super.desc.GetNumDims() - subLens.size()),
-                                    superStrides.end());
+        std::vector<int> subStrides(
+            superStrides.begin() + (super.desc.GetNumDims() - subLens.size()), superStrides.end());
 
         subDesc = miopen::TensorDescriptor(this->type, subLens, subStrides);
 

--- a/test/tensor_set.cpp
+++ b/test/tensor_set.cpp
@@ -129,7 +129,7 @@ struct tensor_set_driver : test_driver
         super = tensor<T>{superLens}.generate(tensor_elem_gen_integer{max_value});
 
         std::vector<size_t> superStrides = super.desc.GetStrides();
-        std::vector<int> subStrides(superStrides.begin() + (super.desc.GetSize() - subLens.size()),
+        std::vector<int> subStrides(superStrides.begin() + (super.desc.GetNumDims() - subLens.size()),
                                     superStrides.end());
 
         subDesc = miopen::TensorDescriptor(this->type, subLens, subStrides);

--- a/test/tensor_set.cpp
+++ b/test/tensor_set.cpp
@@ -129,8 +129,8 @@ struct tensor_set_driver : test_driver
         super = tensor<T>{superLens}.generate(tensor_elem_gen_integer{max_value});
 
         std::vector<size_t> superStrides = super.desc.GetStrides();
-        std::vector<int> subStrides(superStrides.begin() + (super.desc.GetNumDims() - subLens.size()),
-                                    superStrides.end());
+        std::vector<int> subStrides(
+            superStrides.begin() + (super.desc.GetNumDims() - subLens.size()), superStrides.end());
 
         subDesc = miopen::TensorDescriptor(this->type, subLens, subStrides);
 

--- a/test/tensor_transform.cpp
+++ b/test/tensor_transform.cpp
@@ -436,10 +436,10 @@ struct tensor_transform_driver : test_driver
         std::vector<size_t> superStrides_src = super_src.desc.GetStrides();
         std::vector<size_t> superStrides_dst = super_dst.desc.GetStrides();
         std::vector<int> subStrides_src(superStrides_src.begin() +
-                                            (super_src.desc.GetSize() - subLens.size()),
+                                            (super_src.desc.GetNumDims() - subLens.size()),
                                         superStrides_src.end());
         std::vector<int> subStrides_dst(superStrides_dst.begin() +
-                                            (super_dst.desc.GetSize() - subLens.size()),
+                                            (super_dst.desc.GetNumDims() - subLens.size()),
                                         superStrides_dst.end());
 
         subDesc_src = miopen::TensorDescriptor(this->type, subLens, subStrides_src);

--- a/test/tensor_util.hpp
+++ b/test/tensor_util.hpp
@@ -27,11 +27,8 @@
 #ifndef GUARD_TENSOR_UTIL_HPP
 #define GUARD_TENSOR_UTIL_HPP
 
-#include <iostream>
 #include <miopen/miopen.h>
 #include <miopen/tensor.hpp>
-#include <utility>
-#include <cstdlib>
 #include "tensor_holder.hpp"
 
 // loop over sub-tensor, and operate on each data
@@ -72,116 +69,6 @@ void operate_over_subtensor_impl(const data_operator_t<T>& r_data_operator,
 
         index += current_stride;
     }
-}
-
-template <typename T>
-void output_tensor_to_csv(const tensor<T>& x, std::string filename)
-{
-    int dim = x.desc.GetSize();
-    std::vector<int> index(dim);
-
-    std::ofstream file;
-
-    file.open(filename);
-
-    for(int j = 0; j < dim; ++j)
-        file << "d" << j << ", ";
-    file << "x" << std::endl;
-
-    for(int i = 0; i < x.data.size(); ++i)
-    {
-        int is = i;
-        for(int j = 0; j < dim; ++j)
-        {
-            index[j] = is / x.desc.GetStrides()[j];
-            is -= index[j] * x.desc.GetStrides()[j];
-        }
-
-        for(int j = 0; j < dim; ++j)
-        {
-            file << index[j] << ", ";
-        }
-        file << x[i] << std::endl;
-    }
-
-    file.close();
-}
-
-template <typename T>
-void output_tensor_to_bin(const char* fileName, T* data, size_t dataNumItems)
-{
-    std::ofstream outFile(fileName, std::ios::binary);
-    if(outFile)
-    {
-        outFile.write(reinterpret_cast<char*>(data), dataNumItems * sizeof(T));
-        outFile.close();
-    }
-    else
-    {
-        std::cerr << "Could not open file " << fileName << " for writing" << std::endl;
-    }
-}
-
-template <typename T>
-void output_tensor_to_screen(const tensor<T>& tensor_val,
-                             std::string header_msg = "start",
-                             size_t set_precision   = 2)
-{
-    std::cout << "\n================= " << header_msg << " =====================\n";
-
-    const auto lens = tensor_val.desc.GetLengths();
-    size_t dim      = lens.size();
-    if(dim == 2)
-    {
-        ford(lens[0], lens[1])([&](int ii, int jj) {
-            std::cout << std::fixed << std::setprecision(set_precision) << tensor_val(ii, jj)
-                      << ", ";
-            if(jj == lens[1] - 1)
-            {
-                std::cout << "\n";
-            }
-        });
-    }
-    else if(dim == 3)
-    {
-        ford(lens[0], lens[1], lens[2])([&](int ii, int jj, int kk) {
-            std::cout << std::fixed << std::setprecision(set_precision) << tensor_val(ii, jj, kk)
-                      << ", ";
-            if(kk == lens[2] - 1)
-            {
-                std::cout << "\n";
-            }
-            if(kk == lens[2] - 1 && jj == lens[1] - 1)
-            {
-                std::cout << "\n";
-            }
-        });
-    }
-    else if(dim == 4)
-    {
-        ford(lens[0], lens[1], lens[2], lens[3])([&](int ii, int jj, int kk, int ll) {
-            std::cout << std::fixed << std::setprecision(set_precision)
-                      << tensor_val(ii, jj, kk, ll) << ", ";
-            if(ll == lens[3] - 1)
-            {
-                std::cout << "\n";
-            }
-            if(ll == lens[3] - 1 && kk == lens[2] - 1)
-            {
-                std::cout << "\n";
-            }
-            if(ll == lens[3] - 1 && kk == lens[2] - 1 && jj == lens[1] - 1)
-            {
-                std::cout << "\n";
-            }
-        });
-    }
-    else
-    {
-        std::cerr << "Need to handle print for dim : " << dim << std::endl;
-    }
-
-    std::cout << "\n=================end=====================\n";
 }
 
 #endif


### PR DESCRIPTION
Currently, strides are not taken into account in `GetInSize()`, `GetOutSize()` and `GetWeightsSize()`. This PR fixes the issue.

Additional changes:

- Some code refactoring in the `ProblemDescription`
- TensorDescriptor: Misleading `GetSize()` has been replaced with `GetNumDims()`
- Some dead code has been removed