### PR TITLE
[TESTS] Fix KTN test failures

### DIFF
--- a/test/gtest/group_conv.hpp
+++ b/test/gtest/group_conv.hpp
@@ -306,7 +306,7 @@ private:
 
         /// \todo figure out a better threshold for error checking, esp. for bwd
         /// data and weight passes. --amberhassaan
-        double threshold = 80;
+        double threshold = 160;
         if(CONV_DIR == Direction::Forward)
         {
             threshold *= std::numeric_limits<T>::epsilon();

--- a/test/gtest/group_conv.hpp
+++ b/test/gtest/group_conv.hpp
@@ -71,7 +71,7 @@ struct GroupConvTestConfig<2u>
         return os << " G:" << tc.G << " N:" << tc.N << " C:" << tc.C << " K:" << tc.K
                   << " H:" << tc.img.y << " W:" << tc.img.x << " y:" << tc.filter.y
                   << " x:" << tc.filter.x << " pad.y:" << tc.pad.y << " pad.x:" << tc.pad.x
-                  << " stride.y:" << tc.stride.y << "stride.x" << tc.stride.x
+                  << " stride.y:" << tc.stride.y << " stride.x" << tc.stride.x
                   << " dilation.y:" << tc.dilation.y << " dilation.x" << tc.dilation.x;
     }
 
@@ -306,7 +306,7 @@ private:
 
         /// \todo figure out a better threshold for error checking, esp. for bwd
         /// data and weight passes. --amberhassaan
-        double threshold = 160;
+        double threshold = 80;
         if(CONV_DIR == Direction::Forward)
         {
             threshold *= std::numeric_limits<T>::epsilon();

--- a/test/gtest/kernel_tuning_net.cpp
+++ b/test/gtest/kernel_tuning_net.cpp
@@ -72,7 +72,7 @@ std::vector<KernelTuningNetTestCase> GetConvHipIgemmGroupFwdXdlopsTestCases_FP16
               miopen::conv::Direction::Forward,
               miopenHalf,
               miopenTensorNHWC},
-             "DeviceGroupedConvFwdMultipleABD_Xdl_CShuffle<64, 64, 64, 32, Filter1x1Stride1Pad0, "
+             "DeviceGroupedConvFwdMultipleABD_Xdl_CShuffle<64, 64, 64, 32, Filter1x1Pad0, "
              "32, 32, 2, 2, 1, 1, 1, 1, 1, 1>",
              "gfx942"}};
 }
@@ -125,7 +125,7 @@ std::vector<KernelTuningNetTestCase> GetConvHipIgemmGroupWrwXdlopsTestCases_FP16
           miopenHalf,
           miopenTensorNHWC},
          "DeviceGroupedConvBwdWeightTwoStage_Xdl_CShuffle<64, 16, 16, 32, Default, 8, 1, 1, 1, 4, "
-         "1, 4, 1, 1, 1, BlkGemmPipelineScheduler: Intrawave, BlkGemmPipelineVersion: v5, 1>+128",
+         "1, 4, 1, 1, 1, BlkGemmPipelineScheduler: Intrawave, BlkGemmPipelineVersion: v1, 1>+1",
          "gfx942"},
         {{{1, 2, 2, 1, {9, 1}, {1, 1}, {1, 0}, {3, 1}, {2, 1}},
           miopen::conv::Direction::BackwardWeights,


### PR DESCRIPTION
KN behavior has changed after

```
200bc5df809983f1f99ea5c0ae2720bd04feab20 KernelTuningNet for CK [Update CK Fwd, CK Wrw + New integration CK Bwd] (#3464)
```

We are aligning the tests with the new behavior