### PR TITLE
Set mFinalized to true in BackendEngineDescriptor contructor

### DIFF
--- a/src/include/miopen/graphapi/engine.hpp
+++ b/src/include/miopen/graphapi/engine.hpp
@@ -203,6 +203,7 @@ public:
     BackendEngineDescriptor(const Engine& engine, miopenBackendDescriptor_t opGraphDescriptor)
         : mEngine(engine), mOpGraphDescriptor(opGraphDescriptor)
     {
+        mFinalized = true;
     }
 
     void setAttribute(miopenBackendAttributeName_t attributeName,


### PR DESCRIPTION
The constructor is called as part of BackendEngineHeurDescriptor::finalize() to store the Engine results from findEngines(), so it should already be finalized.