### PR TITLE
Rollback CK hash to resolve build issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -114,7 +114,7 @@ DEBIAN_FRONTEND=noninteractive apt-get purge -y --allow-unauthenticated \
     miopen-hip
 
 # TODO: it should be able to automatically get commit hash from requirements.txt
-ARG CK_COMMIT=e9ee56868191830d9169bc1596ae1cbc2ee2cf62
+ARG CK_COMMIT=a8c5bd9b9ad950c3e742877e01cb784da91664e3
 RUN wget -O ck.tar.gz https://www.github.com/ROCm/composable_kernel/archive/${CK_COMMIT}.tar.gz && \
     tar zxvf ck.tar.gz &&\
     cd composable_kernel-${CK_COMMIT} && \

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ nlohmann/json@v3.11.2 -DJSON_MultipleHeaders=ON -DJSON_BuildTests=Off
 ROCm/FunctionalPlus@v0.2.18-p0
 ROCm/eigen@3.4.0
 ROCm/frugally-deep@9683d557eb672ee2304f80f6682c51242d748a50
-ROCm/composable_kernel@e9ee56868191830d9169bc1596ae1cbc2ee2cf62 -DCMAKE_BUILD_TYPE=Release
+ROCm/composable_kernel@a8c5bd9b9ad950c3e742877e01cb784da91664e3 -DCMAKE_BUILD_TYPE=Release
 google/googletest@v1.14.0


### PR DESCRIPTION
Rolling back CK hash change to previous to prevent memory issues during compilation