### PR TITLE
Fix memory leak when using deref()

### DIFF
--- a/src/activ_api.cpp
+++ b/src/activ_api.cpp
@@ -36,7 +36,10 @@ extern "C" miopenStatus_t miopenCreateActivationDescriptor(miopenActivationDescr
 {
 
     MIOPEN_LOG_FUNCTION(activDesc);
-    return miopen::try_([&] { miopen::deref(activDesc) = new miopen::ActivationDescriptor(); });
+    return miopen::try_([&] {
+        auto& desc = miopen::deref(activDesc);
+        desc       = new miopen::ActivationDescriptor();
+    });
 }
 
 extern "C" miopenStatus_t miopenSetActivationDescriptor(miopenActivationDescriptor_t activDesc,

--- a/src/api/find2_0_commons.cpp
+++ b/src/api/find2_0_commons.cpp
@@ -44,7 +44,8 @@ static miopenStatus_t MakeProblem(miopenProblem_t* problem,
                                   miopenProblemDirection_t direction)
 {
     return miopen::try_([&] {
-        miopen::deref(problem) = new miopen::ProblemContainer();
+        auto& in_problem_deref = miopen::deref(problem);
+        in_problem_deref       = new miopen::ProblemContainer();
         auto& container_deref  = miopen::deref(*problem);
 
         container_deref.item = miopen::Problem();
@@ -282,7 +283,10 @@ miopenStatus_t miopenFindSolutions(miopenHandle_t handle,
             problem_deref);
 
         for(auto i = 0; i < solutions_deref.size(); ++i)
-            miopen::deref(solutions + i) = new miopen::Solution{std::move(solutions_deref[i])};
+        {
+            auto& theSolution = miopen::deref(solutions + i);
+            theSolution       = new miopen::Solution{std::move(solutions_deref[i])};
+        }
 
         if(numSolutions != nullptr)
             *numSolutions = solutions_deref.size();

--- a/src/convolution_api.cpp
+++ b/src/convolution_api.cpp
@@ -116,7 +116,10 @@ static inline auto MakeWrWCtxAndProblem(miopenHandle_t handle,
 extern "C" miopenStatus_t miopenCreateConvolutionDescriptor(miopenConvolutionDescriptor_t* convDesc)
 {
     MIOPEN_LOG_FUNCTION(convDesc);
-    return miopen::try_([&] { miopen::deref(convDesc) = new miopen::ConvolutionDescriptor(); });
+    return miopen::try_([&] {
+        auto& desc = miopen::deref(convDesc);
+        desc       = new miopen::ConvolutionDescriptor();
+    });
 }
 
 extern "C" miopenStatus_t miopenInitConvolutionDescriptor(miopenConvolutionDescriptor_t convDesc,

--- a/src/ctc_api.cpp
+++ b/src/ctc_api.cpp
@@ -34,7 +34,10 @@
 extern "C" miopenStatus_t miopenCreateCTCLossDescriptor(miopenCTCLossDescriptor_t* ctcLossDesc)
 {
     MIOPEN_LOG_FUNCTION(ctcLossDesc);
-    return miopen::try_([&] { miopen::deref(ctcLossDesc) = new miopen::CTCLossDescriptor(); });
+    return miopen::try_([&] {
+        auto& desc = miopen::deref(ctcLossDesc);
+        desc       = new miopen::CTCLossDescriptor();
+    });
 }
 
 extern "C" miopenStatus_t miopenDestroyCTCLossDescriptor(miopenCTCLossDescriptor_t ctcLossDesc)

--- a/src/dropout_api.cpp
+++ b/src/dropout_api.cpp
@@ -34,7 +34,10 @@ extern "C" miopenStatus_t miopenCreateDropoutDescriptor(miopenDropoutDescriptor_
 {
 
     MIOPEN_LOG_FUNCTION(dropoutDesc);
-    return miopen::try_([&] { miopen::deref(dropoutDesc) = new miopen::DropoutDescriptor(); });
+    return miopen::try_([&] {
+        auto& desc = miopen::deref(dropoutDesc);
+        desc       = new miopen::DropoutDescriptor();
+    });
 }
 
 extern "C" miopenStatus_t miopenDestroyDropoutDescriptor(miopenDropoutDescriptor_t dropoutDesc)

--- a/src/fused_api.cpp
+++ b/src/fused_api.cpp
@@ -45,8 +45,8 @@ extern "C" miopenStatus_t miopenCreateFusionPlan(miopenFusionPlanDescriptor_t* f
 {
     MIOPEN_LOG_FUNCTION(fusePlanDesc, fuseDirection, inputDesc);
     return miopen::try_([&] {
-        miopen::deref(fusePlanDesc) =
-            new miopen::FusionPlanDescriptor(fuseDirection, miopen::deref(inputDesc));
+        auto& desc = miopen::deref(fusePlanDesc);
+        desc       = new miopen::FusionPlanDescriptor(fuseDirection, miopen::deref(inputDesc));
     });
 }
 

--- a/src/fused_api.cpp
+++ b/src/fused_api.cpp
@@ -236,7 +236,10 @@ extern "C" miopenStatus_t miopenCreateOpBatchNormBackward(miopenFusionPlanDescri
 extern "C" miopenStatus_t miopenCreateOperatorArgs(miopenOperatorArgs_t* args)
 {
     MIOPEN_LOG_FUNCTION(args);
-    return miopen::try_([&] { miopen::deref(args) = new miopen::OperatorArgs(); });
+    return miopen::try_([&] {
+        auto& theArgs = miopen::deref(args);
+        theArgs       = new miopen::OperatorArgs();
+    });
 }
 
 extern "C" miopenStatus_t miopenDestroyOperatorArgs(miopenOperatorArgs_t args)

--- a/src/handle_api.cpp
+++ b/src/handle_api.cpp
@@ -72,14 +72,20 @@ extern "C" miopenStatus_t miopenGetVersion(size_t* major, size_t* minor, size_t*
 extern "C" miopenStatus_t miopenCreate(miopenHandle_t* handle)
 {
 
-    return miopen::try_([&] { miopen::deref(handle) = new miopen::Handle(); });
+    return miopen::try_([&] {
+        auto& h = miopen::deref(handle);
+        h       = new miopen::Handle();
+    });
 }
 
 extern "C" miopenStatus_t miopenCreateWithStream(miopenHandle_t* handle,
                                                  miopenAcceleratorQueue_t stream)
 {
 
-    return miopen::try_([&] { miopen::deref(handle) = new miopen::Handle(stream); });
+    return miopen::try_([&] {
+        auto& h = miopen::deref(handle);
+        h       = new miopen::Handle(stream);
+    });
 }
 
 extern "C" miopenStatus_t miopenSetStream(miopenHandle_t handle, miopenAcceleratorQueue_t streamID)

--- a/src/lrn_api.cpp
+++ b/src/lrn_api.cpp
@@ -32,7 +32,10 @@
 extern "C" miopenStatus_t miopenCreateLRNDescriptor(miopenLRNDescriptor_t* lrnDesc)
 {
 
-    return miopen::try_([&] { miopen::deref(lrnDesc) = new miopen::LRNDescriptor(); });
+    return miopen::try_([&] {
+        auto& desc = miopen::deref(lrnDesc);
+        desc       = new miopen::LRNDescriptor();
+    });
 }
 
 extern "C" miopenStatus_t miopenSetLRNDescriptor(miopenLRNDescriptor_t lrnDesc,

--- a/src/pooling_api.cpp
+++ b/src/pooling_api.cpp
@@ -125,7 +125,10 @@ inline void Pooling_logging_cmd(const miopenPoolingDescriptor_t poolDesc,
 extern "C" miopenStatus_t miopenCreatePoolingDescriptor(miopenPoolingDescriptor_t* poolDesc)
 {
     MIOPEN_LOG_FUNCTION(poolDesc);
-    return miopen::try_([&] { miopen::deref(poolDesc) = new miopen::PoolingDescriptor(); });
+    return miopen::try_([&] {
+        auto& desc = miopen::deref(poolDesc);
+        desc       = new miopen::PoolingDescriptor();
+    });
 }
 
 extern "C" miopenStatus_t miopenSetPoolingIndexType(miopenPoolingDescriptor_t poolDesc,

--- a/src/reducetensor_api.cpp
+++ b/src/reducetensor_api.cpp
@@ -90,8 +90,10 @@ extern "C" miopenStatus_t
 miopenCreateReduceTensorDescriptor(miopenReduceTensorDescriptor_t* reduceTensorDesc)
 {
     MIOPEN_LOG_FUNCTION(reduceTensorDesc);
-    return miopen::try_(
-        [&] { miopen::deref(reduceTensorDesc) = new miopen::ReduceTensorDescriptor(); });
+    return miopen::try_([&] {
+        auto& desc = miopen::deref(reduceTensorDesc);
+        desc       = new miopen::ReduceTensorDescriptor();
+    });
 };
 
 extern "C" miopenStatus_t

--- a/src/rnn.cpp
+++ b/src/rnn.cpp
@@ -276,18 +276,19 @@ std::vector<int> RNNDescriptor::pTensorLengthsCalculation(const TensorDescriptor
 
 RNNDescriptor::RNNDescriptor()
 {
-    nLayers                     = 1;
-    hsize                       = 0;
-    nHiddenTensorsPerLayer      = 0;
-    rnnMode                     = miopenRNNTANH;
-    dirMode                     = miopenRNNunidirection;
-    biasMode                    = miopenRNNNoBias;
-    algoMode                    = miopenRNNdefault;
-    inputMode                   = miopenRNNlinear;
-    dataType                    = miopenFloat;
-    typeSize                    = 4;
-    workspaceScale              = 1;
-    miopen::deref(&dropoutDesc) = new miopen::DropoutDescriptor();
+    nLayers                = 1;
+    hsize                  = 0;
+    nHiddenTensorsPerLayer = 0;
+    rnnMode                = miopenRNNTANH;
+    dirMode                = miopenRNNunidirection;
+    biasMode               = miopenRNNNoBias;
+    algoMode               = miopenRNNdefault;
+    inputMode              = miopenRNNlinear;
+    dataType               = miopenFloat;
+    typeSize               = 4;
+    workspaceScale         = 1;
+    auto& desc             = miopen::deref(&dropoutDesc);
+    desc                   = new miopen::DropoutDescriptor();
 }
 
 RNNDescriptor::RNNDescriptor(int hsz,
@@ -337,15 +338,16 @@ RNNDescriptor::RNNDescriptor(int hsz,
         typeSize = dType == miopenHalf ? 2 : 4;
     }
 
-    hsize                       = hsz;
-    nLayers                     = layers;
-    inputMode                   = inMode;
-    dirMode                     = bidir;
-    rnnMode                     = rmode;
-    algoMode                    = amode;
-    biasMode                    = bmode;
-    dataType                    = dType;
-    miopen::deref(&dropoutDesc) = new miopen::DropoutDescriptor();
+    hsize      = hsz;
+    nLayers    = layers;
+    inputMode  = inMode;
+    dirMode    = bidir;
+    rnnMode    = rmode;
+    algoMode   = amode;
+    biasMode   = bmode;
+    dataType   = dType;
+    auto& desc = miopen::deref(&dropoutDesc);
+    desc       = new miopen::DropoutDescriptor();
 
     switch(rmode)
     {

--- a/src/rnn.cpp
+++ b/src/rnn.cpp
@@ -276,19 +276,18 @@ std::vector<int> RNNDescriptor::pTensorLengthsCalculation(const TensorDescriptor
 
 RNNDescriptor::RNNDescriptor()
 {
-    nLayers                = 1;
-    hsize                  = 0;
-    nHiddenTensorsPerLayer = 0;
-    rnnMode                = miopenRNNTANH;
-    dirMode                = miopenRNNunidirection;
-    biasMode               = miopenRNNNoBias;
-    algoMode               = miopenRNNdefault;
-    inputMode              = miopenRNNlinear;
-    dataType               = miopenFloat;
-    typeSize               = 4;
-    workspaceScale         = 1;
-    auto& desc             = miopen::deref(&dropoutDesc);
-    desc                   = new miopen::DropoutDescriptor();
+    nLayers                     = 1;
+    hsize                       = 0;
+    nHiddenTensorsPerLayer      = 0;
+    rnnMode                     = miopenRNNTANH;
+    dirMode                     = miopenRNNunidirection;
+    biasMode                    = miopenRNNNoBias;
+    algoMode                    = miopenRNNdefault;
+    inputMode                   = miopenRNNlinear;
+    dataType                    = miopenFloat;
+    typeSize                    = 4;
+    workspaceScale              = 1;
+    miopen::deref(&dropoutDesc) = new miopen::DropoutDescriptor();
 }
 
 RNNDescriptor::RNNDescriptor(int hsz,
@@ -338,16 +337,15 @@ RNNDescriptor::RNNDescriptor(int hsz,
         typeSize = dType == miopenHalf ? 2 : 4;
     }
 
-    hsize      = hsz;
-    nLayers    = layers;
-    inputMode  = inMode;
-    dirMode    = bidir;
-    rnnMode    = rmode;
-    algoMode   = amode;
-    biasMode   = bmode;
-    dataType   = dType;
-    auto& desc = miopen::deref(&dropoutDesc);
-    desc       = new miopen::DropoutDescriptor();
+    hsize                       = hsz;
+    nLayers                     = layers;
+    inputMode                   = inMode;
+    dirMode                     = bidir;
+    rnnMode                     = rmode;
+    algoMode                    = amode;
+    biasMode                    = bmode;
+    dataType                    = dType;
+    miopen::deref(&dropoutDesc) = new miopen::DropoutDescriptor();
 
     switch(rmode)
     {

--- a/src/rnn_api.cpp
+++ b/src/rnn_api.cpp
@@ -106,7 +106,10 @@ miopenGetRNNDataSeqTensorDescriptor(miopenSeqTensorDescriptor_t seqTensorDesc,
 extern "C" miopenStatus_t miopenCreateRNNDescriptor(miopenRNNDescriptor_t* rnnDesc)
 {
     MIOPEN_LOG_FUNCTION(rnnDesc);
-    return miopen::try_([&] { miopen::deref(rnnDesc) = new miopen::RNNDescriptor(); });
+    return miopen::try_([&] {
+        auto& desc = miopen::deref(rnnDesc);
+        desc       = new miopen::RNNDescriptor();
+    });
 }
 
 extern "C" miopenStatus_t miopenDestroyRNNDescriptor(miopenRNNDescriptor_t rnnDesc)

--- a/src/tensor_api.cpp
+++ b/src/tensor_api.cpp
@@ -35,13 +35,19 @@
 extern "C" miopenStatus_t miopenCreateTensorDescriptor(miopenTensorDescriptor_t* tensorDesc)
 {
     MIOPEN_LOG_FUNCTION(tensorDesc);
-    return miopen::try_([&] { miopen::deref(tensorDesc) = new miopen::TensorDescriptor(); });
+    return miopen::try_([&] {
+        auto& desc = miopen::deref(tensorDesc);
+        desc       = new miopen::TensorDescriptor();
+    });
 }
 
 extern "C" miopenStatus_t miopenCreateSeqTensorDescriptor(miopenSeqTensorDescriptor_t* tensorDesc)
 {
     MIOPEN_LOG_FUNCTION(tensorDesc);
-    return miopen::try_([&] { miopen::deref(tensorDesc) = new miopen::SeqTensorDescriptor(); });
+    return miopen::try_([&] {
+        auto& desc = miopen::deref(tensorDesc);
+        desc       = new miopen::SeqTensorDescriptor();
+    });
 }
 
 extern "C" miopenStatus_t miopenSet4dTensorDescriptor(


### PR DESCRIPTION
`deref()` is often used improperly, without taking into account that the right part of operator `=` in c++17 is evaluated before the left part. Prior c++17 the order of evaluation was undefined.

The following code will produce a memory leak if `desc` is `null` because `deref` throws an exception when memory is already allocated (and object is created). `destructor` won't be called possibly producing even more issues.

```C++
miopen::deref(desc) = new SomeDescriptor();
```

A branch _`sg/deref_mem_leak_demo`_ was created with the gtest file `deref_mem_leak.cpp` to demonstrate this misuse of `deref`.

Take a look and try its first commit [Demonstrate a memory leak with deref()](https://github.com/ROCm/MIOpen/commit/5c9c4596372212946ce8977307a401a04564f4d6) which shows the above issue for `miopenCreateTensorDescriptor()` by counting leaked objects and failing a corresponding `TEST`.

Also a fix was added with the same `TEST` in this branch's second commit [Fix memory leak with deref() for TensorDescriptor](https://github.com/ROCm/MIOpen/commit/e7005f24b3edabc440401660f238a9912f34912a)

I was searching for the instances of this issue using the following cmd
```bash
git grep -n -e 'deref([^(^)]*) *= *new'
```
I'm encouraging you to suggest other instances or search techniques.

Do you think if there is a way of writing a test to detect this issue without altering the source class (like in the demo branch)?