### PR TITLE
GTests renaming: Letters "T"-"Z". Enabling name checker

### DIFF
--- a/test/gtest/bn_infer.cpp
+++ b/test/gtest/bn_infer.cpp
@@ -71,22 +71,22 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
                          testing::Combine(testing::ValuesIn(Network1<BNTestCase>()),
                                           testing::Values(miopenTensorNCHW)));
 
-INSTANTIATE_TEST_SUITE_P(BNInferTestHalfSuiteNHWC,
+INSTANTIATE_TEST_SUITE_P(Smoke,
                          GPU_BNInferNHWC_FP16,
                          testing::Combine(testing::ValuesIn(Network1<BNTestCase>()),
                                           testing::Values(miopenTensorNHWC)));
 
-INSTANTIATE_TEST_SUITE_P(BNInferTestFloatSuite,
+INSTANTIATE_TEST_SUITE_P(Smoke,
                          GPU_BNInfer_FP32,
                          testing::Combine(testing::ValuesIn(Network1<BNTestCase>()),
                                           testing::ValuesIn({miopenTensorNHWC, miopenTensorNCHW})));
 
-INSTANTIATE_TEST_SUITE_P(BNInferTestDoubleNHWCSuite,
+INSTANTIATE_TEST_SUITE_P(Smoke,
                          GPU_BNInfer_FP64,
                          testing::Combine(testing::ValuesIn(Network1<BNTestCase>()),
                                           testing::ValuesIn({miopenTensorNHWC})));
 
-INSTANTIATE_TEST_SUITE_P(BNInferTestBFloat16NHWCSuite,
+INSTANTIATE_TEST_SUITE_P(Smoke,
                          GPU_BNInfer_BFP16,
                          testing::Combine(testing::ValuesIn(Network1<BNTestCase>()),
                                           testing::ValuesIn({miopenTensorNHWC})));

--- a/test/gtest/check_names.py
+++ b/test/gtest/check_names.py
@@ -39,7 +39,7 @@ logger = logging.getLogger("GTest name checker")
 re_prefix = re.compile(r"^((Smoke.*)|(Full.*)|(Perf.*)|(Unit.*))$")
 re_hw = re.compile(r"^((CPU)|(GPU))$")
 re_datatype = re.compile(
-    r"^((FP((8)|(16)|(32)|(64)))|(BFP((8)|(16)))|(I((8)|(16)|(32)|(64)))|(NONE))\.$"
+    r"^((FP((8)|(16)|(32)|(64)))|(BFP((8)|(16)))|(I((8)|(16)|(32)|(64)))|(NONE))\.?$"
 )
 
 
@@ -76,6 +76,12 @@ def parse_tests(args):
             if len(full_name) == 2:
                 prefix = re.search(re_prefix, full_name[0])
                 name = full_name[1].split("_")
+
+                # Try to recognize pattern like HW_NAME_TYPE/<number>. This pattern is used in case of TYPED_TEST_SUITE
+                if not prefix and full_name[1].replace(".", "").isnumeric():
+                    name = full_name[0].split("_")
+                    prefix = ["empty"]
+
             else:
                 prefix = ["empty"]
                 name = full_name[0].split("_")

--- a/test/gtest/check_names.py
+++ b/test/gtest/check_names.py
@@ -36,10 +36,10 @@ logging.basicConfig(level=logging.WARNING)
 logger = logging.getLogger("GTest name checker")
 
 """regexp based on https://github.com/ROCm/MIOpen/wiki/GTest-development#naming"""
-re_prefix = re.compile(r"^((Smoke)|(Full)|(Perf)|(Unit.*))$")
+re_prefix = re.compile(r"^((Smoke.*)|(Full.*)|(Perf.*)|(Unit.*))$")
 re_hw = re.compile(r"^((CPU)|(GPU))$")
 re_datatype = re.compile(
-    r"^((FP((8)|(16)|(32)|(64)))|(BFP((8)|(16)))|(I((8)|(32)))|(NONE))\.$"
+    r"^((FP((8)|(16)|(32)|(64)))|(BFP((8)|(16)))|(I((8)|(16)|(32)|(64)))|(NONE))\.$"
 )
 
 
@@ -96,7 +96,7 @@ def parse_tests(args):
             logger.critical(
                 "Tests do not match to the test naming scheme (see https://github.com/ROCm/MIOpen/wiki/GTest-development#naming )"
             )
-            # return -1  # uncomment when all the tests will be renamed
+            return -1  # uncomment when all the tests will be renamed
     return 0
 
 

--- a/test/gtest/conv_igemm_dynamic_xdlops_half.cpp
+++ b/test/gtest/conv_igemm_dynamic_xdlops_half.cpp
@@ -161,6 +161,6 @@ TEST_P(GPU_Conv2dHalf_conv_igemm_dynamic_xdlops_FP16, HalfTest_conv_igemm_dynami
     }
 };
 
-INSTANTIATE_TEST_SUITE_P(ConvIgemmDynamicXdlopsFwdWrw,
+INSTANTIATE_TEST_SUITE_P(Full,
                          GPU_Conv2dHalf_conv_igemm_dynamic_xdlops_FP16,
                          testing::Values(GetTestCases("--half")));

--- a/test/gtest/db_sync.cpp
+++ b/test/gtest/db_sync.cpp
@@ -463,7 +463,7 @@ void SetupPaths(fs::path& fdb_file_path,
         << "Db file does not exist" << kdb_file_path;
 }
 
-TEST(DBSync, KDBTargetID)
+TEST(CPU_DBSync_NONE, KDBTargetID)
 {
     if(env::enabled(MIOPEN_TEST_DBSYNC))
     {

--- a/test/gtest/graphapi_conv_bias_res_add_activ_fwd.cpp
+++ b/test/gtest/graphapi_conv_bias_res_add_activ_fwd.cpp
@@ -479,7 +479,7 @@ using namespace conv_graph_api_test;
     {                                                                               \
     };                                                                              \
     TEST_P(GPU_ConvBiasResAddActivation_##dir##_##type, Test) { Run(); }            \
-    INSTANTIATE_TEST_SUITE_P(GPU_ConvBiasResAddActivation_##dir##_##type##_Suite,   \
+    INSTANTIATE_TEST_SUITE_P(Smoke,                                                 \
                              GPU_ConvBiasResAddActivation_##dir##_##type,           \
                              testing::Combine(testing::ValuesIn(ConvTestConfigs()), \
                                               testing::ValuesIn({1.0f, 2.5f}),      \
@@ -489,4 +489,4 @@ using namespace conv_graph_api_test;
 
 DEFINE_GRAPH_API_CONV_BIAS_ACTIV_TEST(FP16, half_float::half, fwd);
 DEFINE_GRAPH_API_CONV_BIAS_ACTIV_TEST(FP32, float, fwd);
-DEFINE_GRAPH_API_CONV_BIAS_ACTIV_TEST(BF16, bfloat16, fwd);
+DEFINE_GRAPH_API_CONV_BIAS_ACTIV_TEST(BFP16, bfloat16, fwd);

--- a/test/gtest/graphapi_convolution.cpp
+++ b/test/gtest/graphapi_convolution.cpp
@@ -45,7 +45,7 @@ using GraphApiConvolutionTuple = std::tuple<bool,
                                             std::vector<int64_t>,
                                             std::vector<int64_t>>;
 
-class GraphApiConvolution : public testing::TestWithParam<GraphApiConvolutionTuple>
+class CPU_GraphApiConvolution_NONE : public testing::TestWithParam<GraphApiConvolutionTuple>
 {
 protected:
     void SetUp() override
@@ -69,7 +69,7 @@ protected:
     bool attrsValid;
 };
 
-TEST_P(GraphApiConvolution, BuilderValidateAttributes)
+TEST_P(CPU_GraphApiConvolution_NONE, BuilderValidateAttributes)
 {
     bool thrown = false;
     try
@@ -110,7 +110,7 @@ TEST_P(GraphApiConvolution, BuilderValidateAttributes)
     EXPECT_NE(thrown, attrsValid) << "L-value builder failure";
 }
 
-TEST_P(GraphApiConvolution, RVBuilderMissingSetter)
+TEST_P(CPU_GraphApiConvolution_NONE, RVBuilderMissingSetter)
 {
     EXPECT_ANY_THROW({
         auto conv = miopen::graphapi::ConvolutionBuilder()
@@ -197,7 +197,7 @@ TEST_P(GraphApiConvolution, RVBuilderMissingSetter)
           "graphapi::ConvolutionBuilder::setPostPaddings() call";
 }
 
-TEST_P(GraphApiConvolution, LVBuilderMissingSetter)
+TEST_P(CPU_GraphApiConvolution_NONE, LVBuilderMissingSetter)
 {
     EXPECT_ANY_THROW({
         miopen::graphapi::ConvolutionBuilder builder;
@@ -284,7 +284,7 @@ TEST_P(GraphApiConvolution, LVBuilderMissingSetter)
           "graphapi::ConvolutionBuilder::setPostPaddings() call";
 }
 
-TEST_P(GraphApiConvolution, BuilderCopyValues)
+TEST_P(CPU_GraphApiConvolution_NONE, BuilderCopyValues)
 {
     auto srcDilations     = dilations;
     auto srcFilterStrides = filterStrides;
@@ -344,7 +344,7 @@ TEST_P(GraphApiConvolution, BuilderCopyValues)
         << "graphapi::ConvolutionBuilder::setPostPaddings unexpectedly moved the parameter";
 }
 
-TEST_P(GraphApiConvolution, BuilderMoveValues)
+TEST_P(CPU_GraphApiConvolution_NONE, BuilderMoveValues)
 {
     auto srcDilations     = dilations;
     auto srcFilterStrides = filterStrides;
@@ -404,7 +404,7 @@ TEST_P(GraphApiConvolution, BuilderMoveValues)
         << "graphapi::ConvolutionBuilder::setPostPaddings didn't move the parameter";
 }
 
-TEST_P(GraphApiConvolution, CFunctions)
+TEST_P(CPU_GraphApiConvolution_NONE, CFunctions)
 {
     // clang-format off
     // Create Desctiptor
@@ -670,8 +670,8 @@ TEST_P(GraphApiConvolution, CFunctions)
 }
 
 INSTANTIATE_TEST_SUITE_P(
-    GraphApiConvolution,
-    GraphApiConvolution,
+    Unit,
+    CPU_GraphApiConvolution_NONE,
     testing::Values(
         GraphApiConvolutionTuple{
             true, miopenInt8, miopenConvolution, 2, {5, 6}, {20, 21}, {3, 4}, {1, 2}},
@@ -695,7 +695,7 @@ INSTANTIATE_TEST_SUITE_P(
             false, miopenInt8, miopenConvolution, 2, {1, 1}, {1, 1}, {0, 0}, {0, -1}}));
 
 template <typename T>
-class GraphApiOperationConvolutionBuilder : public testing::Test
+class CPU_GraphApiOperationConvolutionBuilder_NONE : public testing::Test
 {
 protected:
     using TestCase = std::tuple<bool,
@@ -731,9 +731,10 @@ using GraphApiOperationConvolutionBuilderClasses =
                    miopen::graphapi::OperationConvolutionBackwardDataBuilder,
                    miopen::graphapi::OperationConvolutionBackwardFilterBuilder>;
 
-TYPED_TEST_SUITE(GraphApiOperationConvolutionBuilder, GraphApiOperationConvolutionBuilderClasses);
+TYPED_TEST_SUITE(CPU_GraphApiOperationConvolutionBuilder_NONE,
+                 GraphApiOperationConvolutionBuilderClasses);
 
-TYPED_TEST(GraphApiOperationConvolutionBuilder, ValidateAttributes)
+TYPED_TEST(CPU_GraphApiOperationConvolutionBuilder_NONE, ValidateAttributes)
 {
     for(auto [attrsValid, convolution, x, y, w, message] : this->testCases)
     {
@@ -767,7 +768,7 @@ TYPED_TEST(GraphApiOperationConvolutionBuilder, ValidateAttributes)
     }
 }
 
-TYPED_TEST(GraphApiOperationConvolutionBuilder, MissingSetter)
+TYPED_TEST(CPU_GraphApiOperationConvolutionBuilder_NONE, MissingSetter)
 {
     for(auto [attrsValid, convolution, x, y, w, message] : this->testCases)
     {

--- a/test/gtest/graphapi_matmul.cpp
+++ b/test/gtest/graphapi_matmul.cpp
@@ -85,6 +85,4 @@ protected:
 
 TEST_P(CPU_GraphApiMatMul_NONE, CFuncions) { execute(); }
 
-INSTANTIATE_TEST_SUITE_P(CFuncionsTest,
-                         CPU_GraphApiMatMul_NONE,
-                         testing::Values(miopenFloat, miopenDouble));
+INSTANTIATE_TEST_SUITE_P(Unit, CPU_GraphApiMatMul_NONE, testing::Values(miopenFloat, miopenDouble));

--- a/test/gtest/graphapi_mha_bwd.cpp
+++ b/test/gtest/graphapi_mha_bwd.cpp
@@ -28,7 +28,7 @@
 
 namespace mha_graph_test {
 
-class MhaBwdGraphTest : public MhaGraphTestBase
+class GPU_MhaBwdGraphTest_FP32 : public MhaGraphTestBase
 {
 
     tensor<float> mSoftMax;
@@ -372,10 +372,10 @@ public:
   //
 using namespace mha_graph_test;
 
-TEST_P(MhaBwdGraphTest, MhaBwdGraph) { Run(MhaDir::Bwd); }
+TEST_P(GPU_MhaBwdGraphTest_FP32, MhaBwdGraph) { Run(MhaDir::Bwd); }
 
-INSTANTIATE_TEST_SUITE_P(MhaGraphBwdSuite,
-                         MhaBwdGraphTest,
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         GPU_MhaBwdGraphTest_FP32,
                          testing::Combine(testing::ValuesIn(std::vector<std::size_t>{2}),     // n
                                           testing::ValuesIn(std::vector<std::size_t>{8}),     // h
                                           testing::ValuesIn(std::vector<std::size_t>{4, 64}), // s

--- a/test/gtest/t5layernorm.cpp
+++ b/test/gtest/t5layernorm.cpp
@@ -42,34 +42,34 @@ std::string GetFloatArg()
     return tmp;
 }
 
-struct T5LayerNormTestFloat : T5LayerNormFwdTest<float>
+struct GPU_T5LayerNormTest_FP32 : T5LayerNormFwdTest<float>
 {
 };
 
-struct T5LayerNormTestHalf : T5LayerNormFwdTest<half_float::half>
+struct GPU_T5LayerNormTest_FP16 : T5LayerNormFwdTest<half_float::half>
 {
 };
 
-struct T5LayerNormTestBFloat16 : T5LayerNormFwdTest<bfloat16>
+struct GPU_T5LayerNormTest_BFP16 : T5LayerNormFwdTest<bfloat16>
 {
 };
 
-struct T5LayerNormBwdTestFloat : T5LayerNormBwdTest<float>
+struct GPU_T5LayerNormBwdTest_FP32 : T5LayerNormBwdTest<float>
 {
 };
 
-struct T5LayerNormBwdTestHalf : T5LayerNormBwdTest<half_float::half>
+struct GPU_T5LayerNormBwdTest_FP16 : T5LayerNormBwdTest<half_float::half>
 {
 };
 
-struct T5LayerNormBwdTestBFloat16 : T5LayerNormBwdTest<bfloat16>
+struct GPU_T5LayerNormBwdTest_BFP16 : T5LayerNormBwdTest<bfloat16>
 {
 };
 
 } // namespace t5layernorm
 using namespace t5layernorm;
 
-TEST_P(T5LayerNormTestFloat, T5LayerNormFwdTest)
+TEST_P(GPU_T5LayerNormTest_FP32, T5LayerNormFwdTest)
 {
     if(!MIOPEN_TEST_ALL ||
        (env::enabled(MIOPEN_TEST_ALL) && env::value(MIOPEN_TEST_FLOAT_ARG) == "--float"))
@@ -83,7 +83,7 @@ TEST_P(T5LayerNormTestFloat, T5LayerNormFwdTest)
     }
 };
 
-TEST_P(T5LayerNormTestHalf, T5LayerNormFwdTest)
+TEST_P(GPU_T5LayerNormTest_FP16, T5LayerNormFwdTest)
 {
     if(!MIOPEN_TEST_ALL ||
        (env::enabled(MIOPEN_TEST_ALL) && env::value(MIOPEN_TEST_FLOAT_ARG) == "--half"))
@@ -97,7 +97,7 @@ TEST_P(T5LayerNormTestHalf, T5LayerNormFwdTest)
     }
 };
 
-TEST_P(T5LayerNormTestBFloat16, T5LayerNormFwdTest)
+TEST_P(GPU_T5LayerNormTest_BFP16, T5LayerNormFwdTest)
 {
     if(!MIOPEN_TEST_ALL ||
        (env::enabled(MIOPEN_TEST_ALL) && env::value(MIOPEN_TEST_FLOAT_ARG) == "--bfloat16"))
@@ -111,7 +111,7 @@ TEST_P(T5LayerNormTestBFloat16, T5LayerNormFwdTest)
     }
 };
 
-TEST_P(T5LayerNormBwdTestFloat, T5LayerNormBwdTest)
+TEST_P(GPU_T5LayerNormBwdTest_FP32, T5LayerNormBwdTest)
 {
     if(!MIOPEN_TEST_ALL ||
        (env::enabled(MIOPEN_TEST_ALL) && env::value(MIOPEN_TEST_FLOAT_ARG) == "--float"))
@@ -125,7 +125,7 @@ TEST_P(T5LayerNormBwdTestFloat, T5LayerNormBwdTest)
     }
 };
 
-TEST_P(T5LayerNormBwdTestHalf, T5LayerNormBwdTest)
+TEST_P(GPU_T5LayerNormBwdTest_FP16, T5LayerNormBwdTest)
 {
     if(!MIOPEN_TEST_ALL ||
        (env::enabled(MIOPEN_TEST_ALL) && env::value(MIOPEN_TEST_FLOAT_ARG) == "--half"))
@@ -139,7 +139,7 @@ TEST_P(T5LayerNormBwdTestHalf, T5LayerNormBwdTest)
     }
 };
 
-TEST_P(T5LayerNormBwdTestBFloat16, T5LayerNormBwdTest)
+TEST_P(GPU_T5LayerNormBwdTest_BFP16, T5LayerNormBwdTest)
 {
     if(!MIOPEN_TEST_ALL ||
        (env::enabled(MIOPEN_TEST_ALL) && env::value(MIOPEN_TEST_FLOAT_ARG) == "--bfloat16"))
@@ -153,21 +153,21 @@ TEST_P(T5LayerNormBwdTestBFloat16, T5LayerNormBwdTest)
     }
 };
 
-INSTANTIATE_TEST_SUITE_P(T5LayerNormTestSet,
-                         T5LayerNormTestFloat,
+INSTANTIATE_TEST_SUITE_P(Full,
+                         GPU_T5LayerNormTest_FP32,
                          testing::ValuesIn(T5LayerNormTestConfigs()));
-INSTANTIATE_TEST_SUITE_P(T5LayerNormTestSet,
-                         T5LayerNormTestHalf,
+INSTANTIATE_TEST_SUITE_P(Full,
+                         GPU_T5LayerNormTest_FP16,
                          testing::ValuesIn(T5LayerNormTestConfigs()));
-INSTANTIATE_TEST_SUITE_P(T5LayerNormTestSet,
-                         T5LayerNormTestBFloat16,
+INSTANTIATE_TEST_SUITE_P(Full,
+                         GPU_T5LayerNormTest_BFP16,
                          testing::ValuesIn(T5LayerNormTestConfigs()));
-INSTANTIATE_TEST_SUITE_P(T5LayerNormTestSet,
-                         T5LayerNormBwdTestFloat,
+INSTANTIATE_TEST_SUITE_P(Full,
+                         GPU_T5LayerNormBwdTest_FP32,
                          testing::ValuesIn(T5LayerNormTestConfigs()));
-INSTANTIATE_TEST_SUITE_P(T5LayerNormTestSet,
-                         T5LayerNormBwdTestHalf,
+INSTANTIATE_TEST_SUITE_P(Full,
+                         GPU_T5LayerNormBwdTest_FP16,
                          testing::ValuesIn(T5LayerNormTestConfigs()));
-INSTANTIATE_TEST_SUITE_P(T5LayerNormTestSet,
-                         T5LayerNormBwdTestBFloat16,
+INSTANTIATE_TEST_SUITE_P(Full,
+                         GPU_T5LayerNormBwdTest_BFP16,
                          testing::ValuesIn(T5LayerNormTestConfigs()));

--- a/test/gtest/tensor_api.cpp
+++ b/test/gtest/tensor_api.cpp
@@ -264,7 +264,7 @@ TestStatus GetTensorDescriptor(miopenTensorDescriptor_t tensorDesc, const Tensor
 
 const auto get_tensor_descr_funcs = {Get4dTensorDescriptor, GetTensorDescriptor};
 
-class TestSetTensor : public ::testing::TestWithParam<TestConfig>
+class CPU_TestSetTensor_NONE : public ::testing::TestWithParam<TestConfig>
 {
 protected:
     static void GenerateValidConfigs(bool use_strides, std::vector<TestConfig>& configs)
@@ -520,14 +520,14 @@ public:
 
 } // namespace
 
-TEST_P(TestSetTensor, SetTensor) { RunTest(); }
+TEST_P(CPU_TestSetTensor_NONE, SetTensor) { RunTest(); }
 
-INSTANTIATE_TEST_SUITE_P(TensorApiSetTensor,
-                         TestSetTensor,
-                         testing::ValuesIn(TestSetTensor::GetValidConfigs()),
-                         TestSetTensor::GetNameSuffix);
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         CPU_TestSetTensor_NONE,
+                         testing::ValuesIn(CPU_TestSetTensor_NONE::GetValidConfigs()),
+                         CPU_TestSetTensor_NONE::GetNameSuffix);
 
-INSTANTIATE_TEST_SUITE_P(TensorApiSetWrongTensor,
-                         TestSetTensor,
-                         testing::ValuesIn(TestSetTensor::GetWrongConfigs()),
-                         TestSetTensor::GetNameSuffix);
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         CPU_TestSetTensor_NONE,
+                         testing::ValuesIn(CPU_TestSetTensor_NONE::GetWrongConfigs()),
+                         CPU_TestSetTensor_NONE::GetNameSuffix);

--- a/test/gtest/tensor_api.cpp
+++ b/test/gtest/tensor_api.cpp
@@ -522,12 +522,12 @@ public:
 
 TEST_P(CPU_TestSetTensor_NONE, SetTensor) { RunTest(); }
 
-INSTANTIATE_TEST_SUITE_P(Smoke,
+INSTANTIATE_TEST_SUITE_P(SmokeApiSet,
                          CPU_TestSetTensor_NONE,
                          testing::ValuesIn(CPU_TestSetTensor_NONE::GetValidConfigs()),
                          CPU_TestSetTensor_NONE::GetNameSuffix);
 
-INSTANTIATE_TEST_SUITE_P(Smoke,
+INSTANTIATE_TEST_SUITE_P(SmokeApiSetWrong,
                          CPU_TestSetTensor_NONE,
                          testing::ValuesIn(CPU_TestSetTensor_NONE::GetWrongConfigs()),
                          CPU_TestSetTensor_NONE::GetNameSuffix);

--- a/test/gtest/transformers_adam_w.cpp
+++ b/test/gtest/transformers_adam_w.cpp
@@ -41,22 +41,22 @@ bool CheckFloatArg(std::string arg)
     return false;
 }
 
-struct TransformersAdamWTestFloat : TransformersAdamWTest<float, float>
+struct GPU_TransformersAdamWTest_FP32 : TransformersAdamWTest<float, float>
 {
 };
 
-struct TransformersAdamWTestFloat16 : TransformersAdamWTest<half_float::half, half_float::half>
+struct GPU_TransformersAdamWTest_FP16 : TransformersAdamWTest<half_float::half, half_float::half>
 {
 };
 
-struct TransformersAmpAdamWTestFloat : TransformersAdamWTest<float, half_float::half, true>
+struct GPU_TransformersAmpAdamWTest_FP32 : TransformersAdamWTest<float, half_float::half, true>
 {
 };
 
 } // namespace transformers_adam_w
 using namespace transformers_adam_w;
 
-TEST_P(TransformersAdamWTestFloat, TransformersAdamWFloatTest)
+TEST_P(GPU_TransformersAdamWTest_FP32, TransformersAdamWFloatTest)
 {
     if(CheckFloatArg("--float"))
     {
@@ -69,7 +69,7 @@ TEST_P(TransformersAdamWTestFloat, TransformersAdamWFloatTest)
     }
 };
 
-TEST_P(TransformersAdamWTestFloat16, TransformersAdamWFloat16Test)
+TEST_P(GPU_TransformersAdamWTest_FP16, TransformersAdamWFloat16Test)
 {
     if(CheckFloatArg("--half"))
     {
@@ -82,7 +82,7 @@ TEST_P(TransformersAdamWTestFloat16, TransformersAdamWFloat16Test)
     }
 };
 
-TEST_P(TransformersAmpAdamWTestFloat, TransformersAmpAdamWTest)
+TEST_P(GPU_TransformersAmpAdamWTest_FP32, TransformersAmpAdamWTest)
 {
     if(CheckFloatArg("--float"))
     {
@@ -95,12 +95,12 @@ TEST_P(TransformersAmpAdamWTestFloat, TransformersAmpAdamWTest)
     }
 };
 
-INSTANTIATE_TEST_SUITE_P(TransformersAdamWTestSet,
-                         TransformersAdamWTestFloat,
+INSTANTIATE_TEST_SUITE_P(Full,
+                         GPU_TransformersAdamWTest_FP32,
                          testing::ValuesIn(TransformersAdamWTestConfigs()));
-INSTANTIATE_TEST_SUITE_P(TransformersAdamWTestSet,
-                         TransformersAdamWTestFloat16,
+INSTANTIATE_TEST_SUITE_P(Full,
+                         GPU_TransformersAdamWTest_FP16,
                          testing::ValuesIn(TransformersAdamWTestConfigs()));
-INSTANTIATE_TEST_SUITE_P(TransformersAdamWTestSet,
-                         TransformersAmpAdamWTestFloat,
+INSTANTIATE_TEST_SUITE_P(Full,
+                         GPU_TransformersAmpAdamWTest_FP32,
                          testing::ValuesIn(TransformersAdamWTestConfigs()));

--- a/test/gtest/tuna_net.cpp
+++ b/test/gtest/tuna_net.cpp
@@ -106,15 +106,15 @@ protected:
     std::string device_architecture;
 };
 
-struct TunaNetTestFloat : TunaNetTest<float>
+struct GPU_TunaNetTest_FP32 : TunaNetTest<float>
 {
 };
 
-struct TunaNetTestHalf : TunaNetTest<half_float::half>
+struct GPU_TunaNetTest_FP16 : TunaNetTest<half_float::half>
 {
 };
 
-struct TunaNetTestBF16 : TunaNetTest<bfloat16>
+struct GPU_TunaNetTest_BFP16 : TunaNetTest<bfloat16>
 {
 };
 
@@ -143,41 +143,41 @@ void TestSolverPredictionModel(miopen::conv::ProblemDescription& problem,
 #endif
 }
 
-TEST_P(TunaNetTestFloat, TestSolverPredictionModelFloat)
+TEST_P(GPU_TunaNetTest_FP32, TestSolverPredictionModelFloat)
 {
     TestSolverPredictionModel(problem, expected_solver, device_architecture);
 }
 
-TEST_P(TunaNetTestHalf, TestSolverPredictionModelHalf)
+TEST_P(GPU_TunaNetTest_FP16, TestSolverPredictionModelHalf)
 {
     TestSolverPredictionModel(problem, expected_solver, device_architecture);
 }
 
-TEST_P(TunaNetTestBF16, TestSolverPredictionModelBF16)
+TEST_P(GPU_TunaNetTest_BFP16, TestSolverPredictionModelBF16)
 {
     TestSolverPredictionModel(problem, expected_solver, device_architecture);
 }
 
-INSTANTIATE_TEST_SUITE_P(Gfx908TestSolverPredictionModelFloat,
-                         TunaNetTestFloat,
+INSTANTIATE_TEST_SUITE_P(SmokeGfx908,
+                         GPU_TunaNetTest_FP32,
                          testing::ValuesIn(GetGfx908FloatTestCases()));
 
-INSTANTIATE_TEST_SUITE_P(Gfx908TestSolverPredictionModelHalfTest,
-                         TunaNetTestHalf,
+INSTANTIATE_TEST_SUITE_P(SmokeGfx908,
+                         GPU_TunaNetTest_FP16,
                          testing::ValuesIn(GetGfx908HalfTestCases()));
 
-INSTANTIATE_TEST_SUITE_P(Gfx908TestSolverPredictionModelBF16Test,
-                         TunaNetTestBF16,
+INSTANTIATE_TEST_SUITE_P(SmokeGfx908,
+                         GPU_TunaNetTest_BFP16,
                          testing::ValuesIn(GetGfx908BF16TestCases()));
 
-INSTANTIATE_TEST_SUITE_P(Gfx90aTestSolverPredictionModelFloat,
-                         TunaNetTestFloat,
+INSTANTIATE_TEST_SUITE_P(SmokeGfx90a,
+                         GPU_TunaNetTest_FP32,
                          testing::ValuesIn(GetGfx90aFloatTestCases()));
 
-INSTANTIATE_TEST_SUITE_P(Gfx90aTestSolverPredictionModelHalfTest,
-                         TunaNetTestHalf,
+INSTANTIATE_TEST_SUITE_P(SmokeGfx90a,
+                         GPU_TunaNetTest_FP16,
                          testing::ValuesIn(GetGfx90aHalfTestCases()));
 
-INSTANTIATE_TEST_SUITE_P(Gfx90aTestSolverPredictionModelBF16Test,
-                         TunaNetTestBF16,
+INSTANTIATE_TEST_SUITE_P(SmokeGfx90a,
+                         GPU_TunaNetTest_BFP16,
                          testing::ValuesIn(GetGfx90aBF16TestCases()));

--- a/test/gtest/unit_conv_solver.hpp
+++ b/test/gtest/unit_conv_solver.hpp
@@ -122,9 +122,9 @@ using GPU_UnitTestConvSolverFwd_FP16 = UnitTestConvSolverFwd;
 using GPU_UnitTestConvSolverBwd_FP16 = UnitTestConvSolverBwd;
 using GPU_UnitTestConvSolverWrw_FP16 = UnitTestConvSolverWrw;
 
-using GPU_UnitTestConvSolverFwd_BF16 = UnitTestConvSolverFwd;
-using GPU_UnitTestConvSolverBwd_BF16 = UnitTestConvSolverBwd;
-using GPU_UnitTestConvSolverWrw_BF16 = UnitTestConvSolverWrw;
+using GPU_UnitTestConvSolverFwd_BFP16 = UnitTestConvSolverFwd;
+using GPU_UnitTestConvSolverBwd_BFP16 = UnitTestConvSolverBwd;
+using GPU_UnitTestConvSolverWrw_BFP16 = UnitTestConvSolverWrw;
 
 using GPU_UnitTestConvSolverFwd_FP32 = UnitTestConvSolverFwd;
 using GPU_UnitTestConvSolverBwd_FP32 = UnitTestConvSolverBwd;

--- a/test/gtest/unit_conv_solver_GemmBwd1x1_stride1.cpp
+++ b/test/gtest/unit_conv_solver_GemmBwd1x1_stride1.cpp
@@ -52,7 +52,7 @@ TEST_P(GPU_UnitTestConvSolverBwd_FP16, GemmBwd1x1_stride1)
     this->RunTest(miopen::solver::conv::GemmBwd1x1_stride1{});
 };
 
-TEST_P(GPU_UnitTestConvSolverBwd_BF16, GemmBwd1x1_stride1)
+TEST_P(GPU_UnitTestConvSolverBwd_BFP16, GemmBwd1x1_stride1)
 {
     this->RunTest(miopen::solver::conv::GemmBwd1x1_stride1{});
 };
@@ -75,7 +75,7 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
                                           testing::ValuesIn(GetConvTestCases(miopenHalf))));
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         GPU_UnitTestConvSolverBwd_BF16,
+                         GPU_UnitTestConvSolverBwd_BFP16,
                          testing::Combine(testing::Values(GetSupportedDevices()),
                                           testing::Values(miopenConvolutionAlgoGEMM),
                                           testing::ValuesIn(GetConvTestCases(miopenBFloat16))));

--- a/test/gtest/unit_conv_solver_GemmBwd1x1_stride2.cpp
+++ b/test/gtest/unit_conv_solver_GemmBwd1x1_stride2.cpp
@@ -52,7 +52,7 @@ TEST_P(GPU_UnitTestConvSolverBwd_FP16, GemmBwd1x1_stride2)
     this->RunTest(miopen::solver::conv::GemmBwd1x1_stride2{});
 };
 
-TEST_P(GPU_UnitTestConvSolverBwd_BF16, GemmBwd1x1_stride2)
+TEST_P(GPU_UnitTestConvSolverBwd_BFP16, GemmBwd1x1_stride2)
 {
     this->RunTest(miopen::solver::conv::GemmBwd1x1_stride2{});
 };
@@ -75,7 +75,7 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
                                           testing::ValuesIn(GetConvTestCases(miopenHalf))));
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         GPU_UnitTestConvSolverBwd_BF16,
+                         GPU_UnitTestConvSolverBwd_BFP16,
                          testing::Combine(testing::Values(GetSupportedDevices()),
                                           testing::Values(miopenConvolutionAlgoGEMM),
                                           testing::ValuesIn(GetConvTestCases(miopenBFloat16))));

--- a/test/gtest/unit_conv_solver_GemmBwdRest.cpp
+++ b/test/gtest/unit_conv_solver_GemmBwdRest.cpp
@@ -69,7 +69,7 @@ TEST_P(GPU_UnitTestConvSolverBwd_FP16, GemmBwdRest)
     this->RunTest(miopen::solver::conv::GemmBwdRest{});
 };
 
-TEST_P(GPU_UnitTestConvSolverBwd_BF16, GemmBwdRest)
+TEST_P(GPU_UnitTestConvSolverBwd_BFP16, GemmBwdRest)
 {
     this->RunTest(miopen::solver::conv::GemmBwdRest{});
 };
@@ -92,7 +92,7 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
                                           testing::ValuesIn(GetConvTestCases(miopenHalf))));
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         GPU_UnitTestConvSolverBwd_BF16,
+                         GPU_UnitTestConvSolverBwd_BFP16,
                          testing::Combine(testing::Values(GetSupportedDevices()),
                                           testing::Values(miopenConvolutionAlgoGEMM),
                                           testing::ValuesIn(GetConvTestCases(miopenBFloat16))));

--- a/test/gtest/unit_conv_solver_GemmFwd1x1_0_1.cpp
+++ b/test/gtest/unit_conv_solver_GemmFwd1x1_0_1.cpp
@@ -52,7 +52,7 @@ TEST_P(GPU_UnitTestConvSolverFwd_FP16, GemmFwd1x1_0_1)
     this->RunTest(miopen::solver::conv::GemmFwd1x1_0_1{});
 };
 
-TEST_P(GPU_UnitTestConvSolverFwd_BF16, GemmFwd1x1_0_1)
+TEST_P(GPU_UnitTestConvSolverFwd_BFP16, GemmFwd1x1_0_1)
 {
     this->RunTest(miopen::solver::conv::GemmFwd1x1_0_1{});
 };
@@ -75,7 +75,7 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
                                           testing::ValuesIn(GetConvTestCases(miopenHalf))));
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         GPU_UnitTestConvSolverFwd_BF16,
+                         GPU_UnitTestConvSolverFwd_BFP16,
                          testing::Combine(testing::Values(GetSupportedDevices()),
                                           testing::Values(miopenConvolutionAlgoGEMM),
                                           testing::ValuesIn(GetConvTestCases(miopenBFloat16))));

--- a/test/gtest/unit_conv_solver_GemmFwd1x1_0_2.cpp
+++ b/test/gtest/unit_conv_solver_GemmFwd1x1_0_2.cpp
@@ -52,7 +52,7 @@ TEST_P(GPU_UnitTestConvSolverFwd_FP16, GemmFwd1x1_0_2)
     this->RunTest(miopen::solver::conv::GemmFwd1x1_0_2{});
 };
 
-TEST_P(GPU_UnitTestConvSolverFwd_BF16, GemmFwd1x1_0_2)
+TEST_P(GPU_UnitTestConvSolverFwd_BFP16, GemmFwd1x1_0_2)
 {
     this->RunTest(miopen::solver::conv::GemmFwd1x1_0_2{});
 };
@@ -75,7 +75,7 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
                                           testing::ValuesIn(GetConvTestCases(miopenHalf))));
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         GPU_UnitTestConvSolverFwd_BF16,
+                         GPU_UnitTestConvSolverFwd_BFP16,
                          testing::Combine(testing::Values(GetSupportedDevices()),
                                           testing::Values(miopenConvolutionAlgoGEMM),
                                           testing::ValuesIn(GetConvTestCases(miopenBFloat16))));

--- a/test/gtest/unit_conv_solver_GemmFwdRest.cpp
+++ b/test/gtest/unit_conv_solver_GemmFwdRest.cpp
@@ -72,7 +72,7 @@ TEST_P(GPU_UnitTestConvSolverFwd_FP16, GemmFwdRest)
     this->RunTest(miopen::solver::conv::GemmFwdRest{});
 };
 
-TEST_P(GPU_UnitTestConvSolverFwd_BF16, GemmFwdRest)
+TEST_P(GPU_UnitTestConvSolverFwd_BFP16, GemmFwdRest)
 {
     this->RunTest(miopen::solver::conv::GemmFwdRest{});
 };
@@ -100,7 +100,7 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
                                           testing::ValuesIn(GetConvTestCases(miopenHalf))));
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         GPU_UnitTestConvSolverFwd_BF16,
+                         GPU_UnitTestConvSolverFwd_BFP16,
                          testing::Combine(testing::Values(GetSupportedDevices()),
                                           testing::Values(miopenConvolutionAlgoGEMM),
                                           testing::ValuesIn(GetConvTestCases(miopenBFloat16))));
@@ -131,7 +131,7 @@ INSTANTIATE_TEST_SUITE_P(Full,
                                           testing::ValuesIn(GetConvTestCasesFull(miopenHalf))));
 
 INSTANTIATE_TEST_SUITE_P(Full,
-                         GPU_UnitTestConvSolverFwd_BF16,
+                         GPU_UnitTestConvSolverFwd_BFP16,
                          testing::Combine(testing::Values(GetSupportedDevices()),
                                           testing::Values(miopenConvolutionAlgoGEMM),
                                           testing::ValuesIn(GetConvTestCasesFull(miopenBFloat16))));

--- a/test/gtest/unit_conv_solver_GemmWrw1x1_stride1.cpp
+++ b/test/gtest/unit_conv_solver_GemmWrw1x1_stride1.cpp
@@ -52,7 +52,7 @@ TEST_P(GPU_UnitTestConvSolverWrw_FP16, GemmWrw1x1_stride1)
     this->RunTest(miopen::solver::conv::GemmWrw1x1_stride1{});
 };
 
-TEST_P(GPU_UnitTestConvSolverWrw_BF16, GemmWrw1x1_stride1)
+TEST_P(GPU_UnitTestConvSolverWrw_BFP16, GemmWrw1x1_stride1)
 {
     this->RunTest(miopen::solver::conv::GemmWrw1x1_stride1{});
 };
@@ -75,7 +75,7 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
                                           testing::ValuesIn(GetConvTestCases(miopenHalf))));
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         GPU_UnitTestConvSolverWrw_BF16,
+                         GPU_UnitTestConvSolverWrw_BFP16,
                          testing::Combine(testing::Values(GetSupportedDevices()),
                                           testing::Values(miopenConvolutionAlgoGEMM),
                                           testing::ValuesIn(GetConvTestCases(miopenBFloat16))));

--- a/test/gtest/unit_conv_solver_GemmWrwUniversal.cpp
+++ b/test/gtest/unit_conv_solver_GemmWrwUniversal.cpp
@@ -52,7 +52,7 @@ TEST_P(GPU_UnitTestConvSolverWrw_FP16, GemmWrwUniversal)
     this->RunTest(miopen::solver::conv::GemmWrwUniversal{});
 };
 
-TEST_P(GPU_UnitTestConvSolverWrw_BF16, GemmWrwUniversal)
+TEST_P(GPU_UnitTestConvSolverWrw_BFP16, GemmWrwUniversal)
 {
     this->RunTest(miopen::solver::conv::GemmWrwUniversal{});
 };
@@ -75,7 +75,7 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
                                           testing::ValuesIn(GetConvTestCases(miopenHalf))));
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         GPU_UnitTestConvSolverWrw_BF16,
+                         GPU_UnitTestConvSolverWrw_BFP16,
                          testing::Combine(testing::Values(GetSupportedDevices()),
                                           testing::Values(miopenConvolutionAlgoGEMM),
                                           testing::ValuesIn(GetConvTestCases(miopenBFloat16))));

--- a/test/gtest/vec_add.cpp
+++ b/test/gtest/vec_add.cpp
@@ -201,14 +201,14 @@ protected:
 
 namespace vecadd {
 
-struct VecAddTestFloat : VecAddTest<float>
+struct GPU_VecAddTest_FP32 : VecAddTest<float>
 {
 };
 
 } // namespace vecadd
 using namespace vecadd;
 
-TEST_P(VecAddTestFloat, VecAddTestFw)
+TEST_P(GPU_VecAddTest_FP32, VecAddTestFw)
 {
     RunTestOCL();
     // Verify OCL results against CPU reference
@@ -222,4 +222,4 @@ TEST_P(VecAddTestFloat, VecAddTestFw)
     VerifyGPU();
 };
 
-INSTANTIATE_TEST_SUITE_P(VecAddTestSet, VecAddTestFloat, testing::ValuesIn(VecAddTestConfigs()));
+INSTANTIATE_TEST_SUITE_P(Smoke, GPU_VecAddTest_FP32, testing::ValuesIn(VecAddTestConfigs()));


### PR DESCRIPTION
GTests renaming according to the document:
https://github.com/ROCm/MIOpen/wiki/GTest-development

All filenames on letters "t"-"z" and other letters which had issues.

PR also contains small fixes for python checker script.