### PR TITLE
Fix Segfault on WRW Backwards

### DIFF
--- a/src/include/miopen/solver/implicitgemm_ck_util.hpp
+++ b/src/include/miopen/solver/implicitgemm_ck_util.hpp
@@ -838,13 +838,9 @@ ConvTensors GetTensors(const CastType& data_ctx)
 
         return tensors;
     }
-    else if constexpr(std::is_same_v<CastType, miopen::conv::DataInvokeParams>)
-    {
-        return ConvTensors(data_ctx.tensors);
-    }
     else
     {
-        MIOPEN_THROW(miopenStatusNotImplemented, "Unsupported CastType for tensor extraction");
+        return ConvTensors(data_ctx.tensors);
     }
 }
 

--- a/src/include/miopen/solver/implicitgemm_ck_util.hpp
+++ b/src/include/miopen/solver/implicitgemm_ck_util.hpp
@@ -919,7 +919,7 @@ MakeNCHWCKArgPtr(const CKArgsType& ck_args,
             GetOutElementOp<typename CKArgsType::OutputDataType,
                             typename CKArgsType::OutputElementOpType>(*activ_param_ptr));
     }
-    else if constexpr(std::is_same_v<CastType, miopen::conv::DataInvokeParams>)
+    else
     {
         if constexpr(NeedsSplitK)
         {
@@ -948,6 +948,9 @@ MakeNCHWCKArgPtr(const CKArgsType& ck_args,
                                               data_ctx.beta.GetAsFloat());
         }
     }
+
+    MIOPEN_THROW_IF(argument_ptr == nullptr,
+                    "Failed to create argument pointer ck_args argument ptr.");
 
     return argument_ptr;
 }
@@ -1007,7 +1010,7 @@ MakeNHWCCKArgPtr(const std::shared_ptr<DeviceOpType>& sh_conv_ptr,
             GetOutElementOp<typename CKArgsType::OutputDataType,
                             typename CKArgsType::OutputElementOpType>(*activ_param_ptr));
     }
-    else if constexpr(std::is_same_v<CastType, miopen::conv::DataInvokeParams>)
+    else
     {
         if constexpr(NeedsSplitK)
         {
@@ -1033,6 +1036,9 @@ MakeNHWCCKArgPtr(const std::shared_ptr<DeviceOpType>& sh_conv_ptr,
                                               data_ctx.beta.GetAsFloat());
         }
     }
+
+    MIOPEN_THROW_IF(argument_ptr == nullptr,
+                    "Failed to create argument pointer ck_args argument ptr.");
 
     return argument_ptr;
 }


### PR DESCRIPTION
With a refactor to the InitInvokerFactoryNCHW and InitInvokerFactoryNHWC functions we guarded a few sections in the newly refactored functions with `else if constexpr(std::is_same_v<CastType, miopen::conv::DataInvokeParams>)`.  This causes issues when the `CastType` is `miopen::conv::WrWInvokeParam`.  Looking at the previous code, we did not guard the default function flow.  I think the best fix for now is to remove this guard as we likely do want some default behaviour we can fallback on rather than crashing/throwing.