### PR TITLE
Temporarily disable conv_hip_implicit_gemm_grouped_bwd_xdlops solver due to precision issues

### DIFF
--- a/src/solver/conv/conv_hip_implicit_gemm_grouped_bwd_xdlops.cpp
+++ b/src/solver/conv/conv_hip_implicit_gemm_grouped_bwd_xdlops.cpp
@@ -39,6 +39,9 @@
 #include <miopen/solver/implicitgemm_ck_util.hpp>
 MIOPEN_DECLARE_ENV_VAR_BOOL(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_GROUP_BWD_XDLOPS)
 MIOPEN_DECLARE_ENV_VAR_BOOL(MIOPEN_DEBUG_GROUP_CONV_IMPLICIT_GEMM_HIP_BWD_XDLOPS_AI_HEUR)
+
+// Temporarily disable solver due to precision issues
+#define WORKAROUND_SWDEV_496711 1
 namespace miopen {
 namespace solver {
 namespace conv {
@@ -472,7 +475,7 @@ bool ConvHipImplicitGemmGroupBwdXdlops::IsApplicable(
     [[maybe_unused]] const ExecutionContext& ctx,
     [[maybe_unused]] const ProblemDescription& problem) const
 {
-#if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
+#if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL && !WORKAROUND_SWDEV_496711
     if(env::enabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_GROUP_BWD_XDLOPS))
         return false;
     if(env::enabled(MIOPEN_DEBUG_CONVOLUTION_DETERMINISTIC))


### PR DESCRIPTION
Add a workaround to temporarily disable solver that has precision issues for certain shapes.