### PR TITLE
[GTest] Disable DBSync test for gfx11 and gfx12

### DIFF
--- a/test/gtest/db_sync.cpp
+++ b/test/gtest/db_sync.cpp
@@ -527,13 +527,14 @@ void SetupPaths(fs::path& fdb_file_path,
 
 TEST(CPU_DBSync_NONE, KDBTargetID)
 {
-    // Skip this test for gfx11 and gfx12 to avoid test failure (we don't have databases for those devices yet)
+    // Skip this test for gfx11 and gfx12 to avoid test failure (we don't have databases for those
+    // devices yet)
     const auto& handle = get_handle();
     if(miopen::StartsWith(handle.GetDeviceName(), "gfx11") ||
-        miopen::StartsWith(handle.GetDeviceName(), "gfx12"))
-        {
-            GTEST_SKIP();
-        }
+       miopen::StartsWith(handle.GetDeviceName(), "gfx12"))
+    {
+        GTEST_SKIP();
+    }
 
     fs::path fdb_file_path, pdb_file_path, kdb_file_path;
 #if WORKAROUND_ISSUE_2492

--- a/test/gtest/db_sync.cpp
+++ b/test/gtest/db_sync.cpp
@@ -527,6 +527,14 @@ void SetupPaths(fs::path& fdb_file_path,
 
 TEST(CPU_DBSync_NONE, KDBTargetID)
 {
+    // Skip this test for gfx11 and gfx12 to avoid test failure (we don't have databases for those devices yet)
+    const auto& handle = get_handle();
+    if(miopen::StartsWith(handle.GetDeviceName(), "gfx11") ||
+        miopen::StartsWith(handle.GetDeviceName(), "gfx12"))
+        {
+            GTEST_SKIP();
+        }
+
     fs::path fdb_file_path, pdb_file_path, kdb_file_path;
 #if WORKAROUND_ISSUE_2492
     SetEnvironmentVariable("MIOPEN_DEBUG_WORKAROUND_ISSUE_2492", "0");


### PR DESCRIPTION
We dont have databases for Gfx11xx and Gfx12xx targets, so we have to skip DBSync test to avoid failures.
It was discussed with Chris who confirmed that we are not going to create those databases for now.