### PR TITLE
[Docs] Cherry pick - Bump rocm-docs-core[api_reference] from 1.7.2 to 1.8.2 in /docs/sphinx (#3271)

### DIFF
--- a/docs/sphinx/requirements.in
+++ b/docs/sphinx/requirements.in
@@ -1,1 +1,1 @@
-rocm-docs-core[api_reference]==1.2.0
+rocm-docs-core[api_reference]==1.8.2

--- a/docs/sphinx/requirements.txt
+++ b/docs/sphinx/requirements.txt
@@ -112,7 +112,7 @@ requests==2.32.2
     # via
     #   pygithub
     #   sphinx
-rocm-docs-core[api-reference]==1.2.0
+rocm-docs-core[api-reference]==1.8.2
     # via -r requirements.in
 smmap==5.0.1
     # via gitdb


### PR DESCRIPTION
Includes updates for rocm-docs-core to keep header version number current for the "latest" version of the doc build

ie: https://rocm.docs.amd.com/projects/MIOpen/en/latest/