### PR TITLE
Suppress MLIR ubsan errors

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,7 +30,7 @@ def cmake_build(Map conf=[:]){
 
     def compiler = conf.get("compiler","/opt/rocm/llvm/bin/clang++")
     def make_targets = conf.get("make_targets","check")
-    def debug_flags = "-g -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined -Wno-option-ignored " + conf.get("extradebugflags", "")
+    def debug_flags = "-g -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined -Wno-option-ignored -fsanitize-ignorelist=$(pwd)/../UBSanSuppress.supp"  + conf.get("extradebugflags", "")
     def build_envs = "CTEST_PARALLEL_LEVEL=4 " + conf.get("build_env","")
     def prefixpath = conf.get("prefixpath","/opt/rocm")
     def mlir_args = " -DMIOPEN_USE_MLIR=" + conf.get("mlir_build", "ON")
@@ -73,7 +73,7 @@ def cmake_build(Map conf=[:]){
     }
 
     if(conf.get("codecov", false)){ //Need
-        setup_args = " -DCMAKE_BUILD_TYPE=debug -DCMAKE_CXX_FLAGS_DEBUG='${debug_flags} -fprofile-arcs -ftest-coverage' -DCODECOV_TEST=On " + setup_args
+        setup_args = " -DCMAKE_BUILD_TYPE=debug -DCMAKE_CXX_FLAGS_DEBUG=\"${debug_flags} -fprofile-arcs -ftest-coverage\" -DCODECOV_TEST=On " + setup_args
     }else if(build_type_debug){
         setup_args = " -DCMAKE_BUILD_TYPE=debug -DCMAKE_CXX_FLAGS_DEBUG='${debug_flags}'" + setup_args
     }else{

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,7 +30,7 @@ def cmake_build(Map conf=[:]){
 
     def compiler = conf.get("compiler","/opt/rocm/llvm/bin/clang++")
     def make_targets = conf.get("make_targets","check")
-    def debug_flags = "-g -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined -Wno-option-ignored -fsanitize-ignorelist=\$(pwd)/../UBSanSuppress.supp"  + conf.get("extradebugflags", "")
+    def debug_flags = "-g -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined -Wno-option-ignored -fsanitize-ignorelist=\$(pwd)/../UBSanIgnoreList.txt"  + conf.get("extradebugflags", "")
     def build_envs = "CTEST_PARALLEL_LEVEL=4 " + conf.get("build_env","")
     def prefixpath = conf.get("prefixpath","/opt/rocm")
     def mlir_args = " -DMIOPEN_USE_MLIR=" + conf.get("mlir_build", "ON")
@@ -75,7 +75,7 @@ def cmake_build(Map conf=[:]){
     if(conf.get("codecov", false)){ //Need
         setup_args = " -DCMAKE_BUILD_TYPE=debug -DCMAKE_CXX_FLAGS_DEBUG=\"${debug_flags} -fprofile-arcs -ftest-coverage\" -DCODECOV_TEST=On " + setup_args
     }else if(build_type_debug){
-        setup_args = " -DCMAKE_BUILD_TYPE=debug -DCMAKE_CXX_FLAGS_DEBUG='${debug_flags}'" + setup_args
+        setup_args = " -DCMAKE_BUILD_TYPE=debug -DCMAKE_CXX_FLAGS_DEBUG=\"${debug_flags}\"" + setup_args
     }else{
         setup_args = " -DCMAKE_BUILD_TYPE=release" + setup_args
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,7 +30,7 @@ def cmake_build(Map conf=[:]){
 
     def compiler = conf.get("compiler","/opt/rocm/llvm/bin/clang++")
     def make_targets = conf.get("make_targets","check")
-    def debug_flags = "-g -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined -Wno-option-ignored -fsanitize-ignorelist=$(pwd)/../UBSanSuppress.supp"  + conf.get("extradebugflags", "")
+    def debug_flags = "-g -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined -Wno-option-ignored -fsanitize-ignorelist=\$(pwd)/../UBSanSuppress.supp"  + conf.get("extradebugflags", "")
     def build_envs = "CTEST_PARALLEL_LEVEL=4 " + conf.get("build_env","")
     def prefixpath = conf.get("prefixpath","/opt/rocm")
     def mlir_args = " -DMIOPEN_USE_MLIR=" + conf.get("mlir_build", "ON")

--- a/UBSanIgnoreList.txt
+++ b/UBSanIgnoreList.txt
@@ -1,0 +1,1 @@
+src:*/shared_ptr_base.h

--- a/UBSanSuppress.supp
+++ b/UBSanSuppress.supp
@@ -1,0 +1,1 @@
+vptr:shared_ptr_base.h

--- a/UBSanSuppress.supp
+++ b/UBSanSuppress.supp
@@ -1,1 +1,0 @@
-vptr:shared_ptr_base.h

--- a/test/nightlies/JenkinsfileNightlyAux
+++ b/test/nightlies/JenkinsfileNightlyAux
@@ -46,7 +46,7 @@ def buildJob(compiler, flags, image, test, testargs){
             timeout(time: 8, unit: 'HOURS')
             {
                 sh "echo \$HSA_ENABLE_SDMA"
-                sh "rm -rf build; mkdir build; cd build; export PATH=/opt/rocm/bin:$PATH; CXX=${compiler} CXXFLAGS='-Werror' cmake -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS='--disable-verification-cache' -DCMAKE_CXX_FLAGS_DEBUG=\"-g -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined -fsanitize-ignorelist=$(pwd)/../UBSanSuppress.supp \" ${flags} .."
+                sh "rm -rf build; mkdir build; cd build; export PATH=/opt/rocm/bin:$PATH; CXX=${compiler} CXXFLAGS='-Werror' cmake -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS='--disable-verification-cache' -DCMAKE_CXX_FLAGS_DEBUG=\"-g -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined -fsanitize-ignorelist=\$(pwd)/../UBSanSuppress.supp \" ${flags} .."
                 sh "cd build; CTEST_PARALLEL_LEVEL=4 MIOPEN_VERIFY_CACHE_PATH=/var/jenkins/.cache/miopen/vcache dumb-init make -j\$(nproc) ${test}"
                 sh "MIOPEN_LOG_LEVEL=5 ./build/bin/${test} ${testargs}"
 

--- a/test/nightlies/JenkinsfileNightlyAux
+++ b/test/nightlies/JenkinsfileNightlyAux
@@ -46,7 +46,7 @@ def buildJob(compiler, flags, image, test, testargs){
             timeout(time: 8, unit: 'HOURS')
             {
                 sh "echo \$HSA_ENABLE_SDMA"
-                sh "rm -rf build; mkdir build; cd build; export PATH=/opt/rocm/bin:$PATH; CXX=${compiler} CXXFLAGS='-Werror' cmake -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS='--disable-verification-cache' -DCMAKE_CXX_FLAGS_DEBUG='-g -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined' ${flags} .."
+                sh "rm -rf build; mkdir build; cd build; export PATH=/opt/rocm/bin:$PATH; CXX=${compiler} CXXFLAGS='-Werror' cmake -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS='--disable-verification-cache' -DCMAKE_CXX_FLAGS_DEBUG=\"-g -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined -fsanitize-ignorelist=$(pwd)/../UBSanSuppress.supp \" ${flags} .."
                 sh "cd build; CTEST_PARALLEL_LEVEL=4 MIOPEN_VERIFY_CACHE_PATH=/var/jenkins/.cache/miopen/vcache dumb-init make -j\$(nproc) ${test}"
                 sh "MIOPEN_LOG_LEVEL=5 ./build/bin/${test} ${testargs}"
 

--- a/test/nightlies/JenkinsfileNightlyAux
+++ b/test/nightlies/JenkinsfileNightlyAux
@@ -46,7 +46,7 @@ def buildJob(compiler, flags, image, test, testargs){
             timeout(time: 8, unit: 'HOURS')
             {
                 sh "echo \$HSA_ENABLE_SDMA"
-                sh "rm -rf build; mkdir build; cd build; export PATH=/opt/rocm/bin:$PATH; CXX=${compiler} CXXFLAGS='-Werror' cmake -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS='--disable-verification-cache' -DCMAKE_CXX_FLAGS_DEBUG=\"-g -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined -fsanitize-ignorelist=\$(pwd)/../UBSanSuppress.supp \" ${flags} .."
+                sh "rm -rf build; mkdir build; cd build; export PATH=/opt/rocm/bin:$PATH; CXX=${compiler} CXXFLAGS='-Werror' cmake -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS='--disable-verification-cache' -DCMAKE_CXX_FLAGS_DEBUG=\"-g -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined -fsanitize-ignorelist=\$(pwd)/../UBSanIgnoreList.txt \" ${flags} .."
                 sh "cd build; CTEST_PARALLEL_LEVEL=4 MIOPEN_VERIFY_CACHE_PATH=/var/jenkins/.cache/miopen/vcache dumb-init make -j\$(nproc) ${test}"
                 sh "MIOPEN_LOG_LEVEL=5 ./build/bin/${test} ${testargs}"
 

--- a/test/nightlies/JenkinsfileNightlyConv2D
+++ b/test/nightlies/JenkinsfileNightlyConv2D
@@ -47,7 +47,7 @@ def buildJob(compiler, flags, image, test, testargs){
             timeout(time: 8, unit: 'HOURS')
             {
                 sh "echo \$HSA_ENABLE_SDMA"
-                sh "rm -rf build; mkdir build; cd build; export PATH=/opt/rocm/bin:$PATH; CXX=${compiler} CXXFLAGS='-Werror' cmake -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS='--disable-verification-cache' -DCMAKE_CXX_FLAGS_DEBUG=\"-g -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined -fsanitize-ignorelist=$(pwd)/../UBSanSuppress.supp \" ${flags} .."
+                sh "rm -rf build; mkdir build; cd build; export PATH=/opt/rocm/bin:$PATH; CXX=${compiler} CXXFLAGS='-Werror' cmake -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS='--disable-verification-cache' -DCMAKE_CXX_FLAGS_DEBUG=\"-g -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined -fsanitize-ignorelist=\$(pwd)/../UBSanSuppress.supp \" ${flags} .."
                 sh "cd build; CTEST_PARALLEL_LEVEL=4 MIOPEN_VERIFY_CACHE_PATH=/var/jenkins/.cache/miopen/vcache dumb-init make -j\$(nproc) ${test}"
                 sh "MIOPEN_LOG_LEVEL=6 ./build/bin/${test} ${testargs}"
 

--- a/test/nightlies/JenkinsfileNightlyConv2D
+++ b/test/nightlies/JenkinsfileNightlyConv2D
@@ -47,7 +47,7 @@ def buildJob(compiler, flags, image, test, testargs){
             timeout(time: 8, unit: 'HOURS')
             {
                 sh "echo \$HSA_ENABLE_SDMA"
-                sh "rm -rf build; mkdir build; cd build; export PATH=/opt/rocm/bin:$PATH; CXX=${compiler} CXXFLAGS='-Werror' cmake -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS='--disable-verification-cache' -DCMAKE_CXX_FLAGS_DEBUG='-g -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined' ${flags} .."
+                sh "rm -rf build; mkdir build; cd build; export PATH=/opt/rocm/bin:$PATH; CXX=${compiler} CXXFLAGS='-Werror' cmake -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS='--disable-verification-cache' -DCMAKE_CXX_FLAGS_DEBUG=\"-g -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined -fsanitize-ignorelist=$(pwd)/../UBSanSuppress.supp \" ${flags} .."
                 sh "cd build; CTEST_PARALLEL_LEVEL=4 MIOPEN_VERIFY_CACHE_PATH=/var/jenkins/.cache/miopen/vcache dumb-init make -j\$(nproc) ${test}"
                 sh "MIOPEN_LOG_LEVEL=6 ./build/bin/${test} ${testargs}"
 

--- a/test/nightlies/JenkinsfileNightlyConv2D
+++ b/test/nightlies/JenkinsfileNightlyConv2D
@@ -47,7 +47,7 @@ def buildJob(compiler, flags, image, test, testargs){
             timeout(time: 8, unit: 'HOURS')
             {
                 sh "echo \$HSA_ENABLE_SDMA"
-                sh "rm -rf build; mkdir build; cd build; export PATH=/opt/rocm/bin:$PATH; CXX=${compiler} CXXFLAGS='-Werror' cmake -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS='--disable-verification-cache' -DCMAKE_CXX_FLAGS_DEBUG=\"-g -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined -fsanitize-ignorelist=\$(pwd)/../UBSanSuppress.supp \" ${flags} .."
+                sh "rm -rf build; mkdir build; cd build; export PATH=/opt/rocm/bin:$PATH; CXX=${compiler} CXXFLAGS='-Werror' cmake -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS='--disable-verification-cache' -DCMAKE_CXX_FLAGS_DEBUG=\"-g -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined -fsanitize-ignorelist=\$(pwd)/../UBSanIgnoreList.txt \" ${flags} .."
                 sh "cd build; CTEST_PARALLEL_LEVEL=4 MIOPEN_VERIFY_CACHE_PATH=/var/jenkins/.cache/miopen/vcache dumb-init make -j\$(nproc) ${test}"
                 sh "MIOPEN_LOG_LEVEL=6 ./build/bin/${test} ${testargs}"
 

--- a/test/nightlies/JenkinsfileNightlyConv2Daux
+++ b/test/nightlies/JenkinsfileNightlyConv2Daux
@@ -48,7 +48,7 @@ def buildJob(compiler, flags, image, test, testargs){
             timeout(time: 8, unit: 'HOURS')
             {
                 sh "echo \$HSA_ENABLE_SDMA"
-                sh "rm -rf build; mkdir build; cd build; export PATH=/opt/rocm/bin:$PATH; CXX=${compiler} CXXFLAGS='-Werror' cmake -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS='--disable-verification-cache' -DCMAKE_CXX_FLAGS_DEBUG='-g -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined' ${flags} .."
+                sh "rm -rf build; mkdir build; cd build; export PATH=/opt/rocm/bin:$PATH; CXX=${compiler} CXXFLAGS='-Werror' cmake -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS='--disable-verification-cache' -DCMAKE_CXX_FLAGS_DEBUG=\"-g -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined -fsanitize-ignorelist=$(pwd)/../UBSanSuppress.supp \" ${flags} .."
                 sh "cd build; CTEST_PARALLEL_LEVEL=4 MIOPEN_VERIFY_CACHE_PATH=/var/jenkins/.cache/miopen/vcache dumb-init make -j\$(nproc) ${test}"
                 sh "MIOPEN_LOG_LEVEL=6 ./build/bin/${test} ${testargs}"
 

--- a/test/nightlies/JenkinsfileNightlyConv2Daux
+++ b/test/nightlies/JenkinsfileNightlyConv2Daux
@@ -48,7 +48,7 @@ def buildJob(compiler, flags, image, test, testargs){
             timeout(time: 8, unit: 'HOURS')
             {
                 sh "echo \$HSA_ENABLE_SDMA"
-                sh "rm -rf build; mkdir build; cd build; export PATH=/opt/rocm/bin:$PATH; CXX=${compiler} CXXFLAGS='-Werror' cmake -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS='--disable-verification-cache' -DCMAKE_CXX_FLAGS_DEBUG=\"-g -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined -fsanitize-ignorelist=$(pwd)/../UBSanSuppress.supp \" ${flags} .."
+                sh "rm -rf build; mkdir build; cd build; export PATH=/opt/rocm/bin:$PATH; CXX=${compiler} CXXFLAGS='-Werror' cmake -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS='--disable-verification-cache' -DCMAKE_CXX_FLAGS_DEBUG=\"-g -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined -fsanitize-ignorelist=\$(pwd)/../UBSanSuppress.supp \" ${flags} .."
                 sh "cd build; CTEST_PARALLEL_LEVEL=4 MIOPEN_VERIFY_CACHE_PATH=/var/jenkins/.cache/miopen/vcache dumb-init make -j\$(nproc) ${test}"
                 sh "MIOPEN_LOG_LEVEL=6 ./build/bin/${test} ${testargs}"
 

--- a/test/nightlies/JenkinsfileNightlyConv2Daux
+++ b/test/nightlies/JenkinsfileNightlyConv2Daux
@@ -48,7 +48,7 @@ def buildJob(compiler, flags, image, test, testargs){
             timeout(time: 8, unit: 'HOURS')
             {
                 sh "echo \$HSA_ENABLE_SDMA"
-                sh "rm -rf build; mkdir build; cd build; export PATH=/opt/rocm/bin:$PATH; CXX=${compiler} CXXFLAGS='-Werror' cmake -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS='--disable-verification-cache' -DCMAKE_CXX_FLAGS_DEBUG=\"-g -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined -fsanitize-ignorelist=\$(pwd)/../UBSanSuppress.supp \" ${flags} .."
+                sh "rm -rf build; mkdir build; cd build; export PATH=/opt/rocm/bin:$PATH; CXX=${compiler} CXXFLAGS='-Werror' cmake -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS='--disable-verification-cache' -DCMAKE_CXX_FLAGS_DEBUG=\"-g -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined -fsanitize-ignorelist=\$(pwd)/../UBSanIgnoreList.txt \" ${flags} .."
                 sh "cd build; CTEST_PARALLEL_LEVEL=4 MIOPEN_VERIFY_CACHE_PATH=/var/jenkins/.cache/miopen/vcache dumb-init make -j\$(nproc) ${test}"
                 sh "MIOPEN_LOG_LEVEL=6 ./build/bin/${test} ${testargs}"
 

--- a/test/nightlies/JenkinsfileNightlyFastFullConv2D
+++ b/test/nightlies/JenkinsfileNightlyFastFullConv2D
@@ -43,7 +43,7 @@ def buildJob(compiler, flags, image, test, testargs){
             timeout(time: 12, unit: 'HOURS')
             {
                 sh "echo \$HSA_ENABLE_SDMA"
-                sh "rm -rf build; mkdir build; cd build; CXX=${compiler} CXXFLAGS='-Werror' cmake -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS='--disable-verification-cache' -DCMAKE_CXX_FLAGS_DEBUG=\"-g -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined -fsanitize-ignorelist=$(pwd)/../UBSanSuppress.supp\" ${flags} .."
+                sh "rm -rf build; mkdir build; cd build; CXX=${compiler} CXXFLAGS='-Werror' cmake -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS='--disable-verification-cache' -DCMAKE_CXX_FLAGS_DEBUG=\"-g -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined -fsanitize-ignorelist=\$(pwd)/../UBSanSuppress.supp\" ${flags} .."
                 sh "cd build; CTEST_PARALLEL_LEVEL=4 MIOPEN_VERIFY_CACHE_PATH=/var/jenkins/.cache/miopen/vcache dumb-init make -j\$(nproc) ${test}"
                 sh "MIOPEN_ENABLE_LOGGING_CMD=1 MIOPEN_LOG_LEVEL=6 ./build/bin/${test} ${testargs}"
 

--- a/test/nightlies/JenkinsfileNightlyFastFullConv2D
+++ b/test/nightlies/JenkinsfileNightlyFastFullConv2D
@@ -43,7 +43,7 @@ def buildJob(compiler, flags, image, test, testargs){
             timeout(time: 12, unit: 'HOURS')
             {
                 sh "echo \$HSA_ENABLE_SDMA"
-                sh "rm -rf build; mkdir build; cd build; CXX=${compiler} CXXFLAGS='-Werror' cmake -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS='--disable-verification-cache' -DCMAKE_CXX_FLAGS_DEBUG=\"-g -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined -fsanitize-ignorelist=\$(pwd)/../UBSanSuppress.supp\" ${flags} .."
+                sh "rm -rf build; mkdir build; cd build; CXX=${compiler} CXXFLAGS='-Werror' cmake -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS='--disable-verification-cache' -DCMAKE_CXX_FLAGS_DEBUG=\"-g -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined -fsanitize-ignorelist=\$(pwd)/../UBSanIgnoreList.txt\" ${flags} .."
                 sh "cd build; CTEST_PARALLEL_LEVEL=4 MIOPEN_VERIFY_CACHE_PATH=/var/jenkins/.cache/miopen/vcache dumb-init make -j\$(nproc) ${test}"
                 sh "MIOPEN_ENABLE_LOGGING_CMD=1 MIOPEN_LOG_LEVEL=6 ./build/bin/${test} ${testargs}"
 

--- a/test/nightlies/JenkinsfileNightlyFastFullConv2D
+++ b/test/nightlies/JenkinsfileNightlyFastFullConv2D
@@ -43,7 +43,7 @@ def buildJob(compiler, flags, image, test, testargs){
             timeout(time: 12, unit: 'HOURS')
             {
                 sh "echo \$HSA_ENABLE_SDMA"
-                sh "rm -rf build; mkdir build; cd build; CXX=${compiler} CXXFLAGS='-Werror' cmake -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS='--disable-verification-cache' -DCMAKE_CXX_FLAGS_DEBUG='-g -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined' ${flags} .."
+                sh "rm -rf build; mkdir build; cd build; CXX=${compiler} CXXFLAGS='-Werror' cmake -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS='--disable-verification-cache' -DCMAKE_CXX_FLAGS_DEBUG=\"-g -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined -fsanitize-ignorelist=$(pwd)/../UBSanSuppress.supp\" ${flags} .."
                 sh "cd build; CTEST_PARALLEL_LEVEL=4 MIOPEN_VERIFY_CACHE_PATH=/var/jenkins/.cache/miopen/vcache dumb-init make -j\$(nproc) ${test}"
                 sh "MIOPEN_ENABLE_LOGGING_CMD=1 MIOPEN_LOG_LEVEL=6 ./build/bin/${test} ${testargs}"
 

--- a/test/nightlies/JenkinsfileNightlyFusions
+++ b/test/nightlies/JenkinsfileNightlyFusions
@@ -46,7 +46,7 @@ def buildJob(compiler, flags, image, test, testargs){
             timeout(time: 8, unit: 'HOURS')
             {
                 sh "echo \$HSA_ENABLE_SDMA"
-                sh "rm -rf build; mkdir build; cd build; export PATH=/opt/rocm/bin:$PATH; CXX=${compiler} CXXFLAGS='-Werror' cmake -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS='--disable-verification-cache' -DCMAKE_CXX_FLAGS_DEBUG=\"-g -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined -fsanitize-ignorelist=$(pwd)/../UBSanSuppress.supp\" ${flags} .."
+                sh "rm -rf build; mkdir build; cd build; export PATH=/opt/rocm/bin:$PATH; CXX=${compiler} CXXFLAGS='-Werror' cmake -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS='--disable-verification-cache' -DCMAKE_CXX_FLAGS_DEBUG=\"-g -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined -fsanitize-ignorelist=\$(pwd)/../UBSanSuppress.supp\" ${flags} .."
                 sh "cd build; CTEST_PARALLEL_LEVEL=4 MIOPEN_VERIFY_CACHE_PATH=/var/jenkins/.cache/miopen/vcache dumb-init make -j\$(nproc) ${test}"
                 sh "MIOPEN_LOG_LEVEL=5 ./build/bin/${test} ${testargs}"
 

--- a/test/nightlies/JenkinsfileNightlyFusions
+++ b/test/nightlies/JenkinsfileNightlyFusions
@@ -46,7 +46,7 @@ def buildJob(compiler, flags, image, test, testargs){
             timeout(time: 8, unit: 'HOURS')
             {
                 sh "echo \$HSA_ENABLE_SDMA"
-                sh "rm -rf build; mkdir build; cd build; export PATH=/opt/rocm/bin:$PATH; CXX=${compiler} CXXFLAGS='-Werror' cmake -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS='--disable-verification-cache' -DCMAKE_CXX_FLAGS_DEBUG=\"-g -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined -fsanitize-ignorelist=\$(pwd)/../UBSanSuppress.supp\" ${flags} .."
+                sh "rm -rf build; mkdir build; cd build; export PATH=/opt/rocm/bin:$PATH; CXX=${compiler} CXXFLAGS='-Werror' cmake -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS='--disable-verification-cache' -DCMAKE_CXX_FLAGS_DEBUG=\"-g -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined -fsanitize-ignorelist=\$(pwd)/../UBSanIgnoreList.txt\" ${flags} .."
                 sh "cd build; CTEST_PARALLEL_LEVEL=4 MIOPEN_VERIFY_CACHE_PATH=/var/jenkins/.cache/miopen/vcache dumb-init make -j\$(nproc) ${test}"
                 sh "MIOPEN_LOG_LEVEL=5 ./build/bin/${test} ${testargs}"
 

--- a/test/nightlies/JenkinsfileNightlyFusions
+++ b/test/nightlies/JenkinsfileNightlyFusions
@@ -46,7 +46,7 @@ def buildJob(compiler, flags, image, test, testargs){
             timeout(time: 8, unit: 'HOURS')
             {
                 sh "echo \$HSA_ENABLE_SDMA"
-                sh "rm -rf build; mkdir build; cd build; export PATH=/opt/rocm/bin:$PATH; CXX=${compiler} CXXFLAGS='-Werror' cmake -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS='--disable-verification-cache' -DCMAKE_CXX_FLAGS_DEBUG='-g -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined' ${flags} .."
+                sh "rm -rf build; mkdir build; cd build; export PATH=/opt/rocm/bin:$PATH; CXX=${compiler} CXXFLAGS='-Werror' cmake -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS='--disable-verification-cache' -DCMAKE_CXX_FLAGS_DEBUG=\"-g -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined -fsanitize-ignorelist=$(pwd)/../UBSanSuppress.supp\" ${flags} .."
                 sh "cd build; CTEST_PARALLEL_LEVEL=4 MIOPEN_VERIFY_CACHE_PATH=/var/jenkins/.cache/miopen/vcache dumb-init make -j\$(nproc) ${test}"
                 sh "MIOPEN_LOG_LEVEL=5 ./build/bin/${test} ${testargs}"
 

--- a/test/nightlies/JenkinsfileNightlyRNN
+++ b/test/nightlies/JenkinsfileNightlyRNN
@@ -47,7 +47,7 @@ def buildJob(compiler, flags, image, test, testargs){
             timeout(time: 8, unit: 'HOURS')
             {
                 sh "echo \$HSA_ENABLE_SDMA"
-                sh "rm -rf build; mkdir build; cd build; export PATH=/opt/rocm/bin:$PATH; CXX=${compiler} CXXFLAGS='-Werror' cmake -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS='--disable-verification-cache' -DCMAKE_CXX_FLAGS_DEBUG='-g -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined' ${flags} .."
+                sh "rm -rf build; mkdir build; cd build; export PATH=/opt/rocm/bin:$PATH; CXX=${compiler} CXXFLAGS='-Werror' cmake -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS='--disable-verification-cache' -DCMAKE_CXX_FLAGS_DEBUG=\"-g -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined -fsanitize-ignorelist=$(pwd)/../UBSanSuppress.supp\" ${flags} .."
                 sh "cd build; CTEST_PARALLEL_LEVEL=4 MIOPEN_VERIFY_CACHE_PATH=/var/jenkins/.cache/miopen/vcache dumb-init make -j\$(nproc) ${test}"
                 sh "MIOPEN_LOG_LEVEL=5 ./build/bin/${test} ${testargs}"
 

--- a/test/nightlies/JenkinsfileNightlyRNN
+++ b/test/nightlies/JenkinsfileNightlyRNN
@@ -47,7 +47,7 @@ def buildJob(compiler, flags, image, test, testargs){
             timeout(time: 8, unit: 'HOURS')
             {
                 sh "echo \$HSA_ENABLE_SDMA"
-                sh "rm -rf build; mkdir build; cd build; export PATH=/opt/rocm/bin:$PATH; CXX=${compiler} CXXFLAGS='-Werror' cmake -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS='--disable-verification-cache' -DCMAKE_CXX_FLAGS_DEBUG=\"-g -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined -fsanitize-ignorelist=\$(pwd)/../UBSanSuppress.supp\" ${flags} .."
+                sh "rm -rf build; mkdir build; cd build; export PATH=/opt/rocm/bin:$PATH; CXX=${compiler} CXXFLAGS='-Werror' cmake -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS='--disable-verification-cache' -DCMAKE_CXX_FLAGS_DEBUG=\"-g -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined -fsanitize-ignorelist=\$(pwd)/../UBSanIgnoreList.txt\" ${flags} .."
                 sh "cd build; CTEST_PARALLEL_LEVEL=4 MIOPEN_VERIFY_CACHE_PATH=/var/jenkins/.cache/miopen/vcache dumb-init make -j\$(nproc) ${test}"
                 sh "MIOPEN_LOG_LEVEL=5 ./build/bin/${test} ${testargs}"
 

--- a/test/nightlies/JenkinsfileNightlyRNN
+++ b/test/nightlies/JenkinsfileNightlyRNN
@@ -47,7 +47,7 @@ def buildJob(compiler, flags, image, test, testargs){
             timeout(time: 8, unit: 'HOURS')
             {
                 sh "echo \$HSA_ENABLE_SDMA"
-                sh "rm -rf build; mkdir build; cd build; export PATH=/opt/rocm/bin:$PATH; CXX=${compiler} CXXFLAGS='-Werror' cmake -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS='--disable-verification-cache' -DCMAKE_CXX_FLAGS_DEBUG=\"-g -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined -fsanitize-ignorelist=$(pwd)/../UBSanSuppress.supp\" ${flags} .."
+                sh "rm -rf build; mkdir build; cd build; export PATH=/opt/rocm/bin:$PATH; CXX=${compiler} CXXFLAGS='-Werror' cmake -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS='--disable-verification-cache' -DCMAKE_CXX_FLAGS_DEBUG=\"-g -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined -fsanitize-ignorelist=\$(pwd)/../UBSanSuppress.supp\" ${flags} .."
                 sh "cd build; CTEST_PARALLEL_LEVEL=4 MIOPEN_VERIFY_CACHE_PATH=/var/jenkins/.cache/miopen/vcache dumb-init make -j\$(nproc) ${test}"
                 sh "MIOPEN_LOG_LEVEL=5 ./build/bin/${test} ${testargs}"
 

--- a/test/nightlies/JenkinsfileNightlyReduce
+++ b/test/nightlies/JenkinsfileNightlyReduce
@@ -47,7 +47,7 @@ def buildJob(compiler, flags, image, test, testargs){
             timeout(time: 6, unit: 'HOURS')
             {
                 sh "echo \$HSA_ENABLE_SDMA"
-                sh "rm -rf build; mkdir build; cd build; export PATH=/opt/rocm/bin:$PATH; CXX=${compiler} CXXFLAGS='-Werror' cmake -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS='--disable-verification-cache' -DCMAKE_CXX_FLAGS_DEBUG=\"-g -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined -fsanitize-ignorelist=$(pwd)/../UBSanSuppress.supp\" ${flags} .."
+                sh "rm -rf build; mkdir build; cd build; export PATH=/opt/rocm/bin:$PATH; CXX=${compiler} CXXFLAGS='-Werror' cmake -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS='--disable-verification-cache' -DCMAKE_CXX_FLAGS_DEBUG=\"-g -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined -fsanitize-ignorelist=\$(pwd)/../UBSanSuppress.supp\" ${flags} .."
                 sh "cd build; CTEST_PARALLEL_LEVEL=4 MIOPEN_VERIFY_CACHE_PATH=/var/jenkins/.cache/miopen/vcache dumb-init make -j\$(nproc) ${test}"
                 sh "MIOPEN_LOG_LEVEL=5 ./build/bin/${test} ${testargs}"
 

--- a/test/nightlies/JenkinsfileNightlyReduce
+++ b/test/nightlies/JenkinsfileNightlyReduce
@@ -47,7 +47,7 @@ def buildJob(compiler, flags, image, test, testargs){
             timeout(time: 6, unit: 'HOURS')
             {
                 sh "echo \$HSA_ENABLE_SDMA"
-                sh "rm -rf build; mkdir build; cd build; export PATH=/opt/rocm/bin:$PATH; CXX=${compiler} CXXFLAGS='-Werror' cmake -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS='--disable-verification-cache' -DCMAKE_CXX_FLAGS_DEBUG=\"-g -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined -fsanitize-ignorelist=\$(pwd)/../UBSanSuppress.supp\" ${flags} .."
+                sh "rm -rf build; mkdir build; cd build; export PATH=/opt/rocm/bin:$PATH; CXX=${compiler} CXXFLAGS='-Werror' cmake -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS='--disable-verification-cache' -DCMAKE_CXX_FLAGS_DEBUG=\"-g -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined -fsanitize-ignorelist=\$(pwd)/../UBSanIgnoreList.txt\" ${flags} .."
                 sh "cd build; CTEST_PARALLEL_LEVEL=4 MIOPEN_VERIFY_CACHE_PATH=/var/jenkins/.cache/miopen/vcache dumb-init make -j\$(nproc) ${test}"
                 sh "MIOPEN_LOG_LEVEL=5 ./build/bin/${test} ${testargs}"
 

--- a/test/nightlies/JenkinsfileNightlyReduce
+++ b/test/nightlies/JenkinsfileNightlyReduce
@@ -47,7 +47,7 @@ def buildJob(compiler, flags, image, test, testargs){
             timeout(time: 6, unit: 'HOURS')
             {
                 sh "echo \$HSA_ENABLE_SDMA"
-                sh "rm -rf build; mkdir build; cd build; export PATH=/opt/rocm/bin:$PATH; CXX=${compiler} CXXFLAGS='-Werror' cmake -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS='--disable-verification-cache' -DCMAKE_CXX_FLAGS_DEBUG='-g -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined' ${flags} .."
+                sh "rm -rf build; mkdir build; cd build; export PATH=/opt/rocm/bin:$PATH; CXX=${compiler} CXXFLAGS='-Werror' cmake -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS='--disable-verification-cache' -DCMAKE_CXX_FLAGS_DEBUG=\"-g -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined -fsanitize-ignorelist=$(pwd)/../UBSanSuppress.supp\" ${flags} .."
                 sh "cd build; CTEST_PARALLEL_LEVEL=4 MIOPEN_VERIFY_CACHE_PATH=/var/jenkins/.cache/miopen/vcache dumb-init make -j\$(nproc) ${test}"
                 sh "MIOPEN_LOG_LEVEL=5 ./build/bin/${test} ${testargs}"
 

--- a/test/nightlies/JenkinsfileNightlyTensorOps
+++ b/test/nightlies/JenkinsfileNightlyTensorOps
@@ -48,7 +48,7 @@ def buildJob(compiler, flags, image, test, testargs){
             timeout(time: 6, unit: 'HOURS')
             {
                 sh "echo \$HSA_ENABLE_SDMA"
-                sh "rm -rf build; mkdir build; cd build; export PATH=/opt/rocm/bin:$PATH; CXX=${compiler} CXXFLAGS='-Werror' cmake -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS='--disable-verification-cache' -DCMAKE_CXX_FLAGS_DEBUG=\"-g -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined -fsanitize-ignorelist=\$(pwd)/../UBSanSuppress.supp\" ${flags} .."
+                sh "rm -rf build; mkdir build; cd build; export PATH=/opt/rocm/bin:$PATH; CXX=${compiler} CXXFLAGS='-Werror' cmake -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS='--disable-verification-cache' -DCMAKE_CXX_FLAGS_DEBUG=\"-g -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined -fsanitize-ignorelist=\$(pwd)/../UBSanIgnoreList.txt\" ${flags} .."
                 sh "cd build; CTEST_PARALLEL_LEVEL=4 MIOPEN_VERIFY_CACHE_PATH=/var/jenkins/.cache/miopen/vcache dumb-init make -j\$(nproc) ${test}"
                 sh "MIOPEN_LOG_LEVEL=5 ./build/bin/${test} ${testargs}"
 

--- a/test/nightlies/JenkinsfileNightlyTensorOps
+++ b/test/nightlies/JenkinsfileNightlyTensorOps
@@ -48,7 +48,7 @@ def buildJob(compiler, flags, image, test, testargs){
             timeout(time: 6, unit: 'HOURS')
             {
                 sh "echo \$HSA_ENABLE_SDMA"
-                sh "rm -rf build; mkdir build; cd build; export PATH=/opt/rocm/bin:$PATH; CXX=${compiler} CXXFLAGS='-Werror' cmake -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS='--disable-verification-cache' -DCMAKE_CXX_FLAGS_DEBUG='-g -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined' ${flags} .."
+                sh "rm -rf build; mkdir build; cd build; export PATH=/opt/rocm/bin:$PATH; CXX=${compiler} CXXFLAGS='-Werror' cmake -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS='--disable-verification-cache' -DCMAKE_CXX_FLAGS_DEBUG=\"-g -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined -fsanitize-ignorelist=$(pwd)/../UBSanSuppress.supp\" ${flags} .."
                 sh "cd build; CTEST_PARALLEL_LEVEL=4 MIOPEN_VERIFY_CACHE_PATH=/var/jenkins/.cache/miopen/vcache dumb-init make -j\$(nproc) ${test}"
                 sh "MIOPEN_LOG_LEVEL=5 ./build/bin/${test} ${testargs}"
 

--- a/test/nightlies/JenkinsfileNightlyTensorOps
+++ b/test/nightlies/JenkinsfileNightlyTensorOps
@@ -48,7 +48,7 @@ def buildJob(compiler, flags, image, test, testargs){
             timeout(time: 6, unit: 'HOURS')
             {
                 sh "echo \$HSA_ENABLE_SDMA"
-                sh "rm -rf build; mkdir build; cd build; export PATH=/opt/rocm/bin:$PATH; CXX=${compiler} CXXFLAGS='-Werror' cmake -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS='--disable-verification-cache' -DCMAKE_CXX_FLAGS_DEBUG=\"-g -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined -fsanitize-ignorelist=$(pwd)/../UBSanSuppress.supp\" ${flags} .."
+                sh "rm -rf build; mkdir build; cd build; export PATH=/opt/rocm/bin:$PATH; CXX=${compiler} CXXFLAGS='-Werror' cmake -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS='--disable-verification-cache' -DCMAKE_CXX_FLAGS_DEBUG=\"-g -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined -fsanitize-ignorelist=\$(pwd)/../UBSanSuppress.supp\" ${flags} .."
                 sh "cd build; CTEST_PARALLEL_LEVEL=4 MIOPEN_VERIFY_CACHE_PATH=/var/jenkins/.cache/miopen/vcache dumb-init make -j\$(nproc) ${test}"
                 sh "MIOPEN_LOG_LEVEL=5 ./build/bin/${test} ${testargs}"
 


### PR DESCRIPTION
Add suppressing ubsan errors for the file shared_ptr_base.h to workaround errors when upgrading to ROCm 6.2 in the base docker. 

See relevant PR #3181, and Issue #3192 for additional details.

The issue can be tracked down to simply creating the MLIR handle after upgrading to the latest ROCm 6.2.
Since we froze MLIR to an older release, suppressing this warning is our only real option.

Note: 
- Params used when constructing the MLIR handle to replicate, "--x2 1 --operation conv2d --kernel_id 0 --num_cu 104 --arch amdgcn-amd-amdhsa:gfx90a:sramecc+:xnack- --groupsize 1 --fil_layout GNCHW --fil_type fp32 --in_layout NGCHW --out_layout NGCHW --in_type fp32 --out_type fp32 --batchsize 100 --in_channels 25 --out_channels 300 --in_h 32 --in_w 32 --out_h 30 --out_w 30 --fil_h 3 --fil_w 3 --dilation_h 1 --dilation_w 1 --conv_stride_h 1 --conv_stride_w 1 --padding_h 0 --padding_w 0 --kernel_name mlir_gen_igemm_conv2d_v4r4_fwd_xdlops0". Simply creating a handle with those command line arguments will result in the vptr issue when the test application is exiting after upgrading to ROCm 6.2. 
- ROCm 6.2 also updated the version of clang.