### PR TITLE
Fix driver being leaked in MIOpenDriver

### DIFF
--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -52,10 +52,10 @@ int main(int argc, char* argv[])
         std::cout << " " << argv[i];
     std::cout << std::endl;
 
-    Driver* drv = nullptr;
+    std::shared_ptr<Driver> drv;
     for(auto f : rdm::GetRegistry())
     {
-        drv = f(base_arg);
+        drv = std::shared_ptr<Driver>(f(base_arg));
         if(drv != nullptr)
             break;
     }

--- a/driver/main.cpp
+++ b/driver/main.cpp
@@ -55,7 +55,7 @@ int main(int argc, char* argv[])
     std::shared_ptr<Driver> drv;
     for(auto f : rdm::GetRegistry())
     {
-        drv = std::shared_ptr<Driver>(f(base_arg));
+        drv.reset(f(base_arg));
         if(drv != nullptr)
             break;
     }


### PR DESCRIPTION
This change will clean-up the driver implementation before exiting MIOpenDriver.