### PR TITLE
MIOpenDriver: exit with status 1 on usage error

### DIFF
--- a/driver/driver.hpp
+++ b/driver/driver.hpp
@@ -403,7 +403,7 @@ inline std::string ParseBaseArg(int argc, char* argv[])
        arg != "--version")
     {
         printf("FAILED: Invalid Base Input Argument\n");
-        Usage(1);
+        Usage(EXIT_FAILURE);
     }
     else if(arg == "-h" || arg == "--help" || arg == "-?")
         Usage(EXIT_SUCCESS);

--- a/driver/driver.hpp
+++ b/driver/driver.hpp
@@ -351,7 +351,7 @@ inline void PadBufferSize(size_t& sz, int datatype_sz)
     }
 }
 
-[[noreturn]] inline void Usage()
+[[noreturn]] inline void Usage(int e)
 {
     printf("Usage: ./driver *base_arg* *other_args*\n");
     printf("Supported Base Arguments: conv[fp16|int8|bfp16], pool[fp16], lrn[fp16], "
@@ -363,7 +363,7 @@ inline void PadBufferSize(size_t& sz, int datatype_sz)
            "getitem[bfp16|fp16], reducecalculation[bfp16|fp16], rope[bfp16|fp16], "
            "prelu[bfp16|fp16], kthvalue[bfp16|fp16], glu[bfp16|fp16], softmarginloss[bfp16|fp16], "
            "multimarginloss[bfp16|fp16]\n");
-    exit(0); // NOLINT (concurrency-mt-unsafe)
+    exit(e); // NOLINT (concurrency-mt-unsafe)
 }
 
 inline std::string ParseBaseArg(int argc, char* argv[])
@@ -371,7 +371,7 @@ inline std::string ParseBaseArg(int argc, char* argv[])
     if(argc < 2)
     {
         printf("FAILED: Invalid Number of Input Arguments\n");
-        Usage();
+        Usage(1);
     }
 
     std::string arg = argv[1];
@@ -403,10 +403,10 @@ inline std::string ParseBaseArg(int argc, char* argv[])
        arg != "--version")
     {
         printf("FAILED: Invalid Base Input Argument\n");
-        Usage();
+        Usage(1);
     }
     else if(arg == "-h" || arg == "--help" || arg == "-?")
-        Usage();
+        Usage(0);
     else
         return arg;
 }

--- a/driver/driver.hpp
+++ b/driver/driver.hpp
@@ -371,7 +371,7 @@ inline std::string ParseBaseArg(int argc, char* argv[])
     if(argc < 2)
     {
         printf("FAILED: Invalid Number of Input Arguments\n");
-        Usage(1);
+        Usage(EXIT_FAILURE);
     }
 
     std::string arg = argv[1];

--- a/driver/driver.hpp
+++ b/driver/driver.hpp
@@ -406,7 +406,7 @@ inline std::string ParseBaseArg(int argc, char* argv[])
         Usage(1);
     }
     else if(arg == "-h" || arg == "--help" || arg == "-?")
-        Usage(0);
+        Usage(EXIT_SUCCESS);
     else
         return arg;
 }

--- a/driver/tensorop_driver.hpp
+++ b/driver/tensorop_driver.hpp
@@ -184,8 +184,7 @@ int TensorOpDriver<Tgpu, Tref>::SetTensorOpFromCmdLineArgs()
             op = static_cast<miopenTensorOp_t>(raw_op - 2);
         else
         {
-            Usage();
-            exit(-1); // NOLINT (concurrency-mt-unsafe)
+            Usage(1);
         }
     }
     return miopenStatusSuccess;

--- a/driver/tensorop_driver.hpp
+++ b/driver/tensorop_driver.hpp
@@ -184,7 +184,7 @@ int TensorOpDriver<Tgpu, Tref>::SetTensorOpFromCmdLineArgs()
             op = static_cast<miopenTensorOp_t>(raw_op - 2);
         else
         {
-            Usage(1);
+            Usage(EXIT_FAILURE);
         }
     }
     return miopenStatusSuccess;


### PR DESCRIPTION
This makes inspecting MIOpenDriver exit status after light manual testing easier.

Fixes https://github.com/ROCm/TheRock/issues/436