### PR TITLE
Removed redundant boost::thread include

### DIFF
--- a/src/include/miopen/sqlite_db.hpp
+++ b/src/include/miopen/sqlite_db.hpp
@@ -42,8 +42,6 @@
 #include <boost/core/explicit_operator_bool.hpp>
 #include <boost/none.hpp>
 #include <boost/optional/optional.hpp>
-#include <boost/thread.hpp>
-#include <boost/thread/thread_time.hpp>
 #include "sqlite3.h"
 #include <mutex>
 #include <thread>


### PR DESCRIPTION
Ditto. This make it possible to build without boost::thread installed.
Useful when using vcpkg for managing dependencies or just manually installing them as boost::thread stops being manadatory for an unused include.