### PR TITLE
[GTests] Rename non-unique test names (TEST, TEST_P, TEST_F, TYPED_TEST). Part 1.

### DIFF
--- a/test/gtest/conv_igemm_mlir_bwd_wrw.cpp
+++ b/test/gtest/conv_igemm_mlir_bwd_wrw.cpp
@@ -80,18 +80,18 @@ bool IsTestSupportedForDevice()
 
 } // namespace
 
-class GPU_Conv2dDefaultMLIRTest_FP32 : public FloatTestCase<std::vector<TestCase>>
+class GPU_Conv2dIGemmBwdWrwMLIRTest_FP32 : public FloatTestCase<std::vector<TestCase>>
 {
 };
-class GPU_Conv2dDefaultMLIRTest_FP16 : public HalfTestCase<std::vector<TestCase>>
+class GPU_Conv2dIGemmBwdWrwMLIRTest_FP16 : public HalfTestCase<std::vector<TestCase>>
 {
 };
 
-TEST_P(GPU_Conv2dDefaultMLIRTest_FP32, FloatTest_conv_igemm_mlir_bwd_wrw)
+TEST_P(GPU_Conv2dIGemmBwdWrwMLIRTest_FP32, FloatTest_conv_igemm_mlir_bwd_wrw)
 {
     if(IsTestSupportedForDevice())
     {
-        invoke_with_params<conv2d_driver, GPU_Conv2dDefaultMLIRTest_FP32>(db_check);
+        invoke_with_params<conv2d_driver, GPU_Conv2dIGemmBwdWrwMLIRTest_FP32>(db_check);
     }
     else
     {
@@ -99,11 +99,11 @@ TEST_P(GPU_Conv2dDefaultMLIRTest_FP32, FloatTest_conv_igemm_mlir_bwd_wrw)
     }
 };
 
-TEST_P(GPU_Conv2dDefaultMLIRTest_FP16, HalfTest_conv_igemm_mlir_bwd_wrw)
+TEST_P(GPU_Conv2dIGemmBwdWrwMLIRTest_FP16, HalfTest_conv_igemm_mlir_bwd_wrw)
 {
     if(IsTestSupportedForDevice())
     {
-        invoke_with_params<conv2d_driver, GPU_Conv2dDefaultMLIRTest_FP16>(db_check);
+        invoke_with_params<conv2d_driver, GPU_Conv2dIGemmBwdWrwMLIRTest_FP16>(db_check);
     }
     else
     {
@@ -112,6 +112,6 @@ TEST_P(GPU_Conv2dDefaultMLIRTest_FP16, HalfTest_conv_igemm_mlir_bwd_wrw)
 };
 
 // Float for FWD, BWD, WRW
-INSTANTIATE_TEST_SUITE_P(Full, GPU_Conv2dDefaultMLIRTest_FP32, testing::Values(GetTestCases()));
+INSTANTIATE_TEST_SUITE_P(Full, GPU_Conv2dIGemmBwdWrwMLIRTest_FP32, testing::Values(GetTestCases()));
 // Half for FWD, BWD, WRW
-INSTANTIATE_TEST_SUITE_P(Full, GPU_Conv2dDefaultMLIRTest_FP16, testing::Values(GetTestCases()));
+INSTANTIATE_TEST_SUITE_P(Full, GPU_Conv2dIGemmBwdWrwMLIRTest_FP16, testing::Values(GetTestCases()));

--- a/test/gtest/graphapi_engine.cpp
+++ b/test/gtest/graphapi_engine.cpp
@@ -50,7 +50,7 @@ public:
 
 } // namespace
 
-TEST(CPU_GraphApi_NONE, EngineBuilder)
+TEST(CPU_GraphApiEngineBuilder_NONE, EngineBuilder)
 {
     OpGraph opGraph;
     auto executor = std::make_shared<MockPatternExecutor>();
@@ -83,7 +83,7 @@ public:
 
 } // namespace
 
-TEST(CPU_GraphApi_NONE, Engine)
+TEST(CPU_GraphApiEngine_NONE, Engine)
 {
     MockOpGraphDescriptor opGraphDescriptor;
 

--- a/test/gtest/graphapi_enginecfg.cpp
+++ b/test/gtest/graphapi_enginecfg.cpp
@@ -37,7 +37,7 @@ using miopen::graphapi::EngineCfgBuilder;
 
 } // namespace
 
-TEST(CPU_GraphApi_NONE, EngineCfgBuilder)
+TEST(CPU_GraphApiEngineCfgBuilder_NONE, EngineCfgBuilder)
 {
     Engine engine;
 
@@ -62,7 +62,7 @@ using miopen::graphapi::GTestGraphApiExecute;
 
 } // namespace
 
-TEST(CPU_GraphApi_NONE, EngineCfg)
+TEST(CPU_GraphApiEngineCfg_NONE, EngineCfg)
 {
     MockEngineDescriptor engineDescriptor;
 

--- a/test/gtest/graphapi_engineheur.cpp
+++ b/test/gtest/graphapi_engineheur.cpp
@@ -37,7 +37,7 @@ using miopen::graphapi::OpGraph;
 
 } // namespace
 
-TEST(CPU_GraphApi_NONE, EngineHeurBuilder)
+TEST(CPU_GraphApiEngineHeurBuilder_NONE, EngineHeurBuilder)
 {
     OpGraph opGraph;
 
@@ -70,7 +70,7 @@ using miopen::graphapi::GTestGraphApiExecute;
 
 } // namespace
 
-TEST(CPU_GraphApi_NONE, EngineHeur)
+TEST(CPU_GraphApiEngineHeur_NONE, EngineHeur)
 {
     MockOpGraphDescriptor opGraphDescriptor;
 

--- a/test/gtest/graphapi_execution_plan.cpp
+++ b/test/gtest/graphapi_execution_plan.cpp
@@ -37,7 +37,7 @@ using miopen::graphapi::ExecutionPlanBuilder;
 
 } // namespace
 
-TEST(CPU_GraphApi_NONE, ExecutionPlanBuilder)
+TEST(CPU_GraphApiExecutionPlanBuilder_NONE, ExecutionPlanBuilder)
 {
     miopenHandle_t handle;
     auto status = miopenCreate(&handle);
@@ -77,7 +77,7 @@ using miopen::graphapi::GTestGraphApiExecute;
 
 } // namespace
 
-TEST(CPU_GraphApi_NONE, ExecutionPlan)
+TEST(CPU_GraphApiExecutionPlanBuilder_NONE, ExecutionPlan)
 {
     miopenHandle_t handle;
     auto status = miopenCreate(&handle);

--- a/test/gtest/pooling2d_asymmetric.cpp
+++ b/test/gtest/pooling2d_asymmetric.cpp
@@ -36,7 +36,7 @@ namespace env = miopen::env;
 
 namespace pooling2d_asymmetric {
 
-class GPU_Pooling2d_FP32 : public testing::TestWithParam<std::vector<std::string>>
+class GPU_AsymPooling2d_FP32 : public testing::TestWithParam<std::vector<std::string>>
 {
 };
 
@@ -59,7 +59,7 @@ void Run2dDriver(miopenDataType_t prec)
     std::vector<std::string> params;
     switch(prec)
     {
-    case miopenFloat: params = GPU_Pooling2d_FP32::GetParam(); break;
+    case miopenFloat: params = GPU_AsymPooling2d_FP32::GetParam(); break;
     case miopenHalf: params = GPU_AsymPooling2d_FP16::GetParam(); break;
     case miopenBFloat16:
     case miopenInt8:
@@ -73,7 +73,7 @@ void Run2dDriver(miopenDataType_t prec)
                "data type not supported by "
                "pooling2d_asymmetric test";
 
-    default: params = GPU_Pooling2d_FP32::GetParam();
+    default: params = GPU_AsymPooling2d_FP32::GetParam();
     }
 
     for(const auto& test_value : params)
@@ -112,7 +112,7 @@ std::vector<std::string> GetTestCases(const std::string& precision)
 using namespace pooling2d_asymmetric;
 
 /*
-TEST_P(GPU_Pooling2d_FP32, FloatTest_pooling2d_asymmetric)
+TEST_P(GPU_AsymPooling2d_FP32, FloatTest_pooling2d_asymmetric)
 {
     const auto& handle = get_handle();
     if(IsTestSupportedForDevice(handle) && !SkipTest() && IsTestRunWith("--float"))
@@ -139,6 +139,6 @@ TEST_P(GPU_AsymPooling2d_FP16, HalfTest_pooling2d_asymmetric)
     }
 };
 
-// INSTANTIATE_TEST_SUITE_P(Full, GPU_Pooling2d_FP32, testing::Values(GetTestCases("--float")));
+// INSTANTIATE_TEST_SUITE_P(Full, GPU_AsymPooling2d_FP32, testing::Values(GetTestCases("--float")));
 
 INSTANTIATE_TEST_SUITE_P(Full, GPU_AsymPooling2d_FP16, testing::Values(GetTestCases("--half")));

--- a/test/gtest/pooling2d_wide.cpp
+++ b/test/gtest/pooling2d_wide.cpp
@@ -36,7 +36,7 @@ namespace env = miopen::env;
 
 namespace pooling2d_wide {
 
-class GPU_Pooling2d_FP32 : public testing::TestWithParam<std::vector<std::string>>
+class GPU_WidePooling2d_FP32 : public testing::TestWithParam<std::vector<std::string>>
 {
 };
 
@@ -59,7 +59,7 @@ void Run2dDriver(miopenDataType_t prec)
     std::vector<std::string> params;
     switch(prec)
     {
-    case miopenFloat: params = GPU_Pooling2d_FP32::GetParam(); break;
+    case miopenFloat: params = GPU_WidePooling2d_FP32::GetParam(); break;
     case miopenHalf: params = GPU_WidePooling2d_FP16::GetParam(); break;
     case miopenBFloat16:
     case miopenInt8:
@@ -73,7 +73,7 @@ void Run2dDriver(miopenDataType_t prec)
                "data type not supported by "
                "pooling2d_wide test";
 
-    default: params = GPU_Pooling2d_FP32::GetParam();
+    default: params = GPU_WidePooling2d_FP32::GetParam();
     }
 
     for(const auto& test_value : params)
@@ -112,7 +112,7 @@ std::vector<std::string> GetTestCases(const std::string& precision)
 using namespace pooling2d_wide;
 
 /*
-TEST_P(GPU_Pooling2d_FP32, FloatTest_pooling2d_wide)
+TEST_P(GPU_WidePooling2d_FP32, FloatTest_pooling2d_wide)
 {
     const auto& handle = get_handle();
     if(IsTestSupportedForDevice(handle) && !SkipTest() && IsTestRunWith("--float"))
@@ -139,6 +139,6 @@ TEST_P(GPU_WidePooling2d_FP16, HalfTest_pooling2d_wide)
     }
 };
 
-// INSTANTIATE_TEST_SUITE_P(Full, GPU_Pooling2d_FP32, testing::Values(GetTestCases("--float")));
+// INSTANTIATE_TEST_SUITE_P(Full, GPU_WidePooling2d_FP32, testing::Values(GetTestCases("--float")));
 
 INSTANTIATE_TEST_SUITE_P(Full, GPU_WidePooling2d_FP16, testing::Values(GetTestCases("--half")));

--- a/test/gtest/smoke_solver_ConvAsmImplicitGemmGTCDynamicFwdDlopsNCHWC.cpp
+++ b/test/gtest/smoke_solver_ConvAsmImplicitGemmGTCDynamicFwdDlopsNCHWC.cpp
@@ -64,15 +64,16 @@ bool IsTestSupportedForDevice()
 
 } // namespace
 
-class GPU_Conv2dTuning_FP16 : public HalfTestCase<std::vector<TestCase>>
+class GPU_Conv2dTuningDynamicFwdDlops_FP16 : public HalfTestCase<std::vector<TestCase>>
 {
 };
 
-TEST_P(GPU_Conv2dTuning_FP16, HalfTest_smoke_solver_ConvAsmImplicitGemmGTCDynamicFwdDlopsNCHWC)
+TEST_P(GPU_Conv2dTuningDynamicFwdDlops_FP16,
+       HalfTest_smoke_solver_ConvAsmImplicitGemmGTCDynamicFwdDlopsNCHWC)
 {
     if(IsTestSupportedForDevice() && !SkipTest())
     {
-        invoke_with_params<conv2d_driver, GPU_Conv2dTuning_FP16>(tuning_check);
+        invoke_with_params<conv2d_driver, GPU_Conv2dTuningDynamicFwdDlops_FP16>(tuning_check);
     }
     else
     {
@@ -80,4 +81,6 @@ TEST_P(GPU_Conv2dTuning_FP16, HalfTest_smoke_solver_ConvAsmImplicitGemmGTCDynami
     }
 };
 
-INSTANTIATE_TEST_SUITE_P(Smoke, GPU_Conv2dTuning_FP16, testing::Values(GetTestCases()));
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         GPU_Conv2dTuningDynamicFwdDlops_FP16,
+                         testing::Values(GetTestCases()));

--- a/test/gtest/smoke_solver_ConvAsmImplicitGemmGTCDynamicXdlopsNHWC_fp32_fp16.cpp
+++ b/test/gtest/smoke_solver_ConvAsmImplicitGemmGTCDynamicXdlopsNHWC_fp32_fp16.cpp
@@ -68,20 +68,20 @@ bool IsTestSupportedForDevice()
 
 } // namespace
 
-class GPU_Conv2dTuning_FP32 : public FloatTestCase<std::vector<TestCase>>
+class GPU_Conv2dTuningDynamicXdlops_FP32 : public FloatTestCase<std::vector<TestCase>>
 {
 };
 
-class GPU_Conv2dTuning_FP16 : public HalfTestCase<std::vector<TestCase>>
+class GPU_Conv2dTuningDynamicXdlops_FP16 : public HalfTestCase<std::vector<TestCase>>
 {
 };
 
-TEST_P(GPU_Conv2dTuning_FP32,
+TEST_P(GPU_Conv2dTuningDynamicXdlops_FP32,
        FloatTest_smoke_solver_ConvAsmImplicitGemmGTCDynamicXdlopsNHWC_fp32_fp16)
 {
     if(IsTestSupportedForDevice() && !SkipTest())
     {
-        invoke_with_params<conv2d_driver, GPU_Conv2dTuning_FP32>(tuning_check);
+        invoke_with_params<conv2d_driver, GPU_Conv2dTuningDynamicXdlops_FP32>(tuning_check);
     }
     else
     {
@@ -89,12 +89,12 @@ TEST_P(GPU_Conv2dTuning_FP32,
     }
 };
 
-TEST_P(GPU_Conv2dTuning_FP16,
+TEST_P(GPU_Conv2dTuningDynamicXdlops_FP16,
        HalfTest_smoke_solver_ConvAsmImplicitGemmGTCDynamicXdlopsNHWC_fp32_fp16)
 {
     if(IsTestSupportedForDevice() && !SkipTest())
     {
-        invoke_with_params<conv2d_driver, GPU_Conv2dTuning_FP16>(tuning_check);
+        invoke_with_params<conv2d_driver, GPU_Conv2dTuningDynamicXdlops_FP16>(tuning_check);
     }
     else
     {
@@ -102,6 +102,10 @@ TEST_P(GPU_Conv2dTuning_FP16,
     }
 };
 
-INSTANTIATE_TEST_SUITE_P(Smoke, GPU_Conv2dTuning_FP32, testing::Values(GetTestCases()));
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         GPU_Conv2dTuningDynamicXdlops_FP32,
+                         testing::Values(GetTestCases()));
 
-INSTANTIATE_TEST_SUITE_P(Smoke, GPU_Conv2dTuning_FP16, testing::Values(GetTestCases()));
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         GPU_Conv2dTuningDynamicXdlops_FP16,
+                         testing::Values(GetTestCases()));

--- a/test/gtest/smoke_solver_convasmbwdwrw.cpp
+++ b/test/gtest/smoke_solver_convasmbwdwrw.cpp
@@ -61,23 +61,23 @@ bool IsTestSupportedForDevice()
 
 } // namespace
 
-class GPU_Conv2dTuning_FP32 : public FloatTestCase<std::vector<TestCase>>
+class GPU_Conv2dTuningAsmBwdWrw_FP32 : public FloatTestCase<std::vector<TestCase>>
 {
 };
 
-class GPU_Conv2dTuning_FP16 : public HalfTestCase<std::vector<TestCase>>
+class GPU_Conv2dTuningAsmBwdWrw_FP16 : public HalfTestCase<std::vector<TestCase>>
 {
 };
 
-class GPU_Conv2dTuning_BFP16 : public Bf16TestCase<std::vector<TestCase>>
+class GPU_Conv2dTuningAsmBwdWrw_BFP16 : public Bf16TestCase<std::vector<TestCase>>
 {
 };
 
-TEST_P(GPU_Conv2dTuning_FP32, FloatTest_smoke_solver_convasmbwdwrw)
+TEST_P(GPU_Conv2dTuningAsmBwdWrw_FP32, FloatTest_smoke_solver_convasmbwdwrw)
 {
     if(IsTestSupportedForDevice() && !SkipTest())
     {
-        invoke_with_params<conv2d_driver, GPU_Conv2dTuning_FP32>(tuning_check);
+        invoke_with_params<conv2d_driver, GPU_Conv2dTuningAsmBwdWrw_FP32>(tuning_check);
     }
     else
     {
@@ -85,11 +85,11 @@ TEST_P(GPU_Conv2dTuning_FP32, FloatTest_smoke_solver_convasmbwdwrw)
     }
 };
 
-TEST_P(GPU_Conv2dTuning_FP16, HalfTest_smoke_solver_convasmbwdwrw)
+TEST_P(GPU_Conv2dTuningAsmBwdWrw_FP16, HalfTest_smoke_solver_convasmbwdwrw)
 {
     if(IsTestSupportedForDevice() && !SkipTest())
     {
-        invoke_with_params<conv2d_driver, GPU_Conv2dTuning_FP16>(tuning_check);
+        invoke_with_params<conv2d_driver, GPU_Conv2dTuningAsmBwdWrw_FP16>(tuning_check);
     }
     else
     {
@@ -97,11 +97,11 @@ TEST_P(GPU_Conv2dTuning_FP16, HalfTest_smoke_solver_convasmbwdwrw)
     }
 };
 
-TEST_P(GPU_Conv2dTuning_BFP16, Bf16Test_smoke_solver_convasmbwdwrw)
+TEST_P(GPU_Conv2dTuningAsmBwdWrw_BFP16, Bf16Test_smoke_solver_convasmbwdwrw)
 {
     if(IsTestSupportedForDevice() && !SkipTest())
     {
-        invoke_with_params<conv2d_driver, GPU_Conv2dTuning_BFP16>(tuning_check);
+        invoke_with_params<conv2d_driver, GPU_Conv2dTuningAsmBwdWrw_BFP16>(tuning_check);
     }
     else
     {
@@ -109,6 +109,6 @@ TEST_P(GPU_Conv2dTuning_BFP16, Bf16Test_smoke_solver_convasmbwdwrw)
     }
 };
 
-INSTANTIATE_TEST_SUITE_P(Smoke, GPU_Conv2dTuning_FP32, testing::Values(GetTestCases()));
-INSTANTIATE_TEST_SUITE_P(Smoke, GPU_Conv2dTuning_FP16, testing::Values(GetTestCases()));
-INSTANTIATE_TEST_SUITE_P(Smoke, GPU_Conv2dTuning_BFP16, testing::Values(GetTestCases()));
+INSTANTIATE_TEST_SUITE_P(Smoke, GPU_Conv2dTuningAsmBwdWrw_FP32, testing::Values(GetTestCases()));
+INSTANTIATE_TEST_SUITE_P(Smoke, GPU_Conv2dTuningAsmBwdWrw_FP16, testing::Values(GetTestCases()));
+INSTANTIATE_TEST_SUITE_P(Smoke, GPU_Conv2dTuningAsmBwdWrw_BFP16, testing::Values(GetTestCases()));

--- a/test/gtest/smoke_solver_convasmbwdwrw3x3_fp16.cpp
+++ b/test/gtest/smoke_solver_convasmbwdwrw3x3_fp16.cpp
@@ -61,15 +61,15 @@ bool IsTestSupportedForDevice()
 
 } // namespace
 
-class GPU_Conv2dTuning_FP16 : public HalfTestCase<std::vector<TestCase>>
+class GPU_Conv2dTuningAsmBwdWrw3x3_FP16 : public HalfTestCase<std::vector<TestCase>>
 {
 };
 
-TEST_P(GPU_Conv2dTuning_FP16, HalfTest_smoke_solver_convasmbwdwrw3x3_fp16)
+TEST_P(GPU_Conv2dTuningAsmBwdWrw3x3_FP16, HalfTest_smoke_solver_convasmbwdwrw3x3_fp16)
 {
     if(IsTestSupportedForDevice() && !SkipTest())
     {
-        invoke_with_params<conv2d_driver, GPU_Conv2dTuning_FP16>(tuning_check);
+        invoke_with_params<conv2d_driver, GPU_Conv2dTuningAsmBwdWrw3x3_FP16>(tuning_check);
     }
     else
     {
@@ -77,4 +77,4 @@ TEST_P(GPU_Conv2dTuning_FP16, HalfTest_smoke_solver_convasmbwdwrw3x3_fp16)
     }
 };
 
-INSTANTIATE_TEST_SUITE_P(Smoke, GPU_Conv2dTuning_FP16, testing::Values(GetTestCases()));
+INSTANTIATE_TEST_SUITE_P(Smoke, GPU_Conv2dTuningAsmBwdWrw3x3_FP16, testing::Values(GetTestCases()));

--- a/test/gtest/unit_conv_solver_ConvDirectNaiveConvFwd.cpp
+++ b/test/gtest/unit_conv_solver_ConvDirectNaiveConvFwd.cpp
@@ -84,77 +84,84 @@ const auto& GetTestParams()
 
 } // namespace
 
-TEST_P(GPU_UnitTestConvSolverFwd_I8, ConvDirectNaiveConvFwd)
+using GPU_UnitTestConvDirectNaiveSolverFwd_FP16  = GPU_UnitTestConvSolverFwd_FP16;
+using GPU_UnitTestConvDirectNaiveSolverFwd_BFP16 = GPU_UnitTestConvSolverFwd_BFP16;
+using GPU_UnitTestConvDirectNaiveSolverFwd_FP32  = GPU_UnitTestConvSolverFwd_FP32;
+using GPU_UnitTestConvDirectNaiveSolverFwd_I8    = GPU_UnitTestConvSolverFwd_I8;
+using CPU_UnitTestConvDirectNaiveSolverDevApplicabilityFwd_NONE =
+    CPU_UnitTestConvSolverDevApplicabilityFwd_NONE;
+
+TEST_P(GPU_UnitTestConvDirectNaiveSolverFwd_I8, ConvDirectNaiveConvFwd)
 {
     this->RunTest(miopen::solver::conv::ConvDirectNaiveConvFwd{});
 };
 
-TEST_P(GPU_UnitTestConvSolverFwd_FP16, ConvDirectNaiveConvFwd)
+TEST_P(GPU_UnitTestConvDirectNaiveSolverFwd_FP16, ConvDirectNaiveConvFwd)
 {
     this->RunTest(miopen::solver::conv::ConvDirectNaiveConvFwd{});
 };
 
-TEST_P(GPU_UnitTestConvSolverFwd_BFP16, ConvDirectNaiveConvFwd)
+TEST_P(GPU_UnitTestConvDirectNaiveSolverFwd_BFP16, ConvDirectNaiveConvFwd)
 {
     this->RunTest(miopen::solver::conv::ConvDirectNaiveConvFwd{});
 };
 
-TEST_P(GPU_UnitTestConvSolverFwd_FP32, ConvDirectNaiveConvFwd)
+TEST_P(GPU_UnitTestConvDirectNaiveSolverFwd_FP32, ConvDirectNaiveConvFwd)
 {
     this->RunTest(miopen::solver::conv::ConvDirectNaiveConvFwd{});
 };
 
-TEST_P(CPU_UnitTestConvSolverDevApplicabilityFwd_NONE, ConvDirectNaiveConvFwd)
+TEST_P(CPU_UnitTestConvDirectNaiveSolverDevApplicabilityFwd_NONE, ConvDirectNaiveConvFwd)
 {
     this->RunTest(miopen::solver::conv::ConvDirectNaiveConvFwd{});
 };
 
 // Smoke tests
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         GPU_UnitTestConvSolverFwd_I8,
+                         GPU_UnitTestConvDirectNaiveSolverFwd_I8,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(miopenConvolutionAlgoDirect),
                                           testing::ValuesIn(GetConvTestCases(miopenInt8))));
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         GPU_UnitTestConvSolverFwd_FP16,
+                         GPU_UnitTestConvDirectNaiveSolverFwd_FP16,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(miopenConvolutionAlgoDirect),
                                           testing::ValuesIn(GetConvTestCases(miopenHalf))));
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         GPU_UnitTestConvSolverFwd_BFP16,
+                         GPU_UnitTestConvDirectNaiveSolverFwd_BFP16,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(miopenConvolutionAlgoDirect),
                                           testing::ValuesIn(GetConvTestCases(miopenBFloat16))));
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         GPU_UnitTestConvSolverFwd_FP32,
+                         GPU_UnitTestConvDirectNaiveSolverFwd_FP32,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(miopenConvolutionAlgoDirect),
                                           testing::ValuesIn(GetConvTestCases(miopenFloat))));
 
 // Device applicability test
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         CPU_UnitTestConvSolverDevApplicabilityFwd_NONE,
+                         CPU_UnitTestConvDirectNaiveSolverDevApplicabilityFwd_NONE,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(GetConvTestCases(miopenFloat)[0])));
 
 // Full tests
 INSTANTIATE_TEST_SUITE_P(Full,
-                         GPU_UnitTestConvSolverFwd_I8,
+                         GPU_UnitTestConvDirectNaiveSolverFwd_I8,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(miopenConvolutionAlgoDirect),
                                           testing::ValuesIn(GetConvTestCasesFull(miopenInt8))));
 
 INSTANTIATE_TEST_SUITE_P(Full,
-                         GPU_UnitTestConvSolverFwd_FP16,
+                         GPU_UnitTestConvDirectNaiveSolverFwd_FP16,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(miopenConvolutionAlgoDirect),
                                           testing::ValuesIn(GetConvTestCasesFull(miopenHalf))));
 
 INSTANTIATE_TEST_SUITE_P(Full,
-                         GPU_UnitTestConvSolverFwd_FP32,
+                         GPU_UnitTestConvDirectNaiveSolverFwd_FP32,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(miopenConvolutionAlgoDirect),
                                           testing::ValuesIn(GetConvTestCasesFull(miopenFloat))));

--- a/test/gtest/unit_conv_solver_ConvDirectNaiveConvFwd.cpp
+++ b/test/gtest/unit_conv_solver_ConvDirectNaiveConvFwd.cpp
@@ -84,84 +84,84 @@ const auto& GetTestParams()
 
 } // namespace
 
-using GPU_UnitTestConvDirectNaiveSolverFwd_FP16  = GPU_UnitTestConvSolverFwd_FP16;
-using GPU_UnitTestConvDirectNaiveSolverFwd_BFP16 = GPU_UnitTestConvSolverFwd_BFP16;
-using GPU_UnitTestConvDirectNaiveSolverFwd_FP32  = GPU_UnitTestConvSolverFwd_FP32;
-using GPU_UnitTestConvDirectNaiveSolverFwd_I8    = GPU_UnitTestConvSolverFwd_I8;
-using CPU_UnitTestConvDirectNaiveSolverDevApplicabilityFwd_NONE =
+using GPU_UnitTestConvSolverDirectNaiveFwd_FP16  = GPU_UnitTestConvSolverFwd_FP16;
+using GPU_UnitTestConvSolverDirectNaiveFwd_BFP16 = GPU_UnitTestConvSolverFwd_BFP16;
+using GPU_UnitTestConvSolverDirectNaiveFwd_FP32  = GPU_UnitTestConvSolverFwd_FP32;
+using GPU_UnitTestConvSolverDirectNaiveFwd_I8    = GPU_UnitTestConvSolverFwd_I8;
+using CPU_UnitTestConvSolverDirectNaiveDevApplicabilityFwd_NONE =
     CPU_UnitTestConvSolverDevApplicabilityFwd_NONE;
 
-TEST_P(GPU_UnitTestConvDirectNaiveSolverFwd_I8, ConvDirectNaiveConvFwd)
+TEST_P(GPU_UnitTestConvSolverDirectNaiveFwd_I8, ConvDirectNaiveConvFwd)
 {
     this->RunTest(miopen::solver::conv::ConvDirectNaiveConvFwd{});
 };
 
-TEST_P(GPU_UnitTestConvDirectNaiveSolverFwd_FP16, ConvDirectNaiveConvFwd)
+TEST_P(GPU_UnitTestConvSolverDirectNaiveFwd_FP16, ConvDirectNaiveConvFwd)
 {
     this->RunTest(miopen::solver::conv::ConvDirectNaiveConvFwd{});
 };
 
-TEST_P(GPU_UnitTestConvDirectNaiveSolverFwd_BFP16, ConvDirectNaiveConvFwd)
+TEST_P(GPU_UnitTestConvSolverDirectNaiveFwd_BFP16, ConvDirectNaiveConvFwd)
 {
     this->RunTest(miopen::solver::conv::ConvDirectNaiveConvFwd{});
 };
 
-TEST_P(GPU_UnitTestConvDirectNaiveSolverFwd_FP32, ConvDirectNaiveConvFwd)
+TEST_P(GPU_UnitTestConvSolverDirectNaiveFwd_FP32, ConvDirectNaiveConvFwd)
 {
     this->RunTest(miopen::solver::conv::ConvDirectNaiveConvFwd{});
 };
 
-TEST_P(CPU_UnitTestConvDirectNaiveSolverDevApplicabilityFwd_NONE, ConvDirectNaiveConvFwd)
+TEST_P(CPU_UnitTestConvSolverDirectNaiveDevApplicabilityFwd_NONE, ConvDirectNaiveConvFwd)
 {
     this->RunTest(miopen::solver::conv::ConvDirectNaiveConvFwd{});
 };
 
 // Smoke tests
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         GPU_UnitTestConvDirectNaiveSolverFwd_I8,
+                         GPU_UnitTestConvSolverDirectNaiveFwd_I8,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(miopenConvolutionAlgoDirect),
                                           testing::ValuesIn(GetConvTestCases(miopenInt8))));
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         GPU_UnitTestConvDirectNaiveSolverFwd_FP16,
+                         GPU_UnitTestConvSolverDirectNaiveFwd_FP16,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(miopenConvolutionAlgoDirect),
                                           testing::ValuesIn(GetConvTestCases(miopenHalf))));
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         GPU_UnitTestConvDirectNaiveSolverFwd_BFP16,
+                         GPU_UnitTestConvSolverDirectNaiveFwd_BFP16,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(miopenConvolutionAlgoDirect),
                                           testing::ValuesIn(GetConvTestCases(miopenBFloat16))));
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         GPU_UnitTestConvDirectNaiveSolverFwd_FP32,
+                         GPU_UnitTestConvSolverDirectNaiveFwd_FP32,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(miopenConvolutionAlgoDirect),
                                           testing::ValuesIn(GetConvTestCases(miopenFloat))));
 
 // Device applicability test
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         CPU_UnitTestConvDirectNaiveSolverDevApplicabilityFwd_NONE,
+                         CPU_UnitTestConvSolverDirectNaiveDevApplicabilityFwd_NONE,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(GetConvTestCases(miopenFloat)[0])));
 
 // Full tests
 INSTANTIATE_TEST_SUITE_P(Full,
-                         GPU_UnitTestConvDirectNaiveSolverFwd_I8,
+                         GPU_UnitTestConvSolverDirectNaiveFwd_I8,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(miopenConvolutionAlgoDirect),
                                           testing::ValuesIn(GetConvTestCasesFull(miopenInt8))));
 
 INSTANTIATE_TEST_SUITE_P(Full,
-                         GPU_UnitTestConvDirectNaiveSolverFwd_FP16,
+                         GPU_UnitTestConvSolverDirectNaiveFwd_FP16,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(miopenConvolutionAlgoDirect),
                                           testing::ValuesIn(GetConvTestCasesFull(miopenHalf))));
 
 INSTANTIATE_TEST_SUITE_P(Full,
-                         GPU_UnitTestConvDirectNaiveSolverFwd_FP32,
+                         GPU_UnitTestConvSolverDirectNaiveFwd_FP32,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(miopenConvolutionAlgoDirect),
                                           testing::ValuesIn(GetConvTestCasesFull(miopenFloat))));

--- a/test/gtest/unit_conv_solver_ConvDirectNaiveConvWrw.cpp
+++ b/test/gtest/unit_conv_solver_ConvDirectNaiveConvWrw.cpp
@@ -51,53 +51,53 @@ const auto& GetTestParams()
 
 } // namespace
 
-using GPU_UnitTestConvDirectNaiveSolverWrw_FP16  = GPU_UnitTestConvSolverWrw_FP16;
-using GPU_UnitTestConvDirectNaiveSolverWrw_BFP16 = GPU_UnitTestConvSolverWrw_BFP16;
-using GPU_UnitTestConvDirectNaiveSolverWrw_FP32  = GPU_UnitTestConvSolverWrw_FP32;
-using CPU_UnitTestConvDirectNaiveSolverDevApplicabilityWrw_NONE =
+using GPU_UnitTestConvSolverDirectNaiveWrw_FP16  = GPU_UnitTestConvSolverWrw_FP16;
+using GPU_UnitTestConvSolverDirectNaiveWrw_BFP16 = GPU_UnitTestConvSolverWrw_BFP16;
+using GPU_UnitTestConvSolverDirectNaiveWrw_FP32  = GPU_UnitTestConvSolverWrw_FP32;
+using CPU_UnitTestConvSolverDirectNaiveDevApplicabilityWrw_NONE =
     CPU_UnitTestConvSolverDevApplicabilityWrw_NONE;
 
-TEST_P(GPU_UnitTestConvDirectNaiveSolverWrw_FP16, ConvDirectNaiveConvWrw)
+TEST_P(GPU_UnitTestConvSolverDirectNaiveWrw_FP16, ConvDirectNaiveConvWrw)
 {
     this->RunTest(miopen::solver::conv::ConvDirectNaiveConvWrw{});
 };
 
-TEST_P(GPU_UnitTestConvDirectNaiveSolverWrw_BFP16, ConvDirectNaiveConvWrw)
+TEST_P(GPU_UnitTestConvSolverDirectNaiveWrw_BFP16, ConvDirectNaiveConvWrw)
 {
     this->RunTest(miopen::solver::conv::ConvDirectNaiveConvWrw{});
 };
 
-TEST_P(GPU_UnitTestConvDirectNaiveSolverWrw_FP32, ConvDirectNaiveConvWrw)
+TEST_P(GPU_UnitTestConvSolverDirectNaiveWrw_FP32, ConvDirectNaiveConvWrw)
 {
     this->RunTest(miopen::solver::conv::ConvDirectNaiveConvWrw{});
 };
 
-TEST_P(CPU_UnitTestConvDirectNaiveSolverDevApplicabilityWrw_NONE, ConvDirectNaiveConvWrw)
+TEST_P(CPU_UnitTestConvSolverDirectNaiveDevApplicabilityWrw_NONE, ConvDirectNaiveConvWrw)
 {
     this->RunTest(miopen::solver::conv::ConvDirectNaiveConvWrw{});
 };
 
 // Smoke tests
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         GPU_UnitTestConvDirectNaiveSolverWrw_FP16,
+                         GPU_UnitTestConvSolverDirectNaiveWrw_FP16,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(miopenConvolutionAlgoDirect),
                                           testing::ValuesIn(GetConvTestCases(miopenHalf))));
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         GPU_UnitTestConvDirectNaiveSolverWrw_BFP16,
+                         GPU_UnitTestConvSolverDirectNaiveWrw_BFP16,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(miopenConvolutionAlgoDirect),
                                           testing::ValuesIn(GetConvTestCases(miopenBFloat16))));
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         GPU_UnitTestConvDirectNaiveSolverWrw_FP32,
+                         GPU_UnitTestConvSolverDirectNaiveWrw_FP32,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(miopenConvolutionAlgoDirect),
                                           testing::ValuesIn(GetConvTestCases(miopenFloat))));
 
 // Device applicability test
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         CPU_UnitTestConvDirectNaiveSolverDevApplicabilityWrw_NONE,
+                         CPU_UnitTestConvSolverDirectNaiveDevApplicabilityWrw_NONE,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(GetConvTestCases(miopenFloat)[0])));

--- a/test/gtest/unit_conv_solver_ConvDirectNaiveConvWrw.cpp
+++ b/test/gtest/unit_conv_solver_ConvDirectNaiveConvWrw.cpp
@@ -51,47 +51,53 @@ const auto& GetTestParams()
 
 } // namespace
 
-TEST_P(GPU_UnitTestConvSolverWrw_FP16, ConvDirectNaiveConvWrw)
+using GPU_UnitTestConvDirectNaiveSolverWrw_FP16  = GPU_UnitTestConvSolverWrw_FP16;
+using GPU_UnitTestConvDirectNaiveSolverWrw_BFP16 = GPU_UnitTestConvSolverWrw_BFP16;
+using GPU_UnitTestConvDirectNaiveSolverWrw_FP32  = GPU_UnitTestConvSolverWrw_FP32;
+using CPU_UnitTestConvDirectNaiveSolverDevApplicabilityWrw_NONE =
+    CPU_UnitTestConvSolverDevApplicabilityWrw_NONE;
+
+TEST_P(GPU_UnitTestConvDirectNaiveSolverWrw_FP16, ConvDirectNaiveConvWrw)
 {
     this->RunTest(miopen::solver::conv::ConvDirectNaiveConvWrw{});
 };
 
-TEST_P(GPU_UnitTestConvSolverWrw_BFP16, ConvDirectNaiveConvWrw)
+TEST_P(GPU_UnitTestConvDirectNaiveSolverWrw_BFP16, ConvDirectNaiveConvWrw)
 {
     this->RunTest(miopen::solver::conv::ConvDirectNaiveConvWrw{});
 };
 
-TEST_P(GPU_UnitTestConvSolverWrw_FP32, ConvDirectNaiveConvWrw)
+TEST_P(GPU_UnitTestConvDirectNaiveSolverWrw_FP32, ConvDirectNaiveConvWrw)
 {
     this->RunTest(miopen::solver::conv::ConvDirectNaiveConvWrw{});
 };
 
-TEST_P(CPU_UnitTestConvSolverDevApplicabilityWrw_NONE, ConvDirectNaiveConvWrw)
+TEST_P(CPU_UnitTestConvDirectNaiveSolverDevApplicabilityWrw_NONE, ConvDirectNaiveConvWrw)
 {
     this->RunTest(miopen::solver::conv::ConvDirectNaiveConvWrw{});
 };
 
 // Smoke tests
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         GPU_UnitTestConvSolverWrw_FP16,
+                         GPU_UnitTestConvDirectNaiveSolverWrw_FP16,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(miopenConvolutionAlgoDirect),
                                           testing::ValuesIn(GetConvTestCases(miopenHalf))));
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         GPU_UnitTestConvSolverWrw_BFP16,
+                         GPU_UnitTestConvDirectNaiveSolverWrw_BFP16,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(miopenConvolutionAlgoDirect),
                                           testing::ValuesIn(GetConvTestCases(miopenBFloat16))));
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         GPU_UnitTestConvSolverWrw_FP32,
+                         GPU_UnitTestConvDirectNaiveSolverWrw_FP32,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(miopenConvolutionAlgoDirect),
                                           testing::ValuesIn(GetConvTestCases(miopenFloat))));
 
 // Device applicability test
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         CPU_UnitTestConvSolverDevApplicabilityWrw_NONE,
+                         CPU_UnitTestConvDirectNaiveSolverDevApplicabilityWrw_NONE,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(GetConvTestCases(miopenFloat)[0])));

--- a/test/gtest/unit_conv_solver_ConvOclBwdWrW2NonTunable.cpp
+++ b/test/gtest/unit_conv_solver_ConvOclBwdWrW2NonTunable.cpp
@@ -51,53 +51,53 @@ const auto& GetTestParams()
 
 } // namespace
 
-using GPU_UnitTestConvOclBwdWrW2SolverWrw_FP16  = GPU_UnitTestConvSolverWrw_FP16;
-using GPU_UnitTestConvOclBwdWrW2SolverWrw_BFP16 = GPU_UnitTestConvSolverWrw_BFP16;
-using GPU_UnitTestConvOclBwdWrW2SolverWrw_FP32  = GPU_UnitTestConvSolverWrw_FP32;
-using CPU_UnitTestConvOclBwdWrW2SolverDevApplicabilityWrw_NONE =
+using GPU_UnitTestConvSolverOclBwdWrW2NonTunableWrw_FP16  = GPU_UnitTestConvSolverWrw_FP16;
+using GPU_UnitTestConvSolverOclBwdWrW2NonTunableWrw_BFP16 = GPU_UnitTestConvSolverWrw_BFP16;
+using GPU_UnitTestConvSolverOclBwdWrW2NonTunableWrw_FP32  = GPU_UnitTestConvSolverWrw_FP32;
+using CPU_UnitTestConvSolverOclBwdWrW2NonTunableDevApplicabilityWrw_NONE =
     CPU_UnitTestConvSolverDevApplicabilityWrw_NONE;
 
-TEST_P(GPU_UnitTestConvOclBwdWrW2SolverWrw_FP16, ConvOclBwdWrW2NonTunable)
+TEST_P(GPU_UnitTestConvSolverOclBwdWrW2NonTunableWrw_FP16, ConvOclBwdWrW2NonTunable)
 {
     this->RunTest(miopen::solver::conv::ConvOclBwdWrW2NonTunable{});
 };
 
-TEST_P(GPU_UnitTestConvOclBwdWrW2SolverWrw_BFP16, ConvOclBwdWrW2NonTunable)
+TEST_P(GPU_UnitTestConvSolverOclBwdWrW2NonTunableWrw_BFP16, ConvOclBwdWrW2NonTunable)
 {
     this->RunTest(miopen::solver::conv::ConvOclBwdWrW2NonTunable{});
 };
 
-TEST_P(GPU_UnitTestConvOclBwdWrW2SolverWrw_FP32, ConvOclBwdWrW2NonTunable)
+TEST_P(GPU_UnitTestConvSolverOclBwdWrW2NonTunableWrw_FP32, ConvOclBwdWrW2NonTunable)
 {
     this->RunTest(miopen::solver::conv::ConvOclBwdWrW2NonTunable{});
 };
 
-TEST_P(CPU_UnitTestConvOclBwdWrW2SolverDevApplicabilityWrw_NONE, ConvOclBwdWrW2NonTunable)
+TEST_P(CPU_UnitTestConvSolverOclBwdWrW2NonTunableDevApplicabilityWrw_NONE, ConvOclBwdWrW2NonTunable)
 {
     this->RunTest(miopen::solver::conv::ConvOclBwdWrW2NonTunable{});
 };
 
 // Smoke tests
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         GPU_UnitTestConvOclBwdWrW2SolverWrw_FP16,
+                         GPU_UnitTestConvSolverOclBwdWrW2NonTunableWrw_FP16,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(miopenConvolutionAlgoDirect),
                                           testing::ValuesIn(GetConvTestCases(miopenHalf))));
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         GPU_UnitTestConvOclBwdWrW2SolverWrw_BFP16,
+                         GPU_UnitTestConvSolverOclBwdWrW2NonTunableWrw_BFP16,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(miopenConvolutionAlgoDirect),
                                           testing::ValuesIn(GetConvTestCases(miopenBFloat16))));
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         GPU_UnitTestConvOclBwdWrW2SolverWrw_FP32,
+                         GPU_UnitTestConvSolverOclBwdWrW2NonTunableWrw_FP32,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(miopenConvolutionAlgoDirect),
                                           testing::ValuesIn(GetConvTestCases(miopenFloat))));
 
 // Device applicability test
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         CPU_UnitTestConvOclBwdWrW2SolverDevApplicabilityWrw_NONE,
+                         CPU_UnitTestConvSolverOclBwdWrW2NonTunableDevApplicabilityWrw_NONE,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(GetConvTestCases(miopenFloat)[0])));

--- a/test/gtest/unit_conv_solver_ConvOclBwdWrW2NonTunable.cpp
+++ b/test/gtest/unit_conv_solver_ConvOclBwdWrW2NonTunable.cpp
@@ -55,9 +55,9 @@ using GPU_UnitTestConvOclBwdWrW2SolverWrw_FP16  = GPU_UnitTestConvSolverWrw_FP16
 using GPU_UnitTestConvOclBwdWrW2SolverWrw_BFP16 = GPU_UnitTestConvSolverWrw_BFP16;
 using GPU_UnitTestConvOclBwdWrW2SolverWrw_FP32  = GPU_UnitTestConvSolverWrw_FP32;
 using CPU_UnitTestConvOclBwdWrW2SolverDevApplicabilityWrw_NONE =
-    CPU_UnitTestConvSolverDevApplicabilityWrw_NONE
+    CPU_UnitTestConvSolverDevApplicabilityWrw_NONE;
 
-        TEST_P(GPU_UnitTestConvOclBwdWrW2SolverWrw_FP16, ConvOclBwdWrW2NonTunable)
+TEST_P(GPU_UnitTestConvOclBwdWrW2SolverWrw_FP16, ConvOclBwdWrW2NonTunable)
 {
     this->RunTest(miopen::solver::conv::ConvOclBwdWrW2NonTunable{});
 };

--- a/test/gtest/unit_conv_solver_ConvOclBwdWrW2NonTunable.cpp
+++ b/test/gtest/unit_conv_solver_ConvOclBwdWrW2NonTunable.cpp
@@ -51,47 +51,53 @@ const auto& GetTestParams()
 
 } // namespace
 
-TEST_P(GPU_UnitTestConvSolverWrw_FP16, ConvOclBwdWrW2NonTunable)
+using GPU_UnitTestConvOclBwdWrW2SolverWrw_FP16  = GPU_UnitTestConvSolverWrw_FP16;
+using GPU_UnitTestConvOclBwdWrW2SolverWrw_BFP16 = GPU_UnitTestConvSolverWrw_BFP16;
+using GPU_UnitTestConvOclBwdWrW2SolverWrw_FP32  = GPU_UnitTestConvSolverWrw_FP32;
+using CPU_UnitTestConvOclBwdWrW2SolverDevApplicabilityWrw_NONE =
+    CPU_UnitTestConvSolverDevApplicabilityWrw_NONE
+
+        TEST_P(GPU_UnitTestConvOclBwdWrW2SolverWrw_FP16, ConvOclBwdWrW2NonTunable)
 {
     this->RunTest(miopen::solver::conv::ConvOclBwdWrW2NonTunable{});
 };
 
-TEST_P(GPU_UnitTestConvSolverWrw_BFP16, ConvOclBwdWrW2NonTunable)
+TEST_P(GPU_UnitTestConvOclBwdWrW2SolverWrw_BFP16, ConvOclBwdWrW2NonTunable)
 {
     this->RunTest(miopen::solver::conv::ConvOclBwdWrW2NonTunable{});
 };
 
-TEST_P(GPU_UnitTestConvSolverWrw_FP32, ConvOclBwdWrW2NonTunable)
+TEST_P(GPU_UnitTestConvOclBwdWrW2SolverWrw_FP32, ConvOclBwdWrW2NonTunable)
 {
     this->RunTest(miopen::solver::conv::ConvOclBwdWrW2NonTunable{});
 };
 
-TEST_P(CPU_UnitTestConvSolverDevApplicabilityWrw_NONE, ConvOclBwdWrW2NonTunable)
+TEST_P(CPU_UnitTestConvOclBwdWrW2SolverDevApplicabilityWrw_NONE, ConvOclBwdWrW2NonTunable)
 {
     this->RunTest(miopen::solver::conv::ConvOclBwdWrW2NonTunable{});
 };
 
 // Smoke tests
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         GPU_UnitTestConvSolverWrw_FP16,
+                         GPU_UnitTestConvOclBwdWrW2SolverWrw_FP16,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(miopenConvolutionAlgoDirect),
                                           testing::ValuesIn(GetConvTestCases(miopenHalf))));
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         GPU_UnitTestConvSolverWrw_BFP16,
+                         GPU_UnitTestConvOclBwdWrW2SolverWrw_BFP16,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(miopenConvolutionAlgoDirect),
                                           testing::ValuesIn(GetConvTestCases(miopenBFloat16))));
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         GPU_UnitTestConvSolverWrw_FP32,
+                         GPU_UnitTestConvOclBwdWrW2SolverWrw_FP32,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(miopenConvolutionAlgoDirect),
                                           testing::ValuesIn(GetConvTestCases(miopenFloat))));
 
 // Device applicability test
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         CPU_UnitTestConvSolverDevApplicabilityWrw_NONE,
+                         CPU_UnitTestConvOclBwdWrW2SolverDevApplicabilityWrw_NONE,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(GetConvTestCases(miopenFloat)[0])));

--- a/test/gtest/unit_conv_solver_ConvWinoFuryRxS.cpp
+++ b/test/gtest/unit_conv_solver_ConvWinoFuryRxS.cpp
@@ -66,7 +66,7 @@ const auto& GetTestParams()
 using GPU_UnitTestConvSolverWinoFury2x3Fwd_FP16 = GPU_UnitTestConvSolverFwd_FP16;
 using GPU_UnitTestConvSolverWinoFury2x3Bwd_FP16 = GPU_UnitTestConvSolverBwd_FP16;
 using GPU_UnitTestConvSolverWinoFury2x3Wrw_FP16 = GPU_UnitTestConvSolverWrw_FP16;
-using CPU_UnitTestConvSolverDevApplicabilityWinoFury2x3Fwd_NONE =
+using CPU_UnitTestConvSolverWinoFury2x3DevApplicabilityFwd_NONE =
     CPU_UnitTestConvSolverDevApplicabilityFwd_NONE;
 
 TEST_P(GPU_UnitTestConvSolverWinoFury2x3Fwd_FP16, ConvWinoFuryRxSf2x3)
@@ -84,7 +84,7 @@ TEST_P(GPU_UnitTestConvSolverWinoFury2x3Wrw_FP16, ConvWinoFuryRxSf2x3)
     this->RunTest(miopen::solver::conv::ConvWinoFuryRxS<2, 3>{});
 };
 
-TEST_P(CPU_UnitTestConvSolverDevApplicabilityWinoFury2x3Fwd_NONE, ConvWinoFuryRxSf2x3)
+TEST_P(CPU_UnitTestConvSolverWinoFury2x3DevApplicabilityFwd_NONE, ConvWinoFuryRxSf2x3)
 {
     this->RunTest(miopen::solver::conv::ConvWinoFuryRxS<2, 3>{});
 };
@@ -110,6 +110,6 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
 
 // Device applicability test
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         CPU_UnitTestConvSolverDevApplicabilityWinoFury2x3Fwd_NONE,
+                         CPU_UnitTestConvSolverWinoFury2x3DevApplicabilityFwd_NONE,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(GetConvTestCases(miopenHalf)[0])));

--- a/test/gtest/unit_conv_solver_ConvWinoFuryRxS.cpp
+++ b/test/gtest/unit_conv_solver_ConvWinoFuryRxS.cpp
@@ -63,47 +63,52 @@ const auto& GetTestParams()
 
 } // namespace
 
-TEST_P(GPU_UnitTestConvSolverFwd_FP16, ConvWinoFuryRxSf2x3)
+using GPU_UnitTestConvSolverWinoFuryFwd_FP16 = GPU_UnitTestConvSolverFwd_FP16;
+using GPU_UnitTestConvSolverWinoFuryBwd_FP16 = GPU_UnitTestConvSolverBwd_FP16;
+using GPU_UnitTestConvSolverWinoFuryWrw_FP16 = GPU_UnitTestConvSolverWrw_FP16;
+using CPU_UnitTestConvSolverDevApplicabilityWinoFuryFwd_NONE = CPU_UnitTestConvSolverDevApplicabilityFwd_NONE;
+
+TEST_P(GPU_UnitTestConvSolverWinoFuryFwd_FP16, ConvWinoFuryRxSf2x3)
 {
     this->RunTest(miopen::solver::conv::ConvWinoFuryRxS<2, 3>{});
 };
 
-TEST_P(GPU_UnitTestConvSolverBwd_FP16, ConvWinoFuryRxSf2x3)
+TEST_P(GPU_UnitTestConvSolverWinoFuryBwd_FP16, ConvWinoFuryRxSf2x3)
 {
     this->RunTest(miopen::solver::conv::ConvWinoFuryRxS<2, 3>{});
 };
 
-TEST_P(GPU_UnitTestConvSolverWrw_FP16, ConvWinoFuryRxSf2x3)
+TEST_P(GPU_UnitTestConvSolverWinoFuryWrw_FP16, ConvWinoFuryRxSf2x3)
 {
     this->RunTest(miopen::solver::conv::ConvWinoFuryRxS<2, 3>{});
 };
 
-TEST_P(CPU_UnitTestConvSolverDevApplicabilityFwd_NONE, ConvWinoFuryRxSf2x3)
+TEST_P(CPU_UnitTestConvSolverDevApplicabilityWinoFuryFwd_NONE, ConvWinoFuryRxSf2x3)
 {
     this->RunTest(miopen::solver::conv::ConvWinoFuryRxS<2, 3>{});
 };
 
 // Smoke tests
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         GPU_UnitTestConvSolverFwd_FP16,
+                         GPU_UnitTestConvSolverWinoFuryFwd_FP16,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(miopenConvolutionAlgoWinograd),
                                           testing::ValuesIn(GetConvTestCases(miopenHalf))));
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         GPU_UnitTestConvSolverBwd_FP16,
+                         GPU_UnitTestConvSolverWinoFuryBwd_FP16,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(miopenConvolutionAlgoWinograd),
                                           testing::ValuesIn(GetConvTestCases(miopenHalf))));
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         GPU_UnitTestConvSolverWrw_FP16,
+                         GPU_UnitTestConvSolverWinoFuryWrw_FP16,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(miopenConvolutionAlgoWinograd),
                                           testing::ValuesIn(GetConvTestCasesWrw(miopenHalf))));
 
 // Device applicability test
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         CPU_UnitTestConvSolverDevApplicabilityFwd_NONE,
+                         CPU_UnitTestConvSolverDevApplicabilityWinoFuryFwd_NONE,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(GetConvTestCases(miopenHalf)[0])));

--- a/test/gtest/unit_conv_solver_ConvWinoFuryRxS.cpp
+++ b/test/gtest/unit_conv_solver_ConvWinoFuryRxS.cpp
@@ -63,52 +63,53 @@ const auto& GetTestParams()
 
 } // namespace
 
-using GPU_UnitTestConvSolverWinoFuryFwd_FP16 = GPU_UnitTestConvSolverFwd_FP16;
-using GPU_UnitTestConvSolverWinoFuryBwd_FP16 = GPU_UnitTestConvSolverBwd_FP16;
-using GPU_UnitTestConvSolverWinoFuryWrw_FP16 = GPU_UnitTestConvSolverWrw_FP16;
-using CPU_UnitTestConvSolverDevApplicabilityWinoFuryFwd_NONE = CPU_UnitTestConvSolverDevApplicabilityFwd_NONE;
+using GPU_UnitTestConvSolverWinoFury2x3Fwd_FP16 = GPU_UnitTestConvSolverFwd_FP16;
+using GPU_UnitTestConvSolverWinoFury2x3Bwd_FP16 = GPU_UnitTestConvSolverBwd_FP16;
+using GPU_UnitTestConvSolverWinoFury2x3Wrw_FP16 = GPU_UnitTestConvSolverWrw_FP16;
+using CPU_UnitTestConvSolverDevApplicabilityWinoFury2x3Fwd_NONE =
+    CPU_UnitTestConvSolverDevApplicabilityFwd_NONE;
 
-TEST_P(GPU_UnitTestConvSolverWinoFuryFwd_FP16, ConvWinoFuryRxSf2x3)
+TEST_P(GPU_UnitTestConvSolverWinoFury2x3Fwd_FP16, ConvWinoFuryRxSf2x3)
 {
     this->RunTest(miopen::solver::conv::ConvWinoFuryRxS<2, 3>{});
 };
 
-TEST_P(GPU_UnitTestConvSolverWinoFuryBwd_FP16, ConvWinoFuryRxSf2x3)
+TEST_P(GPU_UnitTestConvSolverWinoFury2x3Bwd_FP16, ConvWinoFuryRxSf2x3)
 {
     this->RunTest(miopen::solver::conv::ConvWinoFuryRxS<2, 3>{});
 };
 
-TEST_P(GPU_UnitTestConvSolverWinoFuryWrw_FP16, ConvWinoFuryRxSf2x3)
+TEST_P(GPU_UnitTestConvSolverWinoFury2x3Wrw_FP16, ConvWinoFuryRxSf2x3)
 {
     this->RunTest(miopen::solver::conv::ConvWinoFuryRxS<2, 3>{});
 };
 
-TEST_P(CPU_UnitTestConvSolverDevApplicabilityWinoFuryFwd_NONE, ConvWinoFuryRxSf2x3)
+TEST_P(CPU_UnitTestConvSolverDevApplicabilityWinoFury2x3Fwd_NONE, ConvWinoFuryRxSf2x3)
 {
     this->RunTest(miopen::solver::conv::ConvWinoFuryRxS<2, 3>{});
 };
 
 // Smoke tests
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         GPU_UnitTestConvSolverWinoFuryFwd_FP16,
+                         GPU_UnitTestConvSolverWinoFury2x3Fwd_FP16,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(miopenConvolutionAlgoWinograd),
                                           testing::ValuesIn(GetConvTestCases(miopenHalf))));
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         GPU_UnitTestConvSolverWinoFuryBwd_FP16,
+                         GPU_UnitTestConvSolverWinoFury2x3Bwd_FP16,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(miopenConvolutionAlgoWinograd),
                                           testing::ValuesIn(GetConvTestCases(miopenHalf))));
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         GPU_UnitTestConvSolverWinoFuryWrw_FP16,
+                         GPU_UnitTestConvSolverWinoFury2x3Wrw_FP16,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(miopenConvolutionAlgoWinograd),
                                           testing::ValuesIn(GetConvTestCasesWrw(miopenHalf))));
 
 // Device applicability test
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         CPU_UnitTestConvSolverDevApplicabilityWinoFuryFwd_NONE,
+                         CPU_UnitTestConvSolverDevApplicabilityWinoFury2x3Fwd_NONE,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(GetConvTestCases(miopenHalf)[0])));

--- a/test/gtest/unit_conv_solver_GemmFwd1x1_0_1_int8.cpp
+++ b/test/gtest/unit_conv_solver_GemmFwd1x1_0_1_int8.cpp
@@ -54,25 +54,29 @@ const auto& GetTestParams()
 
 } // namespace
 
-TEST_P(GPU_UnitTestConvSolverFwd_I8, GemmFwd1x1_0_1_int8)
+using GPU_UnitTestConvGemm1x1_0_1SolverFwd_I8 = GPU_UnitTestConvSolverFwd_I8;
+using CPU_UnitTestConvGemm1x1_0_1SolverDevApplicabilityFwd_NONE =
+    CPU_UnitTestConvSolverDevApplicabilityFwd_NONE;
+
+TEST_P(GPU_UnitTestConvGemm1x1_0_1SolverFwd_I8, GemmFwd1x1_0_1_int8)
 {
     this->RunTest(miopen::solver::conv::GemmFwd1x1_0_1_int8{});
 };
 
-TEST_P(CPU_UnitTestConvSolverDevApplicabilityFwd_NONE, GemmFwd1x1_0_1_int8)
+TEST_P(CPU_UnitTestConvGemm1x1_0_1SolverDevApplicabilityFwd_NONE, GemmFwd1x1_0_1_int8)
 {
     this->RunTest(miopen::solver::conv::GemmFwd1x1_0_1_int8{});
 };
 
 // Smoke tests
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         GPU_UnitTestConvSolverFwd_I8,
+                         GPU_UnitTestConvGemm1x1_0_1SolverFwd_I8,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(miopenConvolutionAlgoGEMM),
                                           testing::ValuesIn(GetConvTestCases(miopenInt8))));
 
 // Device applicability test
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         CPU_UnitTestConvSolverDevApplicabilityFwd_NONE,
+                         CPU_UnitTestConvGemm1x1_0_1SolverDevApplicabilityFwd_NONE,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(GetConvTestCases(miopenInt8)[0])));

--- a/test/gtest/unit_conv_solver_GemmFwd1x1_0_1_int8.cpp
+++ b/test/gtest/unit_conv_solver_GemmFwd1x1_0_1_int8.cpp
@@ -54,29 +54,29 @@ const auto& GetTestParams()
 
 } // namespace
 
-using GPU_UnitTestConvGemm1x1_0_1SolverFwd_I8 = GPU_UnitTestConvSolverFwd_I8;
-using CPU_UnitTestConvGemm1x1_0_1SolverDevApplicabilityFwd_NONE =
+using GPU_UnitTestConvSolverGemmFwd1x1_0_1_Int8Fwd_I8 = GPU_UnitTestConvSolverFwd_I8;
+using CPU_UnitTestConvSolverGemmFwd1x1_0_1_Int8DevApplicabilityFwd_NONE =
     CPU_UnitTestConvSolverDevApplicabilityFwd_NONE;
 
-TEST_P(GPU_UnitTestConvGemm1x1_0_1SolverFwd_I8, GemmFwd1x1_0_1_int8)
+TEST_P(GPU_UnitTestConvSolverGemmFwd1x1_0_1_Int8Fwd_I8, GemmFwd1x1_0_1_int8)
 {
     this->RunTest(miopen::solver::conv::GemmFwd1x1_0_1_int8{});
 };
 
-TEST_P(CPU_UnitTestConvGemm1x1_0_1SolverDevApplicabilityFwd_NONE, GemmFwd1x1_0_1_int8)
+TEST_P(CPU_UnitTestConvSolverGemmFwd1x1_0_1_Int8DevApplicabilityFwd_NONE, GemmFwd1x1_0_1_int8)
 {
     this->RunTest(miopen::solver::conv::GemmFwd1x1_0_1_int8{});
 };
 
 // Smoke tests
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         GPU_UnitTestConvGemm1x1_0_1SolverFwd_I8,
+                         GPU_UnitTestConvSolverGemmFwd1x1_0_1_Int8Fwd_I8,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(miopenConvolutionAlgoGEMM),
                                           testing::ValuesIn(GetConvTestCases(miopenInt8))));
 
 // Device applicability test
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         CPU_UnitTestConvGemm1x1_0_1SolverDevApplicabilityFwd_NONE,
+                         CPU_UnitTestConvSolverGemmFwd1x1_0_1_Int8DevApplicabilityFwd_NONE,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(GetConvTestCases(miopenInt8)[0])));

--- a/test/gtest/unit_conv_solver_GemmFwdRest.cpp
+++ b/test/gtest/unit_conv_solver_GemmFwdRest.cpp
@@ -70,90 +70,90 @@ const auto& GetTestParams()
 
 } // namespace
 
-using GPU_UnitTestConvGemmRestSolverFwd_FP16  = GPU_UnitTestConvSolverFwd_FP16;
-using GPU_UnitTestConvGemmRestSolverFwd_BFP16 = GPU_UnitTestConvSolverFwd_BFP16;
-using GPU_UnitTestConvGemmRestSolverFwd_FP32  = GPU_UnitTestConvSolverFwd_FP32;
-using GPU_UnitTestConvGemmRestSolverFwd_I8    = GPU_UnitTestConvSolverFwd_I8;
-using CPU_UnitTestConvGemmRestSolverDevApplicabilityFwd_NONE =
+using GPU_UnitTestConvSolverGemmFwdRestFwd_FP16  = GPU_UnitTestConvSolverFwd_FP16;
+using GPU_UnitTestConvSolverGemmFwdRestFwd_BFP16 = GPU_UnitTestConvSolverFwd_BFP16;
+using GPU_UnitTestConvSolverGemmFwdRestFwd_FP32  = GPU_UnitTestConvSolverFwd_FP32;
+using GPU_UnitTestConvSolverGemmFwdRestFwd_I8    = GPU_UnitTestConvSolverFwd_I8;
+using CPU_UnitTestConvSolverGemmFwdRestDevApplicabilityFwd_NONE =
     CPU_UnitTestConvSolverDevApplicabilityFwd_NONE;
 
-TEST_P(GPU_UnitTestConvGemmRestSolverFwd_FP16, GemmFwdRest)
+TEST_P(GPU_UnitTestConvSolverGemmFwdRestFwd_FP16, GemmFwdRest)
 {
     this->RunTest(miopen::solver::conv::GemmFwdRest{});
 };
 
-TEST_P(GPU_UnitTestConvGemmRestSolverFwd_BFP16, GemmFwdRest)
+TEST_P(GPU_UnitTestConvSolverGemmFwdRestFwd_BFP16, GemmFwdRest)
 {
     this->RunTest(miopen::solver::conv::GemmFwdRest{});
 };
 
-TEST_P(GPU_UnitTestConvGemmRestSolverFwd_FP32, GemmFwdRest)
+TEST_P(GPU_UnitTestConvSolverGemmFwdRestFwd_FP32, GemmFwdRest)
 {
     this->RunTest(miopen::solver::conv::GemmFwdRest{});
 };
 
-TEST_P(GPU_UnitTestConvGemmRestSolverFwd_I8, GemmFwdRest)
+TEST_P(GPU_UnitTestConvSolverGemmFwdRestFwd_I8, GemmFwdRest)
 {
     this->RunTest(miopen::solver::conv::GemmFwdRest{});
 };
 
-TEST_P(CPU_UnitTestConvGemmRestSolverDevApplicabilityFwd_NONE, GemmFwdRest)
+TEST_P(CPU_UnitTestConvSolverGemmFwdRestDevApplicabilityFwd_NONE, GemmFwdRest)
 {
     this->RunTest(miopen::solver::conv::GemmFwdRest{});
 };
 
 // Smoke tests
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         GPU_UnitTestConvGemmRestSolverFwd_FP16,
+                         GPU_UnitTestConvSolverGemmFwdRestFwd_FP16,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(miopenConvolutionAlgoGEMM),
                                           testing::ValuesIn(GetConvTestCases(miopenHalf))));
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         GPU_UnitTestConvGemmRestSolverFwd_BFP16,
+                         GPU_UnitTestConvSolverGemmFwdRestFwd_BFP16,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(miopenConvolutionAlgoGEMM),
                                           testing::ValuesIn(GetConvTestCases(miopenBFloat16))));
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         GPU_UnitTestConvGemmRestSolverFwd_FP32,
+                         GPU_UnitTestConvSolverGemmFwdRestFwd_FP32,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(miopenConvolutionAlgoGEMM),
                                           testing::ValuesIn(GetConvTestCases(miopenFloat))));
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         GPU_UnitTestConvGemmRestSolverFwd_I8,
+                         GPU_UnitTestConvSolverGemmFwdRestFwd_I8,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(miopenConvolutionAlgoGEMM),
                                           testing::ValuesIn(GetConvTestCases(miopenInt8))));
 
 // Device applicability test
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         CPU_UnitTestConvGemmRestSolverDevApplicabilityFwd_NONE,
+                         CPU_UnitTestConvSolverGemmFwdRestDevApplicabilityFwd_NONE,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(GetConvTestCases(miopenFloat)[0])));
 
 // Full tests
 INSTANTIATE_TEST_SUITE_P(Full,
-                         GPU_UnitTestConvGemmRestSolverFwd_FP16,
+                         GPU_UnitTestConvSolverGemmFwdRestFwd_FP16,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(miopenConvolutionAlgoGEMM),
                                           testing::ValuesIn(GetConvTestCasesFull(miopenHalf))));
 
 INSTANTIATE_TEST_SUITE_P(Full,
-                         GPU_UnitTestConvGemmRestSolverFwd_BFP16,
+                         GPU_UnitTestConvSolverGemmFwdRestFwd_BFP16,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(miopenConvolutionAlgoGEMM),
                                           testing::ValuesIn(GetConvTestCasesFull(miopenBFloat16))));
 
 INSTANTIATE_TEST_SUITE_P(Full,
-                         GPU_UnitTestConvGemmRestSolverFwd_FP32,
+                         GPU_UnitTestConvSolverGemmFwdRestFwd_FP32,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(miopenConvolutionAlgoGEMM),
                                           testing::ValuesIn(GetConvTestCasesFull(miopenFloat))));
 
 INSTANTIATE_TEST_SUITE_P(Full,
-                         GPU_UnitTestConvGemmRestSolverFwd_I8,
+                         GPU_UnitTestConvSolverGemmFwdRestFwd_I8,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(miopenConvolutionAlgoGEMM),
                                           testing::ValuesIn(GetConvTestCasesFull(miopenInt8))));

--- a/test/gtest/unit_conv_solver_GemmFwdRest.cpp
+++ b/test/gtest/unit_conv_solver_GemmFwdRest.cpp
@@ -70,83 +70,90 @@ const auto& GetTestParams()
 
 } // namespace
 
-TEST_P(GPU_UnitTestConvSolverFwd_FP16, GemmFwdRest)
+using GPU_UnitTestConvGemmRestSolverFwd_FP16  = GPU_UnitTestConvSolverFwd_FP16;
+using GPU_UnitTestConvGemmRestSolverFwd_BFP16 = GPU_UnitTestConvSolverFwd_BFP16;
+using GPU_UnitTestConvGemmRestSolverFwd_FP32  = GPU_UnitTestConvSolverFwd_FP32;
+using GPU_UnitTestConvGemmRestSolverFwd_I8    = GPU_UnitTestConvSolverFwd_I8;
+using CPU_UnitTestConvGemmRestSolverDevApplicabilityFwd_NONE =
+    CPU_UnitTestConvSolverDevApplicabilityFwd_NONE;
+
+TEST_P(GPU_UnitTestConvGemmRestSolverFwd_FP16, GemmFwdRest)
 {
     this->RunTest(miopen::solver::conv::GemmFwdRest{});
 };
 
-TEST_P(GPU_UnitTestConvSolverFwd_BFP16, GemmFwdRest)
+TEST_P(GPU_UnitTestConvGemmRestSolverFwd_BFP16, GemmFwdRest)
 {
     this->RunTest(miopen::solver::conv::GemmFwdRest{});
 };
 
-TEST_P(GPU_UnitTestConvSolverFwd_FP32, GemmFwdRest)
+TEST_P(GPU_UnitTestConvGemmRestSolverFwd_FP32, GemmFwdRest)
 {
     this->RunTest(miopen::solver::conv::GemmFwdRest{});
 };
 
-TEST_P(GPU_UnitTestConvSolverFwd_I8, GemmFwdRest)
+TEST_P(GPU_UnitTestConvGemmRestSolverFwd_I8, GemmFwdRest)
 {
     this->RunTest(miopen::solver::conv::GemmFwdRest{});
 };
 
-TEST_P(CPU_UnitTestConvSolverDevApplicabilityFwd_NONE, GemmFwdRest)
+TEST_P(CPU_UnitTestConvGemmRestSolverDevApplicabilityFwd_NONE, GemmFwdRest)
 {
     this->RunTest(miopen::solver::conv::GemmFwdRest{});
 };
 
 // Smoke tests
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         GPU_UnitTestConvSolverFwd_FP16,
+                         GPU_UnitTestConvGemmRestSolverFwd_FP16,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(miopenConvolutionAlgoGEMM),
                                           testing::ValuesIn(GetConvTestCases(miopenHalf))));
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         GPU_UnitTestConvSolverFwd_BFP16,
+                         GPU_UnitTestConvGemmRestSolverFwd_BFP16,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(miopenConvolutionAlgoGEMM),
                                           testing::ValuesIn(GetConvTestCases(miopenBFloat16))));
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         GPU_UnitTestConvSolverFwd_FP32,
+                         GPU_UnitTestConvGemmRestSolverFwd_FP32,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(miopenConvolutionAlgoGEMM),
                                           testing::ValuesIn(GetConvTestCases(miopenFloat))));
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         GPU_UnitTestConvSolverFwd_I8,
+                         GPU_UnitTestConvGemmRestSolverFwd_I8,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(miopenConvolutionAlgoGEMM),
                                           testing::ValuesIn(GetConvTestCases(miopenInt8))));
 
 // Device applicability test
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         CPU_UnitTestConvSolverDevApplicabilityFwd_NONE,
+                         CPU_UnitTestConvGemmRestSolverDevApplicabilityFwd_NONE,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(GetConvTestCases(miopenFloat)[0])));
 
 // Full tests
 INSTANTIATE_TEST_SUITE_P(Full,
-                         GPU_UnitTestConvSolverFwd_FP16,
+                         GPU_UnitTestConvGemmRestSolverFwd_FP16,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(miopenConvolutionAlgoGEMM),
                                           testing::ValuesIn(GetConvTestCasesFull(miopenHalf))));
 
 INSTANTIATE_TEST_SUITE_P(Full,
-                         GPU_UnitTestConvSolverFwd_BFP16,
+                         GPU_UnitTestConvGemmRestSolverFwd_BFP16,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(miopenConvolutionAlgoGEMM),
                                           testing::ValuesIn(GetConvTestCasesFull(miopenBFloat16))));
 
 INSTANTIATE_TEST_SUITE_P(Full,
-                         GPU_UnitTestConvSolverFwd_FP32,
+                         GPU_UnitTestConvGemmRestSolverFwd_FP32,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(miopenConvolutionAlgoGEMM),
                                           testing::ValuesIn(GetConvTestCasesFull(miopenFloat))));
 
 INSTANTIATE_TEST_SUITE_P(Full,
-                         GPU_UnitTestConvSolverFwd_I8,
+                         GPU_UnitTestConvGemmRestSolverFwd_I8,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(miopenConvolutionAlgoGEMM),
                                           testing::ValuesIn(GetConvTestCasesFull(miopenInt8))));

--- a/test/gtest/unit_conv_solver_GemmWrw1x1_stride1.cpp
+++ b/test/gtest/unit_conv_solver_GemmWrw1x1_stride1.cpp
@@ -50,47 +50,53 @@ const auto& GetTestParams()
 
 } // namespace
 
-TEST_P(GPU_UnitTestConvSolverWrw_FP16, GemmWrw1x1_stride1)
+using GPU_UnitTestConvGemm1x1StrideSolverWrw_FP16  = GPU_UnitTestConvSolverWrw_FP16;
+using GPU_UnitTestConvGemm1x1StrideSolverWrw_BFP16 = GPU_UnitTestConvSolverWrw_BFP16;
+using GPU_UnitTestConvGemm1x1StrideSolverWrw_FP32  = GPU_UnitTestConvSolverWrw_FP32;
+using CPU_UnitTestConvGemm1x1StrideSolverDevApplicabilityWrw_NONE =
+    CPU_UnitTestConvSolverDevApplicabilityWrw_NONE;
+
+TEST_P(GPU_UnitTestConvGemm1x1StrideSolverWrw_FP16, GemmWrw1x1_stride1)
 {
     this->RunTest(miopen::solver::conv::GemmWrw1x1_stride1{});
 };
 
-TEST_P(GPU_UnitTestConvSolverWrw_BFP16, GemmWrw1x1_stride1)
+TEST_P(GPU_UnitTestConvGemm1x1StrideSolverWrw_BFP16, GemmWrw1x1_stride1)
 {
     this->RunTest(miopen::solver::conv::GemmWrw1x1_stride1{});
 };
 
-TEST_P(GPU_UnitTestConvSolverWrw_FP32, GemmWrw1x1_stride1)
+TEST_P(GPU_UnitTestConvGemm1x1StrideSolverWrw_FP32, GemmWrw1x1_stride1)
 {
     this->RunTest(miopen::solver::conv::GemmWrw1x1_stride1{});
 };
 
-TEST_P(CPU_UnitTestConvSolverDevApplicabilityWrw_NONE, GemmWrw1x1_stride1)
+TEST_P(CPU_UnitTestConvGemm1x1StrideSolverDevApplicabilityWrw_NONE, GemmWrw1x1_stride1)
 {
     this->RunTest(miopen::solver::conv::GemmWrw1x1_stride1{});
 };
 
 // Smoke tests
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         GPU_UnitTestConvSolverWrw_FP16,
+                         GPU_UnitTestConvGemm1x1StrideSolverWrw_FP16,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(miopenConvolutionAlgoGEMM),
                                           testing::ValuesIn(GetConvTestCases(miopenHalf))));
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         GPU_UnitTestConvSolverWrw_BFP16,
+                         GPU_UnitTestConvGemm1x1StrideSolverWrw_BFP16,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(miopenConvolutionAlgoGEMM),
                                           testing::ValuesIn(GetConvTestCases(miopenBFloat16))));
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         GPU_UnitTestConvSolverWrw_FP32,
+                         GPU_UnitTestConvGemm1x1StrideSolverWrw_FP32,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(miopenConvolutionAlgoGEMM),
                                           testing::ValuesIn(GetConvTestCases(miopenFloat))));
 
 // Device applicability test
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         CPU_UnitTestConvSolverDevApplicabilityWrw_NONE,
+                         CPU_UnitTestConvGemm1x1StrideSolverDevApplicabilityWrw_NONE,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(GetConvTestCases(miopenFloat)[0])));

--- a/test/gtest/unit_conv_solver_GemmWrw1x1_stride1.cpp
+++ b/test/gtest/unit_conv_solver_GemmWrw1x1_stride1.cpp
@@ -50,53 +50,53 @@ const auto& GetTestParams()
 
 } // namespace
 
-using GPU_UnitTestConvGemm1x1StrideSolverWrw_FP16  = GPU_UnitTestConvSolverWrw_FP16;
-using GPU_UnitTestConvGemm1x1StrideSolverWrw_BFP16 = GPU_UnitTestConvSolverWrw_BFP16;
-using GPU_UnitTestConvGemm1x1StrideSolverWrw_FP32  = GPU_UnitTestConvSolverWrw_FP32;
-using CPU_UnitTestConvGemm1x1StrideSolverDevApplicabilityWrw_NONE =
+using GPU_UnitTestConvSolverGemmWrw1x1Stride1Wrw_FP16  = GPU_UnitTestConvSolverWrw_FP16;
+using GPU_UnitTestConvSolverGemmWrw1x1Stride1Wrw_BFP16 = GPU_UnitTestConvSolverWrw_BFP16;
+using GPU_UnitTestConvSolverGemmWrw1x1Stride1Wrw_FP32  = GPU_UnitTestConvSolverWrw_FP32;
+using CPU_UnitTestConvSolverGemmWrw1x1Stride1DevApplicabilityWrw_NONE =
     CPU_UnitTestConvSolverDevApplicabilityWrw_NONE;
 
-TEST_P(GPU_UnitTestConvGemm1x1StrideSolverWrw_FP16, GemmWrw1x1_stride1)
+TEST_P(GPU_UnitTestConvSolverGemmWrw1x1Stride1Wrw_FP16, GemmWrw1x1_stride1)
 {
     this->RunTest(miopen::solver::conv::GemmWrw1x1_stride1{});
 };
 
-TEST_P(GPU_UnitTestConvGemm1x1StrideSolverWrw_BFP16, GemmWrw1x1_stride1)
+TEST_P(GPU_UnitTestConvSolverGemmWrw1x1Stride1Wrw_BFP16, GemmWrw1x1_stride1)
 {
     this->RunTest(miopen::solver::conv::GemmWrw1x1_stride1{});
 };
 
-TEST_P(GPU_UnitTestConvGemm1x1StrideSolverWrw_FP32, GemmWrw1x1_stride1)
+TEST_P(GPU_UnitTestConvSolverGemmWrw1x1Stride1Wrw_FP32, GemmWrw1x1_stride1)
 {
     this->RunTest(miopen::solver::conv::GemmWrw1x1_stride1{});
 };
 
-TEST_P(CPU_UnitTestConvGemm1x1StrideSolverDevApplicabilityWrw_NONE, GemmWrw1x1_stride1)
+TEST_P(CPU_UnitTestConvSolverGemmWrw1x1Stride1DevApplicabilityWrw_NONE, GemmWrw1x1_stride1)
 {
     this->RunTest(miopen::solver::conv::GemmWrw1x1_stride1{});
 };
 
 // Smoke tests
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         GPU_UnitTestConvGemm1x1StrideSolverWrw_FP16,
+                         GPU_UnitTestConvSolverGemmWrw1x1Stride1Wrw_FP16,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(miopenConvolutionAlgoGEMM),
                                           testing::ValuesIn(GetConvTestCases(miopenHalf))));
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         GPU_UnitTestConvGemm1x1StrideSolverWrw_BFP16,
+                         GPU_UnitTestConvSolverGemmWrw1x1Stride1Wrw_BFP16,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(miopenConvolutionAlgoGEMM),
                                           testing::ValuesIn(GetConvTestCases(miopenBFloat16))));
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         GPU_UnitTestConvGemm1x1StrideSolverWrw_FP32,
+                         GPU_UnitTestConvSolverGemmWrw1x1Stride1Wrw_FP32,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(miopenConvolutionAlgoGEMM),
                                           testing::ValuesIn(GetConvTestCases(miopenFloat))));
 
 // Device applicability test
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         CPU_UnitTestConvGemm1x1StrideSolverDevApplicabilityWrw_NONE,
+                         CPU_UnitTestConvSolverGemmWrw1x1Stride1DevApplicabilityWrw_NONE,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(GetConvTestCases(miopenFloat)[0])));

--- a/test/gtest/unit_conv_solver_GemmWrwUniversal.cpp
+++ b/test/gtest/unit_conv_solver_GemmWrwUniversal.cpp
@@ -71,7 +71,7 @@ TEST_P(GPU_UnitTestConvSolverGemmWrwUniversalWrw_FP32, GemmWrwUniversal)
     this->RunTest(miopen::solver::conv::GemmWrwUniversal{});
 };
 
-TEST_P(CPU_UnitTestConvGemmUniversalSolverDevApplicabilityWrw_NONE, GemmWrwUniversal)
+TEST_P(CPU_UnitTestConvSolverGemmWrwUniversalDevApplicabilityWrw_NONE, GemmWrwUniversal)
 {
     this->RunTest(miopen::solver::conv::GemmWrwUniversal{});
 };

--- a/test/gtest/unit_conv_solver_GemmWrwUniversal.cpp
+++ b/test/gtest/unit_conv_solver_GemmWrwUniversal.cpp
@@ -50,23 +50,23 @@ const auto& GetTestParams()
 
 } // namespace
 
-using GPU_UnitTestConvGemmUniversalSolverWrw_FP16  = GPU_UnitTestConvSolverWrw_FP16;
-using GPU_UnitTestConvGemmUniversalSolverWrw_BFP16 = GPU_UnitTestConvSolverWrw_BFP16;
-using GPU_UnitTestConvGemmUniversalSolverWrw_FP32  = GPU_UnitTestConvSolverWrw_FP32;
-using CPU_UnitTestConvGemmUniversalSolverDevApplicabilityWrw_NONE =
+using GPU_UnitTestConvSolverGemmWrwUniversalWrw_FP16  = GPU_UnitTestConvSolverWrw_FP16;
+using GPU_UnitTestConvSolverGemmWrwUniversalWrw_BFP16 = GPU_UnitTestConvSolverWrw_BFP16;
+using GPU_UnitTestConvSolverGemmWrwUniversalWrw_FP32  = GPU_UnitTestConvSolverWrw_FP32;
+using CPU_UnitTestConvSolverGemmWrwUniversalDevApplicabilityWrw_NONE =
     CPU_UnitTestConvSolverDevApplicabilityWrw_NONE;
 
-TEST_P(GPU_UnitTestConvGemmUniversalSolverWrw_FP16, GemmWrwUniversal)
+TEST_P(GPU_UnitTestConvSolverGemmWrwUniversalWrw_FP16, GemmWrwUniversal)
 {
     this->RunTest(miopen::solver::conv::GemmWrwUniversal{});
 };
 
-TEST_P(GPU_UnitTestConvGemmUniversalSolverWrw_BFP16, GemmWrwUniversal)
+TEST_P(GPU_UnitTestConvSolverGemmWrwUniversalWrw_BFP16, GemmWrwUniversal)
 {
     this->RunTest(miopen::solver::conv::GemmWrwUniversal{});
 };
 
-TEST_P(GPU_UnitTestConvGemmUniversalSolverWrw_FP32, GemmWrwUniversal)
+TEST_P(GPU_UnitTestConvSolverGemmWrwUniversalWrw_FP32, GemmWrwUniversal)
 {
     this->RunTest(miopen::solver::conv::GemmWrwUniversal{});
 };
@@ -78,25 +78,25 @@ TEST_P(CPU_UnitTestConvGemmUniversalSolverDevApplicabilityWrw_NONE, GemmWrwUnive
 
 // Smoke tests
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         GPU_UnitTestConvGemmUniversalSolverWrw_FP16,
+                         GPU_UnitTestConvSolverGemmWrwUniversalWrw_FP16,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(miopenConvolutionAlgoGEMM),
                                           testing::ValuesIn(GetConvTestCases(miopenHalf))));
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         GPU_UnitTestConvGemmUniversalSolverWrw_BFP16,
+                         GPU_UnitTestConvSolverGemmWrwUniversalWrw_BFP16,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(miopenConvolutionAlgoGEMM),
                                           testing::ValuesIn(GetConvTestCases(miopenBFloat16))));
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         GPU_UnitTestConvGemmUniversalSolverWrw_FP32,
+                         GPU_UnitTestConvSolverGemmWrwUniversalWrw_FP32,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(miopenConvolutionAlgoGEMM),
                                           testing::ValuesIn(GetConvTestCases(miopenFloat))));
 
 // Device applicability test
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         CPU_UnitTestConvGemmUniversalSolverDevApplicabilityWrw_NONE,
+                         CPU_UnitTestConvSolverGemmWrwUniversalDevApplicabilityWrw_NONE,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(GetConvTestCases(miopenFloat)[0])));

--- a/test/gtest/unit_conv_solver_GemmWrwUniversal.cpp
+++ b/test/gtest/unit_conv_solver_GemmWrwUniversal.cpp
@@ -50,17 +50,23 @@ const auto& GetTestParams()
 
 } // namespace
 
-TEST_P(GPU_UnitTestConvSolverWrw_FP16, GemmWrwUniversal)
+using GPU_UnitTestConvGemmUniversalSolverWrw_FP16  = GPU_UnitTestConvSolverWrw_FP16;
+using GPU_UnitTestConvGemmUniversalSolverWrw_BFP16 = GPU_UnitTestConvSolverWrw_BFP16;
+using GPU_UnitTestConvGemmUniversalSolverWrw_FP32  = GPU_UnitTestConvSolverWrw_FP32;
+using CPU_UnitTestConvGemmUniversalSolverDevApplicabilityWrw_NONE =
+    CPU_UnitTestConvSolverDevApplicabilityWrw_NONE;
+
+TEST_P(GPU_UnitTestConvGemmUniversalSolverWrw_FP16, GemmWrwUniversal)
 {
     this->RunTest(miopen::solver::conv::GemmWrwUniversal{});
 };
 
-TEST_P(GPU_UnitTestConvSolverWrw_BFP16, GemmWrwUniversal)
+TEST_P(GPU_UnitTestConvGemmUniversalSolverWrw_BFP16, GemmWrwUniversal)
 {
     this->RunTest(miopen::solver::conv::GemmWrwUniversal{});
 };
 
-TEST_P(GPU_UnitTestConvSolverWrw_FP32, GemmWrwUniversal)
+TEST_P(GPU_UnitTestConvGemmUniversalSolverWrw_FP32, GemmWrwUniversal)
 {
     this->RunTest(miopen::solver::conv::GemmWrwUniversal{});
 };
@@ -72,25 +78,25 @@ TEST_P(CPU_UnitTestConvSolverDevApplicabilityWrw_NONE, GemmWrwUniversal)
 
 // Smoke tests
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         GPU_UnitTestConvSolverWrw_FP16,
+                         GPU_UnitTestConvGemmUniversalSolverWrw_FP16,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(miopenConvolutionAlgoGEMM),
                                           testing::ValuesIn(GetConvTestCases(miopenHalf))));
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         GPU_UnitTestConvSolverWrw_BFP16,
+                         GPU_UnitTestConvGemmUniversalSolverWrw_BFP16,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(miopenConvolutionAlgoGEMM),
                                           testing::ValuesIn(GetConvTestCases(miopenBFloat16))));
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         GPU_UnitTestConvSolverWrw_FP32,
+                         GPU_UnitTestConvGemmUniversalSolverWrw_FP32,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(miopenConvolutionAlgoGEMM),
                                           testing::ValuesIn(GetConvTestCases(miopenFloat))));
 
 // Device applicability test
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         CPU_UnitTestConvSolverDevApplicabilityWrw_NONE,
+                         CPU_UnitTestConvGemmUniversalSolverDevApplicabilityWrw_NONE,
                          testing::Combine(testing::Values(GetTestParams()),
                                           testing::Values(GetConvTestCases(miopenFloat)[0])));

--- a/test/gtest/unit_conv_solver_GemmWrwUniversal.cpp
+++ b/test/gtest/unit_conv_solver_GemmWrwUniversal.cpp
@@ -71,7 +71,7 @@ TEST_P(GPU_UnitTestConvGemmUniversalSolverWrw_FP32, GemmWrwUniversal)
     this->RunTest(miopen::solver::conv::GemmWrwUniversal{});
 };
 
-TEST_P(CPU_UnitTestConvSolverDevApplicabilityWrw_NONE, GemmWrwUniversal)
+TEST_P(CPU_UnitTestConvGemmUniversalSolverDevApplicabilityWrw_NONE, GemmWrwUniversal)
 {
     this->RunTest(miopen::solver::conv::GemmWrwUniversal{});
 };


### PR DESCRIPTION
When we use single test binary we should keep our test names unique (First parameter in TEST* macros).  Otherwise, we get a lot of failures, which are not related to tests themselves.  Non unique names create a conflict when get combined into one executable.

As an example of this extra failures from the ticket: SWDEV-488434
[  FAILED  ] Full/GPU_UnitTestConvSolverBwd_FP16.ConvWinoFuryRxSf2x3/0, where GetParam() = (4-byte object <FF-FF FF-FF>, 0, (x:{2,64,128,128,128} w:{32,64,3,3,3} pad:{1,1,1} stride:{1,1,1} dilation:{1,1,1} type_x:0 type_w:0 type_y:0))

We can see that "ConvWinoFuryRxSf2x3" is never used in "Full" test suites. So we have reports about the failures in tests which even don't exist!

There will be series of PRs with renaming for easier reviewing.