### PR TITLE
GenericSearch Patience

### DIFF
--- a/src/generic_search.cpp
+++ b/src/generic_search.cpp
@@ -61,11 +61,6 @@ std::chrono::milliseconds GetTuningTimeMax()
     return std::chrono::milliseconds{env::value(MIOPEN_TUNING_TIME_MS_MAX)};
 }
 
-std::size_t GetTuningPatience()
-{
-    return env::value(MIOPEN_TUNING_PATIENCE);
-}
-
 std::size_t GetTuningThreadsMax() { return env::value(MIOPEN_COMPILE_PARALLEL_LEVEL); }
 
 } // namespace solver

--- a/src/generic_search.cpp
+++ b/src/generic_search.cpp
@@ -61,6 +61,11 @@ std::chrono::milliseconds GetTuningTimeMax()
     return std::chrono::milliseconds{env::value(MIOPEN_TUNING_TIME_MS_MAX)};
 }
 
+std::size_t GetTuningPatience()
+{
+    return env::value(MIOPEN_TUNING_PATIENCE);
+}
+
 std::size_t GetTuningThreadsMax() { return env::value(MIOPEN_COMPILE_PARALLEL_LEVEL); }
 
 } // namespace solver

--- a/src/include/miopen/generic_search.hpp
+++ b/src/include/miopen/generic_search.hpp
@@ -398,6 +398,7 @@ auto GenericSearch(const Solver s,
     std::shuffle(all_configs.begin(), all_configs.end(), rng);
     std::size_t n_runs_total = std::min(all_configs.size(), GetTuningIterationsMax());
     all_configs.resize(n_runs_total);
+    std::size_t patience = GetTuningPatience();
 
     if(all_configs.empty())
     {
@@ -443,11 +444,16 @@ auto GenericSearch(const Solver s,
     if(!env::enabled(MIOPEN_DEBUG_COMPILE_ONLY))
     {
         size_t n_current       = 0;
+        size_t last_imprv      = 0;
         auto threads_remaining = total_threads;
         while(true)
         {
             if(n_current >= n_runs_total)
                 break;
+            if(last_imprv >= patience)
+                break;
+
+            last_imprv++;
             MIOPEN_LOG_I2("Waiting for item in queue");
             const auto kinder     = solution_queue.pop();
             auto current_config   = std::get<0>(kinder);
@@ -541,6 +547,7 @@ auto GenericSearch(const Solver s,
                             best_config = current_config;
                             best_time   = elapsed_time;
                             n_best      = n_current;
+                            last_imprv  = 0;
                         }
                         else
                         {

--- a/src/include/miopen/generic_search.hpp
+++ b/src/include/miopen/generic_search.hpp
@@ -450,15 +450,15 @@ auto GenericSearch(const Solver s,
         while(true)
         {
             if(n_current >= n_runs_total)
-	    {
+            {
                 MIOPEN_LOG_I2("Ending Search by total runs: " << n_runs_total);
                 break;
-	    }
+            }
             if(last_imprv >= patience)
-	    {
+            {
                 MIOPEN_LOG_I2("Ending Search by patience: " << patience);
                 break;
-	    }
+            }
 
             last_imprv++;
             MIOPEN_LOG_I2("Waiting for item in queue");

--- a/src/include/miopen/generic_search.hpp
+++ b/src/include/miopen/generic_search.hpp
@@ -316,7 +316,6 @@ GetAllSolutions(const Solver s, const Context& context_, const Problem& problem)
 
 std::size_t GetTuningIterationsMax();
 std::chrono::milliseconds GetTuningTimeMax(); // returns the max allowed time in milliseconds
-std::size_t GetTuningPatience();
 std::size_t GetTuningThreadsMax();
 
 template <typename PerformanceConfig, typename Solver, typename Context, typename Problem>
@@ -399,7 +398,7 @@ auto GenericSearch(const Solver s,
     std::shuffle(all_configs.begin(), all_configs.end(), rng);
     std::size_t n_runs_total = std::min(all_configs.size(), GetTuningIterationsMax());
     all_configs.resize(n_runs_total);
-    std::size_t patience = GetTuningPatience();
+    std::size_t patience = env::value(MIOPEN_TUNING_PATIENCE);
 
     if(all_configs.empty())
     {

--- a/src/include/miopen/generic_search.hpp
+++ b/src/include/miopen/generic_search.hpp
@@ -450,9 +450,15 @@ auto GenericSearch(const Solver s,
         while(true)
         {
             if(n_current >= n_runs_total)
+	    {
+                MIOPEN_LOG_I2("Ending Search by total runs: " << n_runs_total);
                 break;
+	    }
             if(last_imprv >= patience)
+	    {
+                MIOPEN_LOG_I2("Ending Search by patience: " << patience);
                 break;
+	    }
 
             last_imprv++;
             MIOPEN_LOG_I2("Waiting for item in queue");

--- a/src/include/miopen/generic_search.hpp
+++ b/src/include/miopen/generic_search.hpp
@@ -316,6 +316,7 @@ GetAllSolutions(const Solver s, const Context& context_, const Problem& problem)
 
 std::size_t GetTuningIterationsMax();
 std::chrono::milliseconds GetTuningTimeMax(); // returns the max allowed time in milliseconds
+std::size_t GetTuningPatience();
 std::size_t GetTuningThreadsMax();
 
 template <typename PerformanceConfig, typename Solver, typename Context, typename Problem>

--- a/src/include/miopen/generic_search_controls.hpp
+++ b/src/include/miopen/generic_search_controls.hpp
@@ -35,8 +35,9 @@ MIOPEN_DECLARE_ENV_VAR_UINT64(MIOPEN_DEBUG_TUNING_ITERATIONS_MAX,
 MIOPEN_DECLARE_ENV_VAR_UINT64(
     MIOPEN_TUNING_TIME_MS_MAX,
     std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::hours{2}).count())
-MIOPEN_DECLARE_ENV_VAR_UINT64(MIOPEN_TUNING_PATIENCE,
-                              std::numeric_limits<std::size_t>::max()) // End tuning if no improvement in X iterations
+MIOPEN_DECLARE_ENV_VAR_UINT64(
+    MIOPEN_TUNING_PATIENCE,
+    std::numeric_limits<std::size_t>::max()) // End tuning if no improvement in X iterations
 
 #if MIOPEN_USE_COMGR
 MIOPEN_DECLARE_ENV_VAR_UINT64(MIOPEN_COMPILE_PARALLEL_LEVEL, 1) // COMGR is not parallelizable

--- a/src/include/miopen/generic_search_controls.hpp
+++ b/src/include/miopen/generic_search_controls.hpp
@@ -35,6 +35,8 @@ MIOPEN_DECLARE_ENV_VAR_UINT64(MIOPEN_DEBUG_TUNING_ITERATIONS_MAX,
 MIOPEN_DECLARE_ENV_VAR_UINT64(
     MIOPEN_TUNING_TIME_MS_MAX,
     std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::hours{2}).count())
+MIOPEN_DECLARE_ENV_VAR_UINT64(MIOPEN_TUNING_PATIENCE,
+                              std::numeric_limits<std::size_t>::max()) // End tuning if no improvement in X iterations
 
 #if MIOPEN_USE_COMGR
 MIOPEN_DECLARE_ENV_VAR_UINT64(MIOPEN_COMPILE_PARALLEL_LEVEL, 1) // COMGR is not parallelizable


### PR DESCRIPTION
Adds environment variable MIOPEN_TUNING_PATIENCE which will allow the user to set the maximum number of performance configurations GenericSearch will iterate through without improvement before quitting.