### PR TITLE
[RNN] BWD concurrent imp

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -177,6 +177,7 @@ set( MIOpen_Source
     rnn/Solutions/rnn_transformer.cpp
     rnn/Solutions/modular_base.cpp
     rnn/Solutions/bwd_s_stream.cpp
+    rnn/Solutions/bwd_multi_stream.cpp
     scalar.cpp
     softmax.cpp
     softmax_api.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -173,7 +173,10 @@ set( MIOpen_Source
     rnn.cpp
     rnn_api.cpp
     rnn/rnn_util.cpp
+    rnn/selector.cpp
     rnn/Solutions/rnn_transformer.cpp
+    rnn/Solutions/modular_base.cpp
+    rnn/Solutions/bwd_s_stream.cpp
     scalar.cpp
     softmax.cpp
     softmax_api.cpp

--- a/src/include/miopen/rnn.hpp
+++ b/src/include/miopen/rnn.hpp
@@ -121,6 +121,11 @@ struct MIOPEN_INTERNALS_EXPORT RNNDescriptor : miopenRNNDescriptor
                                                        const int* lensPerSeq,
                                                        const void* padding_marker_ptr);
 
+    static SeqTensorDescriptor makeSeqTensorDescriptor(
+        c_array_view<const miopenTensorDescriptor_t> descs,
+        size_t seq_len,
+        miopenRNNBaseLayout_t layout = miopenRNNBaseLayout_t::miopenRNNDataSeqMajorNotPadded);
+
     static void SeqTensorToTensorDescArray(const SeqTensorDescriptor& desc,
                                            std::vector<miopen::TensorDescriptor>& td,
                                            std::vector<miopenTensorDescriptor_t>& ptd);
@@ -363,6 +368,26 @@ struct MIOPEN_INTERNALS_EXPORT RNNDescriptor : miopenRNNDescriptor
 private:
     size_t RNNTransformerWorkspaceSize(const SeqTensorDescriptor& xDesc,
                                        miopenRNNFWDMode_t fwdMode) const;
+
+    // TODO rename
+    void ModularBackward(Handle& handle,
+                         const SeqTensorDescriptor& yDesc,
+                         ConstData_t dy,
+                         const TensorDescriptor& hDesc,
+                         ConstData_t hx,
+                         ConstData_t dhy,
+                         Data_t dhx,
+                         const TensorDescriptor& cDesc,
+                         ConstData_t cx,
+                         ConstData_t dcy,
+                         Data_t dcx,
+                         const SeqTensorDescriptor& xDesc,
+                         Data_t dx,
+                         ConstData_t w,
+                         Data_t workSpace,
+                         size_t workSpaceSize,
+                         Data_t reserveSpace,
+                         size_t reserveSpaceSize) const;
 
     void RNNTransformerForward(Handle& handle,
                                miopenRNNFWDMode_t fwdMode,

--- a/src/include/miopen/rnn/base_ops.hpp
+++ b/src/include/miopen/rnn/base_ops.hpp
@@ -1,0 +1,159 @@
+#pragma once
+
+#include <miopen/rnn.hpp>
+#include <miopen/gemm_v2.hpp>
+
+namespace miopen {
+
+namespace rnn_base {
+
+template <typename T, size_t N, size_t M>
+std::array<T, N + M> Concat(const std::array<T, N>& a, const std::array<T, M>& b)
+{
+    std::array<T, N + M> result;
+    std::copy(a.cbegin(), a.cend(), result.begin());
+    std::copy(b.cbegin(), b.cend(), result.begin() + N);
+    return result;
+}
+
+inline miopen::GemmDescriptor GemmDescriptor64BitWraper(bool isColMajor_,
+                                                        bool transA_,
+                                                        bool transB_,
+                                                        size_t m_,
+                                                        size_t n_,
+                                                        size_t k_,
+                                                        size_t lda_,
+                                                        size_t ldb_,
+                                                        size_t ldc_,
+                                                        size_t batch_count_,
+                                                        long long int strideA_,
+                                                        long long int strideB_,
+                                                        long long int strideC_,
+                                                        float alpha_,
+                                                        float beta_,
+                                                        miopenDataType_t dataType_,
+                                                        bool deterministic_)
+{
+    return GemmDescriptor{isColMajor_,
+                          transA_,
+                          transB_,
+                          static_cast<int>(m_),
+                          static_cast<int>(n_),
+                          static_cast<int>(k_),
+                          static_cast<int>(lda_),
+                          static_cast<int>(ldb_),
+                          static_cast<int>(ldc_),
+                          static_cast<int>(batch_count_),
+                          strideA_,
+                          strideB_,
+                          strideC_,
+                          alpha_,
+                          beta_,
+                          dataType_,
+                          deterministic_};
+}
+
+class RnnBaseFunctions
+{
+    RnnBaseFunctions() {}
+
+public:
+    static miopenStatus_t BWD_GEMM_Hidden_Prop(Handle& handle,
+                                               ConstData_t comb_gates_src_ptr,
+                                               size_t comb_gates_src_offset,
+                                               ConstData_t filter_src_ptr,
+                                               size_t filter_offset,
+                                               Data_t ht_dst_ptr,
+                                               size_t ht_dst_offset,
+                                               size_t gemm_batch_size,
+                                               size_t ht_dest_vec_size,
+                                               size_t comb_gates_size,
+                                               size_t tmp_gate_row_stride,
+                                               size_t filter_row_stride,
+                                               size_t ht_dest_row_stride,
+                                               miopenDataType_t data_type,
+                                               bool add_assign = true)
+    {
+        // no gemm work
+        if(gemm_batch_size == 0)
+            return miopenStatusSuccess;
+
+        const miopen::GemmDescriptor gemm_desc =
+            GemmDescriptor64BitWraper(false,
+                                      false,
+                                      false,
+                                      gemm_batch_size,
+                                      ht_dest_vec_size,
+                                      comb_gates_size,
+                                      tmp_gate_row_stride,
+                                      filter_row_stride,
+                                      ht_dest_row_stride,
+                                      1,                  // batch count
+                                      0,                  // Stride A
+                                      0,                  // Stride B
+                                      0,                  // Stride C
+                                      1,                  // alpha
+                                      add_assign ? 1 : 0, // beta
+                                      data_type,
+                                      false);
+
+        return CallGemm(handle,
+                        gemm_desc,
+                        comb_gates_src_ptr,
+                        comb_gates_src_offset,
+                        filter_src_ptr,
+                        filter_offset,
+                        ht_dst_ptr,
+                        ht_dst_offset,
+                        GemmBackend_t::rocblas);
+    }
+
+    static miopenStatus_t BWD_GEMM_Hidden_Prop(Handle& handle,
+                                               ConstData_t comb_gates_src_ptr,
+                                               size_t comb_gates_src_offset,
+                                               const miopen::TensorDescriptor& tmp_gates_src_dsc,
+
+                                               ConstData_t filter_src_ptr,
+                                               size_t filter_src_offset,
+                                               const miopen::TensorDescriptor& filter_src_dsc,
+
+                                               Data_t ht_dst_ptr,
+                                               size_t ht_dst_offset,
+                                               const miopen::TensorDescriptor& ht_dest_dsc,
+                                               bool add_assign = true)
+    {
+        assert(filter_src_dsc.GetNumDims() == 2 && tmp_gates_src_dsc.GetNumDims() == 2 &&
+               ht_dest_dsc.GetNumDims() == 2);
+
+        const size_t batch_size      = tmp_gates_src_dsc.GetLengths()[0];
+        const size_t comb_gates_size = tmp_gates_src_dsc.GetLengths()[1];
+        const size_t ht_vec_size     = ht_dest_dsc.GetLengths()[1];
+
+        assert(filter_src_dsc.GetLengths()[0] == comb_gates_size);
+        assert(filter_src_dsc.GetLengths()[1] == ht_vec_size);
+        assert(ht_dest_dsc.GetLengths()[0] == batch_size);
+
+        const size_t tmp_gates_ld_stride = tmp_gates_src_dsc.GetStrides()[0]; // {batch, comb_gates}
+        const size_t filter_ld_stride    = filter_src_dsc.GetStrides()[0]; // {comb_gates, ht_vec}
+        const size_t ht_dest_ld_stride   = ht_dest_dsc.GetStrides()[0];    // {batch, ht_vec}
+
+        return BWD_GEMM_Hidden_Prop(handle,
+                                    comb_gates_src_ptr,
+                                    comb_gates_src_offset,
+                                    filter_src_ptr,
+                                    filter_src_offset,
+                                    ht_dst_ptr,
+                                    ht_dst_offset,
+                                    batch_size,
+                                    ht_vec_size,
+                                    comb_gates_size,
+                                    tmp_gates_ld_stride,
+                                    filter_ld_stride,
+                                    ht_dest_ld_stride,
+                                    ht_dest_dsc.GetType(),
+                                    add_assign);
+    }
+};
+
+} // namespace rnn_base
+} // namespace miopen

--- a/src/include/miopen/rnn/base_ops.hpp
+++ b/src/include/miopen/rnn/base_ops.hpp
@@ -58,7 +58,7 @@ class RnnBaseFunctions
     RnnBaseFunctions() {}
 
 public:
-    static miopenStatus_t BWD_GEMM_Hidden_Prop(Handle& handle,
+    static miopenStatus_t BWD_GEMM_Hidden_Prop(const Handle& handle,
                                                ConstData_t comb_gates_src_ptr,
                                                size_t comb_gates_src_offset,
                                                ConstData_t filter_src_ptr,
@@ -108,7 +108,7 @@ public:
                         GemmBackend_t::rocblas);
     }
 
-    static miopenStatus_t BWD_GEMM_Hidden_Prop(Handle& handle,
+    static miopenStatus_t BWD_GEMM_Hidden_Prop(const Handle& handle,
                                                ConstData_t comb_gates_src_ptr,
                                                size_t comb_gates_src_offset,
                                                const miopen::TensorDescriptor& tmp_gates_src_dsc,

--- a/src/include/miopen/rnn/multi_stream_utils.hpp
+++ b/src/include/miopen/rnn/multi_stream_utils.hpp
@@ -1,0 +1,106 @@
+#pragma once
+
+#include <miopen/rnn.hpp>
+#include <miopen/gemm_v2.hpp>
+
+MIOPEN_DECLARE_ENV_VAR_BOOL(MIOPEN_MS_WA_FIX)
+
+namespace miopen {
+
+class MultiStreamController
+{
+public:
+    static constexpr int rootStreamId = 0;
+
+    MultiStreamController(Handle& handle, int extra_stream_cnt)
+        : streamPoolIdsMapping{init_stream_pool_ids(handle, extra_stream_cnt)},
+          streamPoolCache{init_stream_pool(handle, streamPoolIdsMapping)},
+          activeHandle{handle}
+    {
+    }
+
+    hipStream_t getStream(int stream_id) const { return streamPoolCache[stream_id]; }
+
+    void ChangeActiveStream(int stream_id) const
+    {
+        activeHandle.SetStreamFromPool(streamPoolIdsMapping[stream_id]);
+    }
+
+    hipError_t RecordEvent(const hipEvent_t event, int stream_id) const
+    {
+        return hipEventRecord(event, getStream(stream_id));
+    }
+
+    hipError_t SetWaitEvent(const hipEvent_t event, int stream_id) const
+    {
+        return hipStreamWaitEvent(getStream(stream_id), event, 0);
+    }
+
+    void RootWaitToAllStreams() const
+    {
+        for(size_t i = 0, stream_cnt = size(); i < stream_cnt; i++)
+        {
+            if(i != rootStreamId)
+            {
+                const miopen::HipEventPtr sync_event = make_hip_fast_event();
+                RecordEvent(sync_event.get(), i);
+                SetWaitEvent(sync_event.get(), rootStreamId);
+            }
+        }
+    }
+
+    void AllStreamsWaitRoot() const
+    {
+        const miopen::HipEventPtr main_event = make_hip_fast_event();
+
+        RecordEvent(main_event.get(), rootStreamId);
+
+        for(size_t i = 0, stream_cnt = size(); i < stream_cnt; i++)
+        {
+            if(i != rootStreamId)
+                SetWaitEvent(main_event.get(), i);
+        }
+    };
+
+    size_t size() const { return streamPoolIdsMapping.size(); }
+
+private:
+    static std::vector<int> init_stream_pool_ids(const Handle& handle, int extra_stream_cnt)
+    {
+        std::vector<int> ids;
+        ids.reserve(extra_stream_cnt + 1);
+
+        bool ms_wa_fix_active = extra_stream_cnt > 2 && !env::disabled(MIOPEN_MS_WA_FIX);
+        int wa_steams         = ms_wa_fix_active ? 2 : 0;
+
+        handle.ReserveExtraStreamsInPool(extra_stream_cnt + wa_steams);
+
+        for(int i = 0; i <= extra_stream_cnt + wa_steams; i++)
+            if(!(ms_wa_fix_active && (i == 3 || i == 4)))
+                ids.push_back(i);
+
+        return ids;
+    }
+
+    static std::vector<hipStream_t> init_stream_pool(const Handle& handle,
+                                                     const std::vector<int>& pool_ids)
+    {
+        std::vector<hipStream_t> pool;
+        pool.reserve(pool_ids.size());
+
+        for(auto id : pool_ids)
+        {
+            handle.SetStreamFromPool(id);
+            pool.push_back(handle.GetStream());
+        }
+        handle.SetStreamFromPool(0);
+
+        return pool;
+    }
+
+    const std::vector<int> streamPoolIdsMapping;
+    const std::vector<hipStream_t> streamPoolCache;
+    const Handle& activeHandle;
+};
+
+} // namespace miopen

--- a/src/include/miopen/rnn/solvers.hpp
+++ b/src/include/miopen/rnn/solvers.hpp
@@ -62,21 +62,23 @@ public:
                 batch_controller};
     }
 
+    void PrepareWriteBuffers(const Handle& handle, Data_t dhx, Data_t dcx, Data_t workSpace) const;
+
     void PropDhy(const Handle& handle,
                  ConstData_t dhy,
                  Data_t workSpace,
-                 const unsigned int layer,
+                 unsigned int layer,
                  const SequenceIterator& currentSeq,
                  SequenceDirection direction) const;
 
-    void PropHiddenDht(Handle& handle,
+    void PropHiddenDht(const Handle& handle,
                        ConstData_t w,
                        Data_t workSpace,
                        int layer,
                        const SequenceIterator& currentSeq,
                        SequenceDirection direction) const;
 
-    void UpdateHStatePerTimeSeq(Handle& handle,
+    void UpdateHStatePerTimeSeq(const Handle& handle,
                                 ConstData_t dcy,
                                 ConstData_t cx,
                                 Data_t,
@@ -86,7 +88,7 @@ public:
                                 const SequenceIterator& seq,
                                 SequenceDirection direction) const;
 
-    void PropDhxDcx(Handle& handle,
+    void PropDhxDcx(const Handle& handle,
                     ConstData_t w,
                     Data_t dhx,
                     Data_t dcx,
@@ -96,16 +98,16 @@ public:
                     const SequenceIterator& currentSeq,
                     SequenceDirection direction) const;
 
-    void PropDy(Handle& handle, ConstData_t dy, Data_t workSpace) const;
+    void PropDy(const Handle& handle, ConstData_t dy, Data_t workSpace) const;
 
-    void PropHiddenDy(Handle& handle,
+    void PropHiddenDy(const Handle& handle,
                       ConstData_t w,
                       Data_t workSpace,
                       Data_t reserveSpace,
                       size_t layer,
                       SequenceDirection direction) const;
 
-    void PropDx(Handle& handle,
+    void PropDx(const Handle& handle,
                 ConstData_t w,
                 ConstData_t workSpace,
                 Data_t dx,

--- a/src/include/miopen/rnn/solvers.hpp
+++ b/src/include/miopen/rnn/solvers.hpp
@@ -1,0 +1,273 @@
+#pragma once
+
+#include <miopen/rnn.hpp>
+#include <miopen/rnn_util.hpp>
+#include "miopen/rnn/tmp_buffer_utils.hpp"
+
+namespace miopen {
+
+namespace rnn_base {
+
+class RNNBackwardDataModularAlgo
+{
+public:
+    static RNNBackwardDataModularAlgo create(const RNNDescriptor& rnnDesc,
+                                             const SeqTensorDescriptor& xDesc,
+                                             const SeqTensorDescriptor& yDesc,
+                                             const TensorDescriptor& hDesc)
+    {
+        auto [max_layers_hid, max_batch_hid, hidden_vec_sz] = miopen::tien<3>(hDesc.GetLengths());
+        auto [max_batch_in, max_seq, input_vec_sz]          = miopen::tien<3>(xDesc.GetLengths());
+
+        assert(max_batch_in <= max_batch_hid);
+
+        auto layers_cnt         = static_cast<int>(rnnDesc.nLayers);
+        const bool is_seq_bidir = rnnDesc.dirMode == miopenRNNbidirection;
+
+        assert(static_cast<size_t>(layers_cnt) * (is_seq_bidir ? 2 : 1) <= max_layers_hid);
+
+        auto gates_cnt = static_cast<int>(rnnDesc.nHiddenTensorsPerLayer);
+
+        // class update req
+        assert(!is_seq_bidir);
+        const size_t seq_directions = is_seq_bidir ? 2 : 1;
+
+        // TODO all size_t
+        GeneralLstmRedBuffer rb_layout = GeneralLstmRedBuffer::build(
+            layers_cnt, xDesc.GetTotalSequenceLen(), seq_directions, hidden_vec_sz);
+
+        GeneralLstmTempBuffer workspace_info = GeneralLstmTempBuffer::build(
+            layers_cnt, xDesc.GetTotalSequenceLen(), seq_directions, hidden_vec_sz);
+
+        WeightsBufferDescriptor weights_layout{static_cast<int>(input_vec_sz),
+                                               static_cast<int>(hidden_vec_sz),
+                                               layers_cnt,
+                                               rnnDesc.biasMode,
+                                               gates_cnt};
+
+        BatchController batch_controller = BatchController::Create(xDesc);
+
+        HiddenBuffersDescriptor hidden_hxcx_info{hDesc};
+
+        IOBufferDescriptor x_info{IOBufferDescriptor::build(xDesc)};
+        IOBufferDescriptor y_info{IOBufferDescriptor::build(yDesc)};
+
+        return {std::move(rb_layout),
+                workspace_info,
+                weights_layout,
+                hidden_hxcx_info,
+                x_info,
+                y_info,
+                rnnDesc,
+                batch_controller};
+    }
+
+    void PropDhy(const Handle& handle,
+                 ConstData_t dhy,
+                 Data_t workSpace,
+                 const unsigned int layer,
+                 const SequenceIterator& currentSeq,
+                 SequenceDirection direction) const;
+
+    void PropHiddenDht(Handle& handle,
+                       ConstData_t w,
+                       Data_t workSpace,
+                       int layer,
+                       const SequenceIterator& currentSeq,
+                       SequenceDirection direction) const;
+
+    void UpdateHStatePerTimeSeq(Handle& handle,
+                                ConstData_t dcy,
+                                ConstData_t cx,
+                                Data_t,
+                                Data_t workSpace,
+                                Data_t reserveSpace,
+                                int layer,
+                                const SequenceIterator& seq,
+                                SequenceDirection direction) const;
+
+    void PropDhxDcx(Handle& handle,
+                    ConstData_t w,
+                    Data_t dhx,
+                    Data_t dcx,
+                    Data_t workSpace,
+                    Data_t reserveSpace,
+                    size_t layer,
+                    const SequenceIterator& currentSeq,
+                    SequenceDirection direction) const;
+
+    void PropDy(Handle& handle, ConstData_t dy, Data_t workSpace) const;
+
+    void PropHiddenDy(Handle& handle,
+                      ConstData_t w,
+                      Data_t workSpace,
+                      Data_t reserveSpace,
+                      size_t layer,
+                      SequenceDirection direction) const;
+
+    void PropDx(Handle& handle,
+                ConstData_t w,
+                ConstData_t workSpace,
+                Data_t dx,
+                SequenceDirection direction) const;
+
+private:
+    RNNBackwardDataModularAlgo(GeneralLstmRedBuffer rb_layout,
+                               GeneralLstmTempBuffer workspace_info,
+                               WeightsBufferDescriptor weights_layout,
+                               HiddenBuffersDescriptor hidden_hxcx_info,
+                               IOBufferDescriptor x_info,
+                               IOBufferDescriptor y_info,
+                               const RNNDescriptor& rnn_desc,
+                               BatchController batch_controller)
+        : reservLayout(std::move(rb_layout)),
+          workspaceInfo(std::move(workspace_info)),
+          weightsLayout(std::move(weights_layout)),
+          hiddenHxCxInfo(std::move(hidden_hxcx_info)),
+          xInfo(std::move(x_info)),
+          yInfo(std::move(y_info)),
+          rnnDesc(rnn_desc),
+          batchController(std::move(batch_controller))
+    {
+    }
+
+    template <typename BufType>
+    inline miopen::TensorDescriptor BuildLstmTmpBlockDesc2D(const BufType& buf_info,
+                                                            const size_t batch_size) const
+    {
+        const std::array<size_t, 4>& tmp_block_stride = buf_info.getGateBlockStride();
+        const std::array<size_t, 4>& tmp_block_size   = buf_info.getGateBlockSize();
+
+        // batch, gateBlock_elements
+        return miopen::TensorDescriptor{rnnDesc.dataType,
+                                        {batch_size, tmp_block_size[3]},
+                                        {tmp_block_stride[1], tmp_block_stride[3]}};
+    }
+
+    inline miopen::TensorDescriptor BuildLstmFilterXDesc2D(int layer_id) const
+    {
+        // TODO replace by stride
+        auto x_vec = layer_id != 0 ? weightsLayout.x_in_vec : weightsLayout.in_vec;
+
+        // gateBlock_elements, ht_vec
+        return miopen::TensorDescriptor{
+            rnnDesc.dataType, {weightsLayout.gates_cnt * weightsLayout.h_vec, x_vec}, {x_vec, 1}};
+    }
+
+    inline miopen::TensorDescriptor BuildLstmFilterHidDesc2D() const
+    {
+        // TODO replace by stride
+        auto h_vec = weightsLayout.h_vec;
+
+        // gateBlock_elements, ht_vec
+        return miopen::TensorDescriptor{
+            rnnDesc.dataType, {weightsLayout.gates_cnt * weightsLayout.h_vec, h_vec}, {h_vec, 1}};
+    }
+
+    inline miopen::TensorDescriptor BuildWsHtDesc2D(size_t batch_size) const
+    {
+        auto& ht_stride = workspaceInfo.getHiddenStateStride();
+        auto& ht_size   = workspaceInfo.hStateSizes;
+
+        // batch, gateBlock_elements
+        return miopen::TensorDescriptor{
+            rnnDesc.dataType, {batch_size, ht_size[3]}, {ht_stride[1], ht_stride[3]}};
+    }
+
+    // 2 dims batch, vec
+    inline miopen::TensorDescriptor BuildHxCxDesc2D(size_t batch_size) const
+    {
+        const std::vector<size_t> hx_size{batch_size, hiddenHxCxInfo.getHiddenSize()};
+        const std::vector<size_t> hx_stride{hiddenHxCxInfo.getStrides()[1],
+                                            hiddenHxCxInfo.getStrides()[2]};
+
+        return miopen::TensorDescriptor{rnnDesc.dataType, hx_size, hx_stride};
+    }
+
+    // 3 dims layer, batch, vec
+    inline miopen::TensorDescriptor BuildHxCxDesc3D(size_t layer_size, size_t batch_size) const
+    {
+        const std::vector<size_t> hx_accum_size{
+            layer_size, batch_size, hiddenHxCxInfo.getHiddenSize()};
+
+        return miopen::TensorDescriptor{
+            rnnDesc.dataType, hx_accum_size, hiddenHxCxInfo.getStrides()};
+    }
+
+    // 3 dims layer, batch, vec
+    inline miopen::TensorDescriptor BuildTempDhtDesc3D(size_t layer_size, size_t batch_size) const
+    {
+        const std::vector<size_t> dy_dhy_accum_size{
+            layer_size, batch_size, hiddenHxCxInfo.getHiddenSize()};
+
+        const auto ws_dy_stride = [](const auto& ws_4dim_strides) -> std::vector<size_t> {
+            // convert 4dim stride to 3 dim without direction
+            // TODO change hiddenBufferDesc
+            return std::vector<size_t>{ws_4dim_strides[0], ws_4dim_strides[1], ws_4dim_strides[3]};
+        }(workspaceInfo.getHiddenStateStride());
+
+        return miopen::TensorDescriptor{rnnDesc.dataType, dy_dhy_accum_size, ws_dy_stride};
+    }
+
+    inline size_t getVirtualLayer(const size_t layer_id, SequenceDirection direction) const
+    {
+        return layer_id * (isBidirectSeq ? 2 : 1) +
+               (direction == SequenceDirection::Forward ? 0 : 1);
+    }
+
+    const GeneralLstmRedBuffer reservLayout;
+    // const WorkspaceBufferDescriptor workspaceInfo;
+    const GeneralLstmTempBuffer workspaceInfo;
+
+    const WeightsBufferDescriptor weightsLayout;
+    const HiddenBuffersDescriptor hiddenHxCxInfo;
+    const IOBufferDescriptor xInfo;
+    const IOBufferDescriptor yInfo;
+
+    const RNNDescriptor& rnnDesc;
+
+    const ActivationDescriptor tanhDesc = {miopenActivationTANH, 1, 1, 1};
+    const ActivationDescriptor sigDesc  = {miopenActivationLOGISTIC, 1, 0, 1};
+    const ActivationDescriptor reluDesc = {miopenActivationRELU, 1, 0, 1};
+
+    const BatchController batchController;
+
+    const bool isBidirectSeq = false;
+};
+
+class RNNModularSingleStreamBWD
+{
+public:
+    RNNModularSingleStreamBWD(const RNNDescriptor& rnn,
+                              const SeqTensorDescriptor& xDesc,
+                              const SeqTensorDescriptor& yDesc,
+                              const TensorDescriptor& hDesc)
+        : rnnAlgoModules(RNNBackwardDataModularAlgo::create(rnn, xDesc, yDesc, hDesc)),
+          rnnDesc(rnn),
+          max_seq_len(xDesc.GetMaxSequenceLength())
+    {
+    }
+
+    bool isApplicable();
+
+    size_t GetWsSize();
+
+    void ComputeBWD(Handle& handle,
+                    ConstData_t dy,
+                    ConstData_t dhy,
+                    Data_t dhx,
+                    ConstData_t cx,
+                    ConstData_t dcy,
+                    Data_t dcx,
+                    Data_t dx,
+                    ConstData_t w,
+                    Data_t workSpace,
+                    Data_t reserveSpace) const;
+
+    const rnn_base::RNNBackwardDataModularAlgo rnnAlgoModules;
+    const RNNDescriptor& rnnDesc;
+    const size_t max_seq_len;
+};
+
+} // namespace rnn_base
+} // namespace miopen

--- a/src/include/miopen/rnn/tmp_buffer_utils.hpp
+++ b/src/include/miopen/rnn/tmp_buffer_utils.hpp
@@ -1,0 +1,797 @@
+﻿#pragma once
+
+#include <miopen/rnn.hpp>
+#include <miopen/rnn_util.hpp>
+
+#include <miopen/activ.hpp>
+#include <miopen/env.hpp>
+
+#include <vector>
+#include <array>
+#include <numeric>
+#include <algorithm>
+
+#include <cassert>
+#include <miopen/rnn/base_ops.hpp>
+
+namespace miopen {
+
+namespace rnn_base {
+
+enum class SequenceDirection
+{
+    Forward = 0,
+    Reverse = 1
+};
+
+enum class LstmGateAndState
+{
+    I  = 0,
+    F  = 1,
+    O  = 2,
+    G  = 3,
+    St = 4,
+    Ht = 5
+};
+
+/**
+ * \section Extensions for layouts.
+ */
+
+// GRU
+// TODO
+
+// LSTM
+template <typename Derived>
+class GeneralLstmWsExt
+{
+public:
+    size_t getGasOffset(const size_t layer_id,
+                        const size_t vector_id,
+                        const SequenceDirection direction,
+                        LstmGateAndState gas) const
+    {
+        return static_cast<const Derived*>(this)->getGasOffsetImpl(
+            layer_id, vector_id, direction, gas);
+    }
+
+    const std::array<size_t, 4>& getGateAndStateStride(LstmGateAndState gas) const
+    {
+        return static_cast<const Derived*>(this)->getGateAndStateStrideImpl(gas);
+    }
+};
+
+template <typename Derived>
+class LstmWsGateBlockExt
+{
+public:
+    size_t getGateBlockOffset(const size_t layer_id,
+                              const size_t vector_id,
+                              const SequenceDirection direction) const
+    {
+        return static_cast<const Derived*>(this)->getGasOffset(
+            layer_id, vector_id, direction, LstmGateAndState::I);
+    }
+
+    const std::array<size_t, 4>& getGateBlockStride() const
+    {
+        return static_cast<const Derived*>(this)->getGateAndStateStride(LstmGateAndState::I);
+    }
+
+    const std::array<size_t, 4>& getGateBlockSize() const
+    {
+        return static_cast<const Derived*>(this)->getGateBlockSizeImpl();
+    }
+};
+
+template <typename Derived>
+class LstmActiveCellExt
+{
+public:
+    size_t getActiveCellOffset(const size_t layer_id,
+                               const size_t vector_id,
+                               const SequenceDirection direction) const
+    {
+        return static_cast<const Derived*>(this)->getActiveCellOffsetImpl(
+            layer_id, vector_id, direction);
+    }
+
+    const std::array<size_t, 4>& getActiveCellStride() const
+    {
+        return static_cast<const Derived*>(this)->getActiveCellStrideImpl();
+    }
+};
+
+// pure RNN
+template <typename Derived>
+class BaseRnnWsBufferPacked
+{
+public:
+    BaseRnnWsBufferPacked() = default;
+    size_t getHiddenStateOffset(const size_t layer_id,
+                                const size_t vector_id,
+                                const SequenceDirection direction) const
+    {
+        return static_cast<const Derived*>(this)->getHiddenStateOffsetImpl(
+            layer_id, vector_id, direction);
+    }
+
+    // layer, minor dim(seq or sample), directions, element
+    const std::array<size_t, 4>& getHiddenStateStride() const
+    {
+        return static_cast<const Derived*>(this)->getHiddenStateStrideImpl();
+    }
+
+    size_t getBufferSize() const { return static_cast<const Derived*>(this)->getBufferSizeImpl(); }
+};
+
+/**
+ * \section Standard layouts for temporary buffers
+ */
+//////
+
+class GeneralRNNTempBuffer : public BaseRnnWsBufferPacked<GeneralRNNTempBuffer>
+{
+protected:
+    GeneralRNNTempBuffer(const std::array<size_t, 4>& hstate_strides,
+                         const std::array<size_t, 4>& hstate_sizes,
+                         size_t total_element_cnt)
+        : hStateStrides{hstate_strides},
+          hStateSizes{hstate_sizes},
+          totalElementCnt{total_element_cnt}
+    {
+    }
+
+public:
+    static GeneralRNNTempBuffer
+    build(size_t layers_cnt, size_t vectors_per_layer, size_t directions, size_t hidden_vec_sz)
+    {
+        const std::array<size_t, 4> h_state_sizes{
+            layers_cnt, vectors_per_layer, directions, hidden_vec_sz};
+        std::array<size_t, 4> h_state_strides = {0, 0, 0, 1};
+        std::partial_sum(h_state_sizes.crbegin(),
+                         std::prev(h_state_sizes.crend()),
+                         std::next(h_state_strides.rbegin()),
+                         std::multiplies<size_t>{});
+
+        auto total_element_cnt = h_state_strides[0] * h_state_sizes[0];
+        return GeneralRNNTempBuffer{h_state_strides, h_state_sizes, total_element_cnt};
+    }
+
+    size_t getHiddenStateOffsetImpl(const size_t layer_id,
+                                    const size_t vector_id,
+                                    const SequenceDirection direction) const
+    {
+        const std::array<size_t, 3> pos{layer_id, vector_id, static_cast<size_t>(direction)};
+
+        return std::inner_product(
+            pos.cbegin(), pos.cend(), hStateStrides.cbegin(), static_cast<size_t>(0));
+    }
+
+    size_t getBufferSizeImpl() const { return totalElementCnt; }
+
+    const std::array<size_t, 4>& getHiddenStateStrideImpl() const { return hStateStrides; }
+
+    // layer, comb dim(seq, sample), direction, vector element
+    const std::array<size_t, 4> hStateStrides;
+    // layers, comb dims(seq, sample), directions, elements
+    const std::array<size_t, 4> hStateSizes;
+    const size_t totalElementCnt;
+};
+
+/*
+ *struct Workspace_LSTM_BWD{ //packed
+ *  struct layer{
+ *    struct all_sequences_all_samples{
+ *        struct mat_mul_block{
+ *            struct gate_vector{
+ *                float[hidden_size]; HidUpdate-> write
+ *            } I, F, O, G;
+ *        } gemm_block[directions];
+ *
+ *        struct dcx_vec{
+ *            float[hidden_size];  HidUpdate-> write
+ *        } dy[directions];
+ *
+ *        struct dy_vec{
+ *            float[hidden_size]; HidUpdate <-read
+ *        } dy[directions];
+ *
+ *    } combi_dim[seq_len * batch_size=totalBatch]; [seq][batch]
+ *  } layers[nLayer];
+ *}
+ */
+
+class GeneralLstmTempBuffer : public GeneralRNNTempBuffer,
+                              public GeneralLstmWsExt<GeneralLstmTempBuffer>,
+                              public LstmWsGateBlockExt<GeneralLstmTempBuffer>
+{
+protected:
+    GeneralLstmTempBuffer(const std::array<size_t, 4>& h_state_strides,
+                          const std::array<size_t, 4>& h_state_sizes,
+                          const std::array<size_t, 4>& lstm_gate_sizes,
+                          const std::array<size_t, 4>& lstm_gate_strides,
+                          const std::array<size_t, 4>& lstm_gates_block_sizes,
+                          size_t total_element_cnt)
+        : GeneralRNNTempBuffer{h_state_strides, h_state_sizes, total_element_cnt},
+          gateSizes{lstm_gate_sizes},
+          gateStride{lstm_gate_strides},
+          gateBlockSizes{lstm_gates_block_sizes}
+    {
+    }
+
+public:
+    static GeneralLstmTempBuffer
+    build(size_t layers_cnt, size_t comp_dim_per_layer, size_t directions, size_t hidden_vec_sz)
+    {
+
+        constexpr size_t MS_len  = 2;
+        constexpr size_t LS_size = 2;
+        // Most significant sizes
+        //{layer, comp_dim_per_layer}
+        std::array<size_t, MS_len> block_MS_size = {layers_cnt, comp_dim_per_layer};
+
+        //{layer, comp_dim_per_layer, directions,vec}
+        const auto h_state_sizes =
+            Concat(block_MS_size, std::array<size_t, 2>{directions, hidden_vec_sz});
+
+        const auto lstm_gate_sizes =
+            Concat(block_MS_size, std::array<size_t, 2>{directions, hidden_vec_sz});
+
+        const auto lstm_gates_block_sizes =
+            Concat(block_MS_size, std::array<size_t, 2>{directions, 4 * hidden_vec_sz});
+
+        // Less significant stride
+        // LSStride{directions,vec}
+        std::array<size_t, LS_size> h_state_LS_strides{};
+        std::array<size_t, LS_size> lstm_gate_LS_strides{};
+
+        std::exclusive_scan(h_state_sizes.crbegin(),
+                            std::next(h_state_sizes.crbegin(), h_state_LS_strides.size()),
+                            h_state_LS_strides.rbegin(),
+                            1LL,
+                            std::multiplies<size_t>{});
+
+        std::exclusive_scan(
+            lstm_gates_block_sizes.crbegin(),
+            std::next(lstm_gates_block_sizes.crbegin(), lstm_gate_LS_strides.size()),
+            lstm_gate_LS_strides.rbegin(),
+            1LL,
+            std::multiplies<size_t>{});
+
+        const auto gas_block_stride = [&lstm_gates_block_sizes,
+                                       &h_state_sizes,
+                                       &lstm_gate_LS_strides,
+                                       &h_state_LS_strides](const auto last_dim) {
+            auto gate_size_in_block    = lstm_gates_block_sizes[last_dim] * lstm_gate_LS_strides[0];
+            auto h_state_size_in_block = h_state_sizes[last_dim] * h_state_LS_strides[0];
+            auto c_state_size_in_block = h_state_size_in_block;
+            return gate_size_in_block + c_state_size_in_block + h_state_size_in_block;
+        }(MS_len);
+
+        // Most significant stride
+        // MSStride{layer, comp_dim_per_layer}
+        std::array<size_t, MS_len> block_MS_strides{};
+
+        std::exclusive_scan(block_MS_size.crbegin(),
+                            std::next(block_MS_size.crbegin(), block_MS_strides.size()),
+                            block_MS_strides.rbegin(),
+                            gas_block_stride,
+                            std::multiplies<size_t>{});
+
+        const std::array<size_t, 4> h_state_strides = Concat(block_MS_strides, h_state_LS_strides);
+        const std::array<size_t, 4> lstm_gate_strides =
+            Concat(block_MS_strides, lstm_gate_LS_strides);
+
+        auto total_element_cnt = h_state_strides[0] * h_state_sizes[0];
+
+        return {h_state_strides,
+                h_state_sizes,
+                lstm_gate_sizes,
+                lstm_gate_strides,
+                lstm_gates_block_sizes,
+                total_element_cnt};
+    }
+
+    size_t getHiddenStateOffset(const size_t layer_id,
+                                const size_t vector_id,
+                                const SequenceDirection direction) const
+    {
+        return getGasOffset(layer_id, vector_id, direction, LstmGateAndState::Ht);
+    }
+
+    size_t getGasOffsetImpl(const size_t layer_id,
+                            const size_t vector_id,
+                            const SequenceDirection direction,
+                            LstmGateAndState gas) const
+    {
+        auto start_ident = getGasIndent(gas);
+
+        if(gas == LstmGateAndState::Ht || gas == LstmGateAndState::St)
+            return start_ident +
+                   GeneralRNNTempBuffer::getHiddenStateOffset(layer_id, vector_id, direction);
+
+        const std::array<size_t, 3> pos{layer_id, vector_id, static_cast<size_t>(direction)};
+
+        return start_ident +
+               std::inner_product(
+                   pos.cbegin(), pos.cend(), hStateStrides.cbegin(), static_cast<size_t>(0));
+    }
+
+    // layer, minor dim(seq or sample), directions, element
+    const std::array<size_t, 4>& getGateAndStateStrideImpl(LstmGateAndState gas) const
+    {
+        if(gas == LstmGateAndState::Ht || gas == LstmGateAndState::St)
+            return getHiddenStateStride();
+        return gateStride;
+    }
+
+    // layer, minor dim(seq or sample), directions, element
+    const std::array<size_t, 4>& getGateBlockSizeImpl() const { return gateBlockSizes; }
+
+    const std::array<size_t, 4> gateSizes;
+    const std::array<size_t, 4> gateStride;
+    const std::array<size_t, 4> gateBlockSizes;
+
+private:
+    size_t getGasIndent(LstmGateAndState gas) const
+    {
+        switch(gas)
+        {
+        case LstmGateAndState::I:
+        case LstmGateAndState::G:
+        case LstmGateAndState::F:
+        case LstmGateAndState::O: return static_cast<size_t>(gas) * gateStride[3] * gateSizes[3];
+        case LstmGateAndState::St: return gateStride[2] * gateSizes[2]; // direction DIM
+        case LstmGateAndState::Ht:
+            return (gateStride[2] + getHiddenStateStride()[2]) * gateSizes[2];
+        }
+        return 0;
+    }
+};
+
+/*
+ *struct ReserveSpace_LSTM{ //packed
+ *  struct layer{
+ *    struct all_sequences_all_samples{
+ *
+ *        struct mat_mul_block{
+ *            struct gate_vector{
+ *                float[hidden_size]; HidUpdate-> write
+ *            } I, F, O, G;
+ *        } gemm_block[directions];
+ *
+ *        struct dcx_vec{
+ *            float[hidden_size];  HidUpdate-> write
+ *        } dy[directions];
+ *
+ *        struct dy_vec{
+ *            float[hidden_size]; HidUpdate <-read
+ *        } dy[directions];
+ *
+ *    } combi_dim[seq_len * batch_size=totalBatch]; [seq][batch]
+ *  } layers[nLayer];
+ *
+ *  struct extra_activation_vec{
+ *      float[hidden_size];
+ *  } active_cell[nLayer*bidirect*totalBatch];
+ *}
+ */
+
+class GeneralLstmRedBuffer : public GeneralLstmTempBuffer,
+                             public LstmActiveCellExt<GeneralLstmRedBuffer>
+{
+protected:
+    GeneralLstmRedBuffer(const GeneralLstmTempBuffer& base,
+                         const std::array<size_t, 4>& active_cells_sizes,
+                         const std::array<size_t, 4>& active_cells_strides,
+                         size_t active_cells_ident,
+                         size_t active_cell_elements)
+        : GeneralLstmTempBuffer{base},
+          activeCellSize{active_cells_sizes},
+          activeCellStride{active_cells_strides},
+          activeCellsIdent{active_cells_ident},
+          activeCellElements{active_cell_elements}
+    {
+    }
+
+public:
+    static GeneralLstmRedBuffer
+    build(size_t layers_cnt, size_t comp_dim_per_layer, size_t directions, size_t hidden_vec_sz)
+    {
+
+        auto base =
+            GeneralLstmTempBuffer::build(layers_cnt, comp_dim_per_layer, directions, hidden_vec_sz);
+
+        auto active_cells_ident = base.gateStride[0] * base.gateSizes[0];
+
+        std::array<size_t, 4> active_cells_sizes{
+            layers_cnt, comp_dim_per_layer, directions, hidden_vec_sz};
+
+        std::array<size_t, 4> active_cells_strides = {};
+
+        std::exclusive_scan(active_cells_sizes.crbegin(),
+                            active_cells_sizes.crend(),
+                            active_cells_strides.rbegin(),
+                            1LL,
+                            std::multiplies<size_t>{});
+
+        auto active_cell_elements = active_cells_strides[0] * active_cells_sizes[0];
+
+        return {base,
+                active_cells_sizes,
+                active_cells_strides,
+                active_cells_ident,
+                active_cell_elements};
+    }
+
+    size_t getBufferSizeImpl() const { return activeCellsIdent + activeCellElements; }
+
+    size_t getActiveCellOffsetImpl(const size_t layer_id,
+                                   const size_t vector_id,
+                                   const SequenceDirection direction) const
+    {
+        const std::array<size_t, 3> pos{layer_id, vector_id, static_cast<size_t>(direction)};
+
+        return activeCellsIdent +
+               std::inner_product(
+                   pos.cbegin(), pos.cend(), activeCellStride.cbegin(), static_cast<size_t>(0));
+    }
+
+    const std::array<size_t, 4>& getActiveCellStrideImpl() const { return activeCellStride; }
+
+    const std::array<size_t, 4> activeCellSize;
+    const std::array<size_t, 4> activeCellStride;
+    const size_t activeCellsIdent;
+    const size_t activeCellElements;
+};
+
+/**
+ * \section Сlasses for easier navigation.
+ */
+
+class BatchController
+{
+public:
+    template <class VectorT>
+    static BatchController Create(VectorT&& batchs_at_time)
+    {
+        std::vector<size_t> batch{std::forward<VectorT>(batchs_at_time)};
+        std::vector<size_t> b_prefix_sums(batch.size());
+        b_prefix_sums[0] = 0;
+
+        std::partial_sum(batch.cbegin(), std::prev(batch.cend()), std::next(b_prefix_sums.begin()));
+
+        return BatchController{std::move(batch), std::move(b_prefix_sums)};
+    }
+
+    static BatchController Create(const SeqTensorDescriptor& desc)
+    {
+        return Create(desc.GetBatchesPerSequence());
+    }
+
+    size_t getTotalBatchSum() const
+    {
+        return *batchAtTime.crbegin() + *batchPrefSumAtTime.crbegin();
+    }
+
+    template <typename TimeIndexT>
+    size_t getBatchSize(TimeIndexT time_id) const
+    {
+        return batchAtTime[time_id];
+    }
+
+    template <typename TimeIndexT>
+    size_t getBatchSum(TimeIndexT time_id) const
+    {
+        return batchPrefSumAtTime[time_id];
+    }
+
+private:
+    template <class T, std::enable_if_t<std::is_same<T, std::vector<size_t>>::value, bool> = true>
+    explicit BatchController(T&& batch_at_time, T&& batch_prefix_sums)
+        : batchAtTime(batch_at_time), batchPrefSumAtTime{std::forward<T>(batch_prefix_sums)}
+    {
+    }
+
+    const std::vector<size_t> batchAtTime;
+    const std::vector<size_t> batchPrefSumAtTime;
+};
+
+class SequenceIterator
+{
+public:
+    SequenceIterator(size_t logical_value, SequenceDirection dir, size_t seq_size, bool is_fwd_pass)
+        : value(logical_value),
+          startVal(is_fwd_pass ? 0 : seq_size - 1),
+          endVal(is_fwd_pass ? seq_size - 1 : 0),
+          maxVal(seq_size - 1),
+          isReverseSeq(dir == SequenceDirection::Reverse),
+          isFwdPass(is_fwd_pass)
+    {
+        assert(logical_value < seq_size);
+    }
+
+    size_t getLogVal() const { return value; }
+    size_t getPhisVal() const { return !isReverseSeq ? value : maxVal - value; }
+
+    SequenceIterator getNext() const
+    {
+        assert(!isLast());
+        return PartClone(value + (isFwdPass ? 1 : -1));
+    }
+    SequenceIterator getPrev() const
+    {
+        assert(!isFirst());
+        return PartClone(value + (isFwdPass ? -1 : 1));
+    }
+
+    bool isFirst() const { return value == startVal; }
+
+    bool isLast() const { return value == endVal; }
+
+private:
+    SequenceIterator PartClone(const size_t newValue) const
+    {
+        return {newValue, startVal, endVal, maxVal, isReverseSeq, isFwdPass};
+    }
+
+    SequenceIterator(size_t value_,
+                     size_t start_val,
+                     size_t end_val,
+                     size_t max_val,
+                     bool is_reverse_seq,
+                     bool is_fwd_pass)
+        : value(value_),
+          startVal(start_val),
+          endVal(end_val),
+          maxVal(max_val),
+          isReverseSeq(is_reverse_seq),
+          isFwdPass(is_fwd_pass)
+    {
+    }
+
+    const size_t value;
+    const size_t startVal;
+    const size_t endVal;
+    const size_t maxVal;
+    const bool isReverseSeq;
+    const bool isFwdPass;
+};
+
+/**
+ * \section User defined buffers.
+ */
+
+/*
+ *struct Weights{
+ *  struct filter{
+ *
+ *    struct gateInputMatrix{
+ *      float[hidden_size][input_size]
+ *    } gateFilters[gate_cnt];
+ *
+ *    struct gateHiddenMatrix{
+ *      float[hidden_size][hidden_size]
+ *    } gateFiltersHiddden[gate_cnt];
+ *  } filters[n_layers][bidirect];
+ *
+ *  struct bias{
+ *      struct gateBias{
+ *          float[hidden_size]
+ *      }
+ *  }
+ *}
+ */
+struct WeightsBufferDescriptor
+{
+private:
+    static auto hidden_xinput_size(int hidden_sz, int bidirect_mode)
+    {
+        if(bidirect_mode == 0)
+            return hidden_sz;
+        MIOPEN_THROW("execution failure: bidirect is not supported by this solver");
+    }
+
+    static auto matrix_size(int input_vector_sz, int hidden_vec_sz, int gates)
+    {
+        return (input_vector_sz + hidden_vec_sz) * hidden_vec_sz * gates;
+    }
+
+    static size_t bias_start_offset(
+        int input_vector_sz, int hidden_vec_sz, int layers_cnt, int gates, int bidirect_mode)
+    {
+        if(bidirect_mode == 0)
+        {
+            return matrix_size(input_vector_sz, hidden_vec_sz, gates) +
+                   static_cast<size_t>(hidden_vec_sz + hidden_xinput_size(hidden_vec_sz, 0)) *
+                       hidden_vec_sz * static_cast<size_t>(layers_cnt - 1) * gates;
+        }
+
+        MIOPEN_THROW("execution failure: bidirect is not supported by this solver");
+    }
+    // TODO static create function
+
+public:
+    WeightsBufferDescriptor(
+        int input_vector_sz, int hidden_vec_sz, int layers_cnt, int bias_mode, int gates)
+        : in_vec(input_vector_sz),
+          h_vec(hidden_vec_sz),
+          x_in_vec(hidden_xinput_size(hidden_vec_sz, 0)),
+          layers(layers_cnt),
+          gates_cnt(gates),
+          bias_cnt(bias_mode),
+          matrix_normal_start_off(matrix_size(input_vector_sz, hidden_vec_sz, gates)),
+          bias_start_off(bias_start_offset(input_vector_sz, hidden_vec_sz, layers_cnt, gates, 0)),
+          linLayerFilterSize(matrix_size(input_vector_sz, hidden_vec_sz, gates)),
+          hiddenLayerFilterSize(matrix_size(x_in_vec, hidden_vec_sz, gates)),
+          bias_strides{}
+    {
+    }
+
+    const size_t in_vec, h_vec;
+    const size_t x_in_vec; // for bidirect TODO
+
+    const size_t layers;
+    const size_t gates_cnt;
+    const int bias_cnt; // 0 - no bisa; 1 - one bias; 2 - separate bias for x_vec and for hidden_vec
+private:
+    const size_t matrix_normal_start_off;
+    const size_t bias_start_off;
+
+    const size_t linLayerFilterSize;
+    const size_t hiddenLayerFilterSize;
+
+public:
+    size_t getParamRelativeOff(size_t layer_id, int /*dir_id*/, int param_id) const
+    {
+        return param_id * h_vec * (layer_id == 0 ? in_vec : x_in_vec);
+    }
+
+    size_t getMatrixOff(int layer_id, int dir_id, int param_id) const
+    {
+        size_t offset = 0;
+        if(layer_id > 0)
+        {
+            offset += linLayerFilterSize;
+        }
+        if(layer_id > 1)
+        {
+            offset += hiddenLayerFilterSize * (layer_id - 1);
+        }
+        return offset + getParamRelativeOff(layer_id, dir_id, param_id);
+    }
+
+    size_t getMatrixXinOff(int layer_id, int dir_id) const
+    {
+        return getMatrixOff(layer_id, dir_id, 0);
+    }
+
+    size_t getMatrixHidOff(int layer_id, int dir_id) const
+    {
+        return getMatrixOff(layer_id, dir_id, gates_cnt);
+    }
+
+    //[layer][dir][param_id]
+    const std::array<size_t, 3> bias_strides;
+
+    size_t getBiasOff(int layer_id, int dir_id, int param_id) const
+    {
+        return bias_start_off + bias_strides[0] * layer_id + bias_strides[1] * dir_id +
+               bias_strides[2] * param_id;
+    }
+};
+
+class HiddenBuffersDescriptor
+{
+public:
+    explicit HiddenBuffersDescriptor(const TensorDescriptor& hx_desc)
+        : lens(hx_desc.GetLengths()), strides(hx_desc.GetStrides())
+    {
+    }
+
+    inline size_t getOffset(const size_t virtual_layer_id) const
+    {
+        return getOffset(virtual_layer_id, 0);
+    }
+
+    inline size_t getOffset(const size_t virtual_layer_id, const size_t batch_id) const
+    {
+        return strides[0] * virtual_layer_id + strides[1] * batch_id;
+    }
+
+    inline const std::vector<size_t>& getStrides() const { return strides; }
+
+    inline const std::vector<size_t>& GetLengths() const { return lens; }
+
+    inline size_t getVirtualLayersCnt() const { return lens[0]; }
+    inline size_t getMiniBatchSize() const { return lens[1]; }
+    inline size_t getHiddenSize() const { return lens[2]; }
+
+    static std::vector<size_t> MakeStrides(const std::vector<size_t>& lengths)
+    {
+        return {lengths[1] * lengths[2], lengths[2], 1};
+    }
+
+private:
+    // local caching
+
+    const std::vector<size_t> lens;
+    const std::vector<size_t> strides;
+};
+
+class IOBufferDescriptor
+{
+    IOBufferDescriptor() = default;
+    IOBufferDescriptor(std::vector<size_t>&& buffer_lens,
+                       std::vector<size_t>&& buffer_strides,
+                       std::vector<size_t>&& packed_lens,
+                       std::vector<size_t>&& packed_strides,
+                       std::vector<size_t>&& seq_lens_per_sample)
+        : lens{std::move(buffer_lens)},
+          strides{std::move(buffer_strides)},
+          packedLens{std::move(packed_lens)},
+          packedStrides{std::move(packed_strides)},
+          seqLensPerSample{std::move(seq_lens_per_sample)}
+    {
+    }
+
+public:
+    static IOBufferDescriptor build(const SeqTensorDescriptor& xyDesc)
+    {
+        //{batch, seq_cnt, vector}
+        auto lens    = xyDesc.GetLengths();
+        auto strides = xyDesc.GetPaddedStrides();
+
+        //{ combine(batch, seq_cnt), vector}
+        std::vector<size_t> packed_lens{xyDesc.GetTotalSequenceLen(), lens[2]};
+        std::vector<size_t> packed_strides(2);
+
+        std::exclusive_scan(packed_lens.crbegin(),
+                            std::next(packed_lens.crbegin(), packed_strides.size()),
+                            packed_strides.rbegin(),
+                            1LL,
+                            std::multiplies<size_t>{});
+
+        std::vector<size_t> seq_lens_per_sample = xyDesc.GetSequenceLengthsVector();
+        return {(std::move(lens)),
+                (std::move(strides)),
+                (std::move(packed_lens)),
+                (std::move(packed_strides)),
+                (std::move(seq_lens_per_sample))};
+    }
+
+    inline size_t getPackedOffset(const size_t batch_id) const
+    {
+        return packedStrides[0] * batch_id;
+    }
+
+    inline std::vector<size_t> getFullSeqMajorStrides() const { return packedStrides; }
+    inline std::vector<size_t> getFullSeqMajorSize() const { return packedLens; }
+
+    inline size_t getMiniBatchSize() const { return lens[0]; }
+    inline size_t getMaxSeqSize() const { return lens[1]; }
+    inline size_t getHiddenSize() const { return lens[2]; }
+
+    inline size_t getSeqSize(size_t sample_id) const { return seqLensPerSample[sample_id]; }
+    inline size_t getTotalSeqCnt() const { return packedLens[0]; }
+
+    static std::vector<size_t> MakeStrides(const std::vector<size_t>& lengths)
+    {
+        return {lengths[1] * lengths[2], lengths[2], 1};
+    }
+
+    // private:
+    //  local caching
+
+    const std::vector<size_t> lens;
+    const std::vector<size_t> strides;
+
+    const std::vector<size_t> packedLens;
+    const std::vector<size_t> packedStrides;
+
+    const std::vector<size_t> seqLensPerSample;
+};
+
+} // namespace rnn_base
+} // namespace miopen

--- a/src/ocl/rnnocl.cpp
+++ b/src/ocl/rnnocl.cpp
@@ -37,7 +37,7 @@
 #include <numeric>
 #include <algorithm>
 
-MIOPEN_DECLARE_ENV_VAR_BOOL(MIOPEN_RNNFWD_exp)
+MIOPEN_DECLARE_ENV_VAR_BOOL(MIOPEN_RNNFWD_EXP)
 MIOPEN_DECLARE_ENV_VAR_UINT64(MIOPEN_RNNFWD_MS_DISPATCH)
 MIOPEN_DECLARE_ENV_VAR_UINT64(MIOPEN_RNN_MS_STREAM_CNT)
 
@@ -63,10 +63,10 @@ bool RNNForwardMSIsSupported([[maybe_unused]] const RNNDescriptor& desctiptor,
 
 bool RNNForwardMSIsFast(const int seqLen)
 {
-    if(env::enabled(MIOPEN_RNNFWD_exp))
+    if(env::enabled(MIOPEN_RNNFWD_EXP))
         return true;
 
-    if(seqLen >= 32 && !env::disabled(MIOPEN_RNNFWD_exp))
+    if(seqLen >= 32 && !env::disabled(MIOPEN_RNNFWD_EXP))
         return true;
     return false;
 }

--- a/src/ocl/rnnocl.cpp
+++ b/src/ocl/rnnocl.cpp
@@ -284,7 +284,7 @@ void RNNDescriptor::RNNForwardMS(Handle& handle,
 
     MultiStreamController ms_controller{handle, extra_stream_cnt};
 
-    constexpr auto root_stream_id = ms_controller.rootStreamId;
+    constexpr auto root_stream_id = MultiStreamController::rootStreamId;
     ms_controller.ChangeActiveStream(root_stream_id);
 
     int total_batch_size = 0;
@@ -4370,21 +4370,21 @@ void RNNDescriptor::RNNBackwardDataPackedTensors(
     case miopenRNNRELU:
     case miopenRNNTANH:
         // printf("run rnn gpu bwd data \n");
-        wei_len   = hy_h * nHiddenTensorsPerLayer;    // hy_h;
-        wei_len_t = hy_h * nHiddenTensorsPerLayer;    // hy_h;
-        dhd_off   = bi * hy_h * (workspaceScale - 1); // 0;
-        break;
+        // wei_len   = hy_h * nHiddenTensorsPerLayer;    // hy_h;
+        // wei_len_t = hy_h * nHiddenTensorsPerLayer;    // hy_h;
+        // dhd_off   = bi * hy_h * (workspaceScale - 1); // 0;
+        // break;
     case miopenLSTM:
         // printf("run lstm gpu bwd data \n");
-        wei_len   = hy_h * nHiddenTensorsPerLayer;    // hy_h * 4;
-        wei_len_t = hy_h * nHiddenTensorsPerLayer;    // hy_h * 4;
-        dhd_off   = bi * hy_h * (workspaceScale - 1); // bi* hy_h * 5;
+        wei_len   = hy_h * static_cast<int>(nHiddenTensorsPerLayer);  // hy_h * 4;
+        wei_len_t = hy_h * static_cast<int>(nHiddenTensorsPerLayer);  // hy_h * 4;
+        dhd_off   = bi * hy_h * static_cast<int>(workspaceScale - 1); // bi* hy_h * 5;
         break;
     case miopenGRU:
         // printf("run gru gpu bwd data \n");
-        wei_len   = hy_h * nHiddenTensorsPerLayer;       // hy_h * 3;
-        wei_len_t = hy_h * (nHiddenTensorsPerLayer - 1); // hy_h * 2;
-        dhd_off   = bi * hy_h * (workspaceScale - 1);    // bi * hy_h * 3;
+        wei_len   = hy_h * static_cast<int>(nHiddenTensorsPerLayer);     // hy_h * 3;
+        wei_len_t = hy_h * static_cast<int>(nHiddenTensorsPerLayer - 1); // hy_h * 2;
+        dhd_off   = bi * hy_h * static_cast<int>(workspaceScale - 1);    // bi * hy_h * 3;
         break;
     }
 

--- a/src/ocl/rnnocl.cpp
+++ b/src/ocl/rnnocl.cpp
@@ -4356,6 +4356,34 @@ void RNNDescriptor::RNNBackwardDataPackedTensors(
         MIOPEN_THROW(miopenStatusBadParm, "Output size doesn't match hidden state size!");
     }
 
+    if(dirMode == 0 && inputMode == miopenRNNlinear && rnnMode == miopenLSTM)
+    {
+        SeqTensorDescriptor dx_seq =
+            makeSeqTensorDescriptor(dxDesc, seqLen, miopenRNNDataSeqMajorNotPadded);
+
+        SeqTensorDescriptor dy_seq =
+            makeSeqTensorDescriptor(dyDesc, seqLen, miopenRNNDataSeqMajorNotPadded);
+
+        return this->ModularBackward(handle,
+                                     dy_seq,
+                                     dy,
+                                     dhxDesc,
+                                     hx,
+                                     dhy,
+                                     dhx,
+                                     dcxDesc,
+                                     cx,
+                                     dcy,
+                                     dcx,
+                                     dx_seq,
+                                     dx,
+                                     w,
+                                     workSpace,
+                                     workSpaceSize,
+                                     reserveSpace,
+                                     reserveSpaceSize);
+    }
+
     int in_stride  = in_h;
     int hy_stride  = hy_h * bi * static_cast<int>(workspaceScale);
     int out_stride = out_h;

--- a/src/ocl/rnnocl.cpp
+++ b/src/ocl/rnnocl.cpp
@@ -516,8 +516,8 @@ void RNNDescriptor::RNNForwardMS(Handle& handle,
         {
             F  = 1,
             I  = 0,
-            G  = 2,
-            O  = 3,
+            G  = 3,
+            O  = 2,
             St = 4,
             Ht = 5
         };
@@ -4432,21 +4432,21 @@ void RNNDescriptor::RNNBackwardDataPackedTensors(
     case miopenRNNRELU:
     case miopenRNNTANH:
         // printf("run rnn gpu bwd data \n");
-        wei_len   = hy_h;
-        wei_len_t = hy_h;
-        dhd_off   = 0;
+        wei_len   = hy_h * nHiddenTensorsPerLayer;    // hy_h;
+        wei_len_t = hy_h * nHiddenTensorsPerLayer;    // hy_h;
+        dhd_off   = bi * hy_h * (workspaceScale - 1); // 0;
         break;
     case miopenLSTM:
         // printf("run lstm gpu bwd data \n");
-        wei_len   = hy_h * 4;
-        wei_len_t = hy_h * 4;
-        dhd_off   = bi * hy_h * 5;
+        wei_len   = hy_h * nHiddenTensorsPerLayer;    // hy_h * 4;
+        wei_len_t = hy_h * nHiddenTensorsPerLayer;    // hy_h * 4;
+        dhd_off   = bi * hy_h * (workspaceScale - 1); // bi* hy_h * 5;
         break;
     case miopenGRU:
         // printf("run gru gpu bwd data \n");
-        wei_len   = hy_h * 3;
-        wei_len_t = hy_h * 2;
-        dhd_off   = bi * hy_h * 3;
+        wei_len   = hy_h * nHiddenTensorsPerLayer;       // hy_h * 3;
+        wei_len_t = hy_h * (nHiddenTensorsPerLayer + 1); // hy_h * 2;
+        dhd_off   = bi * hy_h * (workspaceScale - 1);    // bi * hy_h * 3;
         break;
     }
 

--- a/src/ocl/rnnocl.cpp
+++ b/src/ocl/rnnocl.cpp
@@ -31,6 +31,7 @@
 #include <miopen/env.hpp>
 #include <miopen/gemm_v2.hpp>
 #include <miopen/logger.hpp>
+#include <miopen/rnn/multi_stream_utils.hpp>
 
 #include <vector>
 #include <numeric>
@@ -39,8 +40,6 @@
 MIOPEN_DECLARE_ENV_VAR_BOOL(MIOPEN_RNNFWD_exp)
 MIOPEN_DECLARE_ENV_VAR_UINT64(MIOPEN_RNNFWD_MS_DISPATCH)
 MIOPEN_DECLARE_ENV_VAR_UINT64(MIOPEN_RNN_MS_STREAM_CNT)
-
-MIOPEN_DECLARE_ENV_VAR_BOOL(MIOPEN_MS_WA_FIX)
 
 namespace miopen {
 
@@ -283,77 +282,9 @@ void RNNDescriptor::RNNForwardMS(Handle& handle,
 
     const int extra_stream_cnt = env::value_or(MIOPEN_RNN_MS_STREAM_CNT, 4);
 
-    class MultiStreamController
-    {
-    public:
-        MultiStreamController(Handle& handle, int extra_stream_cnt)
-            : streamPoolIdsMapping{init_stream_pool_ids(handle, extra_stream_cnt)},
-              streamPoolCache{init_stream_pool(handle, streamPoolIdsMapping)},
-              activeHandle{handle}
-        {
-        }
-
-        hipStream_t getStream(int stream_id) const { return streamPoolCache[stream_id]; }
-
-        void ChangeActiveStream(int stream_id) const
-        {
-            activeHandle.SetStreamFromPool(streamPoolIdsMapping[stream_id]);
-        }
-
-        hipError_t RecordEvent(const hipEvent_t event, int stream_id) const
-        {
-            return hipEventRecord(event, getStream(stream_id));
-        }
-
-        hipError_t SetWaitEvent(const hipEvent_t event, int stream_id) const
-        {
-            return hipStreamWaitEvent(getStream(stream_id), event, 0);
-        }
-
-        size_t size() const { return streamPoolIdsMapping.size(); }
-
-    private:
-        static std::vector<int> init_stream_pool_ids(const Handle& handle, int extra_stream_cnt)
-        {
-            std::vector<int> ids;
-            ids.reserve(extra_stream_cnt + 1);
-
-            bool ms_wa_fix_active = extra_stream_cnt > 2 && !env::disabled(MIOPEN_MS_WA_FIX);
-            int wa_steams         = ms_wa_fix_active ? 2 : 0;
-
-            handle.ReserveExtraStreamsInPool(extra_stream_cnt + wa_steams);
-
-            for(int i = 0; i <= extra_stream_cnt + wa_steams; i++)
-                if(!(ms_wa_fix_active && (i == 3 || i == 4)))
-                    ids.push_back(i);
-
-            return ids;
-        }
-
-        static std::vector<hipStream_t> init_stream_pool(const Handle& handle,
-                                                         const std::vector<int>& pool_ids)
-        {
-            std::vector<hipStream_t> pool;
-            pool.reserve(pool_ids.size());
-
-            for(auto id : pool_ids)
-            {
-                handle.SetStreamFromPool(id);
-                pool.push_back(handle.GetStream());
-            }
-            handle.SetStreamFromPool(0);
-
-            return pool;
-        }
-
-        const std::vector<int> streamPoolIdsMapping;
-        const std::vector<hipStream_t> streamPoolCache;
-        const Handle& activeHandle;
-    };
-
     MultiStreamController ms_controller{handle, extra_stream_cnt};
 
-    constexpr auto root_stream_id = 0;
+    constexpr auto root_stream_id = ms_controller.rootStreamId;
     ms_controller.ChangeActiveStream(root_stream_id);
 
     int total_batch_size = 0;
@@ -919,30 +850,6 @@ void RNNDescriptor::RNNForwardMS(Handle& handle,
         }
     };
 
-    auto call_sync_all_stream_pool_to_root_stream = [&ms_controller]() {
-        const miopen::HipEventPtr main_event = make_hip_fast_event();
-
-        ms_controller.RecordEvent(main_event.get(), root_stream_id);
-
-        for(size_t i = 0; i < ms_controller.size(); i++)
-        {
-            if(i != root_stream_id)
-                ms_controller.SetWaitEvent(main_event.get(), i);
-        }
-    };
-
-    auto sync_root_to_all_stream_pool = [&ms_controller]() {
-        for(size_t i = 0; i < ms_controller.size(); i++)
-        {
-            if(i != root_stream_id)
-            {
-                const miopen::HipEventPtr sync_event = make_hip_fast_event();
-                ms_controller.RecordEvent(sync_event.get(), i);
-                ms_controller.SetWaitEvent(sync_event.get(), root_stream_id);
-            }
-        }
-    };
-
     if(seq_len == 0)
         return;
 
@@ -1043,7 +950,7 @@ void RNNDescriptor::RNNForwardMS(Handle& handle,
     // stage 0 bias and input preload
     // stage 0.2 first chunk compute and preload
     {
-        call_sync_all_stream_pool_to_root_stream();
+        ms_controller.AllStreamsWaitRoot();
         const auto first_layer_id  = 0;
         const auto stream_id       = 1; // 1
         const auto extra_stream_id = 2;
@@ -1236,7 +1143,7 @@ void RNNDescriptor::RNNForwardMS(Handle& handle,
             handle, src_desc, extra_space, y_dst_desc, y, RBuff.ht_offset(nLayers - 1, 0), 0);
     }
 
-    sync_root_to_all_stream_pool();
+    ms_controller.RootWaitToAllStreams();
 #else
     (void)handle;
     (void)seq_array;

--- a/src/rnn/Solutions/bwd_multi_stream.cpp
+++ b/src/rnn/Solutions/bwd_multi_stream.cpp
@@ -1,0 +1,274 @@
+#include <miopen/rnn/solvers.hpp>
+#include <miopen/rnn/multi_stream_utils.hpp>
+
+MIOPEN_DECLARE_ENV_VAR_UINT64(MIOPEN_RNN_MS_STREAM_CNT)
+MIOPEN_DECLARE_ENV_VAR_BOOL(MIOPEN_RNNBWD_EXP)
+
+namespace miopen {
+
+namespace rnn_base {
+
+namespace {
+
+class SpiralDispatch
+{
+
+    static std::vector<std::vector<miopen::HipEventPtr>> chunk_event_init(size_t layers_cnt,
+                                                                          size_t chunks_cnt)
+    {
+        std::vector<std::vector<miopen::HipEventPtr>> chunk_end_events;
+        chunk_end_events.resize(layers_cnt);
+        for(int layer_id = 0; layer_id < layers_cnt; ++layer_id)
+        {
+            chunk_end_events[layer_id].resize(chunks_cnt);
+            for(int chunk_id = 0; chunk_id < chunks_cnt; ++chunk_id)
+                chunk_end_events[layer_id][chunk_id] = make_hip_fast_event();
+        }
+        return chunk_end_events;
+    }
+
+public:
+    SpiralDispatch(const MultiStreamController& stream_controller,
+                   size_t layers,
+                   size_t seq_len,
+                   size_t chunk_size,
+                   size_t chunk_cnt)
+        : msController(stream_controller),
+          layerChunkEndEvent(chunk_event_init(layers, chunk_cnt)),
+          layerTimeState(layers, 0),
+          layerNewTimeState(layers, 0),
+          maxSeqLen(seq_len),
+          timeChunkSz(chunk_size),
+          layersCnt(layers)
+    {
+    }
+
+    const MultiStreamController& msController;
+    const std::vector<std::vector<miopen::HipEventPtr>> layerChunkEndEvent;
+    std::vector<size_t> layerTimeState;
+    std::vector<size_t> layerNewTimeState;
+    const size_t maxSeqLen;
+    const size_t timeChunkSz;
+    const size_t layersCnt;
+
+    inline void PreDispatchSync(size_t layer_id, size_t chunk_id, int stream_id) const
+    {
+        if(chunk_id > 0)
+        {
+            msController.SetWaitEvent(layerChunkEndEvent[layer_id][chunk_id - 1].get(), stream_id);
+        }
+        if(layer_id > 0)
+        {
+            msController.SetWaitEvent(layerChunkEndEvent[layer_id - 1][chunk_id].get(), stream_id);
+        }
+    }
+
+    inline void PostDispatchUpdate(size_t layer_id, size_t chunk_id, int stream_id)
+    {
+        layerNewTimeState[layer_id] += timeChunkSz;
+        msController.RecordEvent(layerChunkEndEvent[layer_id][chunk_id].get(), stream_id);
+    }
+
+    inline bool IsDispatchable(size_t layer_id, size_t dispatch_chunk_time) const
+    {
+        return maxSeqLen <= dispatch_chunk_time ? false
+               : layer_id == 0                  ? true
+                                                : layerTimeState[layer_id - 1] >=
+                                     std::min(dispatch_chunk_time + timeChunkSz, maxSeqLen);
+    };
+
+    inline void ApplyStateUpdate()
+    {
+        std::copy(layerNewTimeState.begin(), layerNewTimeState.end(), layerTimeState.begin());
+    }
+
+    template <typename Invoker>
+    inline void
+    DispatchNextChunk(Invoker& chunk_dispatcher, size_t layer_id, size_t chunk_id, int stream_id)
+    {
+        PreDispatchSync(layer_id, chunk_id, stream_id);
+
+        msController.ChangeActiveStream(stream_id);
+        chunk_dispatcher(timeChunkSz, chunk_id * timeChunkSz, layer_id);
+
+        PostDispatchUpdate(layer_id, chunk_id, stream_id);
+        msController.ChangeActiveStream(miopen::MultiStreamController::rootStreamId);
+    }
+
+    template <typename Invoker>
+    inline bool TryDispatchNextChunk(Invoker& chunk_dispatcher, size_t layer_id, int stream_id)
+    {
+        auto chunk_id = layerNewTimeState[layer_id] / timeChunkSz;
+
+        if(!IsDispatchable(layer_id, chunk_id * timeChunkSz))
+            return false;
+
+        DispatchNextChunk(chunk_dispatcher, layer_id, chunk_id, stream_id);
+
+        return true;
+    }
+
+    template <typename Invoker>
+    void Start(Invoker& chunk_dispatcher)
+    {
+        const auto [first_stream, stream_round] = [](const MultiStreamController& controller) {
+            auto size       = static_cast<int>(controller.size());
+            const int first = size > 1 ? 1 : 0;
+            const int round = size > 1 ? size - first : 1;
+            return std::make_tuple(first, round);
+        }(msController);
+
+        bool nothing_to_dispatch = false;
+
+        while(!nothing_to_dispatch)
+        {
+            ApplyStateUpdate();
+            nothing_to_dispatch = true;
+            int stream_it       = 0;
+
+            for(size_t disp_layer_id = 0; disp_layer_id < layersCnt; ++disp_layer_id)
+            {
+                const auto dispatch_stream_id = first_stream + stream_it;
+                if(TryDispatchNextChunk(chunk_dispatcher, disp_layer_id, dispatch_stream_id))
+                {
+                    stream_it           = (stream_it + 1) % stream_round;
+                    nothing_to_dispatch = false;
+                }
+            }
+        }
+    }
+};
+
+} // namespace
+
+bool RNNModularMultiStreamBWD::ChunkDispatch(const runtimeArgsBwd& args,
+                                             size_t chunk_size,
+                                             size_t chunk_time_offset,
+                                             size_t chunk_layer_offset) const
+{
+    constexpr auto seq_dir = rnn_base::SequenceDirection::Forward;
+    const Handle& handle   = *args.handle;
+
+    if(chunk_time_offset >= max_seq_len)
+        return false;
+
+    auto ti       = max_seq_len - chunk_time_offset;
+    auto layer_id = rnnDesc.nLayers - chunk_layer_offset - 1;
+
+    for(size_t i = 0, loop_size = chunk_size; i < loop_size && ti != 0; ++i)
+    {
+        const rnn_base::SequenceIterator cur_seq(--ti, seq_dir, max_seq_len, false);
+
+        if(!cur_seq.isFirst())
+        {
+            rnnAlgoModules.PropHiddenDht(
+                handle, args.w, args.workSpace, layer_id, cur_seq.getPrev(), seq_dir);
+        }
+
+        rnnAlgoModules.PropDhy(handle, args.dhy, args.workSpace, layer_id, cur_seq, seq_dir);
+
+        rnnAlgoModules.UpdateHStatePerTimeSeq(handle,
+                                              args.dcy,
+                                              args.cx,
+                                              args.dcx,
+                                              args.workSpace,
+                                              args.reserveSpace,
+                                              layer_id,
+                                              cur_seq,
+                                              seq_dir);
+        // GEMM
+
+        if(cur_seq.isLast())
+        {
+            rnnAlgoModules.PropDhxDcx(handle,
+                                      args.w,
+                                      args.dhx,
+                                      args.dcx,
+                                      args.workSpace,
+                                      args.reserveSpace,
+                                      layer_id,
+                                      cur_seq,
+                                      seq_dir);
+        }
+    }
+
+    ti = max_seq_len - chunk_time_offset;
+    if(ti != 0)
+    {
+        auto first_val = ti - 1;
+        const rnn_base::SequenceIterator start_seq(first_val, seq_dir, max_seq_len, false);
+
+        auto last_val = chunk_size > (first_val) ? 0 : first_val - (chunk_size - 1);
+        const rnn_base::SequenceIterator end_seq(last_val, seq_dir, max_seq_len, false);
+
+        if(layer_id != 0)
+        {
+            rnnAlgoModules.PropHiddenDy(handle,
+                                        args.w,
+                                        args.workSpace,
+                                        args.reserveSpace,
+                                        layer_id,
+                                        seq_dir,
+                                        start_seq,
+                                        end_seq);
+        }
+        else
+        {
+            rnnAlgoModules.PropDx(
+                handle, args.w, args.workSpace, args.dx, seq_dir, start_seq, end_seq);
+        }
+    }
+
+    return true;
+}
+
+void RNNModularMultiStreamBWD::PrologueDispatch(const runtimeArgsBwd& args) const
+{
+    rnnAlgoModules.PrepareWriteBuffers(*args.handle, args.dhx, args.dcx, args.workSpace);
+
+    rnnAlgoModules.PropDy(*args.handle, args.dy, args.workSpace);
+}
+
+void RNNModularMultiStreamBWD::ComputeBWD(Handle& handle,
+                                          ConstData_t dy,
+                                          ConstData_t dhy,
+                                          Data_t dhx,
+                                          ConstData_t cx,
+                                          ConstData_t dcy,
+                                          Data_t dcx,
+                                          Data_t dx,
+                                          ConstData_t w,
+                                          Data_t workSpace,
+                                          Data_t reserveSpace) const
+{
+    const auto layers_cnt = rnnDesc.nLayers;
+
+    if(layers_cnt == 0 || max_seq_len == 0)
+        return;
+
+    const runtimeArgsBwd args{&handle, dy, dhy, dhx, cx, dcy, dcx, dx, w, workSpace, reserveSpace};
+
+    MultiStreamController ms_controller{handle, env::value_or(MIOPEN_RNN_MS_STREAM_CNT, 4)};
+
+    constexpr size_t try_chunks_cnt = 16;
+    const auto time_chunk_sz        = ((max_seq_len + try_chunks_cnt - 1) / try_chunks_cnt);
+    const auto chunks_cnt           = (max_seq_len + time_chunk_sz - 1) / time_chunk_sz;
+
+    SpiralDispatch dispatcher{ms_controller, layers_cnt, max_seq_len, time_chunk_sz, chunks_cnt};
+
+    auto single_chunk_disputch =
+        [&](size_t chunk_size, size_t chunk_time_offset, size_t chunk_layer_offset) {
+            return ChunkDispatch(args, chunk_size, chunk_time_offset, chunk_layer_offset);
+        };
+
+    PrologueDispatch(args);
+
+    ms_controller.AllStreamsWaitRoot();
+
+    dispatcher.Start(single_chunk_disputch);
+
+    ms_controller.RootWaitToAllStreams();
+}
+
+} // namespace rnn_base
+} // namespace miopen

--- a/src/rnn/Solutions/bwd_multi_stream.cpp
+++ b/src/rnn/Solutions/bwd_multi_stream.cpp
@@ -2,7 +2,6 @@
 #include <miopen/rnn/multi_stream_utils.hpp>
 
 MIOPEN_DECLARE_ENV_VAR_UINT64(MIOPEN_RNN_MS_STREAM_CNT)
-MIOPEN_DECLARE_ENV_VAR_BOOL(MIOPEN_RNNBWD_EXP)
 
 namespace miopen {
 

--- a/src/rnn/Solutions/bwd_s_stream.cpp
+++ b/src/rnn/Solutions/bwd_s_stream.cpp
@@ -1,0 +1,67 @@
+#include <miopen/rnn/solvers.hpp>
+
+namespace miopen {
+
+namespace rnn_base {
+
+void RNNModularSingleStreamBWD::ComputeBWD(Handle& handle,
+                                           ConstData_t dy,
+                                           ConstData_t dhy,
+                                           Data_t dhx,
+                                           ConstData_t cx,
+                                           ConstData_t dcy,
+                                           Data_t dcx,
+                                           Data_t dx,
+                                           ConstData_t w,
+                                           Data_t workSpace,
+                                           Data_t reserveSpace) const
+{
+    auto layer_i = rnnDesc.nLayers;
+
+    if(layer_i == 0 || max_seq_len == 0)
+        return;
+
+    auto sequence_directions =
+        rnnDesc.dirMode == miopenRNNDirectionMode_t::miopenRNNbidirection ? 2 : 1;
+
+    rnnAlgoModules.PropDy(handle, dy, workSpace);
+
+    do
+    {
+        layer_i--;
+
+        for(int dir = 0; dir < sequence_directions; dir++)
+        {
+            const auto seq_dir = dir == 0 ? rnn_base::SequenceDirection::Forward
+                                          : rnn_base::SequenceDirection::Reverse;
+
+            auto ti = max_seq_len;
+            do
+            {
+                const rnn_base::SequenceIterator cur_seq(--ti, seq_dir, max_seq_len, false);
+
+                rnnAlgoModules.PropDhy(handle, dhy, workSpace, layer_i, cur_seq, seq_dir);
+
+                rnnAlgoModules.UpdateHStatePerTimeSeq(
+                    handle, dcy, cx, dcx, workSpace, reserveSpace, layer_i, cur_seq, seq_dir);
+
+                // GEMM
+                if(ti != 0)
+                    rnnAlgoModules.PropHiddenDht(handle, w, workSpace, layer_i, cur_seq, seq_dir);
+                else
+                    rnnAlgoModules.PropDhxDcx(
+                        handle, w, dhx, dcx, workSpace, reserveSpace, layer_i, cur_seq, seq_dir);
+
+            } while(ti != 0);
+
+            if(layer_i != 0)
+                rnnAlgoModules.PropHiddenDy(handle, w, workSpace, reserveSpace, layer_i, seq_dir);
+            else
+                rnnAlgoModules.PropDx(handle, w, workSpace, dx, seq_dir);
+        }
+
+    } while(layer_i != 0);
+}
+
+} // namespace rnn_base
+} // namespace miopen

--- a/src/rnn/Solutions/bwd_s_stream.cpp
+++ b/src/rnn/Solutions/bwd_s_stream.cpp
@@ -24,8 +24,11 @@ void RNNModularSingleStreamBWD::ComputeBWD(Handle& handle,
     auto sequence_directions =
         rnnDesc.dirMode == miopenRNNDirectionMode_t::miopenRNNbidirection ? 2 : 1;
 
+    rnnAlgoModules.PrepareWriteBuffers(handle, dhx, dcx, workSpace);
+
     rnnAlgoModules.PropDy(handle, dy, workSpace);
 
+#if true
     do
     {
         layer_i--;
@@ -61,6 +64,49 @@ void RNNModularSingleStreamBWD::ComputeBWD(Handle& handle,
         }
 
     } while(layer_i != 0);
+#else
+    // for debugging only, it uses the old order of functions
+    // and allows logs comparison with the old code in aples to aples form
+    do
+    {
+        layer_i--;
+        for(int dir = 0; dir < sequence_directions; dir++)
+        {
+            const auto seq_dir = dir == 0 ? rnn_base::SequenceDirection::Forward
+                                          : rnn_base::SequenceDirection::Reverse;
+            auto ti            = max_seq_len;
+            do
+            {
+                const rnn_base::SequenceIterator cur_seq(--ti, seq_dir, max_seq_len, false);
+                if(ti == max_seq_len - 1)
+                    rnnAlgoModules.PropDhy(handle, dhy, workSpace, layer_i, cur_seq, seq_dir);
+                rnnAlgoModules.UpdateHStatePerTimeSeq(
+                    handle, dcy, cx, dcx, workSpace, reserveSpace, layer_i, cur_seq, seq_dir);
+
+                if(ti != 0)
+                    rnnAlgoModules.PropDhy(
+                        handle, dhy, workSpace, layer_i, cur_seq.getNext(), seq_dir);
+                if(ti != 0)
+                    rnnAlgoModules.PropHiddenDht(handle, w, workSpace, layer_i, cur_seq, seq_dir);
+            } while(ti != 0);
+        }
+        for(int dir = 0; dir < sequence_directions; dir++)
+        {
+            const auto seq_dir = dir == 0 ? rnn_base::SequenceDirection::Forward
+                                          : rnn_base::SequenceDirection::Reverse;
+            for(int ti = 0; ti < max_seq_len; ti++)
+            {
+                const rnn_base::SequenceIterator cur_seq(ti, seq_dir, max_seq_len, false);
+                rnnAlgoModules.PropDhxDcx(
+                    handle, w, dhx, dcx, workSpace, reserveSpace, layer_i, cur_seq, seq_dir);
+            }
+            if(layer_i != 0)
+                rnnAlgoModules.PropHiddenDy(handle, w, workSpace, reserveSpace, layer_i, seq_dir);
+            else
+                rnnAlgoModules.PropDx(handle, w, workSpace, dx, seq_dir);
+        }
+    } while(layer_i != 0);
+#endif
 }
 
 } // namespace rnn_base

--- a/src/rnn/Solutions/modular_base.cpp
+++ b/src/rnn/Solutions/modular_base.cpp
@@ -1,0 +1,540 @@
+#include <miopen/rnn/solvers.hpp>
+#include <miopen/rnn/base_ops.hpp>
+#include <miopen/handle.hpp>
+
+namespace miopen {
+
+namespace rnn_base {
+
+void RNNBackwardDataModularAlgo::PropDhy(const Handle& handle,
+                                         ConstData_t dhy,
+                                         Data_t workSpace,
+                                         const unsigned int layer,
+                                         const SequenceIterator& currentSeq,
+                                         SequenceDirection direction) const
+{
+    if(dhy == nullptr)
+        return;
+
+    if(direction == SequenceDirection::Reverse && !currentSeq.isFirst())
+        return;
+
+    const auto [copy_batch_size, copy_batch_offset_id] = [](const SequenceIterator& current_seq,
+                                                            const BatchController& b_c) {
+        const auto cur_time_batch = b_c.getBatchSize(current_seq.getPhisVal());
+        const auto prev_time_batch =
+            current_seq.isFirst() ? 0 : b_c.getBatchSize(current_seq.getPrev().getPhisVal());
+
+        size_t dst_batch_offset_id_ = prev_time_batch;
+        size_t dst_batch_size_      = cur_time_batch - prev_time_batch;
+        return std::make_tuple(dst_batch_size_, dst_batch_offset_id_);
+    }(currentSeq, batchController);
+
+    // no data so return
+    if(copy_batch_size <= 0)
+        return;
+
+    // ws_dy + dhy
+    const float alpha0 = 1;
+    const float alpha1 = 1;
+    const float beta_t = 0;
+
+    // TODO remove virtual in implementation change getOffset
+    auto virtual_layer      = getVirtualLayer(layer, direction);
+    size_t dhy_layer_offset = hiddenHxCxInfo.getOffset(virtual_layer, copy_batch_offset_id);
+
+    size_t time_batch_offset_id = batchController.getBatchSum(currentSeq.getPhisVal());
+    size_t workspace_dy_offset  = workspaceInfo.getHiddenStateOffset(
+        layer, time_batch_offset_id + copy_batch_offset_id, direction);
+
+    const auto dhy_desc = BuildHxCxDesc3D(1, copy_batch_size);
+
+    const auto workspace_dy_desc = BuildTempDhtDesc3D(1, copy_batch_size);
+
+    OpTensor(handle,
+             miopenTensorOpAdd,
+             &alpha0,
+             dhy_desc,
+             dhy,
+             &alpha1,
+             workspace_dy_desc,
+             workSpace,
+             &beta_t,
+             workspace_dy_desc,
+             workSpace,
+             dhy_layer_offset,
+             workspace_dy_offset,
+             workspace_dy_offset);
+}
+
+void RNNBackwardDataModularAlgo::PropHiddenDht(Handle& handle,
+                                               ConstData_t w,
+                                               Data_t workSpace,
+                                               int layer,
+                                               const SequenceIterator& currentSeq,
+                                               SequenceDirection direction) const
+{
+    // iterating over seq in descending order(from high to low)
+    // take smallest batch
+    const auto gemm_batch_size = batchController.getBatchSize(
+        direction == SequenceDirection::Forward ? currentSeq.getPhisVal()
+                                                : currentSeq.getNext().getPhisVal());
+
+    // no gemm work
+    if(gemm_batch_size == 0)
+        return;
+
+    const miopen::TensorDescriptor tmp_block_src_dsc =
+        BuildLstmTmpBlockDesc2D(workspaceInfo, gemm_batch_size);
+
+    const miopen::TensorDescriptor& filter_src_dsc = BuildLstmFilterHidDesc2D();
+
+    const miopen::TensorDescriptor& ht_dest_dsc = BuildWsHtDesc2D(gemm_batch_size);
+
+    RnnBaseFunctions::BWD_GEMM_Hidden_Prop(
+        handle,
+        workSpace,
+        workspaceInfo.getGateBlockOffset(
+            layer, batchController.getBatchSum(currentSeq.getPhisVal()), direction),
+        tmp_block_src_dsc,
+        w,
+        weightsLayout.getMatrixHidOff(layer, static_cast<int>(direction)),
+        filter_src_dsc,
+        workSpace,
+        workspaceInfo.getHiddenStateOffset(
+            layer, batchController.getBatchSum(currentSeq.getNext().getPhisVal()), direction),
+        ht_dest_dsc);
+}
+
+void RNNBackwardDataModularAlgo::UpdateHStatePerTimeSeq(Handle& handle,
+                                                        ConstData_t dcy,
+                                                        ConstData_t cx,
+                                                        Data_t,
+                                                        Data_t workSpace,
+                                                        Data_t reserveSpace,
+                                                        int layer,
+                                                        const SequenceIterator& seq,
+                                                        SequenceDirection direction) const
+{
+    // Inited
+    const size_t hidden_vec = rnnDesc.hsize;
+    auto rnn_data_type      = rnnDesc.dataType;
+    auto rnn_mode           = rnnDesc.rnnMode;
+    auto rnn_algo_mode      = rnnDesc.algoMode;
+
+    if(rnn_mode == miopenRNNRELU || rnn_mode == miopenRNNTANH)
+    {
+        // float alpha = 1;
+        // float beta  = 0;
+        //
+        //// activation
+        // auto& activDesc = rnn_mode == miopenRNNRELU ? reluDesc : tanhDesc;
+
+        /*
+        activDesc.Backward(handle,
+                           &alpha,
+                           dht_desc,
+                           reserveSpace,
+                           dht_desc,
+                           workSpace,
+                           dht_desc,
+                           reserveSpace,
+                           &beta,
+                           sp_desc,
+                           workSpace,
+                           offset + static_cast<size_t>(ri) * wei_len +
+                               static_cast<size_t>(nLayers) * batch_n * hy_stride,
+                           offset + static_cast<size_t>(ri) * wei_len,
+                           offset + static_cast<size_t>(ri) * wei_len,
+                           offset + static_cast<size_t>(ri) * wei_len);
+        */
+    }
+    else if(rnn_mode == miopenLSTM)
+    {
+        if(rnn_algo_mode == miopenRNNdefault)
+        {
+
+            size_t cur_batch = batchController.getBatchSize(seq.getPhisVal());
+
+            const auto [dcy_use_batch, cx_use_batch] = [](const auto& seq,
+                                                          const BatchController& batch_c,
+                                                          const SequenceDirection dir) {
+                auto current_batch = batch_c.getBatchSize(seq.getPhisVal());
+                if(dir == SequenceDirection::Forward)
+                {
+                    const auto dcy_batch = seq.isFirst()
+                                               ? current_batch
+                                               : batch_c.getBatchSize(seq.getPrev().getPhisVal());
+                    const auto cx_batch  = current_batch;
+                    return std::make_tuple(dcy_batch, cx_batch);
+                }
+                else
+                {
+                    const auto dcy_batch = current_batch;
+                    const auto cx_batch  = seq.isLast()
+                                               ? current_batch
+                                               : batch_c.getBatchSize(seq.getNext().getPhisVal());
+                    return std::make_tuple(dcy_batch, cx_batch);
+                }
+            }(seq, batchController, direction);
+
+            size_t cur_comb_dim  = batchController.getBatchSum(seq.getPhisVal());
+            size_t prev_comb_dim = !seq.isFirst()
+                                       ? batchController.getBatchSum(seq.getPrev().getPhisVal())
+                                       : batchController.getBatchSum(seq.getPhisVal());
+            size_t next_comb_dim = !seq.isLast()
+                                       ? batchController.getBatchSum(seq.getNext().getPhisVal())
+                                       : batchController.getBatchSum(seq.getPhisVal());
+
+            LSTMBackwardHiddenStateUpdate(
+                handle,
+                rnn_data_type,
+                seq.isLast(),  // ti == 0,
+                seq.isFirst(), // ti == seqLen - 1,
+                static_cast<int>(direction),
+                batchController.getBatchSize(0),
+                cur_batch,
+                dcy_use_batch,
+                cx_use_batch,
+                hidden_vec,
+                reservLayout.gateStride[1],
+                -666, // unused
+                -666, // unused
+                cx,
+                hiddenHxCxInfo.getOffset(getVirtualLayer(layer, direction), 0),
+                reserveSpace,
+                reservLayout.getGasOffset(layer, cur_comb_dim, direction, LstmGateAndState::I),
+                reservLayout.getGasOffset(layer, cur_comb_dim, direction, LstmGateAndState::F),
+                reservLayout.getGasOffset(layer, cur_comb_dim, direction, LstmGateAndState::O),
+                reservLayout.getGasOffset(layer, cur_comb_dim, direction, LstmGateAndState::G),
+                reservLayout.getActiveCellOffset(layer, cur_comb_dim, direction),
+                reservLayout.getGasOffset( // TODO
+                    layer,
+                    next_comb_dim,
+                    direction,
+                    LstmGateAndState::St),
+                dcy,
+                hiddenHxCxInfo.getOffset(getVirtualLayer(layer, direction), 0),
+                workSpace,
+                workspaceInfo.getGasOffset(layer, cur_comb_dim, direction, LstmGateAndState::I),
+                workspaceInfo.getGasOffset(layer, cur_comb_dim, direction, LstmGateAndState::F),
+                workspaceInfo.getGasOffset(layer, cur_comb_dim, direction, LstmGateAndState::O),
+                workspaceInfo.getGasOffset(layer, cur_comb_dim, direction, LstmGateAndState::G),
+                workspaceInfo.getGasOffset(layer, cur_comb_dim, direction, LstmGateAndState::St),
+                workspaceInfo.getGasOffset(layer, prev_comb_dim, direction, LstmGateAndState::St),
+                workspaceInfo.getGasOffset(layer, cur_comb_dim, direction, LstmGateAndState::Ht),
+                workspaceInfo.getGasOffset(layer, prev_comb_dim, direction, LstmGateAndState::F));
+        }
+        else
+        {
+            MIOPEN_THROW(miopenStatusInternalError,
+                         "TODO implementation algoMode != miopenRNNdefault");
+            // TODO implementation
+        }
+    }
+    else if(rnn_mode == miopenGRU)
+    {
+        MIOPEN_THROW(miopenStatusInternalError, "TODO implementation miopenGRU");
+        // TODO implementation
+    }
+}
+
+void RNNBackwardDataModularAlgo::PropDhxDcx(Handle& handle,
+                                            ConstData_t w,
+                                            Data_t dhx,
+                                            Data_t dcx,
+                                            Data_t workSpace,
+                                            Data_t reserveSpace,
+                                            size_t layer,
+                                            const SequenceIterator& currentSeq,
+                                            SequenceDirection direction) const
+{
+    // dcx, dhx
+    if(!(dhx != nullptr || (rnnDesc.rnnMode == miopenLSTM && dcx != nullptr)))
+        return;
+
+    if(direction == SequenceDirection::Forward && !currentSeq.isLast())
+        return;
+
+    const auto next_batch_size =
+        currentSeq.isLast()
+            ? 0 // forward and reverse
+            : batchController.getBatchSize(currentSeq.getNext().getPhisVal()); // only reverse
+
+    const auto batch_size = batchController.getBatchSize(currentSeq.getPhisVal()) - next_batch_size;
+
+    if(batch_size > 0)
+    {
+
+        const size_t hx_cx_offset =
+            hiddenHxCxInfo.getOffset(getVirtualLayer(layer, direction), next_batch_size);
+
+        const size_t acc_batch_offset =
+            batchController.getBatchSum(currentSeq.getPhisVal()) + next_batch_size;
+
+        if(dhx != nullptr)
+        {
+            const miopen::TensorDescriptor hx_desc = BuildHxCxDesc2D(batch_size);
+
+            const miopen::TensorDescriptor tmp_block_src_dsc =
+                BuildLstmTmpBlockDesc2D(workspaceInfo, batch_size);
+
+            const size_t tmp_block_src_offset =
+                workspaceInfo.getGateBlockOffset(layer, acc_batch_offset, direction);
+
+            const miopen::TensorDescriptor& filter_src_dsc = BuildLstmFilterHidDesc2D();
+            const size_t filter_src_offset =
+                weightsLayout.getMatrixHidOff(layer, static_cast<int>(direction));
+
+            RnnBaseFunctions::BWD_GEMM_Hidden_Prop(handle,
+                                                   workSpace,
+                                                   tmp_block_src_offset,
+                                                   tmp_block_src_dsc,
+                                                   w,
+                                                   filter_src_offset,
+                                                   filter_src_dsc,
+                                                   dhx,
+                                                   hx_cx_offset,
+                                                   hx_desc);
+        }
+
+        if(rnnDesc.rnnMode == miopenLSTM && dcx != nullptr)
+        {
+            miopen::TensorDescriptor cx_desc = BuildHxCxDesc3D(1, batch_size);
+            const auto& temp_ct_desc         = BuildTempDhtDesc3D(1, batch_size);
+
+            const float alpha0 = 1;
+            const float alpha1 = 1;
+            const float beta_t = 1;
+
+            const auto bOffset = rnnDesc.algoMode == miopenRNNdefault
+                                     ? reservLayout.getGasOffset(layer,
+                                                                 acc_batch_offset,
+                                                                 direction,
+                                                                 LstmGateAndState::F)
+                                     : reservLayout.getActiveCellOffset( // TODO double check
+                                           layer,
+                                           acc_batch_offset,
+                                           direction);
+
+            const auto a_offset = workspaceInfo.getGasOffset(
+                layer, acc_batch_offset, direction, LstmGateAndState::St);
+
+            OpTensor(handle,
+                     miopenTensorOpMul,
+                     &alpha0,
+                     temp_ct_desc,
+                     workSpace,
+                     &alpha1,
+                     temp_ct_desc,
+                     reserveSpace,
+                     &beta_t,
+                     cx_desc,
+                     dcx,
+                     a_offset,
+                     bOffset,
+                     hx_cx_offset);
+        }
+    }
+}
+
+void RNNBackwardDataModularAlgo::PropDy(Handle& handle, ConstData_t dy, Data_t workSpace) const
+{
+    const auto rnn_data_type = rnnDesc.dataType;
+    const auto last_layer_id = rnnDesc.nLayers - 1;
+
+    auto store_offset =
+        workspaceInfo.getHiddenStateOffset(last_layer_id, 0, SequenceDirection::Forward);
+
+    // bwd concat
+    // currently supported only one type, but should be more
+    auto [dy_src_desc, dy_data_ptr] =
+        [](const IOBufferDescriptor& dyInfo, const RNNDescriptor& rnnD, ConstData_t dy) {
+            const auto& dy_raw_size   = dyInfo.getFullSeqMajorSize();
+            const auto& dy_raw_stride = dyInfo.getFullSeqMajorStrides();
+
+            size_t direc_scale = rnnD.dirMode == miopenRNNbidirection ? 2 : 1;
+
+            const auto dy_normalized_size =
+                std::vector<size_t>{1, dy_raw_size[0], direc_scale, dy_raw_size[1] / direc_scale};
+
+            const auto dy_normalized_stride =
+                std::vector<size_t>{dy_normalized_size[1] * dy_raw_stride[0] /*unused*/,
+                                    dy_raw_stride[0],
+                                    dy_normalized_size[3] * dy_raw_stride[1],
+                                    dy_raw_stride[1]};
+
+            auto dy_desc =
+                miopen::TensorDescriptor(rnnD.dataType, dy_normalized_size, dy_normalized_stride);
+
+            return std::make_tuple(dy_desc, dy);
+        }(yInfo, rnnDesc, dy);
+
+    const std::vector<size_t> ws_dst_strides = [](const auto& full_stride_ref) {
+        return std::vector<size_t>(full_stride_ref.begin(), full_stride_ref.end());
+    }(workspaceInfo.getHiddenStateStride());
+
+    const std::vector<size_t> ws_dst_size = [](const auto& full_size_ref) {
+        std::vector<size_t> ws_ht_layer_size(full_size_ref.begin(), full_size_ref.end());
+
+        ws_ht_layer_size[0] = 1;
+
+        return ws_ht_layer_size;
+    }(workspaceInfo.hStateSizes);
+
+    auto ws_dy_dst_desc = miopen::TensorDescriptor(rnn_data_type, ws_dst_size, ws_dst_strides);
+
+    if(store_offset <= INT32_MAX)
+    {
+        CopyTensor(handle,
+                   dy_src_desc,
+                   dy,
+                   ws_dy_dst_desc,
+                   workSpace,
+                   0,
+                   static_cast<int>(store_offset),
+                   true);
+    }
+    else
+    {
+        MIOPEN_THROW(miopenStatusInternalError, "store_offset > INT32_MAX");
+    }
+}
+
+void RNNBackwardDataModularAlgo::PropHiddenDy(Handle& handle,
+                                              ConstData_t w,
+                                              Data_t workSpace,
+                                              Data_t reserveSpace,
+                                              size_t layer,
+                                              SequenceDirection direction) const
+{
+
+    if(layer == 0)
+        return;
+
+    const auto rnn_data_type = rnnDesc.dataType;
+
+    const size_t gemm_batch_size   = batchController.getTotalBatchSum();
+    const size_t gemm_batch_offset = 0;
+
+    const auto ht_x_offset =
+        workspaceInfo.getHiddenStateOffset(layer - 1, gemm_batch_offset, direction);
+
+    const auto filter_offset = weightsLayout.getMatrixXinOff(layer, static_cast<int>(direction));
+
+    if(rnnDesc.rnnMode == miopenLSTM)
+    {
+        const auto tmp_block_offset =
+            workspaceInfo.getGateBlockOffset(layer, gemm_batch_offset, direction);
+
+        const miopen::TensorDescriptor tmp_block_src_dsc =
+            BuildLstmTmpBlockDesc2D(workspaceInfo, gemm_batch_size);
+
+        const auto filter_src_dsc = BuildLstmFilterXDesc2D(layer);
+
+        const auto ht_x_desc = BuildWsHtDesc2D(gemm_batch_size);
+
+        RnnBaseFunctions::BWD_GEMM_Hidden_Prop(handle,
+                                               workSpace,
+                                               tmp_block_offset,
+                                               tmp_block_src_dsc,
+                                               w,
+                                               filter_offset,
+                                               filter_src_dsc,
+                                               workSpace,
+                                               ht_x_offset,
+                                               ht_x_desc);
+    }
+    else
+    {
+        MIOPEN_THROW(miopenStatusInternalError, "Only lstm");
+    }
+
+    if(!float_equal(miopen::deref(rnnDesc.dropoutDesc).dropout, 0))
+    {
+        // size_t hid_shift   = layer * reservLayout.hStateSizes[1] * hy_stride;
+        // auto dhd_off     = direction_mult * hy_h * 5;
+        const size_t dst_data_offset = ht_x_offset; // hid_shift+dhd_off
+
+        auto h_state_sizes = reservLayout.hStateSizes;
+
+        // TODO 3 dim vec, add direction as dim
+        std::vector<size_t> drop_size(2), drop_in_str(2, 1);
+        drop_size[0] = h_state_sizes[1];                    // batch_n;
+        drop_size[1] = h_state_sizes[2] * h_state_sizes[3]; // hy_h* direction_mult;
+
+        drop_in_str[0] = reservLayout.getHiddenStateStride()[1]; // hy_stride;
+        drop_in_str[1] = reservLayout.getHiddenStateStride()[3]; // 1;
+
+        auto drop_in_desc = miopen::TensorDescriptor(rnn_data_type, drop_size, drop_in_str);
+
+        size_t drop_rsv_size = drop_in_desc.GetElementSize();
+
+        size_t drop_rsv_start = reservLayout.getBufferSize();
+
+        size_t drop_rsv_offset = (drop_rsv_start + (rnnDesc.nLayers - 1) * drop_rsv_size) *
+                                     (rnn_data_type == miopenFloat ? 4 : 2) +
+                                 layer * drop_rsv_size;
+
+        miopen::deref(rnnDesc.dropoutDesc)
+            .DropoutBackward(handle,
+                             drop_in_desc,
+                             drop_in_desc,
+                             workSpace,
+                             drop_in_desc,
+                             workSpace,
+                             reserveSpace,
+                             drop_rsv_size,
+                             dst_data_offset,
+                             dst_data_offset,
+                             drop_rsv_offset);
+    }
+}
+
+void RNNBackwardDataModularAlgo::PropDx(Handle& handle,
+                                        ConstData_t w,
+                                        ConstData_t workSpace,
+                                        Data_t dx,
+                                        SequenceDirection direction) const
+{
+    constexpr size_t gemm_batch_offset = 0;
+    constexpr size_t layer             = 0;
+
+    const size_t gemm_batch_size = workspaceInfo.getGateBlockSize()[1];
+
+    const auto tmp_block_offset =
+        workspaceInfo.getGateBlockOffset(layer, gemm_batch_offset, direction);
+
+    const auto filter_offset = weightsLayout.getMatrixXinOff(layer, static_cast<int>(direction));
+
+    const auto ht_x_offset = xInfo.getPackedOffset(gemm_batch_offset);
+
+    const miopen::TensorDescriptor tmp_block_src_dsc =
+        BuildLstmTmpBlockDesc2D(workspaceInfo, gemm_batch_size);
+
+    const auto filter_src_dsc = BuildLstmFilterXDesc2D(layer);
+
+    const auto ht_x_desc =
+        [](const miopenDataType_t dType, const auto& buf_info, const size_t batch_size) {
+            const auto& ht_stride = buf_info.getFullSeqMajorStrides();
+            const auto& ht_size   = buf_info.getFullSeqMajorSize();
+
+            // batch, vec_elements
+            return miopen::TensorDescriptor{dType, {batch_size, ht_size[1]}, ht_stride};
+        }(rnnDesc.dataType, xInfo, gemm_batch_size);
+
+    RnnBaseFunctions::BWD_GEMM_Hidden_Prop(handle,
+                                           workSpace,
+                                           tmp_block_offset,
+                                           tmp_block_src_dsc,
+                                           w,
+                                           filter_offset,
+                                           filter_src_dsc,
+                                           dx,
+                                           ht_x_offset,
+                                           ht_x_desc,
+                                           false);
+}
+
+} // namespace rnn_base
+} // namespace miopen

--- a/src/rnn/selector.cpp
+++ b/src/rnn/selector.cpp
@@ -14,16 +14,16 @@
 
 #include <miopen/rnn/tmp_buffer_utils.hpp>
 
-MIOPEN_DECLARE_ENV_VAR_BOOL(MIOPEN_RNNBWDMS_exp)
+MIOPEN_DECLARE_ENV_VAR_BOOL(MIOPEN_RNNBWDMS_EXP)
 
 namespace miopen {
 
 bool RNNBwdMSIsFast(const int seqLen)
 {
-    if(env::enabled(MIOPEN_RNNBWDMS_exp))
+    if(env::enabled(MIOPEN_RNNBWDMS_EXP))
         return true;
 
-    if(seqLen >= 32 && !env::disabled(MIOPEN_RNNBWDMS_exp))
+    if(seqLen >= 32 && !env::disabled(MIOPEN_RNNBWDMS_EXP))
         return true;
     return false;
 }

--- a/src/rnn/selector.cpp
+++ b/src/rnn/selector.cpp
@@ -1,0 +1,46 @@
+#include <miopen/rnn.hpp>
+#include <miopen/rnn_util.hpp>
+
+#include <miopen/activ.hpp>
+#include <miopen/env.hpp>
+#include <miopen/gemm_v2.hpp>
+#include <miopen/logger.hpp>
+
+#include <vector>
+#include <numeric>
+#include <algorithm>
+
+#include <miopen/rnn/solvers.hpp>
+
+#include <miopen/rnn/tmp_buffer_utils.hpp>
+
+MIOPEN_DECLARE_ENV_VAR_BOOL(MIOPEN_RNNBWDMS_exp)
+
+namespace miopen {
+
+void RNNDescriptor::ModularBackward(Handle& handle,
+                                    const SeqTensorDescriptor& yDesc,
+                                    ConstData_t dy,
+                                    const TensorDescriptor& hDesc,
+                                    ConstData_t /*hx*/,
+                                    ConstData_t dhy,
+                                    Data_t dhx,
+                                    const TensorDescriptor& /*cDesc*/,
+                                    ConstData_t cx,
+                                    ConstData_t dcy,
+                                    Data_t dcx,
+                                    const SeqTensorDescriptor& xDesc,
+                                    Data_t dx,
+                                    ConstData_t w,
+                                    Data_t workSpace,
+                                    size_t /*workSpaceSize*/,
+                                    Data_t reserveSpace,
+                                    size_t /*reserveSpaceSize*/) const
+{
+
+    rnn_base::RNNModularSingleStreamBWD single_stream{*this, xDesc, yDesc, hDesc};
+
+    single_stream.ComputeBWD(handle, dy, dhy, dhx, cx, dcy, dcx, dx, w, workSpace, reserveSpace);
+}
+
+} // namespace miopen


### PR DESCRIPTION
- LSTM BWD refactored code
- - added single-stream solution
- - added multi-stream solution

Solver selection controlled via MIOPEN_RNNBWDMS_exp. 0 - single-stream solution, 1 - multi-stream solution.
Multi-stream solution selected by default for seqLen >= 32



  | old | new | (old-new)/old |  
-- | -- | -- | -- | --
  | Backward Data | Backward Data | Uplift (Incremental) | cmd
A | 31.88 | 19.74 | 38% | MIOpenDriver rnnfp16 -n 1024 -W 224 -H 1000 -l 8 -b 1 -m lstm   -p 0 -r 0 -k 32 -c 0 -F 0 -t 0 -w 1 -V 0 -i 10
B | 62.10 | 56.80 | 9% | MIOpenDriver rnn -n 1024 -W 224 -H 1000 -l 8 -b 1 -m lstm -p 0   -r 0 -k 32 -c 0 -F 0 -t 0 -w 1 -V 0 -i 10
C | 14.25 | 8.32 | 42% | MIOpenDriver rnnfp16 -n 256 -W 224 -H 1000 -l 8 -b 1 -m lstm   -p 0 -r 0 -k 32 -c 0 -F 0 -t 0 -w 1 -V 0 -i 10
D | 18.12 | 17.66 | 3% | MIOpenDriver rnn -n 256 -W 224 -H 1000 -l 8 -b 1 -m lstm -p 0   -r 0 -k 32 -c 0 -F 0 -t 0 -w 1 -V 0 -i 10


