### PR TITLE
Update GraphAPI Tensor to inherit from TensorDescriptor

### DIFF
--- a/src/graphapi/find_engine.cpp
+++ b/src/graphapi/find_engine.cpp
@@ -276,7 +276,7 @@ public:
 
         for(auto& [k, v] : *tensor_map)
         {
-            s = miopenSetProblemTensorDescriptor(mha_prob, v.mEnumId, &(v.mTensDesc));
+            s = miopenSetProblemTensorDescriptor(mha_prob, v.mEnumId, v.mGraphTensor);
             MIOPEN_THROW_IF(s != miopenStatusSuccess,
                             "failed while setting tensor descriptor for mha fwd");
         }

--- a/src/graphapi/find_engine.cpp
+++ b/src/graphapi/find_engine.cpp
@@ -81,7 +81,8 @@ class MHA_Fwd_F8_Pattern : public GraphPatternMatcher
     {
 
         assert(attn_scale);
-        std::vector<std::size_t> all1s = {1LL, 1LL, 1LL, 1LL};
+        std::vector<std::size_t> all1s = {
+            std::size_t{1}, std::size_t{1}, std::size_t{1}, std::size_t{1}};
 
         auto tensor_map = std::make_shared<TensorInfoMap>();
 

--- a/src/graphapi/find_engine.cpp
+++ b/src/graphapi/find_engine.cpp
@@ -81,7 +81,7 @@ class MHA_Fwd_F8_Pattern : public GraphPatternMatcher
     {
 
         assert(attn_scale);
-        std::vector<int64_t> all1s = {1LL, 1LL, 1LL, 1LL};
+        std::vector<std::size_t> all1s = {1LL, 1LL, 1LL, 1LL};
 
         auto tensor_map = std::make_shared<TensorInfoMap>();
 
@@ -126,28 +126,28 @@ class MHA_Fwd_F8_Pattern : public GraphPatternMatcher
                     *attn_scale  = alpha1;
                     /// \note old code assuming attn_scale applies to pw_mult
                     // auto* attn_scl = pw_0->getB();
-                    // assert(attn_scl->getDimensions() == all1s);
+                    // assert(attn_scl->GetLengths() == all1s);
                     // add_mapping(miopenTensorMhaAttnScale, attn_scl);
 
                     auto* pw_1 = dynamic_cast<OperationPointwise*>(
                         graph.findOutNeighByName(pw_0, "OP_POINTWISE:MUL"));
                     assert(pw_1);
                     auto dscl_q = pw_1->getB();
-                    assert(dscl_q->getDimensions() == all1s);
+                    assert(dscl_q->GetLengths() == all1s);
                     add_mapping(miopenTensorMhaDescaleQ, dscl_q);
 
                     auto* pw_2 = dynamic_cast<OperationPointwise*>(
                         graph.findOutNeighByName(pw_1, "OP_POINTWISE:MUL"));
                     assert(pw_2);
                     auto* dscl_k = pw_2->getB();
-                    assert(dscl_k->getDimensions() == all1s);
+                    assert(dscl_k->GetLengths() == all1s);
                     add_mapping(miopenTensorMhaDescaleK, dscl_k);
 
                     auto* red = dynamic_cast<OperationReduction*>(
                         graph.findOutNeighByName(pw_2, "OP_REDUCTION:MAX"));
                     assert(red);
                     auto* m = red->getY();
-                    assert(m->getDimensions()[3] == 1LL);
+                    assert(m->GetLengths()[3] == 1LL);
                     add_mapping(miopenTensorMhaM, m);
                 }
                 else
@@ -158,7 +158,7 @@ class MHA_Fwd_F8_Pattern : public GraphPatternMatcher
                     auto* pw_prev_cast = dynamic_cast<OperationPointwise*>(pw_prev);
                     assert(pw_prev_cast);
                     auto* scl_s = pw_prev_cast->getB();
-                    assert(scl_s->getDimensions() == all1s);
+                    assert(scl_s->GetLengths() == all1s);
                     add_mapping(miopenTensorMhaScaleS, scl_s);
 
                     auto* pw_0 = dynamic_cast<OperationPointwise*>(
@@ -166,28 +166,28 @@ class MHA_Fwd_F8_Pattern : public GraphPatternMatcher
                     assert(pw_0);
 
                     auto* dscl_s = pw_0->getB();
-                    assert(dscl_s->getDimensions() == all1s);
+                    assert(dscl_s->GetLengths() == all1s);
                     add_mapping(miopenTensorMhaDescaleS, dscl_s);
 
                     auto* pw_1 = dynamic_cast<OperationPointwise*>(
                         graph.findOutNeighByName(pw_0, "OP_POINTWISE:MUL"));
                     assert(pw_1);
                     auto* dscl_v = pw_1->getB();
-                    assert(dscl_v->getDimensions() == all1s);
+                    assert(dscl_v->GetLengths() == all1s);
                     add_mapping(miopenTensorMhaDescaleV, dscl_v);
 
                     auto* red = dynamic_cast<OperationReduction*>(
                         graph.findOutNeighByName(pw_1, "OP_REDUCTION:MAX"));
                     assert(red);
                     auto* amax_o = red->getY();
-                    assert(amax_o->getDimensions() == all1s);
+                    assert(amax_o->GetLengths() == all1s);
                     add_mapping(miopenTensorMhaAmaxO, amax_o);
 
                     auto* pw_2 = dynamic_cast<OperationPointwise*>(
                         graph.findOutNeighByName(pw_1, "OP_POINTWISE:MUL"));
                     assert(pw_2);
                     auto* scl_o = pw_2->getB();
-                    assert(scl_o->getDimensions() == all1s);
+                    assert(scl_o->GetLengths() == all1s);
                     add_mapping(miopenTensorMhaScaleO, scl_o);
 
                     auto* o = pw_2->getY();

--- a/src/graphapi/matmul.cpp
+++ b/src/graphapi/matmul.cpp
@@ -107,7 +107,7 @@ void BackendMatmulDescriptor::getAttribute(miopenBackendAttributeName_t attribut
 OperationMatmulBuilder& OperationMatmulBuilder::setA(Tensor* A)
 {
     mOperationMatmul.mA = checkPtr(A);
-    if(mOperationMatmul.mA->getDimensions().size() < 2)
+    if(mOperationMatmul.mA->GetLengths().size() < 2)
         MIOPEN_THROW(miopenStatusBadParm);
     mASet = true;
     return *this;
@@ -115,7 +115,7 @@ OperationMatmulBuilder& OperationMatmulBuilder::setA(Tensor* A)
 OperationMatmulBuilder& OperationMatmulBuilder::setB(Tensor* B)
 {
     mOperationMatmul.mB = checkPtr(B);
-    if(mOperationMatmul.mB->getDimensions().size() < 2)
+    if(mOperationMatmul.mB->GetLengths().size() < 2)
         MIOPEN_THROW(miopenStatusBadParm);
     mBSet = true;
     return *this;
@@ -123,7 +123,7 @@ OperationMatmulBuilder& OperationMatmulBuilder::setB(Tensor* B)
 OperationMatmulBuilder& OperationMatmulBuilder::setC(Tensor* C)
 {
     mOperationMatmul.mC = checkPtr(C);
-    if(mOperationMatmul.mC->getDimensions().size() < 2)
+    if(mOperationMatmul.mC->GetLengths().size() < 2)
         MIOPEN_THROW(miopenStatusBadParm);
     mCSet = true;
     return *this;
@@ -160,9 +160,9 @@ OperationMatmul OperationMatmulBuilder::build()
     if(!mASet || !mBSet || !mCSet || !mMatmulSet)
         MIOPEN_THROW(miopenStatusBadParm);
 
-    auto& aDimensions = mOperationMatmul.mA->getDimensions();
-    auto& bDimensions = mOperationMatmul.mB->getDimensions();
-    auto& cDimensions = mOperationMatmul.mC->getDimensions();
+    auto& aDimensions = mOperationMatmul.mA->GetLengths();
+    auto& bDimensions = mOperationMatmul.mB->GetLengths();
+    auto& cDimensions = mOperationMatmul.mC->GetLengths();
 
     int aDimensionsCount = aDimensions.size();
     int bDimensionsCount = bDimensions.size();
@@ -171,14 +171,14 @@ OperationMatmul OperationMatmulBuilder::build()
     if(cDimensionsCount != std::max(aDimensionsCount, bDimensionsCount))
         MIOPEN_THROW(miopenStatusBadParm);
 
-    int Am = aDimensions[aDimensionsCount - 2];
-    int An = aDimensions[aDimensionsCount - 1];
+    size_t Am = aDimensions[aDimensionsCount - 2];
+    size_t An = aDimensions[aDimensionsCount - 1];
 
-    int Bn = bDimensions[bDimensionsCount - 2];
-    int Bk = bDimensions[bDimensionsCount - 1];
+    size_t Bn = bDimensions[bDimensionsCount - 2];
+    size_t Bk = bDimensions[bDimensionsCount - 1];
 
-    int Cm = cDimensions[cDimensionsCount - 2];
-    int Ck = cDimensions[cDimensionsCount - 1];
+    size_t Cm = cDimensions[cDimensionsCount - 2];
+    size_t Ck = cDimensions[cDimensionsCount - 1];
 
     // non-tranpose case:
     bool nt = (Am == Cm && An == Bn && Bk == Ck);
@@ -188,7 +188,7 @@ OperationMatmul OperationMatmulBuilder::build()
     if(!nt && !tt)
         MIOPEN_THROW(miopenStatusBadParm);
 
-    auto correctBroadcastedDims = [](int dim1, int dim2, int dimOut) -> bool {
+    auto correctBroadcastedDims = [](size_t dim1, size_t dim2, size_t dimOut) -> bool {
         if(dim1 == dim2 && dim2 == dimOut)
             return true;
         if(dim1 == 1)

--- a/src/graphapi/pointwise.cpp
+++ b/src/graphapi/pointwise.cpp
@@ -745,9 +745,9 @@ OperationPointwise OperationPointwiseBuilder::build()
         if(mOperationPointwise.mX == nullptr || mOperationPointwise.mB == nullptr ||
            mOperationPointwise.mY == nullptr || mOperationPointwise.mT != nullptr ||
            mOperationPointwise.mDx != nullptr || mOperationPointwise.mDy != nullptr ||
-           !checkDimsWithPossibleBroadcasting(mOperationPointwise.mX->getDimensions(),
-                                              mOperationPointwise.mB->getDimensions(),
-                                              mOperationPointwise.mY->getDimensions()))
+           !checkDimsWithPossibleBroadcasting(mOperationPointwise.mX->GetLengths(),
+                                              mOperationPointwise.mB->GetLengths(),
+                                              mOperationPointwise.mY->GetLengths()))
         {
             MIOPEN_THROW(miopenStatusBadParm);
         }
@@ -782,10 +782,10 @@ OperationPointwise OperationPointwiseBuilder::build()
         if(mOperationPointwise.mX == nullptr || mOperationPointwise.mY == nullptr ||
            mOperationPointwise.mB != nullptr || mOperationPointwise.mT != nullptr ||
            mOperationPointwise.mDx != nullptr || mOperationPointwise.mDy != nullptr || mAlpha2Set ||
-           !std::equal(mOperationPointwise.mX->getDimensions().cbegin(),
-                       mOperationPointwise.mX->getDimensions().cend(),
-                       mOperationPointwise.mY->getDimensions().cbegin(),
-                       mOperationPointwise.mY->getDimensions().cend()))
+           !std::equal(mOperationPointwise.mX->GetLengths().cbegin(),
+                       mOperationPointwise.mX->GetLengths().cend(),
+                       mOperationPointwise.mY->GetLengths().cbegin(),
+                       mOperationPointwise.mY->GetLengths().cend()))
         {
             MIOPEN_THROW(miopenStatusBadParm);
         }
@@ -801,18 +801,18 @@ OperationPointwise OperationPointwiseBuilder::build()
         if(mOperationPointwise.mX == nullptr || mOperationPointwise.mB == nullptr ||
            mOperationPointwise.mT == nullptr || mOperationPointwise.mY == nullptr ||
            mOperationPointwise.mDx != nullptr || mOperationPointwise.mDy != nullptr ||
-           !std::equal(mOperationPointwise.mX->getDimensions().cbegin(),
-                       mOperationPointwise.mX->getDimensions().cend(),
-                       mOperationPointwise.mB->getDimensions().cbegin(),
-                       mOperationPointwise.mB->getDimensions().cend()) ||
-           !std::equal(mOperationPointwise.mX->getDimensions().cbegin(),
-                       mOperationPointwise.mX->getDimensions().cend(),
-                       mOperationPointwise.mT->getDimensions().cbegin(),
-                       mOperationPointwise.mT->getDimensions().cend()) ||
-           !std::equal(mOperationPointwise.mX->getDimensions().cbegin(),
-                       mOperationPointwise.mX->getDimensions().cend(),
-                       mOperationPointwise.mY->getDimensions().cbegin(),
-                       mOperationPointwise.mY->getDimensions().cend()))
+           !std::equal(mOperationPointwise.mX->GetLengths().cbegin(),
+                       mOperationPointwise.mX->GetLengths().cend(),
+                       mOperationPointwise.mB->GetLengths().cbegin(),
+                       mOperationPointwise.mB->GetLengths().cend()) ||
+           !std::equal(mOperationPointwise.mX->GetLengths().cbegin(),
+                       mOperationPointwise.mX->GetLengths().cend(),
+                       mOperationPointwise.mT->GetLengths().cbegin(),
+                       mOperationPointwise.mT->GetLengths().cend()) ||
+           !std::equal(mOperationPointwise.mX->GetLengths().cbegin(),
+                       mOperationPointwise.mX->GetLengths().cend(),
+                       mOperationPointwise.mY->GetLengths().cbegin(),
+                       mOperationPointwise.mY->GetLengths().cend()))
         {
             MIOPEN_THROW(miopenStatusBadParm);
         }
@@ -834,9 +834,9 @@ OperationPointwise OperationPointwiseBuilder::build()
         if(mOperationPointwise.mY == nullptr || mOperationPointwise.mDy == nullptr ||
            mOperationPointwise.mDx == nullptr || mOperationPointwise.mX != nullptr ||
            mOperationPointwise.mB != nullptr || mOperationPointwise.mT != nullptr ||
-           !checkDimsWithPossibleBroadcasting(mOperationPointwise.mY->getDimensions(),
-                                              mOperationPointwise.mDy->getDimensions(),
-                                              mOperationPointwise.mDx->getDimensions()))
+           !checkDimsWithPossibleBroadcasting(mOperationPointwise.mY->GetLengths(),
+                                              mOperationPointwise.mDy->GetLengths(),
+                                              mOperationPointwise.mDx->GetLengths()))
         {
             MIOPEN_THROW(miopenStatusBadParm);
         }

--- a/src/graphapi/reduction.cpp
+++ b/src/graphapi/reduction.cpp
@@ -202,10 +202,10 @@ OperationReduction OperationReductionBuilder::build()
 {
     if(mOperationReduction.mReduction != nullptr && mOperationReduction.mX != nullptr &&
        mOperationReduction.mY != nullptr &&
-       std::equal(mOperationReduction.mX->getDimensions().cbegin(),
-                  mOperationReduction.mX->getDimensions().cend(),
-                  mOperationReduction.mY->getDimensions().cbegin(),
-                  mOperationReduction.mY->getDimensions().cend(),
+       std::equal(mOperationReduction.mX->GetLengths().cbegin(),
+                  mOperationReduction.mX->GetLengths().cend(),
+                  mOperationReduction.mY->GetLengths().cbegin(),
+                  mOperationReduction.mY->GetLengths().cend(),
                   [](auto inputDim, auto outputDim) {
                       return outputDim == 1 || outputDim == inputDim || outputDim % inputDim == 0;
                   }))

--- a/src/graphapi/reshape.cpp
+++ b/src/graphapi/reshape.cpp
@@ -62,10 +62,10 @@ OperationReshape OperationReshapeBuilder::build()
     if(!valid)
         MIOPEN_THROW(miopenStatusBadParm);
 
-    const auto& inputDims     = mOperationReshape.mX->getDimensions();
-    const auto& inputStrides  = mOperationReshape.mX->getStrides();
-    const auto& outputDims    = mOperationReshape.mY->getDimensions();
-    const auto& outputStrides = mOperationReshape.mY->getStrides();
+    const auto& inputDims     = mOperationReshape.mX->GetLengths();
+    const auto& inputStrides  = mOperationReshape.mX->GetStrides();
+    const auto& outputDims    = mOperationReshape.mY->GetLengths();
+    const auto& outputStrides = mOperationReshape.mY->GetStrides();
     const auto size           = inputDims.size();
 
     /* Detect a case of transpose operation for the last 2 dimensions:

--- a/src/graphapi/rng.cpp
+++ b/src/graphapi/rng.cpp
@@ -236,8 +236,8 @@ OperationRngBuilder& OperationRngBuilder::setSeed(Tensor* seed)
 {
     bool valid = seed != nullptr;
 
-    valid = valid && miopen::all_of(seed->getDimensions(), [](auto v) { return v == 1; }) &&
-            miopen::all_of(seed->getStrides(), [](auto v) { return v == 1; });
+    valid = valid && miopen::all_of(seed->GetLengths(), [](auto v) { return v == 1; }) &&
+            miopen::all_of(seed->GetStrides(), [](auto v) { return v == 1; });
 
     if(valid)
     {
@@ -254,8 +254,8 @@ OperationRngBuilder& OperationRngBuilder::setOffset(Tensor* offset)
 {
     bool valid = offset != nullptr;
 
-    valid = valid && miopen::all_of(offset->getDimensions(), [](auto v) { return v == 1; }) &&
-            miopen::all_of(offset->getStrides(), [](auto v) { return v == 1; });
+    valid = valid && miopen::all_of(offset->GetLengths(), [](auto v) { return v == 1; }) &&
+            miopen::all_of(offset->GetStrides(), [](auto v) { return v == 1; });
 
     if(valid)
     {

--- a/src/graphapi/tensor.cpp
+++ b/src/graphapi/tensor.cpp
@@ -163,7 +163,7 @@ void BackendTensorDescriptor::setAttribute(miopenBackendAttributeName_t attribut
         {
             mBuilder.setDim(
                 std::vector<std::size_t>(static_cast<int64_t*>(arrayOfElements),
-                                     static_cast<int64_t*>(arrayOfElements) + elementCount));
+                                         static_cast<int64_t*>(arrayOfElements) + elementCount));
             return;
         }
         else
@@ -176,7 +176,7 @@ void BackendTensorDescriptor::setAttribute(miopenBackendAttributeName_t attribut
         {
             mBuilder.setStride(
                 std::vector<std::size_t>(static_cast<int64_t*>(arrayOfElements),
-                                     static_cast<int64_t*>(arrayOfElements) + elementCount));
+                                         static_cast<int64_t*>(arrayOfElements) + elementCount));
             return;
         }
         else

--- a/src/graphapi/tensor.cpp
+++ b/src/graphapi/tensor.cpp
@@ -39,9 +39,9 @@ TensorBuilder& TensorBuilder::setDataType(miopenDataType_t dataType) &
     return *this;
 }
 
-TensorBuilder& TensorBuilder::setDim(const std::vector<int64_t>& dimensions) &
+TensorBuilder& TensorBuilder::setDim(const std::vector<std::size_t>& dimensions) &
 {
-    if(dimensions.empty() || miopen::any_of(dimensions, [](int64_t val) { return val <= 0; }))
+    if(dimensions.empty() || miopen::any_of(dimensions, [](std::size_t val) { return val <= 0; }))
     {
         MIOPEN_THROW(miopenStatusBadParm);
     }
@@ -51,9 +51,9 @@ TensorBuilder& TensorBuilder::setDim(const std::vector<int64_t>& dimensions) &
     return *this;
 }
 
-TensorBuilder& TensorBuilder::setDim(std::vector<int64_t>&& dimensions) &
+TensorBuilder& TensorBuilder::setDim(std::vector<std::size_t>&& dimensions) &
 {
-    if(dimensions.empty() || miopen::any_of(dimensions, [](int64_t val) { return val <= 0; }))
+    if(dimensions.empty() || miopen::any_of(dimensions, [](std::size_t val) { return val <= 0; }))
     {
         MIOPEN_THROW(miopenStatusBadParm);
     }
@@ -63,9 +63,9 @@ TensorBuilder& TensorBuilder::setDim(std::vector<int64_t>&& dimensions) &
     return *this;
 }
 
-TensorBuilder& TensorBuilder::setStride(const std::vector<int64_t>& strides) &
+TensorBuilder& TensorBuilder::setStride(const std::vector<std::size_t>& strides) &
 {
-    if(strides.empty() || miopen::any_of(strides, [](int64_t val) { return val <= 0; }))
+    if(strides.empty() || miopen::any_of(strides, [](std::size_t val) { return val <= 0; }))
     {
         MIOPEN_THROW(miopenStatusBadParm);
     }
@@ -75,9 +75,9 @@ TensorBuilder& TensorBuilder::setStride(const std::vector<int64_t>& strides) &
     return *this;
 }
 
-TensorBuilder& TensorBuilder::setStride(std::vector<int64_t>&& strides) &
+TensorBuilder& TensorBuilder::setStride(std::vector<std::size_t>&& strides) &
 {
-    if(strides.empty() || miopen::any_of(strides, [](int64_t val) { return val <= 0; }))
+    if(strides.empty() || miopen::any_of(strides, [](std::size_t val) { return val <= 0; }))
     {
         MIOPEN_THROW(miopenStatusBadParm);
     }
@@ -162,7 +162,7 @@ void BackendTensorDescriptor::setAttribute(miopenBackendAttributeName_t attribut
         if(attributeType == MIOPEN_TYPE_INT64 && elementCount > 0)
         {
             mBuilder.setDim(
-                std::vector<int64_t>(static_cast<int64_t*>(arrayOfElements),
+                std::vector<std::size_t>(static_cast<int64_t*>(arrayOfElements),
                                      static_cast<int64_t*>(arrayOfElements) + elementCount));
             return;
         }
@@ -175,7 +175,7 @@ void BackendTensorDescriptor::setAttribute(miopenBackendAttributeName_t attribut
         if(attributeType == MIOPEN_TYPE_INT64 && elementCount > 0)
         {
             mBuilder.setStride(
-                std::vector<int64_t>(static_cast<int64_t*>(arrayOfElements),
+                std::vector<std::size_t>(static_cast<int64_t*>(arrayOfElements),
                                      static_cast<int64_t*>(arrayOfElements) + elementCount));
             return;
         }
@@ -243,7 +243,7 @@ void BackendTensorDescriptor::getAttribute(miopenBackendAttributeName_t attribut
     case MIOPEN_ATTR_TENSOR_DATA_TYPE:
         if(attributeType == MIOPEN_TYPE_DATA_TYPE && requestedElementCount == 1)
         {
-            *static_cast<miopenDataType_t*>(arrayOfElements) = mDescriptor.getDataType();
+            *static_cast<miopenDataType_t*>(arrayOfElements) = mDescriptor.GetType();
             *elementCount                                    = 1;
             return;
         }
@@ -255,7 +255,7 @@ void BackendTensorDescriptor::getAttribute(miopenBackendAttributeName_t attribut
     case MIOPEN_ATTR_TENSOR_DIMENSIONS:
         if(attributeType == MIOPEN_TYPE_INT64 && requestedElementCount >= 0)
         {
-            const auto& dimensions = mDescriptor.getDimensions();
+            const auto& dimensions = mDescriptor.GetLengths();
             *elementCount          = dimensions.size();
             std::copy_n(dimensions.begin(),
                         minimum(*elementCount, requestedElementCount),
@@ -270,7 +270,7 @@ void BackendTensorDescriptor::getAttribute(miopenBackendAttributeName_t attribut
     case MIOPEN_ATTR_TENSOR_STRIDES:
         if(attributeType == MIOPEN_TYPE_INT64 && requestedElementCount >= 0)
         {
-            const auto& strides = mDescriptor.getStrides();
+            const auto& strides = mDescriptor.GetStrides();
             *elementCount       = strides.size();
             std::copy_n(strides.begin(),
                         minimum(*elementCount, requestedElementCount),

--- a/src/include/miopen/graphapi/engine.hpp
+++ b/src/include/miopen/graphapi/engine.hpp
@@ -57,13 +57,10 @@ struct TensorInfo
 {
     miopenTensorArgumentId_t mEnumId = miopenTensorArgumentIdInvalid;
     Tensor* mGraphTensor             = nullptr;
-    TensorDescriptor mTensDesc{};
-    Data_t mDevBuf = nullptr;
+    Data_t mDevBuf                   = nullptr;
 
     TensorInfo(miopenTensorArgumentId_t enum_id, Tensor* tens_ptr)
-        : mEnumId(enum_id),
-          mGraphTensor(tens_ptr),
-          mTensDesc(static_cast<TensorDescriptor>(*tens_ptr))
+        : mEnumId(enum_id), mGraphTensor(tens_ptr)
     {
         assert(tens_ptr);
         assert(mEnumId != miopenTensorArgumentIdInvalid);
@@ -74,8 +71,6 @@ struct TensorInfo
         assert(ptr);
         mDevBuf = ptr;
     }
-
-    const TensorDescriptor* tensDescPtr() const { return &mTensDesc; }
 };
 
 // int64_t is the graph tensor id

--- a/src/include/miopen/graphapi/tensor.hpp
+++ b/src/include/miopen/graphapi/tensor.hpp
@@ -38,8 +38,8 @@ namespace graphapi {
 class Tensor : public TensorDescriptor
 {
 private:
-    int64_t mId                = 0;
-    bool mVirtual              = false;
+    int64_t mId   = 0;
+    bool mVirtual = false;
 
 public:
     Tensor() noexcept         = default;
@@ -47,20 +47,12 @@ public:
     Tensor(Tensor&&) noexcept = default;
     Tensor& operator=(const Tensor&) = default;
     Tensor& operator=(Tensor&&) noexcept = default;
-    Tensor(const TensorDescriptor& other,
-            int64_t id,
-            bool isVirtual)
-            : TensorDescriptor(other),
-            mId(id),
-            mVirtual(isVirtual)
+    Tensor(const TensorDescriptor& other, int64_t id, bool isVirtual)
+        : TensorDescriptor(other), mId(id), mVirtual(isVirtual)
     {
     }
-    Tensor(TensorDescriptor&& other,
-            int64_t id,
-            bool isVirtual)
-            : TensorDescriptor(std::move(other)),
-            mId(id),
-            mVirtual(isVirtual)
+    Tensor(TensorDescriptor&& other, int64_t id, bool isVirtual)
+        : TensorDescriptor(std::move(other)), mId(id), mVirtual(isVirtual)
     {
     }
     Tensor(miopenDataType_t dataType,
@@ -78,7 +70,7 @@ public:
            std::vector<std::size_t>&& strides,
            int64_t id,
            bool isVirtual) noexcept
-        : TensorDescriptor(dataType, getLayout(strides), std::move(dimensions),  std::move(strides)),
+        : TensorDescriptor(dataType, getLayout(strides), std::move(dimensions), std::move(strides)),
           mId(id),
           mVirtual(isVirtual)
     {
@@ -94,15 +86,19 @@ private:
         {
             int stride_c = strides[1];
 
-            // If channels have the smallest stride, or are tied for smallest stride, then we are assuming NHWC format.
-            // Otherwise, assume NCHW format.
-            if(std::all_of(strides.cbegin(), strides.cend(), [stride_c](std::size_t x) { return x >= stride_c; }))
+            // If channels have the smallest stride, or are tied for smallest stride, then we are
+            // assuming NHWC format. Otherwise, assume NCHW format.
+            if(std::all_of(strides.cbegin(), strides.cend(), [stride_c](std::size_t x) {
+                   return x >= stride_c;
+               }))
             {
-               return strides.size() == 4 ? miopenTensorLayout_t::miopenTensorNHWC : miopenTensorLayout_t::miopenTensorNDHWC;
+                return strides.size() == 4 ? miopenTensorLayout_t::miopenTensorNHWC
+                                           : miopenTensorLayout_t::miopenTensorNDHWC;
             }
             else
             {
-               return strides.size() == 4 ? miopenTensorLayout_t::miopenTensorNCHW : miopenTensorLayout_t::miopenTensorNCDHW;
+                return strides.size() == 4 ? miopenTensorLayout_t::miopenTensorNCHW
+                                           : miopenTensorLayout_t::miopenTensorNCDHW;
             }
         }
 

--- a/src/include/miopen/graphapi/tensor.hpp
+++ b/src/include/miopen/graphapi/tensor.hpp
@@ -35,13 +35,10 @@ namespace miopen {
 
 namespace graphapi {
 
-class Tensor
+class Tensor : public TensorDescriptor
 {
 private:
-    std::vector<int64_t> mDimensions;
-    std::vector<int64_t> mStrides;
     int64_t mId                = 0;
-    miopenDataType_t mDataType = miopenFloat;
     bool mVirtual              = false;
 
 public:
@@ -50,50 +47,74 @@ public:
     Tensor(Tensor&&) noexcept = default;
     Tensor& operator=(const Tensor&) = default;
     Tensor& operator=(Tensor&&) noexcept = default;
+    Tensor(const TensorDescriptor& other,
+            int64_t id,
+            bool isVirtual)
+            : TensorDescriptor(other),
+            mId(id),
+            mVirtual(isVirtual)
+    {
+    }
+    Tensor(TensorDescriptor&& other,
+            int64_t id,
+            bool isVirtual)
+            : TensorDescriptor(std::move(other)),
+            mId(id),
+            mVirtual(isVirtual)
+    {
+    }
     Tensor(miopenDataType_t dataType,
-           const std::vector<int64_t>& dimensions,
-           const std::vector<int64_t>& strides,
+           const std::vector<std::size_t>& dimensions,
+           const std::vector<std::size_t>& strides,
            int64_t id,
            bool isVirtual)
-        : mDimensions(dimensions),
-          mStrides(strides),
+        : TensorDescriptor(dataType, getLayout(strides), dimensions, strides),
           mId(id),
-          mDataType(dataType),
           mVirtual(isVirtual)
     {
     }
     Tensor(miopenDataType_t dataType,
-           std::vector<int64_t>&& dimensions,
-           std::vector<int64_t>&& strides,
+           std::vector<std::size_t>&& dimensions,
+           std::vector<std::size_t>&& strides,
            int64_t id,
            bool isVirtual) noexcept
-        : mDimensions(std::move(dimensions)),
-          mStrides(std::move(strides)),
+        : TensorDescriptor(dataType, getLayout(strides), std::move(dimensions),  std::move(strides)),
           mId(id),
-          mDataType(dataType),
           mVirtual(isVirtual)
     {
     }
 
-    operator miopen::TensorDescriptor() const
-    {
-        return {mDataType,
-                std::vector<std::size_t>(mDimensions.cbegin(), mDimensions.cend()),
-                std::vector<std::size_t>(mStrides.cbegin(), mStrides.cend())};
-    }
-
-    miopenDataType_t getDataType() const noexcept { return mDataType; }
-    const std::vector<int64_t>& getDimensions() const noexcept { return mDimensions; }
-    const std::vector<int64_t>& getStrides() const noexcept { return mStrides; }
     int64_t getId() const noexcept { return mId; }
     bool isVirtual() const noexcept { return mVirtual; }
+
+private:
+    static miopenTensorLayout_t getLayout(const std::vector<std::size_t>& strides)
+    {
+        if(strides.size() >= 4)
+        {
+            int stride_c = strides[1];
+
+            // If channels have the smallest stride, or are tied for smallest stride, then we are assuming NHWC format.
+            // Otherwise, assume NCHW format.
+            if(std::all_of(strides.cbegin(), strides.cend(), [stride_c](std::size_t x) { return x >= stride_c; }))
+            {
+               return strides.size() == 4 ? miopenTensorLayout_t::miopenTensorNHWC : miopenTensorLayout_t::miopenTensorNDHWC;
+            }
+            else
+            {
+               return strides.size() == 4 ? miopenTensorLayout_t::miopenTensorNCHW : miopenTensorLayout_t::miopenTensorNCDHW;
+            }
+        }
+
+        return GetDefaultLayout();
+    }
 };
 
 class MIOPEN_INTERNALS_EXPORT TensorBuilder
 {
 private:
-    std::vector<int64_t> mDimensions;
-    std::vector<int64_t> mStrides;
+    std::vector<std::size_t> mDimensions;
+    std::vector<std::size_t> mStrides;
     int64_t mId                = 0;
     miopenDataType_t mDataType = miopenFloat;
     bool mVirtual              = false;
@@ -104,10 +125,10 @@ private:
 
 public:
     TensorBuilder& setDataType(miopenDataType_t dataType) &;
-    TensorBuilder& setDim(const std::vector<int64_t>& dimensions) &;
-    TensorBuilder& setDim(std::vector<int64_t>&& dimensions) &;
-    TensorBuilder& setStride(const std::vector<int64_t>& strides) &;
-    TensorBuilder& setStride(std::vector<int64_t>&& strides) &;
+    TensorBuilder& setDim(const std::vector<std::size_t>& dimensions) &;
+    TensorBuilder& setDim(std::vector<std::size_t>&& dimensions) &;
+    TensorBuilder& setStride(const std::vector<std::size_t>& strides) &;
+    TensorBuilder& setStride(std::vector<std::size_t>&& strides) &;
     TensorBuilder& setId(int64_t id) &;
     TensorBuilder& setVirtual(bool isVirtual) &;
 
@@ -115,19 +136,19 @@ public:
     {
         return std::move(setDataType(dataType));
     }
-    TensorBuilder&& setDim(const std::vector<int64_t>& dimensions) &&
+    TensorBuilder&& setDim(const std::vector<std::size_t>& dimensions) &&
     {
         return std::move(setDim(dimensions));
     }
-    TensorBuilder&& setDim(std::vector<int64_t>&& dimensions) &&
+    TensorBuilder&& setDim(std::vector<std::size_t>&& dimensions) &&
     {
         return std::move(setDim(std::move(dimensions)));
     }
-    TensorBuilder&& setStride(const std::vector<int64_t>& strides) &&
+    TensorBuilder&& setStride(const std::vector<std::size_t>& strides) &&
     {
         return std::move(setStride(strides));
     }
-    TensorBuilder&& setStride(std::vector<int64_t>&& strides) &&
+    TensorBuilder&& setStride(std::vector<std::size_t>&& strides) &&
     {
         return std::move(setStride(std::move(strides)));
     }

--- a/src/include/miopen/graphapi/util.hpp
+++ b/src/include/miopen/graphapi/util.hpp
@@ -64,24 +64,8 @@ Tensor makeTensor(std::string_view name, miopenDataType_t dt, const Vec& dims, c
 template <bool isVirtual, typename Vec>
 Tensor makeTensor(std::string_view name, miopenDataType_t dt, const Vec& dims)
 {
-
-    Vec strides(dims);
-    using T = typename Vec::value_type;
-    // former std::exclusive_scan(dims.begin(),
-    //                            dims.end(),
-    //                            strides.begin(),
-    //                            T{1LL}, std::multiplies<T>{});
-    // replaced by the loop due to std::exclusive_scan is not supported on gcc older that 11
-    if(!dims.empty())
-    {
-        strides[0] = static_cast<T>(1);
-        for(size_t i = 0; i < dims.size() - 1; ++i)
-        {
-            strides[i + 1] = dims[i] * strides[i];
-        }
-    }
-
-    return makeTensor<isVirtual>(name, dt, dims, strides);
+    TensorDescriptor desc{dt, dims};
+    return makeTensor<isVirtual>(name, dt, desc.GetLengths(), desc.GetStrides());
 }
 
 /// An RAII style class that captures a pointer to an object on heap and frees it

--- a/src/include/miopen/graphapi/util.hpp
+++ b/src/include/miopen/graphapi/util.hpp
@@ -182,7 +182,7 @@ struct PatternGraphGenerator
     inline Tensor* makeDummyTensor(std::string_view name)
     {
 
-        return mAlloc.allocate(makeTensor<true>(name, miopenFloat, std::vector<int64_t>({1})));
+        return mAlloc.allocate(makeTensor<true>(name, miopenFloat, std::vector<size_t>({1})));
     }
 
 private:

--- a/src/include/miopen/tensor.hpp
+++ b/src/include/miopen/tensor.hpp
@@ -307,11 +307,7 @@ private:
                      std::vector<std::size_t>&& strides_in,
                      bool use_strides);
 
-    static void CheckArguments(miopenDataType_t t,
-                               miopenTensorLayout_t layout_in,
-                               const std::vector<std::size_t>& lens_in,
-                               const std::vector<std::size_t>& strides_in,
-                               bool use_strides);
+    void CheckArgsAndInit(bool use_strides);
 
     void SetStrideNd(const std::string& layout);
     void LensReorder(const std::string& layout);

--- a/src/include/miopen/tensor.hpp
+++ b/src/include/miopen/tensor.hpp
@@ -144,6 +144,7 @@ struct MIOPEN_INTERNALS_EXPORT TensorDescriptor : miopenTensorDescriptor
     TensorDescriptor(miopenDataType_t t, const std::vector<int>& lens_in);
     TensorDescriptor(miopenDataType_t t, const std::initializer_list<std::size_t>& lens_in);
     TensorDescriptor(miopenDataType_t t, const std::vector<std::size_t>& lens_in);
+    TensorDescriptor(miopenDataType_t t, std::vector<std::size_t>&& lens_in);
 
     TensorDescriptor(miopenDataType_t t,
                      miopenTensorLayout_t layout_in,
@@ -154,6 +155,9 @@ struct MIOPEN_INTERNALS_EXPORT TensorDescriptor : miopenTensorDescriptor
     TensorDescriptor(miopenDataType_t t,
                      miopenTensorLayout_t layout_in,
                      const std::vector<std::size_t>& lens_in);
+    TensorDescriptor(miopenDataType_t t,
+                     miopenTensorLayout_t layout_in,
+                     std::vector<std::size_t>&& lens_in);
 
     TensorDescriptor(miopenDataType_t t,
                      const std::vector<int>& lens_in,
@@ -164,11 +168,18 @@ struct MIOPEN_INTERNALS_EXPORT TensorDescriptor : miopenTensorDescriptor
     TensorDescriptor(miopenDataType_t t,
                      const std::vector<std::size_t>& lens_in,
                      const std::vector<std::size_t>& strides_in);
+    TensorDescriptor(miopenDataType_t t,
+                     std::vector<std::size_t>&& lens_in,
+                     std::vector<std::size_t>&& strides_in);
 
     TensorDescriptor(miopenDataType_t t,
                      miopenTensorLayout_t layout_in,
                      const std::vector<std::size_t>& lens_in,
                      const std::vector<std::size_t>& strides_in);
+    TensorDescriptor(miopenDataType_t t,
+                    miopenTensorLayout_t layout_in,
+                    std::vector<std::size_t>&& lens_in,
+                    std::vector<std::size_t>&& strides_in);
 
     // Use only for external API
     static TensorDescriptor MakeDescriptor(miopenDataType_t t, const int* plens, int size);
@@ -280,8 +291,23 @@ struct MIOPEN_INTERNALS_EXPORT TensorDescriptor : miopenTensorDescriptor
     friend void to_json(nlohmann::json& j, const TensorDescriptor& descriptor);
     friend void from_json(const nlohmann::json& j, TensorDescriptor& descriptor);
 
+protected:
+    static miopenTensorLayout_t GetDefaultLayout() { return miopenTensorNCHW; };
+
 private:
     TensorDescriptor(miopenDataType_t t,
+                     miopenTensorLayout_t layout_in,
+                     const std::vector<std::size_t>& lens_in,
+                     const std::vector<std::size_t>& strides_in,
+                     bool use_strides);
+
+    TensorDescriptor(miopenDataType_t t,
+                    miopenTensorLayout_t layout_in,
+                    std::vector<std::size_t>&& lens_in,
+                    std::vector<std::size_t>&& strides_in,
+                    bool use_strides);
+
+    static void CheckArguments(miopenDataType_t t,
                      miopenTensorLayout_t layout_in,
                      const std::vector<std::size_t>& lens_in,
                      const std::vector<std::size_t>& strides_in,
@@ -292,8 +318,6 @@ private:
 
     void CalculateStrides();
     void CalculateVectorLength();
-
-    static miopenTensorLayout_t GetDefaultLayout() { return miopenTensorNCHW; };
 
     std::vector<std::size_t> lens;
     std::vector<std::size_t> strides;

--- a/src/include/miopen/tensor.hpp
+++ b/src/include/miopen/tensor.hpp
@@ -177,9 +177,9 @@ struct MIOPEN_INTERNALS_EXPORT TensorDescriptor : miopenTensorDescriptor
                      const std::vector<std::size_t>& lens_in,
                      const std::vector<std::size_t>& strides_in);
     TensorDescriptor(miopenDataType_t t,
-                    miopenTensorLayout_t layout_in,
-                    std::vector<std::size_t>&& lens_in,
-                    std::vector<std::size_t>&& strides_in);
+                     miopenTensorLayout_t layout_in,
+                     std::vector<std::size_t>&& lens_in,
+                     std::vector<std::size_t>&& strides_in);
 
     // Use only for external API
     static TensorDescriptor MakeDescriptor(miopenDataType_t t, const int* plens, int size);
@@ -302,16 +302,16 @@ private:
                      bool use_strides);
 
     TensorDescriptor(miopenDataType_t t,
-                    miopenTensorLayout_t layout_in,
-                    std::vector<std::size_t>&& lens_in,
-                    std::vector<std::size_t>&& strides_in,
-                    bool use_strides);
+                     miopenTensorLayout_t layout_in,
+                     std::vector<std::size_t>&& lens_in,
+                     std::vector<std::size_t>&& strides_in,
+                     bool use_strides);
 
     static void CheckArguments(miopenDataType_t t,
-                     miopenTensorLayout_t layout_in,
-                     const std::vector<std::size_t>& lens_in,
-                     const std::vector<std::size_t>& strides_in,
-                     bool use_strides);
+                               miopenTensorLayout_t layout_in,
+                               const std::vector<std::size_t>& lens_in,
+                               const std::vector<std::size_t>& strides_in,
+                               bool use_strides);
 
     void SetStrideNd(const std::string& layout);
     void LensReorder(const std::string& layout);

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -198,6 +198,13 @@ TensorDescriptor::TensorDescriptor(miopenDataType_t t,
 }
 
 TensorDescriptor::TensorDescriptor(miopenDataType_t t,
+                                   std::vector<std::size_t>&& lens_in,
+                                   std::vector<std::size_t>&& strides_in)
+    : TensorDescriptor(t, GetDefaultLayout(), std::move(lens_in), std::move(strides_in))
+{
+}
+
+TensorDescriptor::TensorDescriptor(miopenDataType_t t,
                                    miopenTensorLayout_t layout_in,
                                    const std::vector<std::size_t>& lens_in,
                                    const std::vector<std::size_t>& strides_in)

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -262,12 +262,11 @@ TensorDescriptor::TensorDescriptor(miopenDataType_t t,
     }
 }
 
-
 void TensorDescriptor::CheckArguments(miopenDataType_t t,
-                                   miopenTensorLayout_t layout_in,
-                                   const std::vector<std::size_t>& lens_in,
-                                   const std::vector<std::size_t>& strides_in,
-                                   bool use_strides)
+                                      miopenTensorLayout_t layout_in,
+                                      const std::vector<std::size_t>& lens_in,
+                                      const std::vector<std::size_t>& strides_in,
+                                      bool use_strides)
 {
     if(!IsDataTypeSupported(t))
         MIOPEN_THROW(miopenStatusBadParm, "Unsupported data type");
@@ -280,7 +279,7 @@ void TensorDescriptor::CheckArguments(miopenDataType_t t,
 
     if(!CheckLengths(lens_in, static_cast<std::size_t>(std::numeric_limits<int64_t>::max())))
         MIOPEN_THROW(miopenStatusBadParm, "Lengths must be > 0 and <= INT64_MAX");
-    
+
     if(use_strides)
     {
         if(lens_in.size() != strides_in.size())

--- a/test/gtest/graphapi_conv_bias_res_add_activ_fwd.cpp
+++ b/test/gtest/graphapi_conv_bias_res_add_activ_fwd.cpp
@@ -1,0 +1,394 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2024 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#include <gtest/gtest.h>
+#include <miopen/miopen.h>
+#include <miopen/env.hpp>
+
+#include <miopen/graphapi/convolution.hpp>
+#include <miopen/graphapi/execution_plan.hpp>
+#include <miopen/graphapi/matmul.hpp>
+#include <miopen/graphapi/opgraph.hpp>
+#include <miopen/graphapi/pointwise.hpp>
+#include <miopen/graphapi/rng.hpp>
+#include <miopen/graphapi/util.hpp>
+#include <miopen/graphapi/variant_pack.hpp>
+
+#include "tensor_util.hpp"
+#include "get_handle.hpp"
+
+#include "conv3d_test_case.hpp"
+
+namespace gr = miopen::graphapi;
+
+namespace conv_graph_api_test {
+
+bool TestIsApplicable() { return true; }
+
+std::vector<Conv3DTestCase> ConvTestConfigs()
+{ //         g, n, c, d,  h,  w, k,  z, y, x, pad_x pad_y pad_z stri_x stri_y stri_z dia_x dia_y
+  //         dia_z
+    return {{1, 1, 4, 14, 11, 1, 4, 3, 3, 3, 1, 1, 1, 1, 1, 1, 1, 1, 1, miopenConvolution},
+            {1, 1, 1, 1, 4, 4, 1, 2, 2, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, miopenConvolution},
+            {1, 1, 1, 8, 8, 8, 1, 2, 2, 2, 0, 0, 0, 1, 1, 1, 1, 1, 1, miopenConvolution},
+            {1, 1, 1, 8, 8, 8, 1, 2, 2, 2, 0, 0, 0, 2, 2, 2, 1, 1, 1, miopenConvolution},
+            {2, 8, 8, 12, 14, 4, 4, 3, 3, 3, 1, 1, 1, 1, 1, 1, 1, 1, 1, miopenConvolution},
+            {4, 8, 8, 11, 11, 11, 16, 3, 3, 3, 1, 1, 1, 1, 1, 1, 1, 1, 1, miopenConvolution},
+            {6, 8, 18, 11, 11, 11, 18, 3, 3, 3, 1, 1, 1, 1, 1, 1, 1, 1, 1, miopenConvolution},
+            {8, 8, 8, 11, 11, 11, 8, 3, 3, 3, 1, 1, 1, 1, 1, 1, 1, 1, 1, miopenConvolution},
+            {4, 8, 4, 11, 11, 11, 8, 3, 4, 5, 1, 1, 1, 1, 1, 1, 1, 1, 1, miopenConvolution},
+            {2, 8, 2, 11, 11, 11, 2, 4, 4, 4, 1, 1, 1, 1, 1, 1, 1, 1, 1, miopenConvolution}};
+}
+
+template <typename T>
+class GPU_ConvBiasResAddActivation_fwd
+    : public ::testing::TestWithParam<
+          std::tuple<Conv3DTestCase, float, float, miopenTensorLayout_t>>
+{
+
+    static gr::OperationPointwise* MakeAddNode(gr::AutoDeleteAllocator& nodeAllocator,
+                                               miopenDataType_t dataType,
+                                               gr::Tensor* x,
+                                               gr::Tensor* b,
+                                               gr::Tensor* y,
+                                               gr::OperationPointwise::Alpha alpha1 = 1.0f,
+                                               gr::OperationPointwise::Alpha alpha2 = 1.0f)
+    {
+        auto add = nodeAllocator.allocate(gr::PointwiseBuilder{}
+                                              .setMode(MIOPEN_POINTWISE_ADD)
+                                              .setMathPrecision(dataType)
+                                              .build());
+
+        return nodeAllocator.allocate(gr::OperationPointwiseBuilder{}
+                                          .setPointwise(add)
+                                          .setX(x)
+                                          .setB(b)
+                                          .setAlpha1(alpha1)
+                                          .setAlpha2(alpha2)
+                                          .setY(y)
+                                          .build());
+    }
+
+    template <typename DataT>
+    static std::vector<int64_t> Convert(const std::vector<DataT>& value)
+    {
+        return {value.cbegin(), value.cend()};
+    }
+
+    struct TensorData
+    {
+        gr::Tensor* mTensPtr;
+        tensor<T> mCpuTensor;
+        miopen::Allocator::ManageDataPtr mGpuBuf;
+
+        explicit TensorData(gr::Tensor* tensorPtr, const miopen::TensorDescriptor& desc)
+            : mTensPtr(tensorPtr), mCpuTensor(tensor<T>(desc))
+        {
+            assert(mTensPtr);
+            assert(mTensPtr->getDataType() == miopen_type<T>());
+        }
+
+        template <typename G>
+        void Init(G generator)
+        {
+            mCpuTensor.generate(generator);
+            auto& handle = get_handle();
+            mGpuBuf      = handle.Write(mCpuTensor.data);
+        }
+
+        void CopyBack()
+        {
+            auto& handle = get_handle();
+            handle.ReadToVec(mGpuBuf, mCpuTensor.data);
+        }
+
+        TensorData(const TensorData&) = delete;
+        TensorData(TensorData&&)      = default;
+
+        TensorData& operator=(const TensorData&) = delete;
+        TensorData& operator=(TensorData&&) = default;
+
+        ~TensorData() = default;
+    };
+
+    struct GraphTensorAllocator
+    {
+        gr::AutoDeleteAllocator mAlloc;
+        std::unordered_map<std::string, TensorData> mFilledTensors;
+
+        GraphTensorAllocator() {}
+
+        template <bool isVirtual>
+        gr::Tensor* MakeTensor(std::string_view name,
+                               miopenDataType_t dataType,
+                               const miopen::TensorDescriptor& tensorDesc)
+        {
+            auto ptr = mAlloc.allocate(gr::makeTensor<isVirtual>(
+                name, dataType, Convert(tensorDesc.GetLengths()), Convert(tensorDesc.GetStrides())));
+            if constexpr(!isVirtual)
+            {
+                mFilledTensors.emplace(std::string(name), TensorData(ptr, tensorDesc));
+            }
+            return ptr;
+        }
+
+        TensorData& LookupTensorData(const std::string& name)
+        {
+            auto it = mFilledTensors.find(name);
+            assert(it != mFilledTensors.end());
+            return it->second;
+        }
+
+        gr::VariantPack MakeVariantPack(void* workspacePtr)
+        {
+            std::vector<int64_t> tensorIds;
+            std::vector<void*> gpuPtrs;
+
+            for(const auto& [k, v] : mFilledTensors)
+            {
+                tensorIds.emplace_back(v.mTensPtr->getId());
+                assert(v.mGpuBuf.get());
+                gpuPtrs.emplace_back(v.mGpuBuf.get());
+            }
+
+            return gr::VariantPackBuilder()
+                .setTensorIds(tensorIds)
+                .setDataPointers(gpuPtrs)
+                .setWorkspace(workspacePtr)
+                .build();
+        }
+
+        GraphTensorAllocator(const GraphTensorAllocator&) = delete;
+        GraphTensorAllocator(GraphTensorAllocator&&)      = default;
+
+        GraphTensorAllocator& operator=(const GraphTensorAllocator&) = delete;
+        GraphTensorAllocator& operator=(GraphTensorAllocator&&) = default;
+
+        ~GraphTensorAllocator() = default;
+    };
+
+public:
+    void SetUp() override
+    {
+        if(!TestIsApplicable())
+        {
+            GTEST_SKIP();
+        }
+
+        prng::reset_seed();
+    }
+
+    void Run()
+    {
+        Conv3DTestCase convConfig;
+        float alpha1 = 1.0f;
+        float alpha2 = 1.0f;
+        miopenTensorLayout_t tensorLayout;
+        auto dataType = miopen_type<T>();
+
+        std::tie(convConfig, alpha1, alpha2, tensorLayout) = GetParam();
+
+        gr::OpGraphBuilder graphBuilder;
+        gr::AutoDeleteAllocator graphNodeAllocator;
+        GraphTensorAllocator graphTensorAllocator;
+
+        // Graph of Y = activation(Conv(X,W) * alpha1 + Z * alpha2 + B)
+        const std::string convInputName        = "X";
+        const std::string convWeightName       = "W";
+        const std::string convOutputName       = "Tmp0";
+        const std::string addInputName         = "Z";
+        const std::string addOutputName        = "Tmp1";
+        const std::string biasInputName        = "B";
+        const std::string biasOutputName       = "Tmp2";
+        const std::string activationOutputName = "Y";
+
+        auto convInput = graphTensorAllocator.template MakeTensor<false>(
+            convInputName,
+            dataType,
+            miopen::TensorDescriptor{dataType, tensorLayout, convConfig.GetInput()});
+        auto convWeight = graphTensorAllocator.template MakeTensor<false>(
+            convWeightName,
+            dataType,
+            miopen::TensorDescriptor{dataType, tensorLayout, convConfig.GetWeights()});
+        auto convInputDescription = convConfig.GetConv();
+        auto& convInputData       = graphTensorAllocator.LookupTensorData(convInputName);
+        auto& convWeightData      = graphTensorAllocator.LookupTensorData(convWeightName);
+        auto convOutputDesc       = convInputDescription.GetForwardOutputTensor(
+            convInputData.mCpuTensor.desc, convWeightData.mCpuTensor.desc, dataType);
+        auto convOutput = graphTensorAllocator.template MakeTensor<true>(
+            convOutputName, dataType, convOutputDesc);
+
+        gr::Convolution* convolution = nullptr;
+        ASSERT_NO_THROW(
+            convolution = graphNodeAllocator.allocate(
+                gr::ConvolutionBuilder{}
+                    .setCompType(dataType)
+                    .setMode(convConfig.conv_mode)
+                    .setSpatialDims(convInputDescription.GetSpatialDimension())
+                    .setDilations(Convert(convInputDescription.GetConvDilations()))
+                    .setFilterStrides(Convert(convInputDescription.GetConvStrides()))
+                    .setPrePaddings(Convert(convInputDescription.GetConvPads()))
+                    .setPostPaddings(Convert(convInputDescription.GetTransposeConvPads()))
+                    .build()));
+
+        ASSERT_NO_THROW(graphBuilder.addNode(
+            graphNodeAllocator.allocate(gr::OperationConvolutionForwardBuilder()
+                                            .setConvolution(convolution)
+                                            .setX(convInput)
+                                            .setY(convOutput)
+                                            .setW(convWeight)
+                                            .setAlpha(1.0)
+                                            .setBeta(0)
+                                            .build())));
+
+        auto addInput =
+            graphTensorAllocator.template MakeTensor<false>(addInputName, dataType, convOutputDesc);
+        auto addOutput =
+            graphTensorAllocator.template MakeTensor<true>(addOutputName, dataType, convOutputDesc);
+
+        ASSERT_NO_THROW(graphBuilder.addNode(MakeAddNode(
+            graphNodeAllocator, dataType, convOutput, addInput, addOutput, alpha1, alpha2)));
+
+        miopen::TensorDescriptor biasInputTensorDesc{
+            dataType, tensorLayout, {1, convConfig.k, 1, 1, 1}};
+        auto biasInput = graphTensorAllocator.template MakeTensor<false>(
+            biasInputName, dataType, biasInputTensorDesc);
+        auto biasOutput = graphTensorAllocator.template MakeTensor<true>(
+            biasOutputName, dataType, convOutputDesc);
+
+        ASSERT_NO_THROW(graphBuilder.addNode(
+            MakeAddNode(graphNodeAllocator, dataType, addOutput, biasInput, biasOutput)));
+
+        auto activationOutput = graphTensorAllocator.template MakeTensor<false>(
+            activationOutputName, dataType, convOutputDesc);
+
+        gr::Pointwise* activation = nullptr;
+        ASSERT_NO_THROW(activation =
+                            graphNodeAllocator.allocate(gr::PointwiseBuilder{}
+                                                            .setMode(MIOPEN_POINTWISE_RELU_FWD)
+                                                            .setMathPrecision(dataType)
+                                                            .build()));
+        ASSERT_NO_THROW(
+            graphBuilder.addNode(graphNodeAllocator.allocate(gr::OperationPointwiseBuilder{}
+                                                                 .setPointwise(activation)
+                                                                 .setX(biasOutput)
+                                                                 .setY(activationOutput)
+                                                                 .build())));
+
+        auto& addTensorData  = graphTensorAllocator.LookupTensorData(addInputName);
+        auto& biasTensorData = graphTensorAllocator.LookupTensorData(biasInputName);
+
+        auto genValue = [](auto...) {
+            return prng::gen_A_to_B(static_cast<T>(-3.0), static_cast<T>(3.0));
+        };
+
+        convInputData.Init(genValue);
+        convWeightData.Init(genValue);
+        addTensorData.Init(genValue);
+        biasTensorData.Init(genValue);
+
+        auto& handle   = get_handle();
+        auto handlePtr = static_cast<miopenHandle_t>(&handle);
+        graphBuilder.setHandle(handlePtr);
+        gr::OpGraph graph;
+        ASSERT_NO_THROW(graph = std::move(graphBuilder).build());
+        auto engines = gr::findEngines(&graph);
+
+        // No engines exist currently that can handle graphAPI fused convolution
+        EXPECT_EQUAL(engines.size(), 0);
+
+        /// \todo uncomment below to execute plan, and run verification once engine implemented
+        /// --BrianHarrisonAMD July 2024
+        // ASSERT_GT(engines.size(), 0);
+
+        // gr::EngineCfg engineConfig;
+        // ASSERT_NO_THROW(engineConfig = gr::EngineCfgBuilder().setEngine(engines[0]).build());
+
+        // gr::ExecutionPlan plan;
+        // ASSERT_NO_THROW(plan =
+        // gr::ExecutionPlanBuilder().setEngineCfg(engineConfig).setHandle(handlePtr).build());
+
+        // Workspace ws(plan.getWorkspaceSize());
+
+        // gr::VariantPack variantPack;
+        // ASSERT_NO_THROW(variantPack = graphTensorAllocator.MakeVariantPack(ws.ptr()));
+
+        // ASSERT_NO_THROW(plan.execute(handlePtr, variantPack));
+
+        // // Reference implementation for Y = activation(Conv(X,W) * alpha1 + Z * alpha2 + B)
+        // auto referenceOutput = tensor<T>(convOutputDesc);
+        // referenceOutput = ref_conv_fwd(convInputData.mCpuTensor, convWeightData.mCpuTensor,
+        // referenceOutput, convInputDescription);
+
+        // auto& z = addTensorData.mCpuTensor;
+        // auto& bias = biasTensorData.mCpuTensor;
+
+        // referenceOutput.par_for_each([&](auto n, auto k, auto... dhw) {
+        //     auto& o = referenceOutput(n, k, dhw...);
+
+        //     o *= alpha1;
+        //     o += alpha2 * z(n, k, dhw...) + bias(0, k, 0, 0, 0);
+        //     o = (o > T{0}) ? o : T{0};
+        // });
+
+        // auto& activationOutputData = graphTensorAllocator.LookupTensorData(activationOutputName);
+        // activationOutputData.CopyBack();
+        // auto& output = activationOutputData.mCpuTensor;
+
+        // EXPECT_FALSE(miopen::range_zero(referenceOutput)) << "Cpu data is all zeros";
+        // EXPECT_FALSE(miopen::range_zero(output)) << "Gpu data is all zeros";
+        // EXPECT_TRUE(miopen::range_distance(referenceOutput) == miopen::range_distance(output));
+
+        // const double tolerance = 80;
+        // double threshold = std::numeric_limits<T>::epsilon() * tolerance;
+        // auto error = miopen::rms_range(referenceOutput, output);
+
+        // EXPECT_FALSE(miopen::find_idx(referenceOutput, miopen::not_finite) >= 0)
+        //     << "Non finite number found in the CPU data";
+
+        // EXPECT_FALSE(miopen::find_idx(output, miopen::not_finite) >= 0)
+        //     << "Non finite number found in the GPU data";
+
+        // EXPECT_TRUE(error < threshold)
+        //     << "Error beyond tolerance Error:" << error << ",  Threshold: " << threshold;
+    }
+};
+
+struct GPU_ConvBiasResAddActivation_fwd_FP16
+    : GPU_ConvBiasResAddActivation_fwd<half_float::half>
+{
+};
+
+} // end namespace conv_graph_api_test
+using namespace conv_graph_api_test;
+
+TEST_P(GPU_ConvBiasResAddActivation_fwd_FP16, Test) { Run(); }
+
+INSTANTIATE_TEST_SUITE_P(Full,
+                         GPU_ConvBiasResAddActivation_fwd_FP16,
+                         testing::Combine(testing::ValuesIn(ConvTestConfigs()),
+                                          testing::ValuesIn({1.0f, 2.5f}), // alpha1
+                                          testing::ValuesIn({1.0f, 2.0f}), // alpha2
+                                          testing::Values(miopenTensorNDHWC)));

--- a/test/gtest/graphapi_conv_bias_res_add_activ_fwd.cpp
+++ b/test/gtest/graphapi_conv_bias_res_add_activ_fwd.cpp
@@ -145,8 +145,10 @@ class GPU_ConvBiasResAddActivation_fwd
                                miopenDataType_t dataType,
                                const miopen::TensorDescriptor& tensorDesc)
         {
-            auto ptr = mAlloc.allocate(gr::makeTensor<isVirtual>(
-                name, dataType, Convert(tensorDesc.GetLengths()), Convert(tensorDesc.GetStrides())));
+            auto ptr = mAlloc.allocate(gr::makeTensor<isVirtual>(name,
+                                                                 dataType,
+                                                                 Convert(tensorDesc.GetLengths()),
+                                                                 Convert(tensorDesc.GetStrides())));
             if constexpr(!isVirtual)
             {
                 mFilledTensors.emplace(std::string(name), TensorData(ptr, tensorDesc));
@@ -376,8 +378,7 @@ public:
     }
 };
 
-struct GPU_ConvBiasResAddActivation_fwd_FP16
-    : GPU_ConvBiasResAddActivation_fwd<half_float::half>
+struct GPU_ConvBiasResAddActivation_fwd_FP16 : GPU_ConvBiasResAddActivation_fwd<half_float::half>
 {
 };
 

--- a/test/gtest/graphapi_conv_bias_res_add_activ_fwd.cpp
+++ b/test/gtest/graphapi_conv_bias_res_add_activ_fwd.cpp
@@ -145,10 +145,8 @@ class GPU_ConvBiasResAddActivation_fwd
                                miopenDataType_t dataType,
                                const miopen::TensorDescriptor& tensorDesc)
         {
-            auto ptr = mAlloc.allocate(gr::makeTensor<isVirtual>(name,
-                                                                 dataType,
-                                                                tensorDesc.GetLengths(),
-                                                                tensorDesc.GetStrides()));
+            auto ptr = mAlloc.allocate(gr::makeTensor<isVirtual>(
+                name, dataType, tensorDesc.GetLengths(), tensorDesc.GetStrides()));
             if constexpr(!isVirtual)
             {
                 mFilledTensors.emplace(std::string(name), TensorData(ptr, tensorDesc));

--- a/test/gtest/graphapi_conv_bias_res_add_activ_fwd.cpp
+++ b/test/gtest/graphapi_conv_bias_res_add_activ_fwd.cpp
@@ -107,7 +107,7 @@ class GPU_ConvBiasResAddActivation_fwd
             : mTensPtr(tensorPtr), mCpuTensor(tensor<T>(desc))
         {
             assert(mTensPtr);
-            assert(mTensPtr->getDataType() == miopen_type<T>());
+            assert(mTensPtr->GetType() == miopen_type<T>());
         }
 
         template <typename G>
@@ -147,8 +147,8 @@ class GPU_ConvBiasResAddActivation_fwd
         {
             auto ptr = mAlloc.allocate(gr::makeTensor<isVirtual>(name,
                                                                  dataType,
-                                                                 Convert(tensorDesc.GetLengths()),
-                                                                 Convert(tensorDesc.GetStrides())));
+                                                                tensorDesc.GetLengths(),
+                                                                tensorDesc.GetStrides()));
             if constexpr(!isVirtual)
             {
                 mFilledTensors.emplace(std::string(name), TensorData(ptr, tensorDesc));

--- a/test/gtest/graphapi_gtest_common.hpp
+++ b/test/gtest/graphapi_gtest_common.hpp
@@ -410,13 +410,15 @@ class GMockBackendTensorDescriptor : public BackendTensorDescriptor
 public:
     GMockBackendTensorDescriptor& operator=(const Tensor& testCaseTensor)
     {
-        auto dataType = testCaseTensor.getDataType();
+        auto dataType = testCaseTensor.GetType();
         setAttribute(MIOPEN_ATTR_TENSOR_DATA_TYPE, MIOPEN_TYPE_DATA_TYPE, 1, &dataType);
 
-        auto dims = testCaseTensor.getDimensions();
+        auto& d = testCaseTensor.GetLengths();
+        std::vector<int64_t> dims {d.cbegin(), d.cend()};
         setAttribute(MIOPEN_ATTR_TENSOR_DIMENSIONS, MIOPEN_TYPE_INT64, dims.size(), dims.data());
 
-        auto strides = testCaseTensor.getStrides();
+        auto& s = testCaseTensor.GetStrides();
+        std::vector<int64_t> strides {s.cbegin(), s.cend()};
         setAttribute(MIOPEN_ATTR_TENSOR_STRIDES, MIOPEN_TYPE_INT64, strides.size(), strides.data());
 
         auto id = testCaseTensor.getId();

--- a/test/gtest/graphapi_gtest_common.hpp
+++ b/test/gtest/graphapi_gtest_common.hpp
@@ -414,11 +414,11 @@ public:
         setAttribute(MIOPEN_ATTR_TENSOR_DATA_TYPE, MIOPEN_TYPE_DATA_TYPE, 1, &dataType);
 
         auto& d = testCaseTensor.GetLengths();
-        std::vector<int64_t> dims {d.cbegin(), d.cend()};
+        std::vector<int64_t> dims{d.cbegin(), d.cend()};
         setAttribute(MIOPEN_ATTR_TENSOR_DIMENSIONS, MIOPEN_TYPE_INT64, dims.size(), dims.data());
 
         auto& s = testCaseTensor.GetStrides();
-        std::vector<int64_t> strides {s.cbegin(), s.cend()};
+        std::vector<int64_t> strides{s.cbegin(), s.cend()};
         setAttribute(MIOPEN_ATTR_TENSOR_STRIDES, MIOPEN_TYPE_INT64, strides.size(), strides.data());
 
         auto id = testCaseTensor.getId();

--- a/test/gtest/graphapi_mha_fwd_f8.cpp
+++ b/test/gtest/graphapi_mha_fwd_f8.cpp
@@ -51,7 +51,8 @@ namespace gr = miopen::graphapi;
 
 namespace mha_graph_test {
 
-class MhaFwdGraphTest : public testing::TestWithParam<std::tuple<std::size_t, std::size_t, std::size_t, std::size_t, float>>
+class MhaFwdGraphTest : public testing::TestWithParam<
+                            std::tuple<std::size_t, std::size_t, std::size_t, std::size_t, float>>
 {
 
     struct TensorData
@@ -580,9 +581,9 @@ TEST_P(MhaFwdGraphTest, MhaFwdGraph) { Run(); }
 
 INSTANTIATE_TEST_SUITE_P(MhaGraphFwdSuite,
                          MhaFwdGraphTest,
-                         testing::Combine(testing::ValuesIn(std::vector<std::size_t>{2}),         // n
-                                          testing::ValuesIn(std::vector<std::size_t>{8}),         // h
-                                          testing::ValuesIn(std::vector<std::size_t>{4, 64}),     // s
-                                          testing::ValuesIn(std::vector<std::size_t>{16}),        // d
+                         testing::Combine(testing::ValuesIn(std::vector<std::size_t>{2}),     // n
+                                          testing::ValuesIn(std::vector<std::size_t>{8}),     // h
+                                          testing::ValuesIn(std::vector<std::size_t>{4, 64}), // s
+                                          testing::ValuesIn(std::vector<std::size_t>{16}),    // d
                                           testing::ValuesIn({0.0f, 0.5f}) // mProbDropout
                                           ));

--- a/test/gtest/graphapi_mha_fwd_f8.cpp
+++ b/test/gtest/graphapi_mha_fwd_f8.cpp
@@ -51,7 +51,7 @@ namespace gr = miopen::graphapi;
 
 namespace mha_graph_test {
 
-class MhaFwdGraphTest : public testing::TestWithParam<std::tuple<int, int, int, int, float>>
+class MhaFwdGraphTest : public testing::TestWithParam<std::tuple<std::size_t, std::size_t, std::size_t, std::size_t, float>>
 {
 
     struct TensorData
@@ -66,15 +66,13 @@ class MhaFwdGraphTest : public testing::TestWithParam<std::tuple<int, int, int, 
         explicit TensorData(gr::Tensor* tens_ptr) : mTensPtr(tens_ptr), mCpuTensor()
         {
             assert(mTensPtr);
-            const auto& d = mTensPtr->getDimensions();
-            std::vector<size_t> dims(d.begin(), d.end());
-            if(auto dt = mTensPtr->getDataType(); dt == miopenFloat)
+            if(auto dt = mTensPtr->GetType(); dt == miopenFloat)
             {
-                mCpuTensor = TensFlt{dims};
+                mCpuTensor = TensFlt{mTensPtr->GetLengths()};
             }
             else if(dt == miopenInt64)
             {
-                mCpuTensor = TensI64{dims};
+                mCpuTensor = TensI64{mTensPtr->GetLengths()};
             }
             else
             {
@@ -85,7 +83,7 @@ class MhaFwdGraphTest : public testing::TestWithParam<std::tuple<int, int, int, 
         void init(tensor<float>&& tens_val)
         {
             auto& handle = get_handle();
-            assert(mTensPtr->getDataType() == miopenFloat);
+            assert(mTensPtr->GetType() == miopenFloat);
             auto& ct = std::get<TensFlt>(mCpuTensor);
             ct       = std::move(tens_val);
             mGpuBuf  = handle.Write(ct.data);
@@ -271,7 +269,7 @@ class MhaFwdGraphTest : public testing::TestWithParam<std::tuple<int, int, int, 
 
     template <bool IsVirt>
     gr::Tensor*
-    makeTensor(std::string_view name, miopenDataType_t dt, const std::vector<int64_t>& dims)
+    makeTensor(std::string_view name, miopenDataType_t dt, const std::vector<size_t>& dims)
     {
         auto ptr = mAlloc.allocate(gr::makeTensor<IsVirt>(name, dt, dims));
         if constexpr(!IsVirt)
@@ -281,15 +279,15 @@ class MhaFwdGraphTest : public testing::TestWithParam<std::tuple<int, int, int, 
         return ptr;
     }
 
-    void createMhaGraph(int64_t n, int64_t h, int64_t s, int64_t d)
+    void createMhaGraph(size_t n, size_t h, size_t s, size_t d)
     {
 
         mGraphBuilder = std::make_unique<gr::OpGraphBuilder>();
 
-        std::vector<int64_t> nhsd  = {n, h, s, d};
-        std::vector<int64_t> nhss  = {n, h, s, s};
-        std::vector<int64_t> nhs1  = {n, h, s, 1};
-        std::vector<int64_t> all1s = {1, 1, 1, 1};
+        std::vector<size_t> nhsd  = {n, h, s, d};
+        std::vector<size_t> nhss  = {n, h, s, s};
+        std::vector<size_t> nhs1  = {n, h, s, 1};
+        std::vector<size_t> all1s = {1, 1, 1, 1};
 
 #define MAKE_TENSOR_F(name, dims, isVirt) auto* name = makeTensor<isVirt>(#name, miopenFloat, dims)
 #define MAKE_TENSOR_I(name, dims, isVirt) auto* name = makeTensor<isVirt>(#name, miopenInt64, dims)
@@ -582,9 +580,9 @@ TEST_P(MhaFwdGraphTest, MhaFwdGraph) { Run(); }
 
 INSTANTIATE_TEST_SUITE_P(MhaGraphFwdSuite,
                          MhaFwdGraphTest,
-                         testing::Combine(testing::ValuesIn({2}),         // n
-                                          testing::ValuesIn({8}),         // h
-                                          testing::ValuesIn({4, 64}),     // s
-                                          testing::ValuesIn({16}),        // d
+                         testing::Combine(testing::ValuesIn(std::vector<std::size_t>{2}),         // n
+                                          testing::ValuesIn(std::vector<std::size_t>{8}),         // h
+                                          testing::ValuesIn(std::vector<std::size_t>{4, 64}),     // s
+                                          testing::ValuesIn(std::vector<std::size_t>{16}),        // d
                                           testing::ValuesIn({0.0f, 0.5f}) // mProbDropout
                                           ));

--- a/test/gtest/graphapi_operationgraph_descriptor.cpp
+++ b/test/gtest/graphapi_operationgraph_descriptor.cpp
@@ -51,13 +51,13 @@ private:
 public:
     GMockNode()
         : mIn(std::make_shared<Tensor>(miopenFloat,
-                                       std::vector<int64_t>{8, 64, 64},
-                                       std::vector<int64_t>{64 * 64, 64, 1},
+                                       std::vector<std::size_t>{8, 64, 64},
+                                       std::vector<std::size_t>{64 * 64, 64, 1},
                                        ++id,
                                        false)),
           mOut(std::make_shared<Tensor>(miopenFloat,
-                                        std::vector<int64_t>{8, 64, 64},
-                                        std::vector<int64_t>{64 * 64, 64, 1},
+                                        std::vector<std::size_t>{8, 64, 64},
+                                        std::vector<std::size_t>{64 * 64, 64, 1},
                                         ++id,
                                         false))
     {

--- a/test/gtest/graphapi_tensor.cpp
+++ b/test/gtest/graphapi_tensor.cpp
@@ -23,8 +23,10 @@
  * SOFTWARE.
  *
  *******************************************************************************/
-#include <miopen/miopen.h>
 #include <gtest/gtest.h>
+#include <miopen/miopen.h>
+#include <miopen/tensor.hpp>
+#include <miopen/graphapi/tensor.hpp>
 
 TEST(BackendApi, Tensor)
 {
@@ -227,3 +229,60 @@ TEST(BackendApi, Tensor)
     EXPECT_EQ(elementCount, 1);
     EXPECT_TRUE(retrievedIsVirtual == isVirtual);
 }
+
+namespace gr = miopen::graphapi;
+
+namespace graph_api_tensor_test {
+
+    static bool TestIsApplicable() { return true; }
+
+    using TestCase = std::tuple<std::vector<size_t>, std::vector<size_t>, miopenDataType_t, miopenTensorLayout_t>;
+    static std::vector<TestCase> TestConfigs()
+    {
+        return {{{1,4,14,11,1}, {616,1,44,4,4}, miopenFloat, miopenTensorNDHWC},
+                {{1,4,14,11,1}, {616,154,11,1,1}, miopenFloat, miopenTensorNCDHW},
+                {{1,4,11,1}, {44,1,4,4}, miopenFloat, miopenTensorNHWC},
+                {{1,4,11,1}, {44,11,1,1}, miopenFloat, miopenTensorNCHW},
+                {{1,1,1,1,1}, {1,1,1,1,1}, miopenFloat, miopenTensorNDHWC},
+                {{1,1,1,1}, {1,1,1,1}, miopenFloat, miopenTensorNHWC},
+                {{3,5,6}, {30,6,1}, miopenFloat, miopenTensorNCHW}};
+    }
+
+    class CPU_GraphTensor_NONE : public ::testing::TestWithParam<TestCase>
+    {
+        public:
+            void SetUp() override
+            {
+                if(!TestIsApplicable())
+                {
+                    GTEST_SKIP();
+                }
+            }
+
+            void Run()
+            {
+                std::vector<std::size_t> dimensions;
+                std::vector<std::size_t> strides;
+                miopenDataType_t dataType;
+                miopenTensorLayout_t layout;
+
+                std::tie(dimensions, strides, dataType, layout) = GetParam();
+
+                miopen::TensorDescriptor descriptor(dataType, layout, dimensions, strides);
+
+                gr::Tensor graphTensorFromDescription(descriptor, 0, false);
+                EXPECT_EQ(graphTensorFromDescription, descriptor);
+                EXPECT_EQ(graphTensorFromDescription.GetLayout_t(), descriptor.GetLayout_t());
+
+                gr::Tensor graphTensorFromParams(dataType, dimensions, strides, 0, false);
+                EXPECT_EQ(graphTensorFromParams, descriptor);
+                EXPECT_EQ(graphTensorFromParams.GetLayout_t(), descriptor.GetLayout_t());
+            }
+    };
+
+}
+using namespace graph_api_tensor_test;
+
+TEST_P(CPU_GraphTensor_NONE, Test) { Run(); }
+
+INSTANTIATE_TEST_SUITE_P(Smoke, CPU_GraphTensor_NONE, testing::ValuesIn(TestConfigs()));

--- a/test/gtest/graphapi_tensor.cpp
+++ b/test/gtest/graphapi_tensor.cpp
@@ -234,53 +234,54 @@ namespace gr = miopen::graphapi;
 
 namespace graph_api_tensor_test {
 
-    static bool TestIsApplicable() { return true; }
+static bool TestIsApplicable() { return true; }
 
-    using TestCase = std::tuple<std::vector<size_t>, std::vector<size_t>, miopenDataType_t, miopenTensorLayout_t>;
-    static std::vector<TestCase> TestConfigs()
+using TestCase =
+    std::tuple<std::vector<size_t>, std::vector<size_t>, miopenDataType_t, miopenTensorLayout_t>;
+static std::vector<TestCase> TestConfigs()
+{
+    return {{{1, 4, 14, 11, 1}, {616, 1, 44, 4, 4}, miopenFloat, miopenTensorNDHWC},
+            {{1, 4, 14, 11, 1}, {616, 154, 11, 1, 1}, miopenFloat, miopenTensorNCDHW},
+            {{1, 4, 11, 1}, {44, 1, 4, 4}, miopenFloat, miopenTensorNHWC},
+            {{1, 4, 11, 1}, {44, 11, 1, 1}, miopenFloat, miopenTensorNCHW},
+            {{1, 1, 1, 1, 1}, {1, 1, 1, 1, 1}, miopenFloat, miopenTensorNDHWC},
+            {{1, 1, 1, 1}, {1, 1, 1, 1}, miopenFloat, miopenTensorNHWC},
+            {{3, 5, 6}, {30, 6, 1}, miopenFloat, miopenTensorNCHW}};
+}
+
+class CPU_GraphTensor_NONE : public ::testing::TestWithParam<TestCase>
+{
+public:
+    void SetUp() override
     {
-        return {{{1,4,14,11,1}, {616,1,44,4,4}, miopenFloat, miopenTensorNDHWC},
-                {{1,4,14,11,1}, {616,154,11,1,1}, miopenFloat, miopenTensorNCDHW},
-                {{1,4,11,1}, {44,1,4,4}, miopenFloat, miopenTensorNHWC},
-                {{1,4,11,1}, {44,11,1,1}, miopenFloat, miopenTensorNCHW},
-                {{1,1,1,1,1}, {1,1,1,1,1}, miopenFloat, miopenTensorNDHWC},
-                {{1,1,1,1}, {1,1,1,1}, miopenFloat, miopenTensorNHWC},
-                {{3,5,6}, {30,6,1}, miopenFloat, miopenTensorNCHW}};
+        if(!TestIsApplicable())
+        {
+            GTEST_SKIP();
+        }
     }
 
-    class CPU_GraphTensor_NONE : public ::testing::TestWithParam<TestCase>
+    void Run()
     {
-        public:
-            void SetUp() override
-            {
-                if(!TestIsApplicable())
-                {
-                    GTEST_SKIP();
-                }
-            }
+        std::vector<std::size_t> dimensions;
+        std::vector<std::size_t> strides;
+        miopenDataType_t dataType;
+        miopenTensorLayout_t layout;
 
-            void Run()
-            {
-                std::vector<std::size_t> dimensions;
-                std::vector<std::size_t> strides;
-                miopenDataType_t dataType;
-                miopenTensorLayout_t layout;
+        std::tie(dimensions, strides, dataType, layout) = GetParam();
 
-                std::tie(dimensions, strides, dataType, layout) = GetParam();
+        miopen::TensorDescriptor descriptor(dataType, layout, dimensions, strides);
 
-                miopen::TensorDescriptor descriptor(dataType, layout, dimensions, strides);
+        gr::Tensor graphTensorFromDescription(descriptor, 0, false);
+        EXPECT_EQ(graphTensorFromDescription, descriptor);
+        EXPECT_EQ(graphTensorFromDescription.GetLayout_t(), descriptor.GetLayout_t());
 
-                gr::Tensor graphTensorFromDescription(descriptor, 0, false);
-                EXPECT_EQ(graphTensorFromDescription, descriptor);
-                EXPECT_EQ(graphTensorFromDescription.GetLayout_t(), descriptor.GetLayout_t());
+        gr::Tensor graphTensorFromParams(dataType, dimensions, strides, 0, false);
+        EXPECT_EQ(graphTensorFromParams, descriptor);
+        EXPECT_EQ(graphTensorFromParams.GetLayout_t(), descriptor.GetLayout_t());
+    }
+};
 
-                gr::Tensor graphTensorFromParams(dataType, dimensions, strides, 0, false);
-                EXPECT_EQ(graphTensorFromParams, descriptor);
-                EXPECT_EQ(graphTensorFromParams.GetLayout_t(), descriptor.GetLayout_t());
-            }
-    };
-
-}
+} // namespace graph_api_tensor_test
 using namespace graph_api_tensor_test;
 
 TEST_P(CPU_GraphTensor_NONE, Test) { Run(); }


### PR DESCRIPTION
Changes:
- Update GraphAPI Tensor to inherit from TensorDescriptor.
- Remove Dims, Strides, and Type from GraphAPI Tensor. 
    - Instead use base methods / types.
- Update areas to use the correct methods / types.
- Add tests for checking tensor layout is found from strides correctly.