### PR TITLE
Update package name from miopen-hip-client to miopen-hip-clients

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -681,7 +681,7 @@ endif()
 # End KDB package creation
 
 if(NOT MIOPEN_TEST_DISCRETE)
-list(APPEND CPACK_COMPONENTS_ALL client)
+list(APPEND CPACK_COMPONENTS_ALL clients)
 endif()
 
 rocm_create_package(


### PR DESCRIPTION
Per QA's request, update miopen package name with make package command, e.g. 
from 
"miopen-hip-client*.deb" to 
"miopen-hip-clients*.deb"


Test:
make package
...
CPack: Create package
CPack: - package: /MIOpen/build/miopen-hip-clients_3.3.0-1ffcdf3e6~dirty_amd64.deb generated.

