### PR TITLE
Workaround: Ubuntu 20.04 and RHEL no standard hash for std::filesystem::path

### DIFF
--- a/src/kernels/kernel.cpp.in
+++ b/src/kernels/kernel.cpp.in
@@ -24,7 +24,7 @@
  *
  *******************************************************************************/
 #include <algorithm>
-#include <unordered_map>
+#include <map>
 #include <string_view>
 #include <miopen/filesystem.hpp>
 #include <miopen/kernel.hpp>
@@ -37,9 +37,9 @@ ${KERNELS_DECLS}
 
 namespace miopen {
 
-const std::unordered_map<fs::path, std::string_view>& kernels()
+const std::map<fs::path, std::string_view>& kernels()
 {
-    static const std::unordered_map<fs::path, std::string_view> data{
+    static const std::map<fs::path, std::string_view> data{
 #ifndef MIOPEN_USE_CLANG_TIDY // Huge generated source
         ${INIT_KERNELS}
 #endif

--- a/src/kernels/kernel_includes.cpp.in
+++ b/src/kernels/kernel_includes.cpp.in
@@ -24,7 +24,7 @@
  *
  *******************************************************************************/
 #include <algorithm>
-#include <unordered_map>
+#include <map>
 #include <string_view>
 #include <miopen/filesystem.hpp>
 #include <miopen/kernel.hpp>
@@ -37,9 +37,9 @@ ${KERNELS_DECLS}
 
 namespace miopen {
 
-const std::unordered_map<fs::path, std::string_view>& kernel_includes()
+const std::map<fs::path, std::string_view>& kernel_includes()
 {
-    static const std::unordered_map<fs::path, std::string_view> data{
+    static const std::map<fs::path, std::string_view> data{
 #ifndef MIOPEN_USE_CLANG_TIDY // Huge generated source
         ${INIT_KERNELS}
 #endif


### PR DESCRIPTION
#3034