### PR TITLE
Add sql2text missing header and simplify build

### DIFF
--- a/tools/sqlite2txt/CMakeLists.txt
+++ b/tools/sqlite2txt/CMakeLists.txt
@@ -1,11 +1,7 @@
 add_executable(sqlite2txt
-        main.cpp
+    main.cpp
 )
 
-target_link_libraries(sqlite2txt SQLite::SQLite3 Threads::Threads)
-
-if (NOT WIN32)
-    target_link_libraries(sqlite2txt dl)
-endif()
+target_link_libraries(sqlite2txt SQLite::SQLite3 Threads::Threads ${CMAKE_DL_LIBS})
 
 clang_tidy_check(sqlite2txt)

--- a/tools/sqlite2txt/main.cpp
+++ b/tools/sqlite2txt/main.cpp
@@ -6,6 +6,7 @@
 #include <memory>
 #include <string>
 #include <sstream>
+#include <unordered_map>
 
 std::unique_ptr<sqlite3, int (*)(sqlite3*)> OpenDb(const char* filename, int flags)
 {


### PR DESCRIPTION
Patch tracked in https://github.com/ROCm/TheRock/issues/564 to build on Windows:

* Was missing the unordered_map header.
* Replace conditional inclusion of `dl` with `${CMAKE_DL_LIBS}` per best practice.