### PR TITLE
[debugging][NFC] Added logging of paths and versions of several packages (HIP, HIPRTC, COMgr, rocBlas, rocMLIR, rocRand, frugally-deep, Eigen3)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -217,7 +217,7 @@ endif()
 
 # HIP is always required
 find_package(hip REQUIRED PATHS /opt/rocm)
-message(STATUS "Build with HIP ${hip_VERSION}")
+message(STATUS "Build with HIP ${hip_VERSION} ${hip_DIR}")
 
 # Override HIP version in config.h, if necessary.
 # The variables set by find_package() can't be overwritten,
@@ -333,7 +333,7 @@ if( MIOPEN_BACKEND STREQUAL "HIP" OR MIOPEN_BACKEND STREQUAL "HIPOC" OR MIOPEN_B
     set(MIOPEN_USE_ROCBLAS ON CACHE BOOL "")
     if(MIOPEN_USE_ROCBLAS)
         find_package(rocblas REQUIRED PATHS /opt/rocm)
-        message(STATUS "Build with rocblas ${rocblas_VERSION}")
+        message(STATUS "Build with rocblas ${rocblas_VERSION} ${rocblas_DIR}")
     else()
         message(STATUS "Build without rocblas")
     endif()
@@ -402,7 +402,7 @@ if(MIOPEN_USE_MLIR)
             endif()
         endif()
     endif()
-    message(STATUS "Build with rocMLIR::rockCompiler ${rocMLIR_VERSION}")
+    message(STATUS "Build with rocMLIR::rockCompiler ${rocMLIR_VERSION} ${rocMLIR_DIR}")
 endif()
 
 # Update HIP Runtime Package Dependency
@@ -431,7 +431,7 @@ message(STATUS "AMDGCN assembler: ${MIOPEN_AMDGCN_ASSEMBLER}")
 
 if(MIOPEN_USE_COMGR)
     find_package(amd_comgr REQUIRED CONFIG)
-    message(STATUS "Build with comgr ${amd_comgr_VERSION}")
+    message(STATUS "Build with amd_comgr ${amd_comgr_VERSION} ${amd_comgr_DIR}")
     set(MIOPEN_PACKAGE_REQS "${MIOPEN_PACKAGE_REQS}, comgr")
 endif()
 
@@ -440,7 +440,7 @@ if(MIOPEN_USE_HIPRTC)
         message(FATAL_ERROR "HIPRTC can be used only together with COMGR")
     endif()
     find_package(hiprtc REQUIRED)
-    message(STATUS "Build with HIPRTC ${hiprtc_VERSION}")
+    message(STATUS "Build with hiprtc ${hiprtc_VERSION} ${hiprtc_DIR}")
 endif()
 
 option(Boost_USE_STATIC_LIBS "Use boost static libraries" ON)
@@ -471,7 +471,9 @@ endif()
 
 if(MIOPEN_ENABLE_AI_KERNEL_TUNING OR MIOPEN_ENABLE_AI_IMMED_MODE_FALLBACK)
     find_package(frugally-deep CONFIG REQUIRED)
+    message(STATUS "Build with frugally-deep ${frugally-deep_VERSION} ${frugally-deep_DIR}")
     find_package(Eigen3 REQUIRED)
+    message(STATUS "Build with Eigen3 ${Eigen3_VERSION} ${Eigen3_DIR}")
 endif()
 
 if(WIN32)
@@ -533,7 +535,7 @@ endif()
 if(MIOPEN_BUILD_DRIVER)
     # PR #2785 MIOpenDriver to use rocrand to init buffers
     find_package(rocrand REQUIRED)
-    message(STATUS "rocrand_VERSION=${rocrand_VERSION}")
+    message(STATUS "Build with rocrand ${rocrand_VERSION} ${rocrand_DIR}")
     set(MIOPEN_PACKAGE_REQS "${MIOPEN_PACKAGE_REQS}, rocrand")
 endif()
 


### PR DESCRIPTION
- Added logging of:
  - paths to the package configuration files for:
    - HIP
    - HIPRTC
    - COMgr
    - rocBlas
    - rocMLIR
    - rocRand
    - frugally-deep
    - Eigen3
  - versions of the following packages:
    - frugally-deep
    - Eigen3

The above helps to triage library configuration issues.

----
[Attribution] @junliume @JehandadKhan
- https://github.com/ROCm/MIOpen/labels/enhancement
- https://github.com/ROCm/MIOpen/labels/debugging
- https://github.com/ROCm/MIOpen/labels/urgency_normal
- Proposed reviewers:
  - @JehandadKhan 
  - @junliume
  - @DrizztDoUrden 
  - @CAHEK7 