### PR TITLE
[Bug] Fix tensor casting happening for BF16 BWDs when not using a split-k kernel

### DIFF
--- a/src/conv/invokers/impl_gemm_dynamic.cpp
+++ b/src/conv/invokers/impl_gemm_dynamic.cpp
@@ -850,8 +850,7 @@ InvokerFactory MakeImplGemmDynamicBackwardDataXdlopsNHWCInvokerFactory(
             return use_fp32_global_split_on_fp16;
         if(problem.GetOut().GetType() == miopenBFloat16)
         {
-            return (y < stride_h || x < stride_w || dilation_h != 1 || dilation_w != 1 ||
-                    config.gemm_k_global_split > 0);
+            return config.gemm_k_global_split > 0;
         }
         return false;
     }();

--- a/test/gtest/unit_conv_solver_ConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWC.cpp
+++ b/test/gtest/unit_conv_solver_ConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWC.cpp
@@ -68,6 +68,8 @@ auto GetConvFullTestCases(miopenDataType_t datatype)
         TestCase{{16, 2048, 48, 32}, {2048, 2048, 3, 1}, {0, 0}, {3, 1}, {1, 1}, datatype},
         TestCase{{16, 2048, 1, 512}, {2048, 2048, 1, 2}, {0, 0}, {1, 2}, {1, 1}, datatype},
         TestCase{{16, 2048, 1, 30}, {576, 2048, 1, 1}, {0, 0}, {1, 1}, {1, 1}, datatype},
+        TestCase{{16, 48, 48, 32}, {48, 48, 3, 3}, {2, 2}, {1, 1}, {2, 2}, datatype},
+        TestCase{{16, 48, 48, 32}, {48, 48, 1, 1}, {2, 2}, {2, 2}, {1, 1}, datatype},
         // clang-format on
     };
 }


### PR DESCRIPTION
Tensor casting was happening for BWDs when using dilations, or strides that were greater than the filter size, but should only be happening when a split-k kernel  is being used (same as FWDs, and WRW). Tensor casting being used when not needed was leading to inaccurate results, and high error rates.

New tests failing without fix:
```
[----------] Global test environment tear-down
[==========] 31 tests from 7 test suites ran. (83886 ms total)
[  PASSED  ] 29 tests.
[  FAILED  ] 2 tests, listed below:
[  FAILED  ] Full/GPU_UnitTestConvSolverAsmImplicitGemmGTCDynamicBwdXdlopsNHWCBwd_BFP16.ConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWC/7, where GetParam() = (16-byte object <18-00 00-00 00-00 01-01 E8-03 00-00 00-00 00-00>, 5, (x:(5, none, {16,48,48,32}, {}), w:(5, none, {48,48,3,3}, {}), type_y:5), conv:({2,2}, {1,1}, {2,2})))
[  FAILED  ] Full/GPU_UnitTestConvSolverAsmImplicitGemmGTCDynamicBwdXdlopsNHWCBwd_BFP16.ConvAsmImplicitGemmGTCDynamicBwdXdlopsNHWC/8, where GetParam() = (16-byte object <18-00 00-00 00-00 01-01 E8-03 00-00 00-00 00-00>, 5, (x:(5, none, {16,48,48,32}, {}), w:(5, none, {48,48,1,1}, {}), type_y:5), conv:({2,2}, {2,2}, {1,1})))

 2 FAILED TESTS
```

Passing with fix:

```
[----------] Global test environment tear-down
[==========] 31 tests from 7 test suites ran. (82355 ms total)
[  PASSED  ] 31 tests.
```