### PR TITLE
fix negative cache results

### DIFF
--- a/src/conv/solver_finders.cpp
+++ b/src/conv/solver_finders.cpp
@@ -279,7 +279,7 @@ static std::vector<Solution> EvaluateInvokers(Handle& handle,
             }
             // If the execution time was not too long,
             // then the 1st run is not counted (assume it's warm-up):
-            if(i > 1)
+            if(i > N_RUNS_DISCARD)
                 elapsed = (elapsed - first_elapsed) / static_cast<elapsed_t>(i - N_RUNS_DISCARD);
 
             MIOPEN_LOG_I(sol << ": " << elapsed << (elapsed < best ? " < " : " >= ") << best);

--- a/src/conv/solver_finders.cpp
+++ b/src/conv/solver_finders.cpp
@@ -280,7 +280,13 @@ static std::vector<Solution> EvaluateInvokers(Handle& handle,
             // If the execution time was not too long,
             // then the 1st run is not counted (assume it's warm-up):
             if(i > N_RUNS_DISCARD)
+            {
                 elapsed = (elapsed - first_elapsed) / static_cast<elapsed_t>(i - N_RUNS_DISCARD);
+            }
+            else if(i > 0)
+            {
+                elapsed /= i;
+            }
 
             MIOPEN_LOG_I(sol << ": " << elapsed << (elapsed < best ? " < " : " >= ") << best);
             if(elapsed < best)


### PR DESCRIPTION
In some cases the loop would exit early and that would result in negative entries that could cause problems with caching.