### PR TITLE
Jenkins: Remove Shallow clone

### DIFF
--- a/vars/utils.groovy
+++ b/vars/utils.groovy
@@ -31,7 +31,6 @@ def miopenCheckout()
         doGenerateSubmoduleConfigurations: true,
         extensions: scm.extensions + [
             [$class: 'SubmoduleOption', parentCredentials: true],
-            [$class: 'CloneOption', shallow: true, depth: 1, noTags: false, reference: '']
         ],
        userRemoteConfigs: scm.userRemoteConfigs
    ])
@@ -216,7 +215,7 @@ def cmake_fin_build_cmd(prefixpath){
 
 def getDockerImageName(dockerArgs)
 {
-    miopenCheckout()
+    checkout scm
     sh "echo ${dockerArgs} > factors.txt"
     def image = "${env.MIOPEN_DOCKER_IMAGE_URL}"
     sh "md5sum Dockerfile requirements.txt dev-requirements.txt >> factors.txt"
@@ -234,7 +233,7 @@ def getDockerImageName(dockerArgs)
 
 def getDockerImage(Map conf=[:])
 {
-    miopenCheckout()
+    checkout scm
     env.DOCKER_BUILDKIT=1
     def prefixpath = conf.get("prefixpath", "/opt/rocm") // one image for each prefix 1: /usr/local 2:/opt/rocm
     // Note: With offload compress disabled for CK expanding the target list might cause issues with the docker build.
@@ -316,6 +315,7 @@ def getDockerImage(Map conf=[:])
 def buildHipClangJob(Map conf=[:]){
         show_node_info()
         miopenCheckout()
+        checkout scm
         env.HSA_ENABLE_SDMA=0
         env.DOCKER_BUILDKIT=1
         def image
@@ -398,7 +398,7 @@ def buildHipClangJobAndReboot(Map conf=[:]){
 
 
 def RunPerfTest(Map conf=[:]){
-    miopenCheckout()
+    checkout scm
     def dockerOpts="--device=/dev/kfd --device=/dev/dri --group-add video --group-add render --cap-add=SYS_PTRACE --security-opt seccomp=unconfined"
     try {
         def docker_image = conf.get("docker_image")


### PR DESCRIPTION
Attempted to use shallow clone to speed up our jenkins CI checkout speeds.  This was faster but there continues to be random checkout failures for various random reasons.  Going back to what was stable until we can properly diagnose why the change didnt work .