### PR TITLE
[HotFix] add two missing cases in #2869

### DIFF
--- a/src/solver/conv_asm_implicit_gemm_gtc_wrw_nhwc.cpp
+++ b/src/solver/conv_asm_implicit_gemm_gtc_wrw_nhwc.cpp
@@ -877,8 +877,12 @@ bool ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC::IsApplicable(
         const auto pad_h    = problem.GetPadH();
         const auto pad_w    = problem.GetPadW();
 
-        if(c == 1 && k == 1 && hi == 1 && wi == 1 && y == 3 && x == 3 && pad_h == 2 && pad_w == 2 &&
-           stride_h == 2 && stride_w == 2)
+        if((c == 1 && k == 1 && hi == 1 && wi == 1 && y == 3 && x == 3 && pad_h == 2 &&
+            pad_w == 2 && stride_h == 2 && stride_w == 2) ||
+           (c == 1 && k == 1 && hi == 1 && wi == 5 && y == 3 && x == 6 && pad_h == 2 &&
+            pad_w == 1 && stride_h == 2 && stride_w == 1) ||
+           (c == 1 && k == 1 && hi == 1 && wi == 1 && y == 2 && x == 3 && pad_h == 1 &&
+            pad_w == 2 && stride_h == 1 && stride_w == 2))
             return false;
     }
 #endif


### PR DESCRIPTION
With the fix in #2869, it still failed for the following configs in Tensorflow unit tests:
```
./bin/MIOpenDriver conv -n 1 -c 1 -H 1 -W 5 -k 1 -y 3 -x 6 -p 2 -q 1 -u 2 -v 1 -l 1 -j 1 -m conv -g 1 -F 4 -t 1

./bin/MIOpenDriver conv -n 1 -c 1 -H 1 -W 1 -k 1 -y 2 -x 3 -p 1 -q 2 -u 1 -v 2 -l 1 -j 1 -m conv -g 1 -F 4 -t 1
```
