### PR TITLE
Remove gfx942 kernel cache

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -607,8 +607,8 @@ function(install_kdb FILE_NAME COMPONENT_NAME)
 endfunction()
 
 # Both the lists below should be in sync always
-set(KDB_BZ2_FILES gfx942.kdb.bz2 gfx90a.kdb.bz2 gfx1030.kdb.bz2 gfx908.kdb.bz2 gfx906.kdb.bz2 gfx900.kdb.bz2)
-set(COMPONENT_LST gfx942kdb gfx90akdb gfx1030kdb gfx908kdb gfx906kdb gfx900kdb)
+set(KDB_BZ2_FILES gfx90a.kdb.bz2 gfx1030.kdb.bz2 gfx908.kdb.bz2 gfx906.kdb.bz2 gfx900.kdb.bz2)
+set(COMPONENT_LST gfx90akdb gfx1030kdb gfx908kdb gfx906kdb gfx900kdb)
 
 if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.17)
     foreach(__file __component IN ZIP_LISTS KDB_BZ2_FILES COMPONENT_LST)

--- a/src/kernels/gfx942.kdb.bz2
+++ b/src/kernels/gfx942.kdb.bz2
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ebc612b797204cab3150a788dad0fda1a79d309fc94679017007d90f776b6f15
-size 1729359


### PR DESCRIPTION
gfx942 kernel cache is small from the effective heuristics

Delete the entry to prevent conflicts in GPU Targets combinations

Ref: #3001, #3023