### PR TITLE
Fix GCC8 linking issues with stdc++fs

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -768,6 +768,10 @@ rocm_set_soversion(MIOpen ${MIOpen_SOVERSION})
 
 clang_tidy_check(MIOpen)
 
+if(HAS_LIB_STD_FILESYSTEM)
+    target_link_libraries(MIOpen PRIVATE stdc++fs)
+endif()
+
 find_package(zstd)
 if(zstd_FOUND)
     target_link_libraries(MIOpen PRIVATE $<IF:$<TARGET_EXISTS:zstd::libzstd_shared>,zstd::libzstd_shared,zstd::libzstd_static>)


### PR DESCRIPTION
stdc++fs linking was missing for libMIOpen.so, (but present for tests, and other locations), which was leading to filesystem segfault issues when running libMIOpen.so built with gcc8 on environments with a newer gcc/libstdc++. 