### PR TITLE
[W/A] Link dl to MIOpen tests and fix GTest version in requirements

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,3 @@
 ROCm/rocm-recipes@329203d79f9fe77ae5d0d742af0966bc57f4dfc8
 -f requirements.txt
 danmar/cppcheck@2.12.1
-google/googletest@v1.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ ROCm/FunctionalPlus@v0.2.18-p0
 ROCm/eigen@3.4.0
 ROCm/frugally-deep@9683d557eb672ee2304f80f6682c51242d748a50
 ROCm/composable_kernel@e4112de7303af1601c6590b964d0df2b6a7f7d32 -DCMAKE_BUILD_TYPE=Release -DINSTANCES_ONLY=ON
+google/googletest@v1.14.0

--- a/test/gtest/CMakeLists.txt
+++ b/test/gtest/CMakeLists.txt
@@ -24,7 +24,9 @@ function(add_gtest TEST_NAME TEST_CPP)
   if(MIOPEN_ENABLE_AI_KERNEL_TUNING)
     target_link_libraries(${TEST_NAME} frugally-deep::fdeep Eigen3::Eigen)
   endif()
-  target_link_libraries(${TEST_NAME} GTest::gtest GTest::gtest_main MIOpen ${Boost_LIBRARIES} hip::host $<BUILD_INTERFACE:roc::rocblas>)
+  # Workaround : change in rocm-cmake was causing linking error so had to add ${CMAKE_DL_LIBS} 
+  #               We can remove ${CMAKE_DL_LIBS} once root cause is identified.
+  target_link_libraries(${TEST_NAME} ${CMAKE_DL_LIBS} GTest::gtest GTest::gtest_main MIOpen ${Boost_LIBRARIES} hip::host $<BUILD_INTERFACE:roc::rocblas> )
   if(NOT MIOPEN_EMBED_DB STREQUAL "")
       target_link_libraries(${TEST_NAME} $<BUILD_INTERFACE:miopen_data>)
   endif()


### PR DESCRIPTION
Fix testing compilation issue where -ldl is missing when compiling gtest binaries.
I believe this is the same issue as [PR 2177](https://github.com/ROCm/MIOpen/pull/2177), but now with test binaries.

In addition, we also had to move the gtest dependency to requirements.txt. This change was necessary, due to environments that didn't install gtest linking to the wrong gtest binary which was causing build issues.

ref: #3005 