### PR TITLE
Fix gfx908 timing out during pipeline stages

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -291,7 +291,7 @@ def buildHipClangJob(Map conf=[:]){
             }
 
             withDockerContainer(image: image, args: dockerOpts + ' -v=/var/jenkins/:/var/jenkins') {
-                timeout(time: 600, unit:'MINUTES')
+                timeout(time: 420, unit:'MINUTES')
                 {
                     if (lfs_pull) {
                         sh "git lfs pull --exclude="

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -291,7 +291,7 @@ def buildHipClangJob(Map conf=[:]){
             }
 
             withDockerContainer(image: image, args: dockerOpts + ' -v=/var/jenkins/:/var/jenkins') {
-                timeout(time: 300, unit:'MINUTES')
+                timeout(time: 600, unit:'MINUTES')
                 {
                     if (lfs_pull) {
                         sh "git lfs pull --exclude="


### PR DESCRIPTION
The develop pipeline is taking longer than 5 hours to complete the tests on gfx 908.
Extending the timeout for now to allow for pipeline to pass. 

I was surprised, but it seems like the CI increase came from the recent change to the ROCm version for the docker being used #3181.