### PR TITLE
BN: fix bug from sanitizer

### DIFF
--- a/src/include/miopen/batchnorm/common_spatial.hpp
+++ b/src/include/miopen/batchnorm/common_spatial.hpp
@@ -87,10 +87,18 @@ inline void GetSpatialMultipleConfig(const miopen::batchnorm::ProblemDescription
 
     if(problem.IsLayoutNHWC())
     {
+        if(c % vectorsize != 0)
+        {
+            return;
+        }
         GetLocalConfigNHWC(problem, vectorsize, xlocalsize, ylocalsize);
     }
     else
     {
+        if(in_cstride % vectorsize != 0)
+        {
+            return;
+        }
         xlocalsize = 1;
         ylocalsize = 1024;
         if(ylocalsize > in_cstride / vectorsize)


### PR DESCRIPTION
Avoid unnecessary calculations when vectorsize is not supported for a given problem.

This fixes the sanitizer issues in debug mode.