### PR TITLE
[Windows] Workaround conflicting definitions of std::min() MSVC and HIP Clang

### DIFF
--- a/src/graphapi/execution_plan.cpp
+++ b/src/graphapi/execution_plan.cpp
@@ -228,7 +228,10 @@ void BackendExecutionPlanDescriptor::getAttribute(miopenBackendAttributeName_t a
             const auto& vec = mExecutionPlan.getIntermediateIds();
             *elementCount   = vec.size();
             std::copy_n(vec.begin(),
-                        std::min(requestedElementCount, *elementCount),
+                        // WORKAROUND: building on Windows is failing due to conflicting definitions
+                        // of std::min() between the MSVC standard library and HIP Clang wrappers.
+                        requestedElementCount < *elementCount ? requestedElementCount
+                                                              : *elementCount,
                         static_cast<int64_t*>(arrayOfElements));
         }
         else
@@ -243,7 +246,10 @@ void BackendExecutionPlanDescriptor::getAttribute(miopenBackendAttributeName_t a
             std::string s = mExecutionPlan.getJsonRepresentation();
             *elementCount = s.size() + 1;
             std::copy_n(s.c_str(),
-                        std::min(requestedElementCount, *elementCount),
+                        // WORKAROUND: building on Windows is failing due to conflicting definitions
+                        // of std::min() between the MSVC standard library and HIP Clang wrappers.
+                        requestedElementCount < *elementCount ? requestedElementCount
+                                                              : *elementCount,
                         static_cast<char*>(arrayOfElements));
         }
         else

--- a/src/graphapi/opgraph.cpp
+++ b/src/graphapi/opgraph.cpp
@@ -422,7 +422,9 @@ void BackendOperationGraphDescriptor::getAttribute(miopenBackendAttributeName_t 
         {
             *elementCount = mOps.size();
             std::copy_n(mOps.cbegin(),
-                        std::min(*elementCount, requestedElementCount),
+                        // WORKAROUND: building on Windows is failing due to conflicting definitions
+                        // of std::min() between the MSVC standard library and HIP Clang wrappers.
+                        *elementCount < requestedElementCount ? *elementCount : requestedElementCount,
                         static_cast<miopenBackendDescriptor_t*>(arrayOfElements));
         }
         else

--- a/src/graphapi/opgraph.cpp
+++ b/src/graphapi/opgraph.cpp
@@ -424,7 +424,8 @@ void BackendOperationGraphDescriptor::getAttribute(miopenBackendAttributeName_t 
             std::copy_n(mOps.cbegin(),
                         // WORKAROUND: building on Windows is failing due to conflicting definitions
                         // of std::min() between the MSVC standard library and HIP Clang wrappers.
-                        *elementCount < requestedElementCount ? *elementCount : requestedElementCount,
+                        *elementCount < requestedElementCount ? *elementCount
+                                                              : requestedElementCount,
                         static_cast<miopenBackendDescriptor_t*>(arrayOfElements));
         }
         else


### PR DESCRIPTION
The workaround for a similar issue has already been merged in file `convolution.cpp` (#2832)
Building on Windows is failing due to conflicting definitions of `std::min()` between the MSVC standard library and HIP Clang wrappers.
```
In file included from <built-in>:1:
In file included from C:\opt\rocm\lib\clang\19\include\__clang_hip_runtime_wrapper.h:143:
In file included from C:\opt\rocm\lib\clang\19\include\__clang_hip_cmath.h:21:
C:\Program Files\Microsoft Visual Studio\2022\Preview\VC\Tools\MSVC\14.39.33321\include\utility:98:6: error: definition with same mangled name '??$min@_J@std@@YAAEB_JAEB_J0@Z' as another definition
   98 |     (min) (const _Ty& _Left, const _Ty& _Right) noexcept(noexcept(_Right < _Left)) /* strengthened */ {
      |      ^
C:\opt\rocm\lib\clang\19\include\cuda_wrappers\algorithm:101:1: note: previous definition is here
  101 | min(const __T &__a, const __T &__b) {
      | ^
1 error generated when compiling for host.
```
The bug has been reported to the compiler team but has not yet been resolved.