### PR TITLE
Gtest header patch for pre-c++17 compatibility

### DIFF
--- a/test/gtest/perf_helper.hpp
+++ b/test/gtest/perf_helper.hpp
@@ -110,7 +110,7 @@ struct PerfHelper
         }
 
         // If the file was just created (i.e., its size is 0), write the header.
-        if(fs::file_size(filename) == 0)
+        if(miopen::fs::file_size(filename) == 0)
         {
             file << "KernelAndTestInfo,min_exec_time_ratio,max_exec_time_ratio,mean_exec_time_"
                     "ratio,median_exec_time_ratio,SD_ocl,SD_hip\n";

--- a/test/gtest/perf_helper.hpp
+++ b/test/gtest/perf_helper.hpp
@@ -110,8 +110,7 @@ struct PerfHelper
         }
 
         // If the file was just created (i.e., its size is 0), write the header.
-        file.seekp(0, std::ios_base::end);
-        if(file.tellp() == 0)
+        if(fs::file_size(filename) == 0)
         {
             file << "KernelAndTestInfo,min_exec_time_ratio,max_exec_time_ratio,mean_exec_time_"
                     "ratio,median_exec_time_ratio,SD_ocl,SD_hip\n";

--- a/test/gtest/perf_helper.hpp
+++ b/test/gtest/perf_helper.hpp
@@ -110,7 +110,8 @@ struct PerfHelper
         }
 
         // If the file was just created (i.e., its size is 0), write the header.
-        if(std::filesystem::file_size(filename) == 0)
+        file.seekp(0, std::ios_base::end);
+        if(file.tellp() == 0)
         {
             file << "KernelAndTestInfo,min_exec_time_ratio,max_exec_time_ratio,mean_exec_time_"
                     "ratio,median_exec_time_ratio,SD_ocl,SD_hip\n";


### PR DESCRIPTION
patch gtest header for compatibility with pre-c++17

Some docker packages are failing to build make check with reference to std::filesystem
like compute-artifactory.amd.com:5000/rocm-plus-docker/compute-rocm-dkms-no-npi-hipclang:14644-sles-stg2

This removes reference to std::filesystem while preserving intent.