### PR TITLE
[HOTFIX] Fix typo introduced by #2894 and #2902

### DIFF
--- a/src/graphapi/graphapi.cpp
+++ b/src/graphapi/graphapi.cpp
@@ -97,7 +97,7 @@ miopenBackendCreateDescriptor(miopenBackendDescriptorType_t descriptorType,
             break;
 
         case MIOPEN_BACKEND_OPERATION_MATMUL_DESCRIPTOR:
-            outputDesciptor = new miopen::graphapi::BackendOperationMatmulDescriptor();
+            outputDescriptor = new miopen::graphapi::BackendOperationMatmulDescriptor();
             break;
 
         default: MIOPEN_THROW(miopenStatusUnsupportedOp);


### PR DESCRIPTION
Even if #2894 and #2902 had an implicit conflict (`outputDesciptor` and `outputDescriptor`), they were merged without solving.
This solves build error `use of undeclared identifier 'outputDesciptor'`.