### PR TITLE
Skip some tests if MIOpen is built without CK to avoid failing on gfx90a, gfx908 and gfx94x (CK-compatible devices)

### DIFF
--- a/test/gtest/unit_conv_solver_ConvHipImplicitGemmBwdXdlops.cpp
+++ b/test/gtest/unit_conv_solver_ConvHipImplicitGemmBwdXdlops.cpp
@@ -73,8 +73,13 @@ auto GetConvFullTestCases(miopenDataType_t datatype)
 
 auto GetTestParams(miopenDataType_t datatype)
 {
+// If CK is not installed these tests would fail
+#if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
     Gpu supportedDevices = Gpu::gfx908 | Gpu::gfx90A | Gpu::gfx94X;
-    auto params          = miopen::unit_tests::UnitTestConvSolverParams(supportedDevices);
+#else
+    Gpu supportedDevices = Gpu::None;
+#endif
+    auto params = miopen::unit_tests::UnitTestConvSolverParams(supportedDevices);
     params.Tunable(5);
     if(datatype == miopenHalf)
     {

--- a/test/gtest/unit_conv_solver_ConvHipImplicitGemmBwdXdlops.cpp
+++ b/test/gtest/unit_conv_solver_ConvHipImplicitGemmBwdXdlops.cpp
@@ -73,7 +73,7 @@ auto GetConvFullTestCases(miopenDataType_t datatype)
 
 auto GetTestParams(miopenDataType_t datatype)
 {
-// If CK is not installed these tests would fail
+// If MIOpen is built without CK these tests will fail, skip them to avoid failing
 #if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
     Gpu supportedDevices = Gpu::gfx908 | Gpu::gfx90A | Gpu::gfx94X;
 #else

--- a/test/gtest/unit_conv_solver_ConvHipImplicitGemmFwdXdlops.cpp
+++ b/test/gtest/unit_conv_solver_ConvHipImplicitGemmFwdXdlops.cpp
@@ -74,8 +74,13 @@ auto GetConvFullTestCases(miopenDataType_t datatype)
 const auto& GetTestParams()
 {
     static const auto params = [] {
+// If CK is not installed these tests would fail
+#if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
         Gpu supportedDevices = Gpu::gfx908 | Gpu::gfx90A | Gpu::gfx94X;
-        auto p               = miopen::unit_tests::UnitTestConvSolverParams(supportedDevices);
+#else
+        Gpu supportedDevices = Gpu::None;
+#endif
+        auto p = miopen::unit_tests::UnitTestConvSolverParams(supportedDevices);
         p.Tunable(5);
         return p;
     }();

--- a/test/gtest/unit_conv_solver_ConvHipImplicitGemmFwdXdlops.cpp
+++ b/test/gtest/unit_conv_solver_ConvHipImplicitGemmFwdXdlops.cpp
@@ -74,7 +74,7 @@ auto GetConvFullTestCases(miopenDataType_t datatype)
 const auto& GetTestParams()
 {
     static const auto params = [] {
-// If CK is not installed these tests would fail
+// If MIOpen is built without CK these tests will fail, skip them to avoid failing
 #if MIOPEN_BACKEND_HIP && MIOPEN_USE_COMPOSABLEKERNEL
         Gpu supportedDevices = Gpu::gfx908 | Gpu::gfx90A | Gpu::gfx94X;
 #else


### PR DESCRIPTION
Tests ConvHipImplicitGemmFwdXdlops and ConvHipImplicitGemmFwdXdlops will fail on particular devices (CK-compatible devices) if MIOpen is built without CK.
Let's skip these tests to avoid failing.