### PR TITLE
[gTests]Fix GTEST_SKIP kills all gtests in miopen_gtest

### DIFF
--- a/test/gtest/api_convbiasactiv.cpp
+++ b/test/gtest/api_convbiasactiv.cpp
@@ -36,6 +36,7 @@
 
 #include "tensor_util.hpp"
 #include "get_handle.hpp"
+#include "gtest_common.hpp"
 
 struct CBATestCase
 {
@@ -64,6 +65,18 @@ struct CBATestCase
     }
 };
 
+bool IsTestSupportedForDevice()
+{
+#if WORKAROUND_ISSUE_2212
+    using namespace miopen::debug;
+    using e_mask = enabled<Gpu::gfx900, Gpu::gfx906, Gpu::gfx908, Gpu::gfx90A, Gpu::gfx103X>;
+    using d_mask = disabled<Gpu::gfx110X, Gpu::gfx94X>;
+    return ::IsTestSupportedForDevMask<d_mask, e_mask>();
+#else
+    return true;
+#endif
+}
+
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(GPU_ConvBiasActivFwd_FP32);
 struct GPU_ConvBiasActivFwd_FP32
     : public ::testing::TestWithParam<std::tuple<miopenConvFwdAlgorithm_t, CBATestCase>>
@@ -71,6 +84,10 @@ struct GPU_ConvBiasActivFwd_FP32
 protected:
     void SetUp() override
     {
+        if(!IsTestSupportedForDevice())
+        {
+            GTEST_SKIP();
+        }
         std::tie(algo, cba_config) = GetParam();
         const double double_zero   = 0.0f;
         input   = tensor<float>{cba_config.N, cba_config.C, cba_config.H, cba_config.W};
@@ -151,52 +168,35 @@ protected:
 
 TEST_P(GPU_ConvBiasActivFwd_FP32, DISABLED_DriveAPI)
 {
-    const auto dev_name = get_handle().GetDeviceName();
-#if WORKAROUND_ISSUE_2212
-    if(!miopen::StartsWith(dev_name, "gfx11") && !miopen::StartsWith(dev_name, "gfx94"))
-#endif
-    {
 
-        tensor<float> z{};
-        const float alpha = 1.0f;
-        const auto status = miopenConvolutionBiasActivationForward(&get_handle(),
-                                                                   &alpha,
-                                                                   &input.desc,
-                                                                   in_dev.get(),
-                                                                   &weights.desc,
-                                                                   wei_dev.get(),
-                                                                   conv_desc,
-                                                                   algo,
-                                                                   nullptr,
-                                                                   0,
-                                                                   &alpha,
-                                                                   &z.desc,
-                                                                   nullptr,
-                                                                   &bias.desc,
-                                                                   bias_dev.get(),
-                                                                   activ_desc,
-                                                                   &output.desc,
-                                                                   out_dev.get());
-        EXPECT_EQ(status, miopenStatusSuccess);
-    }
-    else
-    {
-        GTEST_SKIP() << " Skipping fusion test on unsupported ASIC";
-    }
-}
-
-void GatherCBATestCases(std::vector<CBATestCase>& cba_test_cases)
-{
-    cba_test_cases.push_back(CBATestCase{
-        16, 128, 16, 16, 128, 3, 3, 0, 0, 1, 1, 1, 1, miopenActivationRELU, miopenConvolution});
+    tensor<float> z{};
+    const float alpha = 1.0f;
+    const auto status = miopenConvolutionBiasActivationForward(&get_handle(),
+                                                               &alpha,
+                                                               &input.desc,
+                                                               in_dev.get(),
+                                                               &weights.desc,
+                                                               wei_dev.get(),
+                                                               conv_desc,
+                                                               algo,
+                                                               nullptr,
+                                                               0,
+                                                               &alpha,
+                                                               &z.desc,
+                                                               nullptr,
+                                                               &bias.desc,
+                                                               bias_dev.get(),
+                                                               activ_desc,
+                                                               &output.desc,
+                                                               out_dev.get());
+    EXPECT_EQ(status, miopenStatusSuccess);
 }
 
 // Extra layer of indirection introduced since GTEST_SKIP() cannot be called from non-void function.
 std::vector<CBATestCase> GetTestValues()
 {
-    std::vector<CBATestCase> cba_test_cases;
-    GatherCBATestCases(cba_test_cases);
-    return cba_test_cases;
+    return {
+        {16, 128, 16, 16, 128, 3, 3, 0, 0, 1, 1, 1, 1, miopenActivationRELU, miopenConvolution}};
 }
 INSTANTIATE_TEST_SUITE_P(Full,
                          GPU_ConvBiasActivFwd_FP32,

--- a/test/gtest/api_convbiasactiv.cpp
+++ b/test/gtest/api_convbiasactiv.cpp
@@ -151,43 +151,44 @@ protected:
 
 TEST_P(GPU_ConvBiasActivFwd_FP32, DISABLED_DriveAPI)
 {
-    tensor<float> z{};
-    const float alpha = 1.0f;
-    const auto status = miopenConvolutionBiasActivationForward(&get_handle(),
-                                                               &alpha,
-                                                               &input.desc,
-                                                               in_dev.get(),
-                                                               &weights.desc,
-                                                               wei_dev.get(),
-                                                               conv_desc,
-                                                               algo,
-                                                               nullptr,
-                                                               0,
-                                                               &alpha,
-                                                               &z.desc,
-                                                               nullptr,
-                                                               &bias.desc,
-                                                               bias_dev.get(),
-                                                               activ_desc,
-                                                               &output.desc,
-                                                               out_dev.get());
-    EXPECT_EQ(status, miopenStatusSuccess);
-}
-
-void GatherCBATestCases(std::vector<CBATestCase>& cba_test_cases)
-{
     const auto dev_name = get_handle().GetDeviceName();
 #if WORKAROUND_ISSUE_2212
     if(!miopen::StartsWith(dev_name, "gfx11") && !miopen::StartsWith(dev_name, "gfx94"))
 #endif
     {
-        cba_test_cases.push_back(CBATestCase{
-            16, 128, 16, 16, 128, 3, 3, 0, 0, 1, 1, 1, 1, miopenActivationRELU, miopenConvolution});
+
+        tensor<float> z{};
+        const float alpha = 1.0f;
+        const auto status = miopenConvolutionBiasActivationForward(&get_handle(),
+                                                                   &alpha,
+                                                                   &input.desc,
+                                                                   in_dev.get(),
+                                                                   &weights.desc,
+                                                                   wei_dev.get(),
+                                                                   conv_desc,
+                                                                   algo,
+                                                                   nullptr,
+                                                                   0,
+                                                                   &alpha,
+                                                                   &z.desc,
+                                                                   nullptr,
+                                                                   &bias.desc,
+                                                                   bias_dev.get(),
+                                                                   activ_desc,
+                                                                   &output.desc,
+                                                                   out_dev.get());
+        EXPECT_EQ(status, miopenStatusSuccess);
     }
     else
     {
         GTEST_SKIP() << " Skipping fusion test on unsupported ASIC";
     }
+}
+
+void GatherCBATestCases(std::vector<CBATestCase>& cba_test_cases)
+{
+    cba_test_cases.push_back(CBATestCase{
+        16, 128, 16, 16, 128, 3, 3, 0, 0, 1, 1, 1, 1, miopenActivationRELU, miopenConvolution});
 }
 
 // Extra layer of indirection introduced since GTEST_SKIP() cannot be called from non-void function.


### PR DESCRIPTION
miopen_gtest wouldn't start on e.g. Navi3x as below. This is because GTEST_SKIP() is invoked in a global environment setup. The fix is to skip the test in TEST_P(). Log with the fix is attached at the bottom.

root@aus-navi3x-09:/MIOpen/build/bin# ./miopen_gtest
Running main() from /opt/rocm/cget/build/tmp-c4f1a42bcee536579a1248d25169f834201170c187fc6d80e8c510a7d28f6f48/googletest-1.14.0/googletest/src/gtest_main                                                                                                          .cc
/MIOpen/test/gtest/api_convbiasactiv.cpp:189: Skipped
 Skipping fusion test on unsupported ASIC

PRNG seed: 12345678
[==========] Running 8939 tests from 394 test suites.
[----------] Global test environment set-up.
 Skipping fusion test on unsupported ASIC

[----------] Global test environment tear-down
[==========] 8939 tests from 394 test suites ran. (0 ms total)
[  PASSED  ] 8939 tests.

  YOU HAVE 133 DISABLED TESTS
  
  Log with the fix on Navi3x
[navi3x.log](https://github.com/user-attachments/files/16757739/navi3x.log)

  