### PR TITLE
Cherry-pick to release/rocm-rel-6.4: Remove phantom example text from API documentation (#3556)

### DIFF
--- a/include/miopen/miopen.h
+++ b/include/miopen/miopen.h
@@ -6092,14 +6092,14 @@ MIOPEN_EXPORT miopenStatus_t miopenCreateBatchnormProblem(miopenProblem_t* probl
  * problems are disposed in the process, so the problem2 should be destroyed manually if it is not
  * needed anymore.
  * @details
- * miopenProblem_t problem = makeSomeProblem1();\n 
- * miopenProblem_t problem2 = makeSomeProblem2();\n 
- * miopenProblem_t problem3 = makeSomeProblem3();\n 
- * miopenFuseProblems(problem, problem2);\n 
- * // Now problem contains {problem1, problem2}\n 
- * miopenFuseProblems(problem, problem3);\n 
- * // Now problem contains {problem1, problem2, problem3}\n 
- * miopenDestroyProblem(problem2);\n 
+ * miopenProblem_t problem = makeSomeProblem1();\n
+ * miopenProblem_t problem2 = makeSomeProblem2();\n
+ * miopenProblem_t problem3 = makeSomeProblem3();\n
+ * miopenFuseProblems(problem, problem2);\n
+ * // Now problem contains {problem1, problem2}\n
+ * miopenFuseProblems(problem, problem3);\n
+ * // Now problem contains {problem1, problem2, problem3}\n
+ * miopenDestroyProblem(problem2);\n
  * miopenDestroyProblem(problem3);
  * @note As of now there is no way to actually get any solution for this kind of problem.
  *

--- a/include/miopen/miopen.h
+++ b/include/miopen/miopen.h
@@ -6091,17 +6091,17 @@ MIOPEN_EXPORT miopenStatus_t miopenCreateBatchnormProblem(miopenProblem_t* probl
 /*! @brief Fuse two problems into a single one. Problems can be either regular, or fused. No
  * problems are disposed in the process, so the problem2 should be destroyed manually if it is not
  * needed anymore.
- * @example
- * miopenProblem_t problem = makeSomeProblem1();
- * miopenProblem_t problem2 = makeSomeProblem2();
- * miopenProblem_t problem3 = makeSomeProblem3();
- * miopenFuseProblems(problem, problem2);
- * // Now problem contains {problem1, problem2}
- * miopenFuseProblems(problem, problem3);
- * // Now problem contains {problem1, problem2, problem3}
- * miopenDestroyProblem(problem2);
+ * @details
+ * miopenProblem_t problem = makeSomeProblem1();\n 
+ * miopenProblem_t problem2 = makeSomeProblem2();\n 
+ * miopenProblem_t problem3 = makeSomeProblem3();\n 
+ * miopenFuseProblems(problem, problem2);\n 
+ * // Now problem contains {problem1, problem2}\n 
+ * miopenFuseProblems(problem, problem3);\n 
+ * // Now problem contains {problem1, problem2, problem3}\n 
+ * miopenDestroyProblem(problem2);\n 
  * miopenDestroyProblem(problem3);
- * @note As of now there is no way to actually get any solution for this kind of problems.
+ * @note As of now there is no way to actually get any solution for this kind of problem.
  *
  * @param problem1     The first problem to fuse. The result would be stored here.
  * @param problem2     The second problem to fuse.


### PR DESCRIPTION
(cherry picked from commit 677619337c9fcecbd78add30addce24b7bce184c)

This fixes the issues where irrelevant example links leading to the same miopenFuseProblems description. The root cause of the problem is a bug with the "@example" keyword, which caused the duplicate entries. It converted it to "https://github.com/details" to treat it as body text in the API. The text still displays as part of the miopenFuseProblems documentation, but no longer repeats elsewhere.