### PR TITLE
fix compilation without rocblas

### DIFF
--- a/src/conv/solver_finders.cpp
+++ b/src/conv/solver_finders.cpp
@@ -351,9 +351,9 @@ bool IsAlgorithmDisabled(miopenConvAlgorithm_t algo)
 {
     switch(algo)
     { // clang-format off
-#if MIOPEN_USE_ROCBLAS
+#if MIOPEN_USE_GEMM
     case miopenConvolutionAlgoGEMM:
-        return !MIOPEN_USE_GEMM || miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_GEMM));
+        return miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_GEMM));
 #endif
     case miopenConvolutionAlgoDirect:
         return miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_DIRECT));

--- a/src/conv/solver_finders.cpp
+++ b/src/conv/solver_finders.cpp
@@ -351,8 +351,10 @@ bool IsAlgorithmDisabled(miopenConvAlgorithm_t algo)
 {
     switch(algo)
     { // clang-format off
+#if MIOPEN_USE_ROCBLAS
     case miopenConvolutionAlgoGEMM:
         return !MIOPEN_USE_GEMM || miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_GEMM));
+#endif
     case miopenConvolutionAlgoDirect:
         return miopen::IsDisabled(ENV(MIOPEN_DEBUG_CONV_DIRECT));
     case miopenConvolutionAlgoFFT:

--- a/src/ocl/rnnocl.cpp
+++ b/src/ocl/rnnocl.cpp
@@ -42,17 +42,17 @@ namespace miopen {
 
 namespace {
 
+#if MIOPEN_USE_ROCBLAS && MIOPEN_BACKEND_HIP
+
 bool RNNForwardMSIsSupported([[maybe_unused]] const RNNDescriptor& desctiptor,
                              [[maybe_unused]] bool use_dropout)
 {
-#if MIOPEN_USE_GEMM && MIOPEN_BACKEND_HIP
     if(desctiptor.rnnMode == miopenLSTM && desctiptor.algoMode == miopenRNNdefault &&
        !use_dropout && desctiptor.nLayers > 1 && desctiptor.dirMode == miopenRNNunidirection &&
        desctiptor.inputMode != miopenRNNskip)
     {
         return true;
     }
-#endif // MIOPEN_USE_GEMM&& MIOPEN_BACKEND_HIP
     return false;
 }
 
@@ -242,6 +242,8 @@ miopenStatus_t ReducAddBias(miopen::Handle& handle,
 
     return miopenStatusSuccess;
 }
+
+#endif // MIOPEN_USE_ROCBLAS && MIOPEN_BACKEND_HIP
 
 } // namespace
 
@@ -1078,8 +1080,6 @@ void RNNDescriptor::RNNForwardMS(Handle& handle,
     (void)y;
     (void)hy;
     (void)cy;
-    (void)reserveSpace;
-    (void)reserveSpaceSize;
 
     MIOPEN_THROW("GEMM is not supported");
 #endif
@@ -1242,7 +1242,7 @@ void RNNDescriptor::RNNForwardInferencePacked(Handle& handle,
     (void)hxDesc;
     (void)cxDesc;
 
-#if MIOPEN_USE_GEMM
+#if MIOPEN_USE_ROCBLAS
 
     float ctime = 0.;
     // reset kernel timer
@@ -2634,7 +2634,7 @@ void RNNDescriptor::RNNForwardTrainingPackedTensors(
 {
     (void)cxDesc;
     (void)cyDesc;
-#if MIOPEN_USE_GEMM
+#if MIOPEN_USE_ROCBLAS
 
     // OCL legacy
     float ctime = 0.;
@@ -4109,7 +4109,7 @@ void RNNDescriptor::RNNBackwardDataPackedTensors(
     Data_t reserveSpace,
     size_t reserveSpaceSize) const
 {
-#if MIOPEN_USE_GEMM
+#if MIOPEN_USE_ROCBLAS
 
     float ctime = 0.;
     // reset kernel timer
@@ -5752,7 +5752,7 @@ void RNNDescriptor::RNNBackwardWeightsPackedTensors(
     size_t reserveSpaceSize) const
 {
 
-#if MIOPEN_USE_GEMM
+#if MIOPEN_USE_ROCBLAS
     float ctime = 0.;
     // reset kernel timer
     profileRNNkernels(handle, 0, ctime);

--- a/src/ocl/rnnocl.cpp
+++ b/src/ocl/rnnocl.cpp
@@ -42,17 +42,19 @@ namespace miopen {
 
 namespace {
 
-#if MIOPEN_USE_ROCBLAS && MIOPEN_BACKEND_HIP
+#if MIOPEN_USE_ROCBLAS
 
 bool RNNForwardMSIsSupported([[maybe_unused]] const RNNDescriptor& desctiptor,
                              [[maybe_unused]] bool use_dropout)
 {
+#if MIOPEN_USE_GEMM && MIOPEN_BACKEND_HIP
     if(desctiptor.rnnMode == miopenLSTM && desctiptor.algoMode == miopenRNNdefault &&
        !use_dropout && desctiptor.nLayers > 1 && desctiptor.dirMode == miopenRNNunidirection &&
        desctiptor.inputMode != miopenRNNskip)
     {
         return true;
     }
+#endif // MIOPEN_USE_GEMM&& MIOPEN_BACKEND_HIP
     return false;
 }
 
@@ -243,7 +245,7 @@ miopenStatus_t ReducAddBias(miopen::Handle& handle,
     return miopenStatusSuccess;
 }
 
-#endif // MIOPEN_USE_ROCBLAS && MIOPEN_BACKEND_HIP
+#endif // MIOPEN_USE_ROCBLAS
 
 } // namespace
 

--- a/src/ocl/rnnocl.cpp
+++ b/src/ocl/rnnocl.cpp
@@ -1242,7 +1242,7 @@ void RNNDescriptor::RNNForwardInferencePacked(Handle& handle,
     (void)hxDesc;
     (void)cxDesc;
 
-#if MIOPEN_USE_ROCBLAS
+#if MIOPEN_USE_GEMM
 
     float ctime = 0.;
     // reset kernel timer
@@ -2634,7 +2634,7 @@ void RNNDescriptor::RNNForwardTrainingPackedTensors(
 {
     (void)cxDesc;
     (void)cyDesc;
-#if MIOPEN_USE_ROCBLAS
+#if MIOPEN_USE_GEMM
 
     // OCL legacy
     float ctime = 0.;
@@ -4109,7 +4109,7 @@ void RNNDescriptor::RNNBackwardDataPackedTensors(
     Data_t reserveSpace,
     size_t reserveSpaceSize) const
 {
-#if MIOPEN_USE_ROCBLAS
+#if MIOPEN_USE_GEMM
 
     float ctime = 0.;
     // reset kernel timer
@@ -5752,7 +5752,7 @@ void RNNDescriptor::RNNBackwardWeightsPackedTensors(
     size_t reserveSpaceSize) const
 {
 
-#if MIOPEN_USE_ROCBLAS
+#if MIOPEN_USE_GEMM
     float ctime = 0.;
     // reset kernel timer
     profileRNNkernels(handle, 0, ctime);

--- a/src/solver/mha/mha_common.hpp
+++ b/src/solver/mha/mha_common.hpp
@@ -46,6 +46,8 @@
 /// strided_batched_ex3 introduced in rocblas 4.0
 #define USE_ROCBLAS_EX3 ((MIOPEN_ROCBLAS_VERSION_FLAT >= 4000000) && ROCBLAS_BETA_FEATURES_API)
 #endif
+#else
+#define USE_ROCBLAS_EX3 false
 #endif
 
 namespace miopen::solver::mha {

--- a/src/solver/mha/mha_common.hpp
+++ b/src/solver/mha/mha_common.hpp
@@ -46,8 +46,6 @@
 /// strided_batched_ex3 introduced in rocblas 4.0
 #define USE_ROCBLAS_EX3 ((MIOPEN_ROCBLAS_VERSION_FLAT >= 4000000) && ROCBLAS_BETA_FEATURES_API)
 #endif
-#else
-#define USE_ROCBLAS_EX3 false
 #endif
 
 namespace miopen::solver::mha {

--- a/src/solver/mha/mha_solver_backward.cpp
+++ b/src/solver/mha/mha_solver_backward.cpp
@@ -90,8 +90,8 @@ bool MhaBackward::IsApplicable([[maybe_unused]] const ExecutionContext& context,
 
     auto [N, H, S, D] = miopen::tien<4>(descsBwd.kDesc.GetLengths());
 
-    return MIOPEN_USE_GEMM                                            //
-           && !miopen::IsDisabled(ENV(MIOPEN_DEBUG_ATTN_NAIVE_BWD))   //
+#if MIOPEN_USE_ROCBLAS
+    return !miopen::IsDisabled(ENV(MIOPEN_DEBUG_ATTN_NAIVE_BWD))      //
            && S <= std::numeric_limits<uint32_t>::max()               //
            && D <= std::numeric_limits<uint32_t>::max()               //
            && descsBwd.kDesc.IsPacked()                               //
@@ -120,6 +120,9 @@ bool MhaBackward::IsApplicable([[maybe_unused]] const ExecutionContext& context,
                || (USE_ROCBLAS_EX3                                    //
                    && (MIOPEN_FP8_IEEE_EXPONENT_BIAS == 0)            //
                    && (descsBwd.doDesc.GetType() == miopenBFloat8))); //
+#else
+    return false;
+#endif
 }
 
 std::size_t MhaBackward::GetWorkspaceSize([[maybe_unused]] const ExecutionContext& context,

--- a/src/solver/mha/mha_solver_backward.cpp
+++ b/src/solver/mha/mha_solver_backward.cpp
@@ -80,6 +80,7 @@ miopen::HipEventPtr make_hip_fast_event()
 bool MhaBackward::IsApplicable([[maybe_unused]] const ExecutionContext& context,
                                const miopen::mha::ProblemDescription& problem) const
 {
+#if MIOPEN_USE_GEMM
     // It's important to have this check before problem.GetDescsBackward() call
     if(problem.IsForward())
     {
@@ -90,8 +91,7 @@ bool MhaBackward::IsApplicable([[maybe_unused]] const ExecutionContext& context,
 
     auto [N, H, S, D] = miopen::tien<4>(descsBwd.kDesc.GetLengths());
 
-    return MIOPEN_USE_GEMM                                            //
-           && !miopen::IsDisabled(ENV(MIOPEN_DEBUG_ATTN_NAIVE_BWD))   //
+    return !miopen::IsDisabled(ENV(MIOPEN_DEBUG_ATTN_NAIVE_BWD))      //
            && S <= std::numeric_limits<uint32_t>::max()               //
            && D <= std::numeric_limits<uint32_t>::max()               //
            && descsBwd.kDesc.IsPacked()                               //
@@ -120,6 +120,10 @@ bool MhaBackward::IsApplicable([[maybe_unused]] const ExecutionContext& context,
                || (USE_ROCBLAS_EX3                                    //
                    && (MIOPEN_FP8_IEEE_EXPONENT_BIAS == 0)            //
                    && (descsBwd.doDesc.GetType() == miopenBFloat8))); //
+#else
+    return false;
+#endif
+
 }
 
 std::size_t MhaBackward::GetWorkspaceSize([[maybe_unused]] const ExecutionContext& context,

--- a/src/solver/mha/mha_solver_backward.cpp
+++ b/src/solver/mha/mha_solver_backward.cpp
@@ -90,8 +90,8 @@ bool MhaBackward::IsApplicable([[maybe_unused]] const ExecutionContext& context,
 
     auto [N, H, S, D] = miopen::tien<4>(descsBwd.kDesc.GetLengths());
 
-#if MIOPEN_USE_ROCBLAS
-    return !miopen::IsDisabled(ENV(MIOPEN_DEBUG_ATTN_NAIVE_BWD))      //
+    return MIOPEN_USE_GEMM                                            //
+           && !miopen::IsDisabled(ENV(MIOPEN_DEBUG_ATTN_NAIVE_BWD))   //
            && S <= std::numeric_limits<uint32_t>::max()               //
            && D <= std::numeric_limits<uint32_t>::max()               //
            && descsBwd.kDesc.IsPacked()                               //
@@ -120,9 +120,6 @@ bool MhaBackward::IsApplicable([[maybe_unused]] const ExecutionContext& context,
                || (USE_ROCBLAS_EX3                                    //
                    && (MIOPEN_FP8_IEEE_EXPONENT_BIAS == 0)            //
                    && (descsBwd.doDesc.GetType() == miopenBFloat8))); //
-#else
-    return false;
-#endif
 }
 
 std::size_t MhaBackward::GetWorkspaceSize([[maybe_unused]] const ExecutionContext& context,

--- a/src/solver/mha/mha_solver_backward.cpp
+++ b/src/solver/mha/mha_solver_backward.cpp
@@ -123,7 +123,6 @@ bool MhaBackward::IsApplicable([[maybe_unused]] const ExecutionContext& context,
 #else
     return false;
 #endif
-
 }
 
 std::size_t MhaBackward::GetWorkspaceSize([[maybe_unused]] const ExecutionContext& context,

--- a/src/solver/mha/mha_solver_forward.cpp
+++ b/src/solver/mha/mha_solver_forward.cpp
@@ -77,8 +77,8 @@ bool MhaForward::IsApplicable([[maybe_unused]] const ExecutionContext& context,
 
     auto [N, H, S, D] = miopen::tien<4>(descsFwd.kDesc.GetLengths());
 
-    return MIOPEN_USE_GEMM                                          //
-           && !miopen::IsDisabled(ENV(MIOPEN_DEBUG_ATTN_NAIVE_FWD)) //
+#if MIOPEN_USE_ROCBLAS
+    return !miopen::IsDisabled(ENV(MIOPEN_DEBUG_ATTN_NAIVE_FWD))    //
            && S <= std::numeric_limits<uint32_t>::max()             //
            && descsFwd.kDesc.IsPacked()                             //
            && descsFwd.qDesc.IsPacked()                             //
@@ -95,6 +95,9 @@ bool MhaForward::IsApplicable([[maybe_unused]] const ExecutionContext& context,
                || (USE_ROCBLAS_EX3                                  //
                    && (MIOPEN_FP8_IEEE_EXPONENT_BIAS == 0)          //
                    && (descsFwd.kDesc.GetType() == miopenFloat8))); //
+#else
+    return false;
+#endif
 }
 
 std::size_t MhaForward::GetWorkspaceSize([[maybe_unused]] const ExecutionContext& context,

--- a/src/solver/mha/mha_solver_forward.cpp
+++ b/src/solver/mha/mha_solver_forward.cpp
@@ -67,6 +67,7 @@ MultiBufferWorkspaceTraits SplitBufferToWorkspace(const std::vector<size_t>& len
 bool MhaForward::IsApplicable([[maybe_unused]] const ExecutionContext& context,
                               const miopen::mha::ProblemDescription& problem) const
 {
+#if MIOPEN_USE_GEMM
     // It's important to have this check before problem.GetDescsForward() call
     if(!problem.IsForward())
     {
@@ -77,8 +78,7 @@ bool MhaForward::IsApplicable([[maybe_unused]] const ExecutionContext& context,
 
     auto [N, H, S, D] = miopen::tien<4>(descsFwd.kDesc.GetLengths());
 
-    return MIOPEN_USE_GEMM                                          //
-           && !miopen::IsDisabled(ENV(MIOPEN_DEBUG_ATTN_NAIVE_FWD)) //
+    return !miopen::IsDisabled(ENV(MIOPEN_DEBUG_ATTN_NAIVE_FWD))    //
            && S <= std::numeric_limits<uint32_t>::max()             //
            && descsFwd.kDesc.IsPacked()                             //
            && descsFwd.qDesc.IsPacked()                             //
@@ -95,6 +95,9 @@ bool MhaForward::IsApplicable([[maybe_unused]] const ExecutionContext& context,
                || (USE_ROCBLAS_EX3                                  //
                    && (MIOPEN_FP8_IEEE_EXPONENT_BIAS == 0)          //
                    && (descsFwd.kDesc.GetType() == miopenFloat8))); //
+#else
+    return false;
+#endif
 }
 
 std::size_t MhaForward::GetWorkspaceSize([[maybe_unused]] const ExecutionContext& context,

--- a/src/solver/mha/mha_solver_forward.cpp
+++ b/src/solver/mha/mha_solver_forward.cpp
@@ -77,8 +77,8 @@ bool MhaForward::IsApplicable([[maybe_unused]] const ExecutionContext& context,
 
     auto [N, H, S, D] = miopen::tien<4>(descsFwd.kDesc.GetLengths());
 
-#if MIOPEN_USE_ROCBLAS
-    return !miopen::IsDisabled(ENV(MIOPEN_DEBUG_ATTN_NAIVE_FWD))    //
+    return MIOPEN_USE_GEMM                                          //
+           && !miopen::IsDisabled(ENV(MIOPEN_DEBUG_ATTN_NAIVE_FWD)) //
            && S <= std::numeric_limits<uint32_t>::max()             //
            && descsFwd.kDesc.IsPacked()                             //
            && descsFwd.qDesc.IsPacked()                             //
@@ -95,9 +95,6 @@ bool MhaForward::IsApplicable([[maybe_unused]] const ExecutionContext& context,
                || (USE_ROCBLAS_EX3                                  //
                    && (MIOPEN_FP8_IEEE_EXPONENT_BIAS == 0)          //
                    && (descsFwd.kDesc.GetType() == miopenFloat8))); //
-#else
-    return false;
-#endif
 }
 
 std::size_t MhaForward::GetWorkspaceSize([[maybe_unused]] const ExecutionContext& context,


### PR DESCRIPTION
Fix the compilation while `MIOPEN_USE_ROCBLAS` is `OFF`. We need to strip off the rocblas library in UAI, so this one is important.