### PR TITLE
Fix kernel time not accumulating properly for gemm wrw

### DIFF
--- a/src/solver/conv/gemm_wrw.cpp
+++ b/src/solver/conv/gemm_wrw.cpp
@@ -250,7 +250,7 @@ ConvSolution GemmWrw1x1_stride1::GetSolution(const ExecutionContext&,
 
             if(group_count > 1)
             {
-                auto time = 0;
+                float time = 0;
 
                 for(std::size_t i = 0; i < in_n; i++)
                 {

--- a/src/solver/conv/gemm_wrw.cpp
+++ b/src/solver/conv/gemm_wrw.cpp
@@ -250,7 +250,7 @@ ConvSolution GemmWrw1x1_stride1::GetSolution(const ExecutionContext&,
 
             if(group_count > 1)
             {
-                float time = 0;
+                float time = 0.0f;
 
                 for(std::size_t i = 0; i < in_n; i++)
                 {


### PR DESCRIPTION
Since time was an integer value the kernel accumulation is inaccurate, and potentially 0 if it runs fast enough.