### PR TITLE
[MHA] turn on 'negative zero as nan' for FP8 numbers

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -39,7 +39,7 @@ endif()
 #     remain in the future)  perform final conversion (and rounding) of FP32
 #     to BF16 results. This affects the main functionality of the library.
 option( MIOPEN_USE_RNE_BFLOAT16 "Sets rounding scheme for bfloat16 type" ON )
-option( MIOPEN_FP8_IEEE_EXPONENT_BIAS "Sets the FP8 exponent bias to IEEE" ON)
+option( MIOPEN_FP8_IEEE_EXPONENT_BIAS "Sets the FP8 exponent bias to IEEE" OFF)
 option( MIOPEN_FP8_CLIPPING "Sets the FP8 clipping" ON)
 set ( MIOPEN_DEFAULT_FIND_MODE "DynamicHybrid" CACHE STRING "Sets the default find mode")
 set_property(CACHE MIOPEN_DEFAULT_FIND_MODE PROPERTY STRINGS

--- a/src/kernels/gfx90a.kdb.bz2
+++ b/src/kernels/gfx90a.kdb.bz2
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d3febff109a05c5a9cac5e3db14d052081f8a15a431270613a27fba741a33947
-size 138714110
+oid sha256:f06de59b6e773d6a94a4a802ded71e13ca68bb1b90f0a63e07671abbc85df2fc
+size 141791876


### PR DESCRIPTION
Switch defaults to HW supported mode for soft-float calculations.
It does not affect GPU code, since it is already used the only available HW mode, but it affects all the host calculations like CPU verification code.

Related to #2971 and blocked by #3001
Probably related to #2996 