### PR TITLE
Update `driverTableCrop.png` reference

### DIFF
--- a/driver/README.md
+++ b/driver/README.md
@@ -40,7 +40,7 @@ The supported base arguments:
 
 Summary of base_args meant for different datatypes and different operations:
 
-![DatatypeSupport](../docs/data/driverTableCrop.png)
+![DatatypeSupport](../docs/data/how-to/driverTableCrop.png)
 
 
 ## Executing MIOpenDriver


### PR DESCRIPTION
# PR Summary
Commit 992a835c210b42d28d33c12ae3c0d245e3b1b6cb moved the `driverTableCrop.png` asset to `docs/data/how-to`. This PR adjusts sources to changes.