### PR TITLE
Unify 'include amd_comgr.h' between Windows and Linux

### DIFF
--- a/src/comgr.cpp
+++ b/src/comgr.cpp
@@ -37,11 +37,7 @@
 #include <miopen/solver/implicitgemm_util.hpp>
 #include <miopen/stringutils.hpp>
 
-#if !defined(_WIN32)
 #include <amd_comgr/amd_comgr.h>
-#else
-#include <amd_comgr.h>
-#endif
 #include <hip/hip_runtime_api.h>
 #if MIOPEN_USE_HIPRTC
 #include <miopen/manage_ptr.hpp>


### PR DESCRIPTION
Windows MIOpen moved to HIP SDK 6.0 and no longer supports HIP SDK 5.7 out of the box. However, HIP SDK 5.7 might still be used to compile MIOpen, but with slight modifications to the source code.