### PR TITLE
Fix ConvBiasResAddActivation_fwd tests failing on Navi

### DIFF
--- a/test/gtest/fused_conv_bias_res_add_activ.cpp
+++ b/test/gtest/fused_conv_bias_res_add_activ.cpp
@@ -24,11 +24,9 @@
  *
  *******************************************************************************/
 #include <gtest/gtest.h>
+#include <gtest/gtest_ck_common.hpp>
 #include <miopen/miopen.h>
 #include <miopen/env.hpp>
-#if MIOPEN_USE_COMPOSABLEKERNEL
-#include <miopen/solver/ck_utility_common.hpp>
-#endif
 
 #include "tensor_util.hpp"
 #include "get_handle.hpp"
@@ -38,28 +36,16 @@
 MIOPEN_DECLARE_ENV_VAR_BOOL(MIOPEN_TEST_ALL)
 MIOPEN_DECLARE_ENV_VAR_STR(MIOPEN_TEST_FLOAT_ARG)
 
-#if MIOPEN_USE_COMPOSABLEKERNEL
-#define WORAROUND_ISSUE_2533 1
-#endif
-
 namespace conv_bias_act_res_add_fwd {
 
 bool TestIsApplicable()
 {
-#if MIOPEN_USE_COMPOSABLEKERNEL
     const auto float_arg = env::value(MIOPEN_TEST_FLOAT_ARG);
-    return
-#if WORAROUND_ISSUE_2533
-        miopen::solver::ck_utility::is_ck_whitelist(get_handle().GetDeviceName()) //
-#else
     /// \todo Check against specific ASCIs.
-#endif
-        && (float_arg == "--half"           // So far only test for fp16 is implemented.
-            || float_arg.empty())           // Empty when gtest is run without parameters.
-        && !env::disabled(MIOPEN_TEST_ALL); // Not disabled when gtest is run without parameters.
-#else
-    return false;
-#endif
+    return ::IsDeviceSupportedForCK() &&
+           (float_arg == "--half"              // So far only test for fp16 is implemented.
+            || float_arg.empty())              // Empty when gtest is run without parameters.
+           && !env::disabled(MIOPEN_TEST_ALL); // Not disabled when gtest is run without parameters.
 }
 
 std::vector<Conv3DTestCase> ConvTestConfigs()

--- a/test/gtest/graphapi_conv_bias_res_add_activ_fwd.cpp
+++ b/test/gtest/graphapi_conv_bias_res_add_activ_fwd.cpp
@@ -45,7 +45,10 @@
 namespace gr = miopen::graphapi;
 namespace conv_graph_api_test {
 
-bool IsTestSupportedForDevice() { return IsTestSupportedByDevice(Gpu::gfx908 | Gpu::gfx90A | Gpu::gfx94X); }
+bool IsTestSupportedForDevice()
+{
+    return IsTestSupportedByDevice(Gpu::gfx908 | Gpu::gfx90A | Gpu::gfx94X);
+}
 
 static bool TestIsApplicable() { return true; }
 

--- a/test/gtest/graphapi_conv_bias_res_add_activ_fwd.cpp
+++ b/test/gtest/graphapi_conv_bias_res_add_activ_fwd.cpp
@@ -25,6 +25,7 @@
  *******************************************************************************/
 #include <gtest/gtest.h>
 #include <gtest/gtest_common.hpp>
+#include <gtest/gtest_ck_common.hpp>
 #include <miopen/miopen.h>
 #include <miopen/env.hpp>
 
@@ -45,13 +46,7 @@
 namespace gr = miopen::graphapi;
 namespace conv_graph_api_test {
 
-bool IsTestSupportedForDevice()
-{
-    using e_mask = enabled<Gpu::gfx94X, Gpu::gfx103X, Gpu::gfx110X>;
-    // gfx120X is not enabled due to WORKAROUND_SWDEV_479810
-    using d_mask = disabled<Gpu::None>;
-    return ::IsTestSupportedForDevMask<d_mask, e_mask>();
-}
+bool IsTestSupportedForDevice() { return ::IsDeviceSupportedForCK(); }
 
 static bool TestIsApplicable() { return true; }
 

--- a/test/gtest/graphapi_conv_bias_res_add_activ_fwd.cpp
+++ b/test/gtest/graphapi_conv_bias_res_add_activ_fwd.cpp
@@ -25,7 +25,6 @@
  *******************************************************************************/
 #include <gtest/gtest.h>
 #include <gtest/gtest_common.hpp>
-#include <gtest/gtest_ck_common.hpp>
 #include <miopen/miopen.h>
 #include <miopen/env.hpp>
 
@@ -46,7 +45,7 @@
 namespace gr = miopen::graphapi;
 namespace conv_graph_api_test {
 
-bool IsTestSupportedForDevice() { return ::IsDeviceSupportedForCK(); }
+bool IsTestSupportedForDevice() { return IsTestSupportedByDevice(Gpu::gfx908 | Gpu::gfx90A | Gpu::gfx94X); }
 
 static bool TestIsApplicable() { return true; }
 

--- a/test/gtest/gtest_ck_common.hpp
+++ b/test/gtest/gtest_ck_common.hpp
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2024 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#include <gtest/gtest_common.hpp>
+
+#if MIOPEN_USE_COMPOSABLEKERNEL
+#define WORAROUND_ISSUE_2533 1
+#endif
+
+// MI100 : gfx908
+// MI200 : gfx90a
+// MI300 : gfx940, gfx941, gfx942
+static inline bool IsDeviceSupportedForCK()
+{
+#if MIOPEN_USE_COMPOSABLEKERNEL
+#if WORAROUND_ISSUE_2533
+    using e_mask = enabled<Gpu::gfx908, Gpu::gfx90A, Gpu::gfx94X>;
+    using d_mask = disabled<Gpu::gfx103X, Gpu::gfx110X, Gpu::gfx120X>;
+    return ::IsTestSupportedForDevMask<d_mask, e_mask>();
+#else
+    return true;
+#endif
+#else
+    return false;
+#endif
+}

--- a/test/gtest/gtest_ck_common.hpp
+++ b/test/gtest/gtest_ck_common.hpp
@@ -36,9 +36,7 @@ static inline bool IsDeviceSupportedForCK()
 {
 #if MIOPEN_USE_COMPOSABLEKERNEL
 #if WORAROUND_ISSUE_2533
-    using e_mask = enabled<Gpu::gfx908, Gpu::gfx90A, Gpu::gfx94X>;
-    using d_mask = disabled<Gpu::gfx103X, Gpu::gfx110X, Gpu::gfx120X>;
-    return ::IsTestSupportedForDevMask<d_mask, e_mask>();
+    return IsTestSupportedByDevice(Gpu::gfx908 | Gpu::gfx90A | Gpu::gfx94X);
 #else
     return true;
 #endif


### PR DESCRIPTION
The graphapi tests for ConvBiasResAddActiv need to be skipped on Navi.
Since these use the same backend as the fused solution, I moved the check to a shared place, and updated to use the new IsTestSupportedForDev check. 