### PR TITLE
Fix tensor casting happening in all cases for BF16 & FP16 WRW

### DIFF
--- a/src/solver/conv/conv_asm_implicit_gemm_gtc_wrw_nhwc.cpp
+++ b/src/solver/conv/conv_asm_implicit_gemm_gtc_wrw_nhwc.cpp
@@ -1117,8 +1117,8 @@ ConvSolution ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC::GetSolution(
 
     const auto isFp16                 = problem.IsFp16();
     const auto isGfx90aFp16altSupport = (ctx.GetStream().GetDeviceName() == "gfx90a") && isFp16;
-    const bool need_cast              = (problem.IsBfp16() && gemm_k_global_splits >= 1) ||
-                           (isFp16 && gemm_k_global_splits >= 1 &&
+    const bool need_cast              = (problem.IsBfp16() && gemm_k_global_splits > 1) ||
+                           (isFp16 && gemm_k_global_splits > 1 &&
                             (config.tensor_b_thread_lengths[3] == 1 || config.vector_store == 1));
 
     const auto is_nchw = problem.IsLayoutDefault();

--- a/src/solver/conv/conv_asm_implicit_gemm_gtc_wrw_nhwc.cpp
+++ b/src/solver/conv/conv_asm_implicit_gemm_gtc_wrw_nhwc.cpp
@@ -1117,8 +1117,8 @@ ConvSolution ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC::GetSolution(
 
     const auto isFp16                 = problem.IsFp16();
     const auto isGfx90aFp16altSupport = (ctx.GetStream().GetDeviceName() == "gfx90a") && isFp16;
-    const bool need_cast              = (problem.IsBfp16() && gemm_k_global_splits > 1) ||
-                           (isFp16 && gemm_k_global_splits > 1 &&
+    const bool need_cast              = (problem.IsBfp16() && config.gemm_k_global_split >= 1) ||
+                           (isFp16 && config.gemm_k_global_split >= 1 &&
                             (config.tensor_b_thread_lengths[3] == 1 || config.vector_store == 1));
 
     const auto is_nchw = problem.IsLayoutDefault();

--- a/test/gtest/unit_conv_solver.cpp
+++ b/test/gtest/unit_conv_solver.cpp
@@ -206,7 +206,7 @@ void UnitTestConvSolverParams::Tunable(std::size_t iterations_max_)
     tuning_iterations_max = iterations_max_;
 }
 
-void UnitTestConvSolverParams::DisableXnack() { disable_xnack = true; }
+void UnitTestConvSolverParams::CheckXnackDisabled() { disable_xnack = true; }
 
 namespace {
 

--- a/test/gtest/unit_conv_solver.cpp
+++ b/test/gtest/unit_conv_solver.cpp
@@ -191,7 +191,8 @@ UnitTestConvSolverParams::UnitTestConvSolverParams(Gpu supported_devs_)
     : supported_devs(supported_devs_),
       use_cpu_ref(false),
       enable_deprecated_solvers(false),
-      tunable(false)
+      tunable(false),
+      disable_xnack(false)
 {
 }
 
@@ -204,6 +205,8 @@ void UnitTestConvSolverParams::Tunable(std::size_t iterations_max_)
     tunable               = true;
     tuning_iterations_max = iterations_max_;
 }
+
+void UnitTestConvSolverParams::DisableXnack() { disable_xnack = true; }
 
 namespace {
 
@@ -237,6 +240,10 @@ double GetThreshold(miopenConvAlgorithm_t algo, miopen::conv::Direction directio
     if constexpr(std::is_same_v<T, half_float::half>)
     {
         if(algo == miopenConvolutionAlgoGEMM && direction != miopen::conv::Direction::Forward)
+        {
+            tolerance *= 2.0;
+        }
+        else if(algo == miopenConvolutionAlgoImplicitGEMM)
         {
             tolerance *= 2.0;
         }
@@ -699,6 +706,10 @@ void RunSolver(const miopen::solver::conv::ConvSolverInterface& solver,
 void UnitTestConvSolverBase::SetUpImpl(const UnitTestConvSolverParams& params)
 {
     if(!IsTestSupportedByDevice(params.supported_devs))
+    {
+        GTEST_SKIP();
+    }
+    else if(params.disable_xnack && get_handle_xnack())
     {
         GTEST_SKIP();
     }

--- a/test/gtest/unit_conv_solver.cpp
+++ b/test/gtest/unit_conv_solver.cpp
@@ -249,6 +249,10 @@ double GetThreshold(miopenConvAlgorithm_t algo, miopen::conv::Direction directio
         {
             tolerance *= 2.0;
         }
+        else if(algo == miopenConvolutionAlgoImplicitGEMM)
+        {
+            tolerance *= 3.0;
+        }
     }
 
     double threshold = std::numeric_limits<T>::epsilon() * tolerance;

--- a/test/gtest/unit_conv_solver.hpp
+++ b/test/gtest/unit_conv_solver.hpp
@@ -95,11 +95,13 @@ struct UnitTestConvSolverParams
     void UseCpuRef();
     void EnableDeprecatedSolvers();
     void Tunable(std::size_t iterations_max);
+    void DisableXnack();
 
     Gpu supported_devs;
     bool use_cpu_ref;
     bool enable_deprecated_solvers;
     bool tunable;
+    bool disable_xnack;
     std::size_t tuning_iterations_max;
 };
 

--- a/test/gtest/unit_conv_solver.hpp
+++ b/test/gtest/unit_conv_solver.hpp
@@ -95,7 +95,7 @@ struct UnitTestConvSolverParams
     void UseCpuRef();
     void EnableDeprecatedSolvers();
     void Tunable(std::size_t iterations_max);
-    void DisableXnack();
+    void CheckXnackDisabled();
 
     Gpu supported_devs;
     bool use_cpu_ref;

--- a/test/gtest/unit_conv_solver_ConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWC.cpp
+++ b/test/gtest/unit_conv_solver_ConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWC.cpp
@@ -84,34 +84,34 @@ auto GetFullTestParams(miopenDataType_t datatype)
 
 } // namespace
 
-using GPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWCBwd_FP16 =
+using GPU_UnitTestConvSolverAsmImplicitGemmGTCDynamicBwdXdlopsNHWCBwd_FP16 =
     GPU_UnitTestConvSolverBwd_FP16;
-using GPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWCBwd_BFP16 =
+using GPU_UnitTestConvSolverAsmImplicitGemmGTCDynamicBwdXdlopsNHWCBwd_BFP16 =
     GPU_UnitTestConvSolverBwd_BFP16;
-using GPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWCBwd_FP32 =
+using GPU_UnitTestConvSolverAsmImplicitGemmGTCDynamicBwdXdlopsNHWCBwd_FP32 =
     GPU_UnitTestConvSolverBwd_FP32;
-using CPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWCDevApplicabilityBwd_NONE =
+using CPU_UnitTestConvSolverAsmImplicitGemmGTCDynamicBwdXdlopsNHWCDevApplicabilityBwd_NONE =
     CPU_UnitTestConvSolverDevApplicabilityBwd_NONE;
 
-TEST_P(GPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWCBwd_FP16,
+TEST_P(GPU_UnitTestConvSolverAsmImplicitGemmGTCDynamicBwdXdlopsNHWCBwd_FP16,
        ConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWC)
 {
     this->RunTest(miopen::solver::conv::ConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWC{});
 };
 
-TEST_P(GPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWCBwd_BFP16,
+TEST_P(GPU_UnitTestConvSolverAsmImplicitGemmGTCDynamicBwdXdlopsNHWCBwd_BFP16,
        ConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWC)
 {
     this->RunTest(miopen::solver::conv::ConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWC{});
 };
 
-TEST_P(GPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWCBwd_FP32,
+TEST_P(GPU_UnitTestConvSolverAsmImplicitGemmGTCDynamicBwdXdlopsNHWCBwd_FP32,
        ConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWC)
 {
     this->RunTest(miopen::solver::conv::ConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWC{});
 };
 
-TEST_P(CPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWCDevApplicabilityBwd_NONE,
+TEST_P(CPU_UnitTestConvSolverAsmImplicitGemmGTCDynamicBwdXdlopsNHWCDevApplicabilityBwd_NONE,
        ConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWC)
 {
     this->RunTest(miopen::solver::conv::ConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWC{});
@@ -119,39 +119,39 @@ TEST_P(CPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWCDevApplic
 
 // Smoke tests
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         GPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWCBwd_FP16,
+                         GPU_UnitTestConvSolverAsmImplicitGemmGTCDynamicBwdXdlopsNHWCBwd_FP16,
                          testing::Combine(testing::Values(GetSmokeTestParams(miopenHalf)),
                                           testing::Values(miopenConvolutionAlgoImplicitGEMM),
                                           testing::ValuesIn(GetConvSmokeTestCases(miopenHalf))));
 
 INSTANTIATE_TEST_SUITE_P(
     Smoke,
-    GPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWCBwd_BFP16,
+    GPU_UnitTestConvSolverAsmImplicitGemmGTCDynamicBwdXdlopsNHWCBwd_BFP16,
     testing::Combine(testing::Values(GetSmokeTestParams(miopenBFloat16)),
                      testing::Values(miopenConvolutionAlgoImplicitGEMM),
                      testing::ValuesIn(GetConvSmokeTestCases(miopenBFloat16))));
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         GPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWCBwd_FP32,
+                         GPU_UnitTestConvSolverAsmImplicitGemmGTCDynamicBwdXdlopsNHWCBwd_FP32,
                          testing::Combine(testing::Values(GetSmokeTestParams(miopenFloat)),
                                           testing::Values(miopenConvolutionAlgoImplicitGEMM),
                                           testing::ValuesIn(GetConvSmokeTestCases(miopenFloat))));
 
 // Full tests
 INSTANTIATE_TEST_SUITE_P(Full,
-                         GPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWCBwd_FP16,
+                         GPU_UnitTestConvSolverAsmImplicitGemmGTCDynamicBwdXdlopsNHWCBwd_FP16,
                          testing::Combine(testing::Values(GetFullTestParams(miopenHalf)),
                                           testing::Values(miopenConvolutionAlgoImplicitGEMM),
                                           testing::ValuesIn(GetConvFullTestCases(miopenHalf))));
 
 INSTANTIATE_TEST_SUITE_P(Full,
-                         GPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWCBwd_BFP16,
+                         GPU_UnitTestConvSolverAsmImplicitGemmGTCDynamicBwdXdlopsNHWCBwd_BFP16,
                          testing::Combine(testing::Values(GetFullTestParams(miopenBFloat16)),
                                           testing::Values(miopenConvolutionAlgoImplicitGEMM),
                                           testing::ValuesIn(GetConvFullTestCases(miopenBFloat16))));
 
 INSTANTIATE_TEST_SUITE_P(Full,
-                         GPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWCBwd_FP32,
+                         GPU_UnitTestConvSolverAsmImplicitGemmGTCDynamicBwdXdlopsNHWCBwd_FP32,
                          testing::Combine(testing::Values(GetFullTestParams(miopenFloat)),
                                           testing::Values(miopenConvolutionAlgoImplicitGEMM),
                                           testing::ValuesIn(GetConvFullTestCases(miopenFloat))));
@@ -159,6 +159,6 @@ INSTANTIATE_TEST_SUITE_P(Full,
 // Device applicability test
 INSTANTIATE_TEST_SUITE_P(
     Smoke,
-    CPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWCDevApplicabilityBwd_NONE,
+    CPU_UnitTestConvSolverAsmImplicitGemmGTCDynamicBwdXdlopsNHWCDevApplicabilityBwd_NONE,
     testing::Combine(testing::Values(GetSmokeTestParams(miopenFloat)),
                      testing::Values(GetConvSmokeTestCases(miopenFloat)[0])));

--- a/test/gtest/unit_conv_solver_ConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWC.cpp
+++ b/test/gtest/unit_conv_solver_ConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWC.cpp
@@ -1,0 +1,164 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2025 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include "unit_conv_solver.hpp"
+
+namespace {
+
+auto GetConvSmokeTestCases(miopenDataType_t datatype)
+{
+    using TestCase = miopen::unit_tests::ConvTestCase;
+
+    return std::vector{
+        // clang-format off
+        TestCase{{1, 8, 8, 8}, {8, 8, 3, 3}, {0, 0}, {1, 1}, {1, 1}, datatype},
+        // clang-format on
+    };
+}
+
+auto GetSmokeTestParams(miopenDataType_t datatype)
+{
+    Gpu supportedDevices = Gpu::gfx90A | Gpu::gfx94X;
+    if(datatype != miopenBFloat16)
+    {
+        supportedDevices = supportedDevices | Gpu::gfx908;
+    }
+    auto testParams = miopen::unit_tests::UnitTestConvSolverParams(supportedDevices);
+    testParams.Tunable(1);
+
+    return testParams;
+}
+
+auto GetConvFullTestCases(miopenDataType_t datatype)
+{
+    using TestCase = miopen::unit_tests::ConvTestCase;
+
+    return std::vector{
+        // clang-format off
+        TestCase{{16, 5, 225, 225}, {64, 5, 3, 3}, {0, 0}, {1, 1}, {1, 1}, datatype},
+        TestCase{{16, 576, 1, 1}, {576, 576, 1, 1}, {0, 0}, {1, 1}, {1, 1}, datatype},
+        TestCase{{16, 2048, 8, 32}, {4096, 2048, 1, 1}, {0, 0}, {1, 1}, {1, 1}, datatype},
+        TestCase{{16, 2048, 8, 32}, {2048, 2048, 1, 1}, {0, 0}, {1, 1}, {1, 1}, datatype},
+        TestCase{{16, 2048, 48, 32}, {2048, 2048, 3, 1}, {0, 0}, {3, 1}, {1, 1}, datatype},
+        TestCase{{16, 2048, 1, 512}, {2048, 2048, 1, 2}, {0, 0}, {1, 2}, {1, 1}, datatype},
+        TestCase{{16, 2048, 1, 30}, {576, 2048, 1, 1}, {0, 0}, {1, 1}, {1, 1}, datatype},
+        // clang-format on
+    };
+}
+
+auto GetFullTestParams(miopenDataType_t datatype)
+{
+    Gpu supportedDevices = Gpu::gfx90A | Gpu::gfx94X;
+    if(datatype != miopenBFloat16)
+    {
+        supportedDevices = supportedDevices | Gpu::gfx908;
+    }
+    auto testParams = miopen::unit_tests::UnitTestConvSolverParams(supportedDevices);
+    testParams.Tunable(1000);
+
+    return testParams;
+}
+
+} // namespace
+
+using GPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWCBwd_FP16 =
+    GPU_UnitTestConvSolverBwd_FP16;
+using GPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWCBwd_BFP16 =
+    GPU_UnitTestConvSolverBwd_BFP16;
+using GPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWCBwd_FP32 =
+    GPU_UnitTestConvSolverBwd_FP32;
+using CPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWCDevApplicabilityBwd_NONE =
+    CPU_UnitTestConvSolverDevApplicabilityBwd_NONE;
+
+TEST_P(GPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWCBwd_FP16,
+       ConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWC)
+{
+    this->RunTest(miopen::solver::conv::ConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWC{});
+};
+
+TEST_P(GPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWCBwd_BFP16,
+       ConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWC)
+{
+    this->RunTest(miopen::solver::conv::ConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWC{});
+};
+
+TEST_P(GPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWCBwd_FP32,
+       ConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWC)
+{
+    this->RunTest(miopen::solver::conv::ConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWC{});
+};
+
+TEST_P(CPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWCDevApplicabilityBwd_NONE,
+       ConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWC)
+{
+    this->RunTest(miopen::solver::conv::ConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWC{});
+};
+
+// Smoke tests
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         GPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWCBwd_FP16,
+                         testing::Combine(testing::Values(GetSmokeTestParams(miopenHalf)),
+                                          testing::Values(miopenConvolutionAlgoImplicitGEMM),
+                                          testing::ValuesIn(GetConvSmokeTestCases(miopenHalf))));
+
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    GPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWCBwd_BFP16,
+    testing::Combine(testing::Values(GetSmokeTestParams(miopenBFloat16)),
+                     testing::Values(miopenConvolutionAlgoImplicitGEMM),
+                     testing::ValuesIn(GetConvSmokeTestCases(miopenBFloat16))));
+
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         GPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWCBwd_FP32,
+                         testing::Combine(testing::Values(GetSmokeTestParams(miopenFloat)),
+                                          testing::Values(miopenConvolutionAlgoImplicitGEMM),
+                                          testing::ValuesIn(GetConvSmokeTestCases(miopenFloat))));
+
+// Full tests
+INSTANTIATE_TEST_SUITE_P(Full,
+                         GPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWCBwd_FP16,
+                         testing::Combine(testing::Values(GetFullTestParams(miopenHalf)),
+                                          testing::Values(miopenConvolutionAlgoImplicitGEMM),
+                                          testing::ValuesIn(GetConvFullTestCases(miopenHalf))));
+
+INSTANTIATE_TEST_SUITE_P(Full,
+                         GPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWCBwd_BFP16,
+                         testing::Combine(testing::Values(GetFullTestParams(miopenBFloat16)),
+                                          testing::Values(miopenConvolutionAlgoImplicitGEMM),
+                                          testing::ValuesIn(GetConvFullTestCases(miopenBFloat16))));
+
+INSTANTIATE_TEST_SUITE_P(Full,
+                         GPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWCBwd_FP32,
+                         testing::Combine(testing::Values(GetFullTestParams(miopenFloat)),
+                                          testing::Values(miopenConvolutionAlgoImplicitGEMM),
+                                          testing::ValuesIn(GetConvFullTestCases(miopenFloat))));
+
+// Device applicability test
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    CPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWCDevApplicabilityBwd_NONE,
+    testing::Combine(testing::Values(GetSmokeTestParams(miopenFloat)),
+                     testing::Values(GetConvSmokeTestCases(miopenFloat)[0])));

--- a/test/gtest/unit_conv_solver_ConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWC.cpp
+++ b/test/gtest/unit_conv_solver_ConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWC.cpp
@@ -48,6 +48,7 @@ auto GetSmokeTestParams(miopenDataType_t datatype)
     }
     auto testParams = miopen::unit_tests::UnitTestConvSolverParams(supportedDevices);
     testParams.Tunable(1);
+    testParams.DisableXnack();
 
     return testParams;
 }
@@ -58,6 +59,8 @@ auto GetConvFullTestCases(miopenDataType_t datatype)
 
     return std::vector{
         // clang-format off
+        // TODO LWPMIOPEN-1314 convert / unify existing ASM solver tests
+        // Regression tests for SWDEV-502833
         TestCase{{16, 5, 225, 225}, {64, 5, 3, 3}, {0, 0}, {1, 1}, {1, 1}, datatype},
         TestCase{{16, 576, 1, 1}, {576, 576, 1, 1}, {0, 0}, {1, 1}, {1, 1}, datatype},
         TestCase{{16, 2048, 8, 32}, {4096, 2048, 1, 1}, {0, 0}, {1, 1}, {1, 1}, datatype},
@@ -78,6 +81,7 @@ auto GetFullTestParams(miopenDataType_t datatype)
     }
     auto testParams = miopen::unit_tests::UnitTestConvSolverParams(supportedDevices);
     testParams.Tunable(1000);
+    testParams.DisableXnack();
 
     return testParams;
 }

--- a/test/gtest/unit_conv_solver_ConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWC.cpp
+++ b/test/gtest/unit_conv_solver_ConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWC.cpp
@@ -48,7 +48,7 @@ auto GetSmokeTestParams(miopenDataType_t datatype)
     }
     auto testParams = miopen::unit_tests::UnitTestConvSolverParams(supportedDevices);
     testParams.Tunable(1);
-    testParams.DisableXnack();
+    testParams.CheckXnackDisabled();
 
     return testParams;
 }
@@ -81,7 +81,7 @@ auto GetFullTestParams(miopenDataType_t datatype)
     }
     auto testParams = miopen::unit_tests::UnitTestConvSolverParams(supportedDevices);
     testParams.Tunable(1000);
-    testParams.DisableXnack();
+    testParams.CheckXnackDisabled();
 
     return testParams;
 }

--- a/test/gtest/unit_conv_solver_ConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWC.cpp
+++ b/test/gtest/unit_conv_solver_ConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWC.cpp
@@ -84,34 +84,34 @@ auto GetFullTestParams(miopenDataType_t datatype)
 
 } // namespace
 
-using GPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWCFwd_FP16 =
+using GPU_UnitTestConvSolverAsmImplicitGemmGTCDynamicFwdXdlopsNHWCFwd_FP16 =
     GPU_UnitTestConvSolverFwd_FP16;
-using GPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWCFwd_BFP16 =
+using GPU_UnitTestConvSolverAsmImplicitGemmGTCDynamicFwdXdlopsNHWCFwd_BFP16 =
     GPU_UnitTestConvSolverFwd_BFP16;
-using GPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWCFwd_FP32 =
+using GPU_UnitTestConvSolverAsmImplicitGemmGTCDynamicFwdXdlopsNHWCFwd_FP32 =
     GPU_UnitTestConvSolverFwd_FP32;
-using CPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWCDevApplicabilityFwd_NONE =
+using CPU_UnitTestConvSolverAsmImplicitGemmGTCDynamicFwdXdlopsNHWCDevApplicabilityFwd_NONE =
     CPU_UnitTestConvSolverDevApplicabilityFwd_NONE;
 
-TEST_P(GPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWCFwd_FP16,
+TEST_P(GPU_UnitTestConvSolverAsmImplicitGemmGTCDynamicFwdXdlopsNHWCFwd_FP16,
        ConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWC)
 {
     this->RunTest(miopen::solver::conv::ConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWC{});
 };
 
-TEST_P(GPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWCFwd_BFP16,
+TEST_P(GPU_UnitTestConvSolverAsmImplicitGemmGTCDynamicFwdXdlopsNHWCFwd_BFP16,
        ConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWC)
 {
     this->RunTest(miopen::solver::conv::ConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWC{});
 };
 
-TEST_P(GPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWCFwd_FP32,
+TEST_P(GPU_UnitTestConvSolverAsmImplicitGemmGTCDynamicFwdXdlopsNHWCFwd_FP32,
        ConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWC)
 {
     this->RunTest(miopen::solver::conv::ConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWC{});
 };
 
-TEST_P(CPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWCDevApplicabilityFwd_NONE,
+TEST_P(CPU_UnitTestConvSolverAsmImplicitGemmGTCDynamicFwdXdlopsNHWCDevApplicabilityFwd_NONE,
        ConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWC)
 {
     this->RunTest(miopen::solver::conv::ConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWC{});
@@ -119,39 +119,39 @@ TEST_P(CPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWCDevApplic
 
 // Smoke tests
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         GPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWCFwd_FP16,
+                         GPU_UnitTestConvSolverAsmImplicitGemmGTCDynamicFwdXdlopsNHWCFwd_FP16,
                          testing::Combine(testing::Values(GetSmokeTestParams(miopenHalf)),
                                           testing::Values(miopenConvolutionAlgoImplicitGEMM),
                                           testing::ValuesIn(GetConvSmokeTestCases(miopenHalf))));
 
 INSTANTIATE_TEST_SUITE_P(
     Smoke,
-    GPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWCFwd_BFP16,
+    GPU_UnitTestConvSolverAsmImplicitGemmGTCDynamicFwdXdlopsNHWCFwd_BFP16,
     testing::Combine(testing::Values(GetSmokeTestParams(miopenBFloat16)),
                      testing::Values(miopenConvolutionAlgoImplicitGEMM),
                      testing::ValuesIn(GetConvSmokeTestCases(miopenBFloat16))));
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         GPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWCFwd_FP32,
+                         GPU_UnitTestConvSolverAsmImplicitGemmGTCDynamicFwdXdlopsNHWCFwd_FP32,
                          testing::Combine(testing::Values(GetSmokeTestParams(miopenFloat)),
                                           testing::Values(miopenConvolutionAlgoImplicitGEMM),
                                           testing::ValuesIn(GetConvSmokeTestCases(miopenFloat))));
 
 // Full tests
 INSTANTIATE_TEST_SUITE_P(Full,
-                         GPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWCFwd_FP16,
+                         GPU_UnitTestConvSolverAsmImplicitGemmGTCDynamicFwdXdlopsNHWCFwd_FP16,
                          testing::Combine(testing::Values(GetFullTestParams(miopenHalf)),
                                           testing::Values(miopenConvolutionAlgoImplicitGEMM),
                                           testing::ValuesIn(GetConvFullTestCases(miopenHalf))));
 
 INSTANTIATE_TEST_SUITE_P(Full,
-                         GPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWCFwd_BFP16,
+                         GPU_UnitTestConvSolverAsmImplicitGemmGTCDynamicFwdXdlopsNHWCFwd_BFP16,
                          testing::Combine(testing::Values(GetFullTestParams(miopenBFloat16)),
                                           testing::Values(miopenConvolutionAlgoImplicitGEMM),
                                           testing::ValuesIn(GetConvFullTestCases(miopenBFloat16))));
 
 INSTANTIATE_TEST_SUITE_P(Full,
-                         GPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWCFwd_FP32,
+                         GPU_UnitTestConvSolverAsmImplicitGemmGTCDynamicFwdXdlopsNHWCFwd_FP32,
                          testing::Combine(testing::Values(GetFullTestParams(miopenFloat)),
                                           testing::Values(miopenConvolutionAlgoImplicitGEMM),
                                           testing::ValuesIn(GetConvFullTestCases(miopenFloat))));
@@ -159,6 +159,6 @@ INSTANTIATE_TEST_SUITE_P(Full,
 // Device applicability test
 INSTANTIATE_TEST_SUITE_P(
     Smoke,
-    CPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWCDevApplicabilityFwd_NONE,
+    CPU_UnitTestConvSolverAsmImplicitGemmGTCDynamicFwdXdlopsNHWCDevApplicabilityFwd_NONE,
     testing::Combine(testing::Values(GetSmokeTestParams(miopenFloat)),
                      testing::Values(GetConvSmokeTestCases(miopenFloat)[0])));

--- a/test/gtest/unit_conv_solver_ConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWC.cpp
+++ b/test/gtest/unit_conv_solver_ConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWC.cpp
@@ -48,6 +48,7 @@ auto GetSmokeTestParams(miopenDataType_t datatype)
     }
     auto testParams = miopen::unit_tests::UnitTestConvSolverParams(supportedDevices);
     testParams.Tunable(1);
+    testParams.DisableXnack();
 
     return testParams;
 }
@@ -58,6 +59,8 @@ auto GetConvFullTestCases(miopenDataType_t datatype)
 
     return std::vector{
         // clang-format off
+        // TODO LWPMIOPEN-1314 convert / unify existing ASM solver tests
+        // Regression tests for SWDEV-502833
         TestCase{{16, 5, 225, 225}, {64, 5, 3, 3}, {0, 0}, {1, 1}, {1, 1}, datatype},
         TestCase{{16, 576, 1, 1}, {576, 576, 1, 1}, {0, 0}, {1, 1}, {1, 1}, datatype},
         TestCase{{16, 2048, 8, 32}, {4096, 2048, 1, 1}, {0, 0}, {1, 1}, {1, 1}, datatype},
@@ -78,6 +81,7 @@ auto GetFullTestParams(miopenDataType_t datatype)
     }
     auto testParams = miopen::unit_tests::UnitTestConvSolverParams(supportedDevices);
     testParams.Tunable(1000);
+    testParams.DisableXnack();
 
     return testParams;
 }

--- a/test/gtest/unit_conv_solver_ConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWC.cpp
+++ b/test/gtest/unit_conv_solver_ConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWC.cpp
@@ -1,0 +1,164 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2025 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include "unit_conv_solver.hpp"
+
+namespace {
+
+auto GetConvSmokeTestCases(miopenDataType_t datatype)
+{
+    using TestCase = miopen::unit_tests::ConvTestCase;
+
+    return std::vector{
+        // clang-format off
+        TestCase{{1, 8, 8, 8}, {8, 8, 3, 3}, {0, 0}, {1, 1}, {1, 1}, datatype},
+        // clang-format on
+    };
+}
+
+auto GetSmokeTestParams(miopenDataType_t datatype)
+{
+    Gpu supportedDevices = Gpu::gfx90A | Gpu::gfx94X;
+    if(datatype != miopenBFloat16)
+    {
+        supportedDevices = supportedDevices | Gpu::gfx908;
+    }
+    auto testParams = miopen::unit_tests::UnitTestConvSolverParams(supportedDevices);
+    testParams.Tunable(1);
+
+    return testParams;
+}
+
+auto GetConvFullTestCases(miopenDataType_t datatype)
+{
+    using TestCase = miopen::unit_tests::ConvTestCase;
+
+    return std::vector{
+        // clang-format off
+        TestCase{{16, 5, 225, 225}, {64, 5, 3, 3}, {0, 0}, {1, 1}, {1, 1}, datatype},
+        TestCase{{16, 576, 1, 1}, {576, 576, 1, 1}, {0, 0}, {1, 1}, {1, 1}, datatype},
+        TestCase{{16, 2048, 8, 32}, {4096, 2048, 1, 1}, {0, 0}, {1, 1}, {1, 1}, datatype},
+        TestCase{{16, 2048, 8, 32}, {2048, 2048, 1, 1}, {0, 0}, {1, 1}, {1, 1}, datatype},
+        TestCase{{16, 2048, 48, 32}, {2048, 2048, 3, 1}, {0, 0}, {3, 1}, {1, 1}, datatype},
+        TestCase{{16, 2048, 1, 512}, {2048, 2048, 1, 2}, {0, 0}, {1, 2}, {1, 1}, datatype},
+        TestCase{{16, 2048, 1, 30}, {576, 2048, 1, 1}, {0, 0}, {1, 1}, {1, 1}, datatype},
+        // clang-format on
+    };
+}
+
+auto GetFullTestParams(miopenDataType_t datatype)
+{
+    Gpu supportedDevices = Gpu::gfx90A | Gpu::gfx94X;
+    if(datatype != miopenBFloat16)
+    {
+        supportedDevices = supportedDevices | Gpu::gfx908;
+    }
+    auto testParams = miopen::unit_tests::UnitTestConvSolverParams(supportedDevices);
+    testParams.Tunable(1000);
+
+    return testParams;
+}
+
+} // namespace
+
+using GPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWCFwd_FP16 =
+    GPU_UnitTestConvSolverFwd_FP16;
+using GPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWCFwd_BFP16 =
+    GPU_UnitTestConvSolverFwd_BFP16;
+using GPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWCFwd_FP32 =
+    GPU_UnitTestConvSolverFwd_FP32;
+using CPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWCDevApplicabilityFwd_NONE =
+    CPU_UnitTestConvSolverDevApplicabilityFwd_NONE;
+
+TEST_P(GPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWCFwd_FP16,
+       ConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWC)
+{
+    this->RunTest(miopen::solver::conv::ConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWC{});
+};
+
+TEST_P(GPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWCFwd_BFP16,
+       ConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWC)
+{
+    this->RunTest(miopen::solver::conv::ConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWC{});
+};
+
+TEST_P(GPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWCFwd_FP32,
+       ConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWC)
+{
+    this->RunTest(miopen::solver::conv::ConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWC{});
+};
+
+TEST_P(CPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWCDevApplicabilityFwd_NONE,
+       ConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWC)
+{
+    this->RunTest(miopen::solver::conv::ConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWC{});
+};
+
+// Smoke tests
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         GPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWCFwd_FP16,
+                         testing::Combine(testing::Values(GetSmokeTestParams(miopenHalf)),
+                                          testing::Values(miopenConvolutionAlgoImplicitGEMM),
+                                          testing::ValuesIn(GetConvSmokeTestCases(miopenHalf))));
+
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    GPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWCFwd_BFP16,
+    testing::Combine(testing::Values(GetSmokeTestParams(miopenBFloat16)),
+                     testing::Values(miopenConvolutionAlgoImplicitGEMM),
+                     testing::ValuesIn(GetConvSmokeTestCases(miopenBFloat16))));
+
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         GPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWCFwd_FP32,
+                         testing::Combine(testing::Values(GetSmokeTestParams(miopenFloat)),
+                                          testing::Values(miopenConvolutionAlgoImplicitGEMM),
+                                          testing::ValuesIn(GetConvSmokeTestCases(miopenFloat))));
+
+// Full tests
+INSTANTIATE_TEST_SUITE_P(Full,
+                         GPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWCFwd_FP16,
+                         testing::Combine(testing::Values(GetFullTestParams(miopenHalf)),
+                                          testing::Values(miopenConvolutionAlgoImplicitGEMM),
+                                          testing::ValuesIn(GetConvFullTestCases(miopenHalf))));
+
+INSTANTIATE_TEST_SUITE_P(Full,
+                         GPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWCFwd_BFP16,
+                         testing::Combine(testing::Values(GetFullTestParams(miopenBFloat16)),
+                                          testing::Values(miopenConvolutionAlgoImplicitGEMM),
+                                          testing::ValuesIn(GetConvFullTestCases(miopenBFloat16))));
+
+INSTANTIATE_TEST_SUITE_P(Full,
+                         GPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWCFwd_FP32,
+                         testing::Combine(testing::Values(GetFullTestParams(miopenFloat)),
+                                          testing::Values(miopenConvolutionAlgoImplicitGEMM),
+                                          testing::ValuesIn(GetConvFullTestCases(miopenFloat))));
+
+// Device applicability test
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    CPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWCDevApplicabilityFwd_NONE,
+    testing::Combine(testing::Values(GetSmokeTestParams(miopenFloat)),
+                     testing::Values(GetConvSmokeTestCases(miopenFloat)[0])));

--- a/test/gtest/unit_conv_solver_ConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWC.cpp
+++ b/test/gtest/unit_conv_solver_ConvAsmImplicitGemmGTCDynamicFwdXdlopsNHWC.cpp
@@ -48,7 +48,7 @@ auto GetSmokeTestParams(miopenDataType_t datatype)
     }
     auto testParams = miopen::unit_tests::UnitTestConvSolverParams(supportedDevices);
     testParams.Tunable(1);
-    testParams.DisableXnack();
+    testParams.CheckXnackDisabled();
 
     return testParams;
 }
@@ -81,7 +81,7 @@ auto GetFullTestParams(miopenDataType_t datatype)
     }
     auto testParams = miopen::unit_tests::UnitTestConvSolverParams(supportedDevices);
     testParams.Tunable(1000);
-    testParams.DisableXnack();
+    testParams.CheckXnackDisabled();
 
     return testParams;
 }

--- a/test/gtest/unit_conv_solver_ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC.cpp
+++ b/test/gtest/unit_conv_solver_ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC.cpp
@@ -84,34 +84,34 @@ auto GetFullTestParams(miopenDataType_t datatype)
 
 } // namespace
 
-using GPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWCWrw_FP16 =
+using GPU_UnitTestConvSolverAsmImplicitGemmGTCDynamicWrwXdlopsNHWCWrw_FP16 =
     GPU_UnitTestConvSolverWrw_FP16;
-using GPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWCWrw_BFP16 =
+using GPU_UnitTestConvSolverAsmImplicitGemmGTCDynamicWrwXdlopsNHWCWrw_BFP16 =
     GPU_UnitTestConvSolverWrw_BFP16;
-using GPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWCWrw_FP32 =
+using GPU_UnitTestConvSolverAsmImplicitGemmGTCDynamicWrwXdlopsNHWCWrw_FP32 =
     GPU_UnitTestConvSolverWrw_FP32;
-using CPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWCDevApplicabilityWrw_NONE =
+using CPU_UnitTestConvSolverAsmImplicitGemmGTCDynamicWrwXdlopsNHWCDevApplicabilityWrw_NONE =
     CPU_UnitTestConvSolverDevApplicabilityWrw_NONE;
 
-TEST_P(GPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWCWrw_FP16,
+TEST_P(GPU_UnitTestConvSolverAsmImplicitGemmGTCDynamicWrwXdlopsNHWCWrw_FP16,
        ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC)
 {
     this->RunTest(miopen::solver::conv::ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC{});
 };
 
-TEST_P(GPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWCWrw_BFP16,
+TEST_P(GPU_UnitTestConvSolverAsmImplicitGemmGTCDynamicWrwXdlopsNHWCWrw_BFP16,
        ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC)
 {
     this->RunTest(miopen::solver::conv::ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC{});
 };
 
-TEST_P(GPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWCWrw_FP32,
+TEST_P(GPU_UnitTestConvSolverAsmImplicitGemmGTCDynamicWrwXdlopsNHWCWrw_FP32,
        ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC)
 {
     this->RunTest(miopen::solver::conv::ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC{});
 };
 
-TEST_P(CPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWCDevApplicabilityWrw_NONE,
+TEST_P(CPU_UnitTestConvSolverAsmImplicitGemmGTCDynamicWrwXdlopsNHWCDevApplicabilityWrw_NONE,
        ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC)
 {
     this->RunTest(miopen::solver::conv::ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC{});
@@ -119,39 +119,39 @@ TEST_P(CPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWCDevApplic
 
 // Smoke tests
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         GPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWCWrw_FP16,
+                         GPU_UnitTestConvSolverAsmImplicitGemmGTCDynamicWrwXdlopsNHWCWrw_FP16,
                          testing::Combine(testing::Values(GetSmokeTestParams(miopenHalf)),
                                           testing::Values(miopenConvolutionAlgoImplicitGEMM),
                                           testing::ValuesIn(GetConvSmokeTestCases(miopenHalf))));
 
 INSTANTIATE_TEST_SUITE_P(
     Smoke,
-    GPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWCWrw_BFP16,
+    GPU_UnitTestConvSolverAsmImplicitGemmGTCDynamicWrwXdlopsNHWCWrw_BFP16,
     testing::Combine(testing::Values(GetSmokeTestParams(miopenBFloat16)),
                      testing::Values(miopenConvolutionAlgoImplicitGEMM),
                      testing::ValuesIn(GetConvSmokeTestCases(miopenBFloat16))));
 
 INSTANTIATE_TEST_SUITE_P(Smoke,
-                         GPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWCWrw_FP32,
+                         GPU_UnitTestConvSolverAsmImplicitGemmGTCDynamicWrwXdlopsNHWCWrw_FP32,
                          testing::Combine(testing::Values(GetSmokeTestParams(miopenFloat)),
                                           testing::Values(miopenConvolutionAlgoImplicitGEMM),
                                           testing::ValuesIn(GetConvSmokeTestCases(miopenFloat))));
 
 // Full tests
 INSTANTIATE_TEST_SUITE_P(Full,
-                         GPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWCWrw_FP16,
+                         GPU_UnitTestConvSolverAsmImplicitGemmGTCDynamicWrwXdlopsNHWCWrw_FP16,
                          testing::Combine(testing::Values(GetFullTestParams(miopenHalf)),
                                           testing::Values(miopenConvolutionAlgoImplicitGEMM),
                                           testing::ValuesIn(GetConvFullTestCases(miopenHalf))));
 
 INSTANTIATE_TEST_SUITE_P(Full,
-                         GPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWCWrw_BFP16,
+                         GPU_UnitTestConvSolverAsmImplicitGemmGTCDynamicWrwXdlopsNHWCWrw_BFP16,
                          testing::Combine(testing::Values(GetFullTestParams(miopenBFloat16)),
                                           testing::Values(miopenConvolutionAlgoImplicitGEMM),
                                           testing::ValuesIn(GetConvFullTestCases(miopenBFloat16))));
 
 INSTANTIATE_TEST_SUITE_P(Full,
-                         GPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWCWrw_FP32,
+                         GPU_UnitTestConvSolverAsmImplicitGemmGTCDynamicWrwXdlopsNHWCWrw_FP32,
                          testing::Combine(testing::Values(GetFullTestParams(miopenFloat)),
                                           testing::Values(miopenConvolutionAlgoImplicitGEMM),
                                           testing::ValuesIn(GetConvFullTestCases(miopenFloat))));
@@ -159,6 +159,6 @@ INSTANTIATE_TEST_SUITE_P(Full,
 // Device applicability test
 INSTANTIATE_TEST_SUITE_P(
     Smoke,
-    CPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWCDevApplicabilityWrw_NONE,
+    CPU_UnitTestConvSolverAsmImplicitGemmGTCDynamicWrwXdlopsNHWCDevApplicabilityWrw_NONE,
     testing::Combine(testing::Values(GetSmokeTestParams(miopenFloat)),
                      testing::Values(GetConvSmokeTestCases(miopenFloat)[0])));

--- a/test/gtest/unit_conv_solver_ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC.cpp
+++ b/test/gtest/unit_conv_solver_ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC.cpp
@@ -48,6 +48,7 @@ auto GetSmokeTestParams(miopenDataType_t datatype)
     }
     auto testParams = miopen::unit_tests::UnitTestConvSolverParams(supportedDevices);
     testParams.Tunable(1);
+    testParams.DisableXnack();
 
     return testParams;
 }
@@ -58,6 +59,8 @@ auto GetConvFullTestCases(miopenDataType_t datatype)
 
     return std::vector{
         // clang-format off
+        // TODO LWPMIOPEN-1314 convert / unify existing ASM solver tests
+        // Regression tests for SWDEV-502833
         TestCase{{16, 5, 225, 225}, {64, 5, 3, 3}, {0, 0}, {1, 1}, {1, 1}, datatype},
         TestCase{{16, 576, 1, 1}, {576, 576, 1, 1}, {0, 0}, {1, 1}, {1, 1}, datatype},
         TestCase{{16, 2048, 8, 32}, {4096, 2048, 1, 1}, {0, 0}, {1, 1}, {1, 1}, datatype},
@@ -78,6 +81,7 @@ auto GetFullTestParams(miopenDataType_t datatype)
     }
     auto testParams = miopen::unit_tests::UnitTestConvSolverParams(supportedDevices);
     testParams.Tunable(1000);
+    testParams.DisableXnack();
 
     return testParams;
 }

--- a/test/gtest/unit_conv_solver_ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC.cpp
+++ b/test/gtest/unit_conv_solver_ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC.cpp
@@ -1,0 +1,164 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2025 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include "unit_conv_solver.hpp"
+
+namespace {
+
+auto GetConvSmokeTestCases(miopenDataType_t datatype)
+{
+    using TestCase = miopen::unit_tests::ConvTestCase;
+
+    return std::vector{
+        // clang-format off
+        TestCase{{1, 8, 8, 8}, {8, 8, 3, 3}, {0, 0}, {1, 1}, {1, 1}, datatype},
+        // clang-format on
+    };
+}
+
+auto GetSmokeTestParams(miopenDataType_t datatype)
+{
+    Gpu supportedDevices = Gpu::gfx90A | Gpu::gfx94X;
+    if(datatype != miopenBFloat16)
+    {
+        supportedDevices = supportedDevices | Gpu::gfx908;
+    }
+    auto testParams = miopen::unit_tests::UnitTestConvSolverParams(supportedDevices);
+    testParams.Tunable(1);
+
+    return testParams;
+}
+
+auto GetConvFullTestCases(miopenDataType_t datatype)
+{
+    using TestCase = miopen::unit_tests::ConvTestCase;
+
+    return std::vector{
+        // clang-format off
+        TestCase{{16, 5, 225, 225}, {64, 5, 3, 3}, {0, 0}, {1, 1}, {1, 1}, datatype},
+        TestCase{{16, 576, 1, 1}, {576, 576, 1, 1}, {0, 0}, {1, 1}, {1, 1}, datatype},
+        TestCase{{16, 2048, 8, 32}, {4096, 2048, 1, 1}, {0, 0}, {1, 1}, {1, 1}, datatype},
+        TestCase{{16, 2048, 8, 32}, {2048, 2048, 1, 1}, {0, 0}, {1, 1}, {1, 1}, datatype},
+        TestCase{{16, 2048, 48, 32}, {2048, 2048, 3, 1}, {0, 0}, {3, 1}, {1, 1}, datatype},
+        TestCase{{16, 2048, 1, 512}, {2048, 2048, 1, 2}, {0, 0}, {1, 2}, {1, 1}, datatype},
+        TestCase{{16, 2048, 1, 30}, {576, 2048, 1, 1}, {0, 0}, {1, 1}, {1, 1}, datatype},
+        // clang-format on
+    };
+}
+
+auto GetFullTestParams(miopenDataType_t datatype)
+{
+    Gpu supportedDevices = Gpu::gfx90A | Gpu::gfx94X;
+    if(datatype != miopenBFloat16)
+    {
+        supportedDevices = supportedDevices | Gpu::gfx908;
+    }
+    auto testParams = miopen::unit_tests::UnitTestConvSolverParams(supportedDevices);
+    testParams.Tunable(1000);
+
+    return testParams;
+}
+
+} // namespace
+
+using GPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWCWrw_FP16 =
+    GPU_UnitTestConvSolverWrw_FP16;
+using GPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWCWrw_BFP16 =
+    GPU_UnitTestConvSolverWrw_BFP16;
+using GPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWCWrw_FP32 =
+    GPU_UnitTestConvSolverWrw_FP32;
+using CPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWCDevApplicabilityWrw_NONE =
+    CPU_UnitTestConvSolverDevApplicabilityWrw_NONE;
+
+TEST_P(GPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWCWrw_FP16,
+       ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC)
+{
+    this->RunTest(miopen::solver::conv::ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC{});
+};
+
+TEST_P(GPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWCWrw_BFP16,
+       ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC)
+{
+    this->RunTest(miopen::solver::conv::ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC{});
+};
+
+TEST_P(GPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWCWrw_FP32,
+       ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC)
+{
+    this->RunTest(miopen::solver::conv::ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC{});
+};
+
+TEST_P(CPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWCDevApplicabilityWrw_NONE,
+       ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC)
+{
+    this->RunTest(miopen::solver::conv::ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC{});
+};
+
+// Smoke tests
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         GPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWCWrw_FP16,
+                         testing::Combine(testing::Values(GetSmokeTestParams(miopenHalf)),
+                                          testing::Values(miopenConvolutionAlgoImplicitGEMM),
+                                          testing::ValuesIn(GetConvSmokeTestCases(miopenHalf))));
+
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    GPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWCWrw_BFP16,
+    testing::Combine(testing::Values(GetSmokeTestParams(miopenBFloat16)),
+                     testing::Values(miopenConvolutionAlgoImplicitGEMM),
+                     testing::ValuesIn(GetConvSmokeTestCases(miopenBFloat16))));
+
+INSTANTIATE_TEST_SUITE_P(Smoke,
+                         GPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWCWrw_FP32,
+                         testing::Combine(testing::Values(GetSmokeTestParams(miopenFloat)),
+                                          testing::Values(miopenConvolutionAlgoImplicitGEMM),
+                                          testing::ValuesIn(GetConvSmokeTestCases(miopenFloat))));
+
+// Full tests
+INSTANTIATE_TEST_SUITE_P(Full,
+                         GPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWCWrw_FP16,
+                         testing::Combine(testing::Values(GetFullTestParams(miopenHalf)),
+                                          testing::Values(miopenConvolutionAlgoImplicitGEMM),
+                                          testing::ValuesIn(GetConvFullTestCases(miopenHalf))));
+
+INSTANTIATE_TEST_SUITE_P(Full,
+                         GPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWCWrw_BFP16,
+                         testing::Combine(testing::Values(GetFullTestParams(miopenBFloat16)),
+                                          testing::Values(miopenConvolutionAlgoImplicitGEMM),
+                                          testing::ValuesIn(GetConvFullTestCases(miopenBFloat16))));
+
+INSTANTIATE_TEST_SUITE_P(Full,
+                         GPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWCWrw_FP32,
+                         testing::Combine(testing::Values(GetFullTestParams(miopenFloat)),
+                                          testing::Values(miopenConvolutionAlgoImplicitGEMM),
+                                          testing::ValuesIn(GetConvFullTestCases(miopenFloat))));
+
+// Device applicability test
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
+    CPU_UnitTestConvSolverConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWCDevApplicabilityWrw_NONE,
+    testing::Combine(testing::Values(GetSmokeTestParams(miopenFloat)),
+                     testing::Values(GetConvSmokeTestCases(miopenFloat)[0])));

--- a/test/gtest/unit_conv_solver_ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC.cpp
+++ b/test/gtest/unit_conv_solver_ConvAsmImplicitGemmGTCDynamicWrwXdlopsNHWC.cpp
@@ -48,7 +48,7 @@ auto GetSmokeTestParams(miopenDataType_t datatype)
     }
     auto testParams = miopen::unit_tests::UnitTestConvSolverParams(supportedDevices);
     testParams.Tunable(1);
-    testParams.DisableXnack();
+    testParams.CheckXnackDisabled();
 
     return testParams;
 }
@@ -81,7 +81,7 @@ auto GetFullTestParams(miopenDataType_t datatype)
     }
     auto testParams = miopen::unit_tests::UnitTestConvSolverParams(supportedDevices);
     testParams.Tunable(1000);
-    testParams.DisableXnack();
+    testParams.CheckXnackDisabled();
 
     return testParams;
 }

--- a/test/verify.hpp
+++ b/test/verify.hpp
@@ -133,7 +133,8 @@ struct square_diff_fn
     template <class T, class U>
     double operator()(T x, U y) const
     {
-        return static_cast<double>((x - y) * (x - y));
+        double diff = static_cast<double>(x - y);
+        return diff * diff;
     }
 };
 static constexpr square_diff_fn square_diff{};


### PR DESCRIPTION
Tensor casting was happening in all cases, but should only be happening when a split-k kernel was being used.