### PR TITLE
Add compile time conditional clearing of the output buffers 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,8 @@ include(ROCMCreatePackage)
 include(CheckCXXCompilerFlag)
 include(ROCMHeaderWrapper)
 
+include(cmake/ClangCheck.cmake)
+
 # Build library with Beta APIs
 add_definitions("-DMIOPEN_BETA_API=1")
 

--- a/cmake/ClangCheck.cmake
+++ b/cmake/ClangCheck.cmake
@@ -1,0 +1,23 @@
+# Copyright © Advanced Micro Devices, Inc., or its affiliates.
+# SPDX-License-Identifier:  MIT
+
+set(CLANG_FORMAT_PRUNE -path "./build" -prune -o -path "./install" -prune -o -path "./fin" -prune -o)
+
+# Note: The clang-format in /opt/rocm produces different results than the one in /usr/bin.  MIOpen
+# formatting is based on the one in /usr/bin so we use that one
+# set(CLANG_FORMAT_BINARY /opt/rocm/llvm/bin/clang-format)
+set(CLANG_FORMAT_BINARY /usr/bin/clang-format-12)
+
+add_custom_target(
+    check_format
+    COMMAND  find . ${CLANG_FORMAT_PRUNE} -regex ".*\\.\\(cpp\\|hpp\\|h.in\\|hpp.in\\|cpp.in\\|cl\\)" -exec ${CLANG_FORMAT_BINARY} --dry-run --Werror {} +
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    VERBATIM
+)
+
+add_custom_target(
+    format
+    COMMAND  find . ${CLANG_FORMAT_PRUNE} -regex ".*\\.\\(cpp\\|hpp\\|h.in\\|hpp.in\\|cpp.in\\|cl\\)" -exec ${CLANG_FORMAT_BINARY} --verbose -i {} +
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    VERBATIM
+)

--- a/driver/conv_driver.hpp
+++ b/driver/conv_driver.hpp
@@ -101,10 +101,10 @@ struct AutoMiopenWarmupMode
         miopen::debug::FindEnforceDisable = true;
         miopen::debug::IsWarmupOngoing    = true;
     }
-    AutoMiopenWarmupMode(const AutoMiopenWarmupMode&) = delete;
-    AutoMiopenWarmupMode(AutoMiopenWarmupMode&&)      = delete;
+    AutoMiopenWarmupMode(const AutoMiopenWarmupMode&)            = delete;
+    AutoMiopenWarmupMode(AutoMiopenWarmupMode&&)                 = delete;
     AutoMiopenWarmupMode& operator=(const AutoMiopenWarmupMode&) = delete;
-    AutoMiopenWarmupMode& operator=(AutoMiopenWarmupMode&&) = delete;
+    AutoMiopenWarmupMode& operator=(AutoMiopenWarmupMode&&)      = delete;
     ~AutoMiopenWarmupMode()
     {
         miopen::debug::LoggingQuiet       = debug_logging_quiet_prev;
@@ -127,10 +127,10 @@ struct AutoPrepareForGpuReference
         miopen::debug::AlwaysEnableConvDirectNaive = true;
         miopen::debug::LoggingQuiet                = true;
     }
-    AutoPrepareForGpuReference(const AutoPrepareForGpuReference&) = delete;
-    AutoPrepareForGpuReference(AutoPrepareForGpuReference&&)      = delete;
+    AutoPrepareForGpuReference(const AutoPrepareForGpuReference&)            = delete;
+    AutoPrepareForGpuReference(AutoPrepareForGpuReference&&)                 = delete;
     AutoPrepareForGpuReference& operator=(const AutoPrepareForGpuReference&) = delete;
-    AutoPrepareForGpuReference& operator=(AutoPrepareForGpuReference&&) = delete;
+    AutoPrepareForGpuReference& operator=(AutoPrepareForGpuReference&&)      = delete;
     ~AutoPrepareForGpuReference()
     {
         miopen::debug::LoggingQuiet                = quiet_prev;
@@ -391,15 +391,16 @@ private:
     miopenConvolutionMode_t mode;
 
     bool is_wrw = true, is_bwd = true, is_fwd = true;
-    bool is_wrw_winograd       = false;
-    bool is_wrw_igemm          = false;
-    bool is_fwd_igemm          = false;
-    bool is_bwd_igemm          = false;
-    bool time_enabled          = false;
-    bool wall_enabled          = false;
-    bool warmup_enabled        = false;
-    bool is_gpualloc           = false;
-    GPUMem::Check buffer_check = GPUMem::Check::None;
+    bool is_wrw_winograd              = false;
+    bool is_wrw_igemm                 = false;
+    bool is_fwd_igemm                 = false;
+    bool is_bwd_igemm                 = false;
+    bool time_enabled                 = false;
+    bool wall_enabled                 = false;
+    bool warmup_enabled               = false;
+    bool is_gpualloc                  = false;
+    bool populate_output_with_garbage = false;
+    GPUMem::Check buffer_check        = GPUMem::Check::None;
 
     int num_iterations = 1;
 
@@ -697,6 +698,11 @@ int ConvDriver<Tgpu, Tref>::ParseCmdLineArgs(int argc, char* argv[])
     warmup_in.SetGpuallocMode(is_gpualloc);
     warmup_wei.SetGpuallocMode(is_gpualloc);
     warmup_out.SetGpuallocMode(is_gpualloc);
+
+    populate_output_with_garbage = (inflags.GetValueInt("populate_output_with_garbage") == 1);
+    out.SetGarbageBufferPopulate(populate_output_with_garbage);
+    dout.SetGarbageBufferPopulate(populate_output_with_garbage);
+    warmup_out.SetGarbageBufferPopulate(populate_output_with_garbage);
 
     buffer_check = GetGpuBufferCheck(inflags);
 
@@ -1000,6 +1006,11 @@ int ConvDriver<Tgpu, Tref>::AddCmdLineArgs()
         "out_cast_type", 'T', "-1", "Cast type for output tensor, default to not set", "string");
     inflags.AddInputFlag(
         "wei_cast_type", 'R', "-1", "Cast type for weight tensor, default to not set", "string");
+    inflags.AddInputFlag("populate_output_with_garbage",
+                         '+',
+                         "0",
+                         "populate output buffers with nans (Default=0)",
+                         "int");
 
     return 0;
 }
@@ -1493,8 +1504,7 @@ int ConvDriver<Tgpu, Tref>::AllocateBuffersAndCopy()
 
         if(!doutRead)
         {
-            auto gen = [&]() -> auto
-            {
+            auto gen = [&]() -> auto {
                 return is_fp8 ? prng::gen_A_to_B(Data_min, Data_max) : prng::gen_0_to_B(Data_scale);
             };
             dout.InitHostData(out_sz, is_bwd || is_wrw, gen);

--- a/driver/conv_driver.hpp
+++ b/driver/conv_driver.hpp
@@ -101,10 +101,10 @@ struct AutoMiopenWarmupMode
         miopen::debug::FindEnforceDisable = true;
         miopen::debug::IsWarmupOngoing    = true;
     }
-    AutoMiopenWarmupMode(const AutoMiopenWarmupMode&)            = delete;
-    AutoMiopenWarmupMode(AutoMiopenWarmupMode&&)                 = delete;
+    AutoMiopenWarmupMode(const AutoMiopenWarmupMode&) = delete;
+    AutoMiopenWarmupMode(AutoMiopenWarmupMode&&)      = delete;
     AutoMiopenWarmupMode& operator=(const AutoMiopenWarmupMode&) = delete;
-    AutoMiopenWarmupMode& operator=(AutoMiopenWarmupMode&&)      = delete;
+    AutoMiopenWarmupMode& operator=(AutoMiopenWarmupMode&&) = delete;
     ~AutoMiopenWarmupMode()
     {
         miopen::debug::LoggingQuiet       = debug_logging_quiet_prev;
@@ -127,10 +127,10 @@ struct AutoPrepareForGpuReference
         miopen::debug::AlwaysEnableConvDirectNaive = true;
         miopen::debug::LoggingQuiet                = true;
     }
-    AutoPrepareForGpuReference(const AutoPrepareForGpuReference&)            = delete;
-    AutoPrepareForGpuReference(AutoPrepareForGpuReference&&)                 = delete;
+    AutoPrepareForGpuReference(const AutoPrepareForGpuReference&) = delete;
+    AutoPrepareForGpuReference(AutoPrepareForGpuReference&&)      = delete;
     AutoPrepareForGpuReference& operator=(const AutoPrepareForGpuReference&) = delete;
-    AutoPrepareForGpuReference& operator=(AutoPrepareForGpuReference&&)      = delete;
+    AutoPrepareForGpuReference& operator=(AutoPrepareForGpuReference&&) = delete;
     ~AutoPrepareForGpuReference()
     {
         miopen::debug::LoggingQuiet                = quiet_prev;
@@ -1502,7 +1502,8 @@ int ConvDriver<Tgpu, Tref>::AllocateBuffersAndCopy()
 
         if(!doutRead)
         {
-            auto gen = [&]() -> auto {
+            auto gen = [&]() -> auto
+            {
                 return is_fp8 ? prng::gen_A_to_B(Data_min, Data_max) : prng::gen_0_to_B(Data_scale);
             };
             dout.InitHostData(out_sz, is_bwd || is_wrw, gen);

--- a/driver/conv_driver.hpp
+++ b/driver/conv_driver.hpp
@@ -205,10 +205,9 @@ public:
     Tgpu* GetVectorData() { return is_gpualloc ? nullptr : host.data(); }
     std::size_t GetVectorSize() const { return is_gpualloc ? 0 : host.size(); }
 
-    status_t FillGpuBufferWithMaxValue(miopenHandle_t handle,
-                                       const miopenTensorDescriptor_t tensorDesc)
+    status_t FillGpuBufferWithNans(miopenHandle_t handle, const miopenTensorDescriptor_t tensorDesc)
     {
-        return dev->FillBufferWithMaxValue<Tgpu>(handle, tensorDesc);
+        return dev->FillBufferWithNans<Tgpu>(handle, tensorDesc);
     }
 
     status_t AllocOnDevice(stream, context_t ctx, const size_t sz, GPUMem::Check check)
@@ -405,7 +404,7 @@ private:
     bool wall_enabled          = false;
     bool warmup_enabled        = false;
     bool is_gpualloc           = false;
-    bool init_output_max       = false;
+    bool init_output_nan       = false;
     GPUMem::Check buffer_check = GPUMem::Check::None;
 
     int num_iterations = 1;
@@ -705,7 +704,7 @@ int ConvDriver<Tgpu, Tref>::ParseCmdLineArgs(int argc, char* argv[])
     warmup_wei.SetGpuallocMode(is_gpualloc);
     warmup_out.SetGpuallocMode(is_gpualloc);
 
-    init_output_max = (inflags.GetValueInt("init_output_max") == 1);
+    init_output_nan = (inflags.GetValueInt("init_output_nan") == 1);
 
     buffer_check = GetGpuBufferCheck(inflags);
 
@@ -1010,7 +1009,7 @@ int ConvDriver<Tgpu, Tref>::AddCmdLineArgs()
     inflags.AddInputFlag(
         "wei_cast_type", 'R', "-1", "Cast type for weight tensor, default to not set", "string");
     inflags.AddInputFlag(
-        "init_output_max", 'N', "0", "populate output buffers with max values (Default=0)", "int");
+        "init_output_nan", 'N', "0", "populate output buffers with nan values (Default=0)", "int");
 
     return 0;
 }
@@ -1854,9 +1853,9 @@ int ConvDriver<Tgpu, Tref>::RunWarmupFindForwardGPU()
 
         warmup_wall_total.resume(wall_enabled);
 
-        if(init_output_max)
+        if(init_output_nan)
         {
-            warmup_out.FillGpuBufferWithMaxValue(handle, warmupOutputTensor);
+            warmup_out.FillGpuBufferWithNans(handle, warmupOutputTensor);
         }
 
         rc = miopenConvolutionForwardImmediate(handle,
@@ -2071,9 +2070,9 @@ int ConvDriver<Tgpu, Tref>::RunForwardGpuFind(const bool is_transform)
 
     for(int i = 0; i < num_iterations; i++)
     {
-        if(init_output_max)
+        if(init_output_nan)
         {
-            out.FillGpuBufferWithMaxValue(handle, outputTensor);
+            out.FillGpuBufferWithNans(handle, outputTensor);
         }
 
         rc = miopenConvolutionForward(GetHandle(),
@@ -2232,9 +2231,9 @@ int ConvDriver<Tgpu, Tref>::RunForwardGpuImmed(const bool is_transform)
 
     for(int i = 0; i < num_iterations; i++)
     {
-        if(init_output_max)
+        if(init_output_nan)
         {
-            out.FillGpuBufferWithMaxValue(handle, outputTensor);
+            out.FillGpuBufferWithNans(handle, outputTensor);
         }
 
         rc = miopenConvolutionForwardImmediate(
@@ -2344,9 +2343,9 @@ int ConvDriver<Tgpu, Tref>::RunForwardGPUReference()
         std::cout << "gpu reference convolution does not support bias yet" << std::endl;
         return -1;
     }
-    if(init_output_max)
+    if(init_output_nan)
     {
-        out.FillGpuBufferWithMaxValue(handle, outputTensor);
+        out.FillGpuBufferWithNans(handle, outputTensor);
     }
 
     auto ref_solution_id = mode == miopenTranspose //
@@ -2557,9 +2556,9 @@ int ConvDriver<Tgpu, Tref>::RunBackwardDataGpuFind()
 
     for(int i = 0; i < num_iterations; i++)
     {
-        if(init_output_max)
+        if(init_output_nan)
         {
-            din.FillGpuBufferWithMaxValue(handle, inputTensor);
+            din.FillGpuBufferWithNans(handle, inputTensor);
         }
         rc = miopenConvolutionBackwardData(GetHandle(),
                                            &alpha,
@@ -2771,9 +2770,9 @@ int ConvDriver<Tgpu, Tref>::RunBackwardWrwGpuFind()
 
     for(int i = 0; i < num_iterations; i++)
     {
-        if(init_output_max)
+        if(init_output_nan)
         {
-            dwei.FillGpuBufferWithMaxValue(handle, weightTensor);
+            dwei.FillGpuBufferWithNans(handle, weightTensor);
         }
 
         rc = miopenConvolutionBackwardWeights(GetHandle(),
@@ -3014,9 +3013,9 @@ int ConvDriver<Tgpu, Tref>::RunBackwardDataGpuImmed()
 
     for(int i = 0; i < num_iterations; i++)
     {
-        if(init_output_max)
+        if(init_output_nan)
         {
-            din.FillGpuBufferWithMaxValue(handle, inputTensor);
+            din.FillGpuBufferWithNans(handle, inputTensor);
         }
 
         rc = miopenConvolutionBackwardDataImmediate(handle,
@@ -3149,9 +3148,9 @@ int ConvDriver<Tgpu, Tref>::RunBackwardWrwGpuImmed()
 
     for(int i = 0; i < num_iterations; i++)
     {
-        if(init_output_max)
+        if(init_output_nan)
         {
-            dwei.FillGpuBufferWithMaxValue(handle, weightTensor);
+            dwei.FillGpuBufferWithNans(handle, weightTensor);
         }
 
         rc = miopenConvolutionBackwardWeightsImmediate(handle,
@@ -3294,9 +3293,9 @@ int ConvDriver<Tgpu, Tref>::RunBackwardWeightsGPUReference()
 {
     AutoPrepareForGpuReference naive_conv_enable;
 
-    if(init_output_max)
+    if(init_output_nan)
     {
-        dwei.FillGpuBufferWithMaxValue(handle, weightTensor);
+        dwei.FillGpuBufferWithNans(handle, weightTensor);
     }
 
     auto ref_solution_id = miopen::solver::Id("ConvDirectNaiveConvWrw").Value();
@@ -3348,9 +3347,9 @@ int ConvDriver<Tgpu, Tref>::RunBackwardDataGPUReference()
 {
     AutoPrepareForGpuReference naive_conv_enable;
 
-    if(init_output_max)
+    if(init_output_nan)
     {
-        din.FillGpuBufferWithMaxValue(handle, inputTensor);
+        din.FillGpuBufferWithNans(handle, inputTensor);
     }
 
     auto ref_solution_id = mode == miopenTranspose //

--- a/driver/conv_driver.hpp
+++ b/driver/conv_driver.hpp
@@ -205,7 +205,11 @@ public:
     Tgpu* GetVectorData() { return is_gpualloc ? nullptr : host.data(); }
     std::size_t GetVectorSize() const { return is_gpualloc ? 0 : host.size(); }
 
-    status_t FillGpuBufferWithMaxValue() { return dev->FillBufferWithMaxValue<Tgpu>(); }
+    status_t FillGpuBufferWithMaxValue(miopenHandle_t handle,
+                                       const miopenTensorDescriptor_t tensorDesc)
+    {
+        return dev->FillBufferWithMaxValue<Tgpu>(handle, tensorDesc);
+    }
 
     status_t AllocOnDevice(stream, context_t ctx, const size_t sz, GPUMem::Check check)
     {
@@ -1852,7 +1856,7 @@ int ConvDriver<Tgpu, Tref>::RunWarmupFindForwardGPU()
 
         if(init_output_max)
         {
-            warmup_out.FillGpuBufferWithMaxValue();
+            warmup_out.FillGpuBufferWithMaxValue(handle, warmupOutputTensor);
         }
 
         rc = miopenConvolutionForwardImmediate(handle,
@@ -2069,7 +2073,7 @@ int ConvDriver<Tgpu, Tref>::RunForwardGpuFind(const bool is_transform)
     {
         if(init_output_max)
         {
-            out.FillGpuBufferWithMaxValue();
+            out.FillGpuBufferWithMaxValue(handle, outputTensor);
         }
 
         rc = miopenConvolutionForward(GetHandle(),
@@ -2230,7 +2234,7 @@ int ConvDriver<Tgpu, Tref>::RunForwardGpuImmed(const bool is_transform)
     {
         if(init_output_max)
         {
-            out.FillGpuBufferWithMaxValue();
+            out.FillGpuBufferWithMaxValue(handle, outputTensor);
         }
 
         rc = miopenConvolutionForwardImmediate(
@@ -2342,7 +2346,7 @@ int ConvDriver<Tgpu, Tref>::RunForwardGPUReference()
     }
     if(init_output_max)
     {
-        out.FillGpuBufferWithMaxValue();
+        out.FillGpuBufferWithMaxValue(handle, outputTensor);
     }
 
     auto ref_solution_id = mode == miopenTranspose //
@@ -2555,7 +2559,7 @@ int ConvDriver<Tgpu, Tref>::RunBackwardDataGpuFind()
     {
         if(init_output_max)
         {
-            din.FillGpuBufferWithMaxValue();
+            din.FillGpuBufferWithMaxValue(handle, inputTensor);
         }
         rc = miopenConvolutionBackwardData(GetHandle(),
                                            &alpha,
@@ -2769,7 +2773,7 @@ int ConvDriver<Tgpu, Tref>::RunBackwardWrwGpuFind()
     {
         if(init_output_max)
         {
-            dwei.FillGpuBufferWithMaxValue();
+            dwei.FillGpuBufferWithMaxValue(handle, weightTensor);
         }
 
         rc = miopenConvolutionBackwardWeights(GetHandle(),
@@ -3012,7 +3016,7 @@ int ConvDriver<Tgpu, Tref>::RunBackwardDataGpuImmed()
     {
         if(init_output_max)
         {
-            din.FillGpuBufferWithMaxValue();
+            din.FillGpuBufferWithMaxValue(handle, inputTensor);
         }
 
         rc = miopenConvolutionBackwardDataImmediate(handle,
@@ -3147,7 +3151,7 @@ int ConvDriver<Tgpu, Tref>::RunBackwardWrwGpuImmed()
     {
         if(init_output_max)
         {
-            dwei.FillGpuBufferWithMaxValue();
+            dwei.FillGpuBufferWithMaxValue(handle, weightTensor);
         }
 
         rc = miopenConvolutionBackwardWeightsImmediate(handle,
@@ -3292,7 +3296,7 @@ int ConvDriver<Tgpu, Tref>::RunBackwardWeightsGPUReference()
 
     if(init_output_max)
     {
-        dwei.FillGpuBufferWithMaxValue();
+        dwei.FillGpuBufferWithMaxValue(handle, weightTensor);
     }
 
     auto ref_solution_id = miopen::solver::Id("ConvDirectNaiveConvWrw").Value();
@@ -3346,7 +3350,7 @@ int ConvDriver<Tgpu, Tref>::RunBackwardDataGPUReference()
 
     if(init_output_max)
     {
-        din.FillGpuBufferWithMaxValue();
+        din.FillGpuBufferWithMaxValue(handle, inputTensor);
     }
 
     auto ref_solution_id = mode == miopenTranspose //

--- a/driver/conv_driver.hpp
+++ b/driver/conv_driver.hpp
@@ -391,16 +391,16 @@ private:
     miopenConvolutionMode_t mode;
 
     bool is_wrw = true, is_bwd = true, is_fwd = true;
-    bool is_wrw_winograd              = false;
-    bool is_wrw_igemm                 = false;
-    bool is_fwd_igemm                 = false;
-    bool is_bwd_igemm                 = false;
-    bool time_enabled                 = false;
-    bool wall_enabled                 = false;
-    bool warmup_enabled               = false;
-    bool is_gpualloc                  = false;
-    bool populate_output_with_garbage = false;
-    GPUMem::Check buffer_check        = GPUMem::Check::None;
+    bool is_wrw_winograd       = false;
+    bool is_wrw_igemm          = false;
+    bool is_fwd_igemm          = false;
+    bool is_bwd_igemm          = false;
+    bool time_enabled          = false;
+    bool wall_enabled          = false;
+    bool warmup_enabled        = false;
+    bool is_gpualloc           = false;
+    bool init_output_nan       = false;
+    GPUMem::Check buffer_check = GPUMem::Check::None;
 
     int num_iterations = 1;
 
@@ -699,11 +699,11 @@ int ConvDriver<Tgpu, Tref>::ParseCmdLineArgs(int argc, char* argv[])
     warmup_wei.SetGpuallocMode(is_gpualloc);
     warmup_out.SetGpuallocMode(is_gpualloc);
 
-    populate_output_with_garbage = (inflags.GetValueInt("populate_output_with_garbage") == 1);
+    init_output_nan = (inflags.GetValueInt("init_output_nan") == 1);
 
-    out.SetGarbageBufferPopulate(populate_output_with_garbage);
-    dout.SetGarbageBufferPopulate(populate_output_with_garbage);
-    warmup_out.SetGarbageBufferPopulate(populate_output_with_garbage);
+    out.SetGpuNanOutputBuffers(init_output_nan);
+    dout.SetGpuNanOutputBuffers(init_output_nan);
+    warmup_out.SetGpuNanOutputBuffers(init_output_nan);
 
     buffer_check = GetGpuBufferCheck(inflags);
 
@@ -1007,11 +1007,8 @@ int ConvDriver<Tgpu, Tref>::AddCmdLineArgs()
         "out_cast_type", 'T', "-1", "Cast type for output tensor, default to not set", "string");
     inflags.AddInputFlag(
         "wei_cast_type", 'R', "-1", "Cast type for weight tensor, default to not set", "string");
-    inflags.AddInputFlag("populate_output_with_garbage",
-                         '+',
-                         "0",
-                         "populate output buffers with nans (Default=0)",
-                         "int");
+    inflags.AddInputFlag(
+        "init_output_nan", 'N', "0", "populate output buffers with nans (Default=0)", "int");
 
     return 0;
 }

--- a/driver/conv_driver.hpp
+++ b/driver/conv_driver.hpp
@@ -205,43 +205,7 @@ public:
     Tgpu* GetVectorData() { return is_gpualloc ? nullptr : host.data(); }
     std::size_t GetVectorSize() const { return is_gpualloc ? 0 : host.size(); }
 
-    status_t FillGpuBufferWithNans()
-    {
-        // In the past we have had some issues with incorrect results due to Nans in the output
-        // buffers.  In order to test the clearing of the output buffers, you can
-        // init the buffers with NaNs.
-        // Note, we only do this for the gpu buffers, adding the behaviour for the host buffers
-        // causes a crash as the host code doesnt handle NaNs.
-        if(std::is_same<Tgpu, float>::value)
-        {
-            hipMemsetD32(dev->GetMem(), std::numeric_limits<float>::quiet_NaN(), dev->GetSize());
-        }
-        else if(std::is_same<Tgpu, bfloat16>::value)
-        {
-            hipMemsetD16(dev->GetMem(), std::numeric_limits<bfloat16>::quiet_NaN(), dev->GetSize());
-        }
-        else if(std::is_same<Tgpu, half_float::half>::value)
-        {
-            hipMemsetD16(
-                dev->GetMem(), std::numeric_limits<half_float::half>::quiet_NaN(), dev->GetSize());
-        }
-        else if(std::is_same<Tgpu, bfloat8_fnuz>::value)
-        {
-            hipMemset(
-                dev->GetMem(), std::numeric_limits<bfloat8_fnuz>::quiet_NaN(), dev->GetSize());
-        }
-        else if(std::is_same<Tgpu, float8_fnuz>::value)
-        {
-            hipMemset(dev->GetMem(), std::numeric_limits<float8_fnuz>::quiet_NaN(), dev->GetSize());
-        }
-        else if(std::is_same<Tgpu, int8_t>::value)
-        {
-            // ints dont have Nan so use min value.
-            hipMemset(dev->GetMem(), std::numeric_limits<int8_t>::min(), dev->GetSize());
-        }
-
-        return STATUS_SUCCESS;
-    }
+    status_t FillGpuBufferWithNans() { return dev->FillBufferWithNans<Tgpu>(); }
 
     status_t AllocOnDevice(stream, context_t ctx, const size_t sz, GPUMem::Check check)
     {

--- a/driver/conv_driver.hpp
+++ b/driver/conv_driver.hpp
@@ -101,10 +101,10 @@ struct AutoMiopenWarmupMode
         miopen::debug::FindEnforceDisable = true;
         miopen::debug::IsWarmupOngoing    = true;
     }
-    AutoMiopenWarmupMode(const AutoMiopenWarmupMode&) = delete;
-    AutoMiopenWarmupMode(AutoMiopenWarmupMode&&)      = delete;
+    AutoMiopenWarmupMode(const AutoMiopenWarmupMode&)            = delete;
+    AutoMiopenWarmupMode(AutoMiopenWarmupMode&&)                 = delete;
     AutoMiopenWarmupMode& operator=(const AutoMiopenWarmupMode&) = delete;
-    AutoMiopenWarmupMode& operator=(AutoMiopenWarmupMode&&) = delete;
+    AutoMiopenWarmupMode& operator=(AutoMiopenWarmupMode&&)      = delete;
     ~AutoMiopenWarmupMode()
     {
         miopen::debug::LoggingQuiet       = debug_logging_quiet_prev;
@@ -127,10 +127,10 @@ struct AutoPrepareForGpuReference
         miopen::debug::AlwaysEnableConvDirectNaive = true;
         miopen::debug::LoggingQuiet                = true;
     }
-    AutoPrepareForGpuReference(const AutoPrepareForGpuReference&) = delete;
-    AutoPrepareForGpuReference(AutoPrepareForGpuReference&&)      = delete;
+    AutoPrepareForGpuReference(const AutoPrepareForGpuReference&)            = delete;
+    AutoPrepareForGpuReference(AutoPrepareForGpuReference&&)                 = delete;
     AutoPrepareForGpuReference& operator=(const AutoPrepareForGpuReference&) = delete;
-    AutoPrepareForGpuReference& operator=(AutoPrepareForGpuReference&&) = delete;
+    AutoPrepareForGpuReference& operator=(AutoPrepareForGpuReference&&)      = delete;
     ~AutoPrepareForGpuReference()
     {
         miopen::debug::LoggingQuiet                = quiet_prev;
@@ -702,9 +702,6 @@ int ConvDriver<Tgpu, Tref>::ParseCmdLineArgs(int argc, char* argv[])
     warmup_out.SetGpuallocMode(is_gpualloc);
 
     init_output_nan = (inflags.GetValueInt("init_output_nan") == 1);
-
-    // out.SetGpuNanOutputBuffers(init_output_nan);
-    //  warmup_out.SetGpuNanOutputBuffers(init_output_nan);
 
     buffer_check = GetGpuBufferCheck(inflags);
 
@@ -1503,8 +1500,7 @@ int ConvDriver<Tgpu, Tref>::AllocateBuffersAndCopy()
 
         if(!doutRead)
         {
-            auto gen = [&]() -> auto
-            {
+            auto gen = [&]() -> auto {
                 return is_fp8 ? prng::gen_A_to_B(Data_min, Data_max) : prng::gen_0_to_B(Data_scale);
             };
             dout.InitHostData(out_sz, is_bwd || is_wrw, gen);

--- a/driver/conv_driver.hpp
+++ b/driver/conv_driver.hpp
@@ -205,6 +205,44 @@ public:
     Tgpu* GetVectorData() { return is_gpualloc ? nullptr : host.data(); }
     std::size_t GetVectorSize() const { return is_gpualloc ? 0 : host.size(); }
 
+    status_t FillGpuBufferWithNans()
+    {
+        // In the past we have had some issues with incorrect results due to Nans in the output
+        // buffers.  In order to test the clearing of the output buffers, you can
+        // init the buffers with NaNs.
+        // Note, we only do this for the gpu buffers, adding the behaviour for the host buffers
+        // causes a crash as the host code doesnt handle NaNs.
+        if(std::is_same<Tgpu, float>::value)
+        {
+            hipMemsetD32(dev->GetMem(), std::numeric_limits<float>::quiet_NaN(), dev->GetSize());
+        }
+        else if(std::is_same<Tgpu, bfloat16>::value)
+        {
+            hipMemsetD16(dev->GetMem(), std::numeric_limits<bfloat16>::quiet_NaN(), dev->GetSize());
+        }
+        else if(std::is_same<Tgpu, half_float::half>::value)
+        {
+            hipMemsetD16(
+                dev->GetMem(), std::numeric_limits<half_float::half>::quiet_NaN(), dev->GetSize());
+        }
+        else if(std::is_same<Tgpu, bfloat8_fnuz>::value)
+        {
+            hipMemset(
+                dev->GetMem(), std::numeric_limits<bfloat8_fnuz>::quiet_NaN(), dev->GetSize());
+        }
+        else if(std::is_same<Tgpu, float8_fnuz>::value)
+        {
+            hipMemset(dev->GetMem(), std::numeric_limits<float8_fnuz>::quiet_NaN(), dev->GetSize());
+        }
+        else if(std::is_same<Tgpu, int8_t>::value)
+        {
+            // ints dont have Nan so use min value.
+            hipMemset(dev->GetMem(), std::numeric_limits<int8_t>::min(), dev->GetSize());
+        }
+
+        return STATUS_SUCCESS;
+    }
+
     status_t AllocOnDevice(stream, context_t ctx, const size_t sz, GPUMem::Check check)
     {
         dev = std::make_unique<GPUMem>(ctx, sz, sizeof(Tgpu), check);
@@ -701,9 +739,8 @@ int ConvDriver<Tgpu, Tref>::ParseCmdLineArgs(int argc, char* argv[])
 
     init_output_nan = (inflags.GetValueInt("init_output_nan") == 1);
 
-    out.SetGpuNanOutputBuffers(init_output_nan);
-    dout.SetGpuNanOutputBuffers(init_output_nan);
-    warmup_out.SetGpuNanOutputBuffers(init_output_nan);
+    // out.SetGpuNanOutputBuffers(init_output_nan);
+    //  warmup_out.SetGpuNanOutputBuffers(init_output_nan);
 
     buffer_check = GetGpuBufferCheck(inflags);
 
@@ -1851,6 +1888,12 @@ int ConvDriver<Tgpu, Tref>::RunWarmupFindForwardGPU()
             return 70;
 
         warmup_wall_total.resume(wall_enabled);
+
+        if(init_output_nan)
+        {
+            warmup_out.FillGpuBufferWithNans();
+        }
+
         rc = miopenConvolutionForwardImmediate(handle,
                                                warmupWeightTensor,
                                                warmup_wei.GetDevicePtr(),
@@ -2063,6 +2106,11 @@ int ConvDriver<Tgpu, Tref>::RunForwardGpuFind(const bool is_transform)
 
     for(int i = 0; i < num_iterations; i++)
     {
+        if(init_output_nan)
+        {
+            out.FillGpuBufferWithNans();
+        }
+
         rc = miopenConvolutionForward(GetHandle(),
                                       &alpha,
                                       in_tens,
@@ -2219,6 +2267,11 @@ int ConvDriver<Tgpu, Tref>::RunForwardGpuImmed(const bool is_transform)
 
     for(int i = 0; i < num_iterations; i++)
     {
+        if(init_output_nan)
+        {
+            out.FillGpuBufferWithNans();
+        }
+
         rc = miopenConvolutionForwardImmediate(
             handle,
             (is_transform ? weightTensor_vect4 : weightTensor),
@@ -2326,6 +2379,11 @@ int ConvDriver<Tgpu, Tref>::RunForwardGPUReference()
         std::cout << "gpu reference convolution does not support bias yet" << std::endl;
         return -1;
     }
+    if(init_output_nan)
+    {
+        out.FillGpuBufferWithNans();
+    }
+
     auto ref_solution_id = mode == miopenTranspose //
                                ? miopen::solver::Id("ConvDirectNaiveConvBwd").Value()
                                : miopen::solver::Id("ConvDirectNaiveConvFwd").Value();
@@ -2534,6 +2592,10 @@ int ConvDriver<Tgpu, Tref>::RunBackwardDataGpuFind()
 
     for(int i = 0; i < num_iterations; i++)
     {
+        if(init_output_nan)
+        {
+            din.FillGpuBufferWithNans();
+        }
         rc = miopenConvolutionBackwardData(GetHandle(),
                                            &alpha,
                                            outputTensor,
@@ -2744,6 +2806,11 @@ int ConvDriver<Tgpu, Tref>::RunBackwardWrwGpuFind()
 
     for(int i = 0; i < num_iterations; i++)
     {
+        if(init_output_nan)
+        {
+            dwei.FillGpuBufferWithNans();
+        }
+
         rc = miopenConvolutionBackwardWeights(GetHandle(),
                                               &alpha,
                                               outputTensor,
@@ -2982,6 +3049,11 @@ int ConvDriver<Tgpu, Tref>::RunBackwardDataGpuImmed()
 
     for(int i = 0; i < num_iterations; i++)
     {
+        if(init_output_nan)
+        {
+            din.FillGpuBufferWithNans();
+        }
+
         rc = miopenConvolutionBackwardDataImmediate(handle,
                                                     outputTensor,
                                                     dout.GetDevicePtr(),
@@ -3112,6 +3184,11 @@ int ConvDriver<Tgpu, Tref>::RunBackwardWrwGpuImmed()
 
     for(int i = 0; i < num_iterations; i++)
     {
+        if(init_output_nan)
+        {
+            dwei.FillGpuBufferWithNans();
+        }
+
         rc = miopenConvolutionBackwardWeightsImmediate(handle,
                                                        outputTensor,
                                                        dout.GetDevicePtr(),
@@ -3252,6 +3329,11 @@ int ConvDriver<Tgpu, Tref>::RunBackwardWeightsGPUReference()
 {
     AutoPrepareForGpuReference naive_conv_enable;
 
+    if(init_output_nan)
+    {
+        dwei.FillGpuBufferWithNans();
+    }
+
     auto ref_solution_id = miopen::solver::Id("ConvDirectNaiveConvWrw").Value();
     auto rc              = miopenConvolutionBackwardWeightsImmediate(handle,
                                                         outputTensor,
@@ -3300,6 +3382,11 @@ template <typename Tgpu, typename Tref>
 int ConvDriver<Tgpu, Tref>::RunBackwardDataGPUReference()
 {
     AutoPrepareForGpuReference naive_conv_enable;
+
+    if(init_output_nan)
+    {
+        din.FillGpuBufferWithNans();
+    }
 
     auto ref_solution_id = mode == miopenTranspose //
                                ? miopen::solver::Id("ConvDirectNaiveConvFwd").Value()

--- a/driver/conv_driver.hpp
+++ b/driver/conv_driver.hpp
@@ -101,10 +101,10 @@ struct AutoMiopenWarmupMode
         miopen::debug::FindEnforceDisable = true;
         miopen::debug::IsWarmupOngoing    = true;
     }
-    AutoMiopenWarmupMode(const AutoMiopenWarmupMode&)            = delete;
-    AutoMiopenWarmupMode(AutoMiopenWarmupMode&&)                 = delete;
+    AutoMiopenWarmupMode(const AutoMiopenWarmupMode&) = delete;
+    AutoMiopenWarmupMode(AutoMiopenWarmupMode&&)      = delete;
     AutoMiopenWarmupMode& operator=(const AutoMiopenWarmupMode&) = delete;
-    AutoMiopenWarmupMode& operator=(AutoMiopenWarmupMode&&)      = delete;
+    AutoMiopenWarmupMode& operator=(AutoMiopenWarmupMode&&) = delete;
     ~AutoMiopenWarmupMode()
     {
         miopen::debug::LoggingQuiet       = debug_logging_quiet_prev;
@@ -127,10 +127,10 @@ struct AutoPrepareForGpuReference
         miopen::debug::AlwaysEnableConvDirectNaive = true;
         miopen::debug::LoggingQuiet                = true;
     }
-    AutoPrepareForGpuReference(const AutoPrepareForGpuReference&)            = delete;
-    AutoPrepareForGpuReference(AutoPrepareForGpuReference&&)                 = delete;
+    AutoPrepareForGpuReference(const AutoPrepareForGpuReference&) = delete;
+    AutoPrepareForGpuReference(AutoPrepareForGpuReference&&)      = delete;
     AutoPrepareForGpuReference& operator=(const AutoPrepareForGpuReference&) = delete;
-    AutoPrepareForGpuReference& operator=(AutoPrepareForGpuReference&&)      = delete;
+    AutoPrepareForGpuReference& operator=(AutoPrepareForGpuReference&&) = delete;
     ~AutoPrepareForGpuReference()
     {
         miopen::debug::LoggingQuiet                = quiet_prev;
@@ -1500,7 +1500,8 @@ int ConvDriver<Tgpu, Tref>::AllocateBuffersAndCopy()
 
         if(!doutRead)
         {
-            auto gen = [&]() -> auto {
+            auto gen = [&]() -> auto
+            {
                 return is_fp8 ? prng::gen_A_to_B(Data_min, Data_max) : prng::gen_0_to_B(Data_scale);
             };
             dout.InitHostData(out_sz, is_bwd || is_wrw, gen);

--- a/driver/conv_driver.hpp
+++ b/driver/conv_driver.hpp
@@ -205,7 +205,7 @@ public:
     Tgpu* GetVectorData() { return is_gpualloc ? nullptr : host.data(); }
     std::size_t GetVectorSize() const { return is_gpualloc ? 0 : host.size(); }
 
-    status_t FillGpuBufferWithNans() { return dev->FillBufferWithNans<Tgpu>(); }
+    status_t FillGpuBufferWithMaxValue() { return dev->FillBufferWithMaxValue<Tgpu>(); }
 
     status_t AllocOnDevice(stream, context_t ctx, const size_t sz, GPUMem::Check check)
     {
@@ -401,7 +401,7 @@ private:
     bool wall_enabled          = false;
     bool warmup_enabled        = false;
     bool is_gpualloc           = false;
-    bool init_output_nan       = false;
+    bool init_output_max       = false;
     GPUMem::Check buffer_check = GPUMem::Check::None;
 
     int num_iterations = 1;
@@ -701,7 +701,7 @@ int ConvDriver<Tgpu, Tref>::ParseCmdLineArgs(int argc, char* argv[])
     warmup_wei.SetGpuallocMode(is_gpualloc);
     warmup_out.SetGpuallocMode(is_gpualloc);
 
-    init_output_nan = (inflags.GetValueInt("init_output_nan") == 1);
+    init_output_max = (inflags.GetValueInt("init_output_max") == 1);
 
     buffer_check = GetGpuBufferCheck(inflags);
 
@@ -1006,7 +1006,7 @@ int ConvDriver<Tgpu, Tref>::AddCmdLineArgs()
     inflags.AddInputFlag(
         "wei_cast_type", 'R', "-1", "Cast type for weight tensor, default to not set", "string");
     inflags.AddInputFlag(
-        "init_output_nan", 'N', "0", "populate output buffers with nans (Default=0)", "int");
+        "init_output_max", 'N', "0", "populate output buffers with max values (Default=0)", "int");
 
     return 0;
 }
@@ -1850,9 +1850,9 @@ int ConvDriver<Tgpu, Tref>::RunWarmupFindForwardGPU()
 
         warmup_wall_total.resume(wall_enabled);
 
-        if(init_output_nan)
+        if(init_output_max)
         {
-            warmup_out.FillGpuBufferWithNans();
+            warmup_out.FillGpuBufferWithMaxValue();
         }
 
         rc = miopenConvolutionForwardImmediate(handle,
@@ -2067,9 +2067,9 @@ int ConvDriver<Tgpu, Tref>::RunForwardGpuFind(const bool is_transform)
 
     for(int i = 0; i < num_iterations; i++)
     {
-        if(init_output_nan)
+        if(init_output_max)
         {
-            out.FillGpuBufferWithNans();
+            out.FillGpuBufferWithMaxValue();
         }
 
         rc = miopenConvolutionForward(GetHandle(),
@@ -2228,9 +2228,9 @@ int ConvDriver<Tgpu, Tref>::RunForwardGpuImmed(const bool is_transform)
 
     for(int i = 0; i < num_iterations; i++)
     {
-        if(init_output_nan)
+        if(init_output_max)
         {
-            out.FillGpuBufferWithNans();
+            out.FillGpuBufferWithMaxValue();
         }
 
         rc = miopenConvolutionForwardImmediate(
@@ -2340,9 +2340,9 @@ int ConvDriver<Tgpu, Tref>::RunForwardGPUReference()
         std::cout << "gpu reference convolution does not support bias yet" << std::endl;
         return -1;
     }
-    if(init_output_nan)
+    if(init_output_max)
     {
-        out.FillGpuBufferWithNans();
+        out.FillGpuBufferWithMaxValue();
     }
 
     auto ref_solution_id = mode == miopenTranspose //
@@ -2553,9 +2553,9 @@ int ConvDriver<Tgpu, Tref>::RunBackwardDataGpuFind()
 
     for(int i = 0; i < num_iterations; i++)
     {
-        if(init_output_nan)
+        if(init_output_max)
         {
-            din.FillGpuBufferWithNans();
+            din.FillGpuBufferWithMaxValue();
         }
         rc = miopenConvolutionBackwardData(GetHandle(),
                                            &alpha,
@@ -2767,9 +2767,9 @@ int ConvDriver<Tgpu, Tref>::RunBackwardWrwGpuFind()
 
     for(int i = 0; i < num_iterations; i++)
     {
-        if(init_output_nan)
+        if(init_output_max)
         {
-            dwei.FillGpuBufferWithNans();
+            dwei.FillGpuBufferWithMaxValue();
         }
 
         rc = miopenConvolutionBackwardWeights(GetHandle(),
@@ -3010,9 +3010,9 @@ int ConvDriver<Tgpu, Tref>::RunBackwardDataGpuImmed()
 
     for(int i = 0; i < num_iterations; i++)
     {
-        if(init_output_nan)
+        if(init_output_max)
         {
-            din.FillGpuBufferWithNans();
+            din.FillGpuBufferWithMaxValue();
         }
 
         rc = miopenConvolutionBackwardDataImmediate(handle,
@@ -3145,9 +3145,9 @@ int ConvDriver<Tgpu, Tref>::RunBackwardWrwGpuImmed()
 
     for(int i = 0; i < num_iterations; i++)
     {
-        if(init_output_nan)
+        if(init_output_max)
         {
-            dwei.FillGpuBufferWithNans();
+            dwei.FillGpuBufferWithMaxValue();
         }
 
         rc = miopenConvolutionBackwardWeightsImmediate(handle,
@@ -3290,9 +3290,9 @@ int ConvDriver<Tgpu, Tref>::RunBackwardWeightsGPUReference()
 {
     AutoPrepareForGpuReference naive_conv_enable;
 
-    if(init_output_nan)
+    if(init_output_max)
     {
-        dwei.FillGpuBufferWithNans();
+        dwei.FillGpuBufferWithMaxValue();
     }
 
     auto ref_solution_id = miopen::solver::Id("ConvDirectNaiveConvWrw").Value();
@@ -3344,9 +3344,9 @@ int ConvDriver<Tgpu, Tref>::RunBackwardDataGPUReference()
 {
     AutoPrepareForGpuReference naive_conv_enable;
 
-    if(init_output_nan)
+    if(init_output_max)
     {
-        din.FillGpuBufferWithNans();
+        din.FillGpuBufferWithMaxValue();
     }
 
     auto ref_solution_id = mode == miopenTranspose //

--- a/driver/conv_driver.hpp
+++ b/driver/conv_driver.hpp
@@ -700,6 +700,7 @@ int ConvDriver<Tgpu, Tref>::ParseCmdLineArgs(int argc, char* argv[])
     warmup_out.SetGpuallocMode(is_gpualloc);
 
     populate_output_with_garbage = (inflags.GetValueInt("populate_output_with_garbage") == 1);
+
     out.SetGarbageBufferPopulate(populate_output_with_garbage);
     dout.SetGarbageBufferPopulate(populate_output_with_garbage);
     warmup_out.SetGarbageBufferPopulate(populate_output_with_garbage);

--- a/driver/driver.hpp
+++ b/driver/driver.hpp
@@ -84,7 +84,7 @@ struct GPUMem
     };
 
 #if MIOPEN_BACKEND_OPENCL
-    GPUMem() {};
+    GPUMem(){};
     GPUMem(cl_context& ctx, size_t psz, size_t pdata_sz, Check ch = Check::None)
         : sz(psz), data_sz(pdata_sz)
     {
@@ -111,7 +111,7 @@ struct GPUMem
 
 #elif MIOPEN_BACKEND_HIP
 
-    GPUMem() {};
+    GPUMem(){};
     GPUMem(uint32_t ctx, size_t psz, size_t pdata_sz, Check ch = Check::None)
         : _ctx(ctx), sz(psz), data_sz(pdata_sz), check(ch)
     {

--- a/driver/driver.hpp
+++ b/driver/driver.hpp
@@ -137,15 +137,12 @@ struct GPUMem
         return static_cast<int>(hipMemcpy(p, buf, GetSize(), hipMemcpyDeviceToHost));
     }
 
-    // To pass the Tgpu type, make FillBufferWithNans a template method:
     template <typename Tgpu>
     status_t FillBufferWithNans()
     {
         // In the past we have had some issues with incorrect results due to Nans in the output
         // buffers.  In order to test the clearing of the output buffers, you can
         // init the buffers with NaNs.
-        // Note, we only do this for the gpu buffers, adding the behaviour for the host buffers
-        // causes a crash as the host code doesnt handle NaNs.
         if(std::is_same<Tgpu, float>::value)
         {
             hipMemsetD32(GetMem(), std::numeric_limits<float>::quiet_NaN(), GetSize());

--- a/driver/driver.hpp
+++ b/driver/driver.hpp
@@ -281,7 +281,7 @@ public:
         if(init_gpu_output_nan)
         {
             // In the past we have had some issues with incorrect results due to Nans in the output
-            // buffers.  In order to test we clear output buffers before computing anything you can
+            // buffers.  In order to test the clearing of the output buffers, you can
             // init the buffers with NaNs.
             // Note, we only do this for the gpu buffers, adding the behaviour for the host buffers
             // causes a crash as the host code doesnt handle NaNs.

--- a/driver/driver.hpp
+++ b/driver/driver.hpp
@@ -138,7 +138,7 @@ struct GPUMem
     }
 
     template <typename Tgpu>
-    status_t FillBufferWithNans()
+    status_t FillBufferWithMaxValue()
     {
         // In the past we have had some issues with incorrect results due to Nans in the output
         // buffers.  In order to test the clearing of the output buffers, you can
@@ -298,7 +298,7 @@ public:
         }
     }
 
-    status_t FillGpuBufferWithNans() { return dev->FillBufferWithNans<Tgpu>(); }
+    status_t FillGpuBufferWithMaxValue() { return dev->FillBufferWithMaxValue<Tgpu>(); }
 
     status_t
     AllocOnDevice(stream, context_t ctx, const size_t sz, GPUMem::Check check = GPUMem::Check::None)

--- a/driver/driver.hpp
+++ b/driver/driver.hpp
@@ -84,7 +84,7 @@ struct GPUMem
     };
 
 #if MIOPEN_BACKEND_OPENCL
-    GPUMem(){};
+    GPUMem() {};
     GPUMem(cl_context& ctx, size_t psz, size_t pdata_sz, Check ch = Check::None)
         : sz(psz), data_sz(pdata_sz)
     {
@@ -111,7 +111,7 @@ struct GPUMem
 
 #elif MIOPEN_BACKEND_HIP
 
-    GPUMem(){};
+    GPUMem() {};
     GPUMem(uint32_t ctx, size_t psz, size_t pdata_sz, Check ch = Check::None)
         : _ctx(ctx), sz(psz), data_sz(pdata_sz), check(ch)
     {
@@ -201,10 +201,12 @@ class GpumemTensor
 {
     std::unique_ptr<GPUMem> dev;
     tensor<Tgpu> host;
-    bool is_gpualloc = false;
+    bool is_gpualloc                   = false;
+    bool populate_buffers_with_garbage = false;
 
 public:
     void SetGpuallocMode(bool v) { is_gpualloc = v; }
+    void SetGarbageBufferPopulate(bool v) { populate_buffers_with_garbage = v; }
     tensor<Tgpu>& GetTensor() { return host; }
 
     void AllocOnHost(miopenTensorDescriptor_t t)
@@ -246,6 +248,15 @@ public:
             /// In gpualloc mode, we do not care about reproducibility of results, because
             /// validation is not used. Therefore, we do not have to always generate random value
             /// (\ref move_rand)
+            return;
+        }
+
+        if(populate_buffers_with_garbage)
+        {
+            for(size_t i = 0; i < sz; ++i)
+            {
+                GetVector()[i] = std::numeric_limits<Tgpu>::quiet_NaN();
+            }
             return;
         }
 

--- a/driver/driver.hpp
+++ b/driver/driver.hpp
@@ -84,7 +84,7 @@ struct GPUMem
     };
 
 #if MIOPEN_BACKEND_OPENCL
-    GPUMem(){};
+    GPUMem() {};
     GPUMem(cl_context& ctx, size_t psz, size_t pdata_sz, Check ch = Check::None)
         : sz(psz), data_sz(pdata_sz)
     {
@@ -111,7 +111,7 @@ struct GPUMem
 
 #elif MIOPEN_BACKEND_HIP
 
-    GPUMem(){};
+    GPUMem() {};
     GPUMem(uint32_t ctx, size_t psz, size_t pdata_sz, Check ch = Check::None)
         : _ctx(ctx), sz(psz), data_sz(pdata_sz), check(ch)
     {
@@ -285,11 +285,7 @@ public:
             // init the buffers with NaNs.
             // Note, we only do this for the gpu buffers, adding the behaviour for the host buffers
             // causes a crash as the host code doesnt handle NaNs.
-            auto dev_buf_ptr = static_cast<Tgpu*>(dev->buf);
-            for(size_t i = 0; i < dev->sz; ++i)
-            {
-                dev_buf_ptr[i] = std::numeric_limits<Tgpu>::quiet_NaN();
-            }
+            hipMemset(dev->GetMem(), std::numeric_limits<Tgpu>::quiet_NaN(), dev->GetSize());
             return 0;
         }
 

--- a/driver/driver.hpp
+++ b/driver/driver.hpp
@@ -138,35 +138,23 @@ struct GPUMem
     }
 
     template <typename Tgpu>
-    status_t FillBufferWithMaxValue()
+    status_t FillBufferWithMaxValue(miopenHandle_t handle,
+                                    const miopenTensorDescriptor_t tensorDesc)
     {
         // In the past we have had some issues with incorrect results due to Nans in the output
         // buffers.  In order to test the clearing of the output buffers, you can
         // init the buffers with NaNs.
-        if(std::is_same<Tgpu, float>::value)
+
+        if(std::is_same<Tgpu, int8_t>::value)
         {
-            hipMemsetD32(GetMem(), std::numeric_limits<float>::max(), GetSize());
+            // ints dont have Nan so use max value.
+            Tgpu max = std::numeric_limits<Tgpu>::max();
+            miopenSetTensor(handle, tensorDesc, GetMem(), &max);
         }
-        else if(std::is_same<Tgpu, bfloat16>::value)
+        else
         {
-            hipMemsetD16(GetMem(), std::numeric_limits<bfloat16>::max(), GetSize());
-        }
-        else if(std::is_same<Tgpu, half_float::half>::value)
-        {
-            hipMemsetD16(GetMem(), std::numeric_limits<half_float::half>::max(), GetSize());
-        }
-        else if(std::is_same<Tgpu, bfloat8_fnuz>::value)
-        {
-            hipMemset(GetMem(), std::numeric_limits<bfloat8_fnuz>::max(), GetSize());
-        }
-        else if(std::is_same<Tgpu, float8_fnuz>::value)
-        {
-            hipMemset(GetMem(), std::numeric_limits<float8_fnuz>::max(), GetSize());
-        }
-        else if(std::is_same<Tgpu, int8_t>::value)
-        {
-            // ints dont have Nan so use min value.
-            hipMemset(GetMem(), std::numeric_limits<int8_t>::max(), GetSize());
+            Tgpu nan = std::numeric_limits<Tgpu>::quiet_NaN();
+            miopenSetTensor(handle, tensorDesc, GetMem(), &nan);
         }
 
         return STATUS_SUCCESS;
@@ -298,7 +286,11 @@ public:
         }
     }
 
-    status_t FillGpuBufferWithMaxValue() { return dev->FillBufferWithMaxValue<Tgpu>(); }
+    status_t FillGpuBufferWithMaxValue(miopenHandle_t handle,
+                                       const miopenTensorDescriptor_t tensorDesc)
+    {
+        return dev->FillBufferWithMaxValue<Tgpu>(handle, tensorDesc);
+    }
 
     status_t
     AllocOnDevice(stream, context_t ctx, const size_t sz, GPUMem::Check check = GPUMem::Check::None)

--- a/driver/driver.hpp
+++ b/driver/driver.hpp
@@ -145,28 +145,28 @@ struct GPUMem
         // init the buffers with NaNs.
         if(std::is_same<Tgpu, float>::value)
         {
-            hipMemsetD32(GetMem(), std::numeric_limits<float>::quiet_NaN(), GetSize());
+            hipMemsetD32(GetMem(), std::numeric_limits<float>::max(), GetSize());
         }
         else if(std::is_same<Tgpu, bfloat16>::value)
         {
-            hipMemsetD16(GetMem(), std::numeric_limits<bfloat16>::quiet_NaN(), GetSize());
+            hipMemsetD16(GetMem(), std::numeric_limits<bfloat16>::max(), GetSize());
         }
         else if(std::is_same<Tgpu, half_float::half>::value)
         {
-            hipMemsetD16(GetMem(), std::numeric_limits<half_float::half>::quiet_NaN(), GetSize());
+            hipMemsetD16(GetMem(), std::numeric_limits<half_float::half>::max(), GetSize());
         }
         else if(std::is_same<Tgpu, bfloat8_fnuz>::value)
         {
-            hipMemset(GetMem(), std::numeric_limits<bfloat8_fnuz>::quiet_NaN(), GetSize());
+            hipMemset(GetMem(), std::numeric_limits<bfloat8_fnuz>::max(), GetSize());
         }
         else if(std::is_same<Tgpu, float8_fnuz>::value)
         {
-            hipMemset(GetMem(), std::numeric_limits<float8_fnuz>::quiet_NaN(), GetSize());
+            hipMemset(GetMem(), std::numeric_limits<float8_fnuz>::max(), GetSize());
         }
         else if(std::is_same<Tgpu, int8_t>::value)
         {
             // ints dont have Nan so use min value.
-            hipMemset(GetMem(), std::numeric_limits<int8_t>::min(), GetSize());
+            hipMemset(GetMem(), std::numeric_limits<int8_t>::max(), GetSize());
         }
 
         return STATUS_SUCCESS;

--- a/driver/driver.hpp
+++ b/driver/driver.hpp
@@ -137,6 +137,44 @@ struct GPUMem
         return static_cast<int>(hipMemcpy(p, buf, GetSize(), hipMemcpyDeviceToHost));
     }
 
+    // To pass the Tgpu type, make FillBufferWithNans a template method:
+    template <typename Tgpu>
+    status_t FillBufferWithNans()
+    {
+        // In the past we have had some issues with incorrect results due to Nans in the output
+        // buffers.  In order to test the clearing of the output buffers, you can
+        // init the buffers with NaNs.
+        // Note, we only do this for the gpu buffers, adding the behaviour for the host buffers
+        // causes a crash as the host code doesnt handle NaNs.
+        if(std::is_same<Tgpu, float>::value)
+        {
+            hipMemsetD32(GetMem(), std::numeric_limits<float>::quiet_NaN(), GetSize());
+        }
+        else if(std::is_same<Tgpu, bfloat16>::value)
+        {
+            hipMemsetD16(GetMem(), std::numeric_limits<bfloat16>::quiet_NaN(), GetSize());
+        }
+        else if(std::is_same<Tgpu, half_float::half>::value)
+        {
+            hipMemsetD16(GetMem(), std::numeric_limits<half_float::half>::quiet_NaN(), GetSize());
+        }
+        else if(std::is_same<Tgpu, bfloat8_fnuz>::value)
+        {
+            hipMemset(GetMem(), std::numeric_limits<bfloat8_fnuz>::quiet_NaN(), GetSize());
+        }
+        else if(std::is_same<Tgpu, float8_fnuz>::value)
+        {
+            hipMemset(GetMem(), std::numeric_limits<float8_fnuz>::quiet_NaN(), GetSize());
+        }
+        else if(std::is_same<Tgpu, int8_t>::value)
+        {
+            // ints dont have Nan so use min value.
+            hipMemset(GetMem(), std::numeric_limits<int8_t>::min(), GetSize());
+        }
+
+        return STATUS_SUCCESS;
+    }
+
     void* GetMem() { return buf; }
     size_t GetSize() { return sz * data_sz; }
 
@@ -263,43 +301,7 @@ public:
         }
     }
 
-    status_t FillGpuBufferWithNans()
-    {
-        // In the past we have had some issues with incorrect results due to Nans in the output
-        // buffers.  In order to test the clearing of the output buffers, you can
-        // init the buffers with NaNs.
-        // Note, we only do this for the gpu buffers, adding the behaviour for the host buffers
-        // causes a crash as the host code doesnt handle NaNs.
-        if(std::is_same<Tgpu, float>::value)
-        {
-            hipMemsetD32(dev->GetMem(), std::numeric_limits<float>::quiet_NaN(), dev->GetSize());
-        }
-        else if(std::is_same<Tgpu, bfloat16>::value)
-        {
-            hipMemsetD16(dev->GetMem(), std::numeric_limits<bfloat16>::quiet_NaN(), dev->GetSize());
-        }
-        else if(std::is_same<Tgpu, half_float::half>::value)
-        {
-            hipMemsetD16(
-                dev->GetMem(), std::numeric_limits<half_float::half>::quiet_NaN(), dev->GetSize());
-        }
-        else if(std::is_same<Tgpu, bfloat8_fnuz>::value)
-        {
-            hipMemset(
-                dev->GetMem(), std::numeric_limits<bfloat8_fnuz>::quiet_NaN(), dev->GetSize());
-        }
-        else if(std::is_same<Tgpu, float8_fnuz>::value)
-        {
-            hipMemset(dev->GetMem(), std::numeric_limits<float8_fnuz>::quiet_NaN(), dev->GetSize());
-        }
-        else if(std::is_same<Tgpu, int8_t>::value)
-        {
-            // ints dont have Nan so use min value.
-            hipMemset(dev->GetMem(), std::numeric_limits<int8_t>::min(), dev->GetSize());
-        }
-
-        return STATUS_SUCCESS;
-    }
+    status_t FillGpuBufferWithNans() { return dev->FillBufferWithNans<Tgpu>(); }
 
     status_t
     AllocOnDevice(stream, context_t ctx, const size_t sz, GPUMem::Check check = GPUMem::Check::None)

--- a/driver/driver.hpp
+++ b/driver/driver.hpp
@@ -138,8 +138,7 @@ struct GPUMem
     }
 
     template <typename Tgpu>
-    status_t FillBufferWithMaxValue(miopenHandle_t handle,
-                                    const miopenTensorDescriptor_t tensorDesc)
+    status_t FillBufferWithNans(miopenHandle_t handle, const miopenTensorDescriptor_t tensorDesc)
     {
         // In the past we have had some issues with incorrect results due to Nans in the output
         // buffers.  In order to test the clearing of the output buffers, you can
@@ -286,10 +285,9 @@ public:
         }
     }
 
-    status_t FillGpuBufferWithMaxValue(miopenHandle_t handle,
-                                       const miopenTensorDescriptor_t tensorDesc)
+    status_t FillGpuBufferWithNans(miopenHandle_t handle, const miopenTensorDescriptor_t tensorDesc)
     {
-        return dev->FillBufferWithMaxValue<Tgpu>(handle, tensorDesc);
+        return dev->FillBufferWithNans<Tgpu>(handle, tensorDesc);
     }
 
     status_t

--- a/driver/driver.hpp
+++ b/driver/driver.hpp
@@ -285,7 +285,38 @@ public:
             // init the buffers with NaNs.
             // Note, we only do this for the gpu buffers, adding the behaviour for the host buffers
             // causes a crash as the host code doesnt handle NaNs.
-            hipMemset(dev->GetMem(), std::numeric_limits<Tgpu>::quiet_NaN(), dev->GetSize());
+            if(std::is_same<Tgpu, float>::value)
+            {
+                hipMemsetD32(
+                    dev->GetMem(), std::numeric_limits<float>::quiet_NaN(), dev->GetSize());
+            }
+            else if(std::is_same<Tgpu, bfloat16>::value)
+            {
+                hipMemsetD16(
+                    dev->GetMem(), std::numeric_limits<bfloat16>::quiet_NaN(), dev->GetSize());
+            }
+            else if(std::is_same<Tgpu, half_float::half>::value)
+            {
+                hipMemsetD16(dev->GetMem(),
+                             std::numeric_limits<half_float::half>::quiet_NaN(),
+                             dev->GetSize());
+            }
+            else if(std::is_same<Tgpu, bfloat8_fnuz>::value)
+            {
+                hipMemset(
+                    dev->GetMem(), std::numeric_limits<bfloat8_fnuz>::quiet_NaN(), dev->GetSize());
+            }
+            else if(std::is_same<Tgpu, float8_fnuz>::value)
+            {
+                hipMemset(
+                    dev->GetMem(), std::numeric_limits<float8_fnuz>::quiet_NaN(), dev->GetSize());
+            }
+            else if(std::is_same<Tgpu, int8_t>::value)
+            {
+                // ints dont have Nan so use min value.
+                hipMemset(dev->GetMem(), std::numeric_limits<int8_t>::min(), dev->GetSize());
+            }
+
             return 0;
         }
 

--- a/driver/driver.hpp
+++ b/driver/driver.hpp
@@ -201,12 +201,12 @@ class GpumemTensor
 {
     std::unique_ptr<GPUMem> dev;
     tensor<Tgpu> host;
-    bool is_gpualloc                   = false;
-    bool populate_buffers_with_garbage = false;
+    bool is_gpualloc         = false;
+    bool init_gpu_output_nan = false;
 
 public:
     void SetGpuallocMode(bool v) { is_gpualloc = v; }
-    void SetGarbageBufferPopulate(bool v) { populate_buffers_with_garbage = v; }
+    void SetGpuNanOutputBuffers(bool v) { init_gpu_output_nan = v; }
     tensor<Tgpu>& GetTensor() { return host; }
 
     void AllocOnHost(miopenTensorDescriptor_t t)
@@ -251,15 +251,6 @@ public:
             return;
         }
 
-        // if(populate_buffers_with_garbage)
-        // {
-        //     for(size_t i = 0; i < sz; ++i)
-        //     {
-        //         GetVector()[i] = std::numeric_limits<Tgpu>::quiet_NaN();
-        //     }
-        //     return;
-        // }
-
         for(size_t i = 0; i < sz; ++i)
         {
             /// \anchor move_rand
@@ -287,8 +278,13 @@ public:
     {
         AllocOnDevice(q, ctx, sz, check);
 
-        if(populate_buffers_with_garbage)
+        if(init_gpu_output_nan)
         {
+            // In the past we have had some issues with incorrect results due to Nans in the output
+            // buffers.  In order to test we clear output buffers before computing anything you can
+            // init the buffers with NaNs.
+            // Note, we only do this for the gpu buffers, adding the behaviour for the host buffers
+            // causes a crash as the host code doesnt handle NaNs.
             auto dev_buf_ptr = static_cast<Tgpu*>(dev->buf);
             for(size_t i = 0; i < dev->sz; ++i)
             {

--- a/driver/driver.hpp
+++ b/driver/driver.hpp
@@ -251,14 +251,14 @@ public:
             return;
         }
 
-        if(populate_buffers_with_garbage)
-        {
-            for(size_t i = 0; i < sz; ++i)
-            {
-                GetVector()[i] = std::numeric_limits<Tgpu>::quiet_NaN();
-            }
-            return;
-        }
+        // if(populate_buffers_with_garbage)
+        // {
+        //     for(size_t i = 0; i < sz; ++i)
+        //     {
+        //         GetVector()[i] = std::numeric_limits<Tgpu>::quiet_NaN();
+        //     }
+        //     return;
+        // }
 
         for(size_t i = 0; i < sz; ++i)
         {
@@ -286,6 +286,17 @@ public:
                                   GPUMem::Check check = GPUMem::Check::None)
     {
         AllocOnDevice(q, ctx, sz, check);
+
+        if(populate_buffers_with_garbage)
+        {
+            auto dev_buf_ptr = static_cast<Tgpu*>(dev->buf);
+            for(size_t i = 0; i < dev->sz; ++i)
+            {
+                dev_buf_ptr[i] = std::numeric_limits<Tgpu>::quiet_NaN();
+            }
+            return 0;
+        }
+
         if(is_gpualloc)
         {
             /// \anchor gpualloc_random_init

--- a/driver/driver.hpp
+++ b/driver/driver.hpp
@@ -206,7 +206,6 @@ class GpumemTensor
 
 public:
     void SetGpuallocMode(bool v) { is_gpualloc = v; }
-    void SetGpuNanOutputBuffers(bool v) { init_gpu_output_nan = v; }
     tensor<Tgpu>& GetTensor() { return host; }
 
     void AllocOnHost(miopenTensorDescriptor_t t)
@@ -264,6 +263,44 @@ public:
         }
     }
 
+    status_t FillGpuBufferWithNans()
+    {
+        // In the past we have had some issues with incorrect results due to Nans in the output
+        // buffers.  In order to test the clearing of the output buffers, you can
+        // init the buffers with NaNs.
+        // Note, we only do this for the gpu buffers, adding the behaviour for the host buffers
+        // causes a crash as the host code doesnt handle NaNs.
+        if(std::is_same<Tgpu, float>::value)
+        {
+            hipMemsetD32(dev->GetMem(), std::numeric_limits<float>::quiet_NaN(), dev->GetSize());
+        }
+        else if(std::is_same<Tgpu, bfloat16>::value)
+        {
+            hipMemsetD16(dev->GetMem(), std::numeric_limits<bfloat16>::quiet_NaN(), dev->GetSize());
+        }
+        else if(std::is_same<Tgpu, half_float::half>::value)
+        {
+            hipMemsetD16(
+                dev->GetMem(), std::numeric_limits<half_float::half>::quiet_NaN(), dev->GetSize());
+        }
+        else if(std::is_same<Tgpu, bfloat8_fnuz>::value)
+        {
+            hipMemset(
+                dev->GetMem(), std::numeric_limits<bfloat8_fnuz>::quiet_NaN(), dev->GetSize());
+        }
+        else if(std::is_same<Tgpu, float8_fnuz>::value)
+        {
+            hipMemset(dev->GetMem(), std::numeric_limits<float8_fnuz>::quiet_NaN(), dev->GetSize());
+        }
+        else if(std::is_same<Tgpu, int8_t>::value)
+        {
+            // ints dont have Nan so use min value.
+            hipMemset(dev->GetMem(), std::numeric_limits<int8_t>::min(), dev->GetSize());
+        }
+
+        return STATUS_SUCCESS;
+    }
+
     status_t
     AllocOnDevice(stream, context_t ctx, const size_t sz, GPUMem::Check check = GPUMem::Check::None)
     {
@@ -277,49 +314,6 @@ public:
                                   GPUMem::Check check = GPUMem::Check::None)
     {
         AllocOnDevice(q, ctx, sz, check);
-
-        if(init_gpu_output_nan)
-        {
-            // In the past we have had some issues with incorrect results due to Nans in the output
-            // buffers.  In order to test the clearing of the output buffers, you can
-            // init the buffers with NaNs.
-            // Note, we only do this for the gpu buffers, adding the behaviour for the host buffers
-            // causes a crash as the host code doesnt handle NaNs.
-            if(std::is_same<Tgpu, float>::value)
-            {
-                hipMemsetD32(
-                    dev->GetMem(), std::numeric_limits<float>::quiet_NaN(), dev->GetSize());
-            }
-            else if(std::is_same<Tgpu, bfloat16>::value)
-            {
-                hipMemsetD16(
-                    dev->GetMem(), std::numeric_limits<bfloat16>::quiet_NaN(), dev->GetSize());
-            }
-            else if(std::is_same<Tgpu, half_float::half>::value)
-            {
-                hipMemsetD16(dev->GetMem(),
-                             std::numeric_limits<half_float::half>::quiet_NaN(),
-                             dev->GetSize());
-            }
-            else if(std::is_same<Tgpu, bfloat8_fnuz>::value)
-            {
-                hipMemset(
-                    dev->GetMem(), std::numeric_limits<bfloat8_fnuz>::quiet_NaN(), dev->GetSize());
-            }
-            else if(std::is_same<Tgpu, float8_fnuz>::value)
-            {
-                hipMemset(
-                    dev->GetMem(), std::numeric_limits<float8_fnuz>::quiet_NaN(), dev->GetSize());
-            }
-            else if(std::is_same<Tgpu, int8_t>::value)
-            {
-                // ints dont have Nan so use min value.
-                hipMemset(dev->GetMem(), std::numeric_limits<int8_t>::min(), dev->GetSize());
-            }
-
-            return 0;
-        }
-
         if(is_gpualloc)
         {
             /// \anchor gpualloc_random_init

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ nlohmann/json@v3.11.2 -DJSON_MultipleHeaders=ON -DJSON_BuildTests=Off
 ROCm/FunctionalPlus@v0.2.18-p0
 ROCm/eigen@3.4.0
 ROCm/frugally-deep@9683d557eb672ee2304f80f6682c51242d748a50
-ROCm/composable_kernel@6e5acee0f951e4d174ac9afb4afce83fc801305d -DCMAKE_BUILD_TYPE=Release
+ROCm/composable_kernel@f20b6e492dc00e7bee410b5a2a1e17fc89c3e636 -DCMAKE_BUILD_TYPE=Release
 google/googletest@v1.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ nlohmann/json@v3.11.2 -DJSON_MultipleHeaders=ON -DJSON_BuildTests=Off
 ROCm/FunctionalPlus@v0.2.18-p0
 ROCm/eigen@3.4.0
 ROCm/frugally-deep@9683d557eb672ee2304f80f6682c51242d748a50
-ROCm/composable_kernel@29f67b795712cba2becb6b0d20add97eec6e2a47 -DCMAKE_BUILD_TYPE=Release
+ROCm/composable_kernel@bb4f471b09d48ff26c9dfb97a36aa61c7a6af2d6 -DCMAKE_BUILD_TYPE=Release
 google/googletest@v1.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ nlohmann/json@v3.11.2 -DJSON_MultipleHeaders=ON -DJSON_BuildTests=Off
 ROCm/FunctionalPlus@v0.2.18-p0
 ROCm/eigen@3.4.0
 ROCm/frugally-deep@9683d557eb672ee2304f80f6682c51242d748a50
-ROCm/composable_kernel@3587c605b4095a351dd82029e0cde268add71785 -DCMAKE_BUILD_TYPE=Release
+ROCm/composable_kernel@29f67b795712cba2becb6b0d20add97eec6e2a47 -DCMAKE_BUILD_TYPE=Release
 google/googletest@v1.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ nlohmann/json@v3.11.2 -DJSON_MultipleHeaders=ON -DJSON_BuildTests=Off
 ROCm/FunctionalPlus@v0.2.18-p0
 ROCm/eigen@3.4.0
 ROCm/frugally-deep@9683d557eb672ee2304f80f6682c51242d748a50
-ROCm/composable_kernel@f20b6e492dc00e7bee410b5a2a1e17fc89c3e636 -DCMAKE_BUILD_TYPE=Release
+ROCm/composable_kernel@3587c605b4095a351dd82029e0cde268add71785 -DCMAKE_BUILD_TYPE=Release
 google/googletest@v1.14.0

--- a/src/include/miopen/solver/implicitgemm_ck_util.hpp
+++ b/src/include/miopen/solver/implicitgemm_ck_util.hpp
@@ -1011,9 +1011,9 @@ ConvSolution InitInvokerFactoryNHWC(const ExecutionContext&,
                 }
 
                 float elapsed = 0.0f;
-                if(alpha_beta_case == DEFAULT)
+                if constexpr(ZeroOutputs)
                 {
-                    if constexpr(ZeroOutputs)
+                    if(alpha_beta_case == DEFAULT)
                     {
                         ZeroOutTensor(handle, data_ctx.tensors.dwDesc, data_ctx.tensors.dw);
 

--- a/src/include/miopen/solver/implicitgemm_ck_util.hpp
+++ b/src/include/miopen/solver/implicitgemm_ck_util.hpp
@@ -1010,9 +1010,9 @@ ConvSolution InitInvokerFactoryNHWC(const ExecutionContext&,
                 }
 
                 float elapsed = 0.0f;
-                if constexpr(ZeroOutputs)
+                if(alpha_beta_case == DEFAULT)
                 {
-                    if(alpha_beta_case == DEFAULT)
+                    if constexpr(ZeroOutputs)
                     {
                         ZeroOutTensor(handle, data_ctx.tensors.dwDesc, data_ctx.tensors.dw);
 

--- a/src/include/miopen/solver/implicitgemm_ck_util.hpp
+++ b/src/include/miopen/solver/implicitgemm_ck_util.hpp
@@ -768,7 +768,8 @@ ZeroOutTensor(const Handle& handle, const TensorDescriptor& tensorDesc, Data_t t
     }
 }
 
-template <typename DeviceOpType,
+template <bool ZeroOutputs,
+          typename DeviceOpType,
           typename CKArgsType,
           typename CastType,
           typename Input1TposeOp,
@@ -868,12 +869,15 @@ ConvSolution InitInvokerFactoryNCHW(const ExecutionContext& ctx,
             input2_tr_inst.ConvertFrom(handle, kernels, conv_tensors);
             output_init_tr_inst.ConvertFrom(handle, kernels, conv_tensors);
 
-            /// \todo: Will need SetTensor() to properly zero out non-packed tensors
-            /// Note: Need to clear buffer memory for output since all values may not be set.
-            elapsed = handle.IsProfilingEnabled() ? handle.GetKernelTime() : 0.0f;
-            output_tr_inst.ZeroOutBuffer(handle);
-            if(handle.IsProfilingEnabled())
-                elapsed += handle.GetKernelTime();
+            if constexpr(ZeroOutputs)
+            {
+                /// \todo: Will need SetTensor() to properly zero out non-packed tensors
+                /// Note: Need to clear buffer memory for output since all values may not be set.
+                elapsed = handle.IsProfilingEnabled() ? handle.GetKernelTime() : 0.0f;
+                output_tr_inst.ZeroOutBuffer(handle);
+                if(handle.IsProfilingEnabled())
+                    elapsed += handle.GetKernelTime();
+            }
 
             std::array<internal::TransposeInstanceTagged*, 3> tr_ptrs = {
                 &input1_tr_inst, &input2_tr_inst, &output_tr_inst};
@@ -1088,7 +1092,7 @@ ConvSolution InitInvokerFactoryNHWC(const ExecutionContext&,
     }
 }
 
-template <int ND, typename DeviceOpType, typename CKArgsType, typename CastType>
+template <int ND, bool ZeroOutputs, typename DeviceOpType, typename CKArgsType, typename CastType>
 ConvSolution InitInvokerFactoryFwdNCHW(const ExecutionContext& ctx,
                                        const miopen::conv::ProblemDescription& problem,
                                        const std::string& kernel_id)
@@ -1100,11 +1104,11 @@ ConvSolution InitInvokerFactoryFwdNCHW(const ExecutionContext& ctx,
     using Input2 = internal::CKTransposeInputOp<ND, internal::ConvOperandTag::Weights>;
     using Output = internal::CKTransposeOutputOp<ND, internal::ConvOperandTag::Output>;
 
-    return InitInvokerFactoryNCHW<DeviceOpType, CKArgsType, CastType>(
+    return InitInvokerFactoryNCHW<ZeroOutputs, DeviceOpType, CKArgsType, CastType>(
         ctx, problem, kernel_id, Input1{}, Input2{}, Output{});
 }
 
-template <int ND, typename DeviceOpType, typename CKArgsType, typename CastType>
+template <int ND, bool ZeroOutputs, typename DeviceOpType, typename CKArgsType, typename CastType>
 ConvSolution InitInvokerFactoryBwdNCHW(const ExecutionContext& ctx,
                                        const miopen::conv::ProblemDescription& problem,
                                        const std::string& kernel_id)
@@ -1116,11 +1120,11 @@ ConvSolution InitInvokerFactoryBwdNCHW(const ExecutionContext& ctx,
     using Input2 = internal::CKTransposeInputOp<ND, internal::ConvOperandTag::Weights>;
     using Output = internal::CKTransposeOutputOp<ND, internal::ConvOperandTag::Input>;
 
-    return InitInvokerFactoryNCHW<DeviceOpType, CKArgsType, CastType>(
+    return InitInvokerFactoryNCHW<ZeroOutputs, DeviceOpType, CKArgsType, CastType>(
         ctx, problem, kernel_id, Input1{}, Input2{}, Output{});
 }
 
-template <int ND, typename DeviceOpType, typename CKArgsType, typename CastType>
+template <int ND, bool ZeroOutputs, typename DeviceOpType, typename CKArgsType, typename CastType>
 ConvSolution InitInvokerFactoryWrwNCHW(const ExecutionContext& ctx,
                                        const miopen::conv::ProblemDescription& problem,
                                        const std::string& kernel_id)
@@ -1131,7 +1135,7 @@ ConvSolution InitInvokerFactoryWrwNCHW(const ExecutionContext& ctx,
     using Input2 = internal::CKTransposeInputOp<ND, internal::ConvOperandTag::Output>;
     using Output = internal::CKTransposeOutputOp<ND, internal::ConvOperandTag::Weights>;
 
-    return InitInvokerFactoryNCHW<DeviceOpType, CKArgsType, CastType>(
+    return InitInvokerFactoryNCHW<ZeroOutputs, DeviceOpType, CKArgsType, CastType>(
         ctx, problem, kernel_id, Input1{}, Input2{}, Output{});
 }
 

--- a/src/include/miopen/solver/implicitgemm_ck_util.hpp
+++ b/src/include/miopen/solver/implicitgemm_ck_util.hpp
@@ -868,12 +868,12 @@ ConvSolution InitInvokerFactoryNCHW(const ExecutionContext& ctx,
             input1_tr_inst.ConvertFrom(handle, kernels, conv_tensors);
             input2_tr_inst.ConvertFrom(handle, kernels, conv_tensors);
             output_init_tr_inst.ConvertFrom(handle, kernels, conv_tensors);
+            /// \todo: Will need SetTensor() to properly zero out non-packed tensors
+            /// Note: Need to clear buffer memory for output since all values may not be set.
+            elapsed = handle.IsProfilingEnabled() ? handle.GetKernelTime() : 0.0f;
 
             if constexpr(ZeroOutputs)
             {
-                /// \todo: Will need SetTensor() to properly zero out non-packed tensors
-                /// Note: Need to clear buffer memory for output since all values may not be set.
-                elapsed = handle.IsProfilingEnabled() ? handle.GetKernelTime() : 0.0f;
                 output_tr_inst.ZeroOutBuffer(handle);
                 if(handle.IsProfilingEnabled())
                     elapsed += handle.GetKernelTime();

--- a/src/include/miopen/solver/implicitgemm_ck_util.hpp
+++ b/src/include/miopen/solver/implicitgemm_ck_util.hpp
@@ -868,12 +868,11 @@ ConvSolution InitInvokerFactoryNCHW(const ExecutionContext& ctx,
             input1_tr_inst.ConvertFrom(handle, kernels, conv_tensors);
             input2_tr_inst.ConvertFrom(handle, kernels, conv_tensors);
             output_init_tr_inst.ConvertFrom(handle, kernels, conv_tensors);
-            /// \todo: Will need SetTensor() to properly zero out non-packed tensors
-            /// Note: Need to clear buffer memory for output since all values may not be set.
             elapsed = handle.IsProfilingEnabled() ? handle.GetKernelTime() : 0.0f;
 
             if constexpr(ZeroOutputs)
             {
+                /// Note: Need to clear buffer memory for output since all values may not be set.
                 output_tr_inst.ZeroOutBuffer(handle);
                 if(handle.IsProfilingEnabled())
                     elapsed += handle.GetKernelTime();

--- a/src/include/miopen/solver/implicitgemm_ck_util.hpp
+++ b/src/include/miopen/solver/implicitgemm_ck_util.hpp
@@ -943,7 +943,8 @@ ConvSolution InitInvokerFactoryNCHW(const ExecutionContext& ctx,
     return result;
 }
 
-template <typename DeviceOpType,
+template <bool ZeroOutputs,
+          typename DeviceOpType,
           typename CKArgsType,
           typename CastType,
           typename ProblemDescriptionType = miopen::conv::ProblemDescription>
@@ -1012,11 +1013,14 @@ ConvSolution InitInvokerFactoryNHWC(const ExecutionContext&,
                 float elapsed = 0.0f;
                 if(alpha_beta_case == DEFAULT)
                 {
-                    ZeroOutTensor(handle, data_ctx.tensors.dwDesc, data_ctx.tensors.dw);
-
-                    if(handle.IsProfilingEnabled())
+                    if constexpr(ZeroOutputs)
                     {
-                        elapsed += handle.GetKernelTime();
+                        ZeroOutTensor(handle, data_ctx.tensors.dwDesc, data_ctx.tensors.dw);
+
+                        if(handle.IsProfilingEnabled())
+                        {
+                            elapsed += handle.GetKernelTime();
+                        }
                     }
                 }
                 // use captured value, other wise getting warning
@@ -1065,7 +1069,8 @@ ConvSolution InitInvokerFactoryNHWC(const ExecutionContext&,
                 // Zero out the buffer for output data since it won't always write all output
                 // values.
                 float elapsed = 0.0f;
-                if constexpr(std::is_same_v<CastType, miopen::conv::DataInvokeParams>)
+                if constexpr(std::is_same_v<CastType, miopen::conv::DataInvokeParams> &&
+                             ZeroOutputs)
                 {
                     ZeroOutTensor(handle, data_ctx.tensors.outDesc, data_ctx.tensors.out);
 

--- a/src/solver/conv/conv_hip_implicit_gemm_3d_grouped_bwd_xdlops.cpp
+++ b/src/solver/conv/conv_hip_implicit_gemm_3d_grouped_bwd_xdlops.cpp
@@ -585,17 +585,20 @@ ConvSolution ConvHipImplicitGemm3DGroupBwdXdlops::GetSolution(
             switch(problem.GetAlphaBetaCase())
             {
             case BILINEAR:
-                return InitInvokerFactoryNHWC<DeviceOpGBwdBilinearPtrs<T>,
+                return InitInvokerFactoryNHWC<false,
+                                              DeviceOpGBwdBilinearPtrs<T>,
                                               CKArgs<T>,
                                               miopen::conv::DataInvokeParams>(
                     ctx, problem, config.kernel_id);
             case SCALE:
-                return InitInvokerFactoryNHWC<DeviceOpGBwdScalePtrs<T>,
+                return InitInvokerFactoryNHWC<false,
+                                              DeviceOpGBwdScalePtrs<T>,
                                               CKArgs<T>,
                                               miopen::conv::DataInvokeParams>(
                     ctx, problem, config.kernel_id);
             default:
-                return InitInvokerFactoryNHWC<DeviceOpGBwdDefaultPtrs<T>,
+                return InitInvokerFactoryNHWC<false,
+                                              DeviceOpGBwdDefaultPtrs<T>,
                                               CKArgs<T>,
                                               miopen::conv::DataInvokeParams>(
                     ctx, problem, config.kernel_id);

--- a/src/solver/conv/conv_hip_implicit_gemm_3d_grouped_bwd_xdlops.cpp
+++ b/src/solver/conv/conv_hip_implicit_gemm_3d_grouped_bwd_xdlops.cpp
@@ -180,21 +180,21 @@ struct CKArgs
         }
 
         filter_strides   = {ProblemInterpreter::GetAdjustedConvolutionStrideD(problem),
-                          ProblemInterpreter::GetAdjustedConvolutionStrideH(problem),
-                          ProblemInterpreter::GetAdjustedConvolutionStrideW(problem)};
+                            ProblemInterpreter::GetAdjustedConvolutionStrideH(problem),
+                            ProblemInterpreter::GetAdjustedConvolutionStrideW(problem)};
         filter_dilations = {ProblemInterpreter::GetAdjustedConvolutionDilationD(problem),
                             ProblemInterpreter::GetAdjustedConvolutionDilationH(problem),
                             ProblemInterpreter::GetAdjustedConvolutionDilationW(problem)};
         lPadding         = {ProblemInterpreter::GetInputLeftPadD(problem),
-                    ProblemInterpreter::GetInputLeftPadH(problem),
-                    ProblemInterpreter::GetInputLeftPadW(problem)};
+                            ProblemInterpreter::GetInputLeftPadH(problem),
+                            ProblemInterpreter::GetInputLeftPadW(problem)};
         rPadding         = {ProblemInterpreter::GetAdjustedInputRightPadD(problem),
-                    ProblemInterpreter::GetAdjustedInputRightPadH(problem),
-                    ProblemInterpreter::GetAdjustedInputRightPadW(problem)};
+                            ProblemInterpreter::GetAdjustedInputRightPadH(problem),
+                            ProblemInterpreter::GetAdjustedInputRightPadW(problem)};
     }
 
-    CKArgs(const CKArgs&) = default;
-    CKArgs(CKArgs&&)      = default;
+    CKArgs(const CKArgs&)            = default;
+    CKArgs(CKArgs&&)                 = default;
     CKArgs& operator=(const CKArgs&) = default;
 
     template <typename ConvPtr>
@@ -559,18 +559,21 @@ ConvSolution ConvHipImplicitGemm3DGroupBwdXdlops::GetSolution(
             {
             case BILINEAR:
                 return InitInvokerFactoryBwdNCHW<3,
+                                                 true,
                                                  DeviceOpGBwdBilinearPtrs<T>,
                                                  CKArgs<T>,
                                                  miopen::conv::DataInvokeParams>(
                     ctx, problem, config.kernel_id);
             case SCALE:
                 return InitInvokerFactoryBwdNCHW<3,
+                                                 true,
                                                  DeviceOpGBwdScalePtrs<T>,
                                                  CKArgs<T>,
                                                  miopen::conv::DataInvokeParams>(
                     ctx, problem, config.kernel_id);
             default:
                 return InitInvokerFactoryBwdNCHW<3,
+                                                 true,
                                                  DeviceOpGBwdDefaultPtrs<T>,
                                                  CKArgs<T>,
                                                  miopen::conv::DataInvokeParams>(

--- a/src/solver/conv/conv_hip_implicit_gemm_3d_grouped_bwd_xdlops.cpp
+++ b/src/solver/conv/conv_hip_implicit_gemm_3d_grouped_bwd_xdlops.cpp
@@ -180,21 +180,21 @@ struct CKArgs
         }
 
         filter_strides   = {ProblemInterpreter::GetAdjustedConvolutionStrideD(problem),
-                            ProblemInterpreter::GetAdjustedConvolutionStrideH(problem),
-                            ProblemInterpreter::GetAdjustedConvolutionStrideW(problem)};
+                          ProblemInterpreter::GetAdjustedConvolutionStrideH(problem),
+                          ProblemInterpreter::GetAdjustedConvolutionStrideW(problem)};
         filter_dilations = {ProblemInterpreter::GetAdjustedConvolutionDilationD(problem),
                             ProblemInterpreter::GetAdjustedConvolutionDilationH(problem),
                             ProblemInterpreter::GetAdjustedConvolutionDilationW(problem)};
         lPadding         = {ProblemInterpreter::GetInputLeftPadD(problem),
-                            ProblemInterpreter::GetInputLeftPadH(problem),
-                            ProblemInterpreter::GetInputLeftPadW(problem)};
+                    ProblemInterpreter::GetInputLeftPadH(problem),
+                    ProblemInterpreter::GetInputLeftPadW(problem)};
         rPadding         = {ProblemInterpreter::GetAdjustedInputRightPadD(problem),
-                            ProblemInterpreter::GetAdjustedInputRightPadH(problem),
-                            ProblemInterpreter::GetAdjustedInputRightPadW(problem)};
+                    ProblemInterpreter::GetAdjustedInputRightPadH(problem),
+                    ProblemInterpreter::GetAdjustedInputRightPadW(problem)};
     }
 
-    CKArgs(const CKArgs&)            = default;
-    CKArgs(CKArgs&&)                 = default;
+    CKArgs(const CKArgs&) = default;
+    CKArgs(CKArgs&&)      = default;
     CKArgs& operator=(const CKArgs&) = default;
 
     template <typename ConvPtr>

--- a/src/solver/conv/conv_hip_implicit_gemm_3d_grouped_bwd_xdlops.cpp
+++ b/src/solver/conv/conv_hip_implicit_gemm_3d_grouped_bwd_xdlops.cpp
@@ -559,21 +559,21 @@ ConvSolution ConvHipImplicitGemm3DGroupBwdXdlops::GetSolution(
             {
             case BILINEAR:
                 return InitInvokerFactoryBwdNCHW<3,
-                                                 true,
+                                                 false,
                                                  DeviceOpGBwdBilinearPtrs<T>,
                                                  CKArgs<T>,
                                                  miopen::conv::DataInvokeParams>(
                     ctx, problem, config.kernel_id);
             case SCALE:
                 return InitInvokerFactoryBwdNCHW<3,
-                                                 true,
+                                                 false,
                                                  DeviceOpGBwdScalePtrs<T>,
                                                  CKArgs<T>,
                                                  miopen::conv::DataInvokeParams>(
                     ctx, problem, config.kernel_id);
             default:
                 return InitInvokerFactoryBwdNCHW<3,
-                                                 true,
+                                                 false,
                                                  DeviceOpGBwdDefaultPtrs<T>,
                                                  CKArgs<T>,
                                                  miopen::conv::DataInvokeParams>(

--- a/src/solver/conv/conv_hip_implicit_gemm_3d_grouped_fwd_xdlops.cpp
+++ b/src/solver/conv/conv_hip_implicit_gemm_3d_grouped_fwd_xdlops.cpp
@@ -173,21 +173,21 @@ struct CKArgs
         }
 
         filter_strides   = {ProblemInterpreter::GetAdjustedConvolutionStrideD(problem),
-                            ProblemInterpreter::GetAdjustedConvolutionStrideH(problem),
-                            ProblemInterpreter::GetAdjustedConvolutionStrideW(problem)};
+                          ProblemInterpreter::GetAdjustedConvolutionStrideH(problem),
+                          ProblemInterpreter::GetAdjustedConvolutionStrideW(problem)};
         filter_dilations = {ProblemInterpreter::GetAdjustedConvolutionDilationD(problem),
                             ProblemInterpreter::GetAdjustedConvolutionDilationH(problem),
                             ProblemInterpreter::GetAdjustedConvolutionDilationW(problem)};
         lPadding         = {ProblemInterpreter::GetInputLeftPadD(problem),
-                            ProblemInterpreter::GetInputLeftPadH(problem),
-                            ProblemInterpreter::GetInputLeftPadW(problem)};
+                    ProblemInterpreter::GetInputLeftPadH(problem),
+                    ProblemInterpreter::GetInputLeftPadW(problem)};
         rPadding         = {ProblemInterpreter::GetAdjustedInputRightPadD(problem),
-                            ProblemInterpreter::GetAdjustedInputRightPadH(problem),
-                            ProblemInterpreter::GetAdjustedInputRightPadW(problem)};
+                    ProblemInterpreter::GetAdjustedInputRightPadH(problem),
+                    ProblemInterpreter::GetAdjustedInputRightPadW(problem)};
     }
 
-    CKArgs(const CKArgs&)            = default;
-    CKArgs(CKArgs&&) noexcept        = default;
+    CKArgs(const CKArgs&)     = default;
+    CKArgs(CKArgs&&) noexcept = default;
     CKArgs& operator=(const CKArgs&) = default;
 
     template <typename ConvPtr>

--- a/src/solver/conv/conv_hip_implicit_gemm_3d_grouped_fwd_xdlops.cpp
+++ b/src/solver/conv/conv_hip_implicit_gemm_3d_grouped_fwd_xdlops.cpp
@@ -580,17 +580,20 @@ ConvSolution ConvHipImplicitGemm3DGroupFwdXdlops::GetSolution(
             switch(problem.GetAlphaBetaCase())
             {
             case BILINEAR:
-                return InitInvokerFactoryNHWC<DeviceOpGFwdBilinearPtrs<T>,
+                return InitInvokerFactoryNHWC<false,
+                                              DeviceOpGFwdBilinearPtrs<T>,
                                               CKArgs<T>,
                                               miopen::conv::DataInvokeParams>(
                     ctx, problem, config.kernel_id);
             case SCALE:
-                return InitInvokerFactoryNHWC<DeviceOpGFwdScalePtrs<T>,
+                return InitInvokerFactoryNHWC<false,
+                                              DeviceOpGFwdScalePtrs<T>,
                                               CKArgs<T>,
                                               miopen::conv::DataInvokeParams>(
                     ctx, problem, config.kernel_id);
             default:
-                return InitInvokerFactoryNHWC<DeviceOpGFwdDefaultPtrs<T>,
+                return InitInvokerFactoryNHWC<false,
+                                              DeviceOpGFwdDefaultPtrs<T>,
                                               CKArgs<T>,
                                               miopen::conv::DataInvokeParams>(
                     ctx, problem, config.kernel_id);

--- a/src/solver/conv/conv_hip_implicit_gemm_3d_grouped_fwd_xdlops.cpp
+++ b/src/solver/conv/conv_hip_implicit_gemm_3d_grouped_fwd_xdlops.cpp
@@ -173,21 +173,21 @@ struct CKArgs
         }
 
         filter_strides   = {ProblemInterpreter::GetAdjustedConvolutionStrideD(problem),
-                          ProblemInterpreter::GetAdjustedConvolutionStrideH(problem),
-                          ProblemInterpreter::GetAdjustedConvolutionStrideW(problem)};
+                            ProblemInterpreter::GetAdjustedConvolutionStrideH(problem),
+                            ProblemInterpreter::GetAdjustedConvolutionStrideW(problem)};
         filter_dilations = {ProblemInterpreter::GetAdjustedConvolutionDilationD(problem),
                             ProblemInterpreter::GetAdjustedConvolutionDilationH(problem),
                             ProblemInterpreter::GetAdjustedConvolutionDilationW(problem)};
         lPadding         = {ProblemInterpreter::GetInputLeftPadD(problem),
-                    ProblemInterpreter::GetInputLeftPadH(problem),
-                    ProblemInterpreter::GetInputLeftPadW(problem)};
+                            ProblemInterpreter::GetInputLeftPadH(problem),
+                            ProblemInterpreter::GetInputLeftPadW(problem)};
         rPadding         = {ProblemInterpreter::GetAdjustedInputRightPadD(problem),
-                    ProblemInterpreter::GetAdjustedInputRightPadH(problem),
-                    ProblemInterpreter::GetAdjustedInputRightPadW(problem)};
+                            ProblemInterpreter::GetAdjustedInputRightPadH(problem),
+                            ProblemInterpreter::GetAdjustedInputRightPadW(problem)};
     }
 
-    CKArgs(const CKArgs&)     = default;
-    CKArgs(CKArgs&&) noexcept = default;
+    CKArgs(const CKArgs&)            = default;
+    CKArgs(CKArgs&&) noexcept        = default;
     CKArgs& operator=(const CKArgs&) = default;
 
     template <typename ConvPtr>
@@ -554,18 +554,21 @@ ConvSolution ConvHipImplicitGemm3DGroupFwdXdlops::GetSolution(
             {
             case BILINEAR:
                 return InitInvokerFactoryFwdNCHW<3,
+                                                 true,
                                                  DeviceOpGFwdBilinearPtrs<T>,
                                                  CKArgs<T>,
                                                  miopen::conv::DataInvokeParams>(
                     ctx, problem, config.kernel_id);
             case SCALE:
                 return InitInvokerFactoryFwdNCHW<3,
+                                                 true,
                                                  DeviceOpGFwdScalePtrs<T>,
                                                  CKArgs<T>,
                                                  miopen::conv::DataInvokeParams>(
                     ctx, problem, config.kernel_id);
             default:
                 return InitInvokerFactoryFwdNCHW<3,
+                                                 true,
                                                  DeviceOpGFwdDefaultPtrs<T>,
                                                  CKArgs<T>,
                                                  miopen::conv::DataInvokeParams>(

--- a/src/solver/conv/conv_hip_implicit_gemm_3d_grouped_fwd_xdlops.cpp
+++ b/src/solver/conv/conv_hip_implicit_gemm_3d_grouped_fwd_xdlops.cpp
@@ -554,21 +554,21 @@ ConvSolution ConvHipImplicitGemm3DGroupFwdXdlops::GetSolution(
             {
             case BILINEAR:
                 return InitInvokerFactoryFwdNCHW<3,
-                                                 true,
+                                                 false,
                                                  DeviceOpGFwdBilinearPtrs<T>,
                                                  CKArgs<T>,
                                                  miopen::conv::DataInvokeParams>(
                     ctx, problem, config.kernel_id);
             case SCALE:
                 return InitInvokerFactoryFwdNCHW<3,
-                                                 true,
+                                                 false,
                                                  DeviceOpGFwdScalePtrs<T>,
                                                  CKArgs<T>,
                                                  miopen::conv::DataInvokeParams>(
                     ctx, problem, config.kernel_id);
             default:
                 return InitInvokerFactoryFwdNCHW<3,
-                                                 true,
+                                                 false,
                                                  DeviceOpGFwdDefaultPtrs<T>,
                                                  CKArgs<T>,
                                                  miopen::conv::DataInvokeParams>(

--- a/src/solver/conv/conv_hip_implicit_gemm_3d_grouped_wrw_xdlops.cpp
+++ b/src/solver/conv/conv_hip_implicit_gemm_3d_grouped_wrw_xdlops.cpp
@@ -109,20 +109,20 @@ struct CKArgs
         }
 
         filter_strides   = {ProblemInterpreter::GetAdjustedConvolutionStrideD(problem),
-                            ProblemInterpreter::GetAdjustedConvolutionStrideH(problem),
-                            ProblemInterpreter::GetAdjustedConvolutionStrideW(problem)};
+                          ProblemInterpreter::GetAdjustedConvolutionStrideH(problem),
+                          ProblemInterpreter::GetAdjustedConvolutionStrideW(problem)};
         filter_dilations = {ProblemInterpreter::GetAdjustedConvolutionDilationD(problem),
                             ProblemInterpreter::GetAdjustedConvolutionDilationH(problem),
                             ProblemInterpreter::GetAdjustedConvolutionDilationW(problem)};
         lPadding         = {ProblemInterpreter::GetInputLeftPadD(problem),
-                            ProblemInterpreter::GetInputLeftPadH(problem),
-                            ProblemInterpreter::GetInputLeftPadW(problem)};
+                    ProblemInterpreter::GetInputLeftPadH(problem),
+                    ProblemInterpreter::GetInputLeftPadW(problem)};
         rPadding         = {ProblemInterpreter::GetAdjustedInputRightPadD(problem),
-                            ProblemInterpreter::GetAdjustedInputRightPadH(problem),
-                            ProblemInterpreter::GetAdjustedInputRightPadW(problem)};
+                    ProblemInterpreter::GetAdjustedInputRightPadH(problem),
+                    ProblemInterpreter::GetAdjustedInputRightPadW(problem)};
     }
-    CKArgs(const CKArgs&)            = default;
-    CKArgs(CKArgs&&)                 = default;
+    CKArgs(const CKArgs&) = default;
+    CKArgs(CKArgs&&)      = default;
     CKArgs& operator=(const CKArgs&) = default;
 
     template <typename ConvPtr>

--- a/src/solver/conv/conv_hip_implicit_gemm_3d_grouped_wrw_xdlops.cpp
+++ b/src/solver/conv/conv_hip_implicit_gemm_3d_grouped_wrw_xdlops.cpp
@@ -563,17 +563,20 @@ ConvSolution ConvHipImplicitGemm3DGroupWrwXdlops::GetSolution(
             switch(problem.GetAlphaBetaCase())
             {
             case BILINEAR:
-                return InitInvokerFactoryNHWC<DeviceOpGBwdWeightBilinearPtrs<T>,
+                return InitInvokerFactoryNHWC<false,
+                                              DeviceOpGBwdWeightBilinearPtrs<T>,
                                               CKArgs<T>,
                                               miopen::conv::WrWInvokeParams>(
                     ctx, problem, config.kernel_id);
             case SCALE:
-                return InitInvokerFactoryNHWC<DeviceOpGBwdWeightScalePtrs<T>,
+                return InitInvokerFactoryNHWC<false,
+                                              DeviceOpGBwdWeightScalePtrs<T>,
                                               CKArgs<T>,
                                               miopen::conv::WrWInvokeParams>(
                     ctx, problem, config.kernel_id);
             default:
-                return InitInvokerFactoryNHWC<DeviceOpGBwdWeightDefaultPtrs<T>,
+                return InitInvokerFactoryNHWC<false,
+                                              DeviceOpGBwdWeightDefaultPtrs<T>,
                                               CKArgs<T>,
                                               miopen::conv::WrWInvokeParams>(
                     ctx, problem, config.kernel_id);

--- a/src/solver/conv/conv_hip_implicit_gemm_3d_grouped_wrw_xdlops.cpp
+++ b/src/solver/conv/conv_hip_implicit_gemm_3d_grouped_wrw_xdlops.cpp
@@ -537,21 +537,21 @@ ConvSolution ConvHipImplicitGemm3DGroupWrwXdlops::GetSolution(
             {
             case BILINEAR:
                 return InitInvokerFactoryWrwNCHW<3,
-                                                 true,
+                                                 false,
                                                  DeviceOpGBwdWeightBilinearPtrs<T>,
                                                  CKArgs<T>,
                                                  miopen::conv::WrWInvokeParams>(
                     ctx, problem, config.kernel_id);
             case SCALE:
                 return InitInvokerFactoryWrwNCHW<3,
-                                                 true,
+                                                 false,
                                                  DeviceOpGBwdWeightScalePtrs<T>,
                                                  CKArgs<T>,
                                                  miopen::conv::WrWInvokeParams>(
                     ctx, problem, config.kernel_id);
             default:
                 return InitInvokerFactoryWrwNCHW<3,
-                                                 true,
+                                                 false,
                                                  DeviceOpGBwdWeightDefaultPtrs<T>,
                                                  CKArgs<T>,
                                                  miopen::conv::WrWInvokeParams>(

--- a/src/solver/conv/conv_hip_implicit_gemm_3d_grouped_wrw_xdlops.cpp
+++ b/src/solver/conv/conv_hip_implicit_gemm_3d_grouped_wrw_xdlops.cpp
@@ -109,20 +109,20 @@ struct CKArgs
         }
 
         filter_strides   = {ProblemInterpreter::GetAdjustedConvolutionStrideD(problem),
-                          ProblemInterpreter::GetAdjustedConvolutionStrideH(problem),
-                          ProblemInterpreter::GetAdjustedConvolutionStrideW(problem)};
+                            ProblemInterpreter::GetAdjustedConvolutionStrideH(problem),
+                            ProblemInterpreter::GetAdjustedConvolutionStrideW(problem)};
         filter_dilations = {ProblemInterpreter::GetAdjustedConvolutionDilationD(problem),
                             ProblemInterpreter::GetAdjustedConvolutionDilationH(problem),
                             ProblemInterpreter::GetAdjustedConvolutionDilationW(problem)};
         lPadding         = {ProblemInterpreter::GetInputLeftPadD(problem),
-                    ProblemInterpreter::GetInputLeftPadH(problem),
-                    ProblemInterpreter::GetInputLeftPadW(problem)};
+                            ProblemInterpreter::GetInputLeftPadH(problem),
+                            ProblemInterpreter::GetInputLeftPadW(problem)};
         rPadding         = {ProblemInterpreter::GetAdjustedInputRightPadD(problem),
-                    ProblemInterpreter::GetAdjustedInputRightPadH(problem),
-                    ProblemInterpreter::GetAdjustedInputRightPadW(problem)};
+                            ProblemInterpreter::GetAdjustedInputRightPadH(problem),
+                            ProblemInterpreter::GetAdjustedInputRightPadW(problem)};
     }
-    CKArgs(const CKArgs&) = default;
-    CKArgs(CKArgs&&)      = default;
+    CKArgs(const CKArgs&)            = default;
+    CKArgs(CKArgs&&)                 = default;
     CKArgs& operator=(const CKArgs&) = default;
 
     template <typename ConvPtr>
@@ -537,18 +537,21 @@ ConvSolution ConvHipImplicitGemm3DGroupWrwXdlops::GetSolution(
             {
             case BILINEAR:
                 return InitInvokerFactoryWrwNCHW<3,
+                                                 true,
                                                  DeviceOpGBwdWeightBilinearPtrs<T>,
                                                  CKArgs<T>,
                                                  miopen::conv::WrWInvokeParams>(
                     ctx, problem, config.kernel_id);
             case SCALE:
                 return InitInvokerFactoryWrwNCHW<3,
+                                                 true,
                                                  DeviceOpGBwdWeightScalePtrs<T>,
                                                  CKArgs<T>,
                                                  miopen::conv::WrWInvokeParams>(
                     ctx, problem, config.kernel_id);
             default:
                 return InitInvokerFactoryWrwNCHW<3,
+                                                 true,
                                                  DeviceOpGBwdWeightDefaultPtrs<T>,
                                                  CKArgs<T>,
                                                  miopen::conv::WrWInvokeParams>(

--- a/src/solver/conv/conv_hip_implicit_gemm_bwd_data_xdlops.cpp
+++ b/src/solver/conv/conv_hip_implicit_gemm_bwd_data_xdlops.cpp
@@ -72,13 +72,13 @@ struct CKArgs
         K        = ProblemInterpreter::GetOutputChannelK(problem);
         C        = ProblemInterpreter::GetInputChannelC(problem);
         input    = {ProblemInterpreter::GetInputHeightHi(problem),
-                 ProblemInterpreter::GetInputWidthWi(problem)};
+                    ProblemInterpreter::GetInputWidthWi(problem)};
         output   = {ProblemInterpreter::GetOutputHeightHo(problem),
-                  ProblemInterpreter::GetOutputWidthWo(problem)};
+                    ProblemInterpreter::GetOutputWidthWo(problem)};
         filter   = {ProblemInterpreter::GetFilterHeightY(problem),
-                  ProblemInterpreter::GetFilterWidthX(problem)};
+                    ProblemInterpreter::GetFilterWidthX(problem)};
         strides  = {ProblemInterpreter::GetAdjustedConvolutionStrideH(problem),
-                   ProblemInterpreter::GetAdjustedConvolutionStrideW(problem)};
+                    ProblemInterpreter::GetAdjustedConvolutionStrideW(problem)};
         dilation = {ProblemInterpreter::GetAdjustedConvolutionDilationH(problem),
                     ProblemInterpreter::GetAdjustedConvolutionDilationW(problem)};
         lPadding = {ProblemInterpreter::GetInputLeftPadH(problem),
@@ -87,8 +87,8 @@ struct CKArgs
                     ProblemInterpreter::GetAdjustedInputRightPadW(problem)};
     }
 
-    CKArgs(const CKArgs&) = default;
-    CKArgs(CKArgs&&)      = default;
+    CKArgs(const CKArgs&)            = default;
+    CKArgs(CKArgs&&)                 = default;
     CKArgs& operator=(const CKArgs&) = default;
     ~CKArgs()                        = default;
 
@@ -326,17 +326,20 @@ ConvSolution ConvHipImplicitGemmBwdXdlops::GetSolution(
     switch(problem.GetInDataType())
     {
     case miopenHalf:
-        return InitInvokerFactoryNHWC<DeviceOpBwdPtrs<ck::half_t>,
+        return InitInvokerFactoryNHWC<true,
+                                      DeviceOpBwdPtrs<ck::half_t>,
                                       CKArgs,
                                       miopen::conv::DataInvokeParams>(
             ctx, problem, config.kernel_id);
     case miopenFloat:
-        return InitInvokerFactoryNHWC<DeviceOpBwdPtrs<float>,
+        return InitInvokerFactoryNHWC<true,
+                                      DeviceOpBwdPtrs<float>,
                                       CKArgs,
                                       miopen::conv::DataInvokeParams>(
             ctx, problem, config.kernel_id);
     case miopenBFloat16:
-        return InitInvokerFactoryNHWC<DeviceOpBwdPtrs<ck::bhalf_t>,
+        return InitInvokerFactoryNHWC<true,
+                                      DeviceOpBwdPtrs<ck::bhalf_t>,
                                       CKArgs,
                                       miopen::conv::DataInvokeParams>(
             ctx, problem, config.kernel_id);

--- a/src/solver/conv/conv_hip_implicit_gemm_bwd_data_xdlops.cpp
+++ b/src/solver/conv/conv_hip_implicit_gemm_bwd_data_xdlops.cpp
@@ -72,13 +72,13 @@ struct CKArgs
         K        = ProblemInterpreter::GetOutputChannelK(problem);
         C        = ProblemInterpreter::GetInputChannelC(problem);
         input    = {ProblemInterpreter::GetInputHeightHi(problem),
-                    ProblemInterpreter::GetInputWidthWi(problem)};
+                 ProblemInterpreter::GetInputWidthWi(problem)};
         output   = {ProblemInterpreter::GetOutputHeightHo(problem),
-                    ProblemInterpreter::GetOutputWidthWo(problem)};
+                  ProblemInterpreter::GetOutputWidthWo(problem)};
         filter   = {ProblemInterpreter::GetFilterHeightY(problem),
-                    ProblemInterpreter::GetFilterWidthX(problem)};
+                  ProblemInterpreter::GetFilterWidthX(problem)};
         strides  = {ProblemInterpreter::GetAdjustedConvolutionStrideH(problem),
-                    ProblemInterpreter::GetAdjustedConvolutionStrideW(problem)};
+                   ProblemInterpreter::GetAdjustedConvolutionStrideW(problem)};
         dilation = {ProblemInterpreter::GetAdjustedConvolutionDilationH(problem),
                     ProblemInterpreter::GetAdjustedConvolutionDilationW(problem)};
         lPadding = {ProblemInterpreter::GetInputLeftPadH(problem),
@@ -87,8 +87,8 @@ struct CKArgs
                     ProblemInterpreter::GetAdjustedInputRightPadW(problem)};
     }
 
-    CKArgs(const CKArgs&)            = default;
-    CKArgs(CKArgs&&)                 = default;
+    CKArgs(const CKArgs&) = default;
+    CKArgs(CKArgs&&)      = default;
     CKArgs& operator=(const CKArgs&) = default;
     ~CKArgs()                        = default;
 

--- a/src/solver/conv/conv_hip_implicit_gemm_fwd_xdlops.cpp
+++ b/src/solver/conv/conv_hip_implicit_gemm_fwd_xdlops.cpp
@@ -72,13 +72,13 @@ struct CKArgs
         K        = ProblemInterpreter::GetOutputChannelK(problem);
         C        = ProblemInterpreter::GetInputChannelC(problem);
         input    = {ProblemInterpreter::GetInputHeightHi(problem),
-                 ProblemInterpreter::GetInputWidthWi(problem)};
+                    ProblemInterpreter::GetInputWidthWi(problem)};
         output   = {ProblemInterpreter::GetOutputHeightHo(problem),
-                  ProblemInterpreter::GetOutputWidthWo(problem)};
+                    ProblemInterpreter::GetOutputWidthWo(problem)};
         filter   = {ProblemInterpreter::GetFilterHeightY(problem),
-                  ProblemInterpreter::GetFilterWidthX(problem)};
+                    ProblemInterpreter::GetFilterWidthX(problem)};
         strides  = {ProblemInterpreter::GetAdjustedConvolutionStrideH(problem),
-                   ProblemInterpreter::GetAdjustedConvolutionStrideW(problem)};
+                    ProblemInterpreter::GetAdjustedConvolutionStrideW(problem)};
         dilation = {ProblemInterpreter::GetAdjustedConvolutionDilationH(problem),
                     ProblemInterpreter::GetAdjustedConvolutionDilationW(problem)};
         lPadding = {ProblemInterpreter::GetInputLeftPadH(problem),
@@ -87,8 +87,8 @@ struct CKArgs
                     ProblemInterpreter::GetAdjustedInputRightPadW(problem)};
     }
 
-    CKArgs(const CKArgs&) = default;
-    CKArgs(CKArgs&&)      = default;
+    CKArgs(const CKArgs&)            = default;
+    CKArgs(CKArgs&&)                 = default;
     CKArgs& operator=(const CKArgs&) = default;
     ~CKArgs()                        = default;
 
@@ -327,18 +327,26 @@ ConvSolution ConvHipImplicitGemmFwdXdlops::GetSolution(
     switch(problem.GetInDataType())
     {
     case miopenInt8:
-        return InitInvokerFactoryNHWC<DeviceOpPtrs<int8_t>, CKArgs, miopen::conv::DataInvokeParams>(
+        return InitInvokerFactoryNHWC<true,
+                                      DeviceOpPtrs<int8_t>,
+                                      CKArgs,
+                                      miopen::conv::DataInvokeParams>(
             ctx, problem, config.kernel_id);
     case miopenHalf:
-        return InitInvokerFactoryNHWC<DeviceOpPtrs<ck::half_t>,
+        return InitInvokerFactoryNHWC<true,
+                                      DeviceOpPtrs<ck::half_t>,
                                       CKArgs,
                                       miopen::conv::DataInvokeParams>(
             ctx, problem, config.kernel_id);
     case miopenFloat:
-        return InitInvokerFactoryNHWC<DeviceOpPtrs<float>, CKArgs, miopen::conv::DataInvokeParams>(
+        return InitInvokerFactoryNHWC<true,
+                                      DeviceOpPtrs<float>,
+                                      CKArgs,
+                                      miopen::conv::DataInvokeParams>(
             ctx, problem, config.kernel_id);
     case miopenBFloat16:
-        return InitInvokerFactoryNHWC<DeviceOpPtrs<ck::bhalf_t>,
+        return InitInvokerFactoryNHWC<true,
+                                      DeviceOpPtrs<ck::bhalf_t>,
                                       CKArgs,
                                       miopen::conv::DataInvokeParams>(
             ctx, problem, config.kernel_id);

--- a/src/solver/conv/conv_hip_implicit_gemm_fwd_xdlops.cpp
+++ b/src/solver/conv/conv_hip_implicit_gemm_fwd_xdlops.cpp
@@ -72,13 +72,13 @@ struct CKArgs
         K        = ProblemInterpreter::GetOutputChannelK(problem);
         C        = ProblemInterpreter::GetInputChannelC(problem);
         input    = {ProblemInterpreter::GetInputHeightHi(problem),
-                    ProblemInterpreter::GetInputWidthWi(problem)};
+                 ProblemInterpreter::GetInputWidthWi(problem)};
         output   = {ProblemInterpreter::GetOutputHeightHo(problem),
-                    ProblemInterpreter::GetOutputWidthWo(problem)};
+                  ProblemInterpreter::GetOutputWidthWo(problem)};
         filter   = {ProblemInterpreter::GetFilterHeightY(problem),
-                    ProblemInterpreter::GetFilterWidthX(problem)};
+                  ProblemInterpreter::GetFilterWidthX(problem)};
         strides  = {ProblemInterpreter::GetAdjustedConvolutionStrideH(problem),
-                    ProblemInterpreter::GetAdjustedConvolutionStrideW(problem)};
+                   ProblemInterpreter::GetAdjustedConvolutionStrideW(problem)};
         dilation = {ProblemInterpreter::GetAdjustedConvolutionDilationH(problem),
                     ProblemInterpreter::GetAdjustedConvolutionDilationW(problem)};
         lPadding = {ProblemInterpreter::GetInputLeftPadH(problem),
@@ -87,8 +87,8 @@ struct CKArgs
                     ProblemInterpreter::GetAdjustedInputRightPadW(problem)};
     }
 
-    CKArgs(const CKArgs&)            = default;
-    CKArgs(CKArgs&&)                 = default;
+    CKArgs(const CKArgs&) = default;
+    CKArgs(CKArgs&&)      = default;
     CKArgs& operator=(const CKArgs&) = default;
     ~CKArgs()                        = default;
 

--- a/src/solver/conv/conv_hip_implicit_gemm_grouped_bwd_xdlops.cpp
+++ b/src/solver/conv/conv_hip_implicit_gemm_grouped_bwd_xdlops.cpp
@@ -123,7 +123,7 @@ struct CKArgs
         }
 
         strides  = {ProblemInterpreter::GetAdjustedConvolutionStrideH(problem),
-                    ProblemInterpreter::GetAdjustedConvolutionStrideW(problem)};
+                   ProblemInterpreter::GetAdjustedConvolutionStrideW(problem)};
         dilation = {ProblemInterpreter::GetAdjustedConvolutionDilationH(problem),
                     ProblemInterpreter::GetAdjustedConvolutionDilationW(problem)};
         lPadding = {ProblemInterpreter::GetInputLeftPadH(problem),
@@ -132,8 +132,8 @@ struct CKArgs
                     ProblemInterpreter::GetAdjustedInputRightPadW(problem)};
     }
 
-    CKArgs(const CKArgs&)            = default;
-    CKArgs(CKArgs&&)                 = default;
+    CKArgs(const CKArgs&) = default;
+    CKArgs(CKArgs&&)      = default;
     CKArgs& operator=(const CKArgs&) = default;
 
     template <typename ConvPtr>

--- a/src/solver/conv/conv_hip_implicit_gemm_grouped_bwd_xdlops.cpp
+++ b/src/solver/conv/conv_hip_implicit_gemm_grouped_bwd_xdlops.cpp
@@ -123,7 +123,7 @@ struct CKArgs
         }
 
         strides  = {ProblemInterpreter::GetAdjustedConvolutionStrideH(problem),
-                   ProblemInterpreter::GetAdjustedConvolutionStrideW(problem)};
+                    ProblemInterpreter::GetAdjustedConvolutionStrideW(problem)};
         dilation = {ProblemInterpreter::GetAdjustedConvolutionDilationH(problem),
                     ProblemInterpreter::GetAdjustedConvolutionDilationW(problem)};
         lPadding = {ProblemInterpreter::GetInputLeftPadH(problem),
@@ -132,8 +132,8 @@ struct CKArgs
                     ProblemInterpreter::GetAdjustedInputRightPadW(problem)};
     }
 
-    CKArgs(const CKArgs&) = default;
-    CKArgs(CKArgs&&)      = default;
+    CKArgs(const CKArgs&)            = default;
+    CKArgs(CKArgs&&)                 = default;
     CKArgs& operator=(const CKArgs&) = default;
 
     template <typename ConvPtr>
@@ -577,6 +577,7 @@ ConvSolution ConvHipImplicitGemmGroupBwdXdlops::GetSolution(
         [&](auto data_type_val) {
             using T = decltype(data_type_val);
             return InitInvokerFactoryBwdNCHW<2,
+                                             true,
                                              DeviceOpGBwdPtrs<T>,
                                              CKArgs,
                                              miopen::conv::DataInvokeParams>(

--- a/src/solver/conv/conv_hip_implicit_gemm_grouped_bwd_xdlops.cpp
+++ b/src/solver/conv/conv_hip_implicit_gemm_grouped_bwd_xdlops.cpp
@@ -577,7 +577,7 @@ ConvSolution ConvHipImplicitGemmGroupBwdXdlops::GetSolution(
         [&](auto data_type_val) {
             using T = decltype(data_type_val);
             return InitInvokerFactoryBwdNCHW<2,
-                                             true,
+                                             false,
                                              DeviceOpGBwdPtrs<T>,
                                              CKArgs,
                                              miopen::conv::DataInvokeParams>(

--- a/src/solver/conv/conv_hip_implicit_gemm_grouped_bwd_xdlops.cpp
+++ b/src/solver/conv/conv_hip_implicit_gemm_grouped_bwd_xdlops.cpp
@@ -585,7 +585,8 @@ ConvSolution ConvHipImplicitGemmGroupBwdXdlops::GetSolution(
         },
         [&](auto data_type_val) {
             using T = decltype(data_type_val);
-            return InitInvokerFactoryNHWC<DeviceOpGBwdPtrs<T>,
+            return InitInvokerFactoryNHWC<false,
+                                          DeviceOpGBwdPtrs<T>,
                                           CKArgs,
                                           miopen::conv::DataInvokeParams>(
                 ctx, problem, config.kernel_id);

--- a/src/solver/conv/conv_hip_implicit_gemm_grouped_fwd_xdlops.cpp
+++ b/src/solver/conv/conv_hip_implicit_gemm_grouped_fwd_xdlops.cpp
@@ -557,7 +557,7 @@ ConvSolution ConvHipImplicitGemmGroupFwdXdlops::GetSolution(
         [&](auto data_type_val) {
             using T = decltype(data_type_val);
             return InitInvokerFactoryFwdNCHW<2,
-                                             true,
+                                             false,
                                              DeviceOpGFwdPtrs<T>,
                                              CKArgs,
                                              miopen::conv::DataInvokeParams>(

--- a/src/solver/conv/conv_hip_implicit_gemm_grouped_fwd_xdlops.cpp
+++ b/src/solver/conv/conv_hip_implicit_gemm_grouped_fwd_xdlops.cpp
@@ -565,7 +565,8 @@ ConvSolution ConvHipImplicitGemmGroupFwdXdlops::GetSolution(
         },
         [&](auto data_type_val) {
             using T = decltype(data_type_val);
-            return InitInvokerFactoryNHWC<DeviceOpGFwdPtrs<T>,
+            return InitInvokerFactoryNHWC<false,
+                                          DeviceOpGFwdPtrs<T>,
                                           CKArgs,
                                           miopen::conv::DataInvokeParams>(
                 ctx, problem, config.kernel_id);

--- a/src/solver/conv/conv_hip_implicit_gemm_grouped_fwd_xdlops.cpp
+++ b/src/solver/conv/conv_hip_implicit_gemm_grouped_fwd_xdlops.cpp
@@ -94,17 +94,17 @@ struct CKArgs
         out_strides = {K, Ho * Wo * G * K, 1, Wo * G * K, G * K};
         wei_strides = {K * Y * X * C, Y * X * C, 1, X * C, C};
         strides     = {ProblemInterpreter::GetAdjustedConvolutionStrideH(problem),
-                   ProblemInterpreter::GetAdjustedConvolutionStrideW(problem)};
+                       ProblemInterpreter::GetAdjustedConvolutionStrideW(problem)};
         dilation    = {ProblemInterpreter::GetAdjustedConvolutionDilationH(problem),
-                    ProblemInterpreter::GetAdjustedConvolutionDilationW(problem)};
+                       ProblemInterpreter::GetAdjustedConvolutionDilationW(problem)};
         lPadding    = {ProblemInterpreter::GetInputLeftPadH(problem),
-                    ProblemInterpreter::GetInputLeftPadW(problem)};
+                       ProblemInterpreter::GetInputLeftPadW(problem)};
         rPadding    = {ProblemInterpreter::GetAdjustedInputRightPadH(problem),
-                    ProblemInterpreter::GetAdjustedInputRightPadW(problem)};
+                       ProblemInterpreter::GetAdjustedInputRightPadW(problem)};
     }
 
-    CKArgs(const CKArgs&) = default;
-    CKArgs(CKArgs&&)      = default;
+    CKArgs(const CKArgs&)            = default;
+    CKArgs(CKArgs&&)                 = default;
     CKArgs& operator=(const CKArgs&) = default;
 
     template <typename ConvPtr>
@@ -557,6 +557,7 @@ ConvSolution ConvHipImplicitGemmGroupFwdXdlops::GetSolution(
         [&](auto data_type_val) {
             using T = decltype(data_type_val);
             return InitInvokerFactoryFwdNCHW<2,
+                                             true,
                                              DeviceOpGFwdPtrs<T>,
                                              CKArgs,
                                              miopen::conv::DataInvokeParams>(

--- a/src/solver/conv/conv_hip_implicit_gemm_grouped_fwd_xdlops.cpp
+++ b/src/solver/conv/conv_hip_implicit_gemm_grouped_fwd_xdlops.cpp
@@ -94,17 +94,17 @@ struct CKArgs
         out_strides = {K, Ho * Wo * G * K, 1, Wo * G * K, G * K};
         wei_strides = {K * Y * X * C, Y * X * C, 1, X * C, C};
         strides     = {ProblemInterpreter::GetAdjustedConvolutionStrideH(problem),
-                       ProblemInterpreter::GetAdjustedConvolutionStrideW(problem)};
+                   ProblemInterpreter::GetAdjustedConvolutionStrideW(problem)};
         dilation    = {ProblemInterpreter::GetAdjustedConvolutionDilationH(problem),
-                       ProblemInterpreter::GetAdjustedConvolutionDilationW(problem)};
+                    ProblemInterpreter::GetAdjustedConvolutionDilationW(problem)};
         lPadding    = {ProblemInterpreter::GetInputLeftPadH(problem),
-                       ProblemInterpreter::GetInputLeftPadW(problem)};
+                    ProblemInterpreter::GetInputLeftPadW(problem)};
         rPadding    = {ProblemInterpreter::GetAdjustedInputRightPadH(problem),
-                       ProblemInterpreter::GetAdjustedInputRightPadW(problem)};
+                    ProblemInterpreter::GetAdjustedInputRightPadW(problem)};
     }
 
-    CKArgs(const CKArgs&)            = default;
-    CKArgs(CKArgs&&)                 = default;
+    CKArgs(const CKArgs&) = default;
+    CKArgs(CKArgs&&)      = default;
     CKArgs& operator=(const CKArgs&) = default;
 
     template <typename ConvPtr>

--- a/src/solver/conv/conv_hip_implicit_gemm_grouped_wrw_xdlops.cpp
+++ b/src/solver/conv/conv_hip_implicit_gemm_grouped_wrw_xdlops.cpp
@@ -110,7 +110,7 @@ struct CKArgs
         }
 
         strides  = {ProblemInterpreter::GetAdjustedConvolutionStrideH(problem),
-                    ProblemInterpreter::GetAdjustedConvolutionStrideW(problem)};
+                   ProblemInterpreter::GetAdjustedConvolutionStrideW(problem)};
         dilation = {ProblemInterpreter::GetAdjustedConvolutionDilationH(problem),
                     ProblemInterpreter::GetAdjustedConvolutionDilationW(problem)};
         lPadding = {ProblemInterpreter::GetInputLeftPadH(problem),
@@ -118,8 +118,8 @@ struct CKArgs
         rPadding = {ProblemInterpreter::GetAdjustedInputRightPadH(problem),
                     ProblemInterpreter::GetAdjustedInputRightPadW(problem)};
     }
-    CKArgs(const CKArgs&)            = default;
-    CKArgs(CKArgs&&)                 = default;
+    CKArgs(const CKArgs&) = default;
+    CKArgs(CKArgs&&)      = default;
     CKArgs& operator=(const CKArgs&) = default;
 
     template <typename ConvPtr>

--- a/src/solver/conv/conv_hip_implicit_gemm_grouped_wrw_xdlops.cpp
+++ b/src/solver/conv/conv_hip_implicit_gemm_grouped_wrw_xdlops.cpp
@@ -634,7 +634,7 @@ ConvSolution ConvHipImplicitGemmGroupWrwXdlops::GetSolution(
         [&](auto data_type_val) {
             using T = decltype(data_type_val);
             return InitInvokerFactoryWrwNCHW<2,
-                                             true,
+                                             false,
                                              DeviceOpGWrwPtrs<T>,
                                              CKArgs,
                                              miopen::conv::WrWInvokeParams>(

--- a/src/solver/conv/conv_hip_implicit_gemm_grouped_wrw_xdlops.cpp
+++ b/src/solver/conv/conv_hip_implicit_gemm_grouped_wrw_xdlops.cpp
@@ -110,7 +110,7 @@ struct CKArgs
         }
 
         strides  = {ProblemInterpreter::GetAdjustedConvolutionStrideH(problem),
-                   ProblemInterpreter::GetAdjustedConvolutionStrideW(problem)};
+                    ProblemInterpreter::GetAdjustedConvolutionStrideW(problem)};
         dilation = {ProblemInterpreter::GetAdjustedConvolutionDilationH(problem),
                     ProblemInterpreter::GetAdjustedConvolutionDilationW(problem)};
         lPadding = {ProblemInterpreter::GetInputLeftPadH(problem),
@@ -118,8 +118,8 @@ struct CKArgs
         rPadding = {ProblemInterpreter::GetAdjustedInputRightPadH(problem),
                     ProblemInterpreter::GetAdjustedInputRightPadW(problem)};
     }
-    CKArgs(const CKArgs&) = default;
-    CKArgs(CKArgs&&)      = default;
+    CKArgs(const CKArgs&)            = default;
+    CKArgs(CKArgs&&)                 = default;
     CKArgs& operator=(const CKArgs&) = default;
 
     template <typename ConvPtr>
@@ -634,6 +634,7 @@ ConvSolution ConvHipImplicitGemmGroupWrwXdlops::GetSolution(
         [&](auto data_type_val) {
             using T = decltype(data_type_val);
             return InitInvokerFactoryWrwNCHW<2,
+                                             true,
                                              DeviceOpGWrwPtrs<T>,
                                              CKArgs,
                                              miopen::conv::WrWInvokeParams>(

--- a/src/solver/conv/conv_hip_implicit_gemm_grouped_wrw_xdlops.cpp
+++ b/src/solver/conv/conv_hip_implicit_gemm_grouped_wrw_xdlops.cpp
@@ -642,7 +642,8 @@ ConvSolution ConvHipImplicitGemmGroupWrwXdlops::GetSolution(
         },
         [&](auto data_type_val) {
             using T = decltype(data_type_val);
-            return InitInvokerFactoryNHWC<DeviceOpGWrwPtrs<T>,
+            return InitInvokerFactoryNHWC<false,
+                                          DeviceOpGWrwPtrs<T>,
                                           CKArgs,
                                           miopen::conv::WrWInvokeParams>(
                 ctx, problem, config.kernel_id);


### PR DESCRIPTION
- grouped 2d/3d conv in CK have clearing built in now, make it so we dont clear as well for grouped conv only.