### PR TITLE
Use different github credentials for MIOpen CI.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -262,7 +262,7 @@ def buildHipClangJob(Map conf=[:]){
         def lfs_pull = conf.get("lfs_pull", false)
 
         def retimage
-        gitStatusWrapper(credentialsId: "${env.status_wrapper_creds}", gitHubContext: "Jenkins - ${variant}", account: 'ROCm', repo: 'MIOpen') {
+        gitStatusWrapper(credentialsId: "${env.miopen_git_creds}", gitHubContext: "Jenkins - ${variant}", account: 'ROCm', repo: 'MIOpen') {
             try {
                 (retimage, image) = getDockerImage(conf)
                 if (needs_gpu) {


### PR DESCRIPTION
When our CI was setup initially, MIOpen, CK, and MIGraphx (both public and private repos) were using the same set of credentials for github API calls everywhere. This has eventually led to the number of API calls exceeding the hourly limit and all the CI pipelines getting stuck.
This PR will diversify the git credentials used in the MIOpen pipelines. I have submitted a similar change in composable kernel. Hopefully, by using 3 different sets of credentials, one for general jenkins services, second for MIOpen CI, and third for composable kernel CI, we can avoid that problem.