### PR TITLE
Use state for disabling deterministic instead of environment variable

### DIFF
--- a/src/solver/conv/conv_hip_implicit_gemm_3d_grouped_bwd_xdlops.cpp
+++ b/src/solver/conv/conv_hip_implicit_gemm_3d_grouped_bwd_xdlops.cpp
@@ -510,8 +510,6 @@ bool ConvHipImplicitGemm3DGroupBwdXdlops::IsApplicable(
 #if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
     if(env::disabled(MIOPEN_DEBUG_3D_CONV_IMPLICIT_GEMM_HIP_BWD_XDLOPS))
         return false;
-    if(problem.GetConv().attribute.deterministic)
-        return false;
     if(!problem.AllTensorsDimsFitIntoInt())
         return false;
     if(problem.HasMixedDataTypes())

--- a/src/solver/conv/conv_hip_implicit_gemm_3d_grouped_bwd_xdlops.cpp
+++ b/src/solver/conv/conv_hip_implicit_gemm_3d_grouped_bwd_xdlops.cpp
@@ -510,7 +510,7 @@ bool ConvHipImplicitGemm3DGroupBwdXdlops::IsApplicable(
 #if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
     if(env::disabled(MIOPEN_DEBUG_3D_CONV_IMPLICIT_GEMM_HIP_BWD_XDLOPS))
         return false;
-    if(env::enabled(MIOPEN_DEBUG_CONVOLUTION_DETERMINISTIC))
+    if(problem.GetConv().attribute.deterministic)
         return false;
     if(!problem.AllTensorsDimsFitIntoInt())
         return false;

--- a/src/solver/conv/conv_hip_implicit_gemm_3d_grouped_fwd_xdlops.cpp
+++ b/src/solver/conv/conv_hip_implicit_gemm_3d_grouped_fwd_xdlops.cpp
@@ -506,9 +506,6 @@ bool ConvHipImplicitGemm3DGroupFwdXdlops::IsApplicable(
 #if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
     if(env::disabled(MIOPEN_DEBUG_3D_CONV_IMPLICIT_GEMM_HIP_FWD_XDLOPS))
         return false;
-    // check if type float else return false
-    if(problem.GetConv().attribute.deterministic)
-        return false;
     if(!problem.AllTensorsDimsFitIntoInt())
         return false;
     if(problem.HasMixedDataTypes())

--- a/src/solver/conv/conv_hip_implicit_gemm_3d_grouped_fwd_xdlops.cpp
+++ b/src/solver/conv/conv_hip_implicit_gemm_3d_grouped_fwd_xdlops.cpp
@@ -506,6 +506,8 @@ bool ConvHipImplicitGemm3DGroupFwdXdlops::IsApplicable(
 #if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
     if(env::disabled(MIOPEN_DEBUG_3D_CONV_IMPLICIT_GEMM_HIP_FWD_XDLOPS))
         return false;
+    if(problem.GetConv().attribute.deterministic)
+        return false;
     if(!problem.AllTensorsDimsFitIntoInt())
         return false;
     if(problem.HasMixedDataTypes())

--- a/src/solver/conv/conv_hip_implicit_gemm_3d_grouped_wrw_xdlops.cpp
+++ b/src/solver/conv/conv_hip_implicit_gemm_3d_grouped_wrw_xdlops.cpp
@@ -486,7 +486,7 @@ bool ConvHipImplicitGemm3DGroupWrwXdlops::IsApplicable(
 #if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
     if(env::disabled(MIOPEN_DEBUG_3D_CONV_IMPLICIT_GEMM_HIP_WRW_XDLOPS))
         return false;
-    if(env::enabled(MIOPEN_DEBUG_CONVOLUTION_DETERMINISTIC))
+    if(problem.GetConv().attribute.deterministic)
         return false;
     if(!problem.AllTensorsDimsFitIntoInt())
         return false;

--- a/src/solver/conv/conv_hip_implicit_gemm_grouped_bwd_xdlops.cpp
+++ b/src/solver/conv/conv_hip_implicit_gemm_grouped_bwd_xdlops.cpp
@@ -531,7 +531,7 @@ bool ConvHipImplicitGemmGroupBwdXdlops::IsApplicable(
 #if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
     if(env::enabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_GROUP_BWD_XDLOPS))
         return false;
-    if(env::enabled(MIOPEN_DEBUG_CONVOLUTION_DETERMINISTIC))
+    if(problem.GetConv().attribute.deterministic)
         return false;
     if(problem.HasMixedDataTypes())
         return false;

--- a/src/solver/conv/conv_hip_implicit_gemm_grouped_bwd_xdlops.cpp
+++ b/src/solver/conv/conv_hip_implicit_gemm_grouped_bwd_xdlops.cpp
@@ -531,8 +531,6 @@ bool ConvHipImplicitGemmGroupBwdXdlops::IsApplicable(
 #if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
     if(env::enabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_GROUP_BWD_XDLOPS))
         return false;
-    if(problem.GetConv().attribute.deterministic)
-        return false;
     if(problem.HasMixedDataTypes())
         return false;
     if(!problem.AllTensorsDimsFitIntoInt())

--- a/src/solver/conv/conv_hip_implicit_gemm_grouped_fwd_xdlops.cpp
+++ b/src/solver/conv/conv_hip_implicit_gemm_grouped_fwd_xdlops.cpp
@@ -514,8 +514,6 @@ bool ConvHipImplicitGemmGroupFwdXdlops::IsApplicable(
         return false;
     if(problem.IsTensorsCasted())
         return false;
-    if(problem.GetConv().attribute.deterministic)
-        return false;
     if(problem.HasMixedDataTypes())
         return false;
     if(!problem.IsDirectionForward())

--- a/src/solver/conv/conv_hip_implicit_gemm_grouped_fwd_xdlops.cpp
+++ b/src/solver/conv/conv_hip_implicit_gemm_grouped_fwd_xdlops.cpp
@@ -508,6 +508,8 @@ bool ConvHipImplicitGemmGroupFwdXdlops::IsApplicable(
 #if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
     if(env::disabled(MIOPEN_DEBUG_GROUP_CONV_IMPLICIT_GEMM_HIP_FWD_XDLOPS))
         return false;
+    if(problem.GetConv().attribute.deterministic)
+        return false;
     if(problem.HasNonPackedTensors())
         return false;
     if(!problem.AllTensorsDimsFitIntoInt())

--- a/src/solver/conv/conv_hip_implicit_gemm_grouped_wrw_xdlops.cpp
+++ b/src/solver/conv/conv_hip_implicit_gemm_grouped_wrw_xdlops.cpp
@@ -587,7 +587,7 @@ bool ConvHipImplicitGemmGroupWrwXdlops::IsApplicable(
 #if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
     if(env::disabled(MIOPEN_DEBUG_GROUP_CONV_IMPLICIT_GEMM_HIP_WRW_XDLOPS))
         return false;
-    if(env::enabled(MIOPEN_DEBUG_CONVOLUTION_DETERMINISTIC))
+    if(problem.GetConv().attribute.deterministic)
         return false;
     if(problem.HasMixedDataTypes())
         return false;


### PR DESCRIPTION
The implicit GEMM solvers from CK were checking the environment variable instead of the attribute flag which resulted in CK solvers still being applicable when deterministic was enabled through the API.

This change will swap to using the attribute flag which will still be set when the environment flags are enabled, but also take into account what is set through the API.

After discussing with @bartekxk I believe only backwards weights (WRW) needs to be disabled for the CK grouped conv solvers when deterministic is set.