### PR TITLE
[MHA] [GTEST] Add Tests for Several Graph API Descriptors

### DIFF
--- a/src/graphapi/graphapi.cpp
+++ b/src/graphapi/graphapi.cpp
@@ -27,6 +27,7 @@
 #include <miopen/graphapi/convolution.hpp>
 #include <miopen/graphapi/engine.hpp>
 #include <miopen/graphapi/enginecfg.hpp>
+#include <miopen/graphapi/engineheur.hpp>
 #include <miopen/graphapi/execution_plan.hpp>
 #include <miopen/graphapi/graphapi.hpp>
 #include <miopen/graphapi/opgraph.hpp>
@@ -64,6 +65,9 @@ miopenBackendCreateDescriptor(miopenBackendDescriptorType_t descriptorType,
 
         case MIOPEN_BACKEND_ENGINECFG_DESCRIPTOR:
             outputDescriptor = new miopen::graphapi::BackendEngineCfgDescriptor(); break;
+
+        case MIOPEN_BACKEND_ENGINEHEUR_DESCRIPTOR:
+            outputDescriptor = new miopen::graphapi::BackendEngineHeurDescriptor(); break;
 
         case MIOPEN_BACKEND_EXECUTION_PLAN_DESCRIPTOR:
             outputDescriptor = new miopen::graphapi::BackendExecutionPlanDescriptor(); break;
@@ -232,6 +236,9 @@ extern "C" miopenStatus_t miopenBackendInitialize(miopenBackendDescriptor_t desc
 
         case MIOPEN_BACKEND_ENGINECFG_DESCRIPTOR:
             initializeBackendDescriptor<miopen::graphapi::BackendEngineCfgDescriptor>(descriptor, sizeInBytes); break;
+
+        case MIOPEN_BACKEND_ENGINEHEUR_DESCRIPTOR:
+            initializeBackendDescriptor<miopen::graphapi::BackendEngineHeurDescriptor>(descriptor, sizeInBytes); break;
 
         case MIOPEN_BACKEND_EXECUTION_PLAN_DESCRIPTOR:
             initializeBackendDescriptor<miopen::graphapi::BackendExecutionPlanDescriptor>(descriptor, sizeInBytes); break;

--- a/test/gtest/graphapi_enginecfg.cpp
+++ b/test/gtest/graphapi_enginecfg.cpp
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2024 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <miopen/graphapi/enginecfg.hpp>
+
+#include <gtest/gtest.h>
+
+#include "graphapi_gtest_common.hpp"
+
+namespace {
+
+using miopen::graphapi::Engine;
+using miopen::graphapi::EngineCfgBuilder;
+
+} // namespace
+
+TEST(GraphApi, EngineCfgBuilder)
+{
+    Engine engine;
+
+    EXPECT_NO_THROW({ EngineCfgBuilder().setEngine(engine).build(); })
+        << "EngineCfgBuilder failed on valid attributes";
+
+    EXPECT_ANY_THROW({ EngineCfgBuilder().build(); })
+        << "EngineCfgBuilder failed on missing setEngine() call";
+}
+
+namespace {
+
+class MockEngineDescriptor : public miopen::graphapi::BackendEngineDescriptor
+{
+public:
+    MockEngineDescriptor() { mFinalized = true; }
+};
+
+using miopen::graphapi::GTestDescriptorAttribute;
+using miopen::graphapi::GTestDescriptorSingleValueAttribute;
+using miopen::graphapi::GTestGraphApiExecute;
+
+} // namespace
+
+TEST(GraphApi, EngineCfg)
+{
+    MockEngineDescriptor engineDescriptor;
+
+    GTestDescriptorSingleValueAttribute<miopenBackendDescriptor_t, char> attrEngine(
+        true,
+        "MIOPEN_ATTR_ENGINECFG_ENGINE",
+        MIOPEN_ATTR_ENGINECFG_ENGINE,
+        MIOPEN_TYPE_BACKEND_DESCRIPTOR,
+        MIOPEN_TYPE_CHAR,
+        2,
+        &engineDescriptor);
+
+    GTestGraphApiExecute<GTestDescriptorAttribute*> execute;
+
+    execute.descriptor.attrsValid = true;
+    execute.descriptor.textName   = "MIOPEN_BACKEND_ENGINECFG_DESCRIPTOR";
+    execute.descriptor.type       = MIOPEN_BACKEND_ENGINECFG_DESCRIPTOR;
+    execute.descriptor.attributes = {&attrEngine};
+
+    execute();
+}

--- a/test/gtest/graphapi_engineheur.cpp
+++ b/test/gtest/graphapi_engineheur.cpp
@@ -1,0 +1,118 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2024 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <miopen/graphapi/engineheur.hpp>
+
+#include <gtest/gtest.h>
+
+#include "graphapi_gtest_common.hpp"
+
+namespace {
+
+using miopen::graphapi::EngineHeurBuilder;
+using miopen::graphapi::OpGraph;
+
+} // namespace
+
+TEST(GraphApi, EngineHeurBuilder)
+{
+    OpGraph opGraph;
+
+    EXPECT_NO_THROW({
+        EngineHeurBuilder().setOpGraph(&opGraph).setMode(MIOPEN_HEUR_MODE_B).setSmCount(1).build();
+    }) << "EngineHeurBuilder failed on valid attributes";
+
+    EXPECT_NO_THROW({
+        EngineHeurBuilder().setOpGraph(&opGraph).setMode(MIOPEN_HEUR_MODE_B).build();
+    }) << "EngineHeurBuilder failed on valid attributes";
+
+    EXPECT_ANY_THROW({ EngineHeurBuilder().setMode(MIOPEN_HEUR_MODE_B).setSmCount(1).build(); })
+        << "EngineHeurBuilder failed on missing setOpGraph() call";
+
+    EXPECT_ANY_THROW({ EngineHeurBuilder().setOpGraph(&opGraph).setSmCount(1).build(); })
+        << "EngineHeurBuilder failed on missing setMode() call";
+}
+
+namespace {
+
+class MockOpGraphDescriptor : public miopen::graphapi::BackendOperationGraphDescriptor
+{
+public:
+    MockOpGraphDescriptor() { mFinalized = true; }
+};
+
+using miopen::graphapi::GTestDescriptorAttribute;
+using miopen::graphapi::GTestDescriptorSingleValueAttribute;
+using miopen::graphapi::GTestGraphApiExecute;
+
+} // namespace
+
+TEST(GraphApi, EngineHeur)
+{
+    MockOpGraphDescriptor opGraphDescriptor;
+
+    GTestDescriptorSingleValueAttribute<miopenBackendDescriptor_t, char> attrOpGraph(
+        true,
+        "MIOPEN_ATTR_ENGINEHEUR_OPERATION_GRAPH",
+        MIOPEN_ATTR_ENGINEHEUR_OPERATION_GRAPH,
+        MIOPEN_TYPE_BACKEND_DESCRIPTOR,
+        MIOPEN_TYPE_CHAR,
+        2,
+        &opGraphDescriptor);
+
+    GTestDescriptorSingleValueAttribute<miopenBackendHeurMode_t, char> attrMode(
+        true,
+        "MIOPEN_ATTR_ENGINEHEUR_MODE",
+        MIOPEN_ATTR_ENGINEHEUR_MODE,
+        MIOPEN_TYPE_HEUR_MODE,
+        MIOPEN_TYPE_CHAR,
+        2,
+        MIOPEN_HEUR_MODE_B);
+
+    GTestDescriptorSingleValueAttribute<int32_t, char> attrSmCount(
+        true,
+        "MIOPEN_ATTR_ENGINEHEUR_SM_COUNT_TARGET",
+        MIOPEN_ATTR_ENGINEHEUR_SM_COUNT_TARGET,
+        MIOPEN_TYPE_INT32,
+        MIOPEN_TYPE_CHAR,
+        2,
+        1);
+
+    GTestGraphApiExecute<GTestDescriptorAttribute*> execute;
+
+    execute.descriptor.attrsValid = false;
+    execute.descriptor.textName   = "MIOPEN_BACKEND_ENGINEHEUR_DESCRIPTOR";
+    execute.descriptor.type       = MIOPEN_BACKEND_ENGINEHEUR_DESCRIPTOR;
+    execute.descriptor.attributes = {&attrOpGraph, &attrSmCount};
+    execute();
+
+    execute.descriptor.attributes = {&attrMode, &attrSmCount};
+    execute();
+
+    execute.descriptor.attrsValid = true;
+    execute.descriptor.attributes = {&attrOpGraph, &attrMode, &attrSmCount};
+    execute();
+}

--- a/test/gtest/graphapi_execution_plan.cpp
+++ b/test/gtest/graphapi_execution_plan.cpp
@@ -1,0 +1,114 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2024 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <miopen/graphapi/execution_plan.hpp>
+
+#include <gtest/gtest.h>
+
+#include "graphapi_gtest_common.hpp"
+
+namespace {
+
+using miopen::graphapi::EngineCfg;
+using miopen::graphapi::ExecutionPlanBuilder;
+
+} // namespace
+
+TEST(GraphApi, ExecutionPlanBuilder)
+{
+    miopenHandle_t handle;
+    auto status = miopenCreate(&handle);
+    ASSERT_EQ(status, miopenStatusSuccess) << "miopenCreate() failed";
+
+    EngineCfg engineCfg;
+
+    EXPECT_NO_THROW({ ExecutionPlanBuilder().setHandle(handle).setEngineCfg(engineCfg).build(); })
+        << "ExecutionPlanBuilder failed on valid attributes";
+
+    EXPECT_NO_THROW({
+        ExecutionPlanBuilder()
+            .setHandle(handle)
+            .setEngineCfg(engineCfg)
+            .setIntermediateIds({1, 2, 3})
+            .build();
+    }) << "ExecutionPlanBuilder failed on valid attributes";
+
+    EXPECT_ANY_THROW({ ExecutionPlanBuilder().setEngineCfg(engineCfg).build(); })
+        << "ExecutionPlanBuilder failed on missing setHandle() call";
+
+    EXPECT_ANY_THROW({ ExecutionPlanBuilder().setHandle(handle).build(); })
+        << "ExecutionPlanBuilder failed on missing setEngineCfg() call";
+}
+
+namespace {
+
+class MockBackendEngineCfgDescriptor : public miopen::graphapi::BackendEngineCfgDescriptor
+{
+public:
+    MockBackendEngineCfgDescriptor() { mFinalized = true; }
+};
+
+using miopen::graphapi::GTestDescriptorAttribute;
+using miopen::graphapi::GTestDescriptorSingleValueAttribute;
+using miopen::graphapi::GTestGraphApiExecute;
+
+} // namespace
+
+TEST(GraphApi, ExecutionPlan)
+{
+    miopenHandle_t handle;
+    auto status = miopenCreate(&handle);
+    ASSERT_EQ(status, miopenStatusSuccess) << "miopenCreate() failed";
+
+    MockBackendEngineCfgDescriptor engineCfgDescriptor;
+
+    GTestDescriptorSingleValueAttribute<miopenHandle_t, char> attrHandle(
+        true,
+        "MIOPEN_ATTR_EXECUTION_PLAN_HANDLE",
+        MIOPEN_ATTR_EXECUTION_PLAN_HANDLE,
+        MIOPEN_TYPE_HANDLE,
+        MIOPEN_TYPE_CHAR,
+        2,
+        handle);
+
+    GTestDescriptorSingleValueAttribute<miopenBackendDescriptor_t, char> attrEngineCfg(
+        true,
+        "MIOPEN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG",
+        MIOPEN_ATTR_EXECUTION_PLAN_ENGINE_CONFIG,
+        MIOPEN_TYPE_BACKEND_DESCRIPTOR,
+        MIOPEN_TYPE_CHAR,
+        2,
+        &engineCfgDescriptor);
+
+    GTestGraphApiExecute<GTestDescriptorAttribute*> execute;
+
+    execute.descriptor.attrsValid = true;
+    execute.descriptor.textName   = "MIOPEN_BACKEND_EXECUTION_PLAN_DESCRIPTOR";
+    execute.descriptor.type       = MIOPEN_BACKEND_EXECUTION_PLAN_DESCRIPTOR;
+    execute.descriptor.attributes = {&attrHandle, &attrEngineCfg};
+
+    execute();
+}


### PR DESCRIPTION
closes #2928 
closes #2924 
closes #2925 

Gtests for MIOPEN_BACKEND_ENGINEHEUR_DESCRIPTOR, MIOPEN_BACKEND_EXECUTION_PLAN_DESCRIPTOR and MIOPEN_BACKEND_ENGINECFG_DESCRIPTOR.

An issue in MIOPEN_BACKEND_ENGINEHEUR_DESCRIPTOR was fixed.