### PR TITLE
[BUG] fix for memcopy data race

### DIFF
--- a/src/hip/handlehip.cpp
+++ b/src/hip/handlehip.cpp
@@ -453,7 +453,7 @@ void Handle::Copy(ConstData_t src, Data_t dest, std::size_t size) const
 {
     MIOPEN_HANDLE_LOCK
     this->impl->set_ctx();
-    auto status = hipMemcpy(dest, src, size, hipMemcpyDeviceToDevice);
+    auto status = hipMemcpyWithStream(dest, src, size, hipMemcpyDeviceToDevice, this->GetStream());
     if(status != hipSuccess)
         MIOPEN_THROW_HIP_STATUS(status, "Hip error copying buffer: ");
 }


### PR DESCRIPTION
This PR should fix the data race related to the use of hipMemcpy. When a user operates in a stream created with the hipStreamNonBlocking flag, using hipMemcpyDeviceToDevice may lead to a race condition. Because HIP runtime will perform operation in the null stream, while the user's working stream is not blocked by it