### PR TITLE
[MHA] Implement MHA backward pattern

### DIFF
--- a/src/graphapi/find_engine.cpp
+++ b/src/graphapi/find_engine.cpp
@@ -395,12 +395,7 @@ class MHA_Bwd_F8_Pattern : public GraphPatternMatcher
 
         auto isTranspose = [](const OpNode::Edge& edge) -> bool {
             auto [node, tensor] = edge;
-
-            // Not sure we should check OpKind because
-            // pattern matcher doesn't do that
-            return node->signName() == "OP_RESHAPE" &&
-                   dynamic_cast<OperationReshape&>(*node).getOpKind() ==
-                       OperationReshape::OpKind::TRANSPOSE;
+            return node->signName() == "OP_RESHAPE";
         };
 
         auto leftOrCenterStartIt1 = std::find_if(starts.cbegin(), starts.cend(), isTranspose);

--- a/src/include/miopen/graphapi/opgraph.hpp
+++ b/src/include/miopen/graphapi/opgraph.hpp
@@ -181,8 +181,10 @@ protected:
 
     void addOutTensor(Tensor* tens_ptr)
     {
-        assert(!hasOutTensor(tens_ptr));
-        mOutTensors.emplace_back(tens_ptr);
+        if(!hasOutTensor(tens_ptr))
+        {
+            mOutTensors.emplace_back(tens_ptr);
+        }
     }
 };
 
@@ -206,8 +208,10 @@ protected:
 
     void addInTensor(Tensor* tens_ptr)
     {
-        assert(!hasInTensor(tens_ptr));
-        mInTensors.emplace_back(tens_ptr);
+        if(!hasInTensor(tens_ptr))
+        {
+            mInTensors.emplace_back(tens_ptr);
+        }
     }
 };
 

--- a/test/gtest/graphapi_capi_mha_backward.cpp
+++ b/test/gtest/graphapi_capi_mha_backward.cpp
@@ -35,6 +35,17 @@ class MhaBackwardTest : public MhaCommonTest
     using dO_T = std::conditional_t<std::is_same_v<T, float>, float, bfloat8>;
 
 protected:
+
+    void SetUp() override
+    {
+        MhaCommonTest::SetUp();
+
+        if((m_bernulliProbability > 0.0f))
+        {
+            GTEST_SKIP() << "CPU Dropout for backward pass currently is not supported";
+        }
+    }
+
     virtual void MakeRealTensorsAndFillData(miopen::Handle& handle) override
     {
         auto q = test::cpu::GenScaledTensorBackward<T>(m_testN, m_testH, m_testS, m_testD);

--- a/test/gtest/graphapi_capi_mha_backward.cpp
+++ b/test/gtest/graphapi_capi_mha_backward.cpp
@@ -134,13 +134,13 @@ protected:
         MakeAndAddRealTensorDescriptor(miopenTensorMhaScaleDK).InitAndWriteToGPU(handle, dkScale);
         MakeAndAddRealTensorDescriptor(miopenTensorMhaScaleDV).InitAndWriteToGPU(handle, dvScale);
 
-        MakeAndAddRealTensorDescriptor(miopenTensorMhaDQ, m_testN, m_testH, m_testS, m_testD);
-        MakeAndAddRealTensorDescriptor(miopenTensorMhaDK, m_testN, m_testH, m_testS, m_testD);
-        MakeAndAddRealTensorDescriptor(miopenTensorMhaDV, m_testN, m_testH, m_testS, m_testD);
-        MakeAndAddRealTensorDescriptor(miopenTensorMhaAmaxDQ);
-        MakeAndAddRealTensorDescriptor(miopenTensorMhaAmaxDK);
-        MakeAndAddRealTensorDescriptor(miopenTensorMhaAmaxDV);
-        MakeAndAddRealTensorDescriptor(miopenTensorMhaAmaxDS);
+        MakeAndAddRealTensorDescriptor(miopenTensorMhaDQ, m_testN, m_testH, m_testS, m_testD).InitAndWriteToGPU(handle, static_cast<T>(0.0f));
+        MakeAndAddRealTensorDescriptor(miopenTensorMhaDK, m_testN, m_testH, m_testS, m_testD).InitAndWriteToGPU(handle, static_cast<T>(0.0f));
+        MakeAndAddRealTensorDescriptor(miopenTensorMhaDV, m_testN, m_testH, m_testS, m_testD).InitAndWriteToGPU(handle, static_cast<T>(0.0f));
+        MakeAndAddRealTensorDescriptor(miopenTensorMhaAmaxDQ).InitAndWriteToGPU(handle, 0.0f);
+        MakeAndAddRealTensorDescriptor(miopenTensorMhaAmaxDK).InitAndWriteToGPU(handle, 0.0f);
+        MakeAndAddRealTensorDescriptor(miopenTensorMhaAmaxDV).InitAndWriteToGPU(handle, 0.0f);
+        MakeAndAddRealTensorDescriptor(miopenTensorMhaAmaxDS).InitAndWriteToGPU(handle, 0.0f);
 
         dQDescRef = tensor<T>{m_testN, m_testH, m_testS, m_testD};
         dKDescRef = tensor<T>{m_testN, m_testH, m_testS, m_testD};

--- a/test/gtest/graphapi_capi_mha_backward.cpp
+++ b/test/gtest/graphapi_capi_mha_backward.cpp
@@ -35,7 +35,6 @@ class MhaBackwardTest : public MhaCommonTest
     using dO_T = std::conditional_t<std::is_same_v<T, float>, float, bfloat8>;
 
 protected:
-
     void SetUp() override
     {
         MhaCommonTest::SetUp();

--- a/test/gtest/graphapi_capi_mha_backward.cpp
+++ b/test/gtest/graphapi_capi_mha_backward.cpp
@@ -142,16 +142,16 @@ protected:
         MakeAndAddRealTensorDescriptor(miopenTensorMhaAmaxDV).InitAndWriteToGPU(handle, 0.0f);
         MakeAndAddRealTensorDescriptor(miopenTensorMhaAmaxDS).InitAndWriteToGPU(handle, 0.0f);
 
-        dQDescRef = tensor<T>{m_testN, m_testH, m_testS, m_testD};
-        dKDescRef = tensor<T>{m_testN, m_testH, m_testS, m_testD};
-        dVDescRef = tensor<T>{m_testN, m_testH, m_testS, m_testD};
+        m_dQDescRef = tensor<T>{m_testN, m_testH, m_testS, m_testD};
+        m_dKDescRef = tensor<T>{m_testN, m_testH, m_testS, m_testD};
+        m_dVDescRef = tensor<T>{m_testN, m_testH, m_testS, m_testD};
 
         test::cpu::MultiHeadAttentionBackwardDataf8(
             GetTensor<T>(m_realTensorMap[miopenTensorMhaQ]->m_tensorVariant),
             GetTensor<T>(m_realTensorMap[miopenTensorMhaK]->m_tensorVariant),
             GetTensor<T>(m_realTensorMap[miopenTensorMhaV]->m_tensorVariant),
             GetTensor<T>(m_realTensorMap[miopenTensorMhaO]->m_tensorVariant),
-            GetTensor<T>(m_realTensorMap[miopenTensorMhaDO]->m_tensorVariant),
+            GetTensor<dO_T>(m_realTensorMap[miopenTensorMhaDO]->m_tensorVariant),
             softmax,
             q.mDescale,
             k.mDescale,
@@ -165,13 +165,13 @@ protected:
             dsDescale,
             oDescale,
             dO.mDescale,
-            amaxDSRef,
-            amaxDQRef,
-            amaxDKRef,
-            amaxDVRef,
-            dQDescRef,
-            dKDescRef,
-            dVDescRef);
+            m_amaxDSRef,
+            m_amaxDQRef,
+            m_amaxDKRef,
+            m_amaxDVRef,
+            m_dQDescRef,
+            m_dKDescRef,
+            m_dVDescRef);
 
         // get next value for the rest of the tensors (which don't have any particular enum value)
         GetNextId();
@@ -374,25 +374,25 @@ protected:
             EXPECT_LT(miopen::rms_range(ref, GetResult<T>(id, handle)), fp8ErrorThreshold) << name;
         };
 
-        checkAmax(miopenTensorMhaAmaxDQ, "amax dQ", amaxDQRef);
-        checkAmax(miopenTensorMhaAmaxDK, "amax dK", amaxDKRef);
-        checkAmax(miopenTensorMhaAmaxDV, "amax dV", amaxDVRef);
-        checkAmax(miopenTensorMhaAmaxDS, "amax dS", amaxDSRef);
+        checkAmax(miopenTensorMhaAmaxDQ, "amax dQ", m_amaxDQRef);
+        checkAmax(miopenTensorMhaAmaxDK, "amax dK", m_amaxDKRef);
+        checkAmax(miopenTensorMhaAmaxDV, "amax dV", m_amaxDVRef);
+        checkAmax(miopenTensorMhaAmaxDS, "amax dS", m_amaxDSRef);
 
-        checkOutput(miopenTensorMhaDQ, "tensor dQ", dQDescRef);
-        checkOutput(miopenTensorMhaDK, "tensor dK", dKDescRef);
-        checkOutput(miopenTensorMhaDV, "tensor dV", dVDescRef);
+        checkOutput(miopenTensorMhaDQ, "tensor dQ", m_dQDescRef);
+        checkOutput(miopenTensorMhaDK, "tensor dK", m_dKDescRef);
+        checkOutput(miopenTensorMhaDV, "tensor dV", m_dVDescRef);
     }
 
 private:
-    tensor<T> dQDescRef;
-    tensor<T> dKDescRef;
-    tensor<T> dVDescRef;
+    tensor<T> m_dQDescRef;
+    tensor<T> m_dKDescRef;
+    tensor<T> m_dVDescRef;
 
-    float amaxDQRef = 0.0f; // values will be set later. Initializetion is reqired for tidy-checks
-    float amaxDKRef = 0.0f;
-    float amaxDVRef = 0.0f;
-    float amaxDSRef = 0.0f;
+    float m_amaxDQRef = 0.0f; // values will be set later. Initializetion is reqired for tidy-checks
+    float m_amaxDKRef = 0.0f;
+    float m_amaxDVRef = 0.0f;
+    float m_amaxDSRef = 0.0f;
 };
 
 class MhaBackwardTestFp32 : public MhaBackwardTest<float>

--- a/test/gtest/graphapi_capi_mha_backward.cpp
+++ b/test/gtest/graphapi_capi_mha_backward.cpp
@@ -41,13 +41,16 @@ protected:
         auto k = test::cpu::GenScaledTensorBackward<T>(m_testN, m_testH, m_testS, m_testD);
         auto v = test::cpu::GenScaledTensorBackward<T>(m_testN, m_testH, m_testS, m_testD);
 
-        MakeAndAddRealTensorDescriptor(miopenTensorMhaQ, m_testN, m_testH, m_testS, m_testD)
+        MakeAndAddRealTensorDescriptor(
+            miopenTensorMhaQ, m_testN, m_testH, m_testS, m_testD, GetMainType<T>())
             .InitAndWriteToGPU(handle, std::move(q.mTensor));
 
-        MakeAndAddRealTensorDescriptor(miopenTensorMhaK, m_testN, m_testH, m_testS, m_testD)
+        MakeAndAddRealTensorDescriptor(
+            miopenTensorMhaK, m_testN, m_testH, m_testS, m_testD, GetMainType<T>())
             .InitAndWriteToGPU(handle, std::move(k.mTensor));
 
-        MakeAndAddRealTensorDescriptor(miopenTensorMhaV, m_testN, m_testH, m_testS, m_testD)
+        MakeAndAddRealTensorDescriptor(
+            miopenTensorMhaV, m_testN, m_testH, m_testS, m_testD, GetMainType<T>())
             .InitAndWriteToGPU(handle, std::move(v.mTensor));
 
         MakeAndAddRealTensorDescriptor(miopenTensorMhaDescaleQ)
@@ -105,10 +108,12 @@ protected:
             oDesc);
 
         auto dO = test::cpu::GenScaledTensorBackward<dO_T>(m_testN, m_testH, m_testS, m_testD);
-        MakeAndAddRealTensorDescriptor(miopenTensorMhaDO, m_testN, m_testH, m_testS, m_testD)
+        MakeAndAddRealTensorDescriptor(
+            miopenTensorMhaDO, m_testN, m_testH, m_testS, m_testD, GetMainType<dO_T>())
             .InitAndWriteToGPU(handle, std::move(dO.mTensor));
 
-        MakeAndAddRealTensorDescriptor(miopenTensorMhaO, m_testN, m_testH, m_testS, m_testD)
+        MakeAndAddRealTensorDescriptor(
+            miopenTensorMhaO, m_testN, m_testH, m_testS, m_testD, GetMainType<T>())
             .InitAndWriteToGPU(handle, std::move(oDesc));
 
         MakeAndAddRealTensorDescriptor(miopenTensorMhaM, m_testN, m_testH, m_testS, 1)
@@ -134,9 +139,15 @@ protected:
         MakeAndAddRealTensorDescriptor(miopenTensorMhaScaleDK).InitAndWriteToGPU(handle, dkScale);
         MakeAndAddRealTensorDescriptor(miopenTensorMhaScaleDV).InitAndWriteToGPU(handle, dvScale);
 
-        MakeAndAddRealTensorDescriptor(miopenTensorMhaDQ, m_testN, m_testH, m_testS, m_testD).InitAndWriteToGPU(handle, static_cast<T>(0.0f));
-        MakeAndAddRealTensorDescriptor(miopenTensorMhaDK, m_testN, m_testH, m_testS, m_testD).InitAndWriteToGPU(handle, static_cast<T>(0.0f));
-        MakeAndAddRealTensorDescriptor(miopenTensorMhaDV, m_testN, m_testH, m_testS, m_testD).InitAndWriteToGPU(handle, static_cast<T>(0.0f));
+        MakeAndAddRealTensorDescriptor(
+            miopenTensorMhaDQ, m_testN, m_testH, m_testS, m_testD, GetMainType<T>())
+            .InitAndWriteToGPU(handle, static_cast<T>(0.0f));
+        MakeAndAddRealTensorDescriptor(
+            miopenTensorMhaDK, m_testN, m_testH, m_testS, m_testD, GetMainType<T>())
+            .InitAndWriteToGPU(handle, static_cast<T>(0.0f));
+        MakeAndAddRealTensorDescriptor(
+            miopenTensorMhaDV, m_testN, m_testH, m_testS, m_testD, GetMainType<T>())
+            .InitAndWriteToGPU(handle, static_cast<T>(0.0f));
         MakeAndAddRealTensorDescriptor(miopenTensorMhaAmaxDQ).InitAndWriteToGPU(handle, 0.0f);
         MakeAndAddRealTensorDescriptor(miopenTensorMhaAmaxDK).InitAndWriteToGPU(handle, 0.0f);
         MakeAndAddRealTensorDescriptor(miopenTensorMhaAmaxDV).InitAndWriteToGPU(handle, 0.0f);

--- a/test/gtest/graphapi_capi_mha_common.hpp
+++ b/test/gtest/graphapi_capi_mha_common.hpp
@@ -583,6 +583,30 @@ protected:
         return rngOperation;
     }
 
+    DescriptorWrapperPtr MakeReshapeTranspose(DescriptorWrapperPtr tensor1,
+                                              DescriptorWrapperPtr output)
+    {
+        DescriptorWrapperPtr reshapeOperation =
+            MakeDescriptor(MIOPEN_BACKEND_OPERATION_RESHAPE_DESCRIPTOR);
+
+        miopenBackendDescriptor_t tensor1Desc = tensor1->GetDescriptor();
+        miopenBackendDescriptor_t outputDesc  = output->GetDescriptor();
+
+        reshapeOperation->SetAttribute(
+            MIOPEN_ATTR_OPERATION_RESHAPE_XDESC, MIOPEN_TYPE_BACKEND_DESCRIPTOR, 1, &tensor1Desc);
+        reshapeOperation->SetAttribute(
+            MIOPEN_ATTR_OPERATION_RESHAPE_YDESC, MIOPEN_TYPE_BACKEND_DESCRIPTOR, 1, &outputDesc);
+
+        reshapeOperation->AddRef(tensor1);
+        reshapeOperation->AddRef(output);
+
+        reshapeOperation->Finalize();
+
+        AddGraphNode(reshapeOperation);
+
+        return reshapeOperation;
+    }
+
     DescriptorWrapperPtr MakeGapiVirtualTensorDesc(size_t n               = 1,
                                                    size_t h               = 1,
                                                    size_t s               = 1,

--- a/test/gtest/graphapi_capi_mha_common.hpp
+++ b/test/gtest/graphapi_capi_mha_common.hpp
@@ -241,7 +241,7 @@ public:
 
     void Run()
     {
-        miopen::Handle& handle = get_handle();        
+        miopen::Handle& handle = get_handle();
 
         try
         {

--- a/test/gtest/graphapi_capi_mha_common.hpp
+++ b/test/gtest/graphapi_capi_mha_common.hpp
@@ -207,6 +207,10 @@ miopenDataType_t GetMainType()
     {
         return miopenFloat;
     }
+    else if(std::is_same_v<T, bfloat8>)
+    {
+        return miopenBFloat8;
+    }
 
     assert(false);
     return miopenFloat;
@@ -645,6 +649,10 @@ protected:
         else if(dtype == miopenFloat8)
         {
             tensorDataPtr->m_tensorVariant = tensor<float8>{n, h, s, d};
+        }
+        else if(dtype == miopenBFloat8)
+        {
+            tensorDataPtr->m_tensorVariant = tensor<bfloat8>{n, h, s, d};
         }
         else
         {

--- a/test/gtest/graphapi_capi_mha_common.hpp
+++ b/test/gtest/graphapi_capi_mha_common.hpp
@@ -219,8 +219,9 @@ miopenDataType_t GetMainType()
 class MhaCommonTest : public testing::TestWithParam<std::tuple<int, int, int, int, float>>
 {
 public:
-    void Run()
+    void SetUp() override
     {
+        prng::reset_seed();
         auto [n, h, s, d, p] = GetParam();
 
         m_testN               = n;
@@ -236,6 +237,11 @@ public:
             GTEST_SKIP() << "CPU Dropout currently supprorts only fully occupied warps. n=" << n
                          << ", h=" << h << ", s=" << s << ", d=" << d << ", bernulli p=" << p;
         }
+    }
+
+    void Run()
+    {
+        miopen::Handle& handle = get_handle();        
 
         try
         {

--- a/test/gtest/graphapi_capi_mha_forward.cpp
+++ b/test/gtest/graphapi_capi_mha_forward.cpp
@@ -167,7 +167,7 @@ protected:
                    m_realTensorMap[miopenTensorMhaK]->m_gapiDesc,
                    tMM0);
 
-        MakePointwise(MIOPEN_POINTWISE_IDENTITY, tMM0, nullptr, pwS0, false, m_attentionScale);
+        MakePointwise(MIOPEN_POINTWISE_IDENTITY, tMM0, nullptr, pwS0, true, m_attentionScale);
         MakePointwise(
             MIOPEN_POINTWISE_MUL, pwS0, m_realTensorMap[miopenTensorMhaDescaleQ]->m_gapiDesc, pwS1);
         MakePointwise(


### PR DESCRIPTION
A pattern for matching and tensor extraction.
Needs aligning with C and C++ Backward MHA tests.
Also, this PR contains some fixes for C API Mha Backward test. (Test itself was merged via another PR)