### PR TITLE
Swap to using median value with outliers removed for deciding on best solution to run

### DIFF
--- a/src/conv/solver_finders.cpp
+++ b/src/conv/solver_finders.cpp
@@ -292,7 +292,7 @@ static std::vector<Solution> EvaluateInvokers(const Handle& handle,
             {
                 // Remove outliers that are more than 2 positive modified z-score's away, and get
                 // the mean.
-                elapsed = miopen::RemoveHighOutliersAndGetMean(samples, 2.0f);
+                elapsed = miopen::removeHighOutliersAndGetMean(samples, 2.0f);
             }
             else
             {

--- a/src/conv/solver_finders.cpp
+++ b/src/conv/solver_finders.cpp
@@ -291,9 +291,9 @@ static std::vector<Solution> EvaluateInvokers(const Handle& handle,
 
             if(samples.size() > 0)
             {
-                // Remove outliers that are more than 2 modified z-score's away, and get the median
-                // result.
-                elapsed = miopen::RemoveOutliersAndGetMedian(samples, 2.0f);
+                // Remove outliers that are more than 2 positive modified z-score's away, and get
+                // the mean.
+                elapsed = miopen::RemoveHighOutliersAndGetMean(samples, 2.0f);
             }
             else
             {

--- a/src/conv/solver_finders.cpp
+++ b/src/conv/solver_finders.cpp
@@ -278,7 +278,6 @@ static std::vector<Solution> EvaluateInvokers(const Handle& handle,
                 // don't include warm-up run in our samples.
                 if(i > 0)
                 {
-
                     samples.push_back(handle.GetKernelTime());
                 }
                 else

--- a/src/conv/solver_finders.cpp
+++ b/src/conv/solver_finders.cpp
@@ -274,15 +274,16 @@ static std::vector<Solution> EvaluateInvokers(const Handle& handle,
             while(i < N_RUNS_MAX && elapsed < TIME_MS_MAX)
             {
                 invoker(handle, invoke_ctx);
+
+                // don't include warm-up run in our samples.
                 if(i > 0)
                 {
-                    // don't include warm-up run in our measurements
+
                     samples.push_back(handle.GetKernelTime());
                 }
                 else
                 {
-                    // Use first_elapsed if we go past max time since we won't have any other
-                    // samples.
+                    // Keep first run just in case we go over the limit, and have no samples.
                     first_elapsed = handle.GetKernelTime();
                 }
                 ++i;

--- a/src/conv/solver_finders.cpp
+++ b/src/conv/solver_finders.cpp
@@ -32,6 +32,7 @@
 #include <miopen/perf_field.hpp>
 #include <miopen/conv/problem_description.hpp>
 #include <miopen/solution.hpp>
+#include <miopen/utility/modified_z.hpp>
 
 MIOPEN_DECLARE_ENV_VAR_BOOL(MIOPEN_DEBUG_CONV_GEMM)
 MIOPEN_DECLARE_ENV_VAR_BOOL(MIOPEN_DEBUG_CONV_DIRECT)
@@ -230,6 +231,7 @@ static std::vector<Solution> EvaluateInvokers(const Handle& handle,
     auto best         = std::numeric_limits<float>::max();
     auto best_invoker = Invoker{};
     auto ret          = std::vector<Solution>{};
+    std::vector<float> samples;
 
     for(const auto& sol : solutions)
     {
@@ -261,31 +263,40 @@ static std::vector<Solution> EvaluateInvokers(const Handle& handle,
 
         try
         {
-            // Run invoker max 6 times, with ~5 sec time limit.
+            // Run invoker max 8 times, with ~5 sec time limit.
             using elapsed_t                 = decltype(handle.GetKernelTime());
             constexpr elapsed_t TIME_MS_MAX = 5000.0;
             constexpr int N_RUNS_MAX        = 8;
-            constexpr int N_RUNS_DISCARD    = 3;
             auto elapsed                    = static_cast<elapsed_t>(0);
             auto first_elapsed              = static_cast<elapsed_t>(0);
             int i                           = 0;
+            samples.clear();
             while(i < N_RUNS_MAX && elapsed < TIME_MS_MAX)
             {
                 invoker(handle, invoke_ctx);
-                elapsed += handle.GetKernelTime();
-                if(i == (N_RUNS_DISCARD - 1))
-                    first_elapsed = elapsed;
+                if(i > 0)
+                {
+                    // don't include warm-up run in our measurements
+                    samples.push_back(handle.GetKernelTime());
+                }
+                else
+                {
+                    // Use first_elapsed if we go past max time since we won't have any other
+                    // samples.
+                    first_elapsed = handle.GetKernelTime();
+                }
                 ++i;
             }
-            // If the execution time was not too long,
-            // then the 1st run is not counted (assume it's warm-up):
-            if(i > N_RUNS_DISCARD)
+
+            if(samples.size() > 0)
             {
-                elapsed = (elapsed - first_elapsed) / static_cast<elapsed_t>(i - N_RUNS_DISCARD);
+                // Remove outliers that are more than 2 modified z-score's away, and get the median
+                // result.
+                elapsed = miopen::RemoveOutliersAndGetMedian(samples, 2.0f);
             }
-            else if(i > 0)
+            else
             {
-                elapsed /= i;
+                elapsed = first_elapsed;
             }
 
             MIOPEN_THROW_IF(elapsed <= 0, "Invalid elapsed time detected in EvaluateInvokers");

--- a/src/include/miopen/generic_search.hpp
+++ b/src/include/miopen/generic_search.hpp
@@ -546,7 +546,7 @@ auto GenericSearch(const Solver s,
 
                         // Remove outliers that are more than 2 positive modified z-score's away,
                         // and get the mean.
-                        elapsed_time = miopen::RemoveHighOutliersAndGetMean(samples, 2.0f);
+                        elapsed_time = miopen::removeHighOutliersAndGetMean(samples, 2.0f);
                         if(elapsed_time < best_time)
                         {
                             MIOPEN_LOG_I('#' << n_current << '/' << n_failed << '/' << n_runs_total
@@ -563,8 +563,8 @@ auto GenericSearch(const Solver s,
                         }
                         else
                         {
-                            MIOPEN_LOG_I2("Median is not better: " << elapsed_time
-                                                                   << " >= " << best_time);
+                            MIOPEN_LOG_I2("Mean is not better: " << elapsed_time
+                                                                 << " >= " << best_time);
                         }
                     }
                 }

--- a/src/include/miopen/generic_search.hpp
+++ b/src/include/miopen/generic_search.hpp
@@ -38,6 +38,7 @@
 #include <miopen/timer.hpp>
 #include <miopen/mt_queue.hpp>
 #include <miopen/generic_search_controls.hpp>
+#include <miopen/utility/modified_z.hpp>
 
 #include <algorithm>
 #include <vector>
@@ -400,10 +401,11 @@ auto GenericSearch(const Solver s,
         }
     }
 
-    bool is_passed  = false; // left false only if all iterations failed.
-    float best_time = std::numeric_limits<float>::max();
-    size_t n_failed = 0;
-    size_t n_best   = 0;
+    bool is_passed   = false; // left false only if all iterations failed.
+    float best_time  = std::numeric_limits<float>::max();
+    float worst_time = std::numeric_limits<float>::max();
+    size_t n_failed  = 0;
+    size_t n_best    = 0;
     HeartBeat<PerformanceConfig> heartbeat;
     heartbeat.Start();
 
@@ -429,6 +431,7 @@ auto GenericSearch(const Solver s,
         size_t n_current       = 0;
         size_t last_imprv      = 0;
         auto threads_remaining = total_threads;
+        std::vector<float> samples;
         while(true)
         {
             if(n_current >= n_runs_total)
@@ -461,6 +464,7 @@ auto GenericSearch(const Solver s,
                 }
             }
 
+            samples.clear();
             float elapsed_time = 0.0f;
             int ret            = 0;
             MIOPEN_LOG_I2('#' << n_current << '/' << n_failed << '/' << n_runs_total << ' '
@@ -481,8 +485,18 @@ auto GenericSearch(const Solver s,
 
                 invoker = profile_h.PrepareInvoker(*current_solution.invoker_factory,
                                                    current_solution.construction_params);
+
+                // Warm-up run for first time invoker is used
+                if(n_current == 0)
+                {
+                    invoker(profile_h, invoke_ctx);
+                    profile_h.ResetKernelTime();
+                }
+
                 invoker(profile_h, invoke_ctx);
                 elapsed_time = profile_h.GetKernelTime();
+                samples.push_back(elapsed_time);
+                profile_h.ResetKernelTime();
             }
             catch(const std::exception& e)
             {
@@ -503,11 +517,11 @@ auto GenericSearch(const Solver s,
             if(ret == 0)
             {
                 // Smooth the jitter of measurements:
-                // If the 1st probe is NOT too bad (measured time <= 1.10 * best known time),
-                // then re-run it 9 times more and compute average time,
-                // and decide using average of all 10 attempts vs. the best.
+                // If the 1st probe is NOT too bad (measured time <= 1.10 * worst sample of the best
+                // config), then gather 9 more samples, and remove outliers. Use the median value
+                // with outliers removed for calculating best config.
                 constexpr int N_RUNS = 10;
-                if(elapsed_time / best_time < 1.10f)
+                if(elapsed_time / worst_time < 1.10f)
                 {
                     MIOPEN_LOG_I2("Finding average for: " << elapsed_time << " / " << best_time
                                                           << " = " << (elapsed_time / best_time));
@@ -517,7 +531,8 @@ auto GenericSearch(const Solver s,
                         for(int i = 1; i < N_RUNS; ++i)
                         {
                             invoker(profile_h, invoke_ctx);
-                            elapsed_time += profile_h.GetKernelTime();
+                            samples.push_back(profile_h.GetKernelTime());
+                            profile_h.ResetKernelTime();
                         }
                     }
                     catch(...)
@@ -528,7 +543,10 @@ auto GenericSearch(const Solver s,
                     if(ret == 0)
                     {
                         is_passed = true;
-                        elapsed_time /= N_RUNS;
+
+                        // Remove outliers that are more than 2 modified z-score's away, and get the
+                        // median result.
+                        elapsed_time = miopen::RemoveOutliersAndGetMedian(samples, 2.0f);
                         if(elapsed_time < best_time)
                         {
                             MIOPEN_LOG_I('#' << n_current << '/' << n_failed << '/' << n_runs_total
@@ -536,13 +554,14 @@ auto GenericSearch(const Solver s,
                                              << current_config);
                             best_config = current_config;
                             best_time   = elapsed_time;
+                            worst_time  = samples.back();
                             n_best      = n_current;
                             last_imprv  = 0;
                         }
                         else
                         {
-                            MIOPEN_LOG_I2("Average is not better: " << elapsed_time
-                                                                    << " >= " << best_time);
+                            MIOPEN_LOG_I2("Median is not better: " << elapsed_time
+                                                                   << " >= " << best_time);
                         }
                     }
                 }

--- a/src/include/miopen/generic_search.hpp
+++ b/src/include/miopen/generic_search.hpp
@@ -518,8 +518,8 @@ auto GenericSearch(const Solver s,
             {
                 // Smooth the jitter of measurements:
                 // If the 1st probe is NOT too bad (measured time <= 1.10 * worst sample of the best
-                // config), then gather 9 more samples, and remove outliers. Use the median value
-                // with outliers removed for calculating best config.
+                // config), then gather 9 more samples, and remove positive z-score outliers. Use
+                // the mean value with outliers removed for calculating best config.
                 constexpr int N_RUNS = 10;
                 if(elapsed_time / worst_time < 1.10f)
                 {
@@ -544,9 +544,9 @@ auto GenericSearch(const Solver s,
                     {
                         is_passed = true;
 
-                        // Remove outliers that are more than 2 modified z-score's away, and get the
-                        // median result.
-                        elapsed_time = miopen::RemoveOutliersAndGetMedian(samples, 2.0f);
+                        // Remove outliers that are more than 2 positive modified z-score's away,
+                        // and get the mean.
+                        elapsed_time = miopen::RemoveHighOutliersAndGetMean(samples, 2.0f);
                         if(elapsed_time < best_time)
                         {
                             MIOPEN_LOG_I('#' << n_current << '/' << n_failed << '/' << n_runs_total
@@ -554,9 +554,12 @@ auto GenericSearch(const Solver s,
                                              << current_config);
                             best_config = current_config;
                             best_time   = elapsed_time;
-                            worst_time  = samples.back();
-                            n_best      = n_current;
-                            last_imprv  = 0;
+
+                            // Samples gets sorted by the RemoveOutliers call so the last element
+                            // will be the slowest.
+                            worst_time = samples.back();
+                            n_best     = n_current;
+                            last_imprv = 0;
                         }
                         else
                         {

--- a/src/include/miopen/utility/modified_z.hpp
+++ b/src/include/miopen/utility/modified_z.hpp
@@ -28,9 +28,19 @@
 
 #include <vector>
 #include <algorithm>
+#include <numeric>
 #include <miopen/errors.hpp>
 
 namespace miopen {
+
+template <typename T>
+T Mean(const std::vector<T>& data)
+{
+    MIOPEN_THROW_IF(data.size() == 0, "Cannot find Mean of 0 length data");
+
+    T sum = std::accumulate(data.begin(), data.end(), 0.0);
+    return sum / data.size();
+}
 
 template <typename T>
 T MedianOfSortedData(const std::vector<T>& sortedData)
@@ -97,7 +107,7 @@ std::vector<T> ModifiedZScores(const std::vector<T>& sortedData)
 }
 
 template <typename T>
-T RemoveOutliersAndGetMedian(std::vector<T>& data, T z_threshold)
+T RemoveHighOutliersAndGetMean(std::vector<T>& data, T z_threshold)
 {
     std::sort(data.begin(), data.end());
 
@@ -106,12 +116,12 @@ T RemoveOutliersAndGetMedian(std::vector<T>& data, T z_threshold)
 
     for(size_t i = 0; i < data.size(); ++i)
     {
-        if(std::abs(modZScores[i]) <= z_threshold)
+        if(modZScores[i] <= z_threshold)
         {
             filteredData.push_back(data[i]);
         }
     }
 
-    return MedianOfSortedData(filteredData);
+    return Mean(filteredData);
 }
 } // namespace miopen

--- a/src/include/miopen/utility/modified_z.hpp
+++ b/src/include/miopen/utility/modified_z.hpp
@@ -1,0 +1,117 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2025 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#pragma once
+
+#include <vector>
+#include <algorithm>
+#include <miopen/errors.hpp>
+
+namespace miopen {
+
+template <typename T>
+T MedianOfSortedData(const std::vector<T>& sortedData)
+{
+    MIOPEN_THROW_IF(sortedData.size() == 0, "Cannot find Median of 0 length data");
+
+    size_t size = sortedData.size();
+
+    T median = (size % 2 == 0) ? (sortedData[size / 2 - 1] + sortedData[size / 2]) / 2.0
+                               : sortedData[size / 2];
+
+    return median;
+}
+
+template <typename T>
+T Median(std::vector<T>& data)
+{
+    std::sort(data.begin(), data.end());
+
+    return MedianOfSortedData(data);
+}
+
+template <typename T>
+std::vector<T> MedianAbsoluteDeviation(const std::vector<T>& sortedData)
+{
+    T median = MedianOfSortedData(sortedData);
+
+    std::vector<T> absDeviation;
+    absDeviation.reserve(sortedData.size());
+
+    std::transform(sortedData.begin(),
+                   sortedData.end(),
+                   std::back_inserter(absDeviation),
+                   [&](auto& value) { return std::abs(value - median); });
+
+    return absDeviation;
+}
+
+template <typename T>
+std::vector<T> ModifiedZScores(const std::vector<T>& sortedData)
+{
+    T median = MedianOfSortedData(sortedData);
+
+    std::vector<T> absolute_deviation = MedianAbsoluteDeviation(sortedData);
+    T mad                             = Median(absolute_deviation);
+
+    // If MAD is 0, then we cannot calcualte the ModifiedZScore
+    if(mad == T{0})
+    {
+        return std::vector<T>(sortedData.size(), 0);
+    }
+    else
+    {
+        std::vector<T> modZScores;
+        modZScores.reserve(sortedData.size());
+
+        std::transform(sortedData.begin(),
+                       sortedData.end(),
+                       std::back_inserter(modZScores),
+                       [&](auto& value) { return 0.6745 * (value - median) / mad; });
+
+        return modZScores;
+    }
+}
+
+template <typename T>
+T RemoveOutliersAndGetMedian(std::vector<T>& data, T z_threshold)
+{
+    std::sort(data.begin(), data.end());
+
+    std::vector<T> modZScores = ModifiedZScores(data);
+    std::vector<T> filteredData;
+
+    for(size_t i = 0; i < data.size(); ++i)
+    {
+        if(std::abs(modZScores[i]) <= z_threshold)
+        {
+            filteredData.push_back(data[i]);
+        }
+    }
+
+    return MedianOfSortedData(filteredData);
+}
+} // namespace miopen

--- a/src/include/miopen/utility/modified_z.hpp
+++ b/src/include/miopen/utility/modified_z.hpp
@@ -38,8 +38,8 @@ T Mean(const std::vector<T>& data)
 {
     MIOPEN_THROW_IF(data.size() == 0, "Cannot find Mean of 0 length data");
 
-    T sum = std::accumulate(data.begin(), data.end(), 0.0);
-    return sum / data.size();
+    T sumOfValues = std::accumulate(data.begin(), data.end(), 0.0);
+    return sumOfValues / data.size();
 }
 
 template <typename T>

--- a/src/include/miopen/utility/modified_z.hpp
+++ b/src/include/miopen/utility/modified_z.hpp
@@ -34,7 +34,7 @@
 namespace miopen {
 
 template <typename T>
-T Mean(const std::vector<T>& data)
+T mean(const std::vector<T>& data)
 {
     MIOPEN_THROW_IF(data.size() == 0, "Cannot find Mean of 0 length data");
 
@@ -43,7 +43,7 @@ T Mean(const std::vector<T>& data)
 }
 
 template <typename T>
-T MedianOfSortedData(const std::vector<T>& sortedData)
+T medianOfSortedData(const std::vector<T>& sortedData)
 {
     MIOPEN_THROW_IF(sortedData.size() == 0, "Cannot find Median of 0 length data");
 
@@ -56,17 +56,17 @@ T MedianOfSortedData(const std::vector<T>& sortedData)
 }
 
 template <typename T>
-T Median(std::vector<T>& data)
+T median(std::vector<T>& data)
 {
     std::sort(data.begin(), data.end());
 
-    return MedianOfSortedData(data);
+    return medianOfSortedData(data);
 }
 
 template <typename T>
-std::vector<T> MedianAbsoluteDeviation(const std::vector<T>& sortedData)
+std::vector<T> medianAbsoluteDeviation(const std::vector<T>& sortedData)
 {
-    T median = MedianOfSortedData(sortedData);
+    T median = medianOfSortedData(sortedData);
 
     std::vector<T> absDeviation;
     absDeviation.reserve(sortedData.size());
@@ -80,12 +80,12 @@ std::vector<T> MedianAbsoluteDeviation(const std::vector<T>& sortedData)
 }
 
 template <typename T>
-std::vector<T> ModifiedZScores(const std::vector<T>& sortedData)
+std::vector<T> modifiedZScores(const std::vector<T>& sortedData)
 {
-    T median = MedianOfSortedData(sortedData);
+    T medianValue = medianOfSortedData(sortedData);
 
-    std::vector<T> absolute_deviation = MedianAbsoluteDeviation(sortedData);
-    T mad                             = Median(absolute_deviation);
+    std::vector<T> absolute_deviation = medianAbsoluteDeviation(sortedData);
+    T mad                             = median(absolute_deviation);
 
     // If MAD is 0, then we cannot calcualte the ModifiedZScore
     if(mad == T{0})
@@ -100,18 +100,18 @@ std::vector<T> ModifiedZScores(const std::vector<T>& sortedData)
         std::transform(sortedData.begin(),
                        sortedData.end(),
                        std::back_inserter(modZScores),
-                       [&](auto& value) { return 0.6745 * (value - median) / mad; });
+                       [&](auto& value) { return 0.6745 * (value - medianValue) / mad; });
 
         return modZScores;
     }
 }
 
 template <typename T>
-T RemoveHighOutliersAndGetMean(std::vector<T>& data, T z_threshold)
+T removeHighOutliersAndGetMean(std::vector<T>& data, T z_threshold)
 {
     std::sort(data.begin(), data.end());
 
-    std::vector<T> modZScores = ModifiedZScores(data);
+    std::vector<T> modZScores = modifiedZScores(data);
     std::vector<T> filteredData;
 
     for(size_t i = 0; i < data.size(); ++i)
@@ -122,6 +122,6 @@ T RemoveHighOutliersAndGetMean(std::vector<T>& data, T z_threshold)
         }
     }
 
-    return Mean(filteredData);
+    return mean(filteredData);
 }
 } // namespace miopen

--- a/src/include/miopen/utility/modified_z.hpp
+++ b/src/include/miopen/utility/modified_z.hpp
@@ -36,6 +36,7 @@ namespace miopen {
 template <typename T>
 T mean(const std::vector<T>& data)
 {
+    static_assert(std::is_floating_point_v<T>);
     MIOPEN_THROW_IF(data.size() == 0, "Cannot find Mean of 0 length data");
 
     T sumOfValues = std::accumulate(data.begin(), data.end(), 0.0);
@@ -45,6 +46,7 @@ T mean(const std::vector<T>& data)
 template <typename T>
 T medianOfSortedData(const std::vector<T>& sortedData)
 {
+    static_assert(std::is_floating_point_v<T>);
     MIOPEN_THROW_IF(sortedData.size() == 0, "Cannot find Median of 0 length data");
 
     size_t size = sortedData.size();
@@ -58,6 +60,8 @@ T medianOfSortedData(const std::vector<T>& sortedData)
 template <typename T>
 T median(std::vector<T>& data)
 {
+    static_assert(std::is_floating_point_v<T>);
+    // Note: The data needs to be sorted for other parts of the algorthim
     std::sort(data.begin(), data.end());
 
     return medianOfSortedData(data);
@@ -66,6 +70,7 @@ T median(std::vector<T>& data)
 template <typename T>
 std::vector<T> medianAbsoluteDeviation(const std::vector<T>& sortedData)
 {
+    static_assert(std::is_floating_point_v<T>);
     T median = medianOfSortedData(sortedData);
 
     std::vector<T> absDeviation;
@@ -82,6 +87,7 @@ std::vector<T> medianAbsoluteDeviation(const std::vector<T>& sortedData)
 template <typename T>
 std::vector<T> modifiedZScores(const std::vector<T>& sortedData)
 {
+    static_assert(std::is_floating_point_v<T>);
     T medianValue = medianOfSortedData(sortedData);
 
     std::vector<T> absolute_deviation = medianAbsoluteDeviation(sortedData);
@@ -109,6 +115,7 @@ std::vector<T> modifiedZScores(const std::vector<T>& sortedData)
 template <typename T>
 T removeHighOutliersAndGetMean(std::vector<T>& data, T z_threshold)
 {
+    static_assert(std::is_floating_point_v<T>);
     std::sort(data.begin(), data.end());
 
     std::vector<T> modZScores = modifiedZScores(data);

--- a/test/gtest/unit_modified_z.cpp
+++ b/test/gtest/unit_modified_z.cpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (c) 2024 Advanced Micro Devices, Inc.
+ * Copyright (c) 2025 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/test/gtest/unit_modified_z.cpp
+++ b/test/gtest/unit_modified_z.cpp
@@ -37,13 +37,13 @@ TEST(CPU_UnitTestModifiedZ_NONE, TestMean)
     std::vector<double> testSingle     = {1};
     std::vector<double> testEmpty      = {};
 
-    EXPECT_DOUBLE_EQ(miopen::Mean(testSorted), 4);
-    EXPECT_DOUBLE_EQ(miopen::Mean(testDuplicates), 1);
-    EXPECT_DOUBLE_EQ(miopen::Mean(testUnsorted), 7);
-    EXPECT_DOUBLE_EQ(miopen::Mean(testOdd), 12.16666666666667);
-    EXPECT_DOUBLE_EQ(miopen::Mean(testEven), 13.0);
-    EXPECT_DOUBLE_EQ(miopen::Mean(testSingle), 1);
-    EXPECT_THROW(miopen::Mean(testEmpty), miopen::Exception);
+    EXPECT_DOUBLE_EQ(miopen::mean(testSorted), 4);
+    EXPECT_DOUBLE_EQ(miopen::mean(testDuplicates), 1);
+    EXPECT_DOUBLE_EQ(miopen::mean(testUnsorted), 7);
+    EXPECT_DOUBLE_EQ(miopen::mean(testOdd), 12.16666666666667);
+    EXPECT_DOUBLE_EQ(miopen::mean(testEven), 13.0);
+    EXPECT_DOUBLE_EQ(miopen::mean(testSingle), 1);
+    EXPECT_THROW(miopen::mean(testEmpty), miopen::Exception);
 }
 
 TEST(CPU_UnitTestModifiedZ_NONE, TestMedian)
@@ -56,13 +56,13 @@ TEST(CPU_UnitTestModifiedZ_NONE, TestMedian)
     std::vector<double> testSingle     = {1};
     std::vector<double> testEmpty      = {};
 
-    EXPECT_DOUBLE_EQ(miopen::Median(testSorted), 4);
-    EXPECT_DOUBLE_EQ(miopen::Median(testDuplicates), 1);
-    EXPECT_DOUBLE_EQ(miopen::Median(testUnsorted), 7);
-    EXPECT_DOUBLE_EQ(miopen::Median(testOdd), 12.5);
-    EXPECT_DOUBLE_EQ(miopen::Median(testEven), 13.0);
-    EXPECT_DOUBLE_EQ(miopen::Median(testSingle), 1);
-    EXPECT_THROW(miopen::Median(testEmpty), miopen::Exception);
+    EXPECT_DOUBLE_EQ(miopen::median(testSorted), 4);
+    EXPECT_DOUBLE_EQ(miopen::median(testDuplicates), 1);
+    EXPECT_DOUBLE_EQ(miopen::median(testUnsorted), 7);
+    EXPECT_DOUBLE_EQ(miopen::median(testOdd), 12.5);
+    EXPECT_DOUBLE_EQ(miopen::median(testEven), 13.0);
+    EXPECT_DOUBLE_EQ(miopen::median(testSingle), 1);
+    EXPECT_THROW(miopen::median(testEmpty), miopen::Exception);
 }
 
 TEST(CPU_UnitTestModifiedZ_NONE, TestMedianOfSortedData)
@@ -73,11 +73,11 @@ TEST(CPU_UnitTestModifiedZ_NONE, TestMedianOfSortedData)
     std::vector<double> testSingle     = {1};
     std::vector<double> testEmpty      = {};
 
-    EXPECT_DOUBLE_EQ(miopen::MedianOfSortedData(testSorted), 4);
-    EXPECT_DOUBLE_EQ(miopen::MedianOfSortedData(testDuplicates), 1);
-    EXPECT_NE(miopen::MedianOfSortedData(testUnsorted), 7);
-    EXPECT_DOUBLE_EQ(miopen::MedianOfSortedData(testSingle), 1);
-    EXPECT_THROW(miopen::MedianOfSortedData(testEmpty), miopen::Exception);
+    EXPECT_DOUBLE_EQ(miopen::medianOfSortedData(testSorted), 4);
+    EXPECT_DOUBLE_EQ(miopen::medianOfSortedData(testDuplicates), 1);
+    EXPECT_NE(miopen::medianOfSortedData(testUnsorted), 7);
+    EXPECT_DOUBLE_EQ(miopen::medianOfSortedData(testSingle), 1);
+    EXPECT_THROW(miopen::medianOfSortedData(testEmpty), miopen::Exception);
 }
 
 TEST(CPU_UnitTestModifiedZ_NONE, TestMedianAbsoluteDeviation)
@@ -90,12 +90,12 @@ TEST(CPU_UnitTestModifiedZ_NONE, TestMedianAbsoluteDeviation)
     std::vector<double> testSingle           = {1};
     std::vector<double> testEmpty            = {};
 
-    std::vector<double> mad1 = miopen::MedianAbsoluteDeviation(testNoDeviation);
-    std::vector<double> mad2 = miopen::MedianAbsoluteDeviation(testZeroMAD);
-    std::vector<double> mad3 = miopen::MedianAbsoluteDeviation(testDeviationOdd);
-    std::vector<double> mad4 = miopen::MedianAbsoluteDeviation(testDeviationEven);
-    std::vector<double> mad5 = miopen::MedianAbsoluteDeviation(testDeviationRepeats);
-    std::vector<double> mad6 = miopen::MedianAbsoluteDeviation(testSingle);
+    std::vector<double> mad1 = miopen::medianAbsoluteDeviation(testNoDeviation);
+    std::vector<double> mad2 = miopen::medianAbsoluteDeviation(testZeroMAD);
+    std::vector<double> mad3 = miopen::medianAbsoluteDeviation(testDeviationOdd);
+    std::vector<double> mad4 = miopen::medianAbsoluteDeviation(testDeviationEven);
+    std::vector<double> mad5 = miopen::medianAbsoluteDeviation(testDeviationRepeats);
+    std::vector<double> mad6 = miopen::medianAbsoluteDeviation(testSingle);
 
     std::vector<double> expected1 = {0, 0, 0};
     std::vector<double> expected2 = {0, 0, 0, 993};
@@ -110,7 +110,7 @@ TEST(CPU_UnitTestModifiedZ_NONE, TestMedianAbsoluteDeviation)
     EXPECT_EQ(mad4, expected4);
     EXPECT_EQ(mad5, expected5);
     EXPECT_EQ(mad6, expected6);
-    EXPECT_THROW(miopen::MedianAbsoluteDeviation(testEmpty), miopen::Exception);
+    EXPECT_THROW(miopen::medianAbsoluteDeviation(testEmpty), miopen::Exception);
 }
 
 TEST(CPU_UnitTestModifiedZ_NONE, TestModifiedZScores)
@@ -123,12 +123,12 @@ TEST(CPU_UnitTestModifiedZ_NONE, TestModifiedZScores)
     std::vector<double> testSingle           = {1};
     std::vector<double> testEmpty            = {};
 
-    std::vector<double> modZScores1 = miopen::ModifiedZScores(testNoDeviation);
-    std::vector<double> modZScores2 = miopen::ModifiedZScores(testZeroMAD);
-    std::vector<double> modZScores3 = miopen::ModifiedZScores(testDeviationOdd);
-    std::vector<double> modZScores4 = miopen::ModifiedZScores(testDeviationEven);
-    std::vector<double> modZScores5 = miopen::ModifiedZScores(testDeviationRepeats);
-    std::vector<double> modZScores6 = miopen::ModifiedZScores(testSingle);
+    std::vector<double> modZScores1 = miopen::modifiedZScores(testNoDeviation);
+    std::vector<double> modZScores2 = miopen::modifiedZScores(testZeroMAD);
+    std::vector<double> modZScores3 = miopen::modifiedZScores(testDeviationOdd);
+    std::vector<double> modZScores4 = miopen::modifiedZScores(testDeviationEven);
+    std::vector<double> modZScores5 = miopen::modifiedZScores(testDeviationRepeats);
+    std::vector<double> modZScores6 = miopen::modifiedZScores(testSingle);
 
     std::vector<double> expected1 = {0, 0, 0};
     std::vector<double> expected2 = {0, 0, 0, 0};
@@ -143,7 +143,7 @@ TEST(CPU_UnitTestModifiedZ_NONE, TestModifiedZScores)
     EXPECT_EQ(modZScores4, expected4);
     EXPECT_EQ(modZScores5, expected5);
     EXPECT_EQ(modZScores6, expected6);
-    EXPECT_THROW(miopen::ModifiedZScores(testEmpty), miopen::Exception);
+    EXPECT_THROW(miopen::modifiedZScores(testEmpty), miopen::Exception);
 }
 
 TEST(CPU_UnitTestModifiedZ_NONE, TestRemoveHighOutliersAndGetMean)
@@ -160,15 +160,15 @@ TEST(CPU_UnitTestModifiedZ_NONE, TestRemoveHighOutliersAndGetMean)
     std::vector<double> testSingle = {1};
     std::vector<double> testEmpty  = {};
 
-    double mean1 = miopen::RemoveHighOutliersAndGetMean(testNoDeviation, 1.0);
-    double mean2 = miopen::RemoveHighOutliersAndGetMean(testZeroMAD, 1.0);
-    double mean3 = miopen::RemoveHighOutliersAndGetMean(testDeviationOdd, 1.0);
-    double mean4 = miopen::RemoveHighOutliersAndGetMean(testDeviationEven, 1.0);
-    double mean5 = miopen::RemoveHighOutliersAndGetMean(testDeviationRepeats, 1.0);
-    double mean6 = miopen::RemoveHighOutliersAndGetMean(testWithOutliers1, 1.0);
-    double mean7 = miopen::RemoveHighOutliersAndGetMean(testWithOutliers2, 1.0);
-    double mean8 = miopen::RemoveHighOutliersAndGetMean(testWithOutliers3, 1.0);
-    double mean9 = miopen::RemoveHighOutliersAndGetMean(testSingle, 1.0);
+    double mean1 = miopen::removeHighOutliersAndGetMean(testNoDeviation, 1.0);
+    double mean2 = miopen::removeHighOutliersAndGetMean(testZeroMAD, 1.0);
+    double mean3 = miopen::removeHighOutliersAndGetMean(testDeviationOdd, 1.0);
+    double mean4 = miopen::removeHighOutliersAndGetMean(testDeviationEven, 1.0);
+    double mean5 = miopen::removeHighOutliersAndGetMean(testDeviationRepeats, 1.0);
+    double mean6 = miopen::removeHighOutliersAndGetMean(testWithOutliers1, 1.0);
+    double mean7 = miopen::removeHighOutliersAndGetMean(testWithOutliers2, 1.0);
+    double mean8 = miopen::removeHighOutliersAndGetMean(testWithOutliers3, 1.0);
+    double mean9 = miopen::removeHighOutliersAndGetMean(testSingle, 1.0);
 
     EXPECT_DOUBLE_EQ(mean1, 1);
     EXPECT_DOUBLE_EQ(mean2, 255.25);
@@ -179,7 +179,7 @@ TEST(CPU_UnitTestModifiedZ_NONE, TestRemoveHighOutliersAndGetMean)
     EXPECT_DOUBLE_EQ(mean7, 2);
     EXPECT_DOUBLE_EQ(mean8, 666.72727272727275);
     EXPECT_DOUBLE_EQ(mean9, 1);
-    EXPECT_THROW(miopen::RemoveHighOutliersAndGetMean(testEmpty, 1.0), miopen::Exception);
-    EXPECT_THROW(miopen::RemoveHighOutliersAndGetMean(testDeviationRepeats, -1.0),
+    EXPECT_THROW(miopen::removeHighOutliersAndGetMean(testEmpty, 1.0), miopen::Exception);
+    EXPECT_THROW(miopen::removeHighOutliersAndGetMean(testDeviationRepeats, -1.0),
                  miopen::Exception);
 }

--- a/test/gtest/unit_modified_z.cpp
+++ b/test/gtest/unit_modified_z.cpp
@@ -27,6 +27,25 @@
 #include <miopen/utility/modified_z.hpp>
 #include <gtest/gtest.h>
 
+TEST(CPU_UnitTestModifiedZ_NONE, TestMean)
+{
+    std::vector<double> testSorted     = {1, 2, 3, 4, 5, 6, 7};
+    std::vector<double> testDuplicates = {1, 1, 1};
+    std::vector<double> testUnsorted   = {5, 9, 11, 7, 3};
+    std::vector<double> testOdd        = {13.5, 10.5, 12.5};
+    std::vector<double> testEven       = {13.5, 10.5, 12.5, 15.5};
+    std::vector<double> testSingle     = {1};
+    std::vector<double> testEmpty      = {};
+
+    EXPECT_DOUBLE_EQ(miopen::Mean(testSorted), 4);
+    EXPECT_DOUBLE_EQ(miopen::Mean(testDuplicates), 1);
+    EXPECT_DOUBLE_EQ(miopen::Mean(testUnsorted), 7);
+    EXPECT_DOUBLE_EQ(miopen::Mean(testOdd), 12.16666666666667);
+    EXPECT_DOUBLE_EQ(miopen::Mean(testEven), 13.0);
+    EXPECT_DOUBLE_EQ(miopen::Mean(testSingle), 1);
+    EXPECT_THROW(miopen::Mean(testEmpty), miopen::Exception);
+}
+
 TEST(CPU_UnitTestModifiedZ_NONE, TestMedian)
 {
     std::vector<double> testSorted     = {1, 2, 3, 4, 5, 6, 7};
@@ -37,12 +56,12 @@ TEST(CPU_UnitTestModifiedZ_NONE, TestMedian)
     std::vector<double> testSingle     = {1};
     std::vector<double> testEmpty      = {};
 
-    EXPECT_EQ(miopen::Median(testSorted), 4);
-    EXPECT_EQ(miopen::Median(testDuplicates), 1);
-    EXPECT_EQ(miopen::Median(testUnsorted), 7);
-    EXPECT_EQ(miopen::Median(testOdd), 12.5);
-    EXPECT_EQ(miopen::Median(testEven), 13.0);
-    EXPECT_EQ(miopen::Median(testSingle), 1);
+    EXPECT_DOUBLE_EQ(miopen::Median(testSorted), 4);
+    EXPECT_DOUBLE_EQ(miopen::Median(testDuplicates), 1);
+    EXPECT_DOUBLE_EQ(miopen::Median(testUnsorted), 7);
+    EXPECT_DOUBLE_EQ(miopen::Median(testOdd), 12.5);
+    EXPECT_DOUBLE_EQ(miopen::Median(testEven), 13.0);
+    EXPECT_DOUBLE_EQ(miopen::Median(testSingle), 1);
     EXPECT_THROW(miopen::Median(testEmpty), miopen::Exception);
 }
 
@@ -54,10 +73,10 @@ TEST(CPU_UnitTestModifiedZ_NONE, TestMedianOfSortedData)
     std::vector<double> testSingle     = {1};
     std::vector<double> testEmpty      = {};
 
-    EXPECT_EQ(miopen::MedianOfSortedData(testSorted), 4);
-    EXPECT_EQ(miopen::MedianOfSortedData(testDuplicates), 1);
+    EXPECT_DOUBLE_EQ(miopen::MedianOfSortedData(testSorted), 4);
+    EXPECT_DOUBLE_EQ(miopen::MedianOfSortedData(testDuplicates), 1);
     EXPECT_NE(miopen::MedianOfSortedData(testUnsorted), 7);
-    EXPECT_EQ(miopen::MedianOfSortedData(testSingle), 1);
+    EXPECT_DOUBLE_EQ(miopen::MedianOfSortedData(testSingle), 1);
     EXPECT_THROW(miopen::MedianOfSortedData(testEmpty), miopen::Exception);
 }
 
@@ -127,39 +146,40 @@ TEST(CPU_UnitTestModifiedZ_NONE, TestModifiedZScores)
     EXPECT_THROW(miopen::ModifiedZScores(testEmpty), miopen::Exception);
 }
 
-TEST(CPU_UnitTestModifiedZ_NONE, TestRemoveOutliersAndGetMedian)
+TEST(CPU_UnitTestModifiedZ_NONE, TestRemoveHighOutliersAndGetMean)
 {
     std::vector<double> testNoDeviation      = {1, 1, 1};
     std::vector<double> testZeroMAD          = {7, 7, 7, 1000};
     std::vector<double> testDeviationOdd     = {1, 2, 3, 4, 5};
     std::vector<double> testDeviationEven    = {1, 2, 3, 4};
-    std::vector<double> testDeviationRepeats = {1, 2, 2, 3, 4};
-    std::vector<double> testWithOutliers1    = {1, 2, 3, 4, 5, 900, 1000, -100};
-    std::vector<double> testWithOutliers2    = {1, 2, 2, 3, 900, 1000, -100};
+    std::vector<double> testDeviationRepeats = {1, 2, 2, 3, 10};
+    std::vector<double> testWithOutliers1    = {1, 2, 3, 4, 5, 900, 1000};
+    std::vector<double> testWithOutliers2    = {1, 2, 2, 3, 900, 1000};
     std::vector<double> testWithOutliers3    = {
-        1, 2, 2, 3, 900, 1000, 1000, 1105, 1106, 1107, 1108, -100};
+        1, 2, 2, 3, 900, 1000, 1000, 1105, 1106, 1107, 1108, 100000};
     std::vector<double> testSingle = {1};
     std::vector<double> testEmpty  = {};
 
-    double median1 = miopen::RemoveOutliersAndGetMedian(testNoDeviation, 1.0);
-    double median2 = miopen::RemoveOutliersAndGetMedian(testZeroMAD, 1.0);
-    double median3 = miopen::RemoveOutliersAndGetMedian(testDeviationOdd, 1.0);
-    double median4 = miopen::RemoveOutliersAndGetMedian(testDeviationEven, 1.0);
-    double median5 = miopen::RemoveOutliersAndGetMedian(testDeviationRepeats, 1.0);
-    double median6 = miopen::RemoveOutliersAndGetMedian(testWithOutliers1, 1.0);
-    double median7 = miopen::RemoveOutliersAndGetMedian(testWithOutliers2, 1.0);
-    double median8 = miopen::RemoveOutliersAndGetMedian(testWithOutliers3, 1.0);
-    double median9 = miopen::RemoveOutliersAndGetMedian(testSingle, 1.0);
+    double mean1 = miopen::RemoveHighOutliersAndGetMean(testNoDeviation, 1.0);
+    double mean2 = miopen::RemoveHighOutliersAndGetMean(testZeroMAD, 1.0);
+    double mean3 = miopen::RemoveHighOutliersAndGetMean(testDeviationOdd, 1.0);
+    double mean4 = miopen::RemoveHighOutliersAndGetMean(testDeviationEven, 1.0);
+    double mean5 = miopen::RemoveHighOutliersAndGetMean(testDeviationRepeats, 1.0);
+    double mean6 = miopen::RemoveHighOutliersAndGetMean(testWithOutliers1, 1.0);
+    double mean7 = miopen::RemoveHighOutliersAndGetMean(testWithOutliers2, 1.0);
+    double mean8 = miopen::RemoveHighOutliersAndGetMean(testWithOutliers3, 1.0);
+    double mean9 = miopen::RemoveHighOutliersAndGetMean(testSingle, 1.0);
 
-    EXPECT_EQ(median1, 1);
-    EXPECT_EQ(median2, 7);
-    EXPECT_EQ(median3, 3);
-    EXPECT_EQ(median4, 2.5);
-    EXPECT_EQ(median5, 2);
-    EXPECT_EQ(median6, 3);
-    EXPECT_EQ(median7, 2);
-    EXPECT_EQ(median8, 1105);
-    EXPECT_EQ(median9, 1);
-    EXPECT_THROW(miopen::RemoveOutliersAndGetMedian(testEmpty, 1.0), miopen::Exception);
-    EXPECT_THROW(miopen::RemoveOutliersAndGetMedian(testDeviationRepeats, -1.0), miopen::Exception);
+    EXPECT_DOUBLE_EQ(mean1, 1);
+    EXPECT_DOUBLE_EQ(mean2, 255.25);
+    EXPECT_DOUBLE_EQ(mean3, 2.5);
+    EXPECT_DOUBLE_EQ(mean4, 2);
+    EXPECT_DOUBLE_EQ(mean5, 2);
+    EXPECT_DOUBLE_EQ(mean6, 3);
+    EXPECT_DOUBLE_EQ(mean7, 2);
+    EXPECT_DOUBLE_EQ(mean8, 666.72727272727275);
+    EXPECT_DOUBLE_EQ(mean9, 1);
+    EXPECT_THROW(miopen::RemoveHighOutliersAndGetMean(testEmpty, 1.0), miopen::Exception);
+    EXPECT_THROW(miopen::RemoveHighOutliersAndGetMean(testDeviationRepeats, -1.0),
+                 miopen::Exception);
 }

--- a/test/gtest/unit_modified_z.cpp
+++ b/test/gtest/unit_modified_z.cpp
@@ -1,0 +1,165 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (c) 2024 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <miopen/utility/modified_z.hpp>
+#include <gtest/gtest.h>
+
+TEST(CPU_UnitTestModifiedZ_NONE, TestMedian)
+{
+    std::vector<double> testSorted     = {1, 2, 3, 4, 5, 6, 7};
+    std::vector<double> testDuplicates = {1, 1, 1};
+    std::vector<double> testUnsorted   = {5, 9, 11, 7, 3};
+    std::vector<double> testOdd        = {13.5, 10.5, 12.5};
+    std::vector<double> testEven       = {13.5, 10.5, 12.5, 15.5};
+    std::vector<double> testSingle     = {1};
+    std::vector<double> testEmpty      = {};
+
+    EXPECT_EQ(miopen::Median(testSorted), 4);
+    EXPECT_EQ(miopen::Median(testDuplicates), 1);
+    EXPECT_EQ(miopen::Median(testUnsorted), 7);
+    EXPECT_EQ(miopen::Median(testOdd), 12.5);
+    EXPECT_EQ(miopen::Median(testEven), 13.0);
+    EXPECT_EQ(miopen::Median(testSingle), 1);
+    EXPECT_THROW(miopen::Median(testEmpty), miopen::Exception);
+}
+
+TEST(CPU_UnitTestModifiedZ_NONE, TestMedianOfSortedData)
+{
+    std::vector<double> testSorted     = {1, 2, 3, 4, 5, 6, 7};
+    std::vector<double> testDuplicates = {1, 1, 1};
+    std::vector<double> testUnsorted   = {5, 9, 11, 7, 3};
+    std::vector<double> testSingle     = {1};
+    std::vector<double> testEmpty      = {};
+
+    EXPECT_EQ(miopen::MedianOfSortedData(testSorted), 4);
+    EXPECT_EQ(miopen::MedianOfSortedData(testDuplicates), 1);
+    EXPECT_NE(miopen::MedianOfSortedData(testUnsorted), 7);
+    EXPECT_EQ(miopen::MedianOfSortedData(testSingle), 1);
+    EXPECT_THROW(miopen::MedianOfSortedData(testEmpty), miopen::Exception);
+}
+
+TEST(CPU_UnitTestModifiedZ_NONE, TestMedianAbsoluteDeviation)
+{
+    std::vector<double> testNoDeviation      = {1, 1, 1};
+    std::vector<double> testZeroMAD          = {7, 7, 7, 1000};
+    std::vector<double> testDeviationOdd     = {1, 2, 3, 4, 5};
+    std::vector<double> testDeviationEven    = {1, 2, 3, 4};
+    std::vector<double> testDeviationRepeats = {1, 2, 2, 3, 4};
+    std::vector<double> testSingle           = {1};
+    std::vector<double> testEmpty            = {};
+
+    std::vector<double> mad1 = miopen::MedianAbsoluteDeviation(testNoDeviation);
+    std::vector<double> mad2 = miopen::MedianAbsoluteDeviation(testZeroMAD);
+    std::vector<double> mad3 = miopen::MedianAbsoluteDeviation(testDeviationOdd);
+    std::vector<double> mad4 = miopen::MedianAbsoluteDeviation(testDeviationEven);
+    std::vector<double> mad5 = miopen::MedianAbsoluteDeviation(testDeviationRepeats);
+    std::vector<double> mad6 = miopen::MedianAbsoluteDeviation(testSingle);
+
+    std::vector<double> expected1 = {0, 0, 0};
+    std::vector<double> expected2 = {0, 0, 0, 993};
+    std::vector<double> expected3 = {2, 1, 0, 1, 2};
+    std::vector<double> expected4 = {1.5, 0.5, 0.5, 1.5};
+    std::vector<double> expected5 = {1, 0, 0, 1, 2};
+    std::vector<double> expected6 = {0};
+
+    EXPECT_EQ(mad1, expected1);
+    EXPECT_EQ(mad2, expected2);
+    EXPECT_EQ(mad3, expected3);
+    EXPECT_EQ(mad4, expected4);
+    EXPECT_EQ(mad5, expected5);
+    EXPECT_EQ(mad6, expected6);
+    EXPECT_THROW(miopen::MedianAbsoluteDeviation(testEmpty), miopen::Exception);
+}
+
+TEST(CPU_UnitTestModifiedZ_NONE, TestModifiedZScores)
+{
+    std::vector<double> testNoDeviation      = {1, 1, 1};
+    std::vector<double> testZeroMAD          = {7, 7, 7, 1000};
+    std::vector<double> testDeviationOdd     = {1, 2, 3, 4, 5};
+    std::vector<double> testDeviationEven    = {1, 2, 3, 4};
+    std::vector<double> testDeviationRepeats = {1, 2, 2, 3, 4};
+    std::vector<double> testSingle           = {1};
+    std::vector<double> testEmpty            = {};
+
+    std::vector<double> modZScores1 = miopen::ModifiedZScores(testNoDeviation);
+    std::vector<double> modZScores2 = miopen::ModifiedZScores(testZeroMAD);
+    std::vector<double> modZScores3 = miopen::ModifiedZScores(testDeviationOdd);
+    std::vector<double> modZScores4 = miopen::ModifiedZScores(testDeviationEven);
+    std::vector<double> modZScores5 = miopen::ModifiedZScores(testDeviationRepeats);
+    std::vector<double> modZScores6 = miopen::ModifiedZScores(testSingle);
+
+    std::vector<double> expected1 = {0, 0, 0};
+    std::vector<double> expected2 = {0, 0, 0, 0};
+    std::vector<double> expected3 = {0.6745 * -2, 0.6745 * -1, 0, 0.6745, 0.6745 * 2};
+    std::vector<double> expected4 = {0.6745 * -1.5, 0.6745 * -0.5, 0.6745 * 0.5, 0.6745 * 1.5};
+    std::vector<double> expected5 = {0.6745 * -1, 0, 0, 0.6745 * 1, 0.6745 * 2};
+    std::vector<double> expected6 = {0};
+
+    EXPECT_EQ(modZScores1, expected1);
+    EXPECT_EQ(modZScores2, expected2);
+    EXPECT_EQ(modZScores3, expected3);
+    EXPECT_EQ(modZScores4, expected4);
+    EXPECT_EQ(modZScores5, expected5);
+    EXPECT_EQ(modZScores6, expected6);
+    EXPECT_THROW(miopen::ModifiedZScores(testEmpty), miopen::Exception);
+}
+
+TEST(CPU_UnitTestModifiedZ_NONE, TestRemoveOutliersAndGetMedian)
+{
+    std::vector<double> testNoDeviation      = {1, 1, 1};
+    std::vector<double> testZeroMAD          = {7, 7, 7, 1000};
+    std::vector<double> testDeviationOdd     = {1, 2, 3, 4, 5};
+    std::vector<double> testDeviationEven    = {1, 2, 3, 4};
+    std::vector<double> testDeviationRepeats = {1, 2, 2, 3, 4};
+    std::vector<double> testWithOutliers1    = {1, 2, 3, 4, 5, 900, 1000, -100};
+    std::vector<double> testWithOutliers2    = {1, 2, 2, 3, 900, 1000, -100};
+    std::vector<double> testWithOutliers3    = {
+        1, 2, 2, 3, 900, 1000, 1000, 1105, 1106, 1107, 1108, -100};
+    std::vector<double> testSingle = {1};
+    std::vector<double> testEmpty  = {};
+
+    double median1 = miopen::RemoveOutliersAndGetMedian(testNoDeviation, 1.0);
+    double median2 = miopen::RemoveOutliersAndGetMedian(testZeroMAD, 1.0);
+    double median3 = miopen::RemoveOutliersAndGetMedian(testDeviationOdd, 1.0);
+    double median4 = miopen::RemoveOutliersAndGetMedian(testDeviationEven, 1.0);
+    double median5 = miopen::RemoveOutliersAndGetMedian(testDeviationRepeats, 1.0);
+    double median6 = miopen::RemoveOutliersAndGetMedian(testWithOutliers1, 1.0);
+    double median7 = miopen::RemoveOutliersAndGetMedian(testWithOutliers2, 1.0);
+    double median8 = miopen::RemoveOutliersAndGetMedian(testWithOutliers3, 1.0);
+    double median9 = miopen::RemoveOutliersAndGetMedian(testSingle, 1.0);
+
+    EXPECT_EQ(median1, 1);
+    EXPECT_EQ(median2, 7);
+    EXPECT_EQ(median3, 3);
+    EXPECT_EQ(median4, 2.5);
+    EXPECT_EQ(median5, 2);
+    EXPECT_EQ(median6, 3);
+    EXPECT_EQ(median7, 2);
+    EXPECT_EQ(median8, 1105);
+    EXPECT_EQ(median9, 1);
+    EXPECT_THROW(miopen::RemoveOutliersAndGetMedian(testEmpty, 1.0), miopen::Exception);
+    EXPECT_THROW(miopen::RemoveOutliersAndGetMedian(testDeviationRepeats, -1.0), miopen::Exception);
+}


### PR DESCRIPTION
These changes are intended to help make solution and instance selection more consistent.

Here are the issues I was seeing:
- There was no warm-up run for the invoker during instance tuning, and as a result, the first sample could have a much higher runtime than the average. 
- Using averages for comparing results caused outliers to have a big impact on the instance selection, and solver selection.

To resolve these issues:

- I have added a warm-up run to the instance tuning. This will ensure we measure all instances in a similar way.
- I have swapped from using averages to instead use the median value with outliers removed via modified Z.