### PR TITLE
[Bug] Fix issue with WRW heuristics instance selection

### DIFF
--- a/src/include/miopen/solver/implicitgemm_ck_util.hpp
+++ b/src/include/miopen/solver/implicitgemm_ck_util.hpp
@@ -140,7 +140,7 @@ bool IsCKArgsSupported(const ProblemDescriptionType& problem, const std::string&
                      std::is_same_v<DeviceOpType, conv::DeviceOpGWrwPtrs<ck::bhalf_t>>)
         {
             auto pos = kernel_id.find_last_of('+');
-            if(pos == string::npos)
+            if(pos == std::string::npos)
             {
                 MIOPEN_LOG_I2("Unable to parse split_k from kernel_id for wrw: " << kernel_id);
                 return false;

--- a/src/include/miopen/solver/implicitgemm_ck_util.hpp
+++ b/src/include/miopen/solver/implicitgemm_ck_util.hpp
@@ -140,7 +140,24 @@ bool IsCKArgsSupported(const ProblemDescriptionType& problem, const std::string&
                      std::is_same_v<DeviceOpType, conv::DeviceOpGWrwPtrs<ck::bhalf_t>>)
         {
             auto pos      = kernel_id.find_last_of('+');
-            int split_k   = std::stoi(kernel_id.substr(pos + 1));
+            if(pos == string::npos)
+            {
+                MIOPEN_LOG_I2("Unable to parse split_k from kernel_id for wrw: " << kernel_id);
+                return false;
+            }
+
+            int split_k = 1;
+            try
+            {
+                split_k   = std::stoi(kernel_id.substr(pos + 1));
+            }
+            catch(std::exception& e)
+            {
+                MIOPEN_LOG_I2("Unable to parse split_k from kernel_id for wrw: " << kernel_id << " : "
+                                                    << e.what());
+                return false;
+            }
+
             auto ptr_iter = FindConvPtrByID(conv_ptrs, kernel_id.substr(0, pos));
             return (ptr_iter != conv_ptrs.end()) &&
                    CKArgsType{problem}.IsSupportedBySplitK(*ptr_iter, split_k);

--- a/src/include/miopen/solver/implicitgemm_ck_util.hpp
+++ b/src/include/miopen/solver/implicitgemm_ck_util.hpp
@@ -139,7 +139,7 @@ bool IsCKArgsSupported(const ProblemDescriptionType& problem, const std::string&
                      std::is_same_v<DeviceOpType, conv::DeviceOpGWrwPtrs<int8_t>> ||
                      std::is_same_v<DeviceOpType, conv::DeviceOpGWrwPtrs<ck::bhalf_t>>)
         {
-            auto pos      = kernel_id.find_last_of('+');
+            auto pos = kernel_id.find_last_of('+');
             if(pos == string::npos)
             {
                 MIOPEN_LOG_I2("Unable to parse split_k from kernel_id for wrw: " << kernel_id);
@@ -149,12 +149,12 @@ bool IsCKArgsSupported(const ProblemDescriptionType& problem, const std::string&
             int split_k = 1;
             try
             {
-                split_k   = std::stoi(kernel_id.substr(pos + 1));
+                split_k = std::stoi(kernel_id.substr(pos + 1));
             }
             catch(std::exception& e)
             {
-                MIOPEN_LOG_I2("Unable to parse split_k from kernel_id for wrw: " << kernel_id << " : "
-                                                    << e.what());
+                MIOPEN_LOG_I2("Unable to parse split_k from kernel_id for wrw: "
+                              << kernel_id << " : " << e.what());
                 return false;
             }
 

--- a/src/include/miopen/solver/implicitgemm_ck_util.hpp
+++ b/src/include/miopen/solver/implicitgemm_ck_util.hpp
@@ -142,7 +142,7 @@ bool IsCKArgsSupported(const ProblemDescriptionType& problem, const std::string&
             auto pos = kernel_id.find_last_of('+');
             if(pos == std::string::npos)
             {
-                MIOPEN_LOG_I2("Unable to parse split_k from kernel_id for wrw: " << kernel_id);
+                MIOPEN_LOG_WE("Unable to parse split_k from kernel_id for wrw: " << kernel_id);
                 return false;
             }
 
@@ -153,7 +153,7 @@ bool IsCKArgsSupported(const ProblemDescriptionType& problem, const std::string&
             }
             catch(std::exception& e)
             {
-                MIOPEN_LOG_I2("Unable to parse split_k from kernel_id for wrw: "
+                MIOPEN_LOG_WE("Unable to parse split_k from kernel_id for wrw: "
                               << kernel_id << " : " << e.what());
                 return false;
             }

--- a/src/include/miopen/solver/implicitgemm_ck_util.hpp
+++ b/src/include/miopen/solver/implicitgemm_ck_util.hpp
@@ -128,7 +128,7 @@ std::vector<std::string> FillValidKernelsIDs(const ProblemDescriptionType& probl
 template <typename DeviceOpType,
           typename CKArgsType,
           typename ProblemDescriptionType = miopen::conv::ProblemDescription,
-          bool checkSplitK                = false>
+          bool CheckSplitK                = false>
 bool IsCKArgsSupported(const ProblemDescriptionType& problem, const std::string& kernel_id)
 {
 #if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
@@ -139,7 +139,7 @@ bool IsCKArgsSupported(const ProblemDescriptionType& problem, const std::string&
                      std::is_same_v<DeviceOpType, conv::DeviceOpGWrwPtrs<float>> ||
                      std::is_same_v<DeviceOpType, conv::DeviceOpGWrwPtrs<int8_t>> ||
                      std::is_same_v<DeviceOpType, conv::DeviceOpGWrwPtrs<ck::bhalf_t>> ||
-                     checkSplitK)
+                     CheckSplitK)
         {
             auto pos = kernel_id.find_last_of('+');
             if(pos == std::string::npos)

--- a/src/include/miopen/solver/implicitgemm_ck_util.hpp
+++ b/src/include/miopen/solver/implicitgemm_ck_util.hpp
@@ -127,7 +127,8 @@ std::vector<std::string> FillValidKernelsIDs(const ProblemDescriptionType& probl
 
 template <typename DeviceOpType,
           typename CKArgsType,
-          typename ProblemDescriptionType = miopen::conv::ProblemDescription>
+          typename ProblemDescriptionType = miopen::conv::ProblemDescription,
+          bool checkSplitK                = false>
 bool IsCKArgsSupported(const ProblemDescriptionType& problem, const std::string& kernel_id)
 {
 #if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
@@ -137,7 +138,8 @@ bool IsCKArgsSupported(const ProblemDescriptionType& problem, const std::string&
         if constexpr(std::is_same_v<DeviceOpType, conv::DeviceOpGWrwPtrs<ck::half_t>> ||
                      std::is_same_v<DeviceOpType, conv::DeviceOpGWrwPtrs<float>> ||
                      std::is_same_v<DeviceOpType, conv::DeviceOpGWrwPtrs<int8_t>> ||
-                     std::is_same_v<DeviceOpType, conv::DeviceOpGWrwPtrs<ck::bhalf_t>>)
+                     std::is_same_v<DeviceOpType, conv::DeviceOpGWrwPtrs<ck::bhalf_t>> ||
+                     checkSplitK)
         {
             auto pos = kernel_id.find_last_of('+');
             if(pos == std::string::npos)

--- a/src/solver/conv/conv_hip_implicit_gemm_grouped_wrw_xdlops.cpp
+++ b/src/solver/conv/conv_hip_implicit_gemm_grouped_wrw_xdlops.cpp
@@ -289,8 +289,7 @@ bool PerformanceConfigHipImplicitGemmGroupWrwXdlops::ModelApplyToken(
             idx += 2;
         if(((idx == 15 && (heuristic_kernels[heuristic_indexes[0]].size() == 15)) || idx == 18))
         {
-            kernel_id =
-                valid_kernels[heuristic_indexes[0]] + "+" + value;
+            kernel_id          = valid_kernels[heuristic_indexes[0]] + "+" + value;
             index              = heuristic_indexes[0];
             bool valid_split_k = false;
             switch(problem.GetInDataType())

--- a/src/solver/conv/conv_hip_implicit_gemm_grouped_wrw_xdlops.cpp
+++ b/src/solver/conv/conv_hip_implicit_gemm_grouped_wrw_xdlops.cpp
@@ -290,7 +290,7 @@ bool PerformanceConfigHipImplicitGemmGroupWrwXdlops::ModelApplyToken(
         if(((idx == 15 && (heuristic_kernels[heuristic_indexes[0]].size() == 15)) || idx == 18))
         {
             kernel_id =
-                valid_kernels[heuristic_indexes[0]] + "+" + value + "+" + std::to_string(split_k);
+                valid_kernels[heuristic_indexes[0]] + "+" + value;
             index              = heuristic_indexes[0];
             bool valid_split_k = false;
             switch(problem.GetInDataType())

--- a/test/gtest/kernel_tuning_net.cpp
+++ b/test/gtest/kernel_tuning_net.cpp
@@ -1,3 +1,29 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2024 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
 #include <gtest/ai_heuristics.hpp>
 #include "../tensor_holder.hpp"
 #include "get_handle.hpp"
@@ -81,6 +107,13 @@ std::vector<KernelTuningNetTestCase> GetConvHipIgemmGroupWrwXdlopsTestCases_FP32
               miopenTensorNHWC},
              "DeviceGroupedConvBwdWeight_Xdl_CShuffle<128, 128, 32, 4, Default, 4, 2, 1, 4, 4, 1, "
              "1, 1, 1, 1>+128",
+             "gfx942"},
+            {{{1, 2, 2, 1, {9, 1}, {1, 1}, {1, 0}, {3, 1}, {2, 1}},
+              miopen::conv::Direction::BackwardWeights,
+              miopenFloat,
+              miopenTensorNHWC},
+             "DeviceGroupedConvBwdWeight_Xdl_CShuffle<64, 64, 64, 4, Default, 4, 2, 2, 1, 4, 1, 4, "
+             "1, 1, 1>+8",
              "gfx942"}};
 }
 
@@ -99,7 +132,7 @@ std::vector<KernelTuningNetTestCase> GetConvHipIgemmGroupWrwXdlopsTestCases_FP16
           miopenHalf,
           miopenTensorNHWC},
          "DeviceGroupedConvBwdWeightTwoStage_Xdl_CShuffle<64, 16, 16, 32, Default, 8, 1, 1, 1, 4, "
-         "1, 4, 1, 1, 1, BlkGemmPipelineScheduler: Intrawave, BlkGemmPipelineVersion: v5, 1>+128",
+         "1, 4, 1, 1, 1, BlkGemmPipelineScheduler: Intrawave, BlkGemmPipelineVersion: v1, 1>+1",
          "gfx942"},
         {{{1, 16, 128, 256, {27, 27}, {3, 3}, {0, 0}, {1, 2}, {1, 1}},
           miopen::conv::Direction::BackwardWeights,

--- a/test/gtest/kernel_tuning_net.cpp
+++ b/test/gtest/kernel_tuning_net.cpp
@@ -94,6 +94,13 @@ std::vector<KernelTuningNetTestCase> GetConvHipIgemmGroupWrwXdlopsTestCases_FP16
          "DeviceGroupedConvBwdWeightTwoStage_Xdl_CShuffle<64, 16, 16, 32, Default, 8, 1, 1, 1, 4, "
          "1, 4, 1, 1, 1, BlkGemmPipelineScheduler: Intrawave, BlkGemmPipelineVersion: v5, 1>+128",
          "gfx942"},
+        {{{1, 2, 2, 1, {9, 1}, {1, 1}, {1, 0}, {3, 1}, {2, 1}},
+          miopen::conv::Direction::BackwardWeights,
+          miopenHalf,
+          miopenTensorNHWC},
+         "DeviceGroupedConvBwdWeightTwoStage_Xdl_CShuffle<64, 16, 16, 32, Default, 8, 1, 1, 1, 4, "
+         "1, 4, 1, 1, 1, BlkGemmPipelineScheduler: Intrawave, BlkGemmPipelineVersion: v5, 1>+128",
+         "gfx942"},
         {{{1, 16, 128, 256, {27, 27}, {3, 3}, {0, 0}, {1, 2}, {1, 1}},
           miopen::conv::Direction::BackwardWeights,
           miopenHalf,

--- a/test/gtest/kernel_tuning_net.cpp
+++ b/test/gtest/kernel_tuning_net.cpp
@@ -79,8 +79,8 @@ std::vector<KernelTuningNetTestCase> GetConvHipIgemmGroupWrwXdlopsTestCases_FP32
               miopen::conv::Direction::BackwardWeights,
               miopenFloat,
               miopenTensorNHWC},
-             "DeviceGroupedConvBwdWeight_Xdl_CShuffle<64, 64, 64, 4, Default, 4, 2, 2, 1, 4, 1, "
-             "4, 1, 1, 1>+1",
+             "DeviceGroupedConvBwdWeight_Xdl_CShuffle<128, 128, 32, 4, Default, 4, 2, 1, 4, 4, 1, "
+             "1, 1, 1, 1>+128",
              "gfx942"}};
 }
 
@@ -92,7 +92,7 @@ std::vector<KernelTuningNetTestCase> GetConvHipIgemmGroupWrwXdlopsTestCases_FP16
           miopenHalf,
           miopenTensorNHWC},
          "DeviceGroupedConvBwdWeightTwoStage_Xdl_CShuffle<64, 16, 16, 32, Default, 8, 1, 1, 1, 4, "
-         "1, 4, 1, 1, 1, BlkGemmPipelineScheduler: Intrawave, BlkGemmPipelineVersion: v2, 1>+1",
+         "1, 4, 1, 1, 1, BlkGemmPipelineScheduler: Intrawave, BlkGemmPipelineVersion: v5, 1>+128",
          "gfx942"},
         {{{1, 16, 128, 256, {27, 27}, {3, 3}, {0, 0}, {1, 2}, {1, 1}},
           miopen::conv::Direction::BackwardWeights,

--- a/test/gtest/unit_implicitgemm_ck_util.cpp
+++ b/test/gtest/unit_implicitgemm_ck_util.cpp
@@ -122,7 +122,7 @@ protected:
         DeviceOpType::deviceOps.clear();
         DeviceOpType::deviceOps.push_back(testCase.instanceToCheck);
 
-        bool success = !testCase.expectedSupported;
+        bool success;
         if(testCase.checkSplitK)
         {
             success = miopen::solver::

--- a/test/gtest/unit_implicitgemm_ck_util.cpp
+++ b/test/gtest/unit_implicitgemm_ck_util.cpp
@@ -25,6 +25,7 @@
  *******************************************************************************/
 
 #include <miopen/conv/problem_description.hpp>
+#include <miopen/conv/solvers.hpp>
 #include <miopen/solver/implicitgemm_ck_util.hpp>
 #include <gtest/gtest.h>
 #include <string>
@@ -149,13 +150,13 @@ protected:
 
 using namespace unit_implicitgemm_ck_util_test;
 
-struct CPU_UnitTestImplicitGemmCKUtilWRW_NONE : CKArgParsingTest<StubbedWRWCKArgs, StubbedDeviceOps>
+struct CPU_UnitTestImplicitGemmCKUtil_NONE : CKArgParsingTest<StubbedWRWCKArgs, StubbedDeviceOps>
 {
 };
 
 // TEST_F(CPU_UnitTestImplicitGemmCKUtilWRW_NONE, TestParsing) { TestParsing(); }
-TEST_P(CPU_UnitTestImplicitGemmCKUtilWRW_NONE, TestParsing) { this->TestParsing(); };
+TEST_P(CPU_UnitTestImplicitGemmCKUtil_NONE, TestParsing) { this->TestParsing(); };
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         CPU_UnitTestImplicitGemmCKUtilWRW_NONE,
+                         CPU_UnitTestImplicitGemmCKUtil_NONE,
                          testing::ValuesIn(GetTestCases()));

--- a/test/gtest/unit_implicitgemm_ck_util.cpp
+++ b/test/gtest/unit_implicitgemm_ck_util.cpp
@@ -28,9 +28,10 @@
 #include <miopen/conv/solvers.hpp>
 #include <miopen/solver/implicitgemm_ck_util.hpp>
 #include <gtest/gtest.h>
+#include <iostream>
+#include <memory>
 #include <string>
 #include <vector>
-#include <memory>
 
 namespace unit_implicitgemm_ck_util_test {
 struct ParsingTestCase
@@ -39,6 +40,13 @@ struct ParsingTestCase
     std::string suffix;
     bool expectedSupported;
     bool checkSplitK;
+
+    friend std::ostream& operator<<(std::ostream& os, const ParsingTestCase& tc)
+    {
+        return os << "(instanceToCheck: " << tc.instanceToCheck << " suffix: " << tc.suffix
+                  << " expectedSupported: " << tc.expectedSupported
+                  << " checkSplitK: " << tc.checkSplitK << ")";
+    }
 };
 
 static std::vector<ParsingTestCase> GetTestCases()

--- a/test/gtest/unit_implicitgemm_ck_util.cpp
+++ b/test/gtest/unit_implicitgemm_ck_util.cpp
@@ -1,0 +1,161 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2024 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <miopen/conv/problem_description.hpp>
+#include <miopen/solver/implicitgemm_ck_util.hpp>
+#include <gtest/gtest.h>
+#include <string>
+#include <vector>
+#include <memory>
+
+namespace unit_implicitgemm_ck_util_test {
+struct ParsingTestCase
+{
+    std::string instanceToCheck;
+    std::string suffix;
+    bool expectedSupported;
+    bool checkSplitK;
+};
+
+static std::vector<ParsingTestCase> GetTestCases()
+{
+    return {{"test0", "+5", true, true},
+            {"test1", "+", false, true},
+            {"test2", "", false, true},
+            {"test3", "+2+3", false, true},
+            {"test4", "+9999999999999999999999999", false, true},
+            {"test5", "", true, false},
+            {"test6", "+", false, false},
+            {"test7", "+2", false, false},
+            {"test8", "+2+3", false, false}};
+}
+
+using ProblemDescription = miopen::conv::ProblemDescription;
+
+struct StubbedDeviceOp
+{
+    StubbedDeviceOp(const std::string& op) : typeString(op) {}
+
+    std::string typeString;
+
+    std::string GetTypeString() { return typeString; }
+};
+
+struct StubbedDeviceOps
+{
+    static std::vector<std::string> deviceOps;
+
+    static std::vector<std::unique_ptr<StubbedDeviceOp>> GetInstances()
+    {
+        std::vector<std::unique_ptr<StubbedDeviceOp>> ops;
+        ops.reserve(deviceOps.size());
+
+        std::transform(deviceOps.begin(),
+                       deviceOps.end(),
+                       std::back_inserter(ops),
+                       [&](auto& deviceOp) { return std::make_unique<StubbedDeviceOp>(deviceOp); });
+
+        return ops;
+    }
+};
+
+std::vector<std::string> StubbedDeviceOps::deviceOps = {};
+
+struct StubbedWRWCKArgs
+{
+    StubbedWRWCKArgs(const ProblemDescription&) {}
+
+    template <typename ConvPtr>
+    bool IsSupportedBy(const ConvPtr&) const
+    {
+        return true;
+    }
+
+    template <typename ConvPtr>
+    bool IsSupportedBySplitK(const ConvPtr&, int) const
+    {
+        return true;
+    }
+};
+
+struct StubbedCKArgs
+{
+    StubbedCKArgs(const ProblemDescription& problem) {}
+
+    template <typename ConvPtr>
+    bool IsSupportedBy(const ConvPtr&) const
+    {
+        return true;
+    }
+
+    template <typename ConvPtr>
+    bool IsSupportedBySplitK(const ConvPtr&, int) const
+    {
+        return false;
+    }
+};
+
+template <typename CKArgsType, typename DeviceOpType>
+class CKArgParsingTest : public ::testing::TestWithParam<ParsingTestCase>
+{
+protected:
+    void TestParsing()
+    {
+        auto testCase = GetParam();
+
+        // Set up stubbed instances to match test
+        DeviceOpType::deviceOps.clear();
+        DeviceOpType::deviceOps.push_back(testCase.instanceToCheck);
+
+        bool success = !testCase.expectedSupported;
+        if(testCase.checkSplitK)
+        {
+            success = miopen::solver::
+                IsCKArgsSupported<DeviceOpType, CKArgsType, ProblemDescription, true>(
+                    ProblemDescription{}, testCase.instanceToCheck + testCase.suffix);
+        }
+        else
+        {
+            success = miopen::solver::IsCKArgsSupported<DeviceOpType, CKArgsType>(
+                ProblemDescription{}, testCase.instanceToCheck + testCase.suffix);
+        }
+        EXPECT_EQ(success, testCase.expectedSupported);
+    }
+};
+} // namespace unit_implicitgemm_ck_util_test
+
+using namespace unit_implicitgemm_ck_util_test;
+
+struct CPU_UnitTestImplicitGemmCKUtilWRW_NONE : CKArgParsingTest<StubbedWRWCKArgs, StubbedDeviceOps>
+{
+};
+
+// TEST_F(CPU_UnitTestImplicitGemmCKUtilWRW_NONE, TestParsing) { TestParsing(); }
+TEST_P(CPU_UnitTestImplicitGemmCKUtilWRW_NONE, TestParsing) { this->TestParsing(); };
+
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         CPU_UnitTestImplicitGemmCKUtilWRW_NONE,
+                         testing::ValuesIn(GetTestCases()));

--- a/test/gtest/unit_implicitgemm_ck_util.cpp
+++ b/test/gtest/unit_implicitgemm_ck_util.cpp
@@ -85,23 +85,6 @@ struct StubbedDeviceOps
 
 std::vector<std::string> StubbedDeviceOps::deviceOps = {};
 
-struct StubbedWRWCKArgs
-{
-    StubbedWRWCKArgs(const ProblemDescription&) {}
-
-    template <typename ConvPtr>
-    bool IsSupportedBy(const ConvPtr&) const
-    {
-        return true;
-    }
-
-    template <typename ConvPtr>
-    bool IsSupportedBySplitK(const ConvPtr&, int) const
-    {
-        return true;
-    }
-};
-
 struct StubbedCKArgs
 {
     StubbedCKArgs(const ProblemDescription& problem) {}
@@ -115,7 +98,7 @@ struct StubbedCKArgs
     template <typename ConvPtr>
     bool IsSupportedBySplitK(const ConvPtr&, int) const
     {
-        return false;
+        return true;
     }
 };
 
@@ -150,11 +133,10 @@ protected:
 
 using namespace unit_implicitgemm_ck_util_test;
 
-struct CPU_UnitTestImplicitGemmCKUtil_NONE : CKArgParsingTest<StubbedWRWCKArgs, StubbedDeviceOps>
+struct CPU_UnitTestImplicitGemmCKUtil_NONE : CKArgParsingTest<StubbedCKArgs, StubbedDeviceOps>
 {
 };
 
-// TEST_F(CPU_UnitTestImplicitGemmCKUtilWRW_NONE, TestParsing) { TestParsing(); }
 TEST_P(CPU_UnitTestImplicitGemmCKUtil_NONE, TestParsing) { this->TestParsing(); };
 
 INSTANTIATE_TEST_SUITE_P(Smoke,


### PR DESCRIPTION
After the fix for #3249 WRW heuristics would fail to parse split_k properly, and this would lead to using the default instance in all cases. This change will prevent issues where the split_k value is missing or malformed, and also allow for valid cases to parse.