### PR TITLE
Remove the apostrophe in package description (#3027)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -641,7 +641,7 @@ endif()
 
 rocm_create_package(
     NAME MIOpen-${MIOPEN_BACKEND}
-    DESCRIPTION "AMD's DNN Library"
+    DESCRIPTION "AMD DNN Library"
     MAINTAINER "MIOpen Maintainer <miopen-lib.support@amd.com>"
     LDCONFIG
     # DEPENDS rocm-opencl hip-rocclr tinygemm


### PR DESCRIPTION
While creating wheel package, the rpm tags are read from the rpm package. The apostrophe in the package description is causing syntax error while parsing the description tag.