### PR TITLE
Temporarily disable igemm wrw solvers for bfloat16 unless device is gfx92

### DIFF
--- a/src/solver/conv/conv_hip_implicit_gemm_3d_grouped_wrw_xdlops.cpp
+++ b/src/solver/conv/conv_hip_implicit_gemm_3d_grouped_wrw_xdlops.cpp
@@ -541,7 +541,9 @@ bool ConvHipImplicitGemm3DGroupWrwXdlops::IsApplicable(
     case miopenHalf: return CheckCKApplicability<ck::half_t>(problem);
     case miopenFloat: return CheckCKApplicability<float>(problem);
     case miopenInt8: return CheckCKApplicability<int8_t>(problem);
-    case miopenBFloat16: return CheckCKApplicability<ck::bhalf_t>(problem);
+    case miopenBFloat16:
+        return StartsWith(ctx.GetStream().GetDeviceName(), "gfx94") &&
+               CheckCKApplicability<ck::bhalf_t>(problem);
     case miopenInt64:
     case miopenInt32:
     case miopenFloat8:

--- a/src/solver/conv/conv_hip_implicit_gemm_grouped_wrw_xdlops.cpp
+++ b/src/solver/conv/conv_hip_implicit_gemm_grouped_wrw_xdlops.cpp
@@ -591,7 +591,9 @@ bool ConvHipImplicitGemmGroupWrwXdlops::IsApplicable(
     case miopenHalf: return CheckCKApplicability<ck::half_t>(problem);
     case miopenFloat: return CheckCKApplicability<float>(problem);
     case miopenInt8: return CheckCKApplicability<int8_t>(problem);
-    case miopenBFloat16: return CheckCKApplicability<ck::bhalf_t>(problem);
+    case miopenBFloat16:
+        return StartsWith(ctx.GetStream().GetDeviceName(), "gfx94") &&
+               CheckCKApplicability<ck::bhalf_t>(problem);
     case miopenInt64:
     case miopenInt32:
     case miopenFloat8:


### PR DESCRIPTION
Temporarily disable solvers that are failing on MI200 to prevent test failures. 