### PR TITLE
Deduplicated ValidateGroupCount and fixed incorrect usage

### DIFF
--- a/src/ocl/convolutionocl.cpp
+++ b/src/ocl/convolutionocl.cpp
@@ -49,6 +49,7 @@
 #include <miopen/datatype.hpp>
 #include <miopen/any_solver.hpp>
 #include <miopen/conv/tensors.hpp>
+#include <miopen/problem.hpp>
 #include <miopen/conv/compiled_in_parameters.hpp>
 #include <miopen/conv/data_invoke_params.hpp>
 #include <miopen/conv/wrw_invoke_params.hpp>
@@ -66,72 +67,6 @@ MIOPEN_DECLARE_ENV_VAR_BOOL(MIOPEN_DEBUG_ENABLE_AI_IMMED_MODE_FALLBACK)
 MIOPEN_DECLARE_ENV_VAR_BOOL(MIOPEN_DEBUG_FORCE_IMMED_MODE_FALLBACK)
 
 namespace miopen {
-
-static inline bool IsValidFilterChannelNumber(const TensorDescriptor& x,
-                                              const TensorDescriptor& w,
-                                              const miopenTensorLayout_t layout,
-                                              const int groups)
-{
-    if(layout == miopenTensorNCHW      //
-       || layout == miopenTensorNCHWc4 //
-       || layout == miopenTensorNCHWc8)
-    {
-        return x.GetLengths()[1] / groups == w.GetLengths()[1];
-    }
-
-    if(layout == miopenTensorCHWNc4 //
-       || layout == miopenTensorCHWNc8)
-    {
-        return x.GetLengths()[1] / groups == w.GetLengths()[0];
-    }
-
-    return true;
-}
-
-static inline bool IsValidGroupCount(const TensorDescriptor& x,
-                                     const TensorDescriptor& w,
-                                     const miopenTensorLayout_t layout,
-                                     const int groups)
-{
-    if(groups > 1) // Optimize for speed
-    {
-        if(x.GetLengths()[1] % groups != 0)
-            return false;
-
-        if(layout == miopenTensorNCHW      //
-           || layout == miopenTensorNCHWc4 //
-           || layout == miopenTensorNCHWc8)
-            return w.GetLengths()[0] % groups == 0;
-
-        if(layout == miopenTensorCHWNc4 //
-           || layout == miopenTensorCHWNc8)
-            return w.GetLengths()[3] % groups == 0;
-    }
-    return true;
-}
-
-static inline void ValidateGroupCount(const TensorDescriptor& x,
-                                      const TensorDescriptor& w,
-                                      const ConvolutionDescriptor& conv)
-{
-    const auto layout = w.GetLayout_t();
-    const auto groups = conv.group_count;
-    assert(groups > 0);
-
-    const auto ok_c = IsValidFilterChannelNumber(x, w, layout, groups);
-    const auto ok_g = IsValidGroupCount(x, w, layout, groups);
-
-    if(ok_c && ok_g)
-        return;
-
-    MIOPEN_LOG_W(w.GetLayout_str() << "w {" << w.ToString() << "}, " //
-                                   << "x {" << x.ToString() << "}, " //
-                                   << "groups = " << conv.group_count);
-    if(!ok_c)
-        MIOPEN_THROW(miopenStatusBadParm, "Invalid filter channel number");
-    if(!ok_g)
-        MIOPEN_THROW(miopenStatusBadParm, "Invalid group number");
-}
 
 static inline void ValidateWorkspace(Data_t workSpace, const size_t workSpaceSize)
 {
@@ -544,7 +479,7 @@ void ConvolutionDescriptor::ConvolutionForward(Handle& handle,
     ValidateAlphaBeta(problem);
 
     ConvForwardCheckNumerics(handle, tensors, [&]() {
-        ValidateGroupCount(xDesc, wDesc, *this);
+        Problem::ValidateGroupCount(xDesc, wDesc, *this);
 
         const auto algorithm_name = AlgorithmName{ConvolutionAlgoToDirectionalString(
             static_cast<miopenConvAlgorithm_t>(algo), conv::Direction::Forward)};
@@ -659,7 +594,7 @@ ConvolutionDescriptor::GetSolutionsFallback(const ExecutionContext& ctx,
     const auto& weightsDesc = problem.GetWeights();
     // This check is needed on fallback path only.
     // On regular path (find-db hit) this was checked during Find().
-    ValidateGroupCount(xDesc, weightsDesc, *this);
+    Problem::ValidateGroupCount(xDesc, weightsDesc, *this);
 
     auto interim = std::vector<miopenConvSolution_t>{};
     interim.reserve(maxSolutionCount); // For speed. In most cases we have less entries than asked.
@@ -942,7 +877,7 @@ void ConvolutionDescriptor::FindConvBwdDataAlgorithm(Handle& handle,
 
     *returnedAlgoCount = 0;
 
-    ValidateGroupCount(dxDesc, wDesc, *this);
+    Problem::ValidateGroupCount(dxDesc, wDesc, *this);
 
     const auto problem =
         conv::ProblemDescription{dyDesc, wDesc, dxDesc, *this, conv::Direction::BackwardData};
@@ -1035,7 +970,7 @@ void ConvolutionDescriptor::ConvolutionBackwardData(Handle& handle,
         {
             MIOPEN_THROW(miopenStatusBadParm);
         }
-        ValidateGroupCount(dxDesc, wDesc, *this);
+        Problem::ValidateGroupCount(dxDesc, wDesc, *this);
 
         const auto algorithm_name = AlgorithmName{ConvolutionAlgoToDirectionalString(
             static_cast<miopenConvAlgorithm_t>(algo), conv::Direction::BackwardData)};
@@ -1108,7 +1043,7 @@ void ConvolutionDescriptor::ConvolutionBackwardImmediate(Handle& handle,
         {
             MIOPEN_THROW(miopenStatusBadParm);
         }
-        ValidateGroupCount(dxDesc, wDesc, *this);
+        Problem::ValidateGroupCount(dxDesc, wDesc, *this);
 
         const auto problem =
             conv::ProblemDescription{dyDesc, wDesc, dxDesc, *this, conv::Direction::BackwardData};
@@ -1240,7 +1175,7 @@ void ConvolutionDescriptor::ConvolutionBackwardWeights(const Handle& handle,
         MIOPEN_THROW(miopenStatusBadParm);
 
     ConvWrwCheckNumerics(handle, tensors, beta, [&]() {
-        ValidateGroupCount(xDesc, dwDesc, *this);
+        Problem::ValidateGroupCount(xDesc, dwDesc, *this);
 
         decltype(auto) algorithm_name = AlgorithmName{ConvolutionAlgoToDirectionalString(
             static_cast<miopenConvAlgorithm_t>(algo), direction)};
@@ -1310,7 +1245,7 @@ void ConvolutionDescriptor::ConvolutionWrwImmediate(Handle& handle,
 
     float beta = 0;
     ConvWrwCheckNumerics(handle, tensors, &beta, [&]() {
-        ValidateGroupCount(xDesc, dwDesc, *this);
+        Problem::ValidateGroupCount(xDesc, dwDesc, *this);
 
         const auto problem = conv::ProblemDescription{
             dyDesc, dwDesc, xDesc, *this, conv::Direction::BackwardWeights};

--- a/src/problem.cpp
+++ b/src/problem.cpp
@@ -472,8 +472,6 @@ std::vector<Solution> Problem::FindSolutionsImpl(Handle& handle,
         GetTensorDescriptorChecked(miopenTensorConvolutionW, "miopenTensorConvolutionW");
     auto y_desc = GetTensorDescriptorChecked(miopenTensorConvolutionY, "miopenTensorConvolutionY");
 
-    ValidateGroupCount(x_desc, w_desc, conv_desc);
-
     auto x        = buffers.at(miopenTensorConvolutionX);
     const auto& w = buffers.at(miopenTensorConvolutionW);
     auto y        = buffers.at(miopenTensorConvolutionY);
@@ -490,6 +488,8 @@ std::vector<Solution> Problem::FindSolutionsImpl(Handle& handle,
         std::swap(x, y);
         std::swap(x_desc, y_desc);
     }
+
+    ValidateGroupCount(x_desc, w_desc, conv_desc);
 
     if(options.preallocated_workspace)
     {

--- a/src/problem.cpp
+++ b/src/problem.cpp
@@ -647,7 +647,9 @@ Problem::FindSolutionsImpl(Handle& handle,
     return ret;
 }
 
-static inline bool IsValidFilterChannelNumber(const TensorDescriptor& x,
+namespace
+{
+inline bool IsValidFilterChannelNumber(const TensorDescriptor& x,
                                               const TensorDescriptor& w,
                                               const miopenTensorLayout_t layout,
                                               const int groups)
@@ -668,7 +670,7 @@ static inline bool IsValidFilterChannelNumber(const TensorDescriptor& x,
     return true;
 }
 
-static inline bool IsValidGroupCount(const TensorDescriptor& x,
+inline bool IsValidGroupCount(const TensorDescriptor& x,
                                      const TensorDescriptor& w,
                                      const miopenTensorLayout_t layout,
                                      const int groups)
@@ -689,6 +691,7 @@ static inline bool IsValidGroupCount(const TensorDescriptor& x,
     }
     return true;
 }
+} // namespace
 
 void Problem::ValidateGroupCount(const TensorDescriptor& x,
                                  const TensorDescriptor& w,

--- a/src/problem.cpp
+++ b/src/problem.cpp
@@ -647,12 +647,11 @@ Problem::FindSolutionsImpl(Handle& handle,
     return ret;
 }
 
-namespace
-{
+namespace {
 inline bool IsValidFilterChannelNumber(const TensorDescriptor& x,
-                                              const TensorDescriptor& w,
-                                              const miopenTensorLayout_t layout,
-                                              const int groups)
+                                       const TensorDescriptor& w,
+                                       const miopenTensorLayout_t layout,
+                                       const int groups)
 {
     if(layout == miopenTensorNCHW      //
        || layout == miopenTensorNCHWc4 //
@@ -671,9 +670,9 @@ inline bool IsValidFilterChannelNumber(const TensorDescriptor& x,
 }
 
 inline bool IsValidGroupCount(const TensorDescriptor& x,
-                                     const TensorDescriptor& w,
-                                     const miopenTensorLayout_t layout,
-                                     const int groups)
+                              const TensorDescriptor& w,
+                              const miopenTensorLayout_t layout,
+                              const int groups)
 {
     if(groups > 1) // Optimize for speed
     {


### PR DESCRIPTION
`convolutionocl.cpp` version of `ValidateGroupCount` has been updated without changes to a copy in `problem.cpp` which made them incomaptible. PR moves the code to `problem.cpp`, changes all the call sites and removes the copy in `convolutioncol.cpp`

Also fixed incorrect usage of `Problem::ValidateGroupCount` in find 2.0 for the transposed cases