### PR TITLE
Fix the nightly build on jenkins.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -470,7 +470,7 @@ pipeline {
         }
         stage("Nightly Tests") {
             when {
-                expression { false } // add way to only do for nightly builds
+                expression { params.RUN_NIGHTLY_TESTS }
             }
             parallel{
                 stage('Fp32 Hip Debug NOMLIR gfx90a') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -473,6 +473,15 @@ pipeline {
                 expression { params.RUN_NIGHTLY_TESTS }
             }
             parallel{
+                stage('Mark Build As Nightly') {
+                    agent{ label rocmnode("nogpu") }
+                    steps{
+                        script {
+                            // Adds a comment under the jenkins build number so you can tell it is a nightly build.
+                            currentBuild.description = "Nightly Build"
+                        }
+                    }
+                }
                 stage('Fp32 Hip Debug NOMLIR gfx90a') {
                     when {
                         beforeAgent true


### PR DESCRIPTION
Originally forgot to update the expression param for nightly build stage.  Added the correct param check and a build description stage to indicate which builds are nightlies.