### PR TITLE
test ck commit hash for Navi support after adding fp16 instances

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ nlohmann/json@v3.11.2 -DJSON_MultipleHeaders=ON -DJSON_BuildTests=Off
 ROCm/FunctionalPlus@v0.2.18-p0
 ROCm/eigen@3.4.0
 ROCm/frugally-deep@9683d557eb672ee2304f80f6682c51242d748a50
-ROCm/composable_kernel@d39c3f5d5e95f3e2fd85b730b9f25fe91fdb7c85 -DCMAKE_BUILD_TYPE=Release -DINSTANCES_ONLY=ON
+ROCm/composable_kernel@5fc1bee4c547d6af39743542d39498453d024f68 -DCMAKE_BUILD_TYPE=Release -DINSTANCES_ONLY=ON
 google/googletest@v1.14.0


### PR DESCRIPTION
This PR is for testing the new ck commit hash that enabled the fp16 conv support on Navi31. 