### PR TITLE
Fixed redundant find on failed fusion fallback

### DIFF
--- a/src/fusion.cpp
+++ b/src/fusion.cpp
@@ -994,13 +994,22 @@ miopenStatus_t FusionPlanDescriptor::Compile(Handle& handle)
 
             if(fallback)
             {
-                bool found = false;
+                auto fallback_failed = true;
+                bool found           = false;
+
                 GetAllFusionSolvers().Foreach([&](auto solver) {
                     if(found || !solver.IsApplicable(ctx, fusion_problem))
                         return;
                     const auto id = solver::Id(solver.SolverDbId());
                     sols.push_back({0, 0, id.Value(), miopenConvolutionAlgoDirect});
+                    fallback_failed = false;
                 });
+
+                if(fallback_failed)
+                {
+                    MIOPEN_LOG_I("No supported fusion solvers found");
+                    return miopenStatusUnsupportedOp;
+                }
             }
 
             // override the normal find with immed mode with env var


### PR DESCRIPTION
After #3095 if fallback fails it tries to do a redundant find. It wastes some time because in fusion fallback actually checks all the solvers on its own.