### PR TITLE
[CONV] fix naive conv kernel for large tensors

### DIFF
--- a/src/solver/conv/conv_direct_naive_conv.cpp
+++ b/src/solver/conv/conv_direct_naive_conv.cpp
@@ -357,11 +357,12 @@ GetConv2DFWDSolution(const ExecutionContext& ctx, const ::miopen::conv::ProblemD
     int c_per_group = c / group;
     int k_per_group = k / group;
 
-    size_t block_size = 256;
+    size_t block_size = 512;
     size_t grid_size  = 1;
     if(problem.IsLayoutDefault())
     {
-        grid_size = static_cast<size_t>(n) * k;
+        // grid_size = static_cast<size_t>(n) * k;
+        grid_size = (static_cast<size_t>(n) * k + block_size - 1) / block_size;
     }
     else if(problem.IsLayoutNHWC())
     {

--- a/src/solver/conv/conv_direct_naive_conv.cpp
+++ b/src/solver/conv/conv_direct_naive_conv.cpp
@@ -357,15 +357,31 @@ GetConv2DFWDSolution(const ExecutionContext& ctx, const ::miopen::conv::ProblemD
     int c_per_group = c / group;
     int k_per_group = k / group;
 
-    size_t block_size = 512;
+    size_t block_size = 256;
     size_t grid_size  = 1;
     if(problem.IsLayoutDefault())
     {
-        grid_size = (static_cast<size_t>(n) * k + block_size - 1) / block_size;
+        size_t all_workload = static_cast<size_t>(n) * k;
+        if(all_workload <= block_size)
+        {
+            grid_size = all_workload;
+        }
+        else
+        {
+            grid_size = (all_workload + block_size - 1) / block_size;
+        }
     }
     else if(problem.IsLayoutNHWC())
     {
-        grid_size = (static_cast<size_t>(group) * n * ho + block_size - 1) / block_size;
+        size_t all_workload = static_cast<size_t>(group) * n * ho;
+        if(all_workload <= block_size)
+        {
+            grid_size = all_workload;
+        }
+        else
+        {
+            grid_size = (all_workload + block_size - 1) / block_size;
+        }
     }
     else
         MIOPEN_THROW("Unsupported layout");
@@ -507,15 +523,30 @@ GetConv3DFWDSolution(const ExecutionContext& ctx, const ::miopen::conv::ProblemD
 
     size_t block_size = 512;
     size_t grid_size  = 1;
+
     if(problem.IsLayoutDefault())
     {
-        grid_size = (static_cast<size_t>(n) * k + block_size - 1) / block_size;
-        ;
+        size_t all_workload = static_cast<size_t>(n) * k;
+        if(all_workload <= block_size)
+        {
+            grid_size = all_workload;
+        }
+        else
+        {
+            grid_size = (all_workload + block_size - 1) / block_size;
+        }
     }
     else if(problem.IsLayoutNHWC())
     {
-        grid_size = (static_cast<size_t>(group) * n * do_ + block_size - 1) / block_size;
-        ;
+        size_t all_workload = static_cast<size_t>(group) * n * do_;
+        if(all_workload <= block_size)
+        {
+            grid_size = all_workload;
+        }
+        else
+        {
+            grid_size = (all_workload + block_size - 1) / block_size;
+        }
     }
     else
         MIOPEN_THROW("Unsupported layout");
@@ -869,11 +900,27 @@ GetConv2DBWDSolution(const ExecutionContext& ctx, const ::miopen::conv::ProblemD
     size_t grid_size  = 1;
     if(problem.IsLayoutDefault())
     {
-        grid_size = (static_cast<size_t>(n) * c + block_size - 1) / block_size;
+        size_t all_workload = static_cast<size_t>(n) * c;
+        if(all_workload <= block_size)
+        {
+            grid_size = all_workload;
+        }
+        else
+        {
+            grid_size = (all_workload + block_size - 1) / block_size;
+        }
     }
     else if(problem.IsLayoutNHWC())
     {
-        grid_size = (static_cast<size_t>(group) * n * hi + block_size - 1) / block_size;
+        size_t all_workload = static_cast<size_t>(group) * n * hi;
+        if(all_workload <= block_size)
+        {
+            grid_size = all_workload;
+        }
+        else
+        {
+            grid_size = (all_workload + block_size - 1) / block_size;
+        }
     }
     else
     {
@@ -1019,13 +1066,27 @@ GetConv3DBWDSolution(const ExecutionContext& ctx, const ::miopen::conv::ProblemD
     size_t grid_size  = 1;
     if(problem.IsLayoutDefault())
     {
-        grid_size = (static_cast<size_t>(n) * c + block_size - 1) / block_size;
-        ;
+        size_t all_workload = static_cast<size_t>(n) * c;
+        if(all_workload <= block_size)
+        {
+            grid_size = all_workload;
+        }
+        else
+        {
+            grid_size = (all_workload + block_size - 1) / block_size;
+        }
     }
     else if(problem.IsLayoutNHWC())
     {
-        grid_size = (static_cast<size_t>(group) * n * di + block_size - 1) / block_size;
-        ;
+        size_t all_workload = static_cast<size_t>(group) * n * di;
+        if(all_workload <= block_size)
+        {
+            grid_size = all_workload;
+        }
+        else
+        {
+            grid_size = (all_workload + block_size - 1) / block_size;
+        }
     }
     else
     {

--- a/src/solver/conv/conv_direct_naive_conv.cpp
+++ b/src/solver/conv/conv_direct_naive_conv.cpp
@@ -361,12 +361,11 @@ GetConv2DFWDSolution(const ExecutionContext& ctx, const ::miopen::conv::ProblemD
     size_t grid_size  = 1;
     if(problem.IsLayoutDefault())
     {
-        // grid_size = static_cast<size_t>(n) * k;
         grid_size = (static_cast<size_t>(n) * k + block_size - 1) / block_size;
     }
     else if(problem.IsLayoutNHWC())
     {
-        grid_size = static_cast<size_t>(group) * n * ho;
+        grid_size = (static_cast<size_t>(group) * n * ho + block_size - 1) / block_size;
     }
     else
         MIOPEN_THROW("Unsupported layout");

--- a/src/solver/conv/conv_direct_naive_conv.cpp
+++ b/src/solver/conv/conv_direct_naive_conv.cpp
@@ -521,7 +521,7 @@ GetConv3DFWDSolution(const ExecutionContext& ctx, const ::miopen::conv::ProblemD
     int c_per_group = c / group;
     int k_per_group = k / group;
 
-    size_t block_size = 512;
+    size_t block_size = 256;
     size_t grid_size  = 1;
 
     if(problem.IsLayoutDefault())
@@ -654,7 +654,7 @@ GetConv2DWRWSolution(const ExecutionContext& ctx, const ::miopen::conv::ProblemD
     int c_per_group = c / group;
     int k_per_group = k / group;
 
-    size_t block_size = 512;
+    size_t block_size = 256;
     size_t grid_size  = static_cast<size_t>(k);
 
     KernelInfo kernel;
@@ -791,7 +791,7 @@ GetConv3DWRWSolution(const ExecutionContext& ctx, const ::miopen::conv::ProblemD
     int c_per_group = c / group;
     int k_per_group = k / group;
 
-    size_t block_size = 512;
+    size_t block_size = 256;
     size_t grid_size  = static_cast<size_t>(k);
 
     KernelInfo kernel;
@@ -896,7 +896,7 @@ GetConv2DBWDSolution(const ExecutionContext& ctx, const ::miopen::conv::ProblemD
     int c_per_group = c / group;
     int k_per_group = k / group;
 
-    size_t block_size = 512;
+    size_t block_size = 256;
     size_t grid_size  = 1;
     if(problem.IsLayoutDefault())
     {
@@ -1062,7 +1062,7 @@ GetConv3DBWDSolution(const ExecutionContext& ctx, const ::miopen::conv::ProblemD
     int c_per_group = c / group;
     int k_per_group = k / group;
 
-    size_t block_size = 512;
+    size_t block_size = 256;
     size_t grid_size  = 1;
     if(problem.IsLayoutDefault())
     {

--- a/src/solver/conv/conv_direct_naive_conv.cpp
+++ b/src/solver/conv/conv_direct_naive_conv.cpp
@@ -505,15 +505,17 @@ GetConv3DFWDSolution(const ExecutionContext& ctx, const ::miopen::conv::ProblemD
     int c_per_group = c / group;
     int k_per_group = k / group;
 
-    size_t block_size = 256;
+    size_t block_size = 512;
     size_t grid_size  = 1;
     if(problem.IsLayoutDefault())
     {
-        grid_size = static_cast<size_t>(n) * k;
+        grid_size = (static_cast<size_t>(n) * k + block_size - 1) / block_size;
+        ;
     }
     else if(problem.IsLayoutNHWC())
     {
-        grid_size = static_cast<size_t>(group) * n * do_;
+        grid_size = (static_cast<size_t>(group) * n * do_ + block_size - 1) / block_size;
+        ;
     }
     else
         MIOPEN_THROW("Unsupported layout");
@@ -621,7 +623,7 @@ GetConv2DWRWSolution(const ExecutionContext& ctx, const ::miopen::conv::ProblemD
     int c_per_group = c / group;
     int k_per_group = k / group;
 
-    size_t block_size = 256;
+    size_t block_size = 512;
     size_t grid_size  = static_cast<size_t>(k);
 
     KernelInfo kernel;
@@ -758,7 +760,7 @@ GetConv3DWRWSolution(const ExecutionContext& ctx, const ::miopen::conv::ProblemD
     int c_per_group = c / group;
     int k_per_group = k / group;
 
-    size_t block_size = 256;
+    size_t block_size = 512;
     size_t grid_size  = static_cast<size_t>(k);
 
     KernelInfo kernel;
@@ -863,15 +865,15 @@ GetConv2DBWDSolution(const ExecutionContext& ctx, const ::miopen::conv::ProblemD
     int c_per_group = c / group;
     int k_per_group = k / group;
 
-    size_t block_size = 256;
+    size_t block_size = 512;
     size_t grid_size  = 1;
     if(problem.IsLayoutDefault())
     {
-        grid_size = static_cast<size_t>(n) * c;
+        grid_size = (static_cast<size_t>(n) * c + block_size - 1) / block_size;
     }
     else if(problem.IsLayoutNHWC())
     {
-        grid_size = static_cast<size_t>(group) * n * hi;
+        grid_size = (static_cast<size_t>(group) * n * hi + block_size - 1) / block_size;
     }
     else
     {
@@ -1013,15 +1015,17 @@ GetConv3DBWDSolution(const ExecutionContext& ctx, const ::miopen::conv::ProblemD
     int c_per_group = c / group;
     int k_per_group = k / group;
 
-    size_t block_size = 256;
+    size_t block_size = 512;
     size_t grid_size  = 1;
     if(problem.IsLayoutDefault())
     {
-        grid_size = static_cast<size_t>(n) * c;
+        grid_size = (static_cast<size_t>(n) * c + block_size - 1) / block_size;
+        ;
     }
     else if(problem.IsLayoutNHWC())
     {
-        grid_size = static_cast<size_t>(group) * n * di;
+        grid_size = (static_cast<size_t>(group) * n * di + block_size - 1) / block_size;
+        ;
     }
     else
     {


### PR DESCRIPTION
for larger tensor I was seeing
gdims[0]         :     38,654,705,664
globalWorkSizeX :  4,294,967,295 (max allowed by uint32_t)
~~MaxGridDimX  : 2,147,483,647~~ 

gdims[0] was exceeding ~~MaxGridDimX~~ globalWorkSizeX  for below driver command.

`./bin/MIOpenDriver convbfp16 -n 589824 -c 256 -H 4 -w 34 -k 256 -y 1 -x 3 -p 0 -q 0 -u 1 -v 1 -l 1 -j 1 -m c
onv -g 1 -F 1 -t 1`

In this PR I reduce the gdims[0] to be set within MaxGridDimX.