### PR TITLE
Changed Fusion to have a separate find mode env variable and default to fast

### DIFF
--- a/src/find_controls.cpp
+++ b/src/find_controls.cpp
@@ -200,10 +200,9 @@ std::ostream& operator<<(std::ostream& os, const FindMode::Values& v)
 }
 
 template <class Variable>
-std::optional<FindMode::Values> GetFindModeValueImpl2(const Variable& variable,
-                                                      std::string_view variable_name)
+std::optional<FindMode::Values> GetFindModeValueImpl2(Variable variable)
 {
-    auto str = env::value(MIOPEN_FIND_MODE);
+    auto str = env::value(variable);
     if(str.empty())
         return std::nullopt;
     for(auto& c : str)
@@ -230,18 +229,16 @@ std::optional<FindMode::Values> GetFindModeValueImpl2(const Variable& variable,
     const auto val = static_cast<FindMode::Values>(stoul(str));
     if(FindMode::Values::Begin_ <= val && val < FindMode::Values::End_)
         return val;
-    MIOPEN_LOG_NQE("Wrong " << variable_name << ", using default.");
+    MIOPEN_LOG_NQE("Wrong " << variable.GetName() << ", using default.");
     return std::nullopt;
 }
 
 template <class Variable>
-FindMode::Values GetFindModeValue(const Variable& variable,
-                                  std::string_view variable_name,
-                                  FindMode::Values defaultValue)
+FindMode::Values GetFindModeValue(Variable variable, FindMode::Values defaultValue)
 {
     static const FindMode::Values val = [&]() {
-        auto rv = GetFindModeValueImpl2(variable, variable_name).value_or(defaultValue);
-        MIOPEN_LOG_NQI(variable_name << " = " << rv);
+        auto rv = GetFindModeValueImpl2(variable).value_or(defaultValue);
+        MIOPEN_LOG_NQI(variable.GetName() << " = " << rv);
         return rv;
     }();
     return val;
@@ -249,23 +246,14 @@ FindMode::Values GetFindModeValue(const Variable& variable,
 
 } // namespace
 
-#if defined(MIOPEN_FIND_MODE_VAR_AND_NAME)
-#error macro MIOPEN_FIND_MODE_VAR_AND_NAME redefined
-#endif
-#define MIOPEN_FIND_MODE_VAR_AND_NAME(VARIABLE) VARIABLE, #VARIABLE
-
 FindMode::FindMode(solver::Primitive primitive)
 {
     switch(primitive)
     {
     case solver::Primitive::Fusion:
-        value = GetFindModeValue(MIOPEN_FIND_MODE_VAR_AND_NAME(MIOPEN_FIND_MODE_FUSION),
-                                 FindMode::Values::Fast);
+        value = GetFindModeValue(MIOPEN_FIND_MODE_FUSION, FindMode::Values::Fast);
         break;
-    default:
-        value = GetFindModeValue(MIOPEN_FIND_MODE_VAR_AND_NAME(MIOPEN_FIND_MODE),
-                                 FindMode::Values::Default_);
-        break;
+    default: value = GetFindModeValue(MIOPEN_FIND_MODE, FindMode::Values::Default_); break;
     }
 }
 

--- a/src/find_controls.cpp
+++ b/src/find_controls.cpp
@@ -45,6 +45,7 @@
 MIOPEN_DECLARE_ENV_VAR_STR(MIOPEN_FIND_ENFORCE)
 MIOPEN_DECLARE_ENV_VAR_STR(MIOPEN_DEBUG_FIND_ONLY_SOLVER)
 MIOPEN_DECLARE_ENV_VAR_STR(MIOPEN_FIND_MODE)
+MIOPEN_DECLARE_ENV_VAR_STR(MIOPEN_FIND_MODE_FUSION)
 
 namespace miopen {
 
@@ -241,7 +242,7 @@ FindMode::Values GetFindModeValue(const Variable& variable,
     static const FindMode::Values val = [&]() {
         auto rv = GetFindModeValueImpl2(variable, variable_name).value_or(defaultValue);
         MIOPEN_LOG_NQI(variable_name << " = " << rv);
-    return rv;
+        return rv;
     }();
     return val;
 }
@@ -257,6 +258,10 @@ FindMode::FindMode(solver::Primitive primitive)
 {
     switch(primitive)
     {
+    case solver::Primitive::Fusion:
+        value = GetFindModeValue(MIOPEN_FIND_MODE_VAR_AND_NAME(MIOPEN_FIND_MODE_FUSION),
+                                 FindMode::Values::Fast);
+        break;
     default:
         value = GetFindModeValue(MIOPEN_FIND_MODE_VAR_AND_NAME(MIOPEN_FIND_MODE),
                                  FindMode::Values::Default_);
@@ -264,9 +269,6 @@ FindMode::FindMode(solver::Primitive primitive)
     }
 }
 
-} // namespace
-
-FindMode::FindMode() { value = GetFindModeValue(); }
 std::ostream& operator<<(std::ostream& os, const FindMode& obj) { return os << obj.value; }
 
 static_assert(miopenConvolutionFindModeNormal ==

--- a/src/fusion.cpp
+++ b/src/fusion.cpp
@@ -1060,7 +1060,7 @@ miopenStatus_t FusionPlanDescriptor::Compile(Handle& handle)
             continue;
         }
 
-        handle.RegisterInvoker(*invoker, network_config, id.ToString(), AlgorithmName{"fusion"});
+        handle.RegisterInvoker(*invoker, network_config, id.ToString());
         invokers.push_back(std::move(*invoker));
         MIOPEN_LOG_I2(miopen::ConvolutionAlgoToString(algorithm));
     }
@@ -1071,6 +1071,7 @@ miopenStatus_t FusionPlanDescriptor::Compile(Handle& handle)
         return miopenStatusUnsupportedOp;
     }
 
+    handle.SetAsFound1_0(network_config, AlgorithmName{"fusion"}, find_results.front().GetSolver().ToString());
     return miopenStatusSuccess;
 }
 

--- a/src/fusion.cpp
+++ b/src/fusion.cpp
@@ -983,7 +983,7 @@ miopenStatus_t FusionPlanDescriptor::Compile(Handle& handle)
     }
 
     {
-        FindMode findMode;
+        FindMode findMode(solver::Primitive::Fusion);
         auto sol = boost::optional<miopenConvSolution_t>{};
 
         if(findMode.IsFast(fusion_problem) || findMode.IsHybrid(fusion_problem))

--- a/src/fusion.cpp
+++ b/src/fusion.cpp
@@ -1071,7 +1071,8 @@ miopenStatus_t FusionPlanDescriptor::Compile(Handle& handle)
         return miopenStatusUnsupportedOp;
     }
 
-    handle.SetAsFound1_0(network_config, AlgorithmName{"fusion"}, find_results.front().GetSolver().ToString());
+    handle.SetAsFound1_0(
+        network_config, AlgorithmName{"fusion"}, find_results.front().GetSolver().ToString());
     return miopenStatusSuccess;
 }
 

--- a/src/include/miopen/env.hpp
+++ b/src/include/miopen/env.hpp
@@ -170,6 +170,7 @@ private:
         }                                                                          \
         operator ::miopen::env::detail::EnvVar<_type>&() const { return ref(); }   \
         operator bool() const { return ref().exist(); }                            \
+        constexpr std::string_view GetName() const { return #_name; }              \
     } _name;
 
 #define MIOPEN_DECLARE_ENV_VAR_BOOL(name, ...) MIOPEN_DECLARE_ENV_VAR(name, bool, __VA_ARGS__)

--- a/src/include/miopen/find_controls.hpp
+++ b/src/include/miopen/find_controls.hpp
@@ -137,7 +137,8 @@ private:
     }
 
 public:
-    FindMode();
+    // Todo: remove default value of primitive
+    FindMode(solver::Primitive primitive = solver::Primitive::Convolution);
     Values Get() const { return value; }
     void Set(Values const v) { value = v; }
 

--- a/src/include/miopen/handle.hpp
+++ b/src/include/miopen/handle.hpp
@@ -254,7 +254,13 @@ public:
     {
         invokers.Register({config, solver}, invoker);
         if(algo.has_value())
-            invokers.SetAsFound1_0(config, *algo, solver);
+            SetAsFound1_0(config, *algo, solver);
+    }
+
+    void
+    SetAsFound1_0(const NetworkConfig& config, const AlgorithmName& algo, const std::string& solver)
+    {
+        invokers.SetAsFound1_0(config, algo, solver);
     }
 
     std::optional<Invoker> GetInvoker(const NetworkConfig& config,


### PR DESCRIPTION
The motivation: our original reasoning to add find into `Compile` was to allow tuning. Hybrid mode actually ignores fallback and goes straight to find, which is slower than it was before the find (what is now in fallback). So unless user explicitly wants to tune, including using Hybrid mode, we should go the fastest way possible.

Also fixed it to only register as found1_0 invoker that would be actually be used later.