### PR TITLE
[WORKAROUND] Allow to use boost:filesystem instead of std::filesystem, [BUGFIX] check_cxx_linker_flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,8 @@ option( BUILD_DEV "Build for development only" OFF)
 option(MIOPEN_ENABLE_FIN "Enable the fin driver for MIOpen"  OFF)
 option(MIOPEN_STRIP_SYMBOLS "Strip symbols in release mode" ON)
 
+option(MIOPEN_WORKAROUND_USE_BOOST_FILESYSTEM "Workaround: Use boost::filesystem instead of std::filesystem" OFF)
+message(STATUS "MIOPEN_WORKAROUND_USE_BOOST_FILESYSTEM ${MIOPEN_WORKAROUND_USE_BOOST_FILESYSTEM}")
 
 # Strip symbols for release
 if(MIOPEN_STRIP_SYMBOLS AND NOT WIN32 AND NOT APPLE)
@@ -147,7 +149,7 @@ else()
     set(MIOPEN_DEFAULT_BACKEND "OpenCL")
 endif()
 
-if(NOT WIN32)
+if(NOT WIN32 AND NOT MIOPEN_WORKAROUND_USE_BOOST_FILESYSTEM)
     include(CheckCXXLinkerFlag)
     check_cxx_linker_flag(stdc++fs HAS_LIB_STD_FILESYSTEM)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,7 +151,7 @@ endif()
 
 if(NOT WIN32 AND NOT MIOPEN_WORKAROUND_USE_BOOST_FILESYSTEM)
     include(CheckCXXLinkerFlag)
-    check_cxx_linker_flag(stdc++fs HAS_LIB_STD_FILESYSTEM)
+    check_cxx_linker_flag(-lstdc++fs HAS_LIB_STD_FILESYSTEM)
 endif()
 
 list(APPEND CMAKE_PREFIX_PATH ${CMAKE_INSTALL_PREFIX} ${CMAKE_INSTALL_PREFIX}/llvm ${CMAKE_INSTALL_PREFIX}/hip /opt/rocm /opt/rocm/llvm /opt/rocm/hip)

--- a/addkernels/CMakeLists.txt
+++ b/addkernels/CMakeLists.txt
@@ -32,4 +32,14 @@ if(HAS_LIB_STD_FILESYSTEM)
     target_link_libraries(addkernels PRIVATE stdc++fs)
 endif()
 
+# This hack is for MIOPEN_WORKAROUND_USE_BOOST_FILESYSTEM.
+# We can't use config.h because it is generated after addkernels.
+target_compile_definitions(addkernels PRIVATE -DMIOPEN_HACK_DO_NOT_INCLUDE_CONFIG_H=1)
+if(MIOPEN_WORKAROUND_USE_BOOST_FILESYSTEM)
+    target_compile_definitions(addkernels PRIVATE -DMIOPEN_WORKAROUND_USE_BOOST_FILESYSTEM=1)
+    target_link_libraries(addkernels PRIVATE Boost::filesystem)
+else()
+    target_compile_definitions(addkernels PRIVATE -DMIOPEN_WORKAROUND_USE_BOOST_FILESYSTEM=0)
+endif()
+
 clang_tidy_check(addkernels)

--- a/cmake/CheckCXXLinkerFlag.cmake
+++ b/cmake/CheckCXXLinkerFlag.cmake
@@ -54,7 +54,17 @@ set(check_cxx_linker_flag_patterns
 include (CheckCXXSourceCompiles)
 
 function(check_cxx_linker_flag _flag _var)
+    # TODO: Replace STATUS with CHECK_START/PASS/FAIL
+    # when cmake_minimum_required becomes >= 3.17
+    message(STATUS "Performing Test ${_var}")
     set (_source "int main() { return 0; }")
+    set(CMAKE_REQUIRED_QUIET TRUE)
     check_cxx_source_compiles("${_source}" _result ${check_cxx_linker_flag_patterns})
+    set(CMAKE_REQUIRED_QUIET FALSE)
     set(${_var} "${_result}" PARENT_SCOPE)
+    if(${_result})
+        message(STATUS "Performing Test ${_var} - Success")
+    else()
+        message(STATUS "Performing Test ${_var} - Failed")
+    endif()
 endfunction()

--- a/cmake/CheckCXXLinkerFlag.cmake
+++ b/cmake/CheckCXXLinkerFlag.cmake
@@ -54,17 +54,8 @@ set(check_cxx_linker_flag_patterns
 include (CheckCXXSourceCompiles)
 
 function(check_cxx_linker_flag _flag _var)
-    # TODO: Replace STATUS with CHECK_START/PASS/FAIL
-    # when cmake_minimum_required becomes >= 3.17
-    message(STATUS "Performing Test ${_var}")
     set (_source "int main() { return 0; }")
-    set(CMAKE_REQUIRED_QUIET TRUE)
-    check_cxx_source_compiles("${_source}" _result ${check_cxx_linker_flag_patterns})
-    set(CMAKE_REQUIRED_QUIET FALSE)
-    set(${_var} "${_result}" PARENT_SCOPE)
-    if(${_result})
-        message(STATUS "Performing Test ${_var} - Success")
-    else()
-        message(STATUS "Performing Test ${_var} - Failed")
-    endif()
+    set(CMAKE_REQUIRED_LINK_OPTIONS "${_flag}")
+    check_cxx_source_compiles("${_source}" "_${_var}" ${check_cxx_linker_flag_patterns})
+    set(${_var} "${_${_var}}" PARENT_SCOPE)
 endfunction()

--- a/include/miopen/config.h.in
+++ b/include/miopen/config.h.in
@@ -52,6 +52,7 @@
 #cmakedefine01 MIOPEN_ENABLE_AI_IMMED_MODE_FALLBACK
 #cmakedefine01 MIOPEN_ENABLE_AI_KERNEL_TUNING
 #cmakedefine01 MIOPEN_HIP_COMPILER_HAS_OPTION_OFFLOAD_UNIFORM_BLOCK
+#cmakedefine01 MIOPEN_WORKAROUND_USE_BOOST_FILESYSTEM
 
 // "_PACKAGE_" to avoid name contentions: the macros like
 // HIP_VERSION_MAJOR are defined in hip_version.h.

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -67,7 +67,7 @@ PlainTextDb::PlainTextDb(DbKinds db_kind_, const fs::path& filename_, bool is_sy
             if(!fs::create_directories(directory))
                 MIOPEN_LOG_W("Unable to create a directory: " << directory);
             else
-                fs::permissions(directory, FS_PERMS_ALL);
+                fs::permissions(directory, FS_ENUM_PERMS_ALL);
         }
     }
 }
@@ -251,7 +251,7 @@ bool PlainTextDb::FlushUnsafe(const DbRecord& record, const RecordPositions* pos
             record.WriteContents(file);
         }
 
-        fs::permissions(filename, FS_PERMS_ALL);
+        fs::permissions(filename, FS_ENUM_PERMS_ALL);
     }
     else
     {
@@ -286,7 +286,7 @@ bool PlainTextDb::FlushUnsafe(const DbRecord& record, const RecordPositions* pos
         fs::remove(filename);
         fs::rename(temp_name, filename);
         /// \todo What if rename fails? Thou shalt not loose the original file.
-        fs::permissions(filename, FS_PERMS_ALL);
+        fs::permissions(filename, FS_ENUM_PERMS_ALL);
     }
     return true;
 }

--- a/src/db.cpp
+++ b/src/db.cpp
@@ -67,7 +67,7 @@ PlainTextDb::PlainTextDb(DbKinds db_kind_, const fs::path& filename_, bool is_sy
             if(!fs::create_directories(directory))
                 MIOPEN_LOG_W("Unable to create a directory: " << directory);
             else
-                fs::permissions(directory, fs::perms::all);
+                fs::permissions(directory, FS_PERMS_ALL);
         }
     }
 }
@@ -251,7 +251,7 @@ bool PlainTextDb::FlushUnsafe(const DbRecord& record, const RecordPositions* pos
             record.WriteContents(file);
         }
 
-        fs::permissions(filename, fs::perms::all);
+        fs::permissions(filename, FS_PERMS_ALL);
     }
     else
     {
@@ -286,7 +286,7 @@ bool PlainTextDb::FlushUnsafe(const DbRecord& record, const RecordPositions* pos
         fs::remove(filename);
         fs::rename(temp_name, filename);
         /// \todo What if rename fails? Thou shalt not loose the original file.
-        fs::permissions(filename, fs::perms::all);
+        fs::permissions(filename, FS_PERMS_ALL);
     }
     return true;
 }

--- a/src/include/miopen/filesystem.hpp
+++ b/src/include/miopen/filesystem.hpp
@@ -79,6 +79,26 @@
 #elif MIOPEN_HAS_FILESYSTEM_TS
 #include <experimental/filesystem>
 #elif MIOPEN_WORKAROUND_USE_BOOST_FILESYSTEM
+/// Explicit inclusion of <boost/container_hash/hash.hpp> is a workaround for the Boost 1.83 issue.
+///
+/// Boost doc is saying:
+///   When writing template classes, you might not want to include the main hash.hpp header as it's
+///   quite an expensive include that brings in a lot of other headers, so instead you can include
+///   the <boost/container_hash/hash_fwd.hpp> header which forward declares boost::hash,
+///   boost::hash_combine, boost::hash_range, and boost::hash_unordered_range. You'll need to
+///   include the main header before instantiating boost::hash.
+///
+/// \ref https://www.boost.org/doc/libs/1_83_0/libs/container_hash/doc/html/hash.html#combine
+///
+/// It seems like boost::filesystem uses boost::hash_range but misses to include hash.hpp, so we
+/// have to include it explicitly. Otherwise an error like this happens at runtime (!):
+///
+/// \code
+/// ...symbol lookup error: .../libMIOpen.so.1: undefined symbol:
+/// _ZN5boost10hash_rangeIN9__gnu_cxx17__normal_iteratorIPKcNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEEEEmT_SC_
+/// \endcode
+#include <boost/container_hash/hash.hpp>
+#define BOOST_FILESYSTEM_NO_DEPRECATED 1
 #include <boost/filesystem.hpp>
 #else
 #error "No filesystem include available"

--- a/src/include/miopen/filesystem.hpp
+++ b/src/include/miopen/filesystem.hpp
@@ -30,35 +30,37 @@
 #include <string>
 #include <string_view>
 
+// clang-format off
 #if defined(CPPCHECK)
-#define MIOPEN_HAS_FILESYSTEM 1
-#define MIOPEN_HAS_FILESYSTEM_TS 1
+  #define MIOPEN_HAS_FILESYSTEM 1
+  #define MIOPEN_HAS_FILESYSTEM_TS 1
 #elif defined(_WIN32)
-#if _MSC_VER >= 1920
-#define MIOPEN_HAS_FILESYSTEM 1
-#define MIOPEN_HAS_FILESYSTEM_TS 0
-#elif _MSC_VER >= 1900
-#define MIOPEN_HAS_FILESYSTEM 0
-#define MIOPEN_HAS_FILESYSTEM_TS 1
-#else
-#define MIOPEN_HAS_FILESYSTEM 0
-#define MIOPEN_HAS_FILESYSTEM_TS 0
-#endif
+  #if _MSC_VER >= 1920
+    #define MIOPEN_HAS_FILESYSTEM 1
+    #define MIOPEN_HAS_FILESYSTEM_TS 0
+  #elif _MSC_VER >= 1900
+    #define MIOPEN_HAS_FILESYSTEM 0
+    #define MIOPEN_HAS_FILESYSTEM_TS 1
+  #else
+    #define MIOPEN_HAS_FILESYSTEM 0
+    #define MIOPEN_HAS_FILESYSTEM_TS 0
+  #endif
 #elif defined(__has_include)
-#if __has_include(<filesystem>) && __cplusplus >= 201703L
-#define MIOPEN_HAS_FILESYSTEM 1
+  #if __has_include(<filesystem>) && __cplusplus >= 201703L
+    #define MIOPEN_HAS_FILESYSTEM 1
+  #else
+    #define MIOPEN_HAS_FILESYSTEM 0
+  #endif
+  #if __has_include(<experimental/filesystem>) && __cplusplus >= 201103L
+    #define MIOPEN_HAS_FILESYSTEM_TS 1
+  #else
+    #define MIOPEN_HAS_FILESYSTEM_TS 0
+  #endif
 #else
-#define MIOPEN_HAS_FILESYSTEM 0
+  #define MIOPEN_HAS_FILESYSTEM 0
+  #define MIOPEN_HAS_FILESYSTEM_TS 0
 #endif
-#if __has_include(<experimental/filesystem>) && __cplusplus >= 201103L
-#define MIOPEN_HAS_FILESYSTEM_TS 1
-#else
-#define MIOPEN_HAS_FILESYSTEM_TS 0
-#endif
-#else
-#define MIOPEN_HAS_FILESYSTEM 0
-#define MIOPEN_HAS_FILESYSTEM_TS 0
-#endif
+// clang-format on
 
 #if MIOPEN_HAS_FILESYSTEM
 #include <filesystem>

--- a/src/include/miopen/filesystem.hpp
+++ b/src/include/miopen/filesystem.hpp
@@ -114,6 +114,13 @@ inline std::string operator+(const miopen::fs::path& path, const std::string_vie
 #endif
 }
 
+// Hack to minimize changes for boost fs.
+#if MIOPEN_WORKAROUND_USE_BOOST_FILESYSTEM
+#define FS_PERMS_ALL fs::perms::all_all
+#else
+#define FS_PERMS_ALL fs::perms::all
+#endif
+
 #if MIOPEN_HAS_FILESYSTEM_TS
 #ifdef __linux__
 #include <linux/limits.h>

--- a/src/include/miopen/filesystem.hpp
+++ b/src/include/miopen/filesystem.hpp
@@ -116,9 +116,9 @@ inline std::string operator+(const miopen::fs::path& path, const std::string_vie
 
 // Hack to minimize changes for boost fs.
 #if MIOPEN_WORKAROUND_USE_BOOST_FILESYSTEM
-#define FS_PERMS_ALL fs::perms::all_all
+#define FS_ENUM_PERMS_ALL fs::perms::all_all
 #else
-#define FS_PERMS_ALL fs::perms::all
+#define FS_ENUM_PERMS_ALL fs::perms::all
 #endif
 
 #if MIOPEN_HAS_FILESYSTEM_TS

--- a/src/include/miopen/sqlite_db.hpp
+++ b/src/include/miopen/sqlite_db.hpp
@@ -240,7 +240,7 @@ public:
                 if(!fs::create_directories(directory))
                     MIOPEN_LOG_W("Unable to create a directory: " << directory);
                 else
-                    fs::permissions(directory, fs::perms::all);
+                    fs::permissions(directory, FS_PERMS_ALL);
             }
         }
         sql = SQLite{filename_, is_system};

--- a/src/include/miopen/sqlite_db.hpp
+++ b/src/include/miopen/sqlite_db.hpp
@@ -240,7 +240,7 @@ public:
                 if(!fs::create_directories(directory))
                     MIOPEN_LOG_W("Unable to create a directory: " << directory);
                 else
-                    fs::permissions(directory, FS_PERMS_ALL);
+                    fs::permissions(directory, FS_ENUM_PERMS_ALL);
             }
         }
         sql = SQLite{filename_, is_system};

--- a/src/load_file.cpp
+++ b/src/load_file.cpp
@@ -37,7 +37,11 @@ namespace miopen {
 
 std::vector<char> LoadFile(const fs::path& path)
 {
+#if MIOPEN_WORKAROUND_USE_BOOST_FILESYSTEM
+    boost::system::error_code error_code;
+#else
     std::error_code error_code;
+#endif
     const auto size = fs::file_size(path, error_code);
     if(error_code)
         MIOPEN_THROW(path.string() + ": " + error_code.message());

--- a/src/lock_file.cpp
+++ b/src/lock_file.cpp
@@ -50,7 +50,7 @@ fs::path LockFilePath(const fs::path& filename_)
         if(!fs::exists(directory))
         {
             fs::create_directories(directory);
-            fs::permissions(directory, fs::perms::all);
+            fs::permissions(directory, FS_PERMS_ALL);
         }
         const auto hash = md5(filename_.parent_path().string());
         const auto file = directory / (hash + "_" + filename_.filename() + ".lock");
@@ -72,7 +72,7 @@ LockFile::LockFile(const fs::path& path_, PassKey) : path(path_)
         {
             if(!std::ofstream{path})
                 MIOPEN_THROW("Error creating file <" + path + "> for locking.");
-            fs::permissions(path, fs::perms::all);
+            fs::permissions(path, FS_PERMS_ALL);
         }
         flock = path.string().c_str();
     }

--- a/src/lock_file.cpp
+++ b/src/lock_file.cpp
@@ -50,7 +50,7 @@ fs::path LockFilePath(const fs::path& filename_)
         if(!fs::exists(directory))
         {
             fs::create_directories(directory);
-            fs::permissions(directory, FS_PERMS_ALL);
+            fs::permissions(directory, FS_ENUM_PERMS_ALL);
         }
         const auto hash = md5(filename_.parent_path().string());
         const auto file = directory / (hash + "_" + filename_.filename() + ".lock");
@@ -72,7 +72,7 @@ LockFile::LockFile(const fs::path& path_, PassKey) : path(path_)
         {
             if(!std::ofstream{path})
                 MIOPEN_THROW("Error creating file <" + path + "> for locking.");
-            fs::permissions(path, FS_PERMS_ALL);
+            fs::permissions(path, FS_ENUM_PERMS_ALL);
         }
         flock = path.string().c_str();
     }


### PR DESCRIPTION
- 🟠 Allows to use `boost:filesystem` instead of `std::filesystem` via CMake flag.
  - This is to workaround runtime issues (SIGSEGV) related to misconfigured/buggy std::filesystem on some host configurations (e.g. CentOS 8 with manually installed gcc 10).
  - Usage: `cmake ... -DMIOPEN_WORKAROUND_USE_BOOST_FILESYSTEM=On ...`
- By-products
  - 🔴 [BUGFIX][CMake] Fixed issue in check_cxx_linker_flag, see https://github.com/ROCm/MIOpen/commit/4549e017af33763b2751c316214399030e954f11#r144783324
  - [NFC][CMake] Improved logging in `check_cxx_linker_flag`
  - [NFC] Some formatting for readability

Locally tested (make check with debug configuration, make analyze etc.)

----
[Attribution] @junliume @JehandadKhan
- https://github.com/ROCm/MIOpen/labels/workaround
- https://github.com/ROCm/MIOpen/labels/non-miopen-bug
- https://github.com/ROCm/MIOpen/labels/urgency_blocker
- Proposed reviewers:
  - @BrianHarrisonAMD 
  - @apwojcik 
  - @junliume
- Optional reviewers:
  - @DrizztDoUrden
  - @CAHEK7 
  - @shurale-nkn 
  - @averinevg 