### PR TITLE
Update tensor check logic 

### DIFF
--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -684,32 +684,49 @@ bool TensorDescriptor::IsPossibleLayout(const std::string& storage_layout,
     std::vector<std::size_t> layout_strides(base_layout.size());
     std::transform(base_layout.cbegin(), base_layout.cend(), layout_strides.begin(), op);
 
+    // Check monotonic decreasing with conservative PyTorch compatibility fix
     for(unsigned i = 0; i < (layout_strides.size() - 1); i++)
     {
         if(layout_strides[i] < layout_strides[i + 1])
         {
-            // Find which dimensions are involved in this stride violation
-            auto char_at_i = base_layout[i];
-            auto char_at_i_plus_1 = base_layout[i + 1];
+            // Conservative fix: Only allow stride violations when:
+            // 1. This is a 5D tensor 
+            // 2. The violating dimension has size 1
+            // 3. The stride values are actually shared (same value appears elsewhere)
+            bool allow_violation = false;
             
-            auto dim_pos_i = storage_layout.find(char_at_i);
-            auto dim_pos_i_plus_1 = storage_layout.find(char_at_i_plus_1);
-            
-            if(dim_pos_i == std::string::npos || dim_pos_i_plus_1 == std::string::npos)
-                MIOPEN_THROW(miopenStatusInternalError, "wrong layout format");
-            
-            // This is memory-safe because size-1 dimensions don't create aliasing
-            if(lens[dim_pos_i] == 1 || lens[dim_pos_i_plus_1] == 1)
+            if(lens.size() == 5)
             {
-                continue; // Skip this violation - it's safe
+                auto char_at_i = base_layout[i];
+                auto char_at_i_plus_1 = base_layout[i + 1];
+                
+                auto dim_pos_i = storage_layout.find(char_at_i);
+                auto dim_pos_i_plus_1 = storage_layout.find(char_at_i_plus_1);
+                
+                if(dim_pos_i != std::string::npos && dim_pos_i_plus_1 != std::string::npos)
+                {
+                    // Only allow if the larger stride dimension has size 1
+                    if(lens[dim_pos_i_plus_1] == 1)
+                    {
+                        // Verify this is genuine stride sharing (not arbitrary values)
+                        std::size_t shared_stride = layout_strides[i + 1];
+                        for(std::size_t k = 0; k < strides.size(); ++k)
+                        {
+                            if(k != dim_pos_i_plus_1 && strides[k] == shared_stride)
+                            {
+                                allow_violation = true;
+                                break;
+                            }
+                        }
+                    }
+                }
             }
             
-            // Real stride violation with non-size-1 dimensions - reject
-            return false;
+            if(!allow_violation)
+                return false;
         }
     }
     return true;
-
 }
 
 // Layout could be NCHW, NHWC, NCDHW, NDHWC, NCHWc, ...

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -689,20 +689,16 @@ bool TensorDescriptor::IsPossibleLayout(const std::string& storage_layout,
     {
         if(layout_strides[i] < layout_strides[i + 1])
         {
-            // Conservative fix: Only allow stride violations when:
-            // 1. This is a 5D tensor 
-            // 2. The violating dimension has size 1
-            // 3. The stride values are actually shared (same value appears elsewhere)
             bool allow_violation = false;
-            
+    
             if(lens.size() == 5)
             {
                 auto char_at_i = base_layout[i];
                 auto char_at_i_plus_1 = base_layout[i + 1];
-                
+    
                 auto dim_pos_i = storage_layout.find(char_at_i);
                 auto dim_pos_i_plus_1 = storage_layout.find(char_at_i_plus_1);
-                
+    
                 if(dim_pos_i != std::string::npos && dim_pos_i_plus_1 != std::string::npos)
                 {
                     // Only allow if the larger stride dimension has size 1
@@ -721,7 +717,7 @@ bool TensorDescriptor::IsPossibleLayout(const std::string& storage_layout,
                     }
                 }
             }
-            
+    
             if(!allow_violation)
                 return false;
         }

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -684,14 +684,32 @@ bool TensorDescriptor::IsPossibleLayout(const std::string& storage_layout,
     std::vector<std::size_t> layout_strides(base_layout.size());
     std::transform(base_layout.cbegin(), base_layout.cend(), layout_strides.begin(), op);
 
-    // Check monotonic decreasing
     for(unsigned i = 0; i < (layout_strides.size() - 1); i++)
     {
         if(layout_strides[i] < layout_strides[i + 1])
+        {
+            // Find which dimensions are involved in this stride violation
+            auto char_at_i = base_layout[i];
+            auto char_at_i_plus_1 = base_layout[i + 1];
+            
+            auto dim_pos_i = storage_layout.find(char_at_i);
+            auto dim_pos_i_plus_1 = storage_layout.find(char_at_i_plus_1);
+            
+            if(dim_pos_i == std::string::npos || dim_pos_i_plus_1 == std::string::npos)
+                MIOPEN_THROW(miopenStatusInternalError, "wrong layout format");
+            
+            // This is memory-safe because size-1 dimensions don't create aliasing
+            if(lens[dim_pos_i] == 1 || lens[dim_pos_i_plus_1] == 1)
+            {
+                continue; // Skip this violation - it's safe
+            }
+            
+            // Real stride violation with non-size-1 dimensions - reject
             return false;
+        }
     }
-
     return true;
+
 }
 
 // Layout could be NCHW, NHWC, NCDHW, NDHWC, NCHWc, ...

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -699,20 +699,18 @@ bool TensorDescriptor::IsPossibleLayout(const std::string& storage_layout,
                 auto dim_pos_i        = storage_layout.find(char_at_i);
                 auto dim_pos_i_plus_1 = storage_layout.find(char_at_i_plus_1);
 
-                if(dim_pos_i != std::string::npos && dim_pos_i_plus_1 != std::string::npos)
+
+                // Only allow if the larger stride dimension has size 1
+                if(lens[dim_pos_i_plus_1] == 1)
                 {
-                    // Only allow if the larger stride dimension has size 1
-                    if(lens[dim_pos_i_plus_1] == 1)
+                    // Verify this is genuine stride sharing (not arbitrary values)
+                    std::size_t shared_stride = layout_strides[i + 1];
+                    for(std::size_t k = 0; k < strides.size(); ++k)
                     {
-                        // Verify this is genuine stride sharing (not arbitrary values)
-                        std::size_t shared_stride = layout_strides[i + 1];
-                        for(std::size_t k = 0; k < strides.size(); ++k)
+                        if(k != dim_pos_i_plus_1 && strides[k] == shared_stride)
                         {
-                            if(k != dim_pos_i_plus_1 && strides[k] == shared_stride)
-                            {
-                                allow_violation = true;
-                                break;
-                            }
+                            allow_violation = true;
+                            break;
                         }
                     }
                 }

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -690,15 +690,15 @@ bool TensorDescriptor::IsPossibleLayout(const std::string& storage_layout,
         if(layout_strides[i] < layout_strides[i + 1])
         {
             bool allow_violation = false;
-    
+
             if(lens.size() == 5)
             {
-                auto char_at_i = base_layout[i];
+                auto char_at_i        = base_layout[i];
                 auto char_at_i_plus_1 = base_layout[i + 1];
-    
-                auto dim_pos_i = storage_layout.find(char_at_i);
+
+                auto dim_pos_i        = storage_layout.find(char_at_i);
                 auto dim_pos_i_plus_1 = storage_layout.find(char_at_i_plus_1);
-    
+
                 if(dim_pos_i != std::string::npos && dim_pos_i_plus_1 != std::string::npos)
                 {
                     // Only allow if the larger stride dimension has size 1
@@ -717,7 +717,7 @@ bool TensorDescriptor::IsPossibleLayout(const std::string& storage_layout,
                     }
                 }
             }
-    
+
             if(!allow_violation)
                 return false;
         }


### PR DESCRIPTION
There is an issue seen by upstream Transformers unit tests 
There are customer models though not common that use strides with dimensions 1 apart here is some example reproducer code from upstream investigations. This happens on 4D and 5D tensors. This PR updates the tensor constraints to allow this customer condition.

```
import torch
from torch.nn import functional as F
if __name__ == "__main__":
    fix_layout = False
    input = torch.randn(13, 4, 1, 15, 15).to(dtype=torch.float32, device="cuda:0")
    input = torch.as_strided(input, size=(13, 4, 1, 15, 15), stride=(900, 225, 900, 15, 1))
    print(f"{input.shape = }, {input.device = }, {input.dtype = }, {input.stride() = }")
    if fix_layout:
        input = input.reshape(input.shape)
        print(f"{input.shape = }, {input.device = }, {input.dtype = }, {input.stride() = } {input.is_contiguous() = }")
    F.batch_norm(
        input=input,
        running_mean=torch.zeros(4).to("cuda:0"),
        running_var=torch.ones(4).to("cuda:0"),
        weight=torch.ones(4).to("cuda:0"),
        bias=torch.zeros(4).to("cuda:0"),
        training=False,
        momentum=0.1,
        eps=1e-5,
    )
```

Before: Any stride violation → reject tensor
After:  Stride violation with size-1 dimension → allow (safe)
        Stride violation with normal dimensions → reject (unsafe)

Example that now works:
- Shape: [13, 4, 1, 15, 15] 
- Stride: [900, 225, 900, 15, 1]
- layout_strides for "NCHW": [900, 225, 900, 15]
- Violation: 225 < 900 at positions 1,2 (C,H dimensions)
- H dimension (pos 2) has size 1 → SAFE → Allow
- Result: Tensor now accepted as "NCHW" layout