### PR TITLE
[WA] Disable MLIR when building debug to workaround sanitizer issue

### DIFF
--- a/test/nightlies/JenkinsfileNightlyAux
+++ b/test/nightlies/JenkinsfileNightlyAux
@@ -46,7 +46,8 @@ def buildJob(compiler, flags, image, test, testargs){
             timeout(time: 8, unit: 'HOURS')
             {
                 sh "echo \$HSA_ENABLE_SDMA"
-                sh "rm -rf build; mkdir build; cd build; export PATH=/opt/rocm/bin:$PATH; CXX=${compiler} CXXFLAGS='-Werror' cmake -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS='--disable-verification-cache' -DCMAKE_CXX_FLAGS_DEBUG='-g -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined' ${flags} .."
+                // WORKAROUND_ISSUE_3192 Disabling MLIR for debug builds since MLIR generates sanitizer errors.
+                sh "rm -rf build; mkdir build; cd build; export PATH=/opt/rocm/bin:$PATH; CXX=${compiler} CXXFLAGS='-Werror' cmake -DMIOPEN_GPU_SYNC=On -DMIOPEN_USE_MLIR=OFF -DMIOPEN_TEST_FLAGS='--disable-verification-cache' -DCMAKE_CXX_FLAGS_DEBUG='-g -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined' ${flags} .."
                 sh "cd build; CTEST_PARALLEL_LEVEL=4 MIOPEN_VERIFY_CACHE_PATH=/var/jenkins/.cache/miopen/vcache dumb-init make -j\$(nproc) ${test}"
                 sh "MIOPEN_LOG_LEVEL=5 ./build/bin/${test} ${testargs}"
 

--- a/test/nightlies/JenkinsfileNightlyConv2D
+++ b/test/nightlies/JenkinsfileNightlyConv2D
@@ -47,7 +47,8 @@ def buildJob(compiler, flags, image, test, testargs){
             timeout(time: 8, unit: 'HOURS')
             {
                 sh "echo \$HSA_ENABLE_SDMA"
-                sh "rm -rf build; mkdir build; cd build; export PATH=/opt/rocm/bin:$PATH; CXX=${compiler} CXXFLAGS='-Werror' cmake -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS='--disable-verification-cache' -DCMAKE_CXX_FLAGS_DEBUG='-g -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined' ${flags} .."
+                // WORKAROUND_ISSUE_3192 Disabling MLIR for debug builds since MLIR generates sanitizer errors.
+                sh "rm -rf build; mkdir build; cd build; export PATH=/opt/rocm/bin:$PATH; CXX=${compiler} CXXFLAGS='-Werror' cmake -DMIOPEN_GPU_SYNC=On -DMIOPEN_USE_MLIR=OFF -DMIOPEN_TEST_FLAGS='--disable-verification-cache' -DCMAKE_CXX_FLAGS_DEBUG='-g -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined' ${flags} .."
                 sh "cd build; CTEST_PARALLEL_LEVEL=4 MIOPEN_VERIFY_CACHE_PATH=/var/jenkins/.cache/miopen/vcache dumb-init make -j\$(nproc) ${test}"
                 sh "MIOPEN_LOG_LEVEL=6 ./build/bin/${test} ${testargs}"
 

--- a/test/nightlies/JenkinsfileNightlyConv2Daux
+++ b/test/nightlies/JenkinsfileNightlyConv2Daux
@@ -48,7 +48,8 @@ def buildJob(compiler, flags, image, test, testargs){
             timeout(time: 8, unit: 'HOURS')
             {
                 sh "echo \$HSA_ENABLE_SDMA"
-                sh "rm -rf build; mkdir build; cd build; export PATH=/opt/rocm/bin:$PATH; CXX=${compiler} CXXFLAGS='-Werror' cmake -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS='--disable-verification-cache' -DCMAKE_CXX_FLAGS_DEBUG='-g -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined' ${flags} .."
+                // WORKAROUND_ISSUE_3192 Disabling MLIR for debug builds since MLIR generates sanitizer errors.
+                sh "rm -rf build; mkdir build; cd build; export PATH=/opt/rocm/bin:$PATH; CXX=${compiler} CXXFLAGS='-Werror' cmake -DMIOPEN_GPU_SYNC=On -DMIOPEN_USE_MLIR=OFF -DMIOPEN_TEST_FLAGS='--disable-verification-cache' -DCMAKE_CXX_FLAGS_DEBUG='-g -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined' ${flags} .."
                 sh "cd build; CTEST_PARALLEL_LEVEL=4 MIOPEN_VERIFY_CACHE_PATH=/var/jenkins/.cache/miopen/vcache dumb-init make -j\$(nproc) ${test}"
                 sh "MIOPEN_LOG_LEVEL=6 ./build/bin/${test} ${testargs}"
 

--- a/test/nightlies/JenkinsfileNightlyFastFullConv2D
+++ b/test/nightlies/JenkinsfileNightlyFastFullConv2D
@@ -43,7 +43,8 @@ def buildJob(compiler, flags, image, test, testargs){
             timeout(time: 12, unit: 'HOURS')
             {
                 sh "echo \$HSA_ENABLE_SDMA"
-                sh "rm -rf build; mkdir build; cd build; CXX=${compiler} CXXFLAGS='-Werror' cmake -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS='--disable-verification-cache' -DCMAKE_CXX_FLAGS_DEBUG='-g -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined' ${flags} .."
+                // WORKAROUND_ISSUE_3192 Disabling MLIR for debug builds since MLIR generates sanitizer errors.
+                sh "rm -rf build; mkdir build; cd build; CXX=${compiler} CXXFLAGS='-Werror' cmake -DMIOPEN_GPU_SYNC=On -DMIOPEN_USE_MLIR=OFF -DMIOPEN_TEST_FLAGS='--disable-verification-cache' -DCMAKE_CXX_FLAGS_DEBUG='-g -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined' ${flags} .."
                 sh "cd build; CTEST_PARALLEL_LEVEL=4 MIOPEN_VERIFY_CACHE_PATH=/var/jenkins/.cache/miopen/vcache dumb-init make -j\$(nproc) ${test}"
                 sh "MIOPEN_ENABLE_LOGGING_CMD=1 MIOPEN_LOG_LEVEL=6 ./build/bin/${test} ${testargs}"
 

--- a/test/nightlies/JenkinsfileNightlyFusions
+++ b/test/nightlies/JenkinsfileNightlyFusions
@@ -46,7 +46,8 @@ def buildJob(compiler, flags, image, test, testargs){
             timeout(time: 8, unit: 'HOURS')
             {
                 sh "echo \$HSA_ENABLE_SDMA"
-                sh "rm -rf build; mkdir build; cd build; export PATH=/opt/rocm/bin:$PATH; CXX=${compiler} CXXFLAGS='-Werror' cmake -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS='--disable-verification-cache' -DCMAKE_CXX_FLAGS_DEBUG='-g -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined' ${flags} .."
+                // WORKAROUND_ISSUE_3192 Disabling MLIR for debug builds since MLIR generates sanitizer errors.
+                sh "rm -rf build; mkdir build; cd build; export PATH=/opt/rocm/bin:$PATH; CXX=${compiler} CXXFLAGS='-Werror' cmake -DMIOPEN_GPU_SYNC=On -DMIOPEN_USE_MLIR=OFF -DMIOPEN_TEST_FLAGS='--disable-verification-cache' -DCMAKE_CXX_FLAGS_DEBUG='-g -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined' ${flags} .."
                 sh "cd build; CTEST_PARALLEL_LEVEL=4 MIOPEN_VERIFY_CACHE_PATH=/var/jenkins/.cache/miopen/vcache dumb-init make -j\$(nproc) ${test}"
                 sh "MIOPEN_LOG_LEVEL=5 ./build/bin/${test} ${testargs}"
 

--- a/test/nightlies/JenkinsfileNightlyRNN
+++ b/test/nightlies/JenkinsfileNightlyRNN
@@ -47,7 +47,8 @@ def buildJob(compiler, flags, image, test, testargs){
             timeout(time: 8, unit: 'HOURS')
             {
                 sh "echo \$HSA_ENABLE_SDMA"
-                sh "rm -rf build; mkdir build; cd build; export PATH=/opt/rocm/bin:$PATH; CXX=${compiler} CXXFLAGS='-Werror' cmake -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS='--disable-verification-cache' -DCMAKE_CXX_FLAGS_DEBUG='-g -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined' ${flags} .."
+                // WORKAROUND_ISSUE_3192 Disabling MLIR for debug builds since MLIR generates sanitizer errors.
+                sh "rm -rf build; mkdir build; cd build; export PATH=/opt/rocm/bin:$PATH; CXX=${compiler} CXXFLAGS='-Werror' cmake -DMIOPEN_GPU_SYNC=On -DMIOPEN_USE_MLIR=Off -DMIOPEN_TEST_FLAGS='--disable-verification-cache' -DCMAKE_CXX_FLAGS_DEBUG='-g -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined' ${flags} .."
                 sh "cd build; CTEST_PARALLEL_LEVEL=4 MIOPEN_VERIFY_CACHE_PATH=/var/jenkins/.cache/miopen/vcache dumb-init make -j\$(nproc) ${test}"
                 sh "MIOPEN_LOG_LEVEL=5 ./build/bin/${test} ${testargs}"
 

--- a/test/nightlies/JenkinsfileNightlyReduce
+++ b/test/nightlies/JenkinsfileNightlyReduce
@@ -47,7 +47,8 @@ def buildJob(compiler, flags, image, test, testargs){
             timeout(time: 6, unit: 'HOURS')
             {
                 sh "echo \$HSA_ENABLE_SDMA"
-                sh "rm -rf build; mkdir build; cd build; export PATH=/opt/rocm/bin:$PATH; CXX=${compiler} CXXFLAGS='-Werror' cmake -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS='--disable-verification-cache' -DCMAKE_CXX_FLAGS_DEBUG='-g -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined' ${flags} .."
+                // WORKAROUND_ISSUE_3192 Disabling MLIR for debug builds since MLIR generates sanitizer errors.
+                sh "rm -rf build; mkdir build; cd build; export PATH=/opt/rocm/bin:$PATH; CXX=${compiler} CXXFLAGS='-Werror' cmake -DMIOPEN_GPU_SYNC=On -DMIOPEN_USE_MLIR=OFF -DMIOPEN_TEST_FLAGS='--disable-verification-cache' -DCMAKE_CXX_FLAGS_DEBUG='-g -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined' ${flags} .."
                 sh "cd build; CTEST_PARALLEL_LEVEL=4 MIOPEN_VERIFY_CACHE_PATH=/var/jenkins/.cache/miopen/vcache dumb-init make -j\$(nproc) ${test}"
                 sh "MIOPEN_LOG_LEVEL=5 ./build/bin/${test} ${testargs}"
 

--- a/test/nightlies/JenkinsfileNightlyTensorOps
+++ b/test/nightlies/JenkinsfileNightlyTensorOps
@@ -48,7 +48,8 @@ def buildJob(compiler, flags, image, test, testargs){
             timeout(time: 6, unit: 'HOURS')
             {
                 sh "echo \$HSA_ENABLE_SDMA"
-                sh "rm -rf build; mkdir build; cd build; export PATH=/opt/rocm/bin:$PATH; CXX=${compiler} CXXFLAGS='-Werror' cmake -DMIOPEN_GPU_SYNC=On -DMIOPEN_TEST_FLAGS='--disable-verification-cache' -DCMAKE_CXX_FLAGS_DEBUG='-g -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined' ${flags} .."
+                // WORKAROUND_ISSUE_3192 Disabling MLIR for debug builds since MLIR generates sanitizer errors.
+                sh "rm -rf build; mkdir build; cd build; export PATH=/opt/rocm/bin:$PATH; CXX=${compiler} CXXFLAGS='-Werror' cmake -DMIOPEN_GPU_SYNC=On -DMIOPEN_USE_MLIR=Off -DMIOPEN_TEST_FLAGS='--disable-verification-cache' -DCMAKE_CXX_FLAGS_DEBUG='-g -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=undefined' ${flags} .."
                 sh "cd build; CTEST_PARALLEL_LEVEL=4 MIOPEN_VERIFY_CACHE_PATH=/var/jenkins/.cache/miopen/vcache dumb-init make -j\$(nproc) ${test}"
                 sh "MIOPEN_LOG_LEVEL=5 ./build/bin/${test} ${testargs}"
 


### PR DESCRIPTION
Update the build pipeline to disable compiling with MLIR when building debug builds.

See relevant PR #3181, PR #3198, and Issue #3192 for additional details.

After a discussion on PR #3198, we want to disable MLIR instead of suppressing the UBSan errors caused by MLIR.

The issue can be tracked down to simply creating the MLIR handle after upgrading to the latest ROCm 6.2.
Since we froze MLIR to an older release, suppressing this warning is our only real option.

Note:

Params used when constructing the MLIR handle to replicate, "--x2 1 --operation conv2d --kernel_id 0 --num_cu 104 --arch amdgcn-amd-amdhsa:gfx90a:sramecc+:xnack- --groupsize 1 --fil_layout GNCHW --fil_type fp32 --in_layout NGCHW --out_layout NGCHW --in_type fp32 --out_type fp32 --batchsize 100 --in_channels 25 --out_channels 300 --in_h 32 --in_w 32 --out_h 30 --out_w 30 --fil_h 3 --fil_w 3 --dilation_h 1 --dilation_w 1 --conv_stride_h 1 --conv_stride_w 1 --padding_h 0 --padding_w 0 --kernel_name mlir_gen_igemm_conv2d_v4r4_fwd_xdlops0". Simply creating a handle with those command line arguments will result in the vptr issue when the test application is exiting after upgrading to ROCm 6.2.
ROCm 6.2 also updated the version of clang.