### PR TITLE
Fix package stage not running properly

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -170,7 +170,7 @@ pipeline {
                     agent{ label rocmnode("nogpu") }
                     steps{
                         script {
-                            utils.buildHipClangJobAndReboot( package_build: "true", needs_gpu:false, needs_reboot:false)
+                            utils.buildHipClangJobAndReboot( package_build:true, needs_gpu:false, needs_reboot:false)
                         }
                     }
                 }


### PR DESCRIPTION
The buildHipClangJobAndReboot utility is checking for a bool value, but we are providing a string value which leads to the package stage running tests, and not doing the packaging step.