### PR TITLE
Test PR for faster, sharded builds (do not merge)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ nlohmann/json@v3.11.2 -DJSON_MultipleHeaders=ON -DJSON_BuildTests=Off
 ROCm/FunctionalPlus@v0.2.18-p0
 ROCm/eigen@3.4.0
 ROCm/frugally-deep@9683d557eb672ee2304f80f6682c51242d748a50
-ROCm/composable_kernel@bb4f471b09d48ff26c9dfb97a36aa61c7a6af2d6 -DCMAKE_BUILD_TYPE=Release
+ROCm/composable_kernel@3a0cb2796605082cdbac4d1649397b9435e49556 -DCMAKE_BUILD_TYPE=Release
 google/googletest@v1.14.0


### PR DESCRIPTION
This PR is to test changes to CK build in MI Open ahead of next week's merge. Do not merge this PR.

I added build sharding of expensive convolution build targets in  ROCM/composable_kernel#2266. That change breaks up source files with a lot of kernel instantiations into smaller units that can be compiled concurrently. With `ninja -j 256`, I found a reduction in total build time from 33 min down to about 22 min.