### PR TITLE
Fixed incorrect transpose in find 2.0

### DIFF
--- a/src/problem.cpp
+++ b/src/problem.cpp
@@ -179,7 +179,11 @@ Problem::FindSolutions(Handle& handle, const FindOptions& options, std::size_t m
     auto ret = std::visit(
         boost::hof::match(
             [&](const ConvolutionDescriptor& op_desc) {
-                return FindSolutionsImpl(handle, options, max_solutions, buffers, op_desc);
+                if(op_desc.mode == miopenTranspose)
+                    return MakeTransposed().FindSolutionsImpl(
+                        handle, options, max_solutions, buffers, op_desc);
+                else
+                    return FindSolutionsImpl(handle, options, max_solutions, buffers, op_desc);
             },
             [&](const SoftmaxDescriptor& op_desc) {
                 return FindSolutionsImpl(handle, options, max_solutions, buffers, op_desc);
@@ -477,20 +481,16 @@ std::vector<Solution> Problem::FindSolutionsImpl(Handle& handle,
     const auto& w = buffers.at(miopenTensorConvolutionW);
     auto y        = buffers.at(miopenTensorConvolutionY);
 
-    const auto conv_problem =
-        conv_desc.mode == miopenTranspose ? MakeTransposed().AsConvolution() : AsConvolution();
+    if(conv_desc.mode == miopenTranspose)
+        std::swap(x, y);
+
+    const auto conv_problem = AsConvolution();
+
+    ValidateGroupCount(x_desc, w_desc, conv_desc);
 
     std::size_t workspace_size;
     Allocator::ManageDataPtr owned_workspace;
     Data_t workspace;
-
-    if(conv_desc.mode == miopenTranspose)
-    {
-        std::swap(x, y);
-        std::swap(x_desc, y_desc);
-    }
-
-    ValidateGroupCount(x_desc, w_desc, conv_desc);
 
     if(options.preallocated_workspace)
     {


### PR DESCRIPTION
Moved the MakeTransposed() call out of FindSolutionsImpl() to remove some duplicated logic and effectively apply previous transpose fix to the rest of the function.