### PR TITLE
Explicitly include GoogleTest helpers.

### DIFF
--- a/test/gtest/CMakeLists.txt
+++ b/test/gtest/CMakeLists.txt
@@ -1,6 +1,8 @@
 find_package(GTest REQUIRED)
 find_package(rocblas)
 
+include(GoogleTest)
+
 if(MIOPEN_USE_HIPBLASLT)
   find_package(hipblas REQUIRED PATHS /opt/rocm $ENV{HIP_PATH})
   find_package(hipblaslt REQUIRED PATHS /opt/rocm $ENV{HIP_PATH})


### PR DESCRIPTION
* These automatically get included in some legacy find modules but are not universally available without an include.

Fixes https://github.com/ROCm/TheRock/issues/412