### PR TITLE
[CK] Replace ENV with MIOPEN_ENV and bump CK commit hash by updating requirements.txt

### DIFF
--- a/driver/CBAInferFusion_driver.hpp
+++ b/driver/CBAInferFusion_driver.hpp
@@ -601,7 +601,7 @@ int CBAInferFusionDriver<Tgpu, Tref>::AllocateBuffersAndCopy()
     else
         out_sz = in_sz; // This is for N+A so the output is the same as the input size
 
-    if(miopen::IsEnabled(ENV(MIOPEN_DRIVER_PAD_BUFFERS_2M)))
+    if(miopen::IsEnabled(MIOPEN_ENV(MIOPEN_DRIVER_PAD_BUFFERS_2M)))
     {
         PadBufferSize(wei_sz, sizeof(Tgpu));
     }

--- a/driver/conv_driver.hpp
+++ b/driver/conv_driver.hpp
@@ -145,7 +145,7 @@ private:
 
 static inline void AdjustWorkspacesizeVariableFromEnv(std::size_t& sz)
 {
-    auto adj = miopen::Value(ENV(MIOPEN_DRIVER_CONV_WORKSPACE_SIZE_ADJUST));
+    auto adj = miopen::Value(MIOPEN_ENV(MIOPEN_DRIVER_CONV_WORKSPACE_SIZE_ADJUST));
     if(adj == 0ULL)
         return; // nop
     auto sz_save = sz;
@@ -1391,12 +1391,12 @@ int ConvDriver<Tgpu, Tref>::AllocateBuffersAndCopy()
     size_t in_sz  = GetTensorSize(inputTensor);
     size_t wei_sz = GetTensorSize(weightTensor);
     size_t out_sz = GetTensorSize(outputTensor);
-    auto subnorm_percentage = miopen::Value(ENV(MIOPEN_DRIVER_SUBNORM_PERCENTAGE));
+    auto subnorm_percentage = miopen::Value(MIOPEN_ENV(MIOPEN_DRIVER_SUBNORM_PERCENTAGE));
     if(subnorm_percentage != 0)
         std::cout << "MIOPEN_DRIVER_SUBNORM_PERCENTAGE = " << subnorm_percentage << std::endl;
 
     // Workaround: Pad buffers allocations to be a multiple of 2M
-    if(miopen::IsEnabled(ENV(MIOPEN_DRIVER_PAD_BUFFERS_2M)))
+    if(miopen::IsEnabled(MIOPEN_ENV(MIOPEN_DRIVER_PAD_BUFFERS_2M)))
     {
         // PadBufferSize(in_sz, sizeof(Tgpu));
         PadBufferSize(wei_sz, sizeof(Tgpu));
@@ -1419,7 +1419,7 @@ int ConvDriver<Tgpu, Tref>::AllocateBuffersAndCopy()
             size_t warmup_in_sz  = GetTensorSize(warmupInputTensor);
             size_t warmup_wei_sz = GetTensorSize(warmupWeightTensor);
             size_t warmup_out_sz = GetTensorSize(warmupOutputTensor);
-            if(miopen::IsEnabled(ENV(MIOPEN_DRIVER_PAD_BUFFERS_2M)))
+            if(miopen::IsEnabled(MIOPEN_ENV(MIOPEN_DRIVER_PAD_BUFFERS_2M)))
             {
                 PadBufferSize(warmup_wei_sz, sizeof(warmup_Tgpu));
                 PadBufferSize(warmup_out_sz, sizeof(warmup_Tgpu));
@@ -1739,7 +1739,7 @@ int ConvDriver<Tgpu, Tref>::AllocateBuffersAndCopy()
 template <typename Tgpu, typename Tref>
 bool ConvDriver<Tgpu, Tref>::UseGPUReference()
 {
-    if(!miopen::IsDisabled(ENV(MIOPEN_DRIVER_USE_GPU_REFERENCE)))
+    if(!miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DRIVER_USE_GPU_REFERENCE)))
     {
         if((miopen_type<Tref>{} == miopenFloat &&
             (miopen_type<Tgpu>{} == miopenFloat || miopen_type<Tgpu>{} == miopenHalf ||

--- a/driver/random.hpp
+++ b/driver/random.hpp
@@ -15,7 +15,7 @@ using glibc_gen = std::linear_congruential_engine<std::uint32_t, 1103515245, 123
 inline std::random_device::result_type get_default_seed()
 {
     static std::random_device::result_type seed{[] {
-        auto external_seed = miopen::Value(ENV(MIOPEN_DEBUG_DRIVER_PRNG_SEED));
+        auto external_seed = miopen::Value(MIOPEN_ENV(MIOPEN_DEBUG_DRIVER_PRNG_SEED));
 
         auto seed = external_seed == 0
                         ? std::random_device{}()

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ nlohmann/json@v3.11.2 -DJSON_MultipleHeaders=ON -DJSON_BuildTests=Off
 ROCm/FunctionalPlus@v0.2.18-p0
 ROCm/eigen@3.4.0
 ROCm/frugally-deep@9683d557eb672ee2304f80f6682c51242d748a50
-ROCm/composable_kernel@7843a8a7fbd0afc49cd4b8fa0766ea9906174b0d -DCMAKE_BUILD_TYPE=Release -DINSTANCES_ONLY=ON
+ROCm/composable_kernel@9b3c4ac4754c7e3d6847e00cb3b553f4e98a747d -DCMAKE_BUILD_TYPE=Release -DINSTANCES_ONLY=ON

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ nlohmann/json@v3.11.2 -DJSON_MultipleHeaders=ON -DJSON_BuildTests=Off
 ROCm/FunctionalPlus@v0.2.18-p0
 ROCm/eigen@3.4.0
 ROCm/frugally-deep@9683d557eb672ee2304f80f6682c51242d748a50
-ROCm/composable_kernel@1d784873eec6d4c41454b8733272aa5da073fbc6 -DCMAKE_BUILD_TYPE=Release -DINSTANCES_ONLY=ON
+ROCm/composable_kernel@7843a8a7fbd0afc49cd4b8fa0766ea9906174b0d -DCMAKE_BUILD_TYPE=Release -DINSTANCES_ONLY=ON

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ nlohmann/json@v3.11.2 -DJSON_MultipleHeaders=ON -DJSON_BuildTests=Off
 ROCm/FunctionalPlus@v0.2.18-p0
 ROCm/eigen@3.4.0
 ROCm/frugally-deep@9683d557eb672ee2304f80f6682c51242d748a50
-ROCm/composable_kernel@7843a8a7fbd0afc49cd4b8fa0766ea9906174b0d -DCMAKE_BUILD_TYPE=Release -DINSTANCES_ONLY=ON 
+ROCm/composable_kernel@7843a8a7fbd0afc49cd4b8fa0766ea9906174b0d -DCMAKE_BUILD_TYPE=Release -DINSTANCES_ONLY=ON

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ nlohmann/json@v3.11.2 -DJSON_MultipleHeaders=ON -DJSON_BuildTests=Off
 ROCm/FunctionalPlus@v0.2.18-p0
 ROCm/eigen@3.4.0
 ROCm/frugally-deep@9683d557eb672ee2304f80f6682c51242d748a50
-ROCm/composable_kernel@7843a8a7fbd0afc49cd4b8fa0766ea9906174b0d -DCMAKE_BUILD_TYPE=Release -DINSTANCES_ONLY=ON
+ROCm/composable_kernel@7843a8a7fbd0afc49cd4b8fa0766ea9906174b0d -DCMAKE_BUILD_TYPE=Release -DINSTANCES_ONLY=ON 

--- a/src/binary_cache.cpp
+++ b/src/binary_cache.cpp
@@ -65,7 +65,7 @@ static fs::path ComputeUserCachePath()
     fs::path p;
     /// If MIOPEN_CUSTOM_CACHE_DIR is set in the environment, then
     /// use exactly that path.
-    const auto& custom = miopen::GetStringEnv(ENV(MIOPEN_CUSTOM_CACHE_DIR));
+    const auto& custom = miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_CUSTOM_CACHE_DIR));
     if(!custom.empty())
     {
         p = ExpandUser(custom);
@@ -118,7 +118,7 @@ bool IsCacheDisabled()
     if(MIOPEN_DISABLE_USERDB && MIOPEN_DISABLE_SYSDB)
         return true;
     else
-        return miopen::IsEnabled(ENV(MIOPEN_DISABLE_CACHE));
+        return miopen::IsEnabled(MIOPEN_ENV(MIOPEN_DISABLE_CACHE));
 #else
     return true;
 #endif

--- a/src/check_numerics.cpp
+++ b/src/check_numerics.cpp
@@ -37,7 +37,7 @@ namespace miopen {
 
 bool CheckNumericsEnabled(const int bitMask)
 {
-    return (miopen::Value(ENV(MIOPEN_CHECK_NUMERICS)) & bitMask) != 0;
+    return (miopen::Value(MIOPEN_ENV(MIOPEN_CHECK_NUMERICS)) & bitMask) != 0;
 }
 
 // Must keep this structure synchronized with one in MIOpenCheckNumerics
@@ -139,8 +139,11 @@ bool checkNumericsImpl(
 // Returns: 1 if abnormal value (inf or nan) detected in specified data, 0 otherwise
 bool checkNumericsInput(const Handle& handle, const TensorDescriptor& dDesc, ConstData_t data)
 {
-    return checkNumericsImpl(
-        handle, static_cast<int>(miopen::Value(ENV(MIOPEN_CHECK_NUMERICS))), dDesc, data, true);
+    return checkNumericsImpl(handle,
+                             static_cast<int>(miopen::Value(MIOPEN_ENV(MIOPEN_CHECK_NUMERICS))),
+                             dDesc,
+                             data,
+                             true);
 }
 
 // Synchronizes to wait for kernel to finish, then checks data for output:
@@ -149,8 +152,11 @@ bool checkNumericsOutput(const Handle& handle, const TensorDescriptor& dDesc, Co
 {
     handle.Finish();
 
-    return checkNumericsImpl(
-        handle, static_cast<int>(miopen::Value(ENV(MIOPEN_CHECK_NUMERICS))), dDesc, data, false);
+    return checkNumericsImpl(handle,
+                             static_cast<int>(miopen::Value(MIOPEN_ENV(MIOPEN_CHECK_NUMERICS))),
+                             dDesc,
+                             data,
+                             false);
 }
 
 } // namespace miopen

--- a/src/comgr.cpp
+++ b/src/comgr.cpp
@@ -123,18 +123,18 @@ MIOPEN_DECLARE_ENV_VAR_BOOL(MIOPEN_DEBUG_COMGR_HIP_PCH_ENFORCE)
 
 #define COMPILER_LC 1
 
-#define EC_BASE(comgrcall, info, action)                                  \
-    do                                                                    \
-    {                                                                     \
-        const amd_comgr_status_t status = (comgrcall);                    \
-        if(status != AMD_COMGR_STATUS_SUCCESS)                            \
-        {                                                                 \
-            MIOPEN_LOG_E("\'" #comgrcall "\' " << to_string(info) << ": " \
-                                               << GetStatusText(status)); \
-            (action);                                                     \
-        }                                                                 \
-        else if(miopen::IsEnabled(ENV(MIOPEN_DEBUG_COMGR_LOG_CALLS)))     \
-            MIOPEN_LOG_I("Ok \'" #comgrcall "\' " << to_string(info));    \
+#define EC_BASE(comgrcall, info, action)                                     \
+    do                                                                       \
+    {                                                                        \
+        const amd_comgr_status_t status = (comgrcall);                       \
+        if(status != AMD_COMGR_STATUS_SUCCESS)                               \
+        {                                                                    \
+            MIOPEN_LOG_E("\'" #comgrcall "\' " << to_string(info) << ": "    \
+                                               << GetStatusText(status));    \
+            (action);                                                        \
+        }                                                                    \
+        else if(miopen::IsEnabled(MIOPEN_ENV(MIOPEN_DEBUG_COMGR_LOG_CALLS))) \
+            MIOPEN_LOG_I("Ok \'" #comgrcall "\' " << to_string(info));       \
     } while(false)
 
 /// \anchor comgr_throw_macros
@@ -212,7 +212,7 @@ static void AddCompilerOptions(OptionList& list)
 #endif
     list.push_back("-mllvm");
     list.push_back("-amdgpu-prelink");
-    if(miopen::IsEnabled(ENV(MIOPEN_DEBUG_OPENCL_WAVE64_NOWGP)))
+    if(miopen::IsEnabled(MIOPEN_ENV(MIOPEN_DEBUG_OPENCL_WAVE64_NOWGP)))
     {
         list.push_back("-mwavefrontsize64");
         list.push_back("-mcumode");
@@ -239,14 +239,17 @@ static void RemoveOptionsUnwanted(OptionList& list)
 namespace hip {
 
 #if PCH_IS_SUPPORTED
-static bool IsPchEnabled() { return !miopen::IsDisabled(ENV(MIOPEN_DEBUG_COMGR_HIP_PCH_ENFORCE)); }
+static bool IsPchEnabled()
+{
+    return !miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_COMGR_HIP_PCH_ENFORCE));
+}
 #endif
 
 static std::string GetPchEnableStatus()
 {
 #if PCH_IS_SUPPORTED
     auto rv = std::string{IsPchEnabled() ? "1" : "0"};
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_COMGR_HIP_PCH_ENFORCE)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_COMGR_HIP_PCH_ENFORCE)))
         return rv += " (enforced)";
     return rv;
 #else
@@ -290,13 +293,14 @@ static void AddCompilerOptions(const OptionList& list) // `const` is for clang-t
 static void RemoveCompilerOptionsUnwanted(OptionList& list)
 {
     RemoveCommonOptionsUnwanted(list);
-    list.erase(remove_if(list.begin(),
-                         list.end(),
-                         [&](const auto& option) { // clang-format off
-                             return (!miopen::IsEnabled(ENV(MIOPEN_DEBUG_COMGR_HIP_BUILD_FATBIN))
+    list.erase(
+        remove_if(list.begin(),
+                  list.end(),
+                  [&](const auto& option) { // clang-format off
+                             return (!miopen::IsEnabled(MIOPEN_ENV(MIOPEN_DEBUG_COMGR_HIP_BUILD_FATBIN))
                                     && (IsLinkerOption(option))); // clang-format on
-                         }),
-               list.end());
+                  }),
+        list.end());
 }
 
 static void RemoveLinkOptionsUnwanted(OptionList& list)
@@ -442,7 +446,7 @@ static std::string GetStatusText(const amd_comgr_status_t status, const bool unk
 
 static void LogOptions(const char* options[], size_t count)
 {
-    static const auto control = miopen::Value(ENV(MIOPEN_DEBUG_COMGR_LOG_OPTIONS));
+    static const auto control = miopen::Value(MIOPEN_ENV(MIOPEN_DEBUG_COMGR_LOG_OPTIONS));
     if(!(control != 0 && miopen::IsLogging(miopen::LoggingLevel::Info)))
         return;
     if(control == 2)
@@ -586,12 +590,12 @@ public:
                  const amd_comgr_data_kind_t type) const
     {
         const Data d(type);
-        if(miopen::IsEnabled(ENV(MIOPEN_DEBUG_COMGR_LOG_SOURCE_NAMES)))
+        if(miopen::IsEnabled(MIOPEN_ENV(MIOPEN_DEBUG_COMGR_LOG_SOURCE_NAMES)))
             MIOPEN_LOG_I(name << ' ' << content.size() << " bytes");
         d.SetName(name);
         d.SetBytes(content);
         AddData(d);
-        const auto show_first = miopen::Value(ENV(MIOPEN_DEBUG_COMGR_LOG_SOURCE_TEXT));
+        const auto show_first = miopen::Value(MIOPEN_ENV(MIOPEN_DEBUG_COMGR_LOG_SOURCE_TEXT));
         if(show_first > 0 && miopen::IsLogging(miopen::LoggingLevel::Info) &&
            (type == AMD_COMGR_DATA_KIND_SOURCE || type == AMD_COMGR_DATA_KIND_INCLUDE))
         {
@@ -605,7 +609,7 @@ public:
     {
         const char name[] = "hip.pch";
         const Data d(AMD_COMGR_DATA_KIND_PRECOMPILED_HEADER);
-        if(miopen::IsEnabled(ENV(MIOPEN_DEBUG_COMGR_LOG_SOURCE_NAMES)))
+        if(miopen::IsEnabled(MIOPEN_ENV(MIOPEN_DEBUG_COMGR_LOG_SOURCE_NAMES)))
         {
             MIOPEN_LOG_I(name << ' ' << size
                               << " bytes,  ptr = " << static_cast<const void*>(content));
@@ -731,7 +735,7 @@ static void SetIsaName(const ActionInfo& action,
 
 static std::string GetDebugCompilerOptionsInsert()
 {
-    const auto& p = miopen::GetStringEnv(ENV(MIOPEN_DEBUG_COMGR_COMPILER_OPTIONS_INSERT));
+    const auto& p = miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_DEBUG_COMGR_COMPILER_OPTIONS_INSERT));
     return {p};
 }
 
@@ -778,7 +782,7 @@ void BuildHip(const std::string& name,
         action.SetLogging(true);
 
         const Dataset exe;
-        if(miopen::IsEnabled(ENV(MIOPEN_DEBUG_COMGR_HIP_BUILD_FATBIN)))
+        if(miopen::IsEnabled(MIOPEN_ENV(MIOPEN_DEBUG_COMGR_HIP_BUILD_FATBIN)))
         {
             auto raw = options                                 //
                        + " " + GetDebugCompilerOptionsInsert() //
@@ -1066,7 +1070,7 @@ static std::string GetStatusText(const hiprtcResult status)
             MIOPEN_LOG_E("\'" #call "\' " << to_string(info) << ": " << GetStatusText(status)); \
             (action);                                                                           \
         }                                                                                       \
-        else if(miopen::IsEnabled(ENV(MIOPEN_DEBUG_COMGR_LOG_CALLS)))                           \
+        else if(miopen::IsEnabled(MIOPEN_ENV(MIOPEN_DEBUG_COMGR_LOG_CALLS)))                    \
             MIOPEN_LOG_I("Ok \'" #call "\' " << to_string(info));                               \
     } while(false)
 
@@ -1201,11 +1205,11 @@ public:
 private:
     void LogInputFile(const std::string& name, const std::string& content)
     {
-        if(miopen::IsEnabled(ENV(MIOPEN_DEBUG_COMGR_LOG_SOURCE_NAMES)))
+        if(miopen::IsEnabled(MIOPEN_ENV(MIOPEN_DEBUG_COMGR_LOG_SOURCE_NAMES)))
             MIOPEN_LOG_I(name << ' ' << content.size() << " bytes");
         if(miopen::IsLogging(miopen::LoggingLevel::Info))
         {
-            const auto show_first = miopen::Value(ENV(MIOPEN_DEBUG_COMGR_LOG_SOURCE_TEXT));
+            const auto show_first = miopen::Value(MIOPEN_ENV(MIOPEN_DEBUG_COMGR_LOG_SOURCE_TEXT));
             if(show_first > 0)
             {
                 const auto text_length =

--- a/src/conv/solver_finders.cpp
+++ b/src/conv/solver_finders.cpp
@@ -60,7 +60,7 @@ protected:
                    const ProblemDescription& /*problem*/,
                    const ConvFindParameters& parameters) const override
     {
-        return !parameters.use_winograd_only && !IsDisabled(ENV(MIOPEN_DEBUG_CONV_DIRECT));
+        return !parameters.use_winograd_only && !IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_DIRECT));
     }
 
     std::vector<solver::ConvSolution> FindImpl(const ExecutionContext& ctx,
@@ -89,7 +89,8 @@ protected:
                    const ProblemDescription& /*problem*/,
                    const ConvFindParameters& parameters) const override
     {
-        return !parameters.use_winograd_only && !IsDisabled(ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM));
+        return !parameters.use_winograd_only &&
+               !IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM));
     }
 
     std::vector<solver::ConvSolution> FindImpl(const ExecutionContext& ctx,
@@ -120,7 +121,7 @@ protected:
     {
         return !parameters.use_winograd_only &&
                problem.GetDirection() != conv::Direction::BackwardWeights &&
-               !IsDisabled(ENV(MIOPEN_DEBUG_CONV_FFT));
+               !IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_FFT));
     }
 
     std::vector<solver::ConvSolution> FindImpl(const ExecutionContext& ctx,
@@ -147,7 +148,7 @@ protected:
                    const ProblemDescription& /*problem*/,
                    const ConvFindParameters& parameters) const override
     {
-        return !parameters.use_winograd_only && !IsDisabled(ENV(MIOPEN_DEBUG_CONV_GEMM));
+        return !parameters.use_winograd_only && !IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_GEMM));
     }
 
     std::vector<solver::ConvSolution> FindImpl(const ExecutionContext& ctx,
@@ -174,7 +175,7 @@ protected:
                    const ProblemDescription& /*problem*/,
                    const ConvFindParameters& /*parameters*/) const override
     {
-        return !IsDisabled(ENV(MIOPEN_DEBUG_CONV_WINOGRAD));
+        return !IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_WINOGRAD));
     }
 
     std::vector<solver::ConvSolution> FindImpl(const ExecutionContext& ctx,
@@ -222,7 +223,7 @@ static void EvaluateInvokers(Handle& handle,
                              DbRecord& record,
                              bool& is_result_optimal)
 {
-    const auto& arch = miopen::GetStringEnv(ENV(MIOPEN_DEVICE_ARCH));
+    const auto& arch = miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_DEVICE_ARCH));
     if(!arch.empty())
         return;
 
@@ -245,7 +246,7 @@ static void EvaluateInvokers(Handle& handle,
             //
             // That is why we do not write sub-optimal results into persistent find-db (on disk)
             // unless this is explicitly enabled via environment setting.
-            if(!IsEnabled(ENV(MIOPEN_FIND_CONV_INSUFFICIENT_WORKSPACE_ALLOW_FINDDB_UPDATE)))
+            if(!IsEnabled(MIOPEN_ENV(MIOPEN_FIND_CONV_INSUFFICIENT_WORKSPACE_ALLOW_FINDDB_UPDATE)))
                 is_result_optimal = false;
             continue;
         }
@@ -342,15 +343,15 @@ bool IsAlgorithmDisabled(miopenConvAlgorithm_t algo)
     switch(algo)
     { // clang-format off
     case miopenConvolutionAlgoGEMM:
-        return !MIOPEN_USE_GEMM || miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_GEMM));
+        return !MIOPEN_USE_GEMM || miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_GEMM));
     case miopenConvolutionAlgoDirect:
-        return miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_DIRECT));
+        return miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_DIRECT));
     case miopenConvolutionAlgoFFT:
-        return miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_FFT));
+        return miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_FFT));
     case miopenConvolutionAlgoWinograd:
-        return miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_WINOGRAD));
+        return miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_WINOGRAD));
     case miopenConvolutionAlgoImplicitGEMM:
-        return miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM));
+        return miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM));
     default: // Disable future algos by default to enforce explicit handling:
         return true;
     } // clang-format on

--- a/src/convolution.cpp
+++ b/src/convolution.cpp
@@ -80,7 +80,7 @@ std::size_t GetWorkSpaceSizeGEMM(const miopen::ExecutionContext& ctx,
                                  const conv::ProblemDescription& problem)
 {
 #if MIOPEN_USE_GEMM
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_GEMM)) ||
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_GEMM)) ||
        miopen::any_of(problem.GetConv().GetConvDilations(), [](auto v) { return v > 1; }))
         return 0;
 
@@ -95,7 +95,7 @@ std::size_t GetWorkSpaceSizeGEMM(const miopen::ExecutionContext& ctx,
 std::size_t GetWorkSpaceSizeImplicitGemm(const miopen::ExecutionContext& ctx,
                                          const conv::ProblemDescription& problem)
 {
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM)))
         return 0;
     return GetMaxWorkSpaceSize(FindAllImplicitGemmWorkspaceSizes(ctx, problem));
 }
@@ -103,7 +103,7 @@ std::size_t GetWorkSpaceSizeImplicitGemm(const miopen::ExecutionContext& ctx,
 std::size_t GetWorkSpaceSizeDirect(const miopen::ExecutionContext& ctx,
                                    const conv::ProblemDescription& problem)
 {
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_DIRECT)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_DIRECT)))
         return 0;
     return GetMaxWorkSpaceSize(AllDirectForwardBackwardDataWorkspaceSize(ctx, problem));
 }
@@ -111,7 +111,7 @@ std::size_t GetWorkSpaceSizeDirect(const miopen::ExecutionContext& ctx,
 std::size_t GetWorkSpaceSizeFFT(const miopen::ExecutionContext& ctx,
                                 const conv::ProblemDescription& problem)
 {
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_FFT)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_FFT)))
         return 0;
     return GetMaxWorkSpaceSize(AllFFTForwardBackwardDataWorkspaceSize(ctx, problem));
 }
@@ -119,7 +119,7 @@ std::size_t GetWorkSpaceSizeFFT(const miopen::ExecutionContext& ctx,
 std::size_t GetWorkSpaceSizeWinograd(const miopen::ExecutionContext& ctx,
                                      const conv::ProblemDescription& problem)
 {
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_WINOGRAD)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_WINOGRAD)))
         return 0;
     return GetMaxWorkSpaceSize(FindAllWinogradWorkspaceSizes(ctx, problem));
 }
@@ -127,7 +127,7 @@ std::size_t GetWorkSpaceSizeWinograd(const miopen::ExecutionContext& ctx,
 std::size_t GetWorkSpaceSizeDirectWrW(const miopen::ExecutionContext& ctx,
                                       const conv::ProblemDescription& problem)
 {
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_DIRECT)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_DIRECT)))
         return 0;
     return GetMaxWorkSpaceSize(AllDirectBwdWrW2DWorkspaceSize(ctx, problem));
 }
@@ -135,7 +135,7 @@ std::size_t GetWorkSpaceSizeDirectWrW(const miopen::ExecutionContext& ctx,
 std::size_t GetWorkSpaceSizeWinogradWrW(const miopen::ExecutionContext& ctx,
                                         const conv::ProblemDescription& problem)
 {
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_WINOGRAD)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_WINOGRAD)))
         return 0;
     return GetMaxWorkSpaceSize(FindWinogradWrWWorkspaceSizes(ctx, problem));
 }
@@ -143,7 +143,7 @@ std::size_t GetWorkSpaceSizeWinogradWrW(const miopen::ExecutionContext& ctx,
 std::size_t GetWorkSpaceSizeImplicitGemmWrW(const miopen::ExecutionContext& ctx,
                                             const conv::ProblemDescription& problem)
 {
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM)))
         return 0;
     return GetMaxWorkSpaceSize(FindImplicitGemmWrWWorkspaceSizes(ctx, problem));
 }
@@ -386,7 +386,7 @@ TensorDescriptor ConvolutionDescriptor::GetForwardOutputTensor(const TensorDescr
 bool ConvolutionDescriptor::IsWinograd3x3SupportedAndFast(
     const miopen::ExecutionContext& ctx, const conv::ProblemDescription& problem) const
 {
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_WINOGRAD)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_WINOGRAD)))
         return false;
 
     // Disable this performance optimization when we want to run some specific Solver.
@@ -424,8 +424,9 @@ std::size_t ConvolutionDescriptor::GetWorkSpaceSize(ExecutionContext ctx,
         /// actually required workspace here.
         auto fallback        = bool{};
         const auto solutions = GetSolutions(ctx, problem, 1, &fallback);
-        if(solutions.empty() || ((findMode.IsHybrid(ctx) && fallback) &&
-                                 !miopen::IsEnabled(ENV(MIOPEN_DEBUG_FORCE_IMMED_MODE_FALLBACK))))
+        if(solutions.empty() ||
+           ((findMode.IsHybrid(ctx) && fallback) &&
+            !miopen::IsEnabled(MIOPEN_ENV(MIOPEN_DEBUG_FORCE_IMMED_MODE_FALLBACK))))
         {
             ctx.use_dynamic_solutions_only = findMode.IsDynamicHybrid(ctx);
             break; // Fall down to Normal Find.

--- a/src/db_path.cpp.in
+++ b/src/db_path.cpp.in
@@ -62,7 +62,7 @@ fs::path GetLibPath()
 
 std::string GetSystemDbPath()
 {
-    auto p = GetStringEnv(ENV(MIOPEN_SYSTEM_DB_PATH));
+    auto p = GetStringEnv(MIOPEN_ENV(MIOPEN_SYSTEM_DB_PATH));
     if(p.empty())
 #if MIOPEN_BUILD_DEV || defined(_WIN32)
     {
@@ -88,7 +88,7 @@ fs::path PrepareUserDbPath()
 {
     /// If MIOPEN_USER_DB_PATH is set in the environment, then assume that the user wants
     /// the library to use exactly that path.
-    const auto p = GetStringEnv(ENV(MIOPEN_USER_DB_PATH));
+    const auto p = GetStringEnv(MIOPEN_ENV(MIOPEN_USER_DB_PATH));
     if(!p.empty())
         return ExpandUser(p);
     /// \anchor nfs-detection

--- a/src/execution_context.cpp
+++ b/src/execution_context.cpp
@@ -86,7 +86,7 @@ static std::ostream& operator<<(std::ostream& os, const rocm_meta_version& rmv)
 bool rocm_meta_version::UseV3() const
 {
     if(val == AMDHSA_COv2_COv3)
-        return !miopen::IsEnabled(ENV(MIOPEN_DEBUG_AMD_ROCM_METADATA_PREFER_OLDER));
+        return !miopen::IsEnabled(MIOPEN_ENV(MIOPEN_DEBUG_AMD_ROCM_METADATA_PREFER_OLDER));
     return (val == AMDHSA_COv3);
 }
 
@@ -138,7 +138,7 @@ static bool CalculateIsAmdRocmOpencl(const miopen::ExecutionContext& context)
 static rocm_meta_version AmdRocmMetadataVersionGetEnv()
 {
     const rocm_meta_version val(
-        static_cast<int>(miopen::Value(ENV(MIOPEN_DEBUG_AMD_ROCM_METADATA_ENFORCE))));
+        static_cast<int>(miopen::Value(MIOPEN_ENV(MIOPEN_DEBUG_AMD_ROCM_METADATA_ENFORCE))));
     if(!val.IsValid())
     {
         MIOPEN_LOG_W("Incorrect MIOPEN_DEBUG_AMD_ROCM_ENFORCE_MDVERSION = " << val.getValue()
@@ -208,9 +208,9 @@ static bool IsAmdRocmOpencl(miopen::ExecutionContext& context)
 bool IsHipKernelsEnabled()
 {
 #if MIOPEN_USE_HIP_KERNELS
-    return !miopen::IsDisabled(ENV(MIOPEN_DEBUG_HIP_KERNELS));
+    return !miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_HIP_KERNELS));
 #else
-    return miopen::IsEnabled(ENV(MIOPEN_DEBUG_HIP_KERNELS));
+    return miopen::IsEnabled(MIOPEN_ENV(MIOPEN_DEBUG_HIP_KERNELS));
 #endif
 }
 
@@ -219,13 +219,14 @@ void ExecutionContext::DetectRocm()
     use_binaries            = false;
     use_asm_kernels         = false;
     use_hip_kernels         = IsHipKernelsEnabled();
-    use_opencl_convolutions = !IsDisabled(ENV(MIOPEN_DEBUG_OPENCL_CONVOLUTIONS));
+    use_opencl_convolutions = !IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_OPENCL_CONVOLUTIONS));
     rmv                     = rocm_meta_version::Default;
     if(IsAmdRocmOpencl(*this))
     {
-        use_asm_kernels = !IsDisabled(ENV(MIOPEN_DEBUG_GCN_ASM_KERNELS)) && ValidateGcnAssembler();
+        use_asm_kernels =
+            !IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_GCN_ASM_KERNELS)) && ValidateGcnAssembler();
 #ifndef HIP_OC_FINALIZER
-        use_binaries = !IsDisabled(ENV(MIOPEN_DEBUG_AMD_ROCM_PRECOMPILED_BINARIES));
+        use_binaries = !IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_AMD_ROCM_PRECOMPILED_BINARIES));
 #endif
     }
 }

--- a/src/expanduser.cpp
+++ b/src/expanduser.cpp
@@ -178,7 +178,7 @@ bool IsNetworkedFilesystem(const fs::path& path_)
 namespace {
 std::string GetHomeDir()
 {
-    const auto p = GetStringEnv(ENV(HOME));
+    const auto p = GetStringEnv(MIOPEN_ENV(HOME));
     if(!(p.empty() || p == std::string("/")))
     {
         return p;

--- a/src/find_controls.cpp
+++ b/src/find_controls.cpp
@@ -70,7 +70,7 @@ const char* ToCString(const FindEnforceAction mode)
 
 FindEnforceAction GetFindEnforceActionImpl()
 {
-    auto str = miopen::GetStringEnv(ENV(MIOPEN_FIND_ENFORCE));
+    auto str = miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_FIND_ENFORCE));
     if(str.empty())
         return FindEnforceAction::Default_;
     for(auto& c : str)
@@ -114,7 +114,7 @@ FindEnforceAction GetFindEnforceAction()
 boost::optional<std::vector<solver::Id>> GetEnvFindOnlySolverImpl()
 {
     static_assert(miopen::solver::Id::invalid_value == 0, "miopen::solver::Id::invalid_value == 0");
-    const auto& slv_str = miopen::GetStringEnv(ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER));
+    const auto& slv_str = miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER));
     std::vector<solver::Id> res;
     if(!slv_str.empty())
     {
@@ -198,7 +198,7 @@ std::ostream& operator<<(std::ostream& os, const FindMode::Values& v)
 
 FindMode::Values GetFindModeValueImpl2()
 {
-    auto str = miopen::GetStringEnv(ENV(MIOPEN_FIND_MODE));
+    auto str = miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_FIND_MODE));
     if(str.empty())
         return FindMode::Values::Default_;
     for(auto& c : str)

--- a/src/gemm_v2.cpp
+++ b/src/gemm_v2.cpp
@@ -337,7 +337,7 @@ static GemmBackend_t enforce_gemm_backend(miopenDataType_t data_type,
     // enforce backend based on env variable
     // I have left the commented lines here to preserve values for the enforce and hint at why are
     // they 1 and 3
-    switch(Value(ENV(MIOPEN_GEMM_ENFORCE_BACKEND)))
+    switch(Value(MIOPEN_ENV(MIOPEN_GEMM_ENFORCE_BACKEND)))
     {
     case 1: gemm_backend_env = GemmBackend_t::rocblas; break;
     // case 2: gemm_backend_env = GemmBackend_t::miopengemm; break;

--- a/src/generic_search.cpp
+++ b/src/generic_search.cpp
@@ -53,15 +53,15 @@ std::size_t GetTuningIterationsMax()
 {
     if(debug::tuning_iterations_limit)
         return *debug::tuning_iterations_limit;
-    return Value(ENV(MIOPEN_DEBUG_TUNING_ITERATIONS_MAX));
+    return Value(MIOPEN_ENV(MIOPEN_DEBUG_TUNING_ITERATIONS_MAX));
 }
 
 std::chrono::milliseconds GetTuningTimeMax()
 {
-    return std::chrono::milliseconds{Value(ENV(MIOPEN_TUNING_TIME_MS_MAX))};
+    return std::chrono::milliseconds{Value(MIOPEN_ENV(MIOPEN_TUNING_TIME_MS_MAX))};
 }
 
-std::size_t GetTuningThreadsMax() { return Value(ENV(MIOPEN_COMPILE_PARALLEL_LEVEL)); }
+std::size_t GetTuningThreadsMax() { return Value(MIOPEN_ENV(MIOPEN_COMPILE_PARALLEL_LEVEL)); }
 
 } // namespace solver
 } // namespace miopen

--- a/src/hip/handlehip.cpp
+++ b/src/hip/handlehip.cpp
@@ -628,7 +628,7 @@ std::size_t Handle::GetGlobalMemorySize() const
 
 std::size_t Handle::GetMaxComputeUnits() const
 {
-    const std::size_t num_cu = Value(ENV(MIOPEN_DEVICE_CU));
+    const std::size_t num_cu = Value(MIOPEN_ENV(MIOPEN_DEVICE_CU));
     if(num_cu > 0)
         return num_cu;
 

--- a/src/hip/hip_build_utils.cpp
+++ b/src/hip/hip_build_utils.cpp
@@ -158,11 +158,11 @@ static fs::path HipBuildImpl(boost::optional<TmpDir>& tmp_dir,
     params += MIOPEN_STRINGIZE(HIP_COMPILER_FLAGS);
 
 #if MIOPEN_BUILD_DEV
-    if(miopen::IsEnabled(ENV(MIOPEN_DEBUG_HIP_VERBOSE)))
+    if(miopen::IsEnabled(MIOPEN_ENV(MIOPEN_DEBUG_HIP_VERBOSE)))
     {
         params += " -v";
     }
-    if(miopen::IsEnabled(ENV(MIOPEN_DEBUG_HIP_DUMP)))
+    if(miopen::IsEnabled(MIOPEN_ENV(MIOPEN_DEBUG_HIP_DUMP)))
     {
         params += " -gline-tables-only";
         params += " -save-temps";

--- a/src/hipoc/hipoc_kernel.cpp
+++ b/src/hipoc/hipoc_kernel.cpp
@@ -81,7 +81,7 @@ void HIPOCKernelInvoke::run(void* args, std::size_t size) const
         stop  = make_hip_event();
     }
 
-    const auto& arch = miopen::GetStringEnv(ENV(MIOPEN_DEVICE_ARCH));
+    const auto& arch = miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_DEVICE_ARCH));
     if(!arch.empty())
     {
         MIOPEN_THROW("MIOPEN_DEVICE_ARCH used, escaping launching kernel");
@@ -133,7 +133,7 @@ void HIPOCKernelInvoke::run_cooperative(void** kern_args) const
                   << GetName() << ", global_work_dim = " << DimToFormattedString(gdims.data(), 3)
                   << ", local_work_dim = " << DimToFormattedString(ldims.data(), 3));
 
-    const auto& arch = miopen::GetStringEnv(ENV(MIOPEN_DEVICE_ARCH));
+    const auto& arch = miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_DEVICE_ARCH));
     if(!arch.empty())
     {
         MIOPEN_THROW("MIOPEN_DEVICE_ARCH used, escaping launching kernel");

--- a/src/hipoc/hipoc_program.cpp
+++ b/src/hipoc/hipoc_program.cpp
@@ -73,7 +73,7 @@ namespace {
 
 int DetectCodeObjectOptionSyntax()
 {
-    auto syntax = miopen::Value(ENV(MIOPEN_DEBUG_OPENCL_ENFORCE_CODE_OBJECT_OPTION));
+    auto syntax = miopen::Value(MIOPEN_ENV(MIOPEN_DEBUG_OPENCL_ENFORCE_CODE_OBJECT_OPTION));
     if(syntax > 4)
     {
         MIOPEN_LOG_E("Bad MIOPEN_DEBUG_OPENCL_ENFORCE_CODE_OBJECT_OPTION, using default");
@@ -90,7 +90,7 @@ int DetectCodeObjectOptionSyntax()
 
 int DetectCodeObjectVersion()
 {
-    auto co_version = miopen::Value(ENV(MIOPEN_DEBUG_OPENCL_ENFORCE_CODE_OBJECT_VERSION));
+    auto co_version = miopen::Value(MIOPEN_ENV(MIOPEN_DEBUG_OPENCL_ENFORCE_CODE_OBJECT_VERSION));
     // Very basic syntax check:
     if(co_version == 1 || co_version > 4)
     {
@@ -175,7 +175,7 @@ HIPOCProgramImpl::HIPOCProgramImpl(const std::string& program_name, const fs::pa
 HIPOCProgramImpl::HIPOCProgramImpl(const std::string& program_name, const std::vector<char>& blob)
     : program(program_name) ///, module(CreateModuleInMem(blob))
 {
-    const auto& arch = miopen::GetStringEnv(ENV(MIOPEN_DEVICE_ARCH));
+    const auto& arch = miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_DEVICE_ARCH));
     if(!arch.empty())
         return;
     module = CreateModuleInMem(blob);
@@ -194,7 +194,7 @@ HIPOCProgramImpl::HIPOCProgramImpl(const std::string& program_name,
     }
     else
     {
-        const auto& arch = miopen::GetStringEnv(ENV(MIOPEN_DEVICE_ARCH));
+        const auto& arch = miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_DEVICE_ARCH));
         if(arch.empty())
         {
             module = CreateModule(hsaco_file);
@@ -235,7 +235,7 @@ void HIPOCProgramImpl::BuildCodeObjectInFile(std::string& params,
     else
     {
         params += " " + GetCodeObjectVersionOption();
-        if(miopen::IsEnabled(ENV(MIOPEN_DEBUG_OPENCL_WAVE64_NOWGP)))
+        if(miopen::IsEnabled(MIOPEN_ENV(MIOPEN_DEBUG_OPENCL_WAVE64_NOWGP)))
             params += " -mwavefrontsize64 -mcumode";
         WriteFile(src, dir->path / filename);
         params += " -target amdgcn-amd-amdhsa -x cl -D__AMD__=1  -O3";
@@ -269,7 +269,7 @@ void HIPOCProgramImpl::BuildCodeObjectInMemory(const std::string& params,
         if(miopen::EndsWith(filename, ".cpp"))
         {
 #if MIOPEN_USE_HIPRTC
-            if(!miopen::IsDisabled(ENV(MIOPEN_DEBUG_USE_HIPRTC)))
+            if(!miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_USE_HIPRTC)))
                 hiprtc::BuildHip(filename, src, params, target, binary);
             else
 #endif // MIOPEN_USE_HIPRTC

--- a/src/include/miopen/convolution.hpp
+++ b/src/include/miopen/convolution.hpp
@@ -76,8 +76,8 @@ struct ConvolutionAttribute
 
         inline int Get() const
         {
-            if(!miopen::IsUnset(ENV(MIOPEN_DEBUG_CONVOLUTION_ATTRIB_FP16_ALT_IMPL)))
-                return miopen::Value(ENV(MIOPEN_DEBUG_CONVOLUTION_ATTRIB_FP16_ALT_IMPL));
+            if(!miopen::IsUnset(MIOPEN_ENV(MIOPEN_DEBUG_CONVOLUTION_ATTRIB_FP16_ALT_IMPL)))
+                return miopen::Value(MIOPEN_ENV(MIOPEN_DEBUG_CONVOLUTION_ATTRIB_FP16_ALT_IMPL));
             return value;
         }
 
@@ -105,17 +105,17 @@ struct ConvolutionAttribute
 
         inline miopenF8RoundingMode_t Get() const
         {
-            if(!miopen::IsUnset(ENV(MIOPEN_DEBUG_CONVOLUTION_ATTRIB_FP8_ROUNDING_MODE)))
+            if(!miopen::IsUnset(MIOPEN_ENV(MIOPEN_DEBUG_CONVOLUTION_ATTRIB_FP8_ROUNDING_MODE)))
                 return static_cast<miopenF8RoundingMode_t>(
-                    miopen::Value(ENV(MIOPEN_DEBUG_CONVOLUTION_ATTRIB_FP8_ROUNDING_MODE)));
+                    miopen::Value(MIOPEN_ENV(MIOPEN_DEBUG_CONVOLUTION_ATTRIB_FP8_ROUNDING_MODE)));
             return rounding_mode;
         }
 
         inline uint32_t GetSeed() const
         {
             // assert(rounding_mode == miopenF8RoundingModeStochastic);
-            if(!miopen::IsUnset(ENV(MIOPEN_DEBUG_CONVOLUTION_ATTRIB_FP8_ROUNDING_SEED)))
-                return miopen::Value(ENV(MIOPEN_DEBUG_CONVOLUTION_ATTRIB_FP8_ROUNDING_SEED));
+            if(!miopen::IsUnset(MIOPEN_ENV(MIOPEN_DEBUG_CONVOLUTION_ATTRIB_FP8_ROUNDING_SEED)))
+                return miopen::Value(MIOPEN_ENV(MIOPEN_DEBUG_CONVOLUTION_ATTRIB_FP8_ROUNDING_SEED));
             return seed;
         }
 
@@ -130,9 +130,9 @@ struct ConvolutionAttribute
     public:
         inline int Get() const
         {
-            if(!miopen::IsUnset(ENV(MIOPEN_DEBUG_CONVOLUTION_DETERMINISTIC)))
+            if(!miopen::IsUnset(MIOPEN_ENV(MIOPEN_DEBUG_CONVOLUTION_DETERMINISTIC)))
                 return static_cast<int>(
-                    miopen::IsEnabled(ENV(MIOPEN_DEBUG_CONVOLUTION_DETERMINISTIC)));
+                    miopen::IsEnabled(MIOPEN_ENV(MIOPEN_DEBUG_CONVOLUTION_DETERMINISTIC)));
             return value;
         }
         operator bool() const

--- a/src/include/miopen/env.hpp
+++ b/src/include/miopen/env.hpp
@@ -153,7 +153,7 @@ public:
 
 #define MIOPEN_DECLARE_ENV_VAR_STR(name) MIOPEN_DECLARE_ENV_VAR(name, std::string, "")
 
-#define ENV(name) \
+#define MIOPEN_ENV(name) \
     miopen::env::name {}
 
 /// \todo the following functions should be renamed to either include the word Env

--- a/src/include/miopen/find_db.hpp
+++ b/src/include/miopen/find_db.hpp
@@ -98,7 +98,8 @@ public:
                              ? *debug::testing_find_db_path_override()
                              : GetInstalledPath(handle, path_suffix)),
           db(boost::make_optional<DbTimer<TDb>>(
-              debug::testing_find_db_enabled && !IsEnabled(ENV(MIOPEN_DEBUG_DISABLE_FIND_DB)),
+              debug::testing_find_db_enabled &&
+                  !IsEnabled(MIOPEN_ENV(MIOPEN_DEBUG_DISABLE_FIND_DB)),
               DbTimer<TDb>{DbKinds::FindDb, installed_path, path}))
     {
         if(!db.is_initialized())
@@ -118,9 +119,10 @@ public:
 #if MIOPEN_DISABLE_USERDB
           db(boost::optional<DbTimer<TDb>>{DbKinds::FindDb})
 #else
-          db(boost::make_optional<DbTimer<TDb>>(debug::testing_find_db_enabled &&
-                                                    !IsEnabled(ENV(MIOPEN_DEBUG_DISABLE_FIND_DB)),
-                                                DbTimer<TDb>{DbKinds::FindDb, path, false}))
+          db(boost::make_optional<DbTimer<TDb>>(
+              debug::testing_find_db_enabled &&
+                  !IsEnabled(MIOPEN_ENV(MIOPEN_DEBUG_DISABLE_FIND_DB)),
+              DbTimer<TDb>{DbKinds::FindDb, path, false}))
 #endif
     {
         if(!db.is_initialized())

--- a/src/include/miopen/generic_search.hpp
+++ b/src/include/miopen/generic_search.hpp
@@ -440,7 +440,7 @@ auto GenericSearch(const Solver s,
                                     std::ref(solution_queue));
     }
 
-    if(!IsEnabled(ENV(MIOPEN_DEBUG_COMPILE_ONLY)))
+    if(!IsEnabled(MIOPEN_ENV(MIOPEN_DEBUG_COMPILE_ONLY)))
     {
         size_t n_current       = 0;
         auto threads_remaining = total_threads;

--- a/src/include/miopen/solver/ck_utility_common.hpp
+++ b/src/include/miopen/solver/ck_utility_common.hpp
@@ -129,14 +129,16 @@ static inline auto get_ck_common_compiler_flag(const Handle& handle)
 
     // sync LDS
     compiler_flag << " -DCK_BLOCK_SYNC_LDS_WITHOUT_SYNC_VMEM="
-                  << (miopen::IsDisabled(ENV(MIOPEN_DEBUG_CK_BLOCK_SYNC_LDS_WITHOUT_SYNC_VMEM))
+                  << (miopen::IsDisabled(
+                          MIOPEN_ENV(MIOPEN_DEBUG_CK_BLOCK_SYNC_LDS_WITHOUT_SYNC_VMEM))
                           ? '0'
                           : '1');
 
     // buffer addressing
     compiler_flag << " -DCK_USE_AMD_BUFFER_ADDRESSING="
-                  << (miopen::IsDisabled(ENV(MIOPEN_DEBUG_CK_USE_AMD_BUFFER_ADDRESSING)) ? '0'
-                                                                                         : '1');
+                  << (miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CK_USE_AMD_BUFFER_ADDRESSING))
+                          ? '0'
+                          : '1');
 
     return compiler_flag.str();
 }

--- a/src/include/miopen/solver/implicitgemm_util.hpp
+++ b/src/include/miopen/solver/implicitgemm_util.hpp
@@ -205,7 +205,7 @@ inline static bool NextFlag(bool& v)
 
 static inline bool IsXdlopsSupport(const ExecutionContext& ctx)
 {
-    if(miopen::IsEnabled(ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_XDLOPS_EMULATE)))
+    if(miopen::IsEnabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_XDLOPS_EMULATE)))
         return true;
 
     // disable xdlops kernels by default due to possible failures:
@@ -214,7 +214,8 @@ static inline bool IsXdlopsSupport(const ExecutionContext& ctx)
     const bool is_xdlops_supported = StartsWith(ctx.GetStream().GetDeviceName(), "gfx908") ||
                                      StartsWith(ctx.GetStream().GetDeviceName(), "gfx90a") ||
                                      StartsWith(ctx.GetStream().GetDeviceName(), "gfx94");
-    return is_xdlops_supported && !miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_XDLOPS));
+    return is_xdlops_supported &&
+           !miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_XDLOPS));
 }
 
 ///\todo remove
@@ -443,7 +444,7 @@ static inline bool use_amd_inline_asm(const ExecutionContext& ctx,
        problem.IsFp16())
         return false;
 
-    return !miopen::IsDisabled(ENV(MIOPEN_DEBUG_IMPLICIT_GEMM_NON_XDLOPS_INLINE_ASM));
+    return !miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_IMPLICIT_GEMM_NON_XDLOPS_INLINE_ASM));
 }
 
 static inline bool is_use_amd_buffer_load_store(const ExecutionContext& ctx)
@@ -550,11 +551,11 @@ static inline auto get_static_ck_common_compiler_flag(const ExecutionContext& ct
                      (support_amd_buffer_atomic_fadd(ctx.GetStream().GetDeviceName()) ? '1' : '0');
 
     // LDS sync
-    compiler_flag +=
-        std::string(" -DCK_BLOCK_SYNC_LDS_WITHOUT_SYNC_VMEM=") +
-        (miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_BLOCK_SYNC_LDS_WITHOUT_SYNC_VMEM))
-             ? '0'
-             : '1');
+    compiler_flag += std::string(" -DCK_BLOCK_SYNC_LDS_WITHOUT_SYNC_VMEM=") +
+                     (miopen::IsDisabled(MIOPEN_ENV(
+                          MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_BLOCK_SYNC_LDS_WITHOUT_SYNC_VMEM))
+                          ? '0'
+                          : '1');
 
     // workaround
     compiler_flag +=

--- a/src/include/miopen/sqlite_db.hpp
+++ b/src/include/miopen/sqlite_db.hpp
@@ -281,7 +281,7 @@ public:
         else
         {
             dbInvalid = false;
-            if(!is_system && !miopen::IsEnabled(ENV(MIOPEN_DEBUG_DISABLE_SQL_WAL)))
+            if(!is_system && !miopen::IsEnabled(MIOPEN_ENV(MIOPEN_DEBUG_DISABLE_SQL_WAL)))
             {
                 auto res = sql.Exec("PRAGMA journal_mode=WAL;");
                 if(res.empty() || res[0]["journal_mode"] != "wal")
@@ -446,7 +446,7 @@ public:
         if(dbInvalid)
             return boost::none;
 
-        const auto& pdb_ovr = miopen::GetStringEnv(ENV(MIOPEN_DEBUG_PERFDB_OVERRIDE));
+        const auto& pdb_ovr = miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_DEBUG_PERFDB_OVERRIDE));
         if(!pdb_ovr.empty())
         {
             MIOPEN_LOG_I2("overriding tuning params with: " << pdb_ovr);

--- a/src/kernel_cache.cpp
+++ b/src/kernel_cache.cpp
@@ -120,7 +120,7 @@ Kernel KernelCache::AddKernel(const Handle& h,
     }
 
     Kernel kernel{};
-    const auto& arch = miopen::GetStringEnv(ENV(MIOPEN_DEVICE_ARCH));
+    const auto& arch = miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_DEVICE_ARCH));
     if(!arch.empty())
     {
         kernel = Kernel{program, kernel_name};

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -120,22 +120,23 @@ inline float GetTimeDiff()
 
 bool IsLoggingDebugQuiet()
 {
-    return debug::LoggingQuiet && !miopen::IsEnabled(ENV(MIOPEN_DEBUG_LOGGING_QUIETING_DISABLE));
+    return debug::LoggingQuiet &&
+           !miopen::IsEnabled(MIOPEN_ENV(MIOPEN_DEBUG_LOGGING_QUIETING_DISABLE));
 }
 
 bool IsLoggingFunctionCalls()
 {
-    return miopen::IsEnabled(ENV(MIOPEN_ENABLE_LOGGING)) && !IsLoggingDebugQuiet();
+    return miopen::IsEnabled(MIOPEN_ENV(MIOPEN_ENABLE_LOGGING)) && !IsLoggingDebugQuiet();
 }
 
 bool IsLoggingToRoctx()
 {
-    return miopen::IsEnabled(ENV(MIOPEN_ENABLE_LOGGING_ROCTX)) && !IsLoggingDebugQuiet();
+    return miopen::IsEnabled(MIOPEN_ENV(MIOPEN_ENABLE_LOGGING_ROCTX)) && !IsLoggingDebugQuiet();
 }
 
 bool IsLogging(const LoggingLevel level, const bool disableQuieting)
 {
-    auto enabled_level = miopen::Value(ENV(MIOPEN_LOG_LEVEL));
+    auto enabled_level = miopen::Value(MIOPEN_ENV(MIOPEN_LOG_LEVEL));
     if(IsLoggingDebugQuiet() && !disableQuieting)
     {
         // Disable all levels higher than fatal.
@@ -176,13 +177,13 @@ const char* LoggingLevelToCString(const LoggingLevel level)
 
 bool IsLoggingCmd()
 {
-    return miopen::IsEnabled(ENV(MIOPEN_ENABLE_LOGGING_CMD)) && !IsLoggingDebugQuiet();
+    return miopen::IsEnabled(MIOPEN_ENV(MIOPEN_ENABLE_LOGGING_CMD)) && !IsLoggingDebugQuiet();
 }
 
 std::string LoggingPrefix()
 {
     std::stringstream ss;
-    if(miopen::IsEnabled(ENV(MIOPEN_ENABLE_LOGGING_MPMT)))
+    if(miopen::IsEnabled(MIOPEN_ENV(MIOPEN_ENABLE_LOGGING_MPMT)))
     {
         ss << GetProcessAndThreadId() << ' ';
     }
@@ -192,7 +193,7 @@ std::string LoggingPrefix()
 #elif MIOPEN_BACKEND_HIP
     ss << "(HIP)";
 #endif
-    if(miopen::IsEnabled(ENV(MIOPEN_ENABLE_LOGGING_ELAPSED_TIME)))
+    if(miopen::IsEnabled(MIOPEN_ENV(MIOPEN_ENABLE_LOGGING_ELAPSED_TIME)))
     {
         ss << std::fixed << std::setprecision(3) << std::setw(8) << GetTimeDiff();
     }

--- a/src/ocl/clhelper.cpp
+++ b/src/ocl/clhelper.cpp
@@ -189,7 +189,7 @@ ClProgramPtr LoadProgram(cl_context ctx,
     else // OpenCL programs.
     {
         ClProgramPtr result{CreateProgram(ctx, source.data(), source.size())};
-        if(miopen::IsEnabled(ENV(MIOPEN_DEBUG_OPENCL_WAVE64_NOWGP)))
+        if(miopen::IsEnabled(MIOPEN_ENV(MIOPEN_DEBUG_OPENCL_WAVE64_NOWGP)))
             params += " -Wf,-mwavefrontsize64 -Wf,-mcumode";
 #if MIOPEN_BUILD_DEV
         params += " -Werror";

--- a/src/ocl/convolutionocl.cpp
+++ b/src/ocl/convolutionocl.cpp
@@ -217,7 +217,7 @@ static inline std::vector<PerfField> FindConvolution(const ExecutionContext& ctx
         auto sols     = conv.GetSolutions(ctx, problem, 1, &fallback, &invoke_ctx);
         // override the normal find with immed mode with env var
         if(!sols.empty() && (!(findMode.IsHybrid(ctx) && fallback) ||
-                             miopen::IsEnabled(ENV(MIOPEN_DEBUG_FORCE_IMMED_MODE_FALLBACK))))
+                             miopen::IsEnabled(MIOPEN_ENV(MIOPEN_DEBUG_FORCE_IMMED_MODE_FALLBACK))))
             sol = sols.front();
         // In Hybrid Find mode, we use Normal Find instead of Immediate fallback kernels.
     }
@@ -247,7 +247,7 @@ static inline std::vector<PerfField> FindConvolution(const ExecutionContext& ctx
         });
     }
 
-    if(IsEnabled(ENV(MIOPEN_DEBUG_COMPILE_ONLY)))
+    if(IsEnabled(MIOPEN_ENV(MIOPEN_DEBUG_COMPILE_ONLY)))
     {
         MIOPEN_THROW(
             miopenStatusGpuOperationsSkipped,
@@ -405,7 +405,7 @@ static void ConvForwardCheckNumerics(const Handle& handle,
 
     flag |= miopen::checkNumericsOutput(handle, tensors.yDesc, tensors.y);
 
-    const auto& file_name = miopen::GetStringEnv(ENV(MIOPEN_DUMP_TENSOR_PATH));
+    const auto& file_name = miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_DUMP_TENSOR_PATH));
     if(flag && !file_name.empty())
     {
         DumpTensorToFileFromDevice(handle, tensors.xDesc, tensors.x, file_name + "_x.bin");
@@ -607,7 +607,7 @@ ConvolutionDescriptor::GetSolutionsFallback(const ExecutionContext& ctx,
                                             const size_t maxSolutionCount,
                                             const AnyInvokeParams* const invokeParams) const
 {
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_IMMED_FALLBACK)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_IMMED_FALLBACK)))
     {
         MIOPEN_LOG_I("Disabled via environment");
         return {};
@@ -625,7 +625,7 @@ ConvolutionDescriptor::GetSolutionsFallback(const ExecutionContext& ctx,
 
     // TunaNet Fallback
 #if MIOPEN_ENABLE_AI_IMMED_MODE_FALLBACK
-    if(!miopen::IsDisabled(ENV(MIOPEN_DEBUG_ENABLE_AI_IMMED_MODE_FALLBACK)))
+    if(!miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_ENABLE_AI_IMMED_MODE_FALLBACK)))
     {
         const static std::string arch = ctx.GetStream().GetDeviceName();
         auto solvers                  = ai::immed_mode::PredictSolver(problem, ctx, arch);
@@ -949,7 +949,7 @@ static void ConvBwdCheckNumerics(const Handle& handle,
 
     flag |= miopen::checkNumericsOutput(handle, tensors.dxDesc, tensors.dx);
 
-    const auto& file_name = miopen::GetStringEnv(ENV(MIOPEN_DUMP_TENSOR_PATH));
+    const auto& file_name = miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_DUMP_TENSOR_PATH));
     if(flag && !file_name.empty())
     {
         DumpTensorToFileFromDevice(handle, tensors.dyDesc, tensors.dy, file_name + "_dy.bin");
@@ -1159,7 +1159,7 @@ static void ConvWrwCheckNumerics(const Handle& handle,
 
     flag |= miopen::checkNumericsOutput(handle, tensors.dwDesc, tensors.dw);
 
-    const auto& file_name = miopen::GetStringEnv(ENV(MIOPEN_DUMP_TENSOR_PATH));
+    const auto& file_name = miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_DUMP_TENSOR_PATH));
     if(flag && !file_name.empty())
     {
         DumpTensorToFileFromDevice(handle, tensors.dyDesc, tensors.dy, file_name + "_dy.bin");

--- a/src/ocl/gcn_asm_utils.cpp
+++ b/src/ocl/gcn_asm_utils.cpp
@@ -73,7 +73,7 @@ static std::string CleanupPath(const char* p);
 
 std::string GetGcnAssemblerPathImpl()
 {
-    const auto& asm_path_env_p = miopen::GetStringEnv(ENV(MIOPEN_EXPERIMENTAL_GCN_ASM_PATH));
+    const auto& asm_path_env_p = miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_EXPERIMENTAL_GCN_ASM_PATH));
     if(!asm_path_env_p.empty())
     {
         return CleanupPath(asm_path_env_p.c_str());

--- a/src/ocl/rnnocl.cpp
+++ b/src/ocl/rnnocl.cpp
@@ -48,7 +48,8 @@ bool RNNForwardMSIsSupported([[maybe_unused]] const RNNDescriptor& desctiptor,
 #if MIOPEN_USE_GEMM && MIOPEN_BACKEND_HIP
     if(desctiptor.rnnMode == miopenLSTM && desctiptor.algoMode == miopenRNNdefault &&
        !use_dropout && desctiptor.nLayers > 1 && desctiptor.dirMode == miopenRNNunidirection &&
-       desctiptor.inputMode != miopenRNNskip && !(miopen::IsDisabled(ENV(MIOPEN_RNNFWD_exp))))
+       desctiptor.inputMode != miopenRNNskip &&
+       !(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_RNNFWD_exp))))
     {
         return true;
     }

--- a/src/ocl_kernel.cpp
+++ b/src/ocl_kernel.cpp
@@ -58,7 +58,7 @@ void OCLKernelInvoke::run() const
 
     MIOPEN_HANDLE_LOCK
 
-    const auto& arch = miopen::GetStringEnv(ENV(MIOPEN_DEVICE_ARCH));
+    const auto& arch = miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_DEVICE_ARCH));
     if(!arch.empty())
     {
         MIOPEN_THROW("MIOPEN_DEVICE_ARCH used, escaping launching kernel");

--- a/src/reducetensor.cpp
+++ b/src/reducetensor.cpp
@@ -551,7 +551,7 @@ std::size_t ReduceTensorDescriptor::GetWorkspaceSize(const Handle& handle,
 
     int blockSize;
 
-    if(!miopen::IsDisabled(ENV(MIOPEN_DEBUG_DYNAMIC_REDUCTION)))
+    if(!miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_DYNAMIC_REDUCTION)))
     {
         const tunable_generic_reduction* tunable = &default_tunable_generic_reduction;
         blockSize                                = tunable->BlockSize;
@@ -576,7 +576,7 @@ std::size_t ReduceTensorDescriptor::GetWorkspaceSize(const Handle& handle,
                             64 + sizeof(int) + workspaceAlignRequirementBytes;
 
     // dynamic reduction use one additional page for storing tensor descriptors
-    if(!miopen::IsDisabled(ENV(MIOPEN_DEBUG_DYNAMIC_REDUCTION)))
+    if(!miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_DYNAMIC_REDUCTION)))
         wsSizeInBytes += 4096;
 
     return (wsSizeInBytes);
@@ -643,7 +643,7 @@ void ReduceTensorDescriptor::ReduceTensor(const Handle& handle,
     const tunable_generic_reduction* tunable = &default_tunable_generic_reduction;
 
     const int blockSize =
-        !miopen::IsDisabled(ENV(MIOPEN_DEBUG_DYNAMIC_REDUCTION)) ? tunable->BlockSize : 256;
+        !miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_DYNAMIC_REDUCTION)) ? tunable->BlockSize : 256;
     detail::ReductionKernelConfigurator configurator(blockSize, handle.GetWavefrontWidth());
 
     const bool need_indices =
@@ -726,7 +726,7 @@ void ReduceTensorDescriptor::ReduceTensor(const Handle& handle,
                          ? static_cast<float>(*reinterpret_cast<const double*>(beta))
                          : *reinterpret_cast<const float*>(beta);
 
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_DYNAMIC_REDUCTION)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_DYNAMIC_REDUCTION)))
     { // use static reduction
         std::vector<std::size_t> invariantLengths;
         std::vector<std::size_t> invariantStrides;

--- a/src/rnn/rnn_util.cpp
+++ b/src/rnn/rnn_util.cpp
@@ -35,9 +35,9 @@ namespace miopen {
 
 int getReductionAlgo()
 {
-    return miopen::IsUnset(ENV(MIOPEN_RNNWRW_REDUCTION))
+    return miopen::IsUnset(MIOPEN_ENV(MIOPEN_RNNWRW_REDUCTION))
                ? 1
-               : miopen::Value(ENV(MIOPEN_RNNWRW_REDUCTION));
+               : miopen::Value(MIOPEN_ENV(MIOPEN_RNNWRW_REDUCTION));
 }
 
 void RNNTensorPaddingConverter::ConvertTensorData(const Handle& handle,

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -666,7 +666,7 @@ inline SolverRegistrar::SolverRegistrar(IdRegistryData& registry)
 bool ThisSolverIsDeprecatedStatic::IsDisabled(const ExecutionContext& ctx)
 {
     static const bool device_is_allowed = [&]() {
-        if(miopen::IsEnabled(ENV(MIOPEN_DEBUG_ENABLE_DEPRECATED_SOLVERS)))
+        if(miopen::IsEnabled(MIOPEN_ENV(MIOPEN_DEBUG_ENABLE_DEPRECATED_SOLVERS)))
             return true;
         const auto device = ctx.GetStream().GetTargetProperties().Name();
         return device == "gfx803"                       // Fiji

--- a/src/solver/batchnorm/backward_ck.cpp
+++ b/src/solver/batchnorm/backward_ck.cpp
@@ -191,7 +191,7 @@ bool BnCKBwdBackward::IsApplicable(
     [[maybe_unused]] const miopen::batchnorm::ProblemDescription& bn_problem) const
 {
 #if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_CK_BN_BACK)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_CK_BN_BACK)))
         return false;
     if(!bn_problem.IsLayoutNHWC())
         return false;

--- a/src/solver/batchnorm/backward_per_activation_fused.cpp
+++ b/src/solver/batchnorm/backward_per_activation_fused.cpp
@@ -47,7 +47,7 @@ bool BnBwdTrgActivationFused::IsApplicable(const FusionContext& /*context*/,
     const auto& desc = *problem.fusion_plan_desc;
     if(desc.op_map.empty())
         MIOPEN_THROW("");
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_BN_BWDTRG_ACTIV_FUSED)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_BN_BWDTRG_ACTIV_FUSED)))
         return false;
     if(desc.op_map.size() != 2)
         return false;

--- a/src/solver/batchnorm/forward_inference_ck.cpp
+++ b/src/solver/batchnorm/forward_inference_ck.cpp
@@ -180,7 +180,7 @@ bool BnCKFwdInference::IsApplicable(
     [[maybe_unused]] const miopen::batchnorm::ProblemDescription& bn_problem) const
 {
 #if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_CK_BN_INFER)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_CK_BN_INFER)))
         return false;
     if(!bn_problem.IsLayoutNHWC())
         return false;

--- a/src/solver/batchnorm/forward_inference_fused.cpp
+++ b/src/solver/batchnorm/forward_inference_fused.cpp
@@ -47,7 +47,7 @@ bool BnFwdInferActivationFused::IsApplicable(const FusionContext& /*context*/,
     const auto& desc = *problem.fusion_plan_desc;
     if(desc.op_map.empty())
         MIOPEN_THROW("");
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_BN_FWDINFER_ACTIV_FUSED)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_BN_FWDINFER_ACTIV_FUSED)))
         return false;
     if(desc.op_map.size() != 2)
         return false;

--- a/src/solver/batchnorm/forward_per_activation_fused.cpp
+++ b/src/solver/batchnorm/forward_per_activation_fused.cpp
@@ -46,7 +46,7 @@ bool BnFwdTrgActivationFused::IsApplicable(const FusionContext& /*context*/,
     const auto& desc = *problem.fusion_plan_desc;
     if(desc.op_map.empty())
         MIOPEN_THROW("");
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_BN_FWDTRG_ACTIV_FUSED)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_BN_FWDTRG_ACTIV_FUSED)))
         return false;
     if(desc.op_map.size() != 2)
         return false;

--- a/src/solver/batchnorm/forward_training_ck.cpp
+++ b/src/solver/batchnorm/forward_training_ck.cpp
@@ -183,7 +183,7 @@ bool BnCKFwdTraining::IsApplicable(
     [[maybe_unused]] const miopen::batchnorm::ProblemDescription& bn_problem) const
 {
 #if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_CK_BN_FWD_TRAINING)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_CK_BN_FWD_TRAINING)))
         return false;
     if(!bn_problem.IsLayoutNHWC())
         return false;

--- a/src/solver/conv/conv_wino_fury_RxS.cpp
+++ b/src/solver/conv/conv_wino_fury_RxS.cpp
@@ -220,12 +220,12 @@ bool ConvWinoFuryRxS<Winodata, Winofilter>::IsApplicable(const ExecutionContext&
 {
     if constexpr(IS2X3)
     {
-        if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_AMD_WINOGRAD_FURY_RXS_F2X3)))
+        if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_AMD_WINOGRAD_FURY_RXS_F2X3)))
             return false;
     }
     if constexpr(IS3X2)
     {
-        if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_AMD_WINOGRAD_FURY_RXS_F3X2)))
+        if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_AMD_WINOGRAD_FURY_RXS_F3X2)))
             return false;
     }
 

--- a/src/solver/conv_MP_bidirectional_winograd.cpp
+++ b/src/solver/conv_MP_bidirectional_winograd.cpp
@@ -160,7 +160,7 @@ static bool IsApplicableGEMM(const ProblemDescription& problem)
 #if(MIOPEN_BACKEND_HIP && MIOPEN_USE_ROCBLAS)
 
     const miopenDataType_t transform_data_type =
-        miopen::IsEnabled(ENV(MIOPEN_DEBUG_AMD_MP_BD_WINOGRAD_EXPEREMENTAL_FP16_TRANSFORM))
+        miopen::IsEnabled(MIOPEN_ENV(MIOPEN_DEBUG_AMD_MP_BD_WINOGRAD_EXPEREMENTAL_FP16_TRANSFORM))
             ? problem.GetInDataType()
             : miopenFloat;
 
@@ -207,7 +207,8 @@ static bool IsApplicableTransform(const ExecutionContext& ctx, const ProblemDesc
 #endif
 
     {
-        std::size_t limit = miopen::Value(ENV(MIOPEN_DEBUG_AMD_MP_BD_WINOGRAD_WORKSPACE_MAX));
+        std::size_t limit =
+            miopen::Value(MIOPEN_ENV(MIOPEN_DEBUG_AMD_MP_BD_WINOGRAD_WORKSPACE_MAX));
 #if WORKAROUND_SWDEV_203031
         if(limit == 0)
         {
@@ -246,7 +247,8 @@ static bool IsApplicableTransform(const ExecutionContext& ctx, const ProblemDesc
     DEFINE_SHADER_ALIASES(problem)
     {
         const miopenDataType_t transform_data_type =
-            miopen::IsEnabled(ENV(MIOPEN_DEBUG_AMD_MP_BD_WINOGRAD_EXPEREMENTAL_FP16_TRANSFORM))
+            miopen::IsEnabled(
+                MIOPEN_ENV(MIOPEN_DEBUG_AMD_MP_BD_WINOGRAD_EXPEREMENTAL_FP16_TRANSFORM))
                 ? problem.GetInDataType()
                 : miopenFloat;
 
@@ -344,27 +346,27 @@ bool ConvMPBidirectWinograd<WinoDataH, WinoFilterH, WinoDataW, WinoFilterW>::IsA
 
     if(wino_data_tile == 6 && wino_filter_tile == 3)
     {
-        if(IS_DISABLED(ENV(MIOPEN_DEBUG_AMD_MP_BD_WINOGRAD_F6X3)))
+        if(IS_DISABLED(MIOPEN_ENV(MIOPEN_DEBUG_AMD_MP_BD_WINOGRAD_F6X3)))
             return false;
     }
     if(wino_data_tile == 5 && wino_filter_tile == 3)
     {
-        if(IS_DISABLED(ENV(MIOPEN_DEBUG_AMD_MP_BD_WINOGRAD_F5X3)))
+        if(IS_DISABLED(MIOPEN_ENV(MIOPEN_DEBUG_AMD_MP_BD_WINOGRAD_F5X3)))
             return false;
     }
     if(wino_data_tile == 4 && wino_filter_tile == 3)
     {
-        if(IS_DISABLED(ENV(MIOPEN_DEBUG_AMD_MP_BD_WINOGRAD_F4X3)))
+        if(IS_DISABLED(MIOPEN_ENV(MIOPEN_DEBUG_AMD_MP_BD_WINOGRAD_F4X3)))
             return false;
     }
     if(wino_data_tile == 3 && wino_filter_tile == 3)
     {
-        if(IS_DISABLED(ENV(MIOPEN_DEBUG_AMD_MP_BD_WINOGRAD_F3X3)))
+        if(IS_DISABLED(MIOPEN_ENV(MIOPEN_DEBUG_AMD_MP_BD_WINOGRAD_F3X3)))
             return false;
     }
     if(wino_data_tile == 2 && wino_filter_tile == 3)
     {
-        if(IS_DISABLED(ENV(MIOPEN_DEBUG_AMD_MP_BD_WINOGRAD_F2X3)))
+        if(IS_DISABLED(MIOPEN_ENV(MIOPEN_DEBUG_AMD_MP_BD_WINOGRAD_F2X3)))
             return false;
     }
 
@@ -376,7 +378,7 @@ size_t ConvMPBidirectWinograd<WinoDataH, WinoFilterH, WinoDataW, WinoFilterW>::G
     const ExecutionContext&, const ProblemDescription& problem) const
 {
     const miopenDataType_t transform_data_type =
-        miopen::IsEnabled(ENV(MIOPEN_DEBUG_AMD_MP_BD_WINOGRAD_EXPEREMENTAL_FP16_TRANSFORM))
+        miopen::IsEnabled(MIOPEN_ENV(MIOPEN_DEBUG_AMD_MP_BD_WINOGRAD_EXPEREMENTAL_FP16_TRANSFORM))
             ? problem.GetInDataType()
             : miopenFloat;
 
@@ -431,7 +433,7 @@ static InvokerFactory MakeWinogradInvokerFactory(const ExecutionContext& ctx,
                      GetTypeSize(problem.GetWeightsDataType()));
 
     const miopenDataType_t transform_data_type =
-        miopen::IsEnabled(ENV(MIOPEN_DEBUG_AMD_MP_BD_WINOGRAD_EXPEREMENTAL_FP16_TRANSFORM))
+        miopen::IsEnabled(MIOPEN_ENV(MIOPEN_DEBUG_AMD_MP_BD_WINOGRAD_EXPEREMENTAL_FP16_TRANSFORM))
             ? problem.GetInDataType()
             : miopenFloat;
     auto wino_in = GetWinoBuffer<WinoDataH, WinoFilterH, WinoDataW, WinoFilterW>(
@@ -667,7 +669,7 @@ ConvSolution ConvMPBidirectWinograd<WinoDataH, WinoFilterH, WinoDataW, WinoFilte
     const size_t g_wk_0 = n_groups * l_wk[0];
     const std::vector<size_t> g_wk{g_wk_0, 1, 1};
     const miopenDataType_t transform_data_type =
-        miopen::IsEnabled(ENV(MIOPEN_DEBUG_AMD_MP_BD_WINOGRAD_EXPEREMENTAL_FP16_TRANSFORM))
+        miopen::IsEnabled(MIOPEN_ENV(MIOPEN_DEBUG_AMD_MP_BD_WINOGRAD_EXPEREMENTAL_FP16_TRANSFORM))
             ? problem.GetInDataType()
             : miopenFloat;
     std::ostringstream options_in;
@@ -759,7 +761,7 @@ ProblemDescription ConvMPBidirectWinograd_xdlops<WinoDataH, WinoFilterH, WinoDat
     DEFINE_GETXFORMHWSIZE()
     int batch_count = wino_xform_h * wino_xform_w * problem.GetGroupCount();
     const miopenDataType_t transform_data_type =
-        miopen::IsEnabled(ENV(MIOPEN_DEBUG_AMD_MP_BD_WINOGRAD_EXPEREMENTAL_FP16_TRANSFORM))
+        miopen::IsEnabled(MIOPEN_ENV(MIOPEN_DEBUG_AMD_MP_BD_WINOGRAD_EXPEREMENTAL_FP16_TRANSFORM))
             ? problem.GetInDataType()
             : miopenFloat;
 
@@ -815,7 +817,7 @@ static miopen::conv::DataInvokeParams GetTransformedInvokeContext(const ProblemD
 {
 #if MIOPEN_BACKEND_HIP
     const miopenDataType_t transform_data_type =
-        miopen::IsEnabled(ENV(MIOPEN_DEBUG_AMD_MP_BD_WINOGRAD_EXPEREMENTAL_FP16_TRANSFORM))
+        miopen::IsEnabled(MIOPEN_ENV(MIOPEN_DEBUG_AMD_MP_BD_WINOGRAD_EXPEREMENTAL_FP16_TRANSFORM))
             ? problem.GetInDataType()
             : miopenFloat;
     WinogradBufferInfo<WinoDataH, WinoFilterH, WinoDataW, WinoFilterW>
@@ -869,27 +871,27 @@ bool ConvMPBidirectWinograd_xdlops<WinoDataH, WinoFilterH, WinoDataW, WinoFilter
 
     if(wino_data_tile == 6 && wino_filter_tile == 3)
     {
-        if(IS_DISABLED(ENV(MIOPEN_DEBUG_AMD_MP_BD_XDLOPS_WINOGRAD_F6X3)))
+        if(IS_DISABLED(MIOPEN_ENV(MIOPEN_DEBUG_AMD_MP_BD_XDLOPS_WINOGRAD_F6X3)))
             return false;
     }
     if(wino_data_tile == 5 && wino_filter_tile == 3)
     {
-        if(IS_DISABLED(ENV(MIOPEN_DEBUG_AMD_MP_BD_XDLOPS_WINOGRAD_F5X3)))
+        if(IS_DISABLED(MIOPEN_ENV(MIOPEN_DEBUG_AMD_MP_BD_XDLOPS_WINOGRAD_F5X3)))
             return false;
     }
     if(wino_data_tile == 4 && wino_filter_tile == 3)
     {
-        if(IS_DISABLED(ENV(MIOPEN_DEBUG_AMD_MP_BD_XDLOPS_WINOGRAD_F4X3)))
+        if(IS_DISABLED(MIOPEN_ENV(MIOPEN_DEBUG_AMD_MP_BD_XDLOPS_WINOGRAD_F4X3)))
             return false;
     }
     if(wino_data_tile == 3 && wino_filter_tile == 3)
     {
-        if(IS_DISABLED(ENV(MIOPEN_DEBUG_AMD_MP_BD_XDLOPS_WINOGRAD_F3X3)))
+        if(IS_DISABLED(MIOPEN_ENV(MIOPEN_DEBUG_AMD_MP_BD_XDLOPS_WINOGRAD_F3X3)))
             return false;
     }
     if(wino_data_tile == 2 && wino_filter_tile == 3)
     {
-        if(IS_DISABLED(ENV(MIOPEN_DEBUG_AMD_MP_BD_XDLOPS_WINOGRAD_F2X3)))
+        if(IS_DISABLED(MIOPEN_ENV(MIOPEN_DEBUG_AMD_MP_BD_XDLOPS_WINOGRAD_F2X3)))
             return false;
     }
 

--- a/src/solver/conv_asm_1x1u.cpp
+++ b/src/solver/conv_asm_1x1u.cpp
@@ -161,7 +161,7 @@ bool PerformanceConfigConvAsm1x1U::SetNextValue(const ProblemDescription&)
     {
         if(!NextLinear<1, 4>(read_size))
             break;
-        if(!miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_DIRECT_ASM_1X1U_SEARCH_OPTIMIZED)))
+        if(!miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_DIRECT_ASM_1X1U_SEARCH_OPTIMIZED)))
         {
             /// Narrow search space in optimized mode.
             if(use_spare_set ? !Next_1_4(k_mult) : !NextTwoPower<8, 32>(k_mult))
@@ -205,7 +205,7 @@ bool PerformanceConfigConvAsm1x1U::SetNextValue(const ProblemDescription&)
 PerformanceConfigConvAsm1x1U::PerformanceConfigConvAsm1x1U(bool spare)
     : PerformanceConfigConvAsm1x1U(1, 1, 1, 1, 1, 1, 1, 1, spare)
 {
-    if(!miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_DIRECT_ASM_1X1U_SEARCH_OPTIMIZED)))
+    if(!miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_DIRECT_ASM_1X1U_SEARCH_OPTIMIZED)))
     {
         k_mult     = spare ? 1 : 8;
         chunk_size = spare ? 1 : 16;
@@ -476,7 +476,7 @@ void PerformanceConfigConvAsm1x1U::StaticHeuristic(const ProblemDescription& pro
 bool PerformanceConfigConvAsm1x1U::IsModelApplicable(const ExecutionContext& ctx,
                                                      const ProblemDescription& problem) const
 {
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_DIRECT_ASM_1X1U_AI_HEUR)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_DIRECT_ASM_1X1U_AI_HEUR)))
         return false;
     if(ctx.GetStream().GetDeviceName() != "gfx908")
         return false;
@@ -521,7 +521,7 @@ bool ConvAsm1x1U::IsValidPerformanceConfig(const ExecutionContext&,
 
 bool ConvAsm1x1U::IsApplicable(const ExecutionContext& ctx, const ProblemDescription& problem) const
 {
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_DIRECT_ASM_1X1U)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_DIRECT_ASM_1X1U)))
         return false;
     if(ThisSolverIsDeprecatedStatic::IsDisabled(ctx))
         return false;
@@ -828,7 +828,8 @@ ConvSolution ConvAsm1x1U::GetSolution(const ExecutionContext& ctx,
 
     PerformanceConfigConvAsm1x1U fromEnv;
     {
-        const auto& s = miopen::GetStringEnv(ENV(MIOPEN_DEBUG_CONV_DIRECT_ASM_1X1U_PERF_VALS));
+        const auto& s =
+            miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_DEBUG_CONV_DIRECT_ASM_1X1U_PERF_VALS));
         if(!s.empty()) // else nothing to parse.
         {
             if(!fromEnv.Deserialize(s) || !fromEnv.IsValidValue())

--- a/src/solver/conv_asm_1x1u_bias_activ_fused.cpp
+++ b/src/solver/conv_asm_1x1u_bias_activ_fused.cpp
@@ -218,7 +218,7 @@ bool ConvBiasActivAsm1x1U::IsApplicable(const FusionContext& context,
     {
         MIOPEN_THROW("");
     }
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_GCN_ASM_KERNELS)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_GCN_ASM_KERNELS)))
         return false;
     // check the sequence of prims
     if(desc.op_map.size() > 3)

--- a/src/solver/conv_asm_1x1u_stride2.cpp
+++ b/src/solver/conv_asm_1x1u_stride2.cpp
@@ -202,7 +202,7 @@ bool PerformanceConfigConvAsm1x1UV2::SetNextValue(const ProblemDescription&)
     // Increment with wrap-around:
     do
     {
-        if(!miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_DIRECT_ASM_1X1UV2_SEARCH_OPTIMIZED)))
+        if(!miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_DIRECT_ASM_1X1UV2_SEARCH_OPTIMIZED)))
         {
             if(!IncPack<16, 32, 64>(chunk_size))
                 break;
@@ -263,7 +263,7 @@ bool PerformanceConfigConvAsm1x1UV2::SetNextValue(const ProblemDescription&)
 PerformanceConfigConvAsm1x1UV2::PerformanceConfigConvAsm1x1UV2(bool spare)
     : PerformanceConfigConvAsm1x1UV2(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, spare)
 {
-    if(!miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_DIRECT_ASM_1X1UV2_SEARCH_OPTIMIZED)))
+    if(!miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_DIRECT_ASM_1X1UV2_SEARCH_OPTIMIZED)))
     {
         k_mult           = spare ? 1 : 8;
         chunk_size       = 16;
@@ -482,7 +482,7 @@ bool ConvAsm1x1UV2::IsValidPerformanceConfig(const ExecutionContext&,
 bool ConvAsm1x1UV2::IsApplicable(const ExecutionContext& ctx,
                                  const ProblemDescription& problem) const
 {
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_DIRECT_ASM_1X1UV2)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_DIRECT_ASM_1X1UV2)))
         return false;
     if(ThisSolverIsDeprecatedStatic::IsDisabled(ctx))
         return false;
@@ -611,7 +611,8 @@ ConvSolution ConvAsm1x1UV2::GetSolution(const ExecutionContext& ctx,
 
     PerformanceConfigConvAsm1x1UV2 fromEnv;
     {
-        const auto& s = miopen::GetStringEnv(ENV(MIOPEN_DEBUG_CONV_DIRECT_ASM_1X1UV2_PERF_VALS));
+        const auto& s =
+            miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_DEBUG_CONV_DIRECT_ASM_1X1UV2_PERF_VALS));
         if(!s.empty()) // else nothing to parse.
         {
             if(!fromEnv.Deserialize(s) || !fromEnv.IsValidValue())

--- a/src/solver/conv_asm_3x3u.cpp
+++ b/src/solver/conv_asm_3x3u.cpp
@@ -173,7 +173,7 @@ bool ConvAsm3x3U::IsValidPerformanceConfig(const ExecutionContext&,
 
 bool ConvAsm3x3U::IsApplicable(const ExecutionContext& ctx, const ProblemDescription& problem) const
 {
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_DIRECT_ASM_3X3U)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_DIRECT_ASM_3X3U)))
         return false;
     if(ThisSolverIsDeprecatedStatic::IsDisabled(ctx))
         return false;
@@ -256,7 +256,8 @@ ConvSolution ConvAsm3x3U::GetSolution(const ExecutionContext& ctx,
 
     PerformanceConfigConvAsm3x3U fromEnv;
     {
-        const auto& s = miopen::GetStringEnv(ENV(MIOPEN_DEBUG_CONV_DIRECT_ASM_3X3U_PERF_VALS));
+        const auto& s =
+            miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_DEBUG_CONV_DIRECT_ASM_3X3U_PERF_VALS));
         if(!s.empty()) // else nothing to parse.
         {
             if(!fromEnv.Deserialize(s) || !fromEnv.IsValid(problem))

--- a/src/solver/conv_asm_5x10u2v2b1.cpp
+++ b/src/solver/conv_asm_5x10u2v2b1.cpp
@@ -42,7 +42,7 @@ using ProblemDescription = miopen::conv::ProblemDescription;
 bool ConvAsm5x10u2v2b1::IsApplicable(const ExecutionContext& ctx,
                                      const ProblemDescription& problem) const
 {
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_DIRECT_ASM_5X10U2V2)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_DIRECT_ASM_5X10U2V2)))
         return false;
     if(!ctx.use_asm_kernels)
         return false;

--- a/src/solver/conv_asm_5x10u2v2f1.cpp
+++ b/src/solver/conv_asm_5x10u2v2f1.cpp
@@ -43,7 +43,7 @@ using ProblemDescription = miopen::conv::ProblemDescription;
 bool ConvAsm5x10u2v2f1::IsApplicable(const ExecutionContext& ctx,
                                      const ProblemDescription& problem) const
 {
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_DIRECT_ASM_5X10U2V2)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_DIRECT_ASM_5X10U2V2)))
         return false;
     if(!ctx.use_asm_kernels)
         return false;

--- a/src/solver/conv_asm_7x7c3h224w224k64u2v2p3q3f1.cpp
+++ b/src/solver/conv_asm_7x7c3h224w224k64u2v2p3q3f1.cpp
@@ -43,7 +43,7 @@ using ProblemDescription = miopen::conv::ProblemDescription;
 bool ConvAsm7x7c3h224w224k64u2v2p3q3f1::IsApplicable(const ExecutionContext& ctx,
                                                      const ProblemDescription& problem) const
 {
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_DIRECT_ASM_7X7C3H224W224)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_DIRECT_ASM_7X7C3H224W224)))
         return false;
     if(!ctx.use_asm_kernels)
         return false;

--- a/src/solver/conv_asm_dir_BwdWrW1x1.cpp
+++ b/src/solver/conv_asm_dir_BwdWrW1x1.cpp
@@ -149,7 +149,7 @@ bool PerformanceConfigConvAsmBwdWrW1x1::SetNextValue(const ProblemDescription&)
 {
     // Increment with wrap-around:
     // select fast or full method
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_DIRECT_ASM_WRW1X1_SEARCH_OPTIMIZED)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_DIRECT_ASM_WRW1X1_SEARCH_OPTIMIZED)))
     {
         do
         {
@@ -475,7 +475,7 @@ bool ConvAsmBwdWrW1x1::IsValidPerformanceConfig(
 bool ConvAsmBwdWrW1x1::IsApplicable(const ExecutionContext& ctx,
                                     const ProblemDescription& problem) const
 {
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_DIRECT_ASM_WRW1X1)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_DIRECT_ASM_WRW1X1)))
         return false;
     if(ThisSolverIsDeprecatedStatic::IsDisabled(ctx))
         return false;
@@ -746,7 +746,8 @@ ConvSolution ConvAsmBwdWrW1x1::GetSolution(const ExecutionContext& ctx,
 
     PerformanceConfigConvAsmBwdWrW1x1 fromEnv;
     {
-        const auto& s = miopen::GetStringEnv(ENV(MIOPEN_DEBUG_CONV_DIRECT_ASM_WRW1X1_PERF_VALS));
+        const auto& s =
+            miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_DEBUG_CONV_DIRECT_ASM_WRW1X1_PERF_VALS));
         if(!s.empty()) // else nothing to parse.
         {
             if(!fromEnv.Deserialize(s) || !fromEnv.IsValid(ctx, problem))

--- a/src/solver/conv_asm_dir_BwdWrW3x3.cpp
+++ b/src/solver/conv_asm_dir_BwdWrW3x3.cpp
@@ -71,7 +71,7 @@ bool PerformanceConfigAsmDirect3x3WrW::SetNextValue(const ProblemDescription&)
     do
     {
 #if MIOPEN_GCN_ASM_DIRECT_3X3WRW_SEARCH_LWC_FIXED == 0
-        if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_DIRECT_ASM_WRW3X3_SEARCH_OPTIMIZED)))
+        if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_DIRECT_ASM_WRW3X3_SEARCH_OPTIMIZED)))
         {
             // (0 <= limit_wave_cnt && limit_wave_cnt <= 9)
             if(++limit_wave_cnt <= 9)
@@ -391,7 +391,7 @@ bool ConvAsmBwdWrW3x3::IsValidPerformanceConfig(
 bool ConvAsmBwdWrW3x3::IsApplicable(const ExecutionContext& ctx,
                                     const ProblemDescription& problem) const
 {
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_DIRECT_ASM_WRW3X3)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_DIRECT_ASM_WRW3X3)))
         return false;
     if(ThisSolverIsDeprecatedStatic::IsDisabled(ctx))
         return false;
@@ -431,7 +431,7 @@ bool ConvAsmBwdWrW3x3::IsApplicable(const ExecutionContext& ctx,
         return false;
 
 #if WORKAROUND_SWDEV_330460
-    if(!miopen::IsEnabled(ENV(MIOPEN_DEBUG_CONV_DIRECT_ASM_WRW3X3)) && name == "gfx90a" &&
+    if(!miopen::IsEnabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_DIRECT_ASM_WRW3X3)) && name == "gfx90a" &&
        problem.IsFp32())
         return false;
 #endif
@@ -513,7 +513,8 @@ ConvSolution ConvAsmBwdWrW3x3::GetSolution(const ExecutionContext& ctx,
 
     PerformanceConfigAsmDirect3x3WrW fromEnv;
     {
-        const auto& s = miopen::GetStringEnv(ENV(MIOPEN_DEBUG_CONV_DIRECT_ASM_WRW3X3_PERF_VALS));
+        const auto& s =
+            miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_DEBUG_CONV_DIRECT_ASM_WRW3X3_PERF_VALS));
         if(!s.empty()) // else nothing to parse.
         {
             if(!fromEnv.Deserialize(s) || !fromEnv.IsValid(ctx, problem))

--- a/src/solver/conv_asm_implicit_gemm_bwd_v4r1_dynamic.cpp
+++ b/src/solver/conv_asm_implicit_gemm_bwd_v4r1_dynamic.cpp
@@ -133,7 +133,7 @@ static inline bool FindImplicitGemmDynamicKernelBwd(const ProblemDescription& pr
 bool ConvAsmImplicitGemmV4R1DynamicBwd::IsApplicable(const ExecutionContext& ctx,
                                                      const ProblemDescription& problem) const
 {
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_ASM_BWD_V4R1)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_ASM_BWD_V4R1)))
         return false;
 
     const auto device_name = ctx.GetStream().GetDeviceName();

--- a/src/solver/conv_asm_implicit_gemm_gtc_bwd.cpp
+++ b/src/solver/conv_asm_implicit_gemm_gtc_bwd.cpp
@@ -979,7 +979,7 @@ FindImplicitGemmGtcDynamicBwdKernel(const ProblemDescription& problem)
 bool ConvAsmImplicitGemmGTCDynamicBwdXdlops::IsApplicable(const ExecutionContext& ctx,
                                                           const ProblemDescription& problem) const
 {
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_ASM_BWD_GTC_XDLOPS)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_ASM_BWD_GTC_XDLOPS)))
         return false;
 
     const auto device_name = ctx.GetStream().GetDeviceName();

--- a/src/solver/conv_asm_implicit_gemm_gtc_bwd_nhwc.cpp
+++ b/src/solver/conv_asm_implicit_gemm_gtc_bwd_nhwc.cpp
@@ -733,7 +733,7 @@ void PerformanceConfigAsmImplicitGemmGTCBwdXdlopsNHWC::HeuristicInit(
                     if(need_k_split)
                     {
                         if(miopen::IsDisabled(
-                               ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_ASM_PK_ATOMIC_ADD_FP16)))
+                               MIOPEN_ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_ASM_PK_ATOMIC_ADD_FP16)))
                         {
                             if(problem.IsFp16() && gks > 0)
                                 vector_store = 1;
@@ -809,7 +809,7 @@ bool PerformanceConfigAsmImplicitGemmGTCBwdXdlopsNHWC::IsValid(
         return false;
     }
 
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_ASM_PK_ATOMIC_ADD_FP16)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_ASM_PK_ATOMIC_ADD_FP16)))
     {
         if(problem.IsFp16() && gemm_k_global_split != 0 && vector_store != 1)
             return false;
@@ -928,7 +928,7 @@ ConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWC::Search(const ExecutionContext& ctx,
 bool ConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWC::IsApplicable(
     const ExecutionContext& ctx, const ProblemDescription& problem) const
 {
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_ASM_BWD_GTC_XDLOPS_NHWC)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_ASM_BWD_GTC_XDLOPS_NHWC)))
         return false;
 
     if(problem.GetConv().attribute.deterministic)

--- a/src/solver/conv_asm_implicit_gemm_gtc_fwd.cpp
+++ b/src/solver/conv_asm_implicit_gemm_gtc_fwd.cpp
@@ -1504,7 +1504,7 @@ FindImplicitGemmGtcDynamicFwdKernel(const ProblemDescription& problem)
 bool ConvAsmImplicitGemmGTCDynamicFwdXdlops::IsApplicable(const ExecutionContext& ctx,
                                                           const ProblemDescription& problem) const
 {
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_ASM_FWD_GTC_XDLOPS)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_ASM_FWD_GTC_XDLOPS)))
         return false;
 
     const auto device_name = ctx.GetStream().GetDeviceName();
@@ -1545,7 +1545,7 @@ bool ConvAsmImplicitGemmGTCDynamicFwdXdlops::IsApplicable(const ExecutionContext
     if((problem.GetWeightsHeight() == 1) && (problem.GetWeightsWidth() == 1) &&
        (problem.GetInChannels() % 8 != 0))
     {
-        if(!miopen::IsEnabled(ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_ASM_FWD_GTC_XDLOPS)))
+        if(!miopen::IsEnabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_ASM_FWD_GTC_XDLOPS)))
             return false;
     }
 #endif

--- a/src/solver/conv_asm_implicit_gemm_gtc_fwd_nchwc.cpp
+++ b/src/solver/conv_asm_implicit_gemm_gtc_fwd_nchwc.cpp
@@ -550,7 +550,7 @@ ConvAsmImplicitGemmGTCDynamicFwdDlopsNCHWC::Search(const ExecutionContext& ctx,
 bool ConvAsmImplicitGemmGTCDynamicFwdDlopsNCHWC::IsApplicable(
     const ExecutionContext& ctx, const ProblemDescription& problem) const
 {
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_ASM_FWD_GTC_DLOPS_NCHWC)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_ASM_FWD_GTC_DLOPS_NCHWC)))
         return false;
 
     const auto device_name = ctx.GetStream().GetDeviceName();

--- a/src/solver/conv_asm_implicit_gemm_gtc_fwd_nhwc.cpp
+++ b/src/solver/conv_asm_implicit_gemm_gtc_fwd_nhwc.cpp
@@ -605,7 +605,7 @@ void PerformanceConfigAsmImplicitGemmGTCFwdXdlopsNHWC::HeuristicInit(
                     if(need_k_split)
                     {
                         if(miopen::IsDisabled(
-                               ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_ASM_PK_ATOMIC_ADD_FP16)))
+                               MIOPEN_ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_ASM_PK_ATOMIC_ADD_FP16)))
                         {
                             if(problem.IsFp16() && gks > 0)
                                 vector_store = 1;
@@ -681,7 +681,7 @@ bool PerformanceConfigAsmImplicitGemmGTCFwdXdlopsNHWC::IsValid(
         return false;
     }
 
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_ASM_PK_ATOMIC_ADD_FP16)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_ASM_PK_ATOMIC_ADD_FP16)))
     {
         if(problem.IsFp16() && gemm_k_global_split != 0 && vector_store != 1)
             return false;
@@ -862,7 +862,7 @@ size_t ConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWC::GetWorkspaceSize(
 bool ConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWC::IsApplicable(
     const ExecutionContext& ctx, const ProblemDescription& problem) const
 {
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_ASM_FWD_GTC_XDLOPS_NHWC)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_ASM_FWD_GTC_XDLOPS_NHWC)))
         return false;
 
     if(problem.GetConv().attribute.deterministic)

--- a/src/solver/conv_asm_implicit_gemm_gtc_wrw_nhwc.cpp
+++ b/src/solver/conv_asm_implicit_gemm_gtc_wrw_nhwc.cpp
@@ -445,7 +445,7 @@ void PerformanceConfigAsmImplicitGemmGTCWrwXdlopsNHWC::SetParamsForKSplit(
     if(problem.IsFp16())
     {
         if(tensor_b_thread_lengths[3] == 1 ||
-           miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_ASM_PK_ATOMIC_ADD_FP16)))
+           miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_ASM_PK_ATOMIC_ADD_FP16)))
             vector_store = 1;
     }
     else if(problem.IsBfp16() && tensor_b_thread_lengths[3] == 1)
@@ -764,7 +764,7 @@ bool PerformanceConfigAsmImplicitGemmGTCWrwXdlopsNHWC::IsValid(
         return false;
     }
 
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_ASM_PK_ATOMIC_ADD_FP16)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_ASM_PK_ATOMIC_ADD_FP16)))
     {
         if(problem.IsFp16() && tensor_b_thread_lengths[3] != 1 && gemm_k_global_split != 0 &&
            vector_store != 1)
@@ -853,7 +853,7 @@ ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC::Search(const ExecutionContext& ctx,
 bool ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC::IsApplicable(
     const ExecutionContext& ctx, const ProblemDescription& problem) const
 {
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_ASM_WRW_GTC_XDLOPS_NHWC)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_ASM_WRW_GTC_XDLOPS_NHWC)))
         return false;
 
     if(problem.GetConv().attribute.deterministic)

--- a/src/solver/conv_asm_implicit_gemm_v4r1_dynamic.cpp
+++ b/src/solver/conv_asm_implicit_gemm_v4r1_dynamic.cpp
@@ -283,7 +283,7 @@ bool TunableImplicitGemmV4R1Dynamic::IsValid(const ExecutionContext& ctx,
 bool ConvAsmImplicitGemmV4R1DynamicFwd::IsApplicable(const ExecutionContext& ctx,
                                                      const ProblemDescription& problem) const
 {
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_ASM_FWD_V4R1)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_ASM_FWD_V4R1)))
         return false;
 
     const auto device_name = ctx.GetStream().GetDeviceName();
@@ -332,7 +332,7 @@ bool ConvAsmImplicitGemmV4R1DynamicFwd::IsApplicable(const ExecutionContext& ctx
 bool ConvAsmImplicitGemmV4R1DynamicFwd_1x1::IsApplicable(const ExecutionContext& ctx,
                                                          const ProblemDescription& problem) const
 {
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_ASM_FWD_V4R1_1X1)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_ASM_FWD_V4R1_1X1)))
         return false;
 
     const auto device_name = ctx.GetStream().GetDeviceName();

--- a/src/solver/conv_asm_implicit_gemm_wrw_gtc_dynamic_xdlops.cpp
+++ b/src/solver/conv_asm_implicit_gemm_wrw_gtc_dynamic_xdlops.cpp
@@ -821,7 +821,7 @@ ConvAsmImplicitGemmGTCDynamicWrwXdlops::GetWorkspaceSize(const ExecutionContext&
 bool ConvAsmImplicitGemmGTCDynamicWrwXdlops::IsApplicable(const ExecutionContext& ctx,
                                                           const ProblemDescription& problem) const
 {
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_ASM_WRW_GTC_XDLOPS)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_ASM_WRW_GTC_XDLOPS)))
         return false;
 
     if(problem.GetConv().attribute.deterministic)

--- a/src/solver/conv_asm_implicit_gemm_wrw_v4r1_dynamic.cpp
+++ b/src/solver/conv_asm_implicit_gemm_wrw_v4r1_dynamic.cpp
@@ -298,7 +298,7 @@ static int GetGemmkGroups(const ProblemDescription& problem)
 bool ConvAsmImplicitGemmV4R1DynamicWrw::IsApplicable(const ExecutionContext& ctx,
                                                      const ProblemDescription& problem) const
 {
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_ASM_WRW_V4R1)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_ASM_WRW_V4R1)))
         return false;
 
     const auto device_name = ctx.GetStream().GetDeviceName();

--- a/src/solver/conv_bin_wino3x3U.cpp
+++ b/src/solver/conv_bin_wino3x3U.cpp
@@ -46,7 +46,7 @@ using ProblemDescription = miopen::conv::ProblemDescription;
 bool ConvBinWinograd3x3U::IsApplicable(const ExecutionContext& ctx,
                                        const ProblemDescription& problem) const
 {
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_AMD_WINOGRAD_3X3)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_AMD_WINOGRAD_3X3)))
         return false;
     if(!problem.Is2d())
         return false;

--- a/src/solver/conv_bin_winoRxS.cpp
+++ b/src/solver/conv_bin_winoRxS.cpp
@@ -229,11 +229,11 @@ bool ConvBinWinogradRxS::IsApplicable(const ExecutionContext& ctx,
         return false;
     if(problem.IsTensorsCasted())
         return false;
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_AMD_WINOGRAD_RXS)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_AMD_WINOGRAD_RXS)))
         return false;
     if(problem.IsDirectionBackwardWrW())
     {
-        if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_AMD_WINOGRAD_RXS_WRW)))
+        if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_AMD_WINOGRAD_RXS_WRW)))
             return false;
         if(!(problem.IsFp32() && problem.GetKernelStrideW() == 1 &&
              problem.GetKernelStrideH() == 1))
@@ -241,7 +241,7 @@ bool ConvBinWinogradRxS::IsApplicable(const ExecutionContext& ctx,
     }
     else
     {
-        if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_AMD_WINOGRAD_RXS_FWD_BWD)))
+        if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_AMD_WINOGRAD_RXS_FWD_BWD)))
             return false;
     }
     if(!ctx.use_asm_kernels)
@@ -347,7 +347,7 @@ ConvSolution ConvBinWinogradRxS::GetSolution(const ExecutionContext& ctx,
     {
         kernel.kernel_name = "miopenSp3AsmConvRxSU";
         kernel.kernel_file = "Conv_Winograd_";
-        if(miopen::IsEnabled(ENV(MIOPEN_DEBUG_SRAM_EDC_DISABLED)))
+        if(miopen::IsEnabled(MIOPEN_ENV(MIOPEN_DEBUG_SRAM_EDC_DISABLED)))
             kernel.kernel_file += "v13_3_12";
         else
             kernel.kernel_file += "v14_3_3";

--- a/src/solver/conv_bin_winoRxS_fused.cpp
+++ b/src/solver/conv_bin_winoRxS_fused.cpp
@@ -58,9 +58,9 @@ namespace fusion {
 bool ConvBinWinogradRxSFused::IsApplicable(const FusionContext& context,
                                            const FusionDescription& problem) const
 {
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_AMD_FUSED_WINOGRAD)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_AMD_FUSED_WINOGRAD)))
         return false;
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_GCN_ASM_KERNELS)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_GCN_ASM_KERNELS)))
         return false;
     if(!WinoCommonIsApplicable(context, problem))
         return false;

--- a/src/solver/conv_ck_igemm_fwd_bias_activ_fused.cpp
+++ b/src/solver/conv_ck_igemm_fwd_bias_activ_fused.cpp
@@ -404,7 +404,7 @@ bool ConvCKIgemmFwdBiasActivFused::IsApplicable(const FusionContext& ctx,
     {
         MIOPEN_THROW(miopenStatusInternalError, "desc.op_map.empty()");
     }
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_CK_IGEMM_FWD_BIAS_ACTIV)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_CK_IGEMM_FWD_BIAS_ACTIV)))
         return false;
     // check the sequence of prims
     if(desc.op_map.size() != 3)

--- a/src/solver/conv_ck_igemm_fwd_bias_res_add_activ_fused.cpp
+++ b/src/solver/conv_ck_igemm_fwd_bias_res_add_activ_fused.cpp
@@ -388,7 +388,7 @@ bool ConvCKIgemmFwdBiasResAddActivFused::IsApplicable(const FusionContext& ctx,
     {
         MIOPEN_THROW(miopenStatusInternalError, "desc.op_map.empty()");
     }
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_CK_IGEMM_FWD_BIAS_RES_ADD_ACTIV)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_CK_IGEMM_FWD_BIAS_RES_ADD_ACTIV)))
         return false;
     // check the sequence of prims
     if(desc.op_map.size() != 4)

--- a/src/solver/conv_ck_igemm_fwd_v6r1_dlops_nchw.cpp
+++ b/src/solver/conv_ck_igemm_fwd_v6r1_dlops_nchw.cpp
@@ -90,9 +90,9 @@ bool ConvCkIgemmFwdV6r1DlopsNchw::IsApplicable(const ExecutionContext& ctx,
                                                const ProblemDescription& problem) const
 {
 #if WORKAROUND_SWDEV_411729
-    if(!miopen::IsEnabled(ENV(MIOPEN_DEBUG_CONV_CK_IGEMM_FWD_V6R1_DLOPS_NCHW)))
+    if(!miopen::IsEnabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_CK_IGEMM_FWD_V6R1_DLOPS_NCHW)))
 #else
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_CK_IGEMM_FWD_V6R1_DLOPS_NCHW)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_CK_IGEMM_FWD_V6R1_DLOPS_NCHW)))
 #endif
     {
         return false;

--- a/src/solver/conv_direct_naive_conv.cpp
+++ b/src/solver/conv_direct_naive_conv.cpp
@@ -127,7 +127,7 @@ std::string ConvDirectNaiveConvKernelName(const ProblemDescription& problem)
 
     /// \todo remove packed reference convolution kernels --amberhassaan
 #ifndef NDEBUG // enable in debug mode only
-    if(miopen::IsEnabled(ENV(MIOPEN_DEBUG_CONV_DIRECT_NAIVE_USE_PACKED_KERNELS)))
+    if(miopen::IsEnabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_DIRECT_NAIVE_USE_PACKED_KERNELS)))
     {
         kernel_name << "naive_conv_packed_";
     }

--- a/src/solver/conv_direct_naive_conv_bwd.cpp
+++ b/src/solver/conv_direct_naive_conv_bwd.cpp
@@ -41,7 +41,7 @@ bool ConvDirectNaiveConvBwd::IsApplicable(const ExecutionContext& ctx,
                                           const ProblemDescription& problem) const
 {
     if(!miopen::debug::AlwaysEnableConvDirectNaive &&
-       miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_DIRECT_NAIVE_CONV_BWD)))
+       miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_DIRECT_NAIVE_CONV_BWD)))
         return false;
 
     if(!ConvDirectNaiveConvIsApplicableByKernelType(ctx, problem))

--- a/src/solver/conv_direct_naive_conv_fwd.cpp
+++ b/src/solver/conv_direct_naive_conv_fwd.cpp
@@ -40,7 +40,7 @@ bool ConvDirectNaiveConvFwd::IsApplicable(const ExecutionContext& ctx,
                                           const ProblemDescription& problem) const
 {
     if(!miopen::debug::AlwaysEnableConvDirectNaive &&
-       miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_DIRECT_NAIVE_CONV_FWD)))
+       miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_DIRECT_NAIVE_CONV_FWD)))
         return false;
 
     if(!ConvDirectNaiveConvIsApplicableByKernelType(ctx, problem))

--- a/src/solver/conv_direct_naive_conv_wrw.cpp
+++ b/src/solver/conv_direct_naive_conv_wrw.cpp
@@ -41,7 +41,7 @@ bool ConvDirectNaiveConvWrw::IsApplicable(const ExecutionContext& ctx,
                                           const ProblemDescription& problem) const
 {
     if(!miopen::debug::AlwaysEnableConvDirectNaive &&
-       miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_DIRECT_NAIVE_CONV_WRW)))
+       miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_DIRECT_NAIVE_CONV_WRW)))
         return false;
 
     if(!ConvDirectNaiveConvIsApplicableByKernelType(ctx, problem))

--- a/src/solver/conv_hip_implicit_gemm_3d_grouped_bwd_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_3d_grouped_bwd_xdlops.cpp
@@ -335,9 +335,9 @@ bool ConvHipImplicitGemm3DGroupBwdXdlops::IsApplicable(
     [[maybe_unused]] const ProblemDescription& problem) const
 {
 #if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_3D_CONV_IMPLICIT_GEMM_HIP_BWD_XDLOPS)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_3D_CONV_IMPLICIT_GEMM_HIP_BWD_XDLOPS)))
         return false;
-    if(miopen::IsEnabled(ENV(MIOPEN_DEBUG_CONVOLUTION_DETERMINISTIC)))
+    if(miopen::IsEnabled(MIOPEN_ENV(MIOPEN_DEBUG_CONVOLUTION_DETERMINISTIC)))
         return false;
     if(!problem.AllTensorsDimsFitIntoInt())
         return false;

--- a/src/solver/conv_hip_implicit_gemm_3d_grouped_fwd_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_3d_grouped_fwd_xdlops.cpp
@@ -331,7 +331,7 @@ bool ConvHipImplicitGemm3DGroupFwdXdlops::IsApplicable(
     [[maybe_unused]] const ProblemDescription& problem) const
 {
 #if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_3D_CONV_IMPLICIT_GEMM_HIP_FWD_XDLOPS)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_3D_CONV_IMPLICIT_GEMM_HIP_FWD_XDLOPS)))
         return false;
     if(problem.GetConv().attribute.deterministic)
         return false;

--- a/src/solver/conv_hip_implicit_gemm_3d_grouped_wrw_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_3d_grouped_wrw_xdlops.cpp
@@ -331,9 +331,9 @@ bool ConvHipImplicitGemm3DGroupWrwXdlops::IsApplicable(
     [[maybe_unused]] const ProblemDescription& problem) const
 {
 #if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_3D_CONV_IMPLICIT_GEMM_HIP_WRW_XDLOPS)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_3D_CONV_IMPLICIT_GEMM_HIP_WRW_XDLOPS)))
         return false;
-    if(miopen::IsEnabled(ENV(MIOPEN_DEBUG_CONVOLUTION_DETERMINISTIC)))
+    if(miopen::IsEnabled(MIOPEN_ENV(MIOPEN_DEBUG_CONVOLUTION_DETERMINISTIC)))
         return false;
     if(!problem.AllTensorsDimsFitIntoInt())
         return false;

--- a/src/solver/conv_hip_implicit_gemm_bwd_data_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_bwd_data_xdlops.cpp
@@ -259,7 +259,7 @@ bool ConvHipImplicitGemmBwdXdlops::IsApplicable(
     [[maybe_unused]] const ProblemDescription& problem) const
 {
 #if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_BWD_XDLOPS)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_BWD_XDLOPS)))
         return false;
     if(problem.GetConv().attribute.deterministic)
         return false;

--- a/src/solver/conv_hip_implicit_gemm_bwd_v1r1.cpp
+++ b/src/solver/conv_hip_implicit_gemm_bwd_v1r1.cpp
@@ -635,7 +635,7 @@ size_t ConvHipImplicitGemmBwdDataV1R1::GetWorkspaceSize(const ExecutionContext&,
 bool ConvHipImplicitGemmBwdDataV1R1::IsApplicable(const ExecutionContext& ctx,
                                                   const ProblemDescription& problem) const
 {
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_BWD_V1R1)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_BWD_V1R1)))
         return false;
     if(ThisSolverIsDeprecatedStatic::IsDisabled(ctx))
         return false;
@@ -668,7 +668,7 @@ bool ConvHipImplicitGemmBwdDataV1R1::IsApplicable(const ExecutionContext& ctx,
 #if WORKAROUND_ISSUE_309
     if(problem.IsBfp16())
     {
-        if(!miopen::IsEnabled(ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_BWD_V1R1)))
+        if(!miopen::IsEnabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_BWD_V1R1)))
             return false;
     }
 #endif

--- a/src/solver/conv_hip_implicit_gemm_bwd_v1r1_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_bwd_v1r1_xdlops.cpp
@@ -759,10 +759,10 @@ bool ConvHipImplicitGemmBwdDataV1R1Xdlops::IsApplicable(const ExecutionContext& 
                                                         const ProblemDescription& problem) const
 {
 #if WORKAROUND_SWDEV_251757
-    if(!miopen::IsEnabled(ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_BWD_V1R1_XDLOPS)))
+    if(!miopen::IsEnabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_BWD_V1R1_XDLOPS)))
         return false;
 #endif
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_BWD_V1R1_XDLOPS)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_BWD_V1R1_XDLOPS)))
         return false;
 
     if(ThisSolverIsDeprecatedStatic::IsDisabled(ctx))
@@ -930,8 +930,8 @@ ConvSolution ConvHipImplicitGemmBwdDataV1R1Xdlops::GetSolution(
         std::string(" -DCK_PARAM_DEPENDENT_GEMM_B_BLOCK_COPY_SRC_DATA_PER_READ_GEMM_N=") + std::to_string(GemmBBlockCopySrcDataPerRead_GemmN) +
         std::string(" -DCK_PARAM_DEPENDENT_GEMM_B_BLOCK_COPY_DST_DATA_PER_WRITE_GEMM_KPACK=") + std::to_string(GemmBBlockCopyDstDataPerWrite_GemmKPack) +
         std::string(" -DCK_USE_AMD_XDLOPS=") + std::to_string(IsXdlopsSupport(ctx) ? 1 : 0) +
-        std::string(" -DCK_USE_AMD_XDLOPS_INLINE_ASM=") + std::to_string(miopen::IsEnabled(ENV(MIOPEN_DEBUG_IMPLICIT_GEMM_XDLOPS_INLINE_ASM)) ? 1 : 0) +
-        std::string(" -DCK_USE_AMD_XDLOPS_EMULATE=") + (miopen::IsEnabled(ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_XDLOPS_EMULATE)) ? '1' : '0') +
+        std::string(" -DCK_USE_AMD_XDLOPS_INLINE_ASM=") + std::to_string(miopen::IsEnabled(MIOPEN_ENV(MIOPEN_DEBUG_IMPLICIT_GEMM_XDLOPS_INLINE_ASM)) ? 1 : 0) +
+        std::string(" -DCK_USE_AMD_XDLOPS_EMULATE=") + (miopen::IsEnabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_XDLOPS_EMULATE)) ? '1' : '0') +
         get_static_ck_common_compiler_flag(ctx) +
         ctx.general_compile_options;
 

--- a/src/solver/conv_hip_implicit_gemm_bwd_v4r1.cpp
+++ b/src/solver/conv_hip_implicit_gemm_bwd_v4r1.cpp
@@ -731,13 +731,13 @@ bool ConvHipImplicitGemmBwdDataV4R1::IsApplicable(const ExecutionContext& ctx,
                                                   const ProblemDescription& problem) const
 {
 #if WORKAROUND_SWDEV_229277_227616_229195
-    if(!miopen::IsEnabled(ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_BWD_V4R1)))
+    if(!miopen::IsEnabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_BWD_V4R1)))
         return false;
 #endif
     if(ThisSolverIsDeprecatedStatic::IsDisabled(ctx))
         return false;
 
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_BWD_V4R1)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_BWD_V4R1)))
         return false;
     if(problem.GetConv().attribute.deterministic)
         return false;

--- a/src/solver/conv_hip_implicit_gemm_bwd_v4r1_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_bwd_v4r1_xdlops.cpp
@@ -816,18 +816,18 @@ bool ConvHipImplicitGemmBwdDataV4R1Xdlops::IsApplicable(const ExecutionContext& 
 #if WORKAROUND_ISSUE_1206
     if(problem.IsFp32())
     {
-        if(!miopen::IsEnabled(ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_BWD_V4R1_XDLOPS)))
+        if(!miopen::IsEnabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_BWD_V4R1_XDLOPS)))
             return false;
     }
 #endif
 #if WORKAROUND_SWDEV_329642
     if(problem.IsBfp16() && ctx.GetStream().GetDeviceName() == "gfx90a")
     {
-        if(!miopen::IsEnabled(ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_BWD_V4R1_XDLOPS)))
+        if(!miopen::IsEnabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_BWD_V4R1_XDLOPS)))
             return false;
     }
 #endif
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_BWD_V4R1_XDLOPS)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_BWD_V4R1_XDLOPS)))
         return false;
     if(ThisSolverIsDeprecatedStatic::IsDisabled(ctx))
         return false;
@@ -915,7 +915,7 @@ ConvSolution ConvHipImplicitGemmBwdDataV4R1Xdlops::GetSolution(
     PerformanceImplicitGemmBwdDataV4R1Xdlops fromEnv;
     {
         const auto& s = miopen::GetStringEnv(
-            ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_BWD_V4R1_XDLOPS_PERF_VALS));
+            MIOPEN_ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_BWD_V4R1_XDLOPS_PERF_VALS));
         if(!s.empty()) // else nothing to parse.
         {
             if(!fromEnv.Deserialize(s) || !fromEnv.IsReallyValid(problem))
@@ -1049,8 +1049,8 @@ ConvSolution ConvHipImplicitGemmBwdDataV4R1Xdlops::GetSolution(
                 std::string(" -DCK_PARAM_TUNABLE_GEMM_B_BLOCK_COPY_SRC_DATA_PER_READ_GEMM_N=") + std::to_string(GemmBBlockCopySrcDataPerRead_GemmN) +
                 std::string(" -DCK_PARAM_DEPENDENT_GRID_SIZE=") + std::to_string(grid_size) +
                 std::string(" -DCK_USE_AMD_XDLOPS=") + std::to_string(IsXdlopsSupport(ctx) ? 1 : 0) +
-                std::string(" -DCK_USE_AMD_XDLOPS_INLINE_ASM=") + std::to_string(miopen::IsEnabled(ENV(MIOPEN_DEBUG_IMPLICIT_GEMM_XDLOPS_INLINE_ASM)) ? 1 : 0) +
-                std::string(" -DCK_USE_AMD_XDLOPS_EMULATE=") + (miopen::IsEnabled(ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_XDLOPS_EMULATE)) ? '1' : '0') +
+                std::string(" -DCK_USE_AMD_XDLOPS_INLINE_ASM=") + std::to_string(miopen::IsEnabled(MIOPEN_ENV(MIOPEN_DEBUG_IMPLICIT_GEMM_XDLOPS_INLINE_ASM)) ? 1 : 0) +
+                std::string(" -DCK_USE_AMD_XDLOPS_EMULATE=") + (miopen::IsEnabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_XDLOPS_EMULATE)) ? '1' : '0') +
                 std::string(" -DCK_PARAM_GEMM_ID=") + std::to_string(gemm_id) +
                 get_static_ck_common_compiler_flag(ctx) +
                 ctx.general_compile_options;

--- a/src/solver/conv_hip_implicit_gemm_f16f8f16_bwd_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_f16f8f16_bwd_xdlops.cpp
@@ -299,7 +299,7 @@ bool ConvHipImplicitGemmF16F8F16BwdXdlops::IsApplicable(
     [[maybe_unused]] const ProblemDescription& problem) const
 {
 #if MIOPEN_USE_COMPOSABLEKERNEL
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_F16F8F16_CONV_IMPLICIT_GEMM_HIP_BWD_XDLOPS)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_F16F8F16_CONV_IMPLICIT_GEMM_HIP_BWD_XDLOPS)))
         return false;
     if(problem.GetConv().attribute.deterministic)
         return false;

--- a/src/solver/conv_hip_implicit_gemm_f16f8f16_fwd_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_f16f8f16_fwd_xdlops.cpp
@@ -296,7 +296,7 @@ bool ConvHipImplicitGemmF16F8F16FwdXdlops::IsApplicable(
     [[maybe_unused]] const ProblemDescription& problem) const
 {
 #if MIOPEN_USE_COMPOSABLEKERNEL
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_F16F8F16_CONV_IMPLICIT_GEMM_HIP_FWD_XDLOPS)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_F16F8F16_CONV_IMPLICIT_GEMM_HIP_FWD_XDLOPS)))
         return false;
     if(problem.HasNonPackedTensors())
         return false;

--- a/src/solver/conv_hip_implicit_gemm_f16f8f16_wrw_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_f16f8f16_wrw_xdlops.cpp
@@ -296,7 +296,7 @@ bool ConvHipImplicitGemmF16F8F16WrwXdlops::IsApplicable(
     [[maybe_unused]] const ProblemDescription& problem) const
 {
 #if MIOPEN_USE_COMPOSABLEKERNEL
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_F16F8F16_CONV_IMPLICIT_GEMM_HIP_WRW_XDLOPS)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_F16F8F16_CONV_IMPLICIT_GEMM_HIP_WRW_XDLOPS)))
         return false;
     if(problem.GetConv().attribute.deterministic)
         return false;

--- a/src/solver/conv_hip_implicit_gemm_fwd_v4r1.cpp
+++ b/src/solver/conv_hip_implicit_gemm_fwd_v4r1.cpp
@@ -46,7 +46,7 @@ using ProblemDescription = miopen::conv::ProblemDescription;
 bool ConvHipImplicitGemmV4R1Fwd::IsApplicable(const ExecutionContext& ctx,
                                               const ProblemDescription& problem) const
 {
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_FWD_V4R1)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_FWD_V4R1)))
         return false;
     if(ThisSolverIsDeprecatedStatic::IsDisabled(ctx))
         return false;
@@ -96,7 +96,7 @@ bool ConvHipImplicitGemmV4R1Fwd::IsApplicable(const ExecutionContext& ctx,
 bool ConvHipImplicitGemmV4R1WrW::IsApplicable(const ExecutionContext& ctx,
                                               const ProblemDescription& problem) const
 {
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_WRW_V4R1)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_WRW_V4R1)))
         return false;
     if(ThisSolverIsDeprecatedStatic::IsDisabled(ctx))
         return false;

--- a/src/solver/conv_hip_implicit_gemm_fwd_v4r4.cpp
+++ b/src/solver/conv_hip_implicit_gemm_fwd_v4r4.cpp
@@ -578,7 +578,7 @@ ConvHipImplicitGemmV4R4Fwd::CalculateGemmSize(const ProblemDescription& problem)
 bool ConvHipImplicitGemmV4R4Fwd::IsApplicable(const ExecutionContext& ctx,
                                               const ProblemDescription& problem) const
 {
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_FWD_V4R4)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_FWD_V4R4)))
         return false;
     if(ThisSolverIsDeprecatedStatic::IsDisabled(ctx))
         return false;

--- a/src/solver/conv_hip_implicit_gemm_fwd_v4r4_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_fwd_v4r4_xdlops.cpp
@@ -97,7 +97,7 @@ bool PerformanceImplicitGemmForwardV4R4Xdlops::SetNextValue(const ProblemDescrip
     {
         // list performance parameters in reverse order, in order for tuning to iterate over the
         // range in normal order
-        if(miopen::IsEnabled(ENV(
+        if(miopen::IsEnabled(MIOPEN_ENV(
                MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_FWD_V4R4_XDLOPS_ADD_VECTOR_LOAD_GEMMN_TUNE_PARAM)))
         {
             if(!NextTwoPower<1, 8>(GemmBThreadDataPerRead_GemmN))
@@ -458,7 +458,7 @@ PerformanceImplicitGemmForwardV4R4Xdlops::CalculateGemmBBlockCopyPerformancePara
         // calculate threadwise copy size
         auto data_per_thread_copy =
             std::max(1, (GemmKPerBlock * GemmNPerBlock * GemmKPack) / block_size);
-        if(miopen::IsEnabled(ENV(
+        if(miopen::IsEnabled(MIOPEN_ENV(
                MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_FWD_V4R4_XDLOPS_ADD_VECTOR_LOAD_GEMMN_TUNE_PARAM)))
         {
             if(problem.IsFp16())
@@ -778,7 +778,7 @@ bool PerformanceImplicitGemmForwardV4R4Xdlops::IsFastToBeUsedForTuning(
     // DstDataPerWrite_GemmKPack should not be too small, otherwise too many ds_write instruction
     // would cause bad performance
     {
-        if(miopen::IsEnabled(ENV(
+        if(miopen::IsEnabled(MIOPEN_ENV(
                MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_FWD_V4R4_XDLOPS_ADD_VECTOR_LOAD_GEMMN_TUNE_PARAM)))
         {
             if(problem.IsFp16())
@@ -958,8 +958,8 @@ ConvSolution ConvHipImplicitGemmForwardV4R4Xdlops::GetSolution(
         std::string(" -DCK_PARAM_DEPENDENT_GEMM_B_BLOCK_COPY_SRC_DATA_PER_READ_GEMM_N=") + std::to_string(GemmBBlockCopySrcDataPerRead_GemmN) +
         std::string(" -DCK_PARAM_DEPENDENT_GEMM_B_BLOCK_COPY_DST_DATA_PER_WRITE_GEMM_KPACK=") + std::to_string(GemmBBlockCopyDstDataPerWrite_GemmKPack) +
         std::string(" -DCK_USE_AMD_XDLOPS=") + std::to_string(IsXdlopsSupport(ctx) ? 1 : 0) +
-        std::string(" -DCK_USE_AMD_XDLOPS_INLINE_ASM=") + std::to_string(miopen::IsEnabled(ENV(MIOPEN_DEBUG_IMPLICIT_GEMM_XDLOPS_INLINE_ASM)) ? 1 : 0) +
-        std::string(" -DCK_USE_AMD_XDLOPS_EMULATE=") + (miopen::IsEnabled(ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_XDLOPS_EMULATE)) ? '1' : '0') +
+        std::string(" -DCK_USE_AMD_XDLOPS_INLINE_ASM=") + std::to_string(miopen::IsEnabled(MIOPEN_ENV(MIOPEN_DEBUG_IMPLICIT_GEMM_XDLOPS_INLINE_ASM)) ? 1 : 0) +
+        std::string(" -DCK_USE_AMD_XDLOPS_EMULATE=") + (miopen::IsEnabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_XDLOPS_EMULATE)) ? '1' : '0') +
         get_static_ck_common_compiler_flag(ctx) +
         ctx.general_compile_options;
     // clang-format on
@@ -972,7 +972,7 @@ ConvSolution ConvHipImplicitGemmForwardV4R4Xdlops::GetSolution(
 bool ConvHipImplicitGemmForwardV4R4Xdlops::IsApplicable(const ExecutionContext& ctx,
                                                         const ProblemDescription& problem) const
 {
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_FWD_V4R4_XDLOPS)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_FWD_V4R4_XDLOPS)))
         return false;
 
     if(ThisSolverIsDeprecatedStatic::IsDisabled(ctx))

--- a/src/solver/conv_hip_implicit_gemm_fwd_v4r4_xdlops_padded_gemm.cpp
+++ b/src/solver/conv_hip_implicit_gemm_fwd_v4r4_xdlops_padded_gemm.cpp
@@ -109,7 +109,7 @@ bool PerformanceImplicitGemmForwardV4R4Xdlops_Padded_Gemm::SetNextValue(const Pr
     {
         // List performance parameters in reverse order, in order for tuning to iterate over the
         // range in normal order.
-        if(miopen::IsEnabled(ENV(
+        if(miopen::IsEnabled(MIOPEN_ENV(
                MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_FWD_V4R4_XDLOPS_ADD_VECTOR_LOAD_GEMMN_TUNE_PARAM)))
         {
             if(!NextTwoPower<1, 8>(GemmBThreadDataPerRead_GemmN))
@@ -491,7 +491,7 @@ PerformanceImplicitGemmForwardV4R4Xdlops_Padded_Gemm::CalculateGemmBBlockCopyPer
         // calculate threadwise copy size
         auto data_per_thread_copy =
             std::max(1, (GemmKPerBlock * GemmNPerBlock * GemmKPack) / block_size);
-        if(miopen::IsEnabled(ENV(
+        if(miopen::IsEnabled(MIOPEN_ENV(
                MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_FWD_V4R4_XDLOPS_ADD_VECTOR_LOAD_GEMMN_TUNE_PARAM)))
         {
             if(problem.IsFp16())
@@ -810,7 +810,7 @@ bool PerformanceImplicitGemmForwardV4R4Xdlops_Padded_Gemm::IsFastToBeUsedForTuni
     // DstDataPerWrite_GemmKPack should not be too small, otherwise too many ds_write instruction
     // would cause bad performance.
     {
-        if(miopen::IsEnabled(ENV(
+        if(miopen::IsEnabled(MIOPEN_ENV(
                MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_FWD_V4R4_XDLOPS_ADD_VECTOR_LOAD_GEMMN_TUNE_PARAM)))
         {
             if(problem.IsFp16())
@@ -1017,8 +1017,8 @@ ConvSolution ConvHipImplicitGemmForwardV4R4Xdlops_Padded_Gemm::GetSolution(
         std::string(" -DCK_GEMM_N_PAD=") + std::to_string(gemm_n_extra) +
         std::string(" -DCK_GEMM_K_PAD=") + std::to_string(gemm_k_extra) +
         std::string(" -DCK_USE_AMD_XDLOPS=") + std::to_string(IsXdlopsSupport(ctx) ? 1 : 0) +
-        std::string(" -DCK_USE_AMD_XDLOPS_INLINE_ASM=") + std::to_string(miopen::IsEnabled(ENV(MIOPEN_DEBUG_IMPLICIT_GEMM_XDLOPS_INLINE_ASM)) ? 1 : 0) +
-        std::string(" -DCK_USE_AMD_XDLOPS_EMULATE=") + (miopen::IsEnabled(ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_XDLOPS_EMULATE)) ? '1' : '0') +
+        std::string(" -DCK_USE_AMD_XDLOPS_INLINE_ASM=") + std::to_string(miopen::IsEnabled(MIOPEN_ENV(MIOPEN_DEBUG_IMPLICIT_GEMM_XDLOPS_INLINE_ASM)) ? 1 : 0) +
+        std::string(" -DCK_USE_AMD_XDLOPS_EMULATE=") + (miopen::IsEnabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_XDLOPS_EMULATE)) ? '1' : '0') +
         get_static_ck_common_compiler_flag(ctx) +
         ctx.general_compile_options;
     // clang-format on
@@ -1031,7 +1031,8 @@ ConvSolution ConvHipImplicitGemmForwardV4R4Xdlops_Padded_Gemm::GetSolution(
 bool ConvHipImplicitGemmForwardV4R4Xdlops_Padded_Gemm::IsApplicable(
     const ExecutionContext& ctx, const ProblemDescription& problem) const
 {
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_FWD_V4R4_PADDED_GEMM_XDLOPS)))
+    if(miopen::IsDisabled(
+           MIOPEN_ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_FWD_V4R4_PADDED_GEMM_XDLOPS)))
         return false;
 
     if(ThisSolverIsDeprecatedStatic::IsDisabled(ctx))

--- a/src/solver/conv_hip_implicit_gemm_fwd_v4r5_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_fwd_v4r5_xdlops.cpp
@@ -128,7 +128,7 @@ bool PerformanceImplicitGemmForwardV4R5Xdlops::SetNextValue(const ProblemDescrip
     {
         // list performance parameters in reverse order, in order for tuning to iterate over the
         // range in normal order
-        if(miopen::IsEnabled(ENV(
+        if(miopen::IsEnabled(MIOPEN_ENV(
                MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_FWD_V4R5_XDLOPS_ADD_VECTOR_LOAD_GEMMN_TUNE_PARAM)))
         {
             if(!NextTwoPower<1, 8>(GemmBThreadDataPerRead_GemmN))
@@ -494,7 +494,7 @@ PerformanceImplicitGemmForwardV4R5Xdlops::CalculateGemmBBlockCopyPerformancePara
         // calculate threadwise copy size
         auto data_per_thread_copy =
             std::max(1, (GemmKPerBlock * NWaves * BPerBlock * GemmKPack) / block_size);
-        if(miopen::IsEnabled(ENV(
+        if(miopen::IsEnabled(MIOPEN_ENV(
                MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_FWD_V4R5_XDLOPS_ADD_VECTOR_LOAD_GEMMN_TUNE_PARAM)))
         {
             if(problem.IsFp16())
@@ -826,7 +826,7 @@ bool PerformanceImplicitGemmForwardV4R5Xdlops::IsFastToBeUsedForTuning(
     // DstDataPerWrite_GemmKPack should not be too small, otherwise too many ds_write instruction
     // would cause bad performance
     {
-        if(miopen::IsEnabled(ENV(
+        if(miopen::IsEnabled(MIOPEN_ENV(
                MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_FWD_V4R5_XDLOPS_ADD_VECTOR_LOAD_GEMMN_TUNE_PARAM)))
         {
             if(problem.IsFp16())
@@ -988,8 +988,8 @@ ConvSolution ConvHipImplicitGemmForwardV4R5Xdlops::GetSolution(
         std::string(" -DCK_PARAM_DEPENDENT_GEMM_B_BLOCK_COPY_SRC_DATA_PER_READ_GEMM_N=") + std::to_string(GemmBBlockCopySrcDataPerRead_GemmN) +
         std::string(" -DCK_PARAM_DEPENDENT_GEMM_B_BLOCK_COPY_DST_DATA_PER_WRITE_GEMM_KPACK=") + std::to_string(GemmBBlockCopyDstDataPerWrite_GemmKPack) +
         std::string(" -DCK_USE_AMD_XDLOPS=") + std::to_string(IsXdlopsSupport(ctx) ? 1 : 0) +
-        std::string(" -DCK_USE_AMD_XDLOPS_INLINE_ASM=") + std::to_string(miopen::IsEnabled(ENV(MIOPEN_DEBUG_IMPLICIT_GEMM_XDLOPS_INLINE_ASM)) ? 1 : 0) +
-        std::string(" -DCK_USE_AMD_XDLOPS_EMULATE=") + (miopen::IsEnabled(ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_XDLOPS_EMULATE)) ? '1' : '0') +
+        std::string(" -DCK_USE_AMD_XDLOPS_INLINE_ASM=") + std::to_string(miopen::IsEnabled(MIOPEN_ENV(MIOPEN_DEBUG_IMPLICIT_GEMM_XDLOPS_INLINE_ASM)) ? 1 : 0) +
+        std::string(" -DCK_USE_AMD_XDLOPS_EMULATE=") + (miopen::IsEnabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_XDLOPS_EMULATE)) ? '1' : '0') +
         get_static_ck_common_compiler_flag(ctx) +
         ctx.general_compile_options;
     // clang-format on
@@ -1002,7 +1002,7 @@ ConvSolution ConvHipImplicitGemmForwardV4R5Xdlops::GetSolution(
 bool ConvHipImplicitGemmForwardV4R5Xdlops::IsApplicable(const ExecutionContext& ctx,
                                                         const ProblemDescription& problem) const
 {
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_FWD_V4R5_XDLOPS)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_FWD_V4R5_XDLOPS)))
         return false;
 
     if(ThisSolverIsDeprecatedStatic::IsDisabled(ctx))

--- a/src/solver/conv_hip_implicit_gemm_fwd_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_fwd_xdlops.cpp
@@ -260,7 +260,7 @@ bool ConvHipImplicitGemmFwdXdlops::IsApplicable(
     [[maybe_unused]] const ProblemDescription& problem) const
 {
 #if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_FWD_XDLOPS)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_FWD_XDLOPS)))
         return false;
     if(problem.GetConv().attribute.deterministic)
         return false;

--- a/src/solver/conv_hip_implicit_gemm_grouped_bwd_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_grouped_bwd_xdlops.cpp
@@ -322,7 +322,7 @@ bool PerformanceConfigHipImplicitGemmGroupBwdXdlops::IsModelApplicable(
         return false;
     if(problem.GetInDataType() != miopenFloat && problem.GetInDataType() != miopenHalf)
         return false;
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_GROUP_CONV_IMPLICIT_GEMM_HIP_BWD_XDLOPS_AI_HEUR)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_GROUP_CONV_IMPLICIT_GEMM_HIP_BWD_XDLOPS_AI_HEUR)))
         return false;
     return true;
 }
@@ -460,9 +460,9 @@ bool ConvHipImplicitGemmGroupBwdXdlops::IsApplicable(
     [[maybe_unused]] const ProblemDescription& problem) const
 {
 #if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_GROUP_BWD_XDLOPS)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_GROUP_BWD_XDLOPS)))
         return false;
-    if(miopen::IsEnabled(ENV(MIOPEN_DEBUG_CONVOLUTION_DETERMINISTIC)))
+    if(miopen::IsEnabled(MIOPEN_ENV(MIOPEN_DEBUG_CONVOLUTION_DETERMINISTIC)))
         return false;
     if(problem.HasMixedDataTypes())
         return false;

--- a/src/solver/conv_hip_implicit_gemm_grouped_fwd_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_grouped_fwd_xdlops.cpp
@@ -334,7 +334,7 @@ bool PerformanceConfigHipImplicitGemmGroupFwdXdlops::IsModelApplicable(
         return false;
     if(problem.GetInDataType() != miopenFloat && problem.GetInDataType() != miopenHalf)
         return false;
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_GROUP_CONV_IMPLICIT_GEMM_HIP_FWD_XDLOPS_AI_HEUR)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_GROUP_CONV_IMPLICIT_GEMM_HIP_FWD_XDLOPS_AI_HEUR)))
         return false;
     return true;
 }
@@ -472,7 +472,7 @@ bool ConvHipImplicitGemmGroupFwdXdlops::IsApplicable(
     [[maybe_unused]] const ProblemDescription& problem) const
 {
 #if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_GROUP_CONV_IMPLICIT_GEMM_HIP_FWD_XDLOPS)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_GROUP_CONV_IMPLICIT_GEMM_HIP_FWD_XDLOPS)))
         return false;
     if(problem.HasNonPackedTensors())
         return false;

--- a/src/solver/conv_hip_implicit_gemm_grouped_wrw_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_grouped_wrw_xdlops.cpp
@@ -318,7 +318,7 @@ bool PerformanceConfigHipImplicitGemmGroupWrwXdlops::IsModelApplicable(
         return false;
     if(problem.GetInDataType() != miopenFloat && problem.GetInDataType() != miopenHalf)
         return false;
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_GROUP_CONV_IMPLICIT_GEMM_HIP_WRW_XDLOPS_AI_HEUR)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_GROUP_CONV_IMPLICIT_GEMM_HIP_WRW_XDLOPS_AI_HEUR)))
         return false;
     return true;
 }
@@ -456,9 +456,9 @@ bool ConvHipImplicitGemmGroupWrwXdlops::IsApplicable(
     [[maybe_unused]] const ProblemDescription& problem) const
 {
 #if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_GROUP_CONV_IMPLICIT_GEMM_HIP_WRW_XDLOPS)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_GROUP_CONV_IMPLICIT_GEMM_HIP_WRW_XDLOPS)))
         return false;
-    if(miopen::IsEnabled(ENV(MIOPEN_DEBUG_CONVOLUTION_DETERMINISTIC)))
+    if(miopen::IsEnabled(MIOPEN_ENV(MIOPEN_DEBUG_CONVOLUTION_DETERMINISTIC)))
         return false;
     if(problem.HasMixedDataTypes())
         return false;

--- a/src/solver/conv_hip_implicit_gemm_wrw_v4r4.cpp
+++ b/src/solver/conv_hip_implicit_gemm_wrw_v4r4.cpp
@@ -581,7 +581,7 @@ ConvHipImplicitGemmV4R4WrW::CalculateGemmSize(const ProblemDescription& problem)
 bool ConvHipImplicitGemmV4R4WrW::IsApplicable(const ExecutionContext& ctx,
                                               const ProblemDescription& problem) const
 {
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_WRW_V4R4)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_WRW_V4R4)))
         return false;
     if(ThisSolverIsDeprecatedStatic::IsDisabled(ctx))
         return false;

--- a/src/solver/conv_hip_implicit_gemm_wrw_v4r4_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_wrw_v4r4_xdlops.cpp
@@ -976,8 +976,8 @@ ConvSolution ConvHipImplicitGemmWrwV4R4Xdlops::GetSolution(
         std::string(" -DCK_PARAM_DEPENDENT_GEMM_B_BLOCK_COPY_SRC_DATA_PER_READ_GEMM_KPACK=") + std::to_string(GemmBBlockCopySrcDataPerRead_GemmKPack) +
         std::string(" -DCK_PARAM_DEPENDENT_GEMM_B_BLOCK_COPY_DST_DATA_PER_WRITE_GEMM_KPACK=") + std::to_string(GemmBBlockCopyDstDataPerWrite_GemmKPack) +
         std::string(" -DCK_USE_AMD_XDLOPS=") + std::to_string(IsXdlopsSupport(ctx) ? 1 : 0) +
-        std::string(" -DCK_USE_AMD_XDLOPS_INLINE_ASM=") + std::to_string(miopen::IsEnabled(ENV(MIOPEN_DEBUG_IMPLICIT_GEMM_XDLOPS_INLINE_ASM)) ? 1 : 0) +
-        std::string(" -DCK_USE_AMD_XDLOPS_EMULATE=") + (miopen::IsEnabled(ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_XDLOPS_EMULATE)) ? '1' : '0') +
+        std::string(" -DCK_USE_AMD_XDLOPS_INLINE_ASM=") + std::to_string(miopen::IsEnabled(MIOPEN_ENV(MIOPEN_DEBUG_IMPLICIT_GEMM_XDLOPS_INLINE_ASM)) ? 1 : 0) +
+        std::string(" -DCK_USE_AMD_XDLOPS_EMULATE=") + (miopen::IsEnabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_XDLOPS_EMULATE)) ? '1' : '0') +
         get_static_ck_common_compiler_flag(ctx) +
         ctx.general_compile_options;
     // clang-format on
@@ -1043,7 +1043,7 @@ ConvSolution ConvHipImplicitGemmWrwV4R4Xdlops::GetSolution(
 bool ConvHipImplicitGemmWrwV4R4Xdlops::IsApplicable(const ExecutionContext& ctx,
                                                     const ProblemDescription& problem) const
 {
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_WRW_V4R4_XDLOPS)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_WRW_V4R4_XDLOPS)))
         return false;
 
     if(ThisSolverIsDeprecatedStatic::IsDisabled(ctx))

--- a/src/solver/conv_hip_implicit_gemm_wrw_v4r4_xdlops_padded_gemm.cpp
+++ b/src/solver/conv_hip_implicit_gemm_wrw_v4r4_xdlops_padded_gemm.cpp
@@ -1039,8 +1039,8 @@ ConvSolution ConvHipImplicitGemmWrwV4R4Xdlops_Padded_Gemm::GetSolution(
         std::string(" -DCK_GEMM_N_PAD=") + std::to_string(GemmNPad) +
         std::string(" -DCK_GEMM_K_TOTAL_PAD=") + std::to_string(GemmKTotalPad) +
         std::string(" -DCK_USE_AMD_XDLOPS=") + std::to_string(IsXdlopsSupport(ctx) ? 1 : 0) +
-        std::string(" -DCK_USE_AMD_XDLOPS_INLINE_ASM=") + std::to_string(miopen::IsEnabled(ENV(MIOPEN_DEBUG_IMPLICIT_GEMM_XDLOPS_INLINE_ASM)) ? 1 : 0) +
-        std::string(" -DCK_USE_AMD_XDLOPS_EMULATE=") + (miopen::IsEnabled(ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_XDLOPS_EMULATE)) ? '1' : '0') +
+        std::string(" -DCK_USE_AMD_XDLOPS_INLINE_ASM=") + std::to_string(miopen::IsEnabled(MIOPEN_ENV(MIOPEN_DEBUG_IMPLICIT_GEMM_XDLOPS_INLINE_ASM)) ? 1 : 0) +
+        std::string(" -DCK_USE_AMD_XDLOPS_EMULATE=") + (miopen::IsEnabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_XDLOPS_EMULATE)) ? '1' : '0') +
         get_static_ck_common_compiler_flag(ctx) +
         ctx.general_compile_options;
     // clang-format on
@@ -1106,7 +1106,8 @@ ConvSolution ConvHipImplicitGemmWrwV4R4Xdlops_Padded_Gemm::GetSolution(
 bool ConvHipImplicitGemmWrwV4R4Xdlops_Padded_Gemm::IsApplicable(
     const ExecutionContext& ctx, const ProblemDescription& problem) const
 {
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_WRW_V4R4_PADDED_GEMM_XDLOPS)))
+    if(miopen::IsDisabled(
+           MIOPEN_ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_WRW_V4R4_PADDED_GEMM_XDLOPS)))
         return false;
 
     if(ThisSolverIsDeprecatedStatic::IsDisabled(ctx))

--- a/src/solver/conv_mlir_igemm_bwd.cpp
+++ b/src/solver/conv_mlir_igemm_bwd.cpp
@@ -44,7 +44,7 @@ bool ConvMlirIgemmBwd::IsApplicable(const ExecutionContext& ctx,
                                     const ProblemDescription& problem) const
 {
 #if MIOPEN_USE_MLIR
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_MLIR_IGEMM_BWD)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_MLIR_IGEMM_BWD)))
         return false;
     if(problem.GetConv().attribute.deterministic)
         return false;

--- a/src/solver/conv_mlir_igemm_bwd_xdlops.cpp
+++ b/src/solver/conv_mlir_igemm_bwd_xdlops.cpp
@@ -45,7 +45,7 @@ bool ConvMlirIgemmBwdXdlops::IsApplicable(const ExecutionContext& ctx,
                                           const ProblemDescription& problem) const
 {
 #if MIOPEN_USE_MLIR
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_MLIR_IGEMM_BWD_XDLOPS)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_MLIR_IGEMM_BWD_XDLOPS)))
         return false;
     if(problem.GetConv().attribute.deterministic)
         return false;

--- a/src/solver/conv_mlir_igemm_fwd.cpp
+++ b/src/solver/conv_mlir_igemm_fwd.cpp
@@ -164,7 +164,7 @@ bool ConvMlirIgemmFwd::IsApplicable(const ExecutionContext& ctx,
                                     const ProblemDescription& problem) const
 {
 #if MIOPEN_USE_MLIR
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_MLIR_IGEMM_FWD)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_MLIR_IGEMM_FWD)))
         return false;
     if(problem.GetConv().attribute.deterministic)
         return false;

--- a/src/solver/conv_mlir_igemm_fwd_xdlops.cpp
+++ b/src/solver/conv_mlir_igemm_fwd_xdlops.cpp
@@ -59,7 +59,7 @@ bool ConvMlirIgemmFwdXdlops::IsApplicable(const ExecutionContext& ctx,
                                           const ProblemDescription& problem) const
 {
 #if MIOPEN_USE_MLIR
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_MLIR_IGEMM_FWD_XDLOPS)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_MLIR_IGEMM_FWD_XDLOPS)))
         return false;
     if(problem.GetConv().attribute.deterministic)
         return false;

--- a/src/solver/conv_mlir_igemm_wrw.cpp
+++ b/src/solver/conv_mlir_igemm_wrw.cpp
@@ -45,7 +45,7 @@ bool ConvMlirIgemmWrW::IsApplicable(const ExecutionContext& ctx,
                                     const ProblemDescription& problem) const
 {
 #if MIOPEN_USE_MLIR
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_MLIR_IGEMM_WRW)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_MLIR_IGEMM_WRW)))
         return false;
     if(problem.GetConv().attribute.deterministic)
         return false;

--- a/src/solver/conv_mlir_igemm_wrw_xdlops.cpp
+++ b/src/solver/conv_mlir_igemm_wrw_xdlops.cpp
@@ -46,7 +46,7 @@ bool ConvMlirIgemmWrWXdlops::IsApplicable(const ExecutionContext& ctx,
                                           const ProblemDescription& problem) const
 {
 #if MIOPEN_USE_MLIR
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_MLIR_IGEMM_WRW_XDLOPS)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_MLIR_IGEMM_WRW_XDLOPS)))
         return false;
     if(problem.GetConv().attribute.deterministic)
         return false;

--- a/src/solver/conv_multipass_wino3x3WrW.cpp
+++ b/src/solver/conv_multipass_wino3x3WrW.cpp
@@ -384,7 +384,7 @@ bool ConvWinograd3x3MultipassWrW<WinoDataH, WinoFilterH, WinoDataW, WinoFilterW>
 
     if(wino_data_tile == 3 && wino_filter_tile == 2)
     {
-        if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_AMD_WINOGRAD_MPASS_F3X2)) ||
+        if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_AMD_WINOGRAD_MPASS_F3X2)) ||
            problem.GetKernelStrideH() == 1)
         {
             return false;
@@ -392,7 +392,7 @@ bool ConvWinograd3x3MultipassWrW<WinoDataH, WinoFilterH, WinoDataW, WinoFilterW>
     }
     if(wino_data_tile == 3 && wino_filter_tile == 3)
     {
-        if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_AMD_WINOGRAD_MPASS_F3X3)) ||
+        if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_AMD_WINOGRAD_MPASS_F3X3)) ||
            problem.GetKernelStrideH() == 1)
         {
             return false;
@@ -405,17 +405,17 @@ bool ConvWinograd3x3MultipassWrW<WinoDataH, WinoFilterH, WinoDataW, WinoFilterW>
     {
         if(wino_data_tile == 3 && wino_filter_tile == 4)
         {
-            if(!miopen::IsEnabled(ENV(MIOPEN_DEBUG_AMD_WINOGRAD_MPASS_F3X4)))
+            if(!miopen::IsEnabled(MIOPEN_ENV(MIOPEN_DEBUG_AMD_WINOGRAD_MPASS_F3X4)))
                 return false;
         }
         if(wino_data_tile == 3 && wino_filter_tile == 5)
         {
-            if(!miopen::IsEnabled(ENV(MIOPEN_DEBUG_AMD_WINOGRAD_MPASS_F3X5)))
+            if(!miopen::IsEnabled(MIOPEN_ENV(MIOPEN_DEBUG_AMD_WINOGRAD_MPASS_F3X5)))
                 return false;
         }
         if(wino_data_tile == 3 && wino_filter_tile == 6)
         {
-            if(!miopen::IsEnabled(ENV(MIOPEN_DEBUG_AMD_WINOGRAD_MPASS_F3X6)))
+            if(!miopen::IsEnabled(MIOPEN_ENV(MIOPEN_DEBUG_AMD_WINOGRAD_MPASS_F3X6)))
                 return false;
         }
     }
@@ -424,39 +424,39 @@ bool ConvWinograd3x3MultipassWrW<WinoDataH, WinoFilterH, WinoDataW, WinoFilterW>
     {
         if(wino_data_tile == 3 && wino_filter_tile == 4)
         {
-            if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_AMD_WINOGRAD_MPASS_F3X4)))
+            if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_AMD_WINOGRAD_MPASS_F3X4)))
                 return false;
         }
         if(wino_data_tile == 3 && wino_filter_tile == 5)
         {
-            if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_AMD_WINOGRAD_MPASS_F3X5)))
+            if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_AMD_WINOGRAD_MPASS_F3X5)))
                 return false;
         }
         if(wino_data_tile == 3 && wino_filter_tile == 6)
         {
-            if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_AMD_WINOGRAD_MPASS_F3X6)))
+            if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_AMD_WINOGRAD_MPASS_F3X6)))
                 return false;
         }
     }
 
     if(wino_data_tile == 7 && wino_filter_tile == 2)
     {
-        if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_AMD_WINOGRAD_MPASS_F7X2)))
+        if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_AMD_WINOGRAD_MPASS_F7X2)))
             return false;
     }
     if(wino_data_tile == 7 && wino_filter_tile == 3)
     {
-        if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_AMD_WINOGRAD_MPASS_F7X3)))
+        if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_AMD_WINOGRAD_MPASS_F7X3)))
             return false;
     }
     if(wino_data_tile == 5 && wino_filter_tile == 3)
     {
-        if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_AMD_WINOGRAD_MPASS_F5X3)))
+        if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_AMD_WINOGRAD_MPASS_F5X3)))
             return false;
     }
     if(wino_data_tile == 5 && wino_filter_tile == 4)
     {
-        if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_AMD_WINOGRAD_MPASS_F5X4)))
+        if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_AMD_WINOGRAD_MPASS_F5X4)))
             return false;
     }
     if(!ctx.use_asm_kernels)
@@ -494,7 +494,8 @@ bool ConvWinograd3x3MultipassWrW<WinoDataH, WinoFilterH, WinoDataW, WinoFilterW>
         return false;
 
     {
-        std::size_t limit = miopen::Value(ENV(MIOPEN_DEBUG_AMD_WINOGRAD_MPASS_WORKSPACE_MAX));
+        std::size_t limit =
+            miopen::Value(MIOPEN_ENV(MIOPEN_DEBUG_AMD_WINOGRAD_MPASS_WORKSPACE_MAX));
 #if WORKAROUND_SWDEV_203031
         if(limit == 0)
         {

--- a/src/solver/conv_ocl_dir2D11x11.cpp
+++ b/src/solver/conv_ocl_dir2D11x11.cpp
@@ -42,7 +42,7 @@ using ProblemDescription = miopen::conv::ProblemDescription;
 bool ConvOclDirectFwd11x11::IsApplicable(const ExecutionContext& ctx,
                                          const ProblemDescription& problem) const
 {
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_DIRECT_OCL_FWD11X11)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_DIRECT_OCL_FWD11X11)))
         return false;
     if(ThisSolverIsDeprecatedStatic::IsDisabled(ctx))
         return false;

--- a/src/solver/conv_ocl_dir2D_bwdWrW_1x1.cpp
+++ b/src/solver/conv_ocl_dir2D_bwdWrW_1x1.cpp
@@ -49,11 +49,11 @@ bool ConvOclBwdWrW1x1::IsApplicable(const ExecutionContext& ctx,
     if(StartsWith(ctx.GetStream().GetDeviceName(), "gfx10") ||
        StartsWith(ctx.GetStream().GetDeviceName(), "gfx11"))
     {
-        if(!miopen::IsEnabled(ENV(MIOPEN_DEBUG_CONV_DIRECT_OCL_WRW1X1)))
+        if(!miopen::IsEnabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_DIRECT_OCL_WRW1X1)))
             return false;
     }
 #endif
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_DIRECT_OCL_WRW1X1)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_DIRECT_OCL_WRW1X1)))
         return false;
     if(ThisSolverIsDeprecatedStatic::IsDisabled(ctx))
         return false;

--- a/src/solver/conv_ocl_dir2D_bwdWrW_2.cpp
+++ b/src/solver/conv_ocl_dir2D_bwdWrW_2.cpp
@@ -175,7 +175,7 @@ template <int N_BATCH_LOOPS>
 bool PerformanceConfigConvOclBwdWrw2<N_BATCH_LOOPS>::SetNextValue(const ProblemDescription&)
 {
     // Increment with wrap-around:
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_DIRECT_OCL_WRW2_SEARCH_OPTIMIZED)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_DIRECT_OCL_WRW2_SEARCH_OPTIMIZED)))
     {
         do
         {
@@ -452,7 +452,7 @@ template <int N_BATCH_LOOPS>
 bool ConvOclBwdWrW2<N_BATCH_LOOPS>::IsApplicableBase(const ExecutionContext& ctx,
                                                      const ProblemDescription& problem) const
 {
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_DIRECT_OCL_WRW2)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_DIRECT_OCL_WRW2)))
         return false;
     if(ThisSolverIsDeprecatedStatic::IsDisabled(ctx))
         return false;

--- a/src/solver/conv_ocl_dir2D_bwdWrW_53.cpp
+++ b/src/solver/conv_ocl_dir2D_bwdWrW_53.cpp
@@ -46,7 +46,7 @@ static bool WorkaroundSwdev168168() { return true; }
 bool ConvOclBwdWrW53::IsApplicable(const ExecutionContext& ctx,
                                    const ProblemDescription& problem) const
 {
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_DIRECT_OCL_WRW53)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_DIRECT_OCL_WRW53)))
         return false;
     if(ThisSolverIsDeprecatedStatic::IsDisabled(ctx))
         return false;

--- a/src/solver/conv_ocl_dir2Dfwd.cpp
+++ b/src/solver/conv_ocl_dir2Dfwd.cpp
@@ -41,7 +41,7 @@ using ProblemDescription = miopen::conv::ProblemDescription;
 bool ConvOclDirectFwd::IsApplicable(const ExecutionContext& ctx,
                                     const ProblemDescription& problem) const
 {
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_DIRECT_OCL_FWD)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_DIRECT_OCL_FWD)))
         return false;
     if(ThisSolverIsDeprecatedStatic::IsDisabled(ctx))
         return false;

--- a/src/solver/conv_ocl_dir2Dfwd1x1.cpp
+++ b/src/solver/conv_ocl_dir2Dfwd1x1.cpp
@@ -48,13 +48,13 @@ bool ConvOclDirectFwd1x1::IsApplicable(const ExecutionContext& ctx,
     if(StartsWith(ctx.GetStream().GetDeviceName(), "gfx10") ||
        StartsWith(ctx.GetStream().GetDeviceName(), "gfx11"))
     {
-        if(!miopen::IsEnabled(ENV(MIOPEN_DEBUG_CONV_DIRECT_OCL_FWD1X1)))
+        if(!miopen::IsEnabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_DIRECT_OCL_FWD1X1)))
             return false;
     }
 #endif
     if(ThisSolverIsDeprecatedStatic::IsDisabled(ctx))
         return false;
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_DIRECT_OCL_FWD1X1)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_DIRECT_OCL_FWD1X1)))
         return false;
     if(!ctx.use_opencl_convolutions)
         return false;

--- a/src/solver/conv_ocl_dir2Dfwdgen.cpp
+++ b/src/solver/conv_ocl_dir2Dfwdgen.cpp
@@ -40,7 +40,7 @@ using ProblemDescription = miopen::conv::ProblemDescription;
 bool ConvOclDirectFwdGen::IsApplicable(const ExecutionContext& ctx,
                                        const ProblemDescription& problem) const
 {
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_DIRECT_OCL_FWDGEN)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_CONV_DIRECT_OCL_FWDGEN)))
         return false;
     if(ThisSolverIsDeprecatedStatic::IsDisabled(ctx))
         return false;

--- a/src/solver/conv_winoRxS.cpp
+++ b/src/solver/conv_winoRxS.cpp
@@ -696,7 +696,7 @@ static bool IsApplicableBase(const ExecutionContext& ctx, const ProblemDescripti
         // clang-format on
 
 #if WORKAROUND_ISSUE_2492_GRANULARITY_LOSS
-    if(!miopen::IsDisabled(ENV(MIOPEN_DEBUG_WORKAROUND_ISSUE_2492)) &&
+    if(!miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_WORKAROUND_ISSUE_2492)) &&
        !miopen::debug::IsWarmupOngoing)
     {
         constexpr double max_perf_drop_due_to_granularity = 200; // Times.
@@ -710,7 +710,7 @@ static bool IsApplicableBase(const ExecutionContext& ctx, const ProblemDescripti
 #endif
 
 #if WORKAROUND_ISSUE_2492_TINY_TENSOR
-    if(!miopen::IsDisabled(ENV(MIOPEN_DEBUG_WORKAROUND_ISSUE_2492)) &&
+    if(!miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_WORKAROUND_ISSUE_2492)) &&
        !miopen::debug::IsWarmupOngoing)
     {
         // Group count is not taken into account intentionally.
@@ -763,7 +763,7 @@ bool ConvBinWinoRxS<Winodata, Winofilter>::IsApplicable(const ExecutionContext& 
 {
     if(IS2X3)
     {
-        if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_AMD_WINOGRAD_RXS_F2X3)))
+        if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_AMD_WINOGRAD_RXS_F2X3)))
             return false;
 #if !WORKAROUND_ISSUE_1681
         if(problem.GetGroupCount() == 1 && !problem.IsDirectionBackwardWrW())
@@ -772,7 +772,7 @@ bool ConvBinWinoRxS<Winodata, Winofilter>::IsApplicable(const ExecutionContext& 
     }
     if(IS3X2)
     {
-        if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_AMD_WINOGRAD_RXS_F3X2)))
+        if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_AMD_WINOGRAD_RXS_F3X2)))
             return false;
     }
     return IsApplicableBase<Winodata, Winofilter>(ctx, problem);
@@ -788,12 +788,12 @@ GetPerfConfFromEnv(const ExecutionContext& ctx)
 
     if(IS2X3)
     {
-        s        = miopen::GetStringEnv(ENV(MIOPEN_DEBUG_AMD_WINOGRAD_RXS_F2X3_PERF_VALS));
+        s        = miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_DEBUG_AMD_WINOGRAD_RXS_F2X3_PERF_VALS));
         env_name = "MIOPEN_DEBUG_AMD_WINOGRAD_RXS_F2X3_PERF_VALS";
     }
     else if(IS3X2)
     {
-        s        = miopen::GetStringEnv(ENV(MIOPEN_DEBUG_AMD_WINOGRAD_RXS_F3X2_PERF_VALS));
+        s        = miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_DEBUG_AMD_WINOGRAD_RXS_F3X2_PERF_VALS));
         env_name = "MIOPEN_DEBUG_AMD_WINOGRAD_RXS_F3X2_PERF_VALS";
     }
 
@@ -1141,7 +1141,7 @@ ConvSolution ConvBinWinoRxS<Winodata, Winofilter>::GetSolution(
 bool ConvBinWinogradRxSf2x3g1::IsApplicable(const ExecutionContext& ctx,
                                             const ProblemDescription& problem) const
 {
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_AMD_WINOGRAD_RXS_F2X3_G1)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_AMD_WINOGRAD_RXS_F2X3_G1)))
         return false;
     return IsApplicableBase<2, 3>(ctx, problem) && problem.GetGroupCount() == 1;
 }

--- a/src/solver/conv_winoRxS_fused.cpp
+++ b/src/solver/conv_winoRxS_fused.cpp
@@ -152,7 +152,7 @@ namespace fusion {
 bool ConvBinWinogradRxSf2x3g1Fused::IsApplicable(const FusionContext& context,
                                                  const FusionDescription& problem) const
 {
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_AMD_WINOGRAD_RXS_F2X3_G1)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_AMD_WINOGRAD_RXS_F2X3_G1)))
         return false;
     if(!WinoCommonIsApplicable(context, problem))
         return false;

--- a/src/solver/gemm.cpp
+++ b/src/solver/gemm.cpp
@@ -301,7 +301,7 @@ ConvSolution GemmFwd1x1_0_2::GetSolution(const ExecutionContext& context,
             out_spatial.begin(), out_spatial.end(), std::size_t(1), std::multiplies<std::size_t>());
 
         const bool time_precision = context.GetStream().IsProfilingEnabled() &&
-                                    (!IsDisabled(ENV(MIOPEN_CONV_PRECISE_ROCBLAS_TIMING)));
+                                    (!IsDisabled(MIOPEN_ENV(MIOPEN_CONV_PRECISE_ROCBLAS_TIMING)));
 
         return [=](const Handle& handle, const AnyInvokeParams& primitive_params) {
             float time_gemm          = 0;
@@ -588,7 +588,7 @@ ConvSolution GemmFwd1x1_0_1_int8::GetSolution(const ExecutionContext& context,
             out_spatial.begin(), out_spatial.end(), std::size_t(1), std::multiplies<std::size_t>());
 
         const bool time_precision = context.GetStream().IsProfilingEnabled() &&
-                                    (!IsDisabled(ENV(MIOPEN_CONV_PRECISE_ROCBLAS_TIMING)));
+                                    (!IsDisabled(MIOPEN_ENV(MIOPEN_CONV_PRECISE_ROCBLAS_TIMING)));
 
         return [=](const Handle& handle, const AnyInvokeParams& primitive_params) {
             const auto& conv_params  = primitive_params.CastTo<miopen::conv::DataInvokeParams>();
@@ -762,8 +762,9 @@ ConvSolution GemmFwd1x1_0_1::GetSolution(const ExecutionContext& context,
             out_spatial.begin(), out_spatial.end(), std::size_t(1), std::multiplies<std::size_t>());
 
         solution.invoker_factory = [=](const std::vector<Kernel>&) {
-            const bool time_precision = context.GetStream().IsProfilingEnabled() &&
-                                        (!IsDisabled(ENV(MIOPEN_CONV_PRECISE_ROCBLAS_TIMING)));
+            const bool time_precision =
+                context.GetStream().IsProfilingEnabled() &&
+                (!IsDisabled(MIOPEN_ENV(MIOPEN_CONV_PRECISE_ROCBLAS_TIMING)));
 
             MIOPEN_LOG_FUNCTION("groupconv, 1x1");
 
@@ -864,8 +865,9 @@ ConvSolution GemmFwd1x1_0_1::GetSolution(const ExecutionContext& context,
         solution.invoker_factory = [=](const std::vector<Kernel>&) {
             MIOPEN_LOG_FUNCTION("convolution, 1x1");
 
-            const bool time_precision = context.GetStream().IsProfilingEnabled() &&
-                                        (!IsDisabled(ENV(MIOPEN_CONV_PRECISE_ROCBLAS_TIMING)));
+            const bool time_precision =
+                context.GetStream().IsProfilingEnabled() &&
+                (!IsDisabled(MIOPEN_ENV(MIOPEN_CONV_PRECISE_ROCBLAS_TIMING)));
 
             return [=](const Handle& handle, const AnyInvokeParams& primitive_params) {
                 float time = 0;
@@ -1049,7 +1051,7 @@ ConvSolution GemmFwdRest::GetSolution(const ExecutionContext& context,
         const auto wei_spatial_size = std::accumulate(
             wei_spatial.begin(), wei_spatial.end(), std::size_t(1), std::multiplies<std::size_t>());
 
-        const bool time_precision = (!IsDisabled(ENV(MIOPEN_CONV_PRECISE_ROCBLAS_TIMING)));
+        const bool time_precision = (!IsDisabled(MIOPEN_ENV(MIOPEN_CONV_PRECISE_ROCBLAS_TIMING)));
 
         return [=](const Handle& handle, const AnyInvokeParams& primitive_params) {
             float time_gemm          = 0;

--- a/src/solver/gemm_bwd.cpp
+++ b/src/solver/gemm_bwd.cpp
@@ -267,7 +267,7 @@ ConvSolution GemmBwd1x1_stride2::GetSolution(const ExecutionContext& context,
     solution.workspace_sz = workspace_req;
 
     solution.invoker_factory = [=](const std::vector<Kernel>&) {
-        const bool time_precision = (!IsDisabled(ENV(MIOPEN_CONV_PRECISE_ROCBLAS_TIMING)));
+        const bool time_precision = (!IsDisabled(MIOPEN_ENV(MIOPEN_CONV_PRECISE_ROCBLAS_TIMING)));
 
         return [=](const Handle& handle, const AnyInvokeParams& primitive_params) {
             const auto& conv_params    = primitive_params.CastTo<miopen::conv::DataInvokeParams>();
@@ -451,7 +451,7 @@ ConvSolution GemmBwd1x1_stride1::GetSolution(const ExecutionContext&,
     solution.workspace_sz = 0;
 
     solution.invoker_factory = [=](const std::vector<Kernel>&) {
-        const bool time_precision = (!IsDisabled(ENV(MIOPEN_CONV_PRECISE_ROCBLAS_TIMING)));
+        const bool time_precision = (!IsDisabled(MIOPEN_ENV(MIOPEN_CONV_PRECISE_ROCBLAS_TIMING)));
 
         return [=](const Handle& handle, const AnyInvokeParams& primitive_params) {
             const auto& conv_params = primitive_params.CastTo<miopen::conv::DataInvokeParams>();
@@ -703,7 +703,7 @@ ConvSolution GemmBwdRest::GetSolution(const ExecutionContext& context,
     solution.workspace_sz = workspace_req;
 
     solution.invoker_factory = [=](const std::vector<Kernel>&) {
-        const bool time_precision = (!IsDisabled(ENV(MIOPEN_CONV_PRECISE_ROCBLAS_TIMING)));
+        const bool time_precision = (!IsDisabled(MIOPEN_ENV(MIOPEN_CONV_PRECISE_ROCBLAS_TIMING)));
 
         return [=](const Handle& handle, const AnyInvokeParams& primitive_params) {
             const auto& conv_params    = primitive_params.CastTo<miopen::conv::DataInvokeParams>();

--- a/src/solver/gemm_common.cpp
+++ b/src/solver/gemm_common.cpp
@@ -59,7 +59,7 @@ std::size_t MaxMemAllocSz(Handle& h,
     const auto m = h.GetMaxMemoryAllocSize();
 #if WORKAROUND_MLOPEN_ISSUE_1430
     auto limit = static_cast<std::size_t>(7287183769);
-    if(!miopen::IsDisabled(ENV(MIOPEN_WORKAROUND_ISSUE_2789)))
+    if(!miopen::IsDisabled(MIOPEN_ENV(MIOPEN_WORKAROUND_ISSUE_2789)))
     {
         if(problem.IsFp32() && double_limit_for_fp32)
             limit *= 2;

--- a/src/solver/gemm_wrw.cpp
+++ b/src/solver/gemm_wrw.cpp
@@ -224,7 +224,7 @@ ConvSolution GemmWrw1x1_stride1::GetSolution(const ExecutionContext&,
     auto solution = ConvSolution{miopenStatusSuccess};
 
     solution.invoker_factory = [=](const std::vector<Kernel>&) {
-        const bool time_precision = (!IsDisabled(ENV(MIOPEN_CONV_PRECISE_ROCBLAS_TIMING)));
+        const bool time_precision = (!IsDisabled(MIOPEN_ENV(MIOPEN_CONV_PRECISE_ROCBLAS_TIMING)));
 
         return [=](const Handle& handle, const AnyInvokeParams& primitive_params) {
             const auto& conv_params = primitive_params.CastTo<miopen::conv::WrWInvokeParams>();
@@ -444,7 +444,7 @@ ConvSolution GemmWrwUniversal::GetSolution(const ExecutionContext& context,
     solution.workspace_sz = workspace_req;
 
     solution.invoker_factory = [=](const std::vector<Kernel>&) {
-        const bool time_precision = (!IsDisabled(ENV(MIOPEN_CONV_PRECISE_ROCBLAS_TIMING)));
+        const bool time_precision = (!IsDisabled(MIOPEN_ENV(MIOPEN_CONV_PRECISE_ROCBLAS_TIMING)));
 
         return [=](const Handle& handle, const AnyInvokeParams& primitive_params) {
             const auto& conv_params    = primitive_params.CastTo<miopen::conv::WrWInvokeParams>();

--- a/src/solver/layernorm/forward_layernorm2d_ck.cpp
+++ b/src/solver/layernorm/forward_layernorm2d_ck.cpp
@@ -213,7 +213,7 @@ bool Layernorm2DCKForward::IsApplicable(
     [[maybe_unused]] const miopen::layernorm::ProblemDescription& problem) const
 {
 #if MIOPEN_USE_COMPOSABLEKERNEL
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_LAYERNORM2DCKFORWARD_CONV_CK_LN)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_LAYERNORM2DCKFORWARD_CONV_CK_LN)))
         return false;
     if(!problem.IsSameType())
         return false;

--- a/src/solver/layernorm/forward_layernorm4d_ck.cpp
+++ b/src/solver/layernorm/forward_layernorm4d_ck.cpp
@@ -221,7 +221,7 @@ bool Layernorm4DCKForward::IsApplicable(
     [[maybe_unused]] const miopen::layernorm::ProblemDescription& problem) const
 {
 #if MIOPEN_USE_COMPOSABLEKERNEL
-    if(miopen::IsDisabled(ENV(MIOPEN_DEBUG_LAYERNORM4DCKFORWARD_CONV_CK_LN)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_LAYERNORM4DCKFORWARD_CONV_CK_LN)))
         return false;
     if(!problem.IsSameType())
         return false;

--- a/src/solver/mha/mha_solver_backward.cpp
+++ b/src/solver/mha/mha_solver_backward.cpp
@@ -124,19 +124,19 @@ bool MhaBackward::IsApplicable([[maybe_unused]] const ExecutionContext& context,
 
     auto [N, H, S, D] = miopen::tien<4>(descsBackward.kDesc.GetLengths());
 
-    return !miopen::IsDisabled(ENV(MIOPEN_DEBUG_ATTN_NAIVE_BWD)) //
-           && S <= std::numeric_limits<uint32_t>::max()          //
-           && D <= std::numeric_limits<uint32_t>::max()          //
-           && descsBackward.kDesc.IsPacked()                     //
-           && descsBackward.qDesc.IsPacked()                     //
-           && descsBackward.vDesc.IsPacked()                     //
-           && descsBackward.oDesc.IsPacked()                     //
-           && descsBackward.doDesc.IsPacked()                    //
-           && descsBackward.mDesc.IsPacked()                     //
-           && descsBackward.zInvDesc.IsPacked()                  //
-           && descsBackward.dkDesc.IsPacked()                    //
-           && descsBackward.dqDesc.IsPacked()                    //
-           && descsBackward.dvDesc.IsPacked()                    //
+    return !miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_ATTN_NAIVE_BWD)) //
+           && S <= std::numeric_limits<uint32_t>::max()                 //
+           && D <= std::numeric_limits<uint32_t>::max()                 //
+           && descsBackward.kDesc.IsPacked()                            //
+           && descsBackward.qDesc.IsPacked()                            //
+           && descsBackward.vDesc.IsPacked()                            //
+           && descsBackward.oDesc.IsPacked()                            //
+           && descsBackward.doDesc.IsPacked()                           //
+           && descsBackward.mDesc.IsPacked()                            //
+           && descsBackward.zInvDesc.IsPacked()                         //
+           && descsBackward.dkDesc.IsPacked()                           //
+           && descsBackward.dqDesc.IsPacked()                           //
+           && descsBackward.dvDesc.IsPacked()                           //
            && MIOPEN_USE_GEMM;
 }
 

--- a/src/solver/mha/mha_solver_forward.cpp
+++ b/src/solver/mha/mha_solver_forward.cpp
@@ -113,14 +113,14 @@ bool MhaForward::IsApplicable([[maybe_unused]] const ExecutionContext& context,
 
     auto [N, H, S, D] = miopen::tien<4>(descsForward.kDesc.GetLengths());
 
-    return !miopen::IsDisabled(ENV(MIOPEN_DEBUG_ATTN_NAIVE_FWD)) //
-           && S <= std::numeric_limits<uint32_t>::max()          //
-           && descsForward.kDesc.IsPacked()                      //
-           && descsForward.qDesc.IsPacked()                      //
-           && descsForward.vDesc.IsPacked()                      //
-           && descsForward.oDesc.IsPacked()                      //
-           && descsForward.mDesc.IsPacked()                      //
-           && descsForward.zInvDesc.IsPacked()                   //
+    return !miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_ATTN_NAIVE_FWD)) //
+           && S <= std::numeric_limits<uint32_t>::max()                 //
+           && descsForward.kDesc.IsPacked()                             //
+           && descsForward.qDesc.IsPacked()                             //
+           && descsForward.vDesc.IsPacked()                             //
+           && descsForward.oDesc.IsPacked()                             //
+           && descsForward.mDesc.IsPacked()                             //
+           && descsForward.zInvDesc.IsPacked()                          //
            && MIOPEN_USE_GEMM;
 }
 

--- a/src/solver/softmax/attn_softmax.cpp
+++ b/src/solver/softmax/attn_softmax.cpp
@@ -70,18 +70,18 @@ bool AttnSoftmax::IsApplicable([[maybe_unused]] const ExecutionContext& context,
     const size_t seq_len = problem.GetXDesc().GetStrides().front(); // c * h * w
     const size_t nhs     = problem.GetXDesc().GetLengths().front(); // n
 
-    return !miopen::IsDisabled(ENV(MIOPEN_DEBUG_ATTN_SOFTMAX)) && //
-           seq_len <= std::numeric_limits<uint32_t>::max() &&     //
-           problem.GetAlgorithm() == MIOPEN_SOFTMAX_ACCURATE &&   //
-           problem.IsForward() &&                                 //
-           problem.GetXDesc().IsPacked() &&                       //
-           problem.GetYDesc().IsPacked() &&                       //
-           problem.GetXDesc().GetType() == miopenFloat &&         //
-           problem.GetYDesc().GetType() == miopenFloat &&         //
-           problem.GetMode() == MIOPEN_SOFTMAX_MODE_INSTANCE &&   //
-           float_equal(problem.GetAlpha(), 1.0f) &&               //
-           float_equal(problem.GetBeta(), 0.f) &&                 //
-           (seq_len > 16 || nhs <= 1024);                         // heuristic
+    return !miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_ATTN_SOFTMAX)) && //
+           seq_len <= std::numeric_limits<uint32_t>::max() &&            //
+           problem.GetAlgorithm() == MIOPEN_SOFTMAX_ACCURATE &&          //
+           problem.IsForward() &&                                        //
+           problem.GetXDesc().IsPacked() &&                              //
+           problem.GetYDesc().IsPacked() &&                              //
+           problem.GetXDesc().GetType() == miopenFloat &&                //
+           problem.GetYDesc().GetType() == miopenFloat &&                //
+           problem.GetMode() == MIOPEN_SOFTMAX_MODE_INSTANCE &&          //
+           float_equal(problem.GetAlpha(), 1.0f) &&                      //
+           float_equal(problem.GetBeta(), 0.f) &&                        //
+           (seq_len > 16 || nhs <= 1024);                                // heuristic
 }
 
 std::size_t AttnSoftmax::GetWorkspaceSize(

--- a/src/solver/softmax/softmax.cpp
+++ b/src/solver/softmax/softmax.cpp
@@ -126,7 +126,7 @@ bool Softmax::IsApplicable(
     [[maybe_unused]] const ExecutionContext& context,
     [[maybe_unused]] const miopen::softmax::ProblemDescription& problem) const
 {
-    return !miopen::IsDisabled(ENV(MIOPEN_DEBUG_OCL_SOFTMAX));
+    return !miopen::IsDisabled(MIOPEN_ENV(MIOPEN_DEBUG_OCL_SOFTMAX));
 }
 
 std::size_t

--- a/src/target_properties.cpp
+++ b/src/target_properties.cpp
@@ -55,7 +55,7 @@ static std::string GetDeviceNameFromMap(const std::string& in)
         {"10.3.0 Sienna_Cichlid 18", "gfx1030"},
     };
 
-    const auto& dev_str = miopen::GetStringEnv(ENV(MIOPEN_DEBUG_ENFORCE_DEVICE));
+    const auto& dev_str = miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_DEBUG_ENFORCE_DEVICE));
     if(!dev_str.empty())
         return dev_str;
 
@@ -76,7 +76,7 @@ const std::size_t TargetProperties::MaxLocalMemorySize = static_cast<const std::
 void TargetProperties::Init(const Handle* const handle)
 {
     const auto rawName = [&]() -> std::string {
-        const auto& arch = miopen::GetStringEnv(ENV(MIOPEN_DEVICE_ARCH));
+        const auto& arch = miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_DEVICE_ARCH));
         if(!arch.empty())
             return arch;
         return handle->GetDeviceNameImpl();

--- a/src/tmp_dir.cpp
+++ b/src/tmp_dir.cpp
@@ -52,12 +52,12 @@ TmpDir::TmpDir(std::string_view prefix) : path{fs::temp_directory_path()}
 
 int TmpDir::Execute(std::string_view cmd, std::string_view args) const
 {
-    if(miopen::IsEnabled(ENV(MIOPEN_DEBUG_SAVE_TEMP_DIR)))
+    if(miopen::IsEnabled(MIOPEN_ENV(MIOPEN_DEBUG_SAVE_TEMP_DIR)))
     {
         MIOPEN_LOG_I2(path);
     }
     auto status = Process{cmd}(args, path);
-    if(miopen::IsEnabled(ENV(MIOPEN_DEBUG_EXIT_STATUS_TEMP_DIR)))
+    if(miopen::IsEnabled(MIOPEN_ENV(MIOPEN_DEBUG_EXIT_STATUS_TEMP_DIR)))
     {
         MIOPEN_LOG_I2(status);
     }
@@ -66,7 +66,7 @@ int TmpDir::Execute(std::string_view cmd, std::string_view args) const
 
 TmpDir::~TmpDir()
 {
-    if(!miopen::IsEnabled(ENV(MIOPEN_DEBUG_SAVE_TEMP_DIR)))
+    if(!miopen::IsEnabled(MIOPEN_ENV(MIOPEN_DEBUG_SAVE_TEMP_DIR)))
     {
 #ifdef _WIN32
         constexpr int remove_max_retries = 5;

--- a/test/driver.hpp
+++ b/test/driver.hpp
@@ -147,7 +147,7 @@ struct test_driver
 
     static std::string compute_cache_path()
     {
-        auto s = miopen::GetStringEnv(ENV(MIOPEN_VERIFY_CACHE_PATH));
+        auto s = miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_VERIFY_CACHE_PATH));
         if(s.empty())
             return "~/.cache/miopen/tests";
         else

--- a/test/gpu_conv.hpp
+++ b/test/gpu_conv.hpp
@@ -76,7 +76,7 @@ bool gpu_ref_convolution_fwd(const tensor<Tin>& input,
                              miopen::ConvolutionDescriptor filter)
 {
     bool gpu_ref_used = false;
-    if(!miopen::IsEnabled(ENV(MIOPEN_DEBUG_TEST_DISABLE_GPU_REF)))
+    if(!miopen::IsEnabled(MIOPEN_ENV(MIOPEN_DEBUG_TEST_DISABLE_GPU_REF)))
     {
         const AutoPrepareForGpuReference guard;
         auto&& handle            = get_handle();
@@ -112,7 +112,7 @@ bool gpu_ref_convolution_bwd(tensor<Tin>& input,
                              miopen::ConvolutionDescriptor filter)
 {
     bool gpu_ref_used = false;
-    if(!miopen::IsEnabled(ENV(MIOPEN_DEBUG_TEST_DISABLE_GPU_REF)))
+    if(!miopen::IsEnabled(MIOPEN_ENV(MIOPEN_DEBUG_TEST_DISABLE_GPU_REF)))
     {
         const AutoPrepareForGpuReference guard;
         auto&& handle            = get_handle();
@@ -148,7 +148,7 @@ bool gpu_ref_convolution_wrw(const tensor<Tin>& input,
                              miopen::ConvolutionDescriptor filter)
 {
     bool gpu_ref_used = false;
-    if(!miopen::IsEnabled(ENV(MIOPEN_DEBUG_TEST_DISABLE_GPU_REF)))
+    if(!miopen::IsEnabled(MIOPEN_ENV(MIOPEN_DEBUG_TEST_DISABLE_GPU_REF)))
     {
         const AutoPrepareForGpuReference guard;
         auto&& handle            = get_handle();

--- a/test/gtest/adam.cpp
+++ b/test/gtest/adam.cpp
@@ -33,7 +33,7 @@ namespace adam {
 
 std::string GetFloatArg()
 {
-    const auto& tmp = miopen::GetStringEnv(ENV(MIOPEN_TEST_FLOAT_ARG));
+    const auto& tmp = miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_TEST_FLOAT_ARG));
     if(tmp.empty())
     {
         return "";
@@ -54,7 +54,7 @@ using namespace adam;
 
 TEST_P(AdamTestFloat, AdamTestFw)
 {
-    if(miopen::IsEnabled(ENV(MIOPEN_TEST_ALL)) && (GetFloatArg() == "--float"))
+    if(miopen::IsEnabled(MIOPEN_ENV(MIOPEN_TEST_ALL)) && (GetFloatArg() == "--float"))
     {
         RunTest();
         Verify();
@@ -67,7 +67,7 @@ TEST_P(AdamTestFloat, AdamTestFw)
 
 TEST_P(AmpAdamTestFloat, AmpAdamTestFw)
 {
-    if(miopen::IsEnabled(ENV(MIOPEN_TEST_ALL)) && (GetFloatArg() == "--float"))
+    if(miopen::IsEnabled(MIOPEN_ENV(MIOPEN_TEST_ALL)) && (GetFloatArg() == "--float"))
     {
         RunTest();
         Verify();

--- a/test/gtest/addlayernorm.cpp
+++ b/test/gtest/addlayernorm.cpp
@@ -34,7 +34,7 @@ namespace addlayernorm {
 
 std::string GetFloatArg()
 {
-    const auto& tmp = miopen::GetStringEnv(ENV(MIOPEN_TEST_FLOAT_ARG));
+    const auto& tmp = miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_TEST_FLOAT_ARG));
     if(tmp.empty())
     {
         return "";
@@ -59,8 +59,8 @@ using namespace addlayernorm;
 
 TEST_P(AddLayerNormTestFloat, AddLayerNormTestFw)
 {
-    auto TypeArg = miopen::GetStringEnv(ENV(MIOPEN_TEST_FLOAT_ARG));
-    if(miopen::IsEnabled(ENV(MIOPEN_TEST_ALL)) && (GetFloatArg() == "--float"))
+    auto TypeArg = miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_TEST_FLOAT_ARG));
+    if(miopen::IsEnabled(MIOPEN_ENV(MIOPEN_TEST_ALL)) && (GetFloatArg() == "--float"))
     {
         RunTest();
         Verify();
@@ -73,8 +73,8 @@ TEST_P(AddLayerNormTestFloat, AddLayerNormTestFw)
 
 TEST_P(AddLayerNormTestHalf, AddLayerNormTestFw)
 {
-    auto TypeArg = miopen::GetStringEnv(ENV(MIOPEN_TEST_FLOAT_ARG));
-    if(miopen::IsEnabled(ENV(MIOPEN_TEST_ALL)) && (GetFloatArg() == "--half"))
+    auto TypeArg = miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_TEST_FLOAT_ARG));
+    if(miopen::IsEnabled(MIOPEN_ENV(MIOPEN_TEST_ALL)) && (GetFloatArg() == "--half"))
     {
         RunTest();
         Verify();
@@ -87,8 +87,8 @@ TEST_P(AddLayerNormTestHalf, AddLayerNormTestFw)
 
 TEST_P(AddLayerNormTestBFloat16, AddLayerNormTestFw)
 {
-    auto TypeArg = miopen::GetStringEnv(ENV(MIOPEN_TEST_FLOAT_ARG));
-    if(miopen::IsEnabled(ENV(MIOPEN_TEST_ALL)) && (GetFloatArg() == "--bfloat16"))
+    auto TypeArg = miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_TEST_FLOAT_ARG));
+    if(miopen::IsEnabled(MIOPEN_ENV(MIOPEN_TEST_ALL)) && (GetFloatArg() == "--bfloat16"))
     {
         RunTest();
         Verify();

--- a/test/gtest/cat.cpp
+++ b/test/gtest/cat.cpp
@@ -33,7 +33,7 @@ namespace cat {
 
 std::string GetFloatArg()
 {
-    const auto& tmp = miopen::GetStringEnv(ENV(MIOPEN_TEST_FLOAT_ARG));
+    const auto& tmp = miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_TEST_FLOAT_ARG));
     if(tmp.empty())
     {
         return "";
@@ -50,7 +50,7 @@ using namespace cat;
 
 TEST_P(CatTestFloat, CatTestFw)
 {
-    if(miopen::IsEnabled(ENV(MIOPEN_TEST_ALL)) && (GetFloatArg() == "--float"))
+    if(miopen::IsEnabled(MIOPEN_ENV(MIOPEN_TEST_ALL)) && (GetFloatArg() == "--float"))
     {
         RunTest();
         Verify();

--- a/test/gtest/conv3d_codecov.cpp
+++ b/test/gtest/conv3d_codecov.cpp
@@ -51,7 +51,7 @@ class Conv3dInt8 : public testing::TestWithParam<std::vector<std::string>>
 {
 };
 
-static bool SkipTest(void) { return !miopen::IsEnabled(ENV(CODECOV_TEST)); }
+static bool SkipTest(void) { return !miopen::IsEnabled(MIOPEN_ENV(CODECOV_TEST)); }
 
 void GetArgs(const std::string& param, std::vector<std::string>& tokens)
 {
@@ -104,7 +104,7 @@ bool IsTestSupportedForDevice(const miopen::Handle& handle) { return true; }
 
 std::vector<std::string> GetTestCases(const std::string& precision)
 {
-    const auto& flag_arg = miopen::GetStringEnv(ENV(MIOPEN_TEST_FLAGS_ARGS));
+    const auto& flag_arg = miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_TEST_FLAGS_ARGS));
 
     const std::vector<std::string> test_cases = {
         // clang-format off

--- a/test/gtest/conv3d_test.cpp
+++ b/test/gtest/conv3d_test.cpp
@@ -38,10 +38,10 @@ namespace conv3d_test {
 static bool IsTestRunWith(const char* float_arg)
 {
     assert(float_arg != nullptr);
-    if(miopen::IsUnset(ENV(MIOPEN_TEST_ALL)))
+    if(miopen::IsUnset(MIOPEN_ENV(MIOPEN_TEST_ALL)))
         return true; // standalone run
-    return miopen::IsEnabled(ENV(MIOPEN_TEST_ALL)) &&
-           miopen::GetStringEnv(ENV(MIOPEN_TEST_FLOAT_ARG)) == float_arg;
+    return miopen::IsEnabled(MIOPEN_ENV(MIOPEN_TEST_ALL)) &&
+           miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_TEST_FLOAT_ARG)) == float_arg;
 }
 
 void GetArgs(const std::string& param, std::vector<std::string>& tokens)

--- a/test/gtest/conv_3d.cpp
+++ b/test/gtest/conv_3d.cpp
@@ -86,10 +86,10 @@ bool IsTestSupportedForDevice()
 
 void Run2dDriver(void)
 {
-    if(!(IsTestSupportedForDevice()                      //
-         && (miopen::IsUnset(ENV(MIOPEN_TEST_ALL))       // standalone run
-             || (miopen::IsEnabled(ENV(MIOPEN_TEST_ALL)) // or --float full tests enabled
-                 && miopen::GetStringEnv(ENV(MIOPEN_TEST_FLOAT_ARG)) == "--float"))))
+    if(!(IsTestSupportedForDevice()                             //
+         && (miopen::IsUnset(MIOPEN_ENV(MIOPEN_TEST_ALL))       // standalone run
+             || (miopen::IsEnabled(MIOPEN_ENV(MIOPEN_TEST_ALL)) // or --float full tests enabled
+                 && miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_TEST_FLOAT_ARG)) == "--float"))))
     {
         GTEST_SKIP();
     }

--- a/test/gtest/conv_ck_igemm_fwd_v6r1_dlops_nchw.cpp
+++ b/test/gtest/conv_ck_igemm_fwd_v6r1_dlops_nchw.cpp
@@ -36,11 +36,12 @@ namespace conv_ck_igemm_fwd_v6r1_dlops_nchw {
 
 auto GetTestCases()
 {
-    const auto env = std::tuple{
-        std::pair{ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
-        std::pair{ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
-                  std::string_view("ConvCkIgemmFwdV6r1DlopsNchw")},
-        std::pair{ENV(MIOPEN_DEBUG_CONV_CK_IGEMM_FWD_V6R1_DLOPS_NCHW), std::string_view("1")}};
+    const auto env =
+        std::tuple{std::pair{MIOPEN_ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
+                   std::pair{MIOPEN_ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
+                             std::string_view("ConvCkIgemmFwdV6r1DlopsNchw")},
+                   std::pair{MIOPEN_ENV(MIOPEN_DEBUG_CONV_CK_IGEMM_FWD_V6R1_DLOPS_NCHW),
+                             std::string_view("1")}};
 
     const std::string v           = " --verbose";
     const std::string dis_bk_data = " --disable-backward-data";
@@ -76,7 +77,7 @@ auto GetTestCases()
 
 using TestCase = decltype(GetTestCases())::value_type;
 
-bool SkipTest() { return miopen::IsDisabled(ENV(MIOPEN_TEST_ALL)); }
+bool SkipTest() { return miopen::IsDisabled(MIOPEN_ENV(MIOPEN_TEST_ALL)); }
 class Conv2dFloat_conv_ck_igemm_fwd_v6r1_dlops_nchw : public FloatTestCase<std::vector<TestCase>>
 {
 };

--- a/test/gtest/conv_extra.cpp
+++ b/test/gtest/conv_extra.cpp
@@ -48,8 +48,8 @@ std::vector<std::string> GetTestCases(void)
 {
     std::string cmd       = "test_conv2d ";
     std::string v         = " --verbose ";
-    std::string float_arg = miopen::GetStringEnv(ENV(MIOPEN_TEST_FLOAT_ARG));
-    std::string flag_arg  = miopen::GetStringEnv(ENV(MIOPEN_TEST_FLAGS_ARGS));
+    std::string float_arg = miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_TEST_FLOAT_ARG));
+    std::string flag_arg  = miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_TEST_FLAGS_ARGS));
 
     // clang-format off
     return std::vector<std::string>{
@@ -102,7 +102,7 @@ bool IsTestSupportedForDevice()
 
 void Run2dDriver(void)
 {
-    if(!(IsTestSupportedForDevice() && (miopen::IsUnset(ENV(MIOPEN_TEST_ALL)))))
+    if(!(IsTestSupportedForDevice() && (miopen::IsUnset(MIOPEN_ENV(MIOPEN_TEST_ALL)))))
     {
         GTEST_SKIP();
     }

--- a/test/gtest/conv_for_implicit_gemm.cpp
+++ b/test/gtest/conv_for_implicit_gemm.cpp
@@ -42,9 +42,9 @@ namespace test_conv_for_implicit_gemm {
 
 static bool SkipTest()
 {
-    if(miopen::IsUnset(ENV(MIOPEN_TEST_ALL)))
+    if(miopen::IsUnset(MIOPEN_ENV(MIOPEN_TEST_ALL)))
         return false;
-    if(miopen::IsEnabled(ENV(IMPLICITGEMM_TESTING_ENV)))
+    if(miopen::IsEnabled(MIOPEN_ENV(IMPLICITGEMM_TESTING_ENV)))
         return false;
     return true;
 }
@@ -52,10 +52,10 @@ static bool SkipTest()
 static bool IsTestRunWith(const char* float_arg)
 {
     assert(float_arg != nullptr);
-    if(miopen::IsUnset(ENV(MIOPEN_TEST_ALL)))
+    if(miopen::IsUnset(MIOPEN_ENV(MIOPEN_TEST_ALL)))
         return true; // standalone run
-    return miopen::IsEnabled(ENV(MIOPEN_TEST_ALL)) &&
-           miopen::GetStringEnv(ENV(MIOPEN_TEST_FLOAT_ARG)) == float_arg;
+    return miopen::IsEnabled(MIOPEN_ENV(MIOPEN_TEST_ALL)) &&
+           miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_TEST_FLOAT_ARG)) == float_arg;
 }
 
 void GetArgs(const TestCase& param, std::vector<std::string>& tokens)

--- a/test/gtest/conv_group.cpp
+++ b/test/gtest/conv_group.cpp
@@ -122,10 +122,10 @@ bool IsTestSupportedForDevice()
 
 void Run2dDriver(void)
 {
-    if(!(IsTestSupportedForDevice()                      //
-         && (miopen::IsUnset(ENV(MIOPEN_TEST_ALL))       // standalone run
-             || (miopen::IsEnabled(ENV(MIOPEN_TEST_ALL)) // or --float full tests enabled
-                 && miopen::GetStringEnv(ENV(MIOPEN_TEST_FLOAT_ARG)) == "--float"))))
+    if(!(IsTestSupportedForDevice()                             //
+         && (miopen::IsUnset(MIOPEN_ENV(MIOPEN_TEST_ALL))       // standalone run
+             || (miopen::IsEnabled(MIOPEN_ENV(MIOPEN_TEST_ALL)) // or --float full tests enabled
+                 && miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_TEST_FLOAT_ARG)) == "--float"))))
     {
         GTEST_SKIP();
     }

--- a/test/gtest/conv_hip_igemm_xdlops.cpp
+++ b/test/gtest/conv_hip_igemm_xdlops.cpp
@@ -151,8 +151,9 @@ TEST_P(ConvHipIgemmXdlopsConfigInt8, Int8Test)
 
 #else // MIOPEN_BACKEND_HIP, OCL_DISABLED
     const auto& handle = get_handle();
-    if(IsTestSupportedForDevice(handle) && miopen::IsEnabled(ENV(MIOPEN_TEST_COMPOSABLEKERNEL)) &&
-       miopen::IsEnabled(ENV(MIOPEN_TEST_ALL)) && IsTestRunWith("--int8"))
+    if(IsTestSupportedForDevice(handle) &&
+       miopen::IsEnabled(MIOPEN_ENV(MIOPEN_TEST_COMPOSABLEKERNEL)) &&
+       miopen::IsEnabled(MIOPEN_ENV(MIOPEN_TEST_ALL)) && IsTestRunWith("--int8"))
     {
         Run2dDriver(miopenInt8);
     }

--- a/test/gtest/conv_igemm_dynamic.cpp
+++ b/test/gtest/conv_igemm_dynamic.cpp
@@ -36,20 +36,20 @@ namespace conv_igemm_dynamic {
 
 auto GetTestCases()
 {
-    const auto env = std::tuple{std::pair{ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
-                                std::pair{ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
+    const auto env = std::tuple{std::pair{MIOPEN_ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
+                                std::pair{MIOPEN_ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
                                           std::string_view("ConvAsmImplicitGemmV4R1DynamicFwd")}};
     const auto env_1x1 =
-        std::tuple{std::pair{ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
-                   std::pair{ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
+        std::tuple{std::pair{MIOPEN_ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
+                   std::pair{MIOPEN_ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
                              std::string_view("ConvAsmImplicitGemmV4R1DynamicFwd_1x1")}};
     const auto env_wrw =
-        std::tuple{std::pair{ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
-                   std::pair{ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
+        std::tuple{std::pair{MIOPEN_ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
+                   std::pair{MIOPEN_ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
                              std::string_view("ConvAsmImplicitGemmV4R1DynamicWrw")}};
     const auto env_bwd =
-        std::tuple{std::pair{ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
-                   std::pair{ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
+        std::tuple{std::pair{MIOPEN_ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
+                   std::pair{MIOPEN_ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
                              std::string_view("ConvAsmImplicitGemmV4R1DynamicBwd")}};
 
     const std::string v           = " --verbose";
@@ -78,7 +78,7 @@ auto GetTestCases()
         // clang-format on
     };
 
-    if(miopen::IsEnabled(ENV(MIOPEN_TEST_ALL)))
+    if(miopen::IsEnabled(MIOPEN_ENV(MIOPEN_TEST_ALL)))
     {
         basic_tests.insert(basic_tests.end(),
                            {

--- a/test/gtest/conv_igemm_dynamic_dlops.cpp
+++ b/test/gtest/conv_igemm_dynamic_dlops.cpp
@@ -37,8 +37,8 @@ namespace {
 auto GetTestCases()
 {
     const auto env_fwd =
-        std::tuple{std::pair{ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
-                   std::pair{ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
+        std::tuple{std::pair{MIOPEN_ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
+                   std::pair{MIOPEN_ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
                              std::string_view("ConvAsmImplicitGemmGTCDynamicFwdDlopsNCHWC")}};
 
     const std::string v           = " --verbose";
@@ -145,7 +145,7 @@ auto GetTestCases()
 
 using TestCase = decltype(GetTestCases())::value_type;
 
-bool SkipTest() { return get_handle_xnack() || miopen::IsDisabled(ENV(MIOPEN_TEST_ALL)); }
+bool SkipTest() { return get_handle_xnack() || miopen::IsDisabled(MIOPEN_ENV(MIOPEN_TEST_ALL)); }
 
 bool IsTestSupportedForDevice()
 {

--- a/test/gtest/conv_igemm_dynamic_xdlops.cpp
+++ b/test/gtest/conv_igemm_dynamic_xdlops.cpp
@@ -38,8 +38,8 @@ namespace conv_igemm_dynamic_xdlops {
 auto GetTestCases()
 {
     const auto env_xdlops =
-        std::tuple{std::pair{ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
-                   std::pair{ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
+        std::tuple{std::pair{MIOPEN_ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
+                   std::pair{MIOPEN_ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
                              std::string_view("ConvAsmImplicitGemmGTCDynamicBwdXdlops;"
                                               "ConvAsmImplicitGemmGTCDynamicFwdXdlops;"
                                               "ConvAsmImplicitGemmGTCDynamicWrwXdlops")}};
@@ -109,10 +109,10 @@ using TestCase = decltype(GetTestCases())::value_type;
 
 static bool SkipTest(const std::string& float_arg)
 {
-    if(miopen::IsUnset(ENV(MIOPEN_TEST_ALL)))
+    if(miopen::IsUnset(MIOPEN_ENV(MIOPEN_TEST_ALL)))
         return false;
-    if(miopen::IsEnabled(ENV(MIOPEN_TEST_ALL)))
-        if(miopen::GetStringEnv(ENV(MIOPEN_TEST_FLOAT_ARG)) == float_arg)
+    if(miopen::IsEnabled(MIOPEN_ENV(MIOPEN_TEST_ALL)))
+        if(miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_TEST_FLOAT_ARG)) == float_arg)
             return false;
     return true;
 }

--- a/test/gtest/conv_igemm_dynamic_xdlops_half.cpp
+++ b/test/gtest/conv_igemm_dynamic_xdlops_half.cpp
@@ -38,19 +38,19 @@ namespace conv_igemm_dynamic_xdlops_half {
 
 static bool SkipTest(const std::string& float_arg)
 {
-    if(miopen::IsUnset(ENV(MIOPEN_TEST_ALL)))
+    if(miopen::IsUnset(MIOPEN_ENV(MIOPEN_TEST_ALL)))
         return false;
-    if(miopen::IsEnabled(ENV(MIOPEN_TEST_ALL)))
-        if(miopen::GetStringEnv(ENV(MIOPEN_TEST_FLOAT_ARG)) == float_arg)
+    if(miopen::IsEnabled(MIOPEN_ENV(MIOPEN_TEST_ALL)))
+        if(miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_TEST_FLOAT_ARG)) == float_arg)
             return false;
     return true;
 }
 
 void SetupEnvVar(void)
 {
-    miopen::UpdateEnvVar(ENV(MIOPEN_FIND_MODE), std::string("normal"));
+    miopen::UpdateEnvVar(MIOPEN_ENV(MIOPEN_FIND_MODE), std::string("normal"));
     miopen::UpdateEnvVar(
-        ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
+        MIOPEN_ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
         std::string(
             "ConvAsmImplicitGemmGTCDynamicFwdXdlops;ConvAsmImplicitGemmGTCDynamicWrwXdlops"));
 }

--- a/test/gtest/conv_igemm_dynamic_xdlops_nhwc_bf16.cpp
+++ b/test/gtest/conv_igemm_dynamic_xdlops_nhwc_bf16.cpp
@@ -38,19 +38,19 @@ namespace conv_igemm_dynamic_xdlops_nhwc_bf16 {
 
 static bool SkipTest(const std::string& float_arg)
 {
-    if(miopen::IsUnset(ENV(MIOPEN_TEST_ALL)))
+    if(miopen::IsUnset(MIOPEN_ENV(MIOPEN_TEST_ALL)))
         return false;
-    if(miopen::IsEnabled(ENV(MIOPEN_TEST_ALL)))
-        if(miopen::GetStringEnv(ENV(MIOPEN_TEST_FLOAT_ARG)) == float_arg)
+    if(miopen::IsEnabled(MIOPEN_ENV(MIOPEN_TEST_ALL)))
+        if(miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_TEST_FLOAT_ARG)) == float_arg)
             return false;
     return true;
 }
 
 void SetupEnvVar(void)
 {
-    miopen::UpdateEnvVar(ENV(MIOPEN_FIND_MODE), std::string("normal"));
+    miopen::UpdateEnvVar(MIOPEN_ENV(MIOPEN_FIND_MODE), std::string("normal"));
     miopen::UpdateEnvVar(
-        ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
+        MIOPEN_ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
         std::string(
             "ConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWC;ConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWC;"
             "ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC"));

--- a/test/gtest/conv_igemm_dynamic_xdlops_nhwc_nchw.cpp
+++ b/test/gtest/conv_igemm_dynamic_xdlops_nhwc_nchw.cpp
@@ -38,19 +38,19 @@ namespace conv_igemm_dynamic_xdlops_nhwc_nchw {
 
 static bool SkipTest(const std::string& float_arg)
 {
-    if(miopen::IsUnset(ENV(MIOPEN_TEST_ALL)))
+    if(miopen::IsUnset(MIOPEN_ENV(MIOPEN_TEST_ALL)))
         return false;
-    if(miopen::IsEnabled(ENV(MIOPEN_TEST_ALL)))
-        if(miopen::GetStringEnv(ENV(MIOPEN_TEST_FLOAT_ARG)) == float_arg)
+    if(miopen::IsEnabled(MIOPEN_ENV(MIOPEN_TEST_ALL)))
+        if(miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_TEST_FLOAT_ARG)) == float_arg)
             return false;
     return true;
 }
 
 void SetupEnvVar(void)
 {
-    miopen::UpdateEnvVar(ENV(MIOPEN_FIND_MODE), std::string("normal"));
+    miopen::UpdateEnvVar(MIOPEN_ENV(MIOPEN_FIND_MODE), std::string("normal"));
     miopen::UpdateEnvVar(
-        ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
+        MIOPEN_ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
         std::string(
             "ConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWC;ConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWC;"
             "ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC"));

--- a/test/gtest/conv_igemm_mlir_bwd_wrw.cpp
+++ b/test/gtest/conv_igemm_mlir_bwd_wrw.cpp
@@ -38,12 +38,12 @@ namespace {
 auto GetTestCases()
 {
     const auto igemm_bwd = std::tuple{
-        std::pair{ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
-        std::pair{ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER), std::string_view("ConvMlirIgemmBwd")}};
+        std::pair{MIOPEN_ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER), std::string_view("ConvMlirIgemmBwd")}};
 
     const auto igemm_wrw = std::tuple{
-        std::pair{ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
-        std::pair{ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER), std::string_view("ConvMlirIgemmWrW")}};
+        std::pair{MIOPEN_ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER), std::string_view("ConvMlirIgemmWrW")}};
 
     const std::string flags_bwd     = " --verbose --disable-forward --disable-backward-weights";
     const std::string flags_wrw     = " --verbose --disable-forward --disable-backward-data";
@@ -78,7 +78,8 @@ using TestCase = decltype(GetTestCases())::value_type;
 
 bool SkipTest()
 {
-    return !(miopen::IsEnabled(ENV(MIOPEN_TEST_MLIR))) || miopen::IsDisabled(ENV(MIOPEN_TEST_ALL));
+    return !(miopen::IsEnabled(MIOPEN_ENV(MIOPEN_TEST_MLIR))) ||
+           miopen::IsDisabled(MIOPEN_ENV(MIOPEN_TEST_ALL));
 }
 
 bool IsTestSupportedForDevice()

--- a/test/gtest/conv_igemm_mlir_fwd.cpp
+++ b/test/gtest/conv_igemm_mlir_fwd.cpp
@@ -38,8 +38,8 @@ namespace {
 auto GetTestCases()
 {
     const auto igemm_fwd = std::tuple{
-        std::pair{ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
-        std::pair{ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER), std::string_view("ConvMlirIgemmFwd")}};
+        std::pair{MIOPEN_ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER), std::string_view("ConvMlirIgemmFwd")}};
 
     const std::string vf     = " --verbose --disable-backward-data --disable-backward-weights";
     const std::string layout = " --in_layout NHWC --fil_layout NHWC --out_layout NHWC";
@@ -64,7 +64,8 @@ using TestCase = decltype(GetTestCases())::value_type;
 
 bool SkipTest()
 {
-    return !(miopen::IsEnabled(ENV(MIOPEN_TEST_MLIR))) || miopen::IsDisabled(ENV(MIOPEN_TEST_ALL));
+    return !(miopen::IsEnabled(MIOPEN_ENV(MIOPEN_TEST_MLIR))) ||
+           miopen::IsDisabled(MIOPEN_ENV(MIOPEN_TEST_ALL));
 }
 
 bool IsTestSupportedForDevice()

--- a/test/gtest/conv_igemm_mlir_xdlops_bwd_wrw.cpp
+++ b/test/gtest/conv_igemm_mlir_xdlops_bwd_wrw.cpp
@@ -38,13 +38,13 @@ namespace {
 
 auto GetTestCases()
 {
-    const auto bwd = std::tuple{
-        std::pair{ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
-        std::pair{ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER), std::string_view("ConvMlirIgemmBwdXdlops")}};
+    const auto bwd = std::tuple{std::pair{MIOPEN_ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
+                                std::pair{MIOPEN_ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
+                                          std::string_view("ConvMlirIgemmBwdXdlops")}};
 
-    const auto wrw = std::tuple{
-        std::pair{ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
-        std::pair{ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER), std::string_view("ConvMlirIgemmWrWXdlops")}};
+    const auto wrw = std::tuple{std::pair{MIOPEN_ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
+                                std::pair{MIOPEN_ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
+                                          std::string_view("ConvMlirIgemmWrWXdlops")}};
 
     const std::string flags_bwd = " --verbose --disable-forward --disable-backward-weights";
     const std::string flags_wrw = " --verbose --disable-forward --disable-backward-data";
@@ -81,7 +81,8 @@ using TestCase = decltype(GetTestCases())::value_type;
 
 bool SkipTest()
 {
-    return !(miopen::IsEnabled(ENV(MIOPEN_TEST_MLIR))) || miopen::IsDisabled(ENV(MIOPEN_TEST_ALL));
+    return !(miopen::IsEnabled(MIOPEN_ENV(MIOPEN_TEST_MLIR))) ||
+           miopen::IsDisabled(MIOPEN_ENV(MIOPEN_TEST_ALL));
 }
 
 bool IsTestSupportedForDevice()

--- a/test/gtest/conv_igemm_mlir_xdlops_fwd.cpp
+++ b/test/gtest/conv_igemm_mlir_xdlops_fwd.cpp
@@ -38,9 +38,9 @@ namespace {
 
 auto GetTestCases()
 {
-    const auto fwd = std::tuple{
-        std::pair{ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
-        std::pair{ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER), std::string_view("ConvMlirIgemmFwdXdlops")}};
+    const auto fwd = std::tuple{std::pair{MIOPEN_ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
+                                std::pair{MIOPEN_ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
+                                          std::string_view("ConvMlirIgemmFwdXdlops")}};
 
     const std::string flags_fwd = " --verbose --disable-backward-data --disable-backward-weights";
     const std::string layout    = " --in_layout NHWC --fil_layout NHWC --out_layout NHWC";
@@ -65,7 +65,8 @@ using TestCase = decltype(GetTestCases())::value_type;
 
 bool SkipTest()
 {
-    return !(miopen::IsEnabled(ENV(MIOPEN_TEST_MLIR))) || miopen::IsDisabled(ENV(MIOPEN_TEST_ALL));
+    return !(miopen::IsEnabled(MIOPEN_ENV(MIOPEN_TEST_MLIR))) ||
+           miopen::IsDisabled(MIOPEN_ENV(MIOPEN_TEST_ALL));
 }
 
 bool IsTestSupportedForDevice()

--- a/test/gtest/conv_trans.cpp
+++ b/test/gtest/conv_trans.cpp
@@ -145,7 +145,7 @@ using namespace conv_trans;
 TEST_P(ConfigWithFloat_conv_trans, FloatTest_conv_trans)
 {
     const auto& handle = get_handle();
-    if(IsTestSupportedForDevice(handle) && miopen::IsEnabled(ENV(MIOPEN_TEST_ALL)))
+    if(IsTestSupportedForDevice(handle) && miopen::IsEnabled(MIOPEN_ENV(MIOPEN_TEST_ALL)))
     {
         Run2dDriver(miopenFloat);
     }

--- a/test/gtest/db_sync.cpp
+++ b/test/gtest/db_sync.cpp
@@ -465,7 +465,7 @@ void SetupPaths(fs::path& fdb_file_path,
 
 TEST(DBSync, KDBTargetID)
 {
-    if(miopen::IsEnabled(ENV(MIOPEN_TEST_DBSYNC)))
+    if(miopen::IsEnabled(MIOPEN_ENV(MIOPEN_TEST_DBSYNC)))
     {
         fs::path fdb_file_path, pdb_file_path, kdb_file_path;
 #if WORKAROUND_ISSUE_2492
@@ -854,7 +854,7 @@ struct DBSync : testing::TestWithParam<std::pair<std::string, size_t>>
 
 TEST_P(DBSync, StaticFDBSync)
 {
-    if(miopen::IsEnabled(ENV(MIOPEN_TEST_DBSYNC)))
+    if(miopen::IsEnabled(MIOPEN_ENV(MIOPEN_TEST_DBSYNC)))
     {
         std::string arch;
         size_t num_cu;

--- a/test/gtest/deepbench_conv.cpp
+++ b/test/gtest/deepbench_conv.cpp
@@ -82,7 +82,7 @@ auto GetTestCases()
 
 using TestCase = decltype(GetTestCases())::value_type;
 
-bool SkipTest() { return miopen::IsDisabled(ENV(MIOPEN_TEST_DEEPBENCH)); }
+bool SkipTest() { return miopen::IsDisabled(MIOPEN_ENV(MIOPEN_TEST_DEEPBENCH)); }
 
 class Conv2dFloat_deepbench : public FloatTestCase<std::vector<TestCase>>
 {

--- a/test/gtest/deepbench_gru.cpp
+++ b/test/gtest/deepbench_gru.cpp
@@ -32,7 +32,7 @@
 MIOPEN_DECLARE_ENV_VAR_BOOL(MIOPEN_TEST_DEEPBENCH)
 
 namespace deepbench_gru {
-static bool SkipTest(void) { return !miopen::IsEnabled(ENV(MIOPEN_TEST_DEEPBENCH)); }
+static bool SkipTest(void) { return !miopen::IsEnabled(MIOPEN_ENV(MIOPEN_TEST_DEEPBENCH)); }
 
 void GetArgs(const std::string& param, std::vector<std::string>& tokens)
 {

--- a/test/gtest/deepbench_lstm.cpp
+++ b/test/gtest/deepbench_lstm.cpp
@@ -109,7 +109,7 @@ using namespace deepbench_lstm;
 
 TEST_P(ConfigWithFloat_deepbench_lstm, FloatTest_deepbench_lstm)
 {
-    if(!miopen::IsEnabled(ENV(MIOPEN_TEST_DEEPBENCH)))
+    if(!miopen::IsEnabled(MIOPEN_ENV(MIOPEN_TEST_DEEPBENCH)))
     {
         GTEST_SKIP();
     }

--- a/test/gtest/deepbench_rnn.cpp
+++ b/test/gtest/deepbench_rnn.cpp
@@ -33,7 +33,7 @@ MIOPEN_DECLARE_ENV_VAR_BOOL(MIOPEN_TEST_DEEPBENCH)
 MIOPEN_DECLARE_ENV_VAR_BOOL(MIOPEN_TEST_ALL)
 
 namespace deepbench_rnn {
-static bool SkipTest(void) { return !miopen::IsEnabled(ENV(MIOPEN_TEST_DEEPBENCH)); }
+static bool SkipTest(void) { return !miopen::IsEnabled(MIOPEN_ENV(MIOPEN_TEST_DEEPBENCH)); }
 
 void GetArgs(const std::string& param, std::vector<std::string>& tokens)
 {

--- a/test/gtest/fused_conv_bias_res_add_activ.cpp
+++ b/test/gtest/fused_conv_bias_res_add_activ.cpp
@@ -47,7 +47,7 @@ namespace conv_bias_act_res_add_fwd {
 bool TestIsApplicable()
 {
 #if MIOPEN_USE_COMPOSABLEKERNEL
-    const auto float_arg = miopen::GetStringEnv(ENV(MIOPEN_TEST_FLOAT_ARG));
+    const auto float_arg = miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_TEST_FLOAT_ARG));
     return
 #if WORAROUND_ISSUE_2533
         miopen::solver::ck_utility::is_ck_whitelist(get_handle().GetDeviceName()) //
@@ -57,7 +57,7 @@ bool TestIsApplicable()
         && (float_arg == "--half" // So far only test for fp16 is implemented.
             || float_arg.empty()) // Empty when gtest is run without parameters.
         && !miopen::IsDisabled(
-               ENV(MIOPEN_TEST_ALL)); // Not disabled when gtest is run without parameters.
+               MIOPEN_ENV(MIOPEN_TEST_ALL)); // Not disabled when gtest is run without parameters.
 #else
     return false;
 #endif

--- a/test/gtest/gpu_mha_backward.cpp
+++ b/test/gtest/gpu_mha_backward.cpp
@@ -49,7 +49,7 @@ using namespace miopen;
 namespace {
 inline bool CheckFloatArg(std::string_view arg)
 {
-    const std::string& tmp = miopen::GetStringEnv(ENV(MIOPEN_TEST_FLOAT_ARG));
+    const std::string& tmp = miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_TEST_FLOAT_ARG));
     return tmp.empty() || tmp == arg;
 }
 
@@ -109,7 +109,7 @@ inline std::vector<TestCase> GetSmokeTestCases()
 
 inline std::vector<TestCase> GetFullTestCases()
 {
-    if(miopen::IsDisabled(ENV(MIOPEN_TEST_ALL)))
+    if(miopen::IsDisabled(MIOPEN_ENV(MIOPEN_TEST_ALL)))
         return {};
 
     if(CheckFloatArg("--float"))

--- a/test/gtest/gpu_mha_forward.cpp
+++ b/test/gtest/gpu_mha_forward.cpp
@@ -47,7 +47,7 @@ using namespace miopen;
 namespace {
 inline bool CheckFloatArg(std::string_view arg)
 {
-    const std::string& tmp = miopen::GetStringEnv(ENV(MIOPEN_TEST_FLOAT_ARG));
+    const std::string& tmp = miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_TEST_FLOAT_ARG));
     return tmp.empty() || tmp == arg;
 }
 
@@ -107,7 +107,8 @@ inline std::vector<TestCase> GetSmokeTestCases()
 
 inline std::vector<TestCase> GetFullTestCases()
 {
-    if((miopen::IsUnset(ENV(MIOPEN_TEST_ALL)) || miopen::IsEnabled(ENV(MIOPEN_TEST_ALL))) &&
+    if((miopen::IsUnset(MIOPEN_ENV(MIOPEN_TEST_ALL)) ||
+        miopen::IsEnabled(MIOPEN_ENV(MIOPEN_TEST_ALL))) &&
        CheckFloatArg("--float"))
     {
         return {

--- a/test/gtest/groupnorm.cpp
+++ b/test/gtest/groupnorm.cpp
@@ -33,7 +33,7 @@ namespace groupnorm {
 
 std::string GetFloatArg()
 {
-    const auto& tmp = miopen::GetStringEnv(ENV(MIOPEN_TEST_FLOAT_ARG));
+    const auto& tmp = miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_TEST_FLOAT_ARG));
     if(tmp.empty())
     {
         return "";
@@ -55,7 +55,7 @@ TEST_P(GroupNormTestFloat, GroupNormTestFw)
     if((miopen::StartsWith(handle.GetDeviceName(), "gfx908") ||
         miopen::StartsWith(handle.GetDeviceName(), "gfx90a") ||
         miopen::StartsWith(handle.GetDeviceName(), "gfx94")) &&
-       miopen::IsEnabled(ENV(MIOPEN_TEST_ALL)) && (GetFloatArg() == "--float"))
+       miopen::IsEnabled(MIOPEN_ENV(MIOPEN_TEST_ALL)) && (GetFloatArg() == "--float"))
     {
         RunTest();
         Verify();

--- a/test/gtest/gru_extra.cpp
+++ b/test/gtest/gru_extra.cpp
@@ -110,9 +110,9 @@ using namespace gru_extra;
 
 TEST_P(GRUExtraConfigWithFloat, FloatTest_gru_extra)
 {
-    if((miopen::IsUnset(ENV(MIOPEN_TEST_ALL)) ||
-        (miopen::IsEnabled(ENV(MIOPEN_TEST_ALL)) &&
-         miopen::GetStringEnv(ENV(MIOPEN_TEST_FLOAT_ARG)) == "--float")))
+    if((miopen::IsUnset(MIOPEN_ENV(MIOPEN_TEST_ALL)) ||
+        (miopen::IsEnabled(MIOPEN_ENV(MIOPEN_TEST_ALL)) &&
+         miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_TEST_FLOAT_ARG)) == "--float")))
         Run2dDriverFloat();
     else
         GTEST_SKIP();

--- a/test/gtest/immed_conv2d_codecov.cpp
+++ b/test/gtest/immed_conv2d_codecov.cpp
@@ -36,7 +36,7 @@ MIOPEN_DECLARE_ENV_VAR_STR(MIOPEN_TEST_FLAGS_ARGS)
 
 namespace immed_conv2d_codecov {
 
-static bool SkipTest(void) { return !miopen::IsEnabled(ENV(CODECOV_TEST)); }
+static bool SkipTest(void) { return !miopen::IsEnabled(MIOPEN_ENV(CODECOV_TEST)); }
 
 void GetArgs(const std::string& param, std::vector<std::string>& tokens)
 {
@@ -105,7 +105,7 @@ bool IsTestSupportedForDevice(const miopen::Handle& handle) { return true; }
 
 std::vector<std::string> GetTestCases(const std::string& precision)
 {
-    const auto& flag_arg = miopen::GetStringEnv(ENV(MIOPEN_TEST_FLAGS_ARGS));
+    const auto& flag_arg = miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_TEST_FLAGS_ARGS));
 
     const std::vector<std::string> test_cases = {
         // clang-format off

--- a/test/gtest/immed_conv3d_codecov.cpp
+++ b/test/gtest/immed_conv3d_codecov.cpp
@@ -51,7 +51,7 @@ class ImmedConv3dInt8 : public testing::TestWithParam<std::vector<std::string>>
 {
 };
 
-static bool SkipTest(void) { return !miopen::IsEnabled(ENV(CODECOV_TEST)); }
+static bool SkipTest(void) { return !miopen::IsEnabled(MIOPEN_ENV(CODECOV_TEST)); }
 
 void GetArgs(const std::string& param, std::vector<std::string>& tokens)
 {
@@ -104,7 +104,7 @@ bool IsTestSupportedForDevice(const miopen::Handle& handle) { return true; }
 
 std::vector<std::string> GetTestCases(const std::string& precision)
 {
-    const auto& flag_arg = miopen::GetStringEnv(ENV(MIOPEN_TEST_FLAGS_ARGS));
+    const auto& flag_arg = miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_TEST_FLAGS_ARGS));
 
     const std::vector<std::string> test_cases = {
         // clang-format off

--- a/test/gtest/layernorm.cpp
+++ b/test/gtest/layernorm.cpp
@@ -34,7 +34,7 @@ namespace layernorm {
 
 std::string GetFloatArg()
 {
-    const auto& tmp = miopen::GetStringEnv(ENV(MIOPEN_TEST_FLOAT_ARG));
+    const auto& tmp = miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_TEST_FLOAT_ARG));
     if(tmp.empty())
     {
         return "";
@@ -59,12 +59,12 @@ using namespace layernorm;
 
 TEST_P(LayerNormTestFloat, LayerNormTestFw)
 {
-    auto TypeArg       = miopen::GetStringEnv(ENV(MIOPEN_TEST_FLOAT_ARG));
+    auto TypeArg       = miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_TEST_FLOAT_ARG));
     const auto& handle = get_handle();
     if((miopen::StartsWith(handle.GetDeviceName(), "gfx908") ||
         miopen::StartsWith(handle.GetDeviceName(), "gfx90a") ||
         miopen::StartsWith(handle.GetDeviceName(), "gfx94")) &&
-       miopen::IsEnabled(ENV(MIOPEN_TEST_ALL)) && (GetFloatArg() == "--float"))
+       miopen::IsEnabled(MIOPEN_ENV(MIOPEN_TEST_ALL)) && (GetFloatArg() == "--float"))
     {
         RunTest();
         Verify();
@@ -77,12 +77,12 @@ TEST_P(LayerNormTestFloat, LayerNormTestFw)
 
 TEST_P(LayerNormTestHalf, LayerNormTestFw)
 {
-    auto TypeArg       = miopen::GetStringEnv(ENV(MIOPEN_TEST_FLOAT_ARG));
+    auto TypeArg       = miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_TEST_FLOAT_ARG));
     const auto& handle = get_handle();
     if((miopen::StartsWith(handle.GetDeviceName(), "gfx908") ||
         miopen::StartsWith(handle.GetDeviceName(), "gfx90a") ||
         miopen::StartsWith(handle.GetDeviceName(), "gfx94")) &&
-       miopen::IsEnabled(ENV(MIOPEN_TEST_ALL)) && (GetFloatArg() == "--half"))
+       miopen::IsEnabled(MIOPEN_ENV(MIOPEN_TEST_ALL)) && (GetFloatArg() == "--half"))
     {
         RunTest();
         Verify();
@@ -95,12 +95,12 @@ TEST_P(LayerNormTestHalf, LayerNormTestFw)
 
 TEST_P(LayerNormTestBFloat16, LayerNormTestFw)
 {
-    auto TypeArg       = miopen::GetStringEnv(ENV(MIOPEN_TEST_FLOAT_ARG));
+    auto TypeArg       = miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_TEST_FLOAT_ARG));
     const auto& handle = get_handle();
     if((miopen::StartsWith(handle.GetDeviceName(), "gfx908") ||
         miopen::StartsWith(handle.GetDeviceName(), "gfx90a") ||
         miopen::StartsWith(handle.GetDeviceName(), "gfx94")) &&
-       miopen::IsEnabled(ENV(MIOPEN_TEST_ALL)) && (GetFloatArg() == "--bfloat16"))
+       miopen::IsEnabled(MIOPEN_ENV(MIOPEN_TEST_ALL)) && (GetFloatArg() == "--bfloat16"))
     {
         RunTest();
         Verify();

--- a/test/gtest/lstm_extra.cpp
+++ b/test/gtest/lstm_extra.cpp
@@ -102,10 +102,10 @@ bool IsTestSupportedForDevice()
 
 void Run2dDriver(miopenDataType_t prec)
 {
-    if(!(IsTestSupportedForDevice()                      //
-         && (miopen::IsUnset(ENV(MIOPEN_TEST_ALL))       // standalone run
-             || (miopen::IsEnabled(ENV(MIOPEN_TEST_ALL)) // or --float full tests enabled
-                 && miopen::GetStringEnv(ENV(MIOPEN_TEST_FLOAT_ARG)) == "--float"))))
+    if(!(IsTestSupportedForDevice()                             //
+         && (miopen::IsUnset(MIOPEN_ENV(MIOPEN_TEST_ALL))       // standalone run
+             || (miopen::IsEnabled(MIOPEN_ENV(MIOPEN_TEST_ALL)) // or --float full tests enabled
+                 && miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_TEST_FLOAT_ARG)) == "--float"))))
     {
         GTEST_SKIP();
     }

--- a/test/gtest/miopen_conv.cpp
+++ b/test/gtest/miopen_conv.cpp
@@ -33,7 +33,7 @@ MIOPEN_DECLARE_ENV_VAR_BOOL(MIOPEN_TEST_CONV)
 
 namespace miopen_conv {
 
-bool SkipTest() { return miopen::IsDisabled(ENV(MIOPEN_TEST_CONV)); }
+bool SkipTest() { return miopen::IsDisabled(MIOPEN_ENV(MIOPEN_TEST_CONV)); }
 
 void GetArgs(const std::string& param, std::vector<std::string>& tokens)
 {

--- a/test/gtest/pooling2d_asymmetric.cpp
+++ b/test/gtest/pooling2d_asymmetric.cpp
@@ -44,7 +44,7 @@ class AsymPooling2dHalf : public testing::TestWithParam<std::vector<std::string>
 {
 };
 
-static bool SkipTest(void) { return miopen::IsDisabled(ENV(MIOPEN_TEST_ALL)); }
+static bool SkipTest(void) { return miopen::IsDisabled(MIOPEN_ENV(MIOPEN_TEST_ALL)); }
 
 void GetArgs(const std::string& param, std::vector<std::string>& tokens)
 {
@@ -98,7 +98,7 @@ bool IsTestSupportedForDevice(const miopen::Handle& handle) { return true; }
 
 std::vector<std::string> GetTestCases(const std::string& precision)
 {
-    const auto& flag_arg = miopen::GetStringEnv(ENV(MIOPEN_TEST_FLAGS_ARGS));
+    const auto& flag_arg = miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_TEST_FLAGS_ARGS));
 
     const std::vector<std::string> test_cases = {
         // clang-format off

--- a/test/gtest/pooling2d_codecov.cpp
+++ b/test/gtest/pooling2d_codecov.cpp
@@ -44,7 +44,7 @@ class Pooling2dHalf : public testing::TestWithParam<std::vector<std::string>>
 {
 };
 
-static bool SkipTest(void) { return !miopen::IsEnabled(ENV(CODECOV_TEST)); }
+static bool SkipTest(void) { return !miopen::IsEnabled(MIOPEN_ENV(CODECOV_TEST)); }
 
 void GetArgs(const std::string& param, std::vector<std::string>& tokens)
 {
@@ -98,7 +98,7 @@ bool IsTestSupportedForDevice(const miopen::Handle& handle) { return true; }
 
 std::vector<std::string> GetTestCases(const std::string& precision)
 {
-    const auto& flag_arg = miopen::GetStringEnv(ENV(MIOPEN_TEST_FLAGS_ARGS));
+    const auto& flag_arg = miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_TEST_FLAGS_ARGS));
 
     const std::vector<std::string> test_cases = {
         // clang-format off

--- a/test/gtest/pooling2d_wide.cpp
+++ b/test/gtest/pooling2d_wide.cpp
@@ -44,7 +44,7 @@ class WidePooling2dHalf : public testing::TestWithParam<std::vector<std::string>
 {
 };
 
-static bool SkipTest(void) { return miopen::IsDisabled(ENV(MIOPEN_TEST_ALL)); }
+static bool SkipTest(void) { return miopen::IsDisabled(MIOPEN_ENV(MIOPEN_TEST_ALL)); }
 
 void GetArgs(const std::string& param, std::vector<std::string>& tokens)
 {
@@ -98,7 +98,7 @@ bool IsTestSupportedForDevice(const miopen::Handle& handle) { return true; }
 
 std::vector<std::string> GetTestCases(const std::string precision)
 {
-    const auto& flag_arg = miopen::GetStringEnv(ENV(MIOPEN_TEST_FLAGS_ARGS));
+    const auto& flag_arg = miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_TEST_FLAGS_ARGS));
 
     const std::vector<std::string> test_cases = {
         // clang-format off

--- a/test/gtest/reduce_custom_fp32.cpp
+++ b/test/gtest/reduce_custom_fp32.cpp
@@ -45,7 +45,7 @@ std::vector<std::string> GetArgs(const std::string& param)
 std::vector<std::string> GetTestCases(void)
 {
     const std::string& cmd       = "test_reduce_test ";
-    const std::string& float_arg = miopen::GetStringEnv(ENV(MIOPEN_TEST_FLOAT_ARG));
+    const std::string& float_arg = miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_TEST_FLOAT_ARG));
 
     // clang-format off
     return std::vector<std::string>{
@@ -70,9 +70,9 @@ bool IsTestSupportedForDevice()
 void Run2dDriver(void)
 {
     if(!(IsTestSupportedForDevice() &&
-         (miopen::IsUnset(ENV(MIOPEN_TEST_ALL))       // standalone run
-          || (miopen::IsEnabled(ENV(MIOPEN_TEST_ALL)) // or --float full tests enabled
-              && miopen::GetStringEnv(ENV(MIOPEN_TEST_FLOAT_ARG)) == "--float"))))
+         (miopen::IsUnset(MIOPEN_ENV(MIOPEN_TEST_ALL))       // standalone run
+          || (miopen::IsEnabled(MIOPEN_ENV(MIOPEN_TEST_ALL)) // or --float full tests enabled
+              && miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_TEST_FLOAT_ARG)) == "--float"))))
     {
         GTEST_SKIP();
     }

--- a/test/gtest/reduce_custom_fp32_fp16.cpp
+++ b/test/gtest/reduce_custom_fp32_fp16.cpp
@@ -129,10 +129,10 @@ using namespace reduce_custom_fp32_fp16;
 
 TEST_P(ConfigWithFloat_reduce_custom_fp32_fp16, FloatTest_reduce_custom_fp32_fp16)
 {
-    if(!(IsTestSupportedForDevice()                      //
-         && (miopen::IsUnset(ENV(MIOPEN_TEST_ALL))       // standalone run
-             || (miopen::IsEnabled(ENV(MIOPEN_TEST_ALL)) // or --float full tests enabled
-                 && miopen::GetStringEnv(ENV(MIOPEN_TEST_FLOAT_ARG)) == "--float"))))
+    if(!(IsTestSupportedForDevice()                             //
+         && (miopen::IsUnset(MIOPEN_ENV(MIOPEN_TEST_ALL))       // standalone run
+             || (miopen::IsEnabled(MIOPEN_ENV(MIOPEN_TEST_ALL)) // or --float full tests enabled
+                 && miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_TEST_FLOAT_ARG)) == "--float"))))
     {
         GTEST_SKIP();
     }
@@ -142,10 +142,10 @@ TEST_P(ConfigWithFloat_reduce_custom_fp32_fp16, FloatTest_reduce_custom_fp32_fp1
 
 TEST_P(ConfigWithHalf_reduce_custom_fp32_fp16, HalfTest_reduce_custom_fp32_fp16)
 {
-    if(!(IsTestSupportedForDevice()                      //
-         && (miopen::IsUnset(ENV(MIOPEN_TEST_ALL))       // standalone run
-             || (miopen::IsEnabled(ENV(MIOPEN_TEST_ALL)) // or --half full tests enabled
-                 && miopen::GetStringEnv(ENV(MIOPEN_TEST_FLOAT_ARG)) == "--half"))))
+    if(!(IsTestSupportedForDevice()                             //
+         && (miopen::IsUnset(MIOPEN_ENV(MIOPEN_TEST_ALL))       // standalone run
+             || (miopen::IsEnabled(MIOPEN_ENV(MIOPEN_TEST_ALL)) // or --half full tests enabled
+                 && miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_TEST_FLOAT_ARG)) == "--half"))))
     {
         GTEST_SKIP();
     }

--- a/test/gtest/reduceextreme.cpp
+++ b/test/gtest/reduceextreme.cpp
@@ -34,7 +34,7 @@ namespace reduceextreme {
 
 std::string GetFloatArg()
 {
-    const auto& tmp = miopen::GetStringEnv(ENV(MIOPEN_TEST_FLOAT_ARG));
+    const auto& tmp = miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_TEST_FLOAT_ARG));
     if(tmp.empty())
     {
         return "";
@@ -59,7 +59,7 @@ using namespace reduceextreme;
 
 TEST_P(ReduceExtremeTestFloat, ReduceExtremeTestFw)
 {
-    if(miopen::IsEnabled(ENV(MIOPEN_TEST_ALL)) && (GetFloatArg() == "--float"))
+    if(miopen::IsEnabled(MIOPEN_ENV(MIOPEN_TEST_ALL)) && (GetFloatArg() == "--float"))
     {
         RunTest();
         Verify();
@@ -72,7 +72,7 @@ TEST_P(ReduceExtremeTestFloat, ReduceExtremeTestFw)
 
 TEST_P(ReduceExtremeTestHalf, ReduceExtremeTestFw)
 {
-    if(miopen::IsEnabled(ENV(MIOPEN_TEST_ALL)) && (GetFloatArg() == "--half"))
+    if(miopen::IsEnabled(MIOPEN_ENV(MIOPEN_TEST_ALL)) && (GetFloatArg() == "--half"))
     {
         RunTest();
         Verify();
@@ -85,7 +85,7 @@ TEST_P(ReduceExtremeTestHalf, ReduceExtremeTestFw)
 
 TEST_P(ReduceExtremeTestBFloat16, ReduceExtremeTestFw)
 {
-    if(miopen::IsEnabled(ENV(MIOPEN_TEST_ALL)) && (GetFloatArg() == "--bfloat16"))
+    if(miopen::IsEnabled(MIOPEN_ENV(MIOPEN_TEST_ALL)) && (GetFloatArg() == "--bfloat16"))
     {
         RunTest();
         Verify();

--- a/test/gtest/regression_float_mi100.cpp
+++ b/test/gtest/regression_float_mi100.cpp
@@ -39,12 +39,12 @@ auto GetTestCases()
 {
     // Regression test for SWDEV-305815 (issue 1206)
     const auto env =
-        std::tuple{std::pair{ENV(MIOPEN_DEBUG_CONV_WINOGRAD), std::string_view("0")},
-                   std::pair{ENV(MIOPEN_DEBUG_CONV_FFT), std::string_view("0")},
-                   std::pair{ENV(MIOPEN_DEBUG_CONV_DIRECT), std::string_view("0")},
-                   std::pair{ENV(MIOPEN_DEBUG_CONV_GEMM), std::string_view("0")},
-                   std::pair{ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM), std::string_view("0")},
-                   std::pair{ENV(MIOPEN_LOG_LEVEL), std::string_view("1")}};
+        std::tuple{std::pair{MIOPEN_ENV(MIOPEN_DEBUG_CONV_WINOGRAD), std::string_view("0")},
+                   std::pair{MIOPEN_ENV(MIOPEN_DEBUG_CONV_FFT), std::string_view("0")},
+                   std::pair{MIOPEN_ENV(MIOPEN_DEBUG_CONV_DIRECT), std::string_view("0")},
+                   std::pair{MIOPEN_ENV(MIOPEN_DEBUG_CONV_GEMM), std::string_view("0")},
+                   std::pair{MIOPEN_ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM), std::string_view("0")},
+                   std::pair{MIOPEN_ENV(MIOPEN_LOG_LEVEL), std::string_view("1")}};
 
     const std::string v          = " --verbose";
     const std::string dis_fwd    = " --disable-forward";
@@ -59,7 +59,7 @@ auto GetTestCases()
 
 using TestCase = decltype(GetTestCases())::value_type;
 
-bool SkipTest() { return miopen::IsDisabled(ENV(MIOPEN_TEST_ALL)); }
+bool SkipTest() { return miopen::IsDisabled(MIOPEN_ENV(MIOPEN_TEST_ALL)); }
 
 class Conv2dFloat_regression_float_mi100 : public FloatTestCase<std::vector<TestCase>>
 {

--- a/test/gtest/regression_half_mi100.cpp
+++ b/test/gtest/regression_half_mi100.cpp
@@ -38,8 +38,8 @@ auto GetTestCases()
 {
     // Regression test for SWDEV-291202
     const auto env =
-        std::tuple{std::pair{ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
-                   std::pair{ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
+        std::tuple{std::pair{MIOPEN_ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
+                   std::pair{MIOPEN_ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
                              std::string_view("ConvHipImplicitGemmBwdDataV4R1Xdlops")}};
 
     const std::string v          = " --verbose";
@@ -55,7 +55,7 @@ auto GetTestCases()
 
 using TestCase = decltype(GetTestCases())::value_type;
 
-bool SkipTest() { return miopen::IsDisabled(ENV(MIOPEN_TEST_ALL)); }
+bool SkipTest() { return miopen::IsDisabled(MIOPEN_ENV(MIOPEN_TEST_ALL)); }
 
 bool IsTestSupportedForDevice()
 {

--- a/test/gtest/regression_half_mi200.cpp
+++ b/test/gtest/regression_half_mi200.cpp
@@ -35,8 +35,8 @@ MIOPEN_DECLARE_ENV_VAR_STR(MIOPEN_TEST_FLOAT_ARG)
 namespace regression_half_mi200 {
 void SetupEnvVar(void)
 {
-    miopen::UpdateEnvVar(ENV(MIOPEN_FIND_MODE), std::string("normal"));
-    miopen::UpdateEnvVar(ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
+    miopen::UpdateEnvVar(MIOPEN_ENV(MIOPEN_FIND_MODE), std::string("normal"));
+    miopen::UpdateEnvVar(MIOPEN_ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
                          std::string("ConvHipImplicitGemmForwardV4R4Xdlops"));
 }
 
@@ -51,7 +51,7 @@ std::vector<std::string> GetArgs(const std::string& param)
 std::vector<std::string> GetTestCases(void)
 {
     const std::string& cmd       = "test_conv2d ";
-    const std::string& float_arg = miopen::GetStringEnv(ENV(MIOPEN_TEST_FLOAT_ARG));
+    const std::string& float_arg = miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_TEST_FLOAT_ARG));
     const std::string& args =
         " --verbose --disable-forward --disable-backward-data --disable-validation";
 
@@ -78,7 +78,7 @@ bool IsTestSupportedForDevice()
 void Run2dDriver(void)
 {
     if(!(IsTestSupportedForDevice() &&
-         miopen::GetStringEnv(ENV(MIOPEN_TEST_FLOAT_ARG)) == "--half"))
+         miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_TEST_FLOAT_ARG)) == "--half"))
     {
         GTEST_SKIP();
     }

--- a/test/gtest/regression_half_vega.cpp
+++ b/test/gtest/regression_half_vega.cpp
@@ -36,8 +36,8 @@ MIOPEN_DECLARE_ENV_VAR_STR(MIOPEN_TEST_FLOAT_ARG)
 namespace regression_half_vega {
 void SetupEnvVar(void)
 {
-    miopen::UpdateEnvVar(ENV(MIOPEN_FIND_MODE), std::string("normal"));
-    miopen::UpdateEnvVar(ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER), std::string("GemmBwdRest"));
+    miopen::UpdateEnvVar(MIOPEN_ENV(MIOPEN_FIND_MODE), std::string("normal"));
+    miopen::UpdateEnvVar(MIOPEN_ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER), std::string("GemmBwdRest"));
 }
 
 std::vector<std::string> GetArgs(const std::string& param)
@@ -51,7 +51,7 @@ std::vector<std::string> GetArgs(const std::string& param)
 std::vector<std::string> GetTestCases(void)
 {
     const std::string& cmd       = "test_conv3d ";
-    const std::string& float_arg = miopen::GetStringEnv(ENV(MIOPEN_TEST_FLOAT_ARG));
+    const std::string& float_arg = miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_TEST_FLOAT_ARG));
     const std::string& conv_verbose_b =
         float_arg + " --verbose --disable-forward --disable-backward-weights";
 
@@ -77,10 +77,10 @@ bool IsTestSupportedForDevice()
 
 void Run2dDriver(void)
 {
-    if(!(IsTestSupportedForDevice()                      //
-         && (miopen::IsUnset(ENV(MIOPEN_TEST_ALL))       // standalone run
-             || (miopen::IsEnabled(ENV(MIOPEN_TEST_ALL)) // or --float full tests enabled
-                 && miopen::GetStringEnv(ENV(MIOPEN_TEST_FLOAT_ARG)) == "--half"))))
+    if(!(IsTestSupportedForDevice()                             //
+         && (miopen::IsUnset(MIOPEN_ENV(MIOPEN_TEST_ALL))       // standalone run
+             || (miopen::IsEnabled(MIOPEN_ENV(MIOPEN_TEST_ALL)) // or --float full tests enabled
+                 && miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_TEST_FLOAT_ARG)) == "--half"))))
     {
         GTEST_SKIP();
     }

--- a/test/gtest/regression_half_vega_gfx908.cpp
+++ b/test/gtest/regression_half_vega_gfx908.cpp
@@ -34,9 +34,9 @@ namespace {
 
 auto GetTestCases()
 {
-    const auto env = std::tuple{
-        std::pair{ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
-        std::pair{ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER), std::string_view("ConvOclDirectFwd1x1")}};
+    const auto env = std::tuple{std::pair{MIOPEN_ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
+                                std::pair{MIOPEN_ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
+                                          std::string_view("ConvOclDirectFwd1x1")}};
 
     const std::string v =
         " --verbose --disable-backward-data --disable-backward-weights "

--- a/test/gtest/regression_issue_2012.cpp
+++ b/test/gtest/regression_issue_2012.cpp
@@ -33,7 +33,10 @@
 MIOPEN_DECLARE_ENV_VAR_STR(MIOPEN_TEST_FLOAT_ARG)
 
 namespace regression_issue_2012 {
-void SetupEnvVar(void) { miopen::UpdateEnvVar(ENV(MIOPEN_FIND_MODE), std::string("normal")); }
+void SetupEnvVar(void)
+{
+    miopen::UpdateEnvVar(MIOPEN_ENV(MIOPEN_FIND_MODE), std::string("normal"));
+}
 
 std::vector<std::string> GetArgs(const std::string& param)
 {
@@ -46,7 +49,7 @@ std::vector<std::string> GetArgs(const std::string& param)
 std::vector<std::string> GetTestCases(void)
 {
     const std::string& cmd       = "test_conv2d ";
-    const std::string& float_arg = miopen::GetStringEnv(ENV(MIOPEN_TEST_FLOAT_ARG));
+    const std::string& float_arg = miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_TEST_FLOAT_ARG));
     const std::string& args =
         " --verbose --disable-forward --disable-backward-data --disable-validation";
 
@@ -79,7 +82,7 @@ bool IsTestSupportedForDevice()
 void Run2dDriver(void)
 {
     if(!(IsTestSupportedForDevice() &&
-         miopen::GetStringEnv(ENV(MIOPEN_TEST_FLOAT_ARG)) == "--float"))
+         miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_TEST_FLOAT_ARG)) == "--float"))
     {
         GTEST_SKIP();
     }

--- a/test/gtest/rnn_extra.cpp
+++ b/test/gtest/rnn_extra.cpp
@@ -123,9 +123,9 @@ using namespace rnn_extra;
 
 TEST_P(RNNExtraConfigWithFloat, FloatTest_rnn_extra)
 {
-    if((miopen::IsUnset(ENV(MIOPEN_TEST_ALL)) ||
-        (miopen::IsEnabled(ENV(MIOPEN_TEST_ALL)) &&
-         miopen::GetStringEnv(ENV(MIOPEN_TEST_FLOAT_ARG)) == "--float")))
+    if((miopen::IsUnset(MIOPEN_ENV(MIOPEN_TEST_ALL)) ||
+        (miopen::IsEnabled(MIOPEN_ENV(MIOPEN_TEST_ALL)) &&
+         miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_TEST_FLOAT_ARG)) == "--float")))
         Run2dDriverFloat();
     else
         GTEST_SKIP();

--- a/test/gtest/smoke_solver_ConvAsmImplicitGemmGTCDynamicFwdDlopsNCHWC.cpp
+++ b/test/gtest/smoke_solver_ConvAsmImplicitGemmGTCDynamicFwdDlopsNCHWC.cpp
@@ -35,10 +35,10 @@ namespace {
 auto GetTestCases()
 {
     const auto env_fwd =
-        std::tuple{std::pair{ENV(MIOPEN_FIND_ENFORCE), std::string_view("SEARCH_DB_UPDATE")},
-                   std::pair{ENV(MIOPEN_DEBUG_TUNING_ITERATIONS_MAX), std::string_view("5")},
-                   std::pair{ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
-                   std::pair{ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
+        std::tuple{std::pair{MIOPEN_ENV(MIOPEN_FIND_ENFORCE), std::string_view("SEARCH_DB_UPDATE")},
+                   std::pair{MIOPEN_ENV(MIOPEN_DEBUG_TUNING_ITERATIONS_MAX), std::string_view("5")},
+                   std::pair{MIOPEN_ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
+                   std::pair{MIOPEN_ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
                              std::string_view("ConvAsmImplicitGemmGTCDynamicFwdDlopsNCHWC")}};
 
     const std::string vf = " --verbose --disable-backward-data --disable-backward-weights";

--- a/test/gtest/smoke_solver_ConvAsmImplicitGemmGTCDynamicXdlops.cpp
+++ b/test/gtest/smoke_solver_ConvAsmImplicitGemmGTCDynamicXdlops.cpp
@@ -35,8 +35,8 @@ namespace {
 auto GetTestCases()
 {
     const auto env =
-        std::tuple{std::pair{ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
-                   std::pair{ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
+        std::tuple{std::pair{MIOPEN_ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
+                   std::pair{MIOPEN_ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
                              std::string_view("ConvAsmImplicitGemmGTCDynamicFwdXdlops;"
                                               "ConvAsmImplicitGemmGTCDynamicBwdXdlops;"
                                               "ConvAsmImplicitGemmGTCDynamicWrwXdlops")}};

--- a/test/gtest/smoke_solver_ConvAsmImplicitGemmGTCDynamicXdlopsNHWC_bf16.cpp
+++ b/test/gtest/smoke_solver_ConvAsmImplicitGemmGTCDynamicXdlopsNHWC_bf16.cpp
@@ -35,10 +35,10 @@ namespace {
 auto GetTestCases()
 {
     const auto env =
-        std::tuple{std::pair{ENV(MIOPEN_FIND_ENFORCE), std::string_view("SEARCH_DB_UPDATE")},
-                   std::pair{ENV(MIOPEN_DEBUG_TUNING_ITERATIONS_MAX), std::string_view("5")},
-                   std::pair{ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
-                   std::pair{ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
+        std::tuple{std::pair{MIOPEN_ENV(MIOPEN_FIND_ENFORCE), std::string_view("SEARCH_DB_UPDATE")},
+                   std::pair{MIOPEN_ENV(MIOPEN_DEBUG_TUNING_ITERATIONS_MAX), std::string_view("5")},
+                   std::pair{MIOPEN_ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
+                   std::pair{MIOPEN_ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
                              std::string_view("ConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWC;"
                                               "ConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWC;"
                                               "ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC")}};

--- a/test/gtest/smoke_solver_ConvAsmImplicitGemmGTCDynamicXdlopsNHWC_fp32_fp16.cpp
+++ b/test/gtest/smoke_solver_ConvAsmImplicitGemmGTCDynamicXdlopsNHWC_fp32_fp16.cpp
@@ -35,10 +35,10 @@ namespace {
 auto GetTestCases()
 {
     const auto env =
-        std::tuple{std::pair{ENV(MIOPEN_FIND_ENFORCE), std::string_view("SEARCH_DB_UPDATE")},
-                   std::pair{ENV(MIOPEN_DEBUG_TUNING_ITERATIONS_MAX), std::string_view("5")},
-                   std::pair{ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
-                   std::pair{ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
+        std::tuple{std::pair{MIOPEN_ENV(MIOPEN_FIND_ENFORCE), std::string_view("SEARCH_DB_UPDATE")},
+                   std::pair{MIOPEN_ENV(MIOPEN_DEBUG_TUNING_ITERATIONS_MAX), std::string_view("5")},
+                   std::pair{MIOPEN_ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
+                   std::pair{MIOPEN_ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
                              std::string_view("ConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWC;"
                                               "ConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWC;"
                                               "ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC")}};

--- a/test/gtest/smoke_solver_ConvAsmImplicitGemmV4R1Dynamic.cpp
+++ b/test/gtest/smoke_solver_ConvAsmImplicitGemmV4R1Dynamic.cpp
@@ -34,8 +34,8 @@ namespace {
 
 auto GetTestCases()
 {
-    const auto env = std::tuple{std::pair{ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
-                                std::pair{ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
+    const auto env = std::tuple{std::pair{MIOPEN_ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
+                                std::pair{MIOPEN_ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
                                           std::string_view("ConvAsmImplicitGemmV4R1DynamicFwd;"
                                                            "ConvAsmImplicitGemmV4R1DynamicBwd;"
                                                            "ConvAsmImplicitGemmV4R1DynamicWrw")}};

--- a/test/gtest/smoke_solver_ConvAsm_5x10_7x7.cpp
+++ b/test/gtest/smoke_solver_ConvAsm_5x10_7x7.cpp
@@ -34,15 +34,17 @@ namespace {
 
 auto GetTestCases()
 {
-    const auto env5x10f = std::tuple{
-        std::pair{ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
-        std::pair{ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER), std::string_view("ConvAsm5x10u2v2f1")}};
-    const auto env5x10b = std::tuple{
-        std::pair{ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
-        std::pair{ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER), std::string_view("ConvAsm5x10u2v2b1")}};
+    const auto env5x10f =
+        std::tuple{std::pair{MIOPEN_ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
+                   std::pair{MIOPEN_ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
+                             std::string_view("ConvAsm5x10u2v2f1")}};
+    const auto env5x10b =
+        std::tuple{std::pair{MIOPEN_ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
+                   std::pair{MIOPEN_ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
+                             std::string_view("ConvAsm5x10u2v2b1")}};
     const auto env7x7 =
-        std::tuple{std::pair{ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
-                   std::pair{ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
+        std::tuple{std::pair{MIOPEN_ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
+                   std::pair{MIOPEN_ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
                              std::string_view("ConvAsm7x7c3h224w224k64u2v2p3q3f1")}};
 
     const std::string vf = " --verbose --disable-backward-data --disable-backward-weights";

--- a/test/gtest/smoke_solver_ConvBinWinograd3x3U.cpp
+++ b/test/gtest/smoke_solver_ConvBinWinograd3x3U.cpp
@@ -34,9 +34,9 @@ namespace {
 
 auto GetTestCases()
 {
-    const auto env = std::tuple{
-        std::pair{ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
-        std::pair{ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER), std::string_view("ConvBinWinograd3x3U")}};
+    const auto env = std::tuple{std::pair{MIOPEN_ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
+                                std::pair{MIOPEN_ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
+                                          std::string_view("ConvBinWinograd3x3U")}};
 
     const std::string vf = " --verbose --disable-backward-data --disable-backward-weights";
     const std::string vb = " --verbose --disable-forward --disable-backward-weights";

--- a/test/gtest/smoke_solver_ConvBinWinogradRxS_fp16.cpp
+++ b/test/gtest/smoke_solver_ConvBinWinogradRxS_fp16.cpp
@@ -34,9 +34,9 @@ namespace {
 
 auto GetTestCases()
 {
-    const auto env = std::tuple{
-        std::pair{ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
-        std::pair{ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER), std::string_view("ConvBinWinogradRxS")}};
+    const auto env = std::tuple{std::pair{MIOPEN_ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
+                                std::pair{MIOPEN_ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
+                                          std::string_view("ConvBinWinogradRxS")}};
 
     const std::string vf = " --verbose --disable-backward-data --disable-backward-weights";
     const std::string vb = " --verbose --disable-forward --disable-backward-weights";

--- a/test/gtest/smoke_solver_ConvBinWinogradRxS_fp32.cpp
+++ b/test/gtest/smoke_solver_ConvBinWinogradRxS_fp32.cpp
@@ -34,9 +34,9 @@ namespace {
 
 auto GetTestCases()
 {
-    const auto env = std::tuple{
-        std::pair{ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
-        std::pair{ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER), std::string_view("ConvBinWinogradRxS")}};
+    const auto env = std::tuple{std::pair{MIOPEN_ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
+                                std::pair{MIOPEN_ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
+                                          std::string_view("ConvBinWinogradRxS")}};
 
     const std::string vf = " --verbose --disable-backward-data --disable-backward-weights";
     const std::string vb = " --verbose --disable-forward --disable-backward-weights";

--- a/test/gtest/smoke_solver_ConvBinWinogradRxSf2x3.cpp
+++ b/test/gtest/smoke_solver_ConvBinWinogradRxSf2x3.cpp
@@ -36,11 +36,12 @@ namespace {
 auto GetTestCases()
 {
     const auto env = std::tuple{
-        std::pair{ENV(MIOPEN_FIND_ENFORCE), std::string_view("SEARCH_DB_UPDATE")},
-        std::pair{ENV(MIOPEN_DEBUG_TUNING_ITERATIONS_MAX), std::string_view("5")},
-        std::pair{ENV(MIOPEN_DEBUG_CONVOLUTION_ATTRIB_FP16_ALT_IMPL), std::string_view("0")},
-        std::pair{ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
-        std::pair{ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER), std::string_view("ConvBinWinogradRxSf2x3")}};
+        std::pair{MIOPEN_ENV(MIOPEN_FIND_ENFORCE), std::string_view("SEARCH_DB_UPDATE")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_TUNING_ITERATIONS_MAX), std::string_view("5")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_CONVOLUTION_ATTRIB_FP16_ALT_IMPL), std::string_view("0")},
+        std::pair{MIOPEN_ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
+                  std::string_view("ConvBinWinogradRxSf2x3")}};
 
     return std::vector{
         // clang-format off

--- a/test/gtest/smoke_solver_ConvBinWinogradRxSf2x3g1.cpp
+++ b/test/gtest/smoke_solver_ConvBinWinogradRxSf2x3g1.cpp
@@ -35,9 +35,9 @@ namespace {
 auto GetTestCases()
 {
     const auto env2x3 = std::tuple{
-        std::pair{ENV(MIOPEN_DEBUG_CONVOLUTION_ATTRIB_FP16_ALT_IMPL), std::string_view("0")},
-        std::pair{ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
-        std::pair{ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_CONVOLUTION_ATTRIB_FP16_ALT_IMPL), std::string_view("0")},
+        std::pair{MIOPEN_ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
                   std::string_view("ConvBinWinogradRxSf2x3g1")}};
 
     return std::vector{

--- a/test/gtest/smoke_solver_ConvBinWinogradRxSf2x3g1_3x2_f16.cpp
+++ b/test/gtest/smoke_solver_ConvBinWinogradRxSf2x3g1_3x2_f16.cpp
@@ -35,15 +35,16 @@ namespace {
 auto GetTestCases()
 {
     const auto env_2x3 = std::tuple{
-        std::pair{ENV(MIOPEN_DEBUG_CONVOLUTION_ATTRIB_FP16_ALT_IMPL), std::string_view("0")},
-        std::pair{ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
-        std::pair{ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_CONVOLUTION_ATTRIB_FP16_ALT_IMPL), std::string_view("0")},
+        std::pair{MIOPEN_ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
                   std::string_view("ConvBinWinogradRxSf2x3g1")}};
 
     const auto env_3x2 = std::tuple{
-        std::pair{ENV(MIOPEN_DEBUG_CONVOLUTION_ATTRIB_FP16_ALT_IMPL), std::string_view("0")},
-        std::pair{ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
-        std::pair{ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER), std::string_view("ConvBinWinogradRxSf3x2")}};
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_CONVOLUTION_ATTRIB_FP16_ALT_IMPL), std::string_view("0")},
+        std::pair{MIOPEN_ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
+                  std::string_view("ConvBinWinogradRxSf3x2")}};
 
     const std::string vf = " --verbose --disable-backward-data --disable-backward-weights";
     const std::string vb = " --verbose --disable-forward --disable-backward-weights";

--- a/test/gtest/smoke_solver_ConvBinWinogradRxSf2x3g1_3x2_f32.cpp
+++ b/test/gtest/smoke_solver_ConvBinWinogradRxSf2x3g1_3x2_f32.cpp
@@ -34,13 +34,15 @@ namespace {
 
 auto GetTestCases()
 {
-    const auto env_2x3 = std::tuple{std::pair{ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
-                                    std::pair{ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
-                                              std::string_view("ConvBinWinogradRxSf2x3g1")}};
+    const auto env_2x3 =
+        std::tuple{std::pair{MIOPEN_ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
+                   std::pair{MIOPEN_ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
+                             std::string_view("ConvBinWinogradRxSf2x3g1")}};
 
-    const auto env_3x2 = std::tuple{
-        std::pair{ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
-        std::pair{ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER), std::string_view("ConvBinWinogradRxSf3x2")}};
+    const auto env_3x2 =
+        std::tuple{std::pair{MIOPEN_ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
+                   std::pair{MIOPEN_ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
+                             std::string_view("ConvBinWinogradRxSf3x2")}};
 
     const std::string vf = " --verbose --disable-backward-data --disable-backward-weights";
     const std::string vb = " --verbose --disable-forward --disable-backward-weights";

--- a/test/gtest/smoke_solver_ConvBinWinogradRxSf3x2.cpp
+++ b/test/gtest/smoke_solver_ConvBinWinogradRxSf3x2.cpp
@@ -35,11 +35,12 @@ namespace {
 auto GetTestCases()
 {
     const auto env3x2 = std::tuple{
-        std::pair{ENV(MIOPEN_FIND_ENFORCE), std::string_view("SEARCH_DB_UPDATE")},
-        std::pair{ENV(MIOPEN_DEBUG_TUNING_ITERATIONS_MAX), std::string_view("5")},
-        std::pair{ENV(MIOPEN_DEBUG_CONVOLUTION_ATTRIB_FP16_ALT_IMPL), std::string_view("0")},
-        std::pair{ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
-        std::pair{ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER), std::string_view("ConvBinWinogradRxSf3x2")}};
+        std::pair{MIOPEN_ENV(MIOPEN_FIND_ENFORCE), std::string_view("SEARCH_DB_UPDATE")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_TUNING_ITERATIONS_MAX), std::string_view("5")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_CONVOLUTION_ATTRIB_FP16_ALT_IMPL), std::string_view("0")},
+        std::pair{MIOPEN_ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
+                  std::string_view("ConvBinWinogradRxSf3x2")}};
 
     return std::vector{
         // clang-format off

--- a/test/gtest/smoke_solver_ConvCkIgemmFwdV6r1DlopsNchw.cpp
+++ b/test/gtest/smoke_solver_ConvCkIgemmFwdV6r1DlopsNchw.cpp
@@ -39,13 +39,14 @@ auto GetTestCases()
     // MIOPEN_DEBUG_CONV_CK_IGEMM_FWD_V6R1_DLOPS_NCHW is explicitly enabled due to the kernel is
     // disabled by default via #2306
     const auto env_fwd = std::tuple{
-        std::pair{ENV(MIOPEN_FIND_ENFORCE), std::string_view("SEARCH_DB_UPDATE")},
-        std::pair{ENV(MIOPEN_DEBUG_TUNING_ITERATIONS_MAX), std::string_view("2")},
-        std::pair{ENV(MIOPEN_DEBUG_CONVOLUTION_ATTRIB_FP16_ALT_IMPL), std::string_view("0")},
-        std::pair{ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
-        std::pair{ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
+        std::pair{MIOPEN_ENV(MIOPEN_FIND_ENFORCE), std::string_view("SEARCH_DB_UPDATE")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_TUNING_ITERATIONS_MAX), std::string_view("2")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_CONVOLUTION_ATTRIB_FP16_ALT_IMPL), std::string_view("0")},
+        std::pair{MIOPEN_ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
                   std::string_view("ConvCkIgemmFwdV6r1DlopsNchw")},
-        std::pair{ENV(MIOPEN_DEBUG_CONV_CK_IGEMM_FWD_V6R1_DLOPS_NCHW), std::string_view("1")}};
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_CONV_CK_IGEMM_FWD_V6R1_DLOPS_NCHW),
+                  std::string_view("1")}};
 
     const std::string vf = " --verbose --disable-backward-data --disable-backward-weights";
 

--- a/test/gtest/smoke_solver_ConvDirectNaiveConv_Bw.cpp
+++ b/test/gtest/smoke_solver_ConvDirectNaiveConv_Bw.cpp
@@ -35,15 +35,17 @@ namespace {
 auto GetTestCases()
 {
     const auto env_bwd = std::tuple{
-        std::pair{ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
-        std::pair{ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER), std::string_view("ConvDirectNaiveConvBwd")},
-        std::pair{ENV(MIOPEN_DRIVER_USE_GPU_REFERENCE), std::string_view("0")},
+        std::pair{MIOPEN_ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
+                  std::string_view("ConvDirectNaiveConvBwd")},
+        std::pair{MIOPEN_ENV(MIOPEN_DRIVER_USE_GPU_REFERENCE), std::string_view("0")},
     };
 
     const auto env_wrw = std::tuple{
-        std::pair{ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
-        std::pair{ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER), std::string_view("ConvDirectNaiveConvWrw")},
-        std::pair{ENV(MIOPEN_DRIVER_USE_GPU_REFERENCE), std::string_view("0")},
+        std::pair{MIOPEN_ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
+                  std::string_view("ConvDirectNaiveConvWrw")},
+        std::pair{MIOPEN_ENV(MIOPEN_DRIVER_USE_GPU_REFERENCE), std::string_view("0")},
     };
 
     const std::string vb = " --verbose --disable-forward --disable-backward-weights";

--- a/test/gtest/smoke_solver_ConvDirectNaiveConv_F.cpp
+++ b/test/gtest/smoke_solver_ConvDirectNaiveConv_F.cpp
@@ -35,9 +35,10 @@ namespace {
 auto GetTestCases()
 {
     const auto env = std::tuple{
-        std::pair{ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
-        std::pair{ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER), std::string_view("ConvDirectNaiveConvFwd")},
-        std::pair{ENV(MIOPEN_DRIVER_USE_GPU_REFERENCE), std::string_view("0")},
+        std::pair{MIOPEN_ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
+                  std::string_view("ConvDirectNaiveConvFwd")},
+        std::pair{MIOPEN_ENV(MIOPEN_DRIVER_USE_GPU_REFERENCE), std::string_view("0")},
     };
 
     const std::string vf = " --verbose --disable-backward-data --disable-backward-weights";

--- a/test/gtest/smoke_solver_ConvFFT.cpp
+++ b/test/gtest/smoke_solver_ConvFFT.cpp
@@ -35,8 +35,8 @@ namespace {
 auto GetTestCases()
 {
     const auto env =
-        std::tuple{std::pair{ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
-                   std::pair{ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER), std::string_view("fft")}};
+        std::tuple{std::pair{MIOPEN_ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
+                   std::pair{MIOPEN_ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER), std::string_view("fft")}};
 
     const std::string vf = " --verbose --disable-backward-data --disable-backward-weights";
     const std::string vb = " --verbose --disable-forward --disable-backward-weights";

--- a/test/gtest/smoke_solver_ConvHipImplicitGemmBwdDataV1R1.cpp
+++ b/test/gtest/smoke_solver_ConvHipImplicitGemmBwdDataV1R1.cpp
@@ -36,10 +36,10 @@ namespace {
 auto GetTestCases()
 {
     const auto env_fwd =
-        std::tuple{std::pair{ENV(MIOPEN_FIND_ENFORCE), std::string_view("SEARCH_DB_UPDATE")},
-                   std::pair{ENV(MIOPEN_DEBUG_TUNING_ITERATIONS_MAX), std::string_view("5")},
-                   std::pair{ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
-                   std::pair{ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
+        std::tuple{std::pair{MIOPEN_ENV(MIOPEN_FIND_ENFORCE), std::string_view("SEARCH_DB_UPDATE")},
+                   std::pair{MIOPEN_ENV(MIOPEN_DEBUG_TUNING_ITERATIONS_MAX), std::string_view("5")},
+                   std::pair{MIOPEN_ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
+                   std::pair{MIOPEN_ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
                              std::string_view("ConvHipImplicitGemmBwdDataV1R1")}};
 
     const std::string vb = " --verbose --disable-forward --disable-backward-weights";

--- a/test/gtest/smoke_solver_ConvHipImplicitGemmBwdDataV1R1Xdlops.cpp
+++ b/test/gtest/smoke_solver_ConvHipImplicitGemmBwdDataV1R1Xdlops.cpp
@@ -38,12 +38,13 @@ auto GetTestCases()
     // However we still want to check that solver is not broken and therefore use
     // MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_BWD_V1R1_XDLOPS=1 to enable it.
     const auto env_bwd = std::tuple{
-        std::pair{ENV(MIOPEN_FIND_ENFORCE), std::string_view("SEARCH_DB_UPDATE")},
-        std::pair{ENV(MIOPEN_DEBUG_TUNING_ITERATIONS_MAX), std::string_view("5")},
-        std::pair{ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_BWD_V1R1_XDLOPS), std::string_view("1")},
-        std::pair{ENV(MIOPEN_DEBUG_CONVOLUTION_ATTRIB_FP16_ALT_IMPL), std::string_view("0")},
-        std::pair{ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
-        std::pair{ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
+        std::pair{MIOPEN_ENV(MIOPEN_FIND_ENFORCE), std::string_view("SEARCH_DB_UPDATE")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_TUNING_ITERATIONS_MAX), std::string_view("5")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_BWD_V1R1_XDLOPS),
+                  std::string_view("1")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_CONVOLUTION_ATTRIB_FP16_ALT_IMPL), std::string_view("0")},
+        std::pair{MIOPEN_ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
                   std::string_view("ConvHipImplicitGemmBwdDataV1R1Xdlops")}};
 
     const std::string vb = " --verbose --disable-forward --disable-backward-weights";

--- a/test/gtest/smoke_solver_ConvHipImplicitGemmBwdDataV4R1.cpp
+++ b/test/gtest/smoke_solver_ConvHipImplicitGemmBwdDataV4R1.cpp
@@ -38,11 +38,11 @@ auto GetTestCases()
     // WORKAROUND_SWDEV_229277_227616_229195, which disables ConvHipImplicitGemmBwdDataV4R1, but we
     // still want to check that the solver is not broken.
     const auto env_bwd = std::tuple{
-        std::pair{ENV(MIOPEN_FIND_ENFORCE), std::string_view("SEARCH_DB_UPDATE")},
-        std::pair{ENV(MIOPEN_DEBUG_TUNING_ITERATIONS_MAX), std::string_view("5")},
-        std::pair{ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_BWD_V4R1), std::string_view("1")},
-        std::pair{ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
-        std::pair{ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
+        std::pair{MIOPEN_ENV(MIOPEN_FIND_ENFORCE), std::string_view("SEARCH_DB_UPDATE")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_TUNING_ITERATIONS_MAX), std::string_view("5")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_BWD_V4R1), std::string_view("1")},
+        std::pair{MIOPEN_ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
                   std::string_view("ConvHipImplicitGemmBwdDataV4R1")}};
 
     const std::string vb = " --verbose --disable-forward --disable-backward-weights";

--- a/test/gtest/smoke_solver_ConvHipImplicitGemmDataV4RxXdlops.cpp
+++ b/test/gtest/smoke_solver_ConvHipImplicitGemmDataV4RxXdlops.cpp
@@ -37,34 +37,37 @@ auto GetTestCases()
     // MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_BWD_V4R1_XDLOPS is reqired due to env_bwd case
     // for this particulaer case it's not needed, but must be there to simplify the code
     const auto env_fwd = std::tuple{
-        std::pair{ENV(MIOPEN_FIND_ENFORCE), std::string_view("SEARCH_DB_UPDATE")},
-        std::pair{ENV(MIOPEN_DEBUG_TUNING_ITERATIONS_MAX), std::string_view("5")},
-        std::pair{ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_BWD_V4R1_XDLOPS), std::string_view("0")},
-        std::pair{ENV(MIOPEN_DEBUG_CONVOLUTION_ATTRIB_FP16_ALT_IMPL), std::string_view("0")},
-        std::pair{ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
-        std::pair{ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
+        std::pair{MIOPEN_ENV(MIOPEN_FIND_ENFORCE), std::string_view("SEARCH_DB_UPDATE")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_TUNING_ITERATIONS_MAX), std::string_view("5")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_BWD_V4R1_XDLOPS),
+                  std::string_view("0")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_CONVOLUTION_ATTRIB_FP16_ALT_IMPL), std::string_view("0")},
+        std::pair{MIOPEN_ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
                   std::string_view("ConvHipImplicitGemmForwardV4R4Xdlops")}};
 
     // MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_BWD_V4R1_XDLOPS is reqired due to env_bwd case
     // for this particulaer case it's not needed, but must be there to simplify the code
     const auto env_fwd_padded = std::tuple{
-        std::pair{ENV(MIOPEN_FIND_ENFORCE), std::string_view("SEARCH_DB_UPDATE")},
-        std::pair{ENV(MIOPEN_DEBUG_TUNING_ITERATIONS_MAX), std::string_view("5")},
-        std::pair{ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_BWD_V4R1_XDLOPS), std::string_view("0")},
-        std::pair{ENV(MIOPEN_DEBUG_CONVOLUTION_ATTRIB_FP16_ALT_IMPL), std::string_view("0")},
-        std::pair{ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
-        std::pair{ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
+        std::pair{MIOPEN_ENV(MIOPEN_FIND_ENFORCE), std::string_view("SEARCH_DB_UPDATE")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_TUNING_ITERATIONS_MAX), std::string_view("5")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_BWD_V4R1_XDLOPS),
+                  std::string_view("0")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_CONVOLUTION_ATTRIB_FP16_ALT_IMPL), std::string_view("0")},
+        std::pair{MIOPEN_ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
                   std::string_view("ConvHipImplicitGemmForwardV4R4Xdlops_Padded_Gemm")}};
 
     // MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_BWD_V4R1_XDLOPS is reqired due to env_bwd case
     // for this particulaer case it's not needed, but must be there to simplify the code
     const auto env_fwd_v4r5 = std::tuple{
-        std::pair{ENV(MIOPEN_FIND_ENFORCE), std::string_view("SEARCH_DB_UPDATE")},
-        std::pair{ENV(MIOPEN_DEBUG_TUNING_ITERATIONS_MAX), std::string_view("5")},
-        std::pair{ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_BWD_V4R1_XDLOPS), std::string_view("0")},
-        std::pair{ENV(MIOPEN_DEBUG_CONVOLUTION_ATTRIB_FP16_ALT_IMPL), std::string_view("0")},
-        std::pair{ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
-        std::pair{ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
+        std::pair{MIOPEN_ENV(MIOPEN_FIND_ENFORCE), std::string_view("SEARCH_DB_UPDATE")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_TUNING_ITERATIONS_MAX), std::string_view("5")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_BWD_V4R1_XDLOPS),
+                  std::string_view("0")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_CONVOLUTION_ATTRIB_FP16_ALT_IMPL), std::string_view("0")},
+        std::pair{MIOPEN_ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
                   std::string_view("ConvHipImplicitGemmForwardV4R5Xdlops")}};
 
     // WORKAROUND_ISSUE_1206 disables this solver for FP32 due to precision issues.
@@ -72,34 +75,37 @@ auto GetTestCases()
     // However we still want to check that these cases are not broken and therefore use
     // MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_BWD_V4R1_XDLOPS=1 to enable the solver.
     const auto env_bwd = std::tuple{
-        std::pair{ENV(MIOPEN_FIND_ENFORCE), std::string_view("SEARCH_DB_UPDATE")},
-        std::pair{ENV(MIOPEN_DEBUG_TUNING_ITERATIONS_MAX), std::string_view("5")},
-        std::pair{ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_BWD_V4R1_XDLOPS), std::string_view("1")},
-        std::pair{ENV(MIOPEN_DEBUG_CONVOLUTION_ATTRIB_FP16_ALT_IMPL), std::string_view("0")},
-        std::pair{ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
-        std::pair{ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
+        std::pair{MIOPEN_ENV(MIOPEN_FIND_ENFORCE), std::string_view("SEARCH_DB_UPDATE")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_TUNING_ITERATIONS_MAX), std::string_view("5")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_BWD_V4R1_XDLOPS),
+                  std::string_view("1")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_CONVOLUTION_ATTRIB_FP16_ALT_IMPL), std::string_view("0")},
+        std::pair{MIOPEN_ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
                   std::string_view("ConvHipImplicitGemmBwdDataV4R1Xdlops")}};
 
     // MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_BWD_V4R1_XDLOPS is reqired due to env_bwd case
     // for this particulaer case it's not needed, but must be there to simplify the code
     const auto env_wrw = std::tuple{
-        std::pair{ENV(MIOPEN_FIND_ENFORCE), std::string_view("SEARCH_DB_UPDATE")},
-        std::pair{ENV(MIOPEN_DEBUG_TUNING_ITERATIONS_MAX), std::string_view("5")},
-        std::pair{ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_BWD_V4R1_XDLOPS), std::string_view("0")},
-        std::pair{ENV(MIOPEN_DEBUG_CONVOLUTION_ATTRIB_FP16_ALT_IMPL), std::string_view("0")},
-        std::pair{ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
-        std::pair{ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
+        std::pair{MIOPEN_ENV(MIOPEN_FIND_ENFORCE), std::string_view("SEARCH_DB_UPDATE")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_TUNING_ITERATIONS_MAX), std::string_view("5")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_BWD_V4R1_XDLOPS),
+                  std::string_view("0")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_CONVOLUTION_ATTRIB_FP16_ALT_IMPL), std::string_view("0")},
+        std::pair{MIOPEN_ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
                   std::string_view("ConvHipImplicitGemmWrwV4R4Xdlops")}};
 
     // MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_BWD_V4R1_XDLOPS is reqired due to env_bwd case
     // for this particulaer case it's not needed, but must be there to simplify the code
     const auto env_wrw_padded = std::tuple{
-        std::pair{ENV(MIOPEN_FIND_ENFORCE), std::string_view("SEARCH_DB_UPDATE")},
-        std::pair{ENV(MIOPEN_DEBUG_TUNING_ITERATIONS_MAX), std::string_view("5")},
-        std::pair{ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_BWD_V4R1_XDLOPS), std::string_view("0")},
-        std::pair{ENV(MIOPEN_DEBUG_CONVOLUTION_ATTRIB_FP16_ALT_IMPL), std::string_view("0")},
-        std::pair{ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
-        std::pair{ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
+        std::pair{MIOPEN_ENV(MIOPEN_FIND_ENFORCE), std::string_view("SEARCH_DB_UPDATE")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_TUNING_ITERATIONS_MAX), std::string_view("5")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_BWD_V4R1_XDLOPS),
+                  std::string_view("0")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_CONVOLUTION_ATTRIB_FP16_ALT_IMPL), std::string_view("0")},
+        std::pair{MIOPEN_ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
                   std::string_view("ConvHipImplicitGemmWrwV4R4Xdlops_Padded_Gemm")}};
 
     const std::string vf = " --verbose --disable-backward-data --disable-backward-weights";

--- a/test/gtest/smoke_solver_ConvHipImplicitGemmV4R1Fwd_fp16_bf16.cpp
+++ b/test/gtest/smoke_solver_ConvHipImplicitGemmV4R1Fwd_fp16_bf16.cpp
@@ -41,12 +41,12 @@ auto GetTestCases()
     // datatypes in this test, see
     // https://github.com/ROCm/MIOpen/pull/2043#issuecomment-1482657160
     const auto env_fwd = std::tuple{
-        std::pair{ENV(MIOPEN_FIND_ENFORCE), std::string_view("SEARCH_DB_UPDATE")},
-        std::pair{ENV(MIOPEN_DEBUG_TUNING_ITERATIONS_MAX), std::string_view("5")},
-        std::pair{ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_FWD_V4R1), std::string_view("1")},
-        std::pair{ENV(MIOPEN_DEBUG_CONVOLUTION_ATTRIB_FP16_ALT_IMPL), std::string_view("0")},
-        std::pair{ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
-        std::pair{ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
+        std::pair{MIOPEN_ENV(MIOPEN_FIND_ENFORCE), std::string_view("SEARCH_DB_UPDATE")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_TUNING_ITERATIONS_MAX), std::string_view("5")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_FWD_V4R1), std::string_view("1")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_CONVOLUTION_ATTRIB_FP16_ALT_IMPL), std::string_view("0")},
+        std::pair{MIOPEN_ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
                   std::string_view("ConvHipImplicitGemmV4R1Fwd")}};
 
     const std::string vf = " --verbose --disable-backward-data --disable-backward-weights";

--- a/test/gtest/smoke_solver_ConvHipImplicitGemmV4R1Fwd_fp32.cpp
+++ b/test/gtest/smoke_solver_ConvHipImplicitGemmV4R1Fwd_fp32.cpp
@@ -38,12 +38,12 @@ auto GetTestCases()
     // Jenkinsfile, which disables ConvHipImplicitGemmV4R1Fwd, but we still want to check that the
     // solver is not broken.
     const auto env_fwd = std::tuple{
-        std::pair{ENV(MIOPEN_FIND_ENFORCE), std::string_view("SEARCH_DB_UPDATE")},
-        std::pair{ENV(MIOPEN_DEBUG_TUNING_ITERATIONS_MAX), std::string_view("5")},
-        std::pair{ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_FWD_V4R1), std::string_view("1")},
-        std::pair{ENV(MIOPEN_DEBUG_CONVOLUTION_ATTRIB_FP16_ALT_IMPL), std::string_view("0")},
-        std::pair{ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
-        std::pair{ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
+        std::pair{MIOPEN_ENV(MIOPEN_FIND_ENFORCE), std::string_view("SEARCH_DB_UPDATE")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_TUNING_ITERATIONS_MAX), std::string_view("5")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_FWD_V4R1), std::string_view("1")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_CONVOLUTION_ATTRIB_FP16_ALT_IMPL), std::string_view("0")},
+        std::pair{MIOPEN_ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
                   std::string_view("ConvHipImplicitGemmV4R1Fwd")}};
 
     const std::string vf = " --verbose --disable-backward-data --disable-backward-weights";

--- a/test/gtest/smoke_solver_ConvHipImplicitGemmV4R1WrW.cpp
+++ b/test/gtest/smoke_solver_ConvHipImplicitGemmV4R1WrW.cpp
@@ -35,11 +35,11 @@ namespace {
 auto GetTestCases()
 {
     const auto env_wrw = std::tuple{
-        std::pair{ENV(MIOPEN_FIND_ENFORCE), std::string_view("SEARCH_DB_UPDATE")},
-        std::pair{ENV(MIOPEN_DEBUG_TUNING_ITERATIONS_MAX), std::string_view("5")},
-        std::pair{ENV(MIOPEN_DEBUG_CONVOLUTION_ATTRIB_FP16_ALT_IMPL), std::string_view("0")},
-        std::pair{ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
-        std::pair{ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
+        std::pair{MIOPEN_ENV(MIOPEN_FIND_ENFORCE), std::string_view("SEARCH_DB_UPDATE")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_TUNING_ITERATIONS_MAX), std::string_view("5")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_CONVOLUTION_ATTRIB_FP16_ALT_IMPL), std::string_view("0")},
+        std::pair{MIOPEN_ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
                   std::string_view("ConvHipImplicitGemmV4R1WrW")}};
 
     const std::string vw = " --verbose --disable-forward --disable-backward-data";

--- a/test/gtest/smoke_solver_ConvHipImplicitGemmV4R4.cpp
+++ b/test/gtest/smoke_solver_ConvHipImplicitGemmV4R4.cpp
@@ -35,17 +35,17 @@ namespace {
 auto GetTestCases()
 {
     const auto env_fwd =
-        std::tuple{std::pair{ENV(MIOPEN_FIND_ENFORCE), std::string_view("SEARCH_DB_UPDATE")},
-                   std::pair{ENV(MIOPEN_DEBUG_TUNING_ITERATIONS_MAX), std::string_view("5")},
-                   std::pair{ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
-                   std::pair{ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
+        std::tuple{std::pair{MIOPEN_ENV(MIOPEN_FIND_ENFORCE), std::string_view("SEARCH_DB_UPDATE")},
+                   std::pair{MIOPEN_ENV(MIOPEN_DEBUG_TUNING_ITERATIONS_MAX), std::string_view("5")},
+                   std::pair{MIOPEN_ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
+                   std::pair{MIOPEN_ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
                              std::string_view("ConvHipImplicitGemmV4R4Fwd")}};
 
     const auto env_wrw =
-        std::tuple{std::pair{ENV(MIOPEN_FIND_ENFORCE), std::string_view("SEARCH_DB_UPDATE")},
-                   std::pair{ENV(MIOPEN_DEBUG_TUNING_ITERATIONS_MAX), std::string_view("5")},
-                   std::pair{ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
-                   std::pair{ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
+        std::tuple{std::pair{MIOPEN_ENV(MIOPEN_FIND_ENFORCE), std::string_view("SEARCH_DB_UPDATE")},
+                   std::pair{MIOPEN_ENV(MIOPEN_DEBUG_TUNING_ITERATIONS_MAX), std::string_view("5")},
+                   std::pair{MIOPEN_ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
+                   std::pair{MIOPEN_ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
                              std::string_view("ConvHipImplicitGemmV4R4WrW")}};
 
     const std::string vf = " --verbose --disable-backward-data --disable-backward-weights";

--- a/test/gtest/smoke_solver_ConvOclBwdWrW1x1.cpp
+++ b/test/gtest/smoke_solver_ConvOclBwdWrW1x1.cpp
@@ -35,8 +35,8 @@ namespace {
 auto GetTestCases()
 {
     const auto env = std::tuple{
-        std::pair{ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
-        std::pair{ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER), std::string_view("ConvOclBwdWrW1x1")}};
+        std::pair{MIOPEN_ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER), std::string_view("ConvOclBwdWrW1x1")}};
 
     const std::string vw = " --verbose --disable-forward --disable-backward-data";
 

--- a/test/gtest/smoke_solver_ConvOcl_Fwd11x11_FwdGen_WrW53.cpp
+++ b/test/gtest/smoke_solver_ConvOcl_Fwd11x11_FwdGen_WrW53.cpp
@@ -34,17 +34,19 @@ namespace {
 
 auto GetTestCases()
 {
-    const auto env_fwd = std::tuple{
-        std::pair{ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
-        std::pair{ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER), std::string_view("ConvOclDirectFwd11x11")}};
+    const auto env_fwd =
+        std::tuple{std::pair{MIOPEN_ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
+                   std::pair{MIOPEN_ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
+                             std::string_view("ConvOclDirectFwd11x11")}};
 
-    const auto env_fwd_gen = std::tuple{
-        std::pair{ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
-        std::pair{ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER), std::string_view("ConvOclDirectFwdGen")}};
+    const auto env_fwd_gen =
+        std::tuple{std::pair{MIOPEN_ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
+                   std::pair{MIOPEN_ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
+                             std::string_view("ConvOclDirectFwdGen")}};
 
     const auto env_wrw = std::tuple{
-        std::pair{ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
-        std::pair{ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER), std::string_view("ConvOclBwdWrW53")}};
+        std::pair{MIOPEN_ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER), std::string_view("ConvOclBwdWrW53")}};
 
     const std::string vf = " --verbose --disable-backward-data --disable-backward-weights";
     const std::string vw = " --verbose --disable-forward --disable-backward-data";

--- a/test/gtest/smoke_solver_ConvWinogradFuryRxSf2x3_f16.cpp
+++ b/test/gtest/smoke_solver_ConvWinogradFuryRxSf2x3_f16.cpp
@@ -34,8 +34,8 @@ namespace {
 
 auto GetTestCases()
 {
-    const auto env = std::tuple{std::pair{ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
-                                std::pair{ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
+    const auto env = std::tuple{std::pair{MIOPEN_ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
+                                std::pair{MIOPEN_ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER),
                                           std::string_view("\'ConvWinoFuryRxS<2-3>\'")}};
 
     const std::string vf = " --verbose --disable-backward-data --disable-backward-weights";

--- a/test/gtest/smoke_solver_convasm.cpp
+++ b/test/gtest/smoke_solver_convasm.cpp
@@ -36,16 +36,16 @@ namespace {
 auto GetTestCases()
 {
     const auto env_1uv2 = std::tuple{
-        std::pair{ENV(MIOPEN_FIND_ENFORCE), std::string_view("SEARCH_DB_UPDATE")},
-        std::pair{ENV(MIOPEN_DEBUG_TUNING_ITERATIONS_MAX), std::string_view("5")},
-        std::pair{ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
-        std::pair{ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER), std::string_view("ConvAsm1x1UV2")}};
+        std::pair{MIOPEN_ENV(MIOPEN_FIND_ENFORCE), std::string_view("SEARCH_DB_UPDATE")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_TUNING_ITERATIONS_MAX), std::string_view("5")},
+        std::pair{MIOPEN_ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER), std::string_view("ConvAsm1x1UV2")}};
 
-    const auto env_3u =
-        std::tuple{std::pair{ENV(MIOPEN_FIND_ENFORCE), std::string_view("SEARCH_DB_UPDATE")},
-                   std::pair{ENV(MIOPEN_DEBUG_TUNING_ITERATIONS_MAX), std::string_view("5")},
-                   std::pair{ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
-                   std::pair{ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER), std::string_view("ConvAsm3x3U")}};
+    const auto env_3u = std::tuple{
+        std::pair{MIOPEN_ENV(MIOPEN_FIND_ENFORCE), std::string_view("SEARCH_DB_UPDATE")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_TUNING_ITERATIONS_MAX), std::string_view("5")},
+        std::pair{MIOPEN_ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER), std::string_view("ConvAsm3x3U")}};
 
     const std::string vf = " --verbose --disable-backward-data --disable-backward-weights";
     const std::string vb = " --verbose --disable-forward --disable-backward-weights";

--- a/test/gtest/smoke_solver_convasm1x1u.cpp
+++ b/test/gtest/smoke_solver_convasm1x1u.cpp
@@ -35,11 +35,11 @@ namespace {
 auto GetTestCases()
 {
     const auto env = std::tuple{
-        std::pair{ENV(MIOPEN_FIND_ENFORCE), std::string_view("SEARCH_DB_UPDATE")},
-        std::pair{ENV(MIOPEN_DEBUG_TUNING_ITERATIONS_MAX), std::string_view("5")},
-        std::pair{ENV(MIOPEN_DEBUG_CONVOLUTION_ATTRIB_FP16_ALT_IMPL), std::string_view("0")},
-        std::pair{ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
-        std::pair{ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER), std::string_view("ConvAsm1x1U")}};
+        std::pair{MIOPEN_ENV(MIOPEN_FIND_ENFORCE), std::string_view("SEARCH_DB_UPDATE")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_TUNING_ITERATIONS_MAX), std::string_view("5")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_CONVOLUTION_ATTRIB_FP16_ALT_IMPL), std::string_view("0")},
+        std::pair{MIOPEN_ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER), std::string_view("ConvAsm1x1U")}};
 
     const std::string vf = " --verbose --disable-backward-data --disable-backward-weights";
     const std::string vb = " --verbose --disable-forward --disable-backward-weights";

--- a/test/gtest/smoke_solver_convasmbwdwrw.cpp
+++ b/test/gtest/smoke_solver_convasmbwdwrw.cpp
@@ -35,10 +35,10 @@ namespace {
 auto GetTestCases()
 {
     const auto env_w1 = std::tuple{
-        std::pair{ENV(MIOPEN_FIND_ENFORCE), std::string_view("SEARCH_DB_UPDATE")},
-        std::pair{ENV(MIOPEN_DEBUG_TUNING_ITERATIONS_MAX), std::string_view("5")},
-        std::pair{ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
-        std::pair{ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER), std::string_view("ConvAsmBwdWrW1x1")}};
+        std::pair{MIOPEN_ENV(MIOPEN_FIND_ENFORCE), std::string_view("SEARCH_DB_UPDATE")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_TUNING_ITERATIONS_MAX), std::string_view("5")},
+        std::pair{MIOPEN_ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER), std::string_view("ConvAsmBwdWrW1x1")}};
 
     const std::string vw = " --verbose --disable-forward --disable-backward-data";
 

--- a/test/gtest/smoke_solver_convasmbwdwrw3x3_fp16.cpp
+++ b/test/gtest/smoke_solver_convasmbwdwrw3x3_fp16.cpp
@@ -35,10 +35,10 @@ namespace {
 auto GetTestCases()
 {
     const auto env_wrw = std::tuple{
-        std::pair{ENV(MIOPEN_FIND_ENFORCE), std::string_view("SEARCH_DB_UPDATE")},
-        std::pair{ENV(MIOPEN_DEBUG_TUNING_ITERATIONS_MAX), std::string_view("5")},
-        std::pair{ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
-        std::pair{ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER), std::string_view("ConvAsmBwdWrW3x3")}};
+        std::pair{MIOPEN_ENV(MIOPEN_FIND_ENFORCE), std::string_view("SEARCH_DB_UPDATE")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_TUNING_ITERATIONS_MAX), std::string_view("5")},
+        std::pair{MIOPEN_ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER), std::string_view("ConvAsmBwdWrW3x3")}};
 
     const std::string vw = " --verbose --disable-forward --disable-backward-data";
 

--- a/test/gtest/smoke_solver_convasmbwdwrw3x3_fp32.cpp
+++ b/test/gtest/smoke_solver_convasmbwdwrw3x3_fp32.cpp
@@ -35,10 +35,10 @@ namespace {
 auto GetTestCases()
 {
     const auto env_wrw = std::tuple{
-        std::pair{ENV(MIOPEN_FIND_ENFORCE), std::string_view("SEARCH_DB_UPDATE")},
-        std::pair{ENV(MIOPEN_DEBUG_TUNING_ITERATIONS_MAX), std::string_view("5")},
-        std::pair{ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
-        std::pair{ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER), std::string_view("ConvAsmBwdWrW3x3")}};
+        std::pair{MIOPEN_ENV(MIOPEN_FIND_ENFORCE), std::string_view("SEARCH_DB_UPDATE")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_TUNING_ITERATIONS_MAX), std::string_view("5")},
+        std::pair{MIOPEN_ENV(MIOPEN_FIND_MODE), std::string_view("normal")},
+        std::pair{MIOPEN_ENV(MIOPEN_DEBUG_FIND_ONLY_SOLVER), std::string_view("ConvAsmBwdWrW3x3")}};
 
     const std::string vw = " --verbose --disable-forward --disable-backward-data";
 

--- a/test/gtest/sum.cpp
+++ b/test/gtest/sum.cpp
@@ -34,7 +34,7 @@ namespace sum {
 
 std::string GetFloatArg()
 {
-    const auto& tmp = miopen::GetStringEnv(ENV(MIOPEN_TEST_FLOAT_ARG));
+    const auto& tmp = miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_TEST_FLOAT_ARG));
     if(tmp.empty())
     {
         return "";
@@ -51,7 +51,7 @@ using namespace sum;
 
 TEST_P(SumTestFloat, SumTestFw)
 {
-    if(miopen::IsEnabled(ENV(MIOPEN_TEST_ALL)) && (GetFloatArg() == "--float"))
+    if(miopen::IsEnabled(MIOPEN_ENV(MIOPEN_TEST_ALL)) && (GetFloatArg() == "--float"))
     {
         RunTest();
         Verify();

--- a/test/gtest/t5layernorm.cpp
+++ b/test/gtest/t5layernorm.cpp
@@ -34,7 +34,7 @@ namespace t5layernorm {
 
 std::string GetFloatArg()
 {
-    const auto& tmp = miopen::GetStringEnv(ENV(MIOPEN_TEST_FLOAT_ARG));
+    const auto& tmp = miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_TEST_FLOAT_ARG));
     if(tmp.empty())
     {
         return "";
@@ -71,8 +71,8 @@ using namespace t5layernorm;
 
 TEST_P(T5LayerNormTestFloat, T5LayerNormTestFw)
 {
-    auto TypeArg = miopen::GetStringEnv(ENV(MIOPEN_TEST_FLOAT_ARG));
-    if(miopen::IsEnabled(ENV(MIOPEN_TEST_ALL)) && (GetFloatArg() == "--float"))
+    auto TypeArg = miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_TEST_FLOAT_ARG));
+    if(miopen::IsEnabled(MIOPEN_ENV(MIOPEN_TEST_ALL)) && (GetFloatArg() == "--float"))
     {
         RunTest();
         Verify();
@@ -85,8 +85,8 @@ TEST_P(T5LayerNormTestFloat, T5LayerNormTestFw)
 
 TEST_P(T5LayerNormTestHalf, T5LayerNormTestFw)
 {
-    auto TypeArg = miopen::GetStringEnv(ENV(MIOPEN_TEST_FLOAT_ARG));
-    if(miopen::IsEnabled(ENV(MIOPEN_TEST_ALL)) && (GetFloatArg() == "--half"))
+    auto TypeArg = miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_TEST_FLOAT_ARG));
+    if(miopen::IsEnabled(MIOPEN_ENV(MIOPEN_TEST_ALL)) && (GetFloatArg() == "--half"))
     {
         RunTest();
         Verify();
@@ -99,8 +99,8 @@ TEST_P(T5LayerNormTestHalf, T5LayerNormTestFw)
 
 TEST_P(T5LayerNormTestBFloat16, T5LayerNormTestFw)
 {
-    auto TypeArg = miopen::GetStringEnv(ENV(MIOPEN_TEST_FLOAT_ARG));
-    if(miopen::IsEnabled(ENV(MIOPEN_TEST_ALL)) && (GetFloatArg() == "--bfloat16"))
+    auto TypeArg = miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_TEST_FLOAT_ARG));
+    if(miopen::IsEnabled(MIOPEN_ENV(MIOPEN_TEST_ALL)) && (GetFloatArg() == "--bfloat16"))
     {
         RunTest();
         Verify();
@@ -113,8 +113,8 @@ TEST_P(T5LayerNormTestBFloat16, T5LayerNormTestFw)
 
 TEST_P(T5LayerNormBwdTestFloat, T5LayerNormBwdTestFw)
 {
-    auto TypeArg = miopen::GetStringEnv(ENV(MIOPEN_TEST_FLOAT_ARG));
-    if(miopen::IsEnabled(ENV(MIOPEN_TEST_ALL)) && (GetFloatArg() == "--float"))
+    auto TypeArg = miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_TEST_FLOAT_ARG));
+    if(miopen::IsEnabled(MIOPEN_ENV(MIOPEN_TEST_ALL)) && (GetFloatArg() == "--float"))
     {
         RunTest();
         Verify();
@@ -127,8 +127,8 @@ TEST_P(T5LayerNormBwdTestFloat, T5LayerNormBwdTestFw)
 
 TEST_P(T5LayerNormBwdTestHalf, T5LayerNormBwdTestFw)
 {
-    auto TypeArg = miopen::GetStringEnv(ENV(MIOPEN_TEST_FLOAT_ARG));
-    if(miopen::IsEnabled(ENV(MIOPEN_TEST_ALL)) && (GetFloatArg() == "--half"))
+    auto TypeArg = miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_TEST_FLOAT_ARG));
+    if(miopen::IsEnabled(MIOPEN_ENV(MIOPEN_TEST_ALL)) && (GetFloatArg() == "--half"))
     {
         RunTest();
         Verify();
@@ -141,8 +141,8 @@ TEST_P(T5LayerNormBwdTestHalf, T5LayerNormBwdTestFw)
 
 TEST_P(T5LayerNormBwdTestBFloat16, T5LayerNormBwdTestFw)
 {
-    auto TypeArg = miopen::GetStringEnv(ENV(MIOPEN_TEST_FLOAT_ARG));
-    if(miopen::IsEnabled(ENV(MIOPEN_TEST_ALL)) && (GetFloatArg() == "--bfloat16"))
+    auto TypeArg = miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_TEST_FLOAT_ARG));
+    if(miopen::IsEnabled(MIOPEN_ENV(MIOPEN_TEST_ALL)) && (GetFloatArg() == "--bfloat16"))
     {
         RunTest();
         Verify();

--- a/test/test_env.hpp
+++ b/test/test_env.hpp
@@ -33,6 +33,6 @@ MIOPEN_DECLARE_ENV_VAR_STR(MIOPEN_TEST_FLOAT_ARG)
 inline bool IsTestRunWith(const char* float_arg)
 {
     assert(float_arg != nullptr);
-    const auto& s_envVar = miopen::GetStringEnv(ENV(MIOPEN_TEST_FLOAT_ARG));
+    const auto& s_envVar = miopen::GetStringEnv(MIOPEN_ENV(MIOPEN_TEST_FLOAT_ARG));
     return (s_envVar.compare(float_arg) == 0);
 }


### PR DESCRIPTION
update ck commit hash to pass [bwd weight half convolution bilinear tests](https://github.com/ROCm/MIOpen/pull/2863).

Had to rename [MIOpen's #define ENV ](https://github.com/ROCm/MIOpen/blob/develop/src/include/miopen/env.hpp#L156) to [#define MIOPEN_ENV](https://github.com/ROCm/MIOpen/blob/426d0a17627e7d6fba555a27be8ffe612c25c97e/src/include/miopen/env.hpp#L156) because it was having name collision with recent introduction of CK's macro with same name [#define ENV](https://github.com/ROCm/composable_kernel/blob/aab4439f0f5e8c2c94c440aa103cecd1b74e3133/include/ck/utility/env.hpp#L127) 