### PR TITLE
Revert "[Staging] Update CK commit hash in requirements.txt (#3122)"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ nlohmann/json@v3.11.2 -DJSON_MultipleHeaders=ON -DJSON_BuildTests=Off
 ROCm/FunctionalPlus@v0.2.18-p0
 ROCm/eigen@3.4.0
 ROCm/frugally-deep@9683d557eb672ee2304f80f6682c51242d748a50
-ROCm/composable_kernel@be3fbf7f5f3bdc3e1668490fb93b8a44aa2638ce -DCMAKE_BUILD_TYPE=Release -DINSTANCES_ONLY=ON
+ROCm/composable_kernel@15baccf2ecad4fb3498b8acb6bbf58fb5359c7a5 -DCMAKE_BUILD_TYPE=Release -DINSTANCES_ONLY=ON
 google/googletest@v1.14.0


### PR DESCRIPTION
This reverts commit 8449363a09ef43106ecc34ed0df13cff022bf637.

Broke by https://github.com/ROCm/composable_kernel/pull/1382/files

include/ck/tensor_operation/gpu/device/impl/device_grouped_conv_fwd_multiple_abd_xdl_cshuffle.hpp

Number of `GetTypeString` is changed which impact heuristics in MIOpen

![image](https://github.com/user-attachments/assets/ab36ceae-0d7b-4583-b34e-dc0571856259)
