### PR TITLE
Testing notes in doxygen

### DIFF
--- a/include/miopen/miopen.h
+++ b/include/miopen/miopen.h
@@ -49,8 +49,14 @@
 #include <hip/hip_runtime_api.h>
 #endif
 
+/**
+ * @defgroup convolutions Convolution Functions
+ * @brief Functions for performing convolution operations.
+ *
+ * @note Convolution APIs currently only support uniform input/output datatypes and tensor layouts.
+ */
+
 /*
- * @defgroup convolutions
  * @defgroup pooling
  * @defgroup handle
  * @defgroup layernorm
@@ -957,7 +963,7 @@ MIOPEN_EXPORT miopenStatus_t miopenTransformTensor(miopenHandle_t handle,
 // CLOSEOUT TENSOR DOXYGEN GROUP
 
 /** @addtogroup convolutions
- *  @note Testing Note functionality
+ *  
  *  @{
  */
 

--- a/include/miopen/miopen.h
+++ b/include/miopen/miopen.h
@@ -957,7 +957,7 @@ MIOPEN_EXPORT miopenStatus_t miopenTransformTensor(miopenHandle_t handle,
 // CLOSEOUT TENSOR DOXYGEN GROUP
 
 /** @addtogroup convolutions
- *
+ *  @note Testing Note functionality
  *  @{
  */
 


### PR DESCRIPTION
Will be adding datatype support notes for convolution APIs in an effort to close out https://github.com/ROCm/MIOpen/issues/1961 and https://github.com/ROCm/MIOpen/issues/1959.