### PR TITLE
[Bug] missing split_k from end of kernel_id in ck wrw

### DIFF
--- a/src/solver/conv/conv_hip_implicit_gemm_grouped_wrw_xdlops.cpp
+++ b/src/solver/conv/conv_hip_implicit_gemm_grouped_wrw_xdlops.cpp
@@ -289,7 +289,7 @@ bool PerformanceConfigHipImplicitGemmGroupWrwXdlops::ModelApplyToken(
             idx += 2;
         if(((idx == 15 && (heuristic_kernels[heuristic_indexes[0]].size() == 15)) || idx == 18))
         {
-            kernel_id          = valid_kernels[heuristic_indexes[0]] + "+" + value;
+            kernel_id          = valid_kernels[heuristic_indexes[0]] + "+" + value + "+" + std::to_string(split_k);
             index              = heuristic_indexes[0];
             bool valid_split_k = false;
             switch(problem.GetInDataType())

--- a/src/solver/conv/conv_hip_implicit_gemm_grouped_wrw_xdlops.cpp
+++ b/src/solver/conv/conv_hip_implicit_gemm_grouped_wrw_xdlops.cpp
@@ -289,7 +289,8 @@ bool PerformanceConfigHipImplicitGemmGroupWrwXdlops::ModelApplyToken(
             idx += 2;
         if(((idx == 15 && (heuristic_kernels[heuristic_indexes[0]].size() == 15)) || idx == 18))
         {
-            kernel_id          = valid_kernels[heuristic_indexes[0]] + "+" + value + "+" + std::to_string(split_k);
+            kernel_id =
+                valid_kernels[heuristic_indexes[0]] + "+" + value + "+" + std::to_string(split_k);
             index              = heuristic_indexes[0];
             bool valid_split_k = false;
             switch(problem.GetInDataType())


### PR DESCRIPTION
This to correct the stoi error found in:
https://ontrack-internal.amd.com/browse/SWDEV-479172