### PR TITLE
[BugFix] Fix ConvDirectNaiveConvFwd not applicable after #3213

### DIFF
--- a/src/conv/problem_description.cpp
+++ b/src/conv/problem_description.cpp
@@ -119,6 +119,24 @@ std::string ProblemDescription::GetAlphaBetaCaseStr() const
     }
 }
 
+void ProblemDescription::HeuristicUpdateLayouts()
+{
+    static const std::vector<std::string> supported_layouts = {"NCHW", "NHWC", "CHWN", "NCDHW"};
+
+    for(const std::string& layout : supported_layouts)
+    {
+        if(in.IsPossibleLayout4D5D(layout) && out.IsPossibleLayout4D5D(layout) &&
+           weights.IsPossibleLayout4D5D(layout))
+        {
+            in_layout      = layout;
+            weights_layout = layout;
+            out_layout     = layout;
+            return;
+        }
+    }
+    // If we did not find consistent layout, leave them as-is
+}
+
 void ProblemDescription::MakeNetworkConfig(std::string& conf_key) const
 {
     std::ostringstream ss;

--- a/src/include/miopen/conv/problem_description.hpp
+++ b/src/include/miopen/conv/problem_description.hpp
@@ -166,6 +166,7 @@ struct MIOPEN_INTERNALS_EXPORT ProblemDescription : ProblemDescriptionBase
           beta(beta_),
           alpha_beta_case(ClassifyAlphaBeta(alpha, beta))
     {
+        HeuristicUpdateLayouts();
     }
 
     // Conv descriptor getters
@@ -367,6 +368,8 @@ struct MIOPEN_INTERNALS_EXPORT ProblemDescription : ProblemDescriptionBase
         return in.AllLengthsFitIntoInt() && weights.AllLengthsFitIntoInt() &&
                out.AllLengthsFitIntoInt();
     }
+
+    void HeuristicUpdateLayouts();
 
     void MakeNetworkConfig(std::string& conf_key) const;
 


### PR DESCRIPTION
Fix ConvDirectNaiveConvFwd not applicable after https://github.com/ROCm/MIOpen/pull/3213:
- Revert HeuristicUpdateLayouts()

Fixes https://github.com/ROCm/MIOpen/issues/3279