### PR TITLE
[DOC] Add readme note and metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 
 MIOpen is AMD's library for high-performance machine learning primitives.
 
-You can find sources and binaries in our [GitHub repository](https://github.com/ROCm/MIOpen) and
-our documentation on
-[ROCm docs](https://rocm.docs.amd.com/projects/MIOpen/en/latest/index.html).
+You can find sources and binaries in our [GitHub repository](https://github.com/ROCm/MIOpen).
+
+> [!NOTE]
+> The published MIOpen documentation is available at [MIOpen](https://rocm.docs.amd.com/projects/MIOpen/en/latest/index.html) in an organized, easy-to-read format, with search and a table of contents. The documentation source files reside in the MIOpen/docs folder of this repository. As with all ROCm projects, the documentation is open source. For more information, see [Contribute to ROCm documentation](https://rocm.docs.amd.com/en/latest/contribute/contributing.html).
 
 MIOpen supports these programming models (backends):
 

--- a/docs/license.md
+++ b/docs/license.md
@@ -1,3 +1,10 @@
+---
+myst:
+    html_meta:
+        "description": "MIOpen licensing information"
+        "keywords": "MIOpen, ROCm, API, documentation, license"
+---
+
 # License
 
 ```{include} ../LICENSE.txt


### PR DESCRIPTION
This adds a short note pointing to the ROCm docs to the read me file. It also adds missing metadata to the license file.