### PR TITLE
[WORKAROUND] Disable solvers with abandoned buffer intrinsics in HIP 6.4

### DIFF
--- a/src/include/miopen/solver/implicitgemm_util.hpp
+++ b/src/include/miopen/solver/implicitgemm_util.hpp
@@ -53,6 +53,9 @@ MIOPEN_DECLARE_ENV_VAR_BOOL(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_BLOCK_SYNC_LDS_WITHO
 #define WORKAROUND_MIOPEN_ISSUE_557 1
 #define WORKAROUND_SWDEV_413051 1
 
+// LLVM buffer intrinsics llvm.amdgcn.buffer.* have been removed in HIP 6.4
+#define WORKAROUND_SWDEV_498660 (HIP_PACKAGE_VERSION_FLAT >= 6004000000)
+
 namespace miopen {
 
 namespace solver {

--- a/src/solver/conv/conv_hip_implicit_gemm_bwd_v1r1.cpp
+++ b/src/solver/conv/conv_hip_implicit_gemm_bwd_v1r1.cpp
@@ -637,6 +637,10 @@ size_t ConvHipImplicitGemmBwdDataV1R1::GetWorkspaceSize(const ExecutionContext&,
 bool ConvHipImplicitGemmBwdDataV1R1::IsApplicable(const ExecutionContext& ctx,
                                                   const ProblemDescription& problem) const
 {
+#if WORKAROUND_SWDEV_498660
+    if(!env::enabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_BWD_V1R1))
+        return false;
+#endif
     if(env::disabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_BWD_V1R1))
         return false;
     if(ThisSolverIsDeprecatedStatic::IsDisabled(ctx))

--- a/src/solver/conv/conv_hip_implicit_gemm_bwd_v1r1_xdlops.cpp
+++ b/src/solver/conv/conv_hip_implicit_gemm_bwd_v1r1_xdlops.cpp
@@ -759,7 +759,7 @@ ConvHipImplicitGemmBwdDataV1R1Xdlops::GetWorkspaceSize(const ExecutionContext&,
 bool ConvHipImplicitGemmBwdDataV1R1Xdlops::IsApplicable(const ExecutionContext& ctx,
                                                         const ProblemDescription& problem) const
 {
-#if WORKAROUND_SWDEV_251757
+#if WORKAROUND_SWDEV_251757 || WORKAROUND_SWDEV_498660
     if(!env::enabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_BWD_V1R1_XDLOPS))
         return false;
 #endif

--- a/src/solver/conv/conv_hip_implicit_gemm_bwd_v4r1.cpp
+++ b/src/solver/conv/conv_hip_implicit_gemm_bwd_v4r1.cpp
@@ -732,7 +732,7 @@ ConvHipImplicitGemmBwdDataV4R1::CalculateGemmSize(const ProblemDescription& prob
 bool ConvHipImplicitGemmBwdDataV4R1::IsApplicable(const ExecutionContext& ctx,
                                                   const ProblemDescription& problem) const
 {
-#if WORKAROUND_SWDEV_229277_227616_229195
+#if WORKAROUND_SWDEV_229277_227616_229195 || WORKAROUND_SWDEV_498660
     if(!env::enabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_BWD_V4R1))
         return false;
 #endif

--- a/src/solver/conv/conv_hip_implicit_gemm_bwd_v4r1_xdlops.cpp
+++ b/src/solver/conv/conv_hip_implicit_gemm_bwd_v4r1_xdlops.cpp
@@ -829,6 +829,10 @@ bool ConvHipImplicitGemmBwdDataV4R1Xdlops::IsApplicable(const ExecutionContext& 
             return false;
     }
 #endif
+#if WORKAROUND_SWDEV_498660
+    if(!env::enabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_BWD_V4R1_XDLOPS))
+        return false;
+#endif
     if(env::disabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_BWD_V4R1_XDLOPS))
         return false;
     if(ThisSolverIsDeprecatedStatic::IsDisabled(ctx))

--- a/src/solver/conv/conv_hip_implicit_gemm_fwd_v4r1.cpp
+++ b/src/solver/conv/conv_hip_implicit_gemm_fwd_v4r1.cpp
@@ -47,6 +47,10 @@ using ProblemDescription = miopen::conv::ProblemDescription;
 bool ConvHipImplicitGemmV4R1Fwd::IsApplicable(const ExecutionContext& ctx,
                                               const ProblemDescription& problem) const
 {
+#if WORKAROUND_SWDEV_498660
+    if(!env::enabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_FWD_V4R1))
+        return false;
+#endif
     if(env::disabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_FWD_V4R1))
         return false;
     if(ThisSolverIsDeprecatedStatic::IsDisabled(ctx))
@@ -97,6 +101,10 @@ bool ConvHipImplicitGemmV4R1Fwd::IsApplicable(const ExecutionContext& ctx,
 bool ConvHipImplicitGemmV4R1WrW::IsApplicable(const ExecutionContext& ctx,
                                               const ProblemDescription& problem) const
 {
+#if WORKAROUND_SWDEV_498660
+    if(!env::enabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_WRW_V4R1))
+        return false;
+#endif
     if(env::disabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_WRW_V4R1))
         return false;
     if(ThisSolverIsDeprecatedStatic::IsDisabled(ctx))

--- a/src/solver/conv/conv_hip_implicit_gemm_fwd_v4r4.cpp
+++ b/src/solver/conv/conv_hip_implicit_gemm_fwd_v4r4.cpp
@@ -579,6 +579,10 @@ ConvHipImplicitGemmV4R4Fwd::CalculateGemmSize(const ProblemDescription& problem)
 bool ConvHipImplicitGemmV4R4Fwd::IsApplicable(const ExecutionContext& ctx,
                                               const ProblemDescription& problem) const
 {
+#if WORKAROUND_SWDEV_498660
+    if(!env::enabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_FWD_V4R4))
+        return false;
+#endif
     if(env::disabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_FWD_V4R4))
         return false;
     if(ThisSolverIsDeprecatedStatic::IsDisabled(ctx))

--- a/src/solver/conv/conv_hip_implicit_gemm_fwd_v4r4_xdlops.cpp
+++ b/src/solver/conv/conv_hip_implicit_gemm_fwd_v4r4_xdlops.cpp
@@ -973,6 +973,10 @@ ConvSolution ConvHipImplicitGemmForwardV4R4Xdlops::GetSolution(
 bool ConvHipImplicitGemmForwardV4R4Xdlops::IsApplicable(const ExecutionContext& ctx,
                                                         const ProblemDescription& problem) const
 {
+#if WORKAROUND_SWDEV_498660
+    if(!env::enabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_FWD_V4R4_XDLOPS))
+        return false;
+#endif
     if(env::disabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_FWD_V4R4_XDLOPS))
         return false;
 

--- a/src/solver/conv/conv_hip_implicit_gemm_fwd_v4r4_xdlops_padded_gemm.cpp
+++ b/src/solver/conv/conv_hip_implicit_gemm_fwd_v4r4_xdlops_padded_gemm.cpp
@@ -1032,6 +1032,10 @@ ConvSolution ConvHipImplicitGemmForwardV4R4Xdlops_Padded_Gemm::GetSolution(
 bool ConvHipImplicitGemmForwardV4R4Xdlops_Padded_Gemm::IsApplicable(
     const ExecutionContext& ctx, const ProblemDescription& problem) const
 {
+#if WORKAROUND_SWDEV_498660
+    if(!env::enabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_FWD_V4R4_PADDED_GEMM_XDLOPS))
+        return false;
+#endif
     if(env::disabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_FWD_V4R4_PADDED_GEMM_XDLOPS))
         return false;
 

--- a/src/solver/conv/conv_hip_implicit_gemm_fwd_v4r5_xdlops.cpp
+++ b/src/solver/conv/conv_hip_implicit_gemm_fwd_v4r5_xdlops.cpp
@@ -1003,6 +1003,10 @@ ConvSolution ConvHipImplicitGemmForwardV4R5Xdlops::GetSolution(
 bool ConvHipImplicitGemmForwardV4R5Xdlops::IsApplicable(const ExecutionContext& ctx,
                                                         const ProblemDescription& problem) const
 {
+#if WORKAROUND_SWDEV_498660
+    if(!env::enabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_FWD_V4R5_XDLOPS))
+        return false;
+#endif
     if(env::disabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_FWD_V4R5_XDLOPS))
         return false;
 

--- a/src/solver/conv/conv_hip_implicit_gemm_wrw_v4r4.cpp
+++ b/src/solver/conv/conv_hip_implicit_gemm_wrw_v4r4.cpp
@@ -583,6 +583,10 @@ ConvHipImplicitGemmV4R4WrW::CalculateGemmSize(const ProblemDescription& problem)
 bool ConvHipImplicitGemmV4R4WrW::IsApplicable(const ExecutionContext& ctx,
                                               const ProblemDescription& problem) const
 {
+#if WORKAROUND_SWDEV_498660
+    if(!env::enabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_WRW_V4R4))
+        return false;
+#endif
     if(env::disabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_WRW_V4R4))
         return false;
     if(ThisSolverIsDeprecatedStatic::IsDisabled(ctx))

--- a/src/solver/conv/conv_hip_implicit_gemm_wrw_v4r4_xdlops.cpp
+++ b/src/solver/conv/conv_hip_implicit_gemm_wrw_v4r4_xdlops.cpp
@@ -1044,6 +1044,10 @@ ConvSolution ConvHipImplicitGemmWrwV4R4Xdlops::GetSolution(
 bool ConvHipImplicitGemmWrwV4R4Xdlops::IsApplicable(const ExecutionContext& ctx,
                                                     const ProblemDescription& problem) const
 {
+#if WORKAROUND_SWDEV_498660
+    if(!env::enabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_WRW_V4R4_XDLOPS))
+        return false;
+#endif
     if(env::disabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_WRW_V4R4_XDLOPS))
         return false;
 

--- a/src/solver/conv/conv_hip_implicit_gemm_wrw_v4r4_xdlops_padded_gemm.cpp
+++ b/src/solver/conv/conv_hip_implicit_gemm_wrw_v4r4_xdlops_padded_gemm.cpp
@@ -1107,6 +1107,10 @@ ConvSolution ConvHipImplicitGemmWrwV4R4Xdlops_Padded_Gemm::GetSolution(
 bool ConvHipImplicitGemmWrwV4R4Xdlops_Padded_Gemm::IsApplicable(
     const ExecutionContext& ctx, const ProblemDescription& problem) const
 {
+#if WORKAROUND_SWDEV_498660
+    if(!env::enabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_WRW_V4R4_PADDED_GEMM_XDLOPS))
+        return false;
+#endif
     if(env::disabled(MIOPEN_DEBUG_CONV_IMPLICIT_GEMM_HIP_WRW_V4R4_PADDED_GEMM_XDLOPS))
         return false;
 


### PR DESCRIPTION
llvm.amdgcn.buffer.* intrinsics have been abandoned in HIP 6.4

A workaround has been created to disable the solvers which use these intrinsics

The definitions for the intrinsics are located in `src/kernels/static_composable_kernel/include/utility/static_kernel_amd_buffer_addressing.hpp` and wrapped in a template `SetData::Run` in `src/kernels/static_composable_kernel/include/utility/static_kernel_in_memory_operation.hpp` which is included in most of the sources in `src/kernels/static_composable_kernel`

`SetData::Run` is called from the following sources:
```
src/kernels/static_composable_kernel/src/kernel_wrapper/static_kernel_gridwise_convolution_backward_data_implicit_gemm_v1r1_ncdhw_kczyx_nkdhw.cpp
src/kernels/static_composable_kernel/src/kernel_wrapper/static_kernel_gridwise_convolution_backward_data_implicit_gemm_v1r1_nchw_kcyx_nkhw.cpp
src/kernels/static_composable_kernel/src/kernel_wrapper/static_kernel_gridwise_convolution_backward_data_implicit_gemm_v1r1_xdlops_nchw_kcyx_nkhw.cpp
src/kernels/static_composable_kernel/src/kernel_wrapper/static_kernel_gridwise_convolution_backward_data_implicit_gemm_v4r1_ncdhw_kczyx_nkdhw.cpp
src/kernels/static_composable_kernel/src/kernel_wrapper/static_kernel_gridwise_convolution_backward_data_implicit_gemm_v4r1_nchw_kcyx_nkhw.cpp
src/kernels/static_composable_kernel/src/kernel_wrapper/static_kernel_gridwise_convolution_backward_data_implicit_gemm_v4r1_xdlops_nchw_kcyx_nkhw.cpp
src/kernels/static_composable_kernel/src/kernel_wrapper/static_kernel_gridwise_convolution_backward_weights_implicit_gemm_v4r4_ncdhw_kczyx_nkdhw.cpp
src/kernels/static_composable_kernel/src/kernel_wrapper/static_kernel_gridwise_convolution_backward_weights_implicit_gemm_v4r4_nchw_kcyx_nkhw.cpp
src/kernels/static_composable_kernel/src/kernel_wrapper/static_kernel_gridwise_convolution_backward_weights_implicit_gemm_v4r4_xdlops_nchw_kcyx_nkhw.cpp
src/kernels/static_composable_kernel/src/kernel_wrapper/static_kernel_gridwise_convolution_backward_weights_implicit_gemm_v4r4_xdlops_nchw_kcyx_nkhw_padded_gemm.cpp
src/kernels/static_composable_kernel/src/kernel_wrapper/static_kernel_gridwise_convolution_forward_implicit_gemm_v4r4_xdlops_nchw_kcyx_nkhw.cpp
src/kernels/static_composable_kernel/src/kernel_wrapper/static_kernel_gridwise_convolution_forward_implicit_gemm_v4r4_xdlops_nchw_kcyx_nkhw_padded_gemm.cpp
src/kernels/static_composable_kernel/src/kernel_wrapper/static_kernel_gridwise_convolution_forward_implicit_gemm_v4r5_xdlops_nchw_kcyx_nkhw.cpp
src/kernels/static_composable_kernel/src/kernel_wrapper/static_kernel_gridwise_convolution_implicit_gemm_v4r1_gnchw_gkcyx_gnkhw_lds_double_buffer.cpp
src/kernels/static_composable_kernel/src/kernel_wrapper/static_kernel_gridwise_convolution_implicit_gemm_v4r1_nchw_kcyx_nkhw_lds_double_buffer.cpp
src/kernels/static_composable_kernel/src/kernel_wrapper/static_kernel_gridwise_convolution_implicit_gemm_v4r4_ncdhw_kczyx_nkdhw.cpp
src/kernels/static_composable_kernel/src/kernel_wrapper/static_kernel_gridwise_convolution_implicit_gemm_v4r4_nchw_kcyx_nkhw.cpp
src/kernels/static_composable_kernel/src/kernel_wrapper/static_kernel_gridwise_generic_reduction.cpp
src/kernels/static_composable_kernel/src/kernel_wrapper/static_kernel_gridwise_generic_reduction_first_call.cpp
src/kernels/static_composable_kernel/src/kernel_wrapper/static_kernel_gridwise_generic_reduction_second_call.cpp
```

These sources are passed for the compilation in the following solvers:

```
src/solver/conv/conv_hip_implicit_gemm_bwd_v1r1.cpp
src/solver/conv/conv_hip_implicit_gemm_bwd_v1r1_xdlops.cpp
src/solver/conv/conv_hip_implicit_gemm_bwd_v4r1.cpp
src/solver/conv/conv_hip_implicit_gemm_bwd_v4r1_xdlops.cpp
src/solver/conv/conv_hip_implicit_gemm_fwd_v4r1.cpp
src/solver/conv/conv_hip_implicit_gemm_fwd_v4r4.cpp
src/solver/conv/conv_hip_implicit_gemm_fwd_v4r4_xdlops.cpp
src/solver/conv/conv_hip_implicit_gemm_fwd_v4r4_xdlops_padded_gemm.cpp
src/solver/conv/conv_hip_implicit_gemm_fwd_v4r5_xdlops.cpp
src/solver/conv/conv_hip_implicit_gemm_wrw_v4r4.cpp
src/solver/conv/conv_hip_implicit_gemm_wrw_v4r4_xdlops.cpp
src/solver/conv/conv_hip_implicit_gemm_wrw_v4r4_xdlops_padded_gemm.cpp
```

Affected solver names are:

```
ConvHipImplicitGemmBwdDataV1R1
ConvHipImplicitGemmBwdDataV1R1Xdlops
ConvHipImplicitGemmBwdDataV4R1
ConvHipImplicitGemmBwdDataV4R1Xdlops
ConvHipImplicitGemmV4R1Fwd
ConvHipImplicitGemmV4R1WrW
ConvHipImplicitGemmV4R4Fwd
ConvHipImplicitGemmForwardV4R4Xdlops
ConvHipImplicitGemmForwardV4R4Xdlops_Padded_Gemm
ConvHipImplicitGemmForwardV4R5Xdlops
ConvHipImplicitGemmV4R4WrW
ConvHipImplicitGemmWrwV4R4Xdlops
ConvHipImplicitGemmWrwV4R4Xdlops_Padded_Gemm
```