### PR TITLE
Remove File reorganization backward compatibility (MIOpen)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -501,9 +501,6 @@ message(STATUS "HALF_INCLUDE_DIR: ${HALF_INCLUDE_DIR}")
 
 option( MIOPEN_DEBUG_FIND_DB_CACHING "Use system find-db caching" ON)
 
-# FOR HANDLING ENABLE/DISABLE OPTIONAL BACKWARD COMPATIBILITY for FILE/FOLDER REORG
-option(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY "Build with file/folder reorg with backward compatibility enabled" OFF)
-
 if(WIN32)
     set( DATA_INSTALL_DIR bin )
     set( DATABASE_INSTALL_DIR ${DATA_INSTALL_DIR})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,11 +49,6 @@ configure_file("${PROJECT_SOURCE_DIR}/include/miopen/config.h.in" "${PROJECT_BIN
 # configure a header file to pass the CMake version settings to the source, and package the header files in the output archive
 configure_file( "${PROJECT_SOURCE_DIR}/include/miopen/version.h.in" "${PROJECT_BINARY_DIR}/include/miopen/version.h" )
 
-if(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY)
-#Copy header to Build Dir for generating backward compatibility
-configure_file( "${PROJECT_SOURCE_DIR}/include/miopen/miopen.h" "${PROJECT_BINARY_DIR}/include/miopen/miopen.h" )
-endif()
-
 message( STATUS "MIOpen_VERSION= ${MIOpen_VERSION}" )
 if(NOT MIOPEN_GENERATOR_IS_MULTI_CONFIG)
     message( STATUS "CMAKE_BUILD_TYPE= ${CMAKE_BUILD_TYPE}" )
@@ -1073,22 +1068,4 @@ if(NOT MIOPEN_EMBED_DB STREQUAL "")
     endif()
     add_embed_library(miopen_data ${CODE_OBJECTS})
     target_link_libraries(MIOpen PRIVATE $<BUILD_INTERFACE:miopen_data> )
-endif()
-
-if(BUILD_FILE_REORG_BACKWARD_COMPATIBILITY)
-  #Generating Wrapper of each headers for backward compatibility
-  rocm_wrap_header_file(
-    export.h config.h version.h miopen.h
-    HEADER_LOCATION include/miopen
-    GUARDS WRAPPER
-    WRAPPER_LOCATIONS miopen/${CMAKE_INSTALL_INCLUDEDIR}/miopen
-    ORIGINAL_FILES ${PROJECT_BINARY_DIR}/include/miopen/version.h ${PROJECT_BINARY_DIR}/include/miopen/config.h
-  )
-
-  #Installing Wrapper Headers
-  rocm_install(
-    DIRECTORY
-       "${PROJECT_BINARY_DIR}/miopen/include"
-        DESTINATION "miopen" )
-  message( STATUS "Backward Compatible Sym Link Created for include directories" )
 endif()


### PR DESCRIPTION
Summary of proposed changes:
remove backwards compatibility code. Feature has been disabled related code is not needed.