### PR TITLE
Fix hipRTC compilation issue for float8

### DIFF
--- a/src/include/miopen/datatype.hpp
+++ b/src/include/miopen/datatype.hpp
@@ -66,11 +66,11 @@ inline std::string GetDataType(miopenDataType_t type)
     }
     break;
     case miopenFloat8_fnuz: {
-        type_str = "float8";
+        type_str = "float8_fnuz";
     }
     break;
     case miopenBFloat8_fnuz: {
-        type_str = "bfloat8";
+        type_str = "bfloat8_fnuz";
     }
     break;
     case miopenInt64: {

--- a/src/kernels/gpu_reference_kernel/fp8_kern_types.h
+++ b/src/kernels/gpu_reference_kernel/fp8_kern_types.h
@@ -41,15 +41,15 @@
 #endif
 
 #ifndef INPUT_CAST_TYPE
-#define INPUT_CAST_TYPE float8
+#define INPUT_CAST_TYPE float8_fnuz
 #endif
 
 #ifndef WEIGHTS_CAST_TYPE
-#define WEIGHTS_CAST_TYPE float8
+#define WEIGHTS_CAST_TYPE float8_fnuz
 #endif
 
 #ifndef OUTPUT_CAST_TYPE
-#define OUTPUT_CAST_TYPE float8
+#define OUTPUT_CAST_TYPE float8_fnuz
 #endif
 
 #ifndef ACCUMULATOR_TYPE


### PR DESCRIPTION
float8 rename is causing hipRTC compilation errors for float8 types