### PR TITLE
run single test case for bn

### DIFF
--- a/test/gtest/CMakeLists.txt
+++ b/test/gtest/CMakeLists.txt
@@ -105,7 +105,12 @@ function(add_gtest TEST_NAME TEST_CPP)
     # Enable CMake to discover the test binary
     # Note: Due to the following cmake issue with gtest_discover_tests https://gitlab.kitware.com/cmake/cmake/-/issues/17812 you cannot pass PROPERTIES as a list.
     #       To work around this limitation, we are passing the environment variables in the format ENVIRONMENT;value1=${value1};ENVIRONMENT;value2=${value2}.
-    gtest_discover_tests(${TEST_NAME} DISCOVERY_TIMEOUT 300 DISCOVERY_MODE PRE_TEST WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/${DATABASE_INSTALL_DIR} PROPERTIES ${TEST_ENVIRONMENT_VARIABLES} TEST_FILTER "${MIOPEN_GTEST_FILTER}")
+    # bn tests are run sequentially since running tests in parallel was causing large tensor case fail with insufficient memory error.
+    if("${TEST_NAME}" STREQUAL "test_bn_bwd" OR "${TEST_NAME}" STREQUAL "test_bn_fwd_train" OR "${TEST_NAME}" STREQUAL "test_bn_infer") 
+      gtest_discover_tests(${TEST_NAME} DISCOVERY_TIMEOUT 300 DISCOVERY_MODE PRE_TEST WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/${DATABASE_INSTALL_DIR} PROPERTIES RUN_SERIAL TRUE ${TEST_ENVIRONMENT_VARIABLES} TEST_FILTER "${MIOPEN_GTEST_FILTER}")
+    else()
+      gtest_discover_tests(${TEST_NAME} DISCOVERY_TIMEOUT 300 DISCOVERY_MODE PRE_TEST WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/${DATABASE_INSTALL_DIR} PROPERTIES ${TEST_ENVIRONMENT_VARIABLES} TEST_FILTER "${MIOPEN_GTEST_FILTER}")
+    endif()
   endif()
   target_link_libraries(${TEST_NAME} BZip2::BZip2)
   if(WIN32)


### PR DESCRIPTION
Tests cases :[  [(NCHW, spatial), (NHWC, spatial), (NCHW, per active), (NHWC, per active)]](https://github.com/ROCm/MIOpen/blob/develop/test/gtest/bn_fwd_train.cpp#L163-L165) for batch norm were running in parallel. Running tests in parallel was causing large tensor case fail with insufficient memory error. This PR now make those batch norm tests run sequentially from cmake's `gtest_discover_tests`. 