### PR TITLE
Replace sync hipMemset with async hipMemset

### DIFF
--- a/src/include/miopen/solver/implicitgemm_ck_util.hpp
+++ b/src/include/miopen/solver/implicitgemm_ck_util.hpp
@@ -378,7 +378,7 @@ public:
 
     void ZeroOutBuffer()
     {
-        [[maybe_unused]] auto status = hipMemset(buf_handle.get(), 0, tensor_sz);
+        [[maybe_unused]] auto status = hipMemsetAsync(buf_handle.get(), 0, tensor_sz);
         assert(status == hipSuccess);
     }
 


### PR DESCRIPTION
Replace sync hipMemset with async hipMemset to fix the issue that hipMemSet call taking too long during convolution backward weight for CVT cases. 