### PR TITLE
Cherry pick of solver fixes for 6.3 release

### DIFF
--- a/src/conv/solver_finders.cpp
+++ b/src/conv/solver_finders.cpp
@@ -279,8 +279,14 @@ static std::vector<Solution> EvaluateInvokers(Handle& handle,
             }
             // If the execution time was not too long,
             // then the 1st run is not counted (assume it's warm-up):
-            if(i > 1)
+            if(i > N_RUNS_DISCARD)
+            {
                 elapsed = (elapsed - first_elapsed) / static_cast<elapsed_t>(i - N_RUNS_DISCARD);
+            }
+            else if(i > 0)
+            {
+                elapsed /= i;
+            }
 
             MIOPEN_LOG_I(sol << ": " << elapsed << (elapsed < best ? " < " : " >= ") << best);
             if(elapsed < best)

--- a/src/conv/solver_finders.cpp
+++ b/src/conv/solver_finders.cpp
@@ -274,7 +274,7 @@ static std::vector<Solution> EvaluateInvokers(Handle& handle,
                 invoker(handle, invoke_ctx);
                 elapsed += handle.GetKernelTime();
                 if(i < N_RUNS_DISCARD)
-                    first_elapsed += elapsed;
+                    first_elapsed = elapsed;
                 ++i;
             }
             // If the execution time was not too long,


### PR DESCRIPTION
Cherry picking develop commits bfdfecde83f86db9066f195f033f96727e7fe3e6 and 481f7758877a5aa6501e4119ba8821e042ce368a to resolve issues with solver selection.  Issue was causing performance issues due to poor solver choices as well as other errors due to rarely used solvers being picked.
