### PR TITLE
fix batch norm driver command for some configs that were failing

### DIFF
--- a/driver/bn_driver.hpp
+++ b/driver/bn_driver.hpp
@@ -232,8 +232,8 @@ int BatchNormDriver<TInput, Tref, TAcc, TScaleBias, TOut>::GetandSetData()
 
         for(int i = 0; i < runVariance.GetVector().size(); i++)
         {
-            runMean.GetVector()[i]     = 0.0f;
-            runVariance.GetVector()[i] = 0.0f;
+            runMean.GetVector()[i]     = prng::gen_canonical<TAcc>();
+            runVariance.GetVector()[i] = prng::gen_canonical<TAcc>();
         }
     }
     else if(isBwd)


### PR DESCRIPTION
updated batch norm driver command for some configs that were failing.
I reverted the way variables were initialized to old way and the driver command start passing. 

these driver command was failing before and now its passing. 
MIOPEN_ENABLE_LOGGING=1 MIOPEN_LOG_LEVEL=6 ./bin/MIOpenDriver bnorm -n 1 -c 1 -H 101 -W 101 -m 1 --forw 1 -b 0 -s 1 -r 1 
MIOPEN_ENABLE_LOGGING=1 MIOPEN_LOG_LEVEL=6  ./bin/MIOpenDriver bnorm -n 8 -c 32 -H 470 -W 725 -m 1 --forw 1 -b 0 -s 1 -r 1