### PR TITLE
Fix variable name issue in activation

### DIFF
--- a/src/kernels/activation_functions.h
+++ b/src/kernels/activation_functions.h
@@ -204,7 +204,7 @@ void ActivationFunction_Clamp(const uint n,
 {
     for(uint i = 0; i < n; ++i)
     {
-        res[i] = fmax((_FLOAT_PREC)alpha, fmin((_FLOAT_PREC)_beta, (_FLOAT_PREC)data[i]));
+        res[i] = fmax((_FLOAT_PREC)alpha, fmin((_FLOAT_PREC)beta, (_FLOAT_PREC)data[i]));
     }
 }
 


### PR DESCRIPTION
Issue with _beta instead of beta in the activation kernels.
