### PR TITLE
Fix "Crunching the latest data, just for you. Hang tight…"

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
-*.kdb filter=lfs diff=lfs merge=lfs -text
+*.db.bz2 binary
+*.fdb.txt.bz2 binary
 *.kdb.bz2 filter=lfs diff=lfs merge=lfs -text
+*.ktn.model binary


### PR DESCRIPTION
Contributors page get stuck with "Crunching the latest data, just for you. Hang tight…". This happens due to large file sizes.
