### PR TITLE
MIOpen error tolerance

### DIFF
--- a/driver/bn_driver.hpp
+++ b/driver/bn_driver.hpp
@@ -1460,9 +1460,8 @@ int BatchNormDriver<TInput, Tref, TAcc, TScaleBias, TOut>::VerifyBackward()
     if(!back)
         return miopenStatusSuccess;
 
-    const Tref maxrms =
-        static_cast<Tref>(((sizeof(TInput) == 4) ? RMSTOL_FP32 : RMSTOL_FP16) * 1000);
-    bool anError = false;
+    const Tref maxrms = static_cast<Tref>((sizeof(TInput) == 4) ? RMSTOL_FP32 : RMSTOL_FP16);
+    bool anError      = false;
 
     RunBackwardCPU();
 

--- a/test/verify.hpp
+++ b/test/verify.hpp
@@ -211,23 +211,25 @@ std::size_t mismatch_diff(R1&& r1, R2&& r2, T diff)
             float_equal, diff, std::bind(abs_diff, std::placeholders::_1, std::placeholders::_2)));
 }
 
-template <class R1, class R2>
-double rms_range(R1&& r1, R2&& r2)
+// Reference values are 'ref', observed (measured) values are 'obs'.
+template <class RefType, class ObsType>
+double rms_range(RefType&& ref, ObsType&& obs)
 {
-    std::size_t n = range_distance(r1);
-    if(n == range_distance(r2))
+    std::size_t n = range_distance(ref);
+    if(n == range_distance(obs))
     {
         if(n == 0)
             return 0;
-        double square_difference = range_product(r1, r2, 0.0, sum_fn{}, square_diff);
-        double mag1 = static_cast<double>(*std::max_element(r1.begin(), r1.end(), compare_mag));
-        double mag2 = static_cast<double>(*std::max_element(r2.begin(), r2.end(), compare_mag));
-        double mag =
-            std::max({std::fabs(mag1), std::fabs(mag2), std::numeric_limits<double>::min()});
-        return std::sqrt(square_difference) / (std::sqrt(n) * mag);
+        double square_difference = range_product(ref, obs, 0.0, sum_fn{}, square_diff);
+        double mag1 = static_cast<double>(*std::max_element(ref.begin(), ref.end(), compare_mag));
+        // If reference is all 0, avoid dividing by 0 when normalizing
+        mag1              = (mag1 == 0.0) ? 1.0 : std::fabs(mag1);
+        double normalizer = std::max(mag1, std::numeric_limits<double>::min());
+
+        return std::sqrt(square_difference) / (std::sqrt(n) * normalizer);
     }
     else
-        return double(std::numeric_limits<range_value<R1>>::max());
+        return double(std::numeric_limits<range_value<RefType>>::max());
 }
 } // namespace miopen
 #endif


### PR DESCRIPTION
## Scope

While testing the variant 0 for bnorm backward spatial single, we observed that the error tolerance in MIOpenDriver is sub-optimal. For instance, the following results were observed

```shell
Backwards prop batch norm verification passed on dx (0.151171)
Backwards prop batch norm verification passed on dscale (0.277024)
Backwards prop batch norm verification passed on dbias (0.217736)
Backwards Prop Batch Norm Verifies on CPU and GPU.
```
Notice that the execution is successful, according to the driver checks. However, the error reported is high so this should actually be failing.

## Notes for the reviewer
- Fixed the `maxrms` definition because it was too big compared to the rms values being computed (due to the rms normalization done). The `VerifyForward` method seems to also be using the same value for `maxrms` as the new implementation in `VerifyBackward`.
- Fixed the normalization of the rms. Previously we were finding the maximum absolute value from both the reference values and the results, but this may not be correct because it reduces the significance of the rms: if the results differ a lot from the reference values (e.g. ref values are order of 10 and results are order 1000) then the normalization will divide the rms obtained (which will be order of 100) by a number order of 1000 and then the normalized rms will be 100/1000 = 0.1 which is way lower than what it should be.
  - The new implementation only takes into account the reference results for computing the normalization factor
