### PR TITLE
Int64 type introduction and basic  support

### DIFF
--- a/include/miopen/miopen.h
+++ b/include/miopen/miopen.h
@@ -378,6 +378,7 @@ typedef enum
 // miopenReserved1 = 7,
 // miopenReserved2 = 8,
 #endif
+    miopenInt64 = 9,
 } miopenDataType_t;
 
 /*! @ingroup tensor

--- a/src/check_numerics.cpp
+++ b/src/check_numerics.cpp
@@ -62,6 +62,7 @@ std::string GetKernelName(miopenDataType_t data_type)
     case miopenBFloat16: return {"check_numerics_bf16"};
     case miopenFloat8: return {"check_numerics_fp8"};
     case miopenBFloat8: return {"check_numerics_bf8"};
+    case miopenInt64:
     case miopenInt32:
     case miopenInt8:
     case miopenDouble:

--- a/src/convolution_api.cpp
+++ b/src/convolution_api.cpp
@@ -218,7 +218,8 @@ miopenConvolutionCKBackwardWeightsGetWorkSpaceSize(const miopenAlphaBetaCase_t a
         case miopenInt8:
         case miopenFloat8:
         case miopenBFloat8: byte_size = 4; break;
-        case miopenDouble: byte_size = 8;
+        case miopenDouble:
+        case miopenInt64: byte_size = 8; break;
         }
         *buffer_size = byte_size * output_tensor_size;
     }

--- a/src/gemm_v2.cpp
+++ b/src/gemm_v2.cpp
@@ -644,6 +644,11 @@ miopenStatus_t CallGemm(const Handle& handle,
             MIOPEN_THROW(miopenStatusBadParm, "miopenDouble data type not supported by rocBLAS.");
         };
         break;
+
+        case miopenInt64: {
+            MIOPEN_THROW(miopenStatusBadParm, "miopenInt64 is not currently supported.");
+        }
+        break;
         }
 
         if(handle.IsProfilingEnabled())
@@ -918,6 +923,10 @@ miopenStatus_t CallGemmStridedBatched(const Handle& handle,
             MIOPEN_THROW(miopenStatusBadParm, "miopenDouble data type not supported by rocBLAS.");
         }
         break;
+        case miopenInt64: {
+            MIOPEN_THROW(miopenStatusBadParm, "miopenInt64 is not currently supported.");
+        }
+        break;
         }
 
         if(handle.IsProfilingEnabled())
@@ -1188,6 +1197,11 @@ miopenStatus_t CallGemmStridedBatchedSequential(const Handle& handle,
 
         case miopenDouble: {
             MIOPEN_THROW(miopenStatusBadParm, "miopenDouble data type not supported by rocBLAS.");
+        }
+        break;
+
+        case miopenInt64: {
+            MIOPEN_THROW(miopenStatusBadParm, "miopenInt64 is not currently supported.");
         }
         break;
         }

--- a/src/include/miopen/datatype.hpp
+++ b/src/include/miopen/datatype.hpp
@@ -73,6 +73,10 @@ inline std::string GetDataType(miopenDataType_t type)
         type_str = "bfloat8";
     }
     break;
+    case miopenInt64: {
+        type_str = "int64";
+    }
+    break;
     }
     return type_str;
 }

--- a/src/include/miopen/problem_description_base.hpp
+++ b/src/include/miopen/problem_description_base.hpp
@@ -45,6 +45,7 @@ inline std::string GetDataTypeName(miopenDataType_t data_type)
     case miopenDouble: return "FP64";
     case miopenFloat8: return "FP8";
     case miopenBFloat8: return "BF8";
+    case miopenInt64: return "INT64";
     }
 
     return "Unknown(" + std::to_string(data_type) + ")";

--- a/src/include/miopen/solver/implicitgemm_ck_util.hpp
+++ b/src/include/miopen/solver/implicitgemm_ck_util.hpp
@@ -887,6 +887,7 @@ MakeSolutionGroupConvImplicitGemmXdlops(const miopen::conv::ProblemDescription& 
         case miopenHalf: return invoker_factory_maker_ncdhw(ck::half_t{});
         case miopenFloat: return invoker_factory_maker_ncdhw(float{});
         case miopenBFloat16: return invoker_factory_maker_ncdhw(ck::bhalf_t{});
+        case miopenInt64:
         case miopenInt32:
         case miopenDouble:
         case miopenFloat8:
@@ -905,6 +906,7 @@ MakeSolutionGroupConvImplicitGemmXdlops(const miopen::conv::ProblemDescription& 
         case miopenHalf: return invoker_factory_maker_ndhwc(ck::half_t{});
         case miopenFloat: return invoker_factory_maker_ndhwc(float{});
         case miopenBFloat16: return invoker_factory_maker_ndhwc(ck::bhalf_t{});
+        case miopenInt64:
         case miopenInt32:
         case miopenDouble:
         case miopenFloat8:

--- a/src/include/miopen/tensor.hpp
+++ b/src/include/miopen/tensor.hpp
@@ -105,6 +105,7 @@ inline std::size_t GetTypeSize(miopenDataType_t d)
     case miopenFloat8:
     case miopenBFloat8: return 1;
     case miopenDouble: return 8;
+    case miopenInt64: return 8;
     }
     MIOPEN_THROW("Unknown or unsupported data type");
 }

--- a/src/include/miopen/tensor.hpp
+++ b/src/include/miopen/tensor.hpp
@@ -104,7 +104,7 @@ inline std::size_t GetTypeSize(miopenDataType_t d)
     case miopenInt8:
     case miopenFloat8:
     case miopenBFloat8: return 1;
-    case miopenDouble: return 8;
+    case miopenDouble:
     case miopenInt64: return 8;
     }
     MIOPEN_THROW("Unknown or unsupported data type");

--- a/src/include/miopen/visit_float.hpp
+++ b/src/include/miopen/visit_float.hpp
@@ -87,6 +87,10 @@ void visit_float(miopenDataType_t t, F f)
         f(as_float<double>{});
         break;
     }
+    case miopenInt64: {
+        f(as_float<int64_t>{});
+        break;
+    }
     }
 }
 

--- a/src/ocl/tensorocl.cpp
+++ b/src/ocl/tensorocl.cpp
@@ -1941,6 +1941,8 @@ std::string GetCastTensorBuildOptionFromType(const std::string& buildOption, mio
     case miopenDouble:
         // TODO
         MIOPEN_THROW(miopenStatusBadParm, "miopenDouble data type not supported in cast tensor.");
+    case miopenInt64:
+        MIOPEN_THROW(miopenStatusBadParm, "miopenInt64 data type not supported in cast tensor.");
     default: MIOPEN_THROW(miopenStatusBadParm, "Invalid data type in cast tensor desc.");
     }
 }

--- a/src/pooling_api.cpp
+++ b/src/pooling_api.cpp
@@ -48,6 +48,7 @@ inline void Pooling_logging_cmd(const miopenPoolingDescriptor_t poolDesc,
         {
         case miopenHalf: ss << "poolfp16"; break;
         case miopenFloat: ss << "pool"; break;
+        case miopenInt64:
         case miopenInt32:
         case miopenInt8:
         case miopenBFloat16:

--- a/src/reducetensor.cpp
+++ b/src/reducetensor.cpp
@@ -236,6 +236,7 @@ inline int GetDataTypeSize(miopenDataType_t t)
     case miopenInt8: return (1);
     case miopenBFloat16: return (2);
     case miopenInt32: return (4);
+    case miopenInt64:
     default: MIOPEN_THROW("Only float, half, double, bfloat16, int8 data types are supported.");
     };
 };
@@ -293,6 +294,7 @@ inline int GetDataTypeId(miopenDataType_t t)
     case miopenFloat8:
     case miopenBFloat8:
     case miopenInt32: return (static_cast<int>('O'));
+    case miopenInt64:
     default: MIOPEN_THROW("Only float, half, bfloat16, float8, bfloat8 data type is supported.");
     };
 };
@@ -332,6 +334,7 @@ static ck::DataTypeEnum_t mapDataTypeId(miopenDataType_t t)
     case miopenInt32: return DataTypeEnum_t::Int32;
     case miopenFloat8:
     case miopenBFloat8:
+    case miopenInt64:
     default: MIOPEN_THROW("Only float, half, double data type is supported.");
     };
 };

--- a/src/reducetensor_api.cpp
+++ b/src/reducetensor_api.cpp
@@ -50,6 +50,7 @@ static void LogCmdRedux(const miopen::ReduceTensorDescriptor reduceTensorDesc,
         case miopenDouble: ss << "reducefp64"; break;
         case miopenFloat8: ss << "reducefp8"; break;
         case miopenBFloat8: ss << "reducebfp8"; break;
+        case miopenInt64:
         default: ss << "reduce";
         }
 

--- a/src/solver/batchnorm/backward_ck.cpp
+++ b/src/solver/batchnorm/backward_ck.cpp
@@ -207,6 +207,7 @@ bool BnCKBwdBackward::IsApplicable(
     case miopenHalf: return CheckCKApplicability<F16, F32, F32, F32, F16, F32, F32>(bn_problem);
     case miopenBFloat16:
         return CheckCKApplicability<BF16, F32, F32, F32, BF16, F32, F32>(bn_problem);
+    case miopenInt64:
     case miopenInt32:
     case miopenInt8:
     case miopenBFloat8:
@@ -231,6 +232,7 @@ ConvSolution BnCKBwdBackward::GetSolution(
         return MakeAnyInvokerFactory<BF16, F32, F32, F32, BF16, F32, F32>(bn_problem);
     case miopenInt8:
     case miopenInt32:
+    case miopenInt64:
     case miopenBFloat8:
     case miopenFloat8:
     default:

--- a/src/solver/batchnorm/forward_inference_ck.cpp
+++ b/src/solver/batchnorm/forward_inference_ck.cpp
@@ -195,6 +195,7 @@ bool BnCKFwdInference::IsApplicable(
         return (CheckCKApplicability<F64, F64, F64, F64, F64, F64>(bn_problem) != -1);
     case miopenBFloat16:
         return (CheckCKApplicability<BF16, BF16, F32, BF16, BF16, F32>(bn_problem) != -1);
+    case miopenInt64:
     case miopenInt32:
     case miopenInt8:
     case miopenFloat8:
@@ -233,6 +234,7 @@ ConvSolution BnCKFwdInference::GetSolution(
                 break;
             case miopenInt8:
             case miopenInt32:
+            case miopenInt64:
             case miopenFloat8:
             case miopenBFloat8:
             default: MIOPEN_THROW("Unsupported datatype");

--- a/src/solver/batchnorm/forward_training_ck.cpp
+++ b/src/solver/batchnorm/forward_training_ck.cpp
@@ -196,6 +196,7 @@ bool BnCKFwdTraining::IsApplicable(
     case miopenFloat: return CheckCKApplicability<F32, F32, F32, F32, F32, F32>(bn_problem);
     case miopenDouble: return CheckCKApplicability<F64, F64, F64, F64, F64, F64>(bn_problem);
     case miopenBFloat16: return CheckCKApplicability<BF16, BF16, F32, BF16, BF16, F32>(bn_problem);
+    case miopenInt64:
     case miopenInt32:
     case miopenInt8:
     case miopenBFloat8:
@@ -219,6 +220,7 @@ ConvSolution BnCKFwdTraining::GetSolution(
     case miopenBFloat16: return MakeAnyInvokerFactory<BF16, BF16, F32, BF16, BF16, F32>(bn_problem);
     case miopenInt8:
     case miopenInt32:
+    case miopenInt64:
     case miopenBFloat8:
     case miopenFloat8:
     default:

--- a/src/solver/conv_ck_igemm_fwd_bias_activ_fused.cpp
+++ b/src/solver/conv_ck_igemm_fwd_bias_activ_fused.cpp
@@ -298,6 +298,7 @@ void PerformanceConfigConvCKIgemmFwdBiasActivFused::HeuristicInit(
     case miopenInt8:
     case miopenFloat:
     case miopenInt32:
+    case miopenInt64:
     case miopenBFloat16:
     case miopenDouble:
     default: MIOPEN_THROW("Unsupported datatype");
@@ -352,6 +353,7 @@ bool PerformanceConfigConvCKIgemmFwdBiasActivFused::IsValid(
     case miopenInt8:
     case miopenFloat:
     case miopenInt32:
+    case miopenInt64:
     case miopenBFloat16:
     case miopenDouble:
     default: MIOPEN_THROW("Unsupported datatype");
@@ -447,6 +449,7 @@ bool ConvCKIgemmFwdBiasActivFused::IsApplicable(const FusionContext& ctx,
     case miopenInt8:
     case miopenFloat:
     case miopenInt32:
+    case miopenInt64:
     case miopenBFloat16:
     case miopenDouble:
     default: MIOPEN_THROW("Unsupported datatype");
@@ -480,6 +483,7 @@ ConvSolution ConvCKIgemmFwdBiasActivFused::GetSolution(
             case miopenInt8:
             case miopenFloat:
             case miopenInt32:
+            case miopenInt64:
             case miopenBFloat16:
             case miopenDouble:
             default: MIOPEN_THROW("Unsupported datatype");

--- a/src/solver/conv_ck_igemm_fwd_bias_res_add_activ_fused.cpp
+++ b/src/solver/conv_ck_igemm_fwd_bias_res_add_activ_fused.cpp
@@ -283,6 +283,7 @@ void PerfConfigConvCKIgemmFwdBiasResAddActivFused::HeuristicInit(
     case miopenFloat8:
     case miopenBFloat8:
     case miopenInt32:
+    case miopenInt64:
     case miopenDouble:
     default: MIOPEN_THROW("Unsupported datatype");
     }
@@ -337,6 +338,7 @@ bool PerfConfigConvCKIgemmFwdBiasResAddActivFused::IsValid(
     case miopenFloat8:
     case miopenBFloat8:
     case miopenInt32:
+    case miopenInt64:
     case miopenDouble:
     default: MIOPEN_THROW("Unsupported datatype");
     }
@@ -432,6 +434,7 @@ bool ConvCKIgemmFwdBiasResAddActivFused::IsApplicable(const FusionContext& ctx,
     case miopenFloat8:
     case miopenBFloat8:
     case miopenInt32:
+    case miopenInt64:
     case miopenDouble:
     default: MIOPEN_THROW("Unsupported datatype");
     }
@@ -468,6 +471,7 @@ ConvSolution ConvCKIgemmFwdBiasResAddActivFused::GetSolution(
             conv_problem, config.kernel_id);
 
     case miopenInt32:
+    case miopenInt64:
     case miopenDouble:
     case miopenFloat8:
     case miopenBFloat8:

--- a/src/solver/conv_hip_implicit_gemm_3d_grouped_bwd_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_3d_grouped_bwd_xdlops.cpp
@@ -401,6 +401,7 @@ void PerformanceConfigHipImplicitGemm3DGroupBwdXdlops::HeuristicInit(
     case miopenFloat: Init<float>(problem); break;
     case miopenInt8: Init<int8_t>(problem); break;
     case miopenBFloat16: Init<ck::bhalf_t>(problem); break;
+    case miopenInt64:
     case miopenInt32:
     case miopenFloat8:
     case miopenBFloat8:
@@ -443,6 +444,7 @@ bool PerformanceConfigHipImplicitGemm3DGroupBwdXdlops::IsValid(
     case miopenFloat: return CheckIsSupportCKArgs<float>(problem);
     case miopenInt8: return CheckIsSupportCKArgs<int8_t>(problem);
     case miopenBFloat16: return CheckIsSupportCKArgs<ck::bhalf_t>(problem);
+    case miopenInt64:
     case miopenInt32:
     case miopenFloat8:
     case miopenBFloat8:
@@ -522,6 +524,7 @@ bool ConvHipImplicitGemm3DGroupBwdXdlops::IsApplicable(
     case miopenFloat: return CheckCKApplicability<float>(problem);
     case miopenInt8: return CheckCKApplicability<int8_t>(problem);
     case miopenBFloat16: return CheckCKApplicability<ck::bhalf_t>(problem);
+    case miopenInt64:
     case miopenInt32:
     case miopenFloat8:
     case miopenBFloat8:

--- a/src/solver/conv_hip_implicit_gemm_3d_grouped_fwd_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_3d_grouped_fwd_xdlops.cpp
@@ -397,6 +397,7 @@ void PerformanceConfigHipImplicitGemm3DGroupFwdXdlops::HeuristicInit(
     case miopenFloat: Init<float>(problem); break;
     case miopenInt8: Init<int8_t>(problem); break;
     case miopenBFloat16: Init<ck::bhalf_t>(problem); break;
+    case miopenInt64:
     case miopenInt32:
     case miopenFloat8:
     case miopenBFloat8:
@@ -439,6 +440,7 @@ bool PerformanceConfigHipImplicitGemm3DGroupFwdXdlops::IsValid(
     case miopenFloat: return CheckIsSupportCKArgs<float>(problem);
     case miopenInt8: return CheckIsSupportCKArgs<int8_t>(problem);
     case miopenBFloat16: return CheckIsSupportCKArgs<ck::bhalf_t>(problem);
+    case miopenInt64:
     case miopenInt32:
     case miopenFloat8:
     case miopenBFloat8:
@@ -517,6 +519,7 @@ bool ConvHipImplicitGemm3DGroupFwdXdlops::IsApplicable(
     case miopenFloat: return CheckCKApplicability<float>(problem);
     case miopenInt8: return CheckCKApplicability<int8_t>(problem);
     case miopenBFloat16: return CheckCKApplicability<ck::bhalf_t>(problem);
+    case miopenInt64:
     case miopenInt32:
     case miopenFloat8:
     case miopenBFloat8:

--- a/src/solver/conv_hip_implicit_gemm_3d_grouped_wrw_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_3d_grouped_wrw_xdlops.cpp
@@ -399,6 +399,7 @@ void PerformanceConfigHipImplicitGemm3DGroupWrwXdlops::HeuristicInit(
     case miopenFloat: Init<float>(problem); break;
     case miopenInt8: Init<int8_t>(problem); break;
     case miopenBFloat16: Init<ck::bhalf_t>(problem); break;
+    case miopenInt64:
     case miopenInt32:
     case miopenFloat8:
     case miopenBFloat8:
@@ -441,6 +442,7 @@ bool PerformanceConfigHipImplicitGemm3DGroupWrwXdlops::IsValid(
     case miopenFloat: return CheckIsSupportCKArgs<float>(problem);
     case miopenInt8: return CheckIsSupportCKArgs<int8_t>(problem);
     case miopenBFloat16: return CheckIsSupportCKArgs<ck::bhalf_t>(problem);
+    case miopenInt64:
     case miopenInt32:
     case miopenFloat8:
     case miopenBFloat8:
@@ -518,6 +520,7 @@ bool ConvHipImplicitGemm3DGroupWrwXdlops::IsApplicable(
     case miopenFloat: return CheckCKApplicability<float>(problem);
     case miopenInt8: return CheckCKApplicability<int8_t>(problem);
     case miopenBFloat16: return CheckCKApplicability<ck::bhalf_t>(problem);
+    case miopenInt64:
     case miopenInt32:
     case miopenFloat8:
     case miopenBFloat8:

--- a/src/solver/conv_hip_implicit_gemm_bwd_data_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_bwd_data_xdlops.cpp
@@ -175,6 +175,7 @@ void PerformanceConfigHipImplicitGemmBwdXdlops::HeuristicInit(
     case miopenBFloat8:
     case miopenInt8:
     case miopenInt32:
+    case miopenInt64:
     case miopenBFloat16:
     case miopenDouble: break;
     }
@@ -216,6 +217,7 @@ bool PerformanceConfigHipImplicitGemmBwdXdlops::IsValid(
     case miopenBFloat8:
     case miopenInt8:
     case miopenInt32:
+    case miopenInt64:
     case miopenBFloat16:
     case miopenDouble: break;
     }
@@ -296,6 +298,7 @@ bool ConvHipImplicitGemmBwdXdlops::IsApplicable(
     case miopenBFloat8:
     case miopenInt8:
     case miopenInt32:
+    case miopenInt64:
     case miopenBFloat16:
     case miopenDouble: break;
     }
@@ -323,6 +326,7 @@ ConvSolution ConvHipImplicitGemmBwdXdlops::GetSolution(
             ctx, problem, config.kernel_id);
     case miopenInt8:
     case miopenInt32:
+    case miopenInt64:
     case miopenBFloat16:
     case miopenDouble:
     case miopenFloat8:

--- a/src/solver/conv_hip_implicit_gemm_fwd_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_fwd_xdlops.cpp
@@ -174,6 +174,7 @@ void PerformanceConfigHipImplicitGemmFwdXdlops::HeuristicInit(
     case miopenFloat: Init<float>(problem); break;
     case miopenFloat8:
     case miopenBFloat8:
+    case miopenInt64:
     case miopenInt32:
     case miopenBFloat16:
     case miopenDouble: break;
@@ -216,6 +217,7 @@ bool PerformanceConfigHipImplicitGemmFwdXdlops::IsValid(
     case miopenFloat: return CheckIsSupportCKArgs<float>(problem);
     case miopenFloat8:
     case miopenBFloat8:
+    case miopenInt64:
     case miopenInt32:
     case miopenBFloat16:
     case miopenDouble: break;
@@ -296,6 +298,7 @@ bool ConvHipImplicitGemmFwdXdlops::IsApplicable(
     case miopenFloat: return CheckCKApplicability<float>(problem);
     case miopenFloat8:
     case miopenBFloat8:
+    case miopenInt64:
     case miopenInt32:
     case miopenBFloat16:
     case miopenDouble: break;
@@ -323,6 +326,7 @@ ConvSolution ConvHipImplicitGemmFwdXdlops::GetSolution(
     case miopenFloat:
         return InitInvokerFactoryNHWC<DeviceOpPtrs<float>, CKArgs, miopen::conv::DataInvokeParams>(
             ctx, problem, config.kernel_id);
+    case miopenInt64:
     case miopenInt32:
     case miopenBFloat16:
     case miopenDouble:

--- a/src/solver/conv_hip_implicit_gemm_grouped_bwd_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_grouped_bwd_xdlops.cpp
@@ -356,6 +356,7 @@ void PerformanceConfigHipImplicitGemmGroupBwdXdlops::HeuristicInit(
     case miopenFloat: Init<float>(problem); break;
     case miopenInt8: Init<int8_t>(problem); break;
     case miopenBFloat16: Init<ck::bhalf_t>(problem); break;
+    case miopenInt64:
     case miopenInt32:
     case miopenFloat8:
     case miopenBFloat8:
@@ -375,6 +376,7 @@ bool PerformanceConfigHipImplicitGemmGroupBwdXdlops::SetNextValue(const ProblemD
         case miopenFloat: Init<float>(problem); break;
         case miopenInt8: Init<int8_t>(problem); break;
         case miopenBFloat16: Init<ck::bhalf_t>(problem); break;
+        case miopenInt64:
         case miopenInt32:
         case miopenFloat8:
         case miopenBFloat8:
@@ -409,6 +411,7 @@ bool PerformanceConfigHipImplicitGemmGroupBwdXdlops::IsValid(
     case miopenFloat: return CheckIsSupportCKArgs<float>(problem);
     case miopenInt8: return CheckIsSupportCKArgs<int8_t>(problem);
     case miopenBFloat16: return CheckIsSupportCKArgs<ck::bhalf_t>(problem);
+    case miopenInt64:
     case miopenInt32:
     case miopenFloat8:
     case miopenBFloat8:
@@ -487,6 +490,7 @@ bool ConvHipImplicitGemmGroupBwdXdlops::IsApplicable(
     case miopenFloat: return CheckCKApplicability<float>(problem);
     case miopenInt8: return CheckCKApplicability<int8_t>(problem);
     case miopenBFloat16: return CheckCKApplicability<ck::bhalf_t>(problem);
+    case miopenInt64:
     case miopenInt32:
     case miopenFloat8:
     case miopenBFloat8:

--- a/src/solver/conv_hip_implicit_gemm_grouped_fwd_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_grouped_fwd_xdlops.cpp
@@ -368,6 +368,7 @@ void PerformanceConfigHipImplicitGemmGroupFwdXdlops::HeuristicInit(
     case miopenFloat: Init<float>(problem); break;
     case miopenInt8: Init<int8_t>(problem); break;
     case miopenBFloat16: Init<ck::bhalf_t>(problem); break;
+    case miopenInt64:
     case miopenInt32:
     case miopenFloat8:
     case miopenBFloat8:
@@ -387,6 +388,7 @@ bool PerformanceConfigHipImplicitGemmGroupFwdXdlops::SetNextValue(const ProblemD
         case miopenFloat: Init<float>(problem); break;
         case miopenInt8: Init<int8_t>(problem); break;
         case miopenBFloat16: Init<ck::bhalf_t>(problem); break;
+        case miopenInt64:
         case miopenInt32:
         case miopenFloat8:
         case miopenBFloat8:
@@ -421,6 +423,7 @@ bool PerformanceConfigHipImplicitGemmGroupFwdXdlops::IsValid(
     case miopenFloat: return CheckIsSupportCKArgs<float>(problem);
     case miopenInt8: return CheckIsSupportCKArgs<int8_t>(problem);
     case miopenBFloat16: return CheckIsSupportCKArgs<ck::bhalf_t>(problem);
+    case miopenInt64:
     case miopenInt32:
     case miopenFloat8:
     case miopenBFloat8:
@@ -501,6 +504,7 @@ bool ConvHipImplicitGemmGroupFwdXdlops::IsApplicable(
     case miopenFloat: return CheckCKApplicability<float>(problem);
     case miopenInt8: return CheckCKApplicability<int8_t>(problem);
     case miopenBFloat16: return CheckCKApplicability<ck::bhalf_t>(problem);
+    case miopenInt64:
     case miopenInt32:
     case miopenFloat8:
     case miopenBFloat8:

--- a/src/solver/conv_hip_implicit_gemm_grouped_wrw_xdlops.cpp
+++ b/src/solver/conv_hip_implicit_gemm_grouped_wrw_xdlops.cpp
@@ -352,6 +352,7 @@ void PerformanceConfigHipImplicitGemmGroupWrwXdlops::HeuristicInit(
     case miopenFloat: Init<float>(problem); break;
     case miopenInt8: Init<int8_t>(problem); break;
     case miopenBFloat16: Init<ck::bhalf_t>(problem); break;
+    case miopenInt64:
     case miopenInt32:
     case miopenFloat8:
     case miopenBFloat8:
@@ -371,6 +372,7 @@ bool PerformanceConfigHipImplicitGemmGroupWrwXdlops::SetNextValue(const ProblemD
         case miopenFloat: Init<float>(problem); break;
         case miopenInt8: Init<int8_t>(problem); break;
         case miopenBFloat16: Init<ck::bhalf_t>(problem); break;
+        case miopenInt64:
         case miopenInt32:
         case miopenFloat8:
         case miopenBFloat8:
@@ -405,6 +407,7 @@ bool PerformanceConfigHipImplicitGemmGroupWrwXdlops::IsValid(
     case miopenFloat: return CheckIsSupportCKArgs<float>(problem);
     case miopenInt8: return CheckIsSupportCKArgs<int8_t>(problem);
     case miopenBFloat16: return CheckIsSupportCKArgs<ck::bhalf_t>(problem);
+    case miopenInt64:
     case miopenInt32:
     case miopenFloat8:
     case miopenBFloat8:
@@ -481,6 +484,7 @@ bool ConvHipImplicitGemmGroupWrwXdlops::IsApplicable(
     case miopenFloat: return CheckCKApplicability<float>(problem);
     case miopenInt8: return CheckCKApplicability<int8_t>(problem);
     case miopenBFloat16: return CheckCKApplicability<ck::bhalf_t>(problem);
+    case miopenInt64:
     case miopenInt32:
     case miopenFloat8:
     case miopenBFloat8:

--- a/src/solver/layernorm/forward_layernorm2d_ck.cpp
+++ b/src/solver/layernorm/forward_layernorm2d_ck.cpp
@@ -236,6 +236,7 @@ bool Layernorm2DCKForward::IsApplicable(
         return CheckCKApplicability<DeviceOpLnFwdPtrs<F32, F32, F32, F32, F32>>(problem);
     case miopenBFloat16:
     case miopenDouble:
+    case miopenInt64:
     case miopenInt32:
     case miopenInt8:
     case miopenFloat8:
@@ -264,6 +265,7 @@ ConvSolution Layernorm2DCKForward::GetSolution(
     case miopenBFloat16:
     case miopenInt8:
     case miopenInt32:
+    case miopenInt64:
     case miopenFloat8:
     case miopenBFloat8:
     default:

--- a/src/solver/layernorm/forward_layernorm4d_ck.cpp
+++ b/src/solver/layernorm/forward_layernorm4d_ck.cpp
@@ -244,6 +244,7 @@ bool Layernorm4DCKForward::IsApplicable(
         return CheckCKApplicability<DeviceOpLnFwdPtrs<F32, F32, F32, F32, F32>>(problem);
     case miopenBFloat16:
     case miopenDouble:
+    case miopenInt64:
     case miopenInt32:
     case miopenInt8:
     case miopenFloat8:
@@ -272,6 +273,7 @@ ConvSolution Layernorm4DCKForward::GetSolution(
     case miopenBFloat16:
     case miopenInt8:
     case miopenInt32:
+    case miopenInt64:
     case miopenFloat8:
     case miopenBFloat8:
     default:

--- a/src/solver/mlir_common.cpp
+++ b/src/solver/mlir_common.cpp
@@ -58,6 +58,7 @@ static const char* DTypeName(miopenDataType_t ty)
     case miopenInt8: return "i8";
     case miopenFloat8: return "fp8";
     case miopenBFloat8: return "bfp8";
+    case miopenInt64: return "i64";
     }
     MIOPEN_THROW(miopenStatusInternalError, "Value outside of datatype enum");
 }

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -52,6 +52,7 @@ bool IsDataTypeSupported(miopenDataType_t t)
     case miopenInt8:
     case miopenBFloat16:
     case miopenDouble: return true;
+    case miopenInt64: return false;
     }
     return false;
 }

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -51,8 +51,8 @@ bool IsDataTypeSupported(miopenDataType_t t)
     case miopenBFloat8:
     case miopenInt8:
     case miopenBFloat16:
-    case miopenDouble: return true;
-    case miopenInt64: return false;
+    case miopenDouble:
+    case miopenInt64: return true;
     }
     return false;
 }

--- a/test/driver.hpp
+++ b/test/driver.hpp
@@ -272,6 +272,7 @@ struct test_driver
         case miopenBFloat16: ss << "--bfloat16 "; break;
         case miopenInt8: ss << "--int8 "; break;
         case miopenInt32: ss << "--int32 "; break;
+        case miopenInt64: ss << "--int64 "; break;
         case miopenFloat: ss << "--float "; break;
         case miopenDouble: ss << "--double "; break;
         case miopenFloat8: ss << "--float8"; break;
@@ -300,6 +301,7 @@ struct test_driver
         case miopenBFloat16: ret.emplace_back("--bf16"); break;
         case miopenInt8: ret.emplace_back("--int8"); break;
         case miopenInt32: ret.emplace_back("--int32"); break;
+        case miopenInt64: ret.emplace_back("--int64"); break;
         case miopenFloat: ret.emplace_back("--float"); break;
         case miopenDouble: ret.emplace_back("--double"); break;
         case miopenFloat8: ret.emplace_back("--float8"); break;

--- a/test/gtest/conv3d_codecov.cpp
+++ b/test/gtest/conv3d_codecov.cpp
@@ -75,6 +75,7 @@ void Run3dDriver(miopenDataType_t prec)
     case miopenFloat8:
     case miopenBFloat8:
     case miopenInt32:
+    case miopenInt64:
     case miopenDouble:
         FAIL() << "miopenInt32, miopenDouble, miopenFloat8, miopenBFloat8 "
                   "data type not supported by "

--- a/test/gtest/conv3d_test.cpp
+++ b/test/gtest/conv3d_test.cpp
@@ -67,6 +67,7 @@ void Run3dDriver(miopenDataType_t prec)
     case miopenHalf:
     case miopenBFloat16:
     case miopenInt32:
+    case miopenInt64:
     case miopenDouble:
         FAIL() << "miopenHalf, miopenBFloat16, miopenInt8, miopenInt32, "
                   "miopenDouble data "

--- a/test/gtest/conv_embed_db.cpp
+++ b/test/gtest/conv_embed_db.cpp
@@ -68,6 +68,7 @@ void Run2dDriver(miopenDataType_t prec)
     case miopenHalf: params = ConvEmbedConfigHalf::GetParam(); break;
     case miopenInt8: params = ConvEmbedConfigInt8::GetParam(); break;
     case miopenBFloat16: params = ConvEmbedConfigBFloat16::GetParam(); break;
+    case miopenInt64:
     case miopenInt32:
     case miopenFloat8:
     case miopenBFloat8:

--- a/test/gtest/conv_for_implicit_gemm.cpp
+++ b/test/gtest/conv_for_implicit_gemm.cpp
@@ -94,6 +94,7 @@ void Run2dDriver(miopenDataType_t prec)
     case miopenFloat:
     case miopenInt8:
     case miopenInt32:
+    case miopenInt64:
     case miopenDouble:
     case miopenFloat8:
     case miopenBFloat8:
@@ -284,9 +285,9 @@ TEST_P(ConfigWithHalf, Test_conv_for_implicit_gemm_half)
 };
 
 INSTANTIATE_TEST_SUITE_P(ConvIgemm,
-                             ConfigWithBF16, 
+                             ConfigWithBF16,
                              testing::Values(GetTestCases("--bf16")));
 
 INSTANTIATE_TEST_SUITE_P(ConvIgemm,
-                             ConfigWithHalf, 
+                             ConfigWithHalf,
                              testing::Values(GetTestCases("--half")));

--- a/test/gtest/conv_hip_igemm_xdlops.cpp
+++ b/test/gtest/conv_hip_igemm_xdlops.cpp
@@ -64,6 +64,7 @@ void Run2dDriver(miopenDataType_t prec)
     case miopenBFloat16:
     case miopenFloat:
     case miopenInt32:
+    case miopenInt64:
     case miopenDouble:
         FAIL() << "miopenHalf, miopenBFloat16, miopenFloat, miopenInt32, "
                   "miopenDouble data "

--- a/test/gtest/conv_igemm_dynamic_xdlops_half.cpp
+++ b/test/gtest/conv_igemm_dynamic_xdlops_half.cpp
@@ -80,6 +80,7 @@ void Run2dDriver(miopenDataType_t prec)
     case miopenInt8:
     case miopenBFloat16:
     case miopenInt32:
+    case miopenInt64:
     case miopenDouble:
     case miopenFloat8:
     case miopenBFloat8:

--- a/test/gtest/conv_igemm_dynamic_xdlops_nhwc_bf16.cpp
+++ b/test/gtest/conv_igemm_dynamic_xdlops_nhwc_bf16.cpp
@@ -80,6 +80,7 @@ void Run2dDriver(miopenDataType_t prec)
     case miopenHalf:
     case miopenInt8:
     case miopenInt32:
+    case miopenInt64:
     case miopenDouble:
     case miopenFloat8:
     case miopenBFloat8:
@@ -156,7 +157,7 @@ std::vector<std::string> GetTestCases(const std::string& precision)
     {flags + " --input  64   3 78 78 --weights  64   3 7 7 --pads_strides_dilations 0 0 2 2 1 1" + args_nhwc_fwd},
     {flags + " --input  16 192 17 17 --weights 224 192 1 7 --pads_strides_dilations 0 3 1 1 1 1" + args_nhwc_fwd},
     {flags + " --input  16   3 17 17 --weights  64   3 1 1 --pads_strides_dilations 0 0 1 1 1 1" + args_nhwc_fwd},
-    
+
     //nhwc_bwd
     {flags + " --input  64 256  7  7 --weights 128 256 1 1 --pads_strides_dilations 0 0 1 1 1 1" + args_nhwc_bwd},
     {flags + " --input  32 160 73 73 --weights  64 160 1 1 --pads_strides_dilations 0 0 1 1 1 1" + args_nhwc_bwd},
@@ -174,7 +175,7 @@ std::vector<std::string> GetTestCases(const std::string& precision)
     {flags + " --input  16  16 25 25 --weights  64  16 3 3 --pads_strides_dilations 0 0 1 1 1 1" + args_nhwc_bwd},
     {flags + " --input  15 256 1  1  --weights 340 256 3 3 --pads_strides_dilations 1 1 1 1 1 1" + args_nhwc_bwd},
     {flags + " --input  15 128 10 10 --weights 340 128 3 3 --pads_strides_dilations 1 1 1 1 1 1" + args_nhwc_bwd},
-    
+
     //nhwc_wrw
     {flags + " --input  64 256  7  7 --weights 128 256 1 1 --pads_strides_dilations 0 0 1 1 1 1 " + args_nhwc_wrw},
     {flags + " --input  32 160 73 73 --weights  64 160 1 1 --pads_strides_dilations 0 0 1 1 1 1 " + args_nhwc_wrw},

--- a/test/gtest/conv_igemm_dynamic_xdlops_nhwc_nchw.cpp
+++ b/test/gtest/conv_igemm_dynamic_xdlops_nhwc_nchw.cpp
@@ -86,6 +86,7 @@ void Run2dDriver(miopenDataType_t prec)
     case miopenInt8:
     case miopenBFloat16:
     case miopenInt32:
+    case miopenInt64:
     case miopenDouble:
     case miopenFloat8:
     case miopenBFloat8:
@@ -163,7 +164,7 @@ std::vector<std::string> GetTestCases(const std::string& precision)
     {flags + "  --input 2048  1 512 1024 --weights 1  1 1 1 --pads_strides_dilations 0 0 1 1 1 1" + dis_bk_data + dis_bk_wei + in_nhwc + fil_nhwc + out_nhwc},
     // ho=wo=1 stride=2
     {flags + "  --input  256 2048 2 2 --weights 1024  2048  1 1 --pads_strides_dilations 0 0 2 2 1 1" + dis_bk_data + dis_bk_wei + in_nhwc + fil_nhwc + out_nhwc},
-    
+
     //nhwc_fwd_nchw
     {flags + "  --input  64 256   7   7 --weights 128 256 1 1 --pads_strides_dilations 0 0 1 1 1 1" + dis_bk_data + dis_bk_wei},
     {flags + "  --input  32 160  73  73 --weights  64 160 1 1 --pads_strides_dilations 0 0 1 1 1 1" + dis_bk_data + dis_bk_wei},

--- a/test/gtest/conv_trans.cpp
+++ b/test/gtest/conv_trans.cpp
@@ -60,6 +60,7 @@ void Run2dDriver(miopenDataType_t prec)
     case miopenInt8:
     case miopenBFloat16:
     case miopenInt32:
+    case miopenInt64:
     case miopenDouble:
         FAIL() << "miopenHalf, miopenInt8, miopenBFloat16, miopenInt32, miopenDouble "
                   "data type not supported by "

--- a/test/gtest/immed_conv2d_codecov.cpp
+++ b/test/gtest/immed_conv2d_codecov.cpp
@@ -76,6 +76,7 @@ void Run2dDriver(miopenDataType_t prec)
     case miopenFloat8:
     case miopenBFloat8:
     case miopenInt32:
+    case miopenInt64:
     case miopenDouble:
         FAIL() << "miopenInt32, miopenDouble, miopenFloat8, miopenBFloat8 "
                   "data type not supported by "

--- a/test/gtest/immed_conv3d_codecov.cpp
+++ b/test/gtest/immed_conv3d_codecov.cpp
@@ -75,6 +75,7 @@ void Run3dDriver(miopenDataType_t prec)
     case miopenFloat8:
     case miopenBFloat8:
     case miopenInt32:
+    case miopenInt64:
     case miopenDouble:
         FAIL() << "miopenInt32, miopenDouble, miopenFloat8, miopenBFloat8 "
                   "data type not supported by "

--- a/test/gtest/miopen_conv.cpp
+++ b/test/gtest/miopen_conv.cpp
@@ -60,6 +60,7 @@ void Run2dDriver(miopenDataType_t prec)
     case miopenHalf:
     case miopenBFloat16:
     case miopenInt32:
+    case miopenInt64:
     case miopenDouble:
         FAIL() << "miopenInt8, miopenBFloat8, miopenFloat8, miopenHalf, miopenBFloat16, "
                   "miopenInt32, "

--- a/test/gtest/pooling2d_asymmetric.cpp
+++ b/test/gtest/pooling2d_asymmetric.cpp
@@ -68,6 +68,7 @@ void Run2dDriver(miopenDataType_t prec)
     case miopenFloat8:
     case miopenBFloat8:
     case miopenInt32:
+    case miopenInt64:
     case miopenDouble:
         FAIL()
             << "miopenBFloat16, miopenInt8, miopenInt32, miopenDouble, miopenFloat8, miopenBFloat8 "

--- a/test/gtest/pooling2d_codecov.cpp
+++ b/test/gtest/pooling2d_codecov.cpp
@@ -68,6 +68,7 @@ void Run2dDriver(miopenDataType_t prec)
     case miopenFloat8:
     case miopenBFloat8:
     case miopenInt32:
+    case miopenInt64:
     case miopenDouble:
         FAIL()
             << "miopenBFloat16, miopenInt8, miopenInt32, miopenDouble, miopenFloat8, miopenBFloat8 "

--- a/test/gtest/pooling2d_wide.cpp
+++ b/test/gtest/pooling2d_wide.cpp
@@ -68,6 +68,7 @@ void Run2dDriver(miopenDataType_t prec)
     case miopenFloat8:
     case miopenBFloat8:
     case miopenInt32:
+    case miopenInt64:
     case miopenDouble:
         FAIL()
             << "miopenBFloat16, miopenInt8, miopenInt32, miopenDouble, miopenFloat8, miopenBFloat8 "

--- a/test/gtest/reduce_custom_fp32_fp16.cpp
+++ b/test/gtest/reduce_custom_fp32_fp16.cpp
@@ -100,6 +100,7 @@ void Run2dDriver(miopenDataType_t prec)
     case miopenInt8:
     case miopenBFloat16:
     case miopenInt32:
+    case miopenInt64:
     case miopenDouble:
     case miopenFloat8:
     case miopenBFloat8:

--- a/test/gtest/tensor_api.cpp
+++ b/test/gtest/tensor_api.cpp
@@ -47,7 +47,7 @@
 
 // miopenLastDataType must be changed if new data types are added
 #define miopenFirstDataType miopenHalf
-#define miopenLastDataType miopenBFloat8
+#define miopenLastDataType miopenInt64
 
 // miopenLastTensorLayout must be changed if new layouts are added
 #define miopenFirstTensorLayout miopenTensorNCHW

--- a/test/tensor_holder.hpp
+++ b/test/tensor_holder.hpp
@@ -113,6 +113,11 @@ struct miopen_type<int> : std::integral_constant<miopenDataType_t, miopenInt32>
 };
 
 template <>
+struct miopen_type<int64_t> : std::integral_constant<miopenDataType_t, miopenInt64>
+{
+};
+
+template <>
 struct miopen_type<float8> : std::integral_constant<miopenDataType_t, miopenFloat8>
 {
 };


### PR DESCRIPTION
We need to have Int64 type in miopenDataType_t enum in order to be able to create correct Mha Forward Graph in terms of Graph Api.
For example: dropout seed and dropout offset parameters in MHA are represented by int64.