### PR TITLE
Fix layout calculation logic to match for Enum & String

### DIFF
--- a/src/conv/problem_description.cpp
+++ b/src/conv/problem_description.cpp
@@ -130,7 +130,8 @@ void ProblemDescription::HeuristicUpdateLayouts()
         return;
     }
 
-    static const std::vector<std::string> supported_layouts = {"NCHW", "NHWC", "CHWN", "NCDHW", "NDHWC"};
+    static const std::vector<std::string> supported_layouts = {
+        "NCHW", "NHWC", "CHWN", "NCDHW", "NDHWC"};
 
     for(const std::string& layout : supported_layouts)
     {

--- a/src/conv/problem_description.cpp
+++ b/src/conv/problem_description.cpp
@@ -130,7 +130,7 @@ void ProblemDescription::HeuristicUpdateLayouts()
         return;
     }
 
-    static const std::vector<std::string> supported_layouts = {"NCHW", "NHWC", "CHWN", "NCDHW"};
+    static const std::vector<std::string> supported_layouts = {"NCHW", "NHWC", "CHWN", "NCDHW", "NDHWC"};
 
     for(const std::string& layout : supported_layouts)
     {

--- a/src/convolution.cpp
+++ b/src/convolution.cpp
@@ -363,7 +363,7 @@ ConvolutionDescriptor::GetForwardOutputTensorWithLayout(const TensorDescriptor& 
                  ? (yType)
                  : xDesc.GetType()), // TODO: This function overrides the output type with
                                      // essentially the input which is incorrect.
-            TensorDescriptor::StringToLayoutType(yLayout),
+            TensorDescriptor::StringToLayoutType(yLayout, xDesc.IsVectorized(), xDesc.GetVectorLength()),
             out_lens,
             out_strides};
 }

--- a/src/convolution.cpp
+++ b/src/convolution.cpp
@@ -363,7 +363,8 @@ ConvolutionDescriptor::GetForwardOutputTensorWithLayout(const TensorDescriptor& 
                  ? (yType)
                  : xDesc.GetType()), // TODO: This function overrides the output type with
                                      // essentially the input which is incorrect.
-            TensorDescriptor::StringToLayoutType(yLayout, xDesc.IsVectorized(), xDesc.GetVectorLength()),
+            TensorDescriptor::StringToLayoutType(
+                yLayout, xDesc.IsVectorized(), xDesc.GetVectorLength()),
             out_lens,
             out_strides};
 }

--- a/src/convolution.cpp
+++ b/src/convolution.cpp
@@ -363,7 +363,7 @@ ConvolutionDescriptor::GetForwardOutputTensorWithLayout(const TensorDescriptor& 
                  ? (yType)
                  : xDesc.GetType()), // TODO: This function overrides the output type with
                                      // essentially the input which is incorrect.
-            xDesc.GetLayout_t(),
+            TensorDescriptor::StringToLayoutType(yLayout),
             out_lens,
             out_strides};
 }

--- a/src/include/miopen/tensor.hpp
+++ b/src/include/miopen/tensor.hpp
@@ -268,7 +268,7 @@ struct MIOPEN_INTERNALS_EXPORT TensorDescriptor : miopenTensorDescriptor
     // layouts, NCDHW for 5D layouts
     std::string GetLayout(std::string storage_layout) const;
 
-    static miopenTensorLayout_t StringToLayoutType(const std::string& layout_str);
+    static miopenTensorLayout_t StringToLayoutType(std::string layout_str, bool vectorized, int vector_length);
 
     friend MIOPEN_INTERNALS_EXPORT std::ostream& operator<<(std::ostream& stream,
                                                             const TensorDescriptor& t);

--- a/src/include/miopen/tensor.hpp
+++ b/src/include/miopen/tensor.hpp
@@ -268,7 +268,8 @@ struct MIOPEN_INTERNALS_EXPORT TensorDescriptor : miopenTensorDescriptor
     // layouts, NCDHW for 5D layouts
     std::string GetLayout(std::string storage_layout) const;
 
-    static miopenTensorLayout_t StringToLayoutType(std::string layout_str, bool vectorized, int vector_length);
+    static miopenTensorLayout_t
+    StringToLayoutType(std::string layout_str, bool vectorized, int vector_length);
 
     friend MIOPEN_INTERNALS_EXPORT std::ostream& operator<<(std::ostream& stream,
                                                             const TensorDescriptor& t);

--- a/src/include/miopen/tensor.hpp
+++ b/src/include/miopen/tensor.hpp
@@ -268,6 +268,8 @@ struct MIOPEN_INTERNALS_EXPORT TensorDescriptor : miopenTensorDescriptor
     // layouts, NCDHW for 5D layouts
     std::string GetLayout(std::string storage_layout) const;
 
+    static miopenTensorLayout_t StringToLayoutType(const std::string& layout_str);
+
     friend MIOPEN_INTERNALS_EXPORT std::ostream& operator<<(std::ostream& stream,
                                                             const TensorDescriptor& t);
 

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -547,15 +547,10 @@ const std::optional<miopenTensorLayout_t>& TensorDescriptor::GetLayoutEnum() con
             if(tensorLayout)
                 return tensorLayout;
 
-            const auto known_layouts = {std::make_pair("NCHW", miopenTensorNCHW),
-                                        std::make_pair("NHWC", miopenTensorNHWC),
-                                        std::make_pair("NCDHW", miopenTensorNCDHW),
-                                        std::make_pair("NDHWC", miopenTensorNDHWC),
-                                        std::make_pair("CHWN", miopenTensorCHWN)};
-            for(const auto& [layout_str, layout_enum] : known_layouts)
+            auto layout = GetLayout_str();
+            if(IsPossibleLayout4D5D(layout))
             {
-                if(this->IsPossibleLayout4D5D(layout_str))
-                    return layout_enum;
+                return StringToLayoutType(layout);
             }
 
             return std::nullopt;
@@ -761,6 +756,41 @@ std::string TensorDescriptor::GetLayout(std::string storage_layout) const
         result += 'c';
 
     return result;
+}
+
+miopenTensorLayout_t TensorDescriptor::StringToLayoutType(const std::string& layout_str)
+{
+    miopenTensorLayout_t default_layout = miopenTensorNCHW;
+    if(layout_str == "NCHWc4")
+        return miopenTensorNCHWc4;
+    else if(layout_str == "NCHWc8")
+        return miopenTensorNCHWc8;
+    else if(layout_str == "CHWNc4")
+        return miopenTensorCHWNc4;
+    else if(layout_str == "CHWNc8")
+        return miopenTensorCHWNc8;
+    else if(layout_str == "NCHW")
+    {
+        return miopenTensorNCHW;
+    }
+    else if(layout_str == "NHWC")
+    {
+        return miopenTensorNHWC;
+    }
+    else if(layout_str == "NDHWC")
+    {
+        return miopenTensorNDHWC;
+    }
+    else if(layout_str == "NCDHW")
+    {
+        return miopenTensorNCDHW;
+    }
+    else
+    {
+        MIOPEN_THROW("We only support NCHWc4, NCHWc8, CHWNc4, CHWNc8, NCHW, NHWC, NDHWC, NCDHW "
+                    "vectorized tensor layout.");
+        return default_layout;
+    }
 }
 
 std::size_t TensorDescriptor::GetNumBytes() const

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -767,7 +767,6 @@ miopenTensorLayout_t TensorDescriptor::StringToLayoutType(std::string layout_str
 {
     if(vectorized)
     {
-        std::cout << layout_str << " is vectorized, vector_length = " << vector_length << std::endl;
         if(vector_length == 4)
         {
             return layout_str == "CHWNc" ? miopenTensorCHWNc4 : miopenTensorNCHWc4;

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -551,7 +551,7 @@ const std::optional<miopenTensorLayout_t>& TensorDescriptor::GetLayoutEnum() con
             
             try
             {
-                return StringToLayoutType(layout);
+                return StringToLayoutType(layout, IsVectorized(), vector_length);
             }
             catch(const miopen::Exception& e)
             {
@@ -762,40 +762,51 @@ std::string TensorDescriptor::GetLayout(std::string storage_layout) const
     return result;
 }
 
-miopenTensorLayout_t TensorDescriptor::StringToLayoutType(const std::string& layout_str)
+
+miopenTensorLayout_t TensorDescriptor::StringToLayoutType(std::string layout_str, bool vectorized, int vector_length)
 {
-    if(layout_str == "NCHWc4")
-        return miopenTensorNCHWc4;
-    else if(layout_str == "NCHWc8")
-        return miopenTensorNCHWc8;
-    else if(layout_str == "CHWNc4")
-        return miopenTensorCHWNc4;
-    else if(layout_str == "CHWNc8")
-        return miopenTensorCHWNc8;
-    else if (layout_str == "CHWN")
+    if(vectorized)
     {
-        return miopenTensorCHWN;
-    }
-    else if(layout_str == "NCHW")
-    {
-        return miopenTensorNCHW;
-    }
-    else if(layout_str == "NHWC")
-    {
-        return miopenTensorNHWC;
-    }
-    else if(layout_str == "NDHWC")
-    {
-        return miopenTensorNDHWC;
-    }
-    else if(layout_str == "NCDHW")
-    {
-        return miopenTensorNCDHW;
+        std::cout << layout_str << " is vectorized, vector_length = " << vector_length << std::endl;
+        if(vector_length == 4)
+        {
+            return layout_str == "CHWNc" ? miopenTensorCHWNc4 : miopenTensorNCHWc4;
+        }
+        else if(vector_length == 8)
+        {
+            return layout_str == "CHWNc" ? miopenTensorCHWNc8 : miopenTensorNCHWc8;
+        }
+        else
+        {
+            MIOPEN_THROW("C-vectorized tensor only support vector length 4 and 8");
+        }
     }
     else
     {
-        MIOPEN_THROW("We only support NCHWc4, NCHWc8, CHWNc4, CHWNc8, NCHW, NHWC, NDHWC, NCDHW "
-                    "vectorized tensor layout.");
+        if(layout_str == "NCHW")
+        {
+            return miopenTensorNCHW;
+        }
+        else if(layout_str == "NHWC")
+        {
+            return miopenTensorNHWC;
+        }
+        else if(layout_str == "NDHWC")
+        {
+            return miopenTensorNDHWC;
+        }
+        else if(layout_str == "NCDHW")
+        {
+            return miopenTensorNCDHW;
+        }
+        else if (layout_str == "CHWN")
+        {
+            return miopenTensorCHWN;
+        }
+        else
+        {
+            MIOPEN_THROW("Non-vectorized tensor only support layout NCHW, NHWC, NCDHW and NDHWC");
+        }
     }
 }
 

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -548,14 +548,15 @@ const std::optional<miopenTensorLayout_t>& TensorDescriptor::GetLayoutEnum() con
                 return tensorLayout;
 
             auto layout = GetLayout_str();
-            
+
             try
             {
                 return StringToLayoutType(layout, IsVectorized(), vector_length);
             }
             catch(const miopen::Exception& e)
             {
-                MIOPEN_LOG_W("Failed to convert layout string '" << layout << "' to enum: " << e.what());
+                MIOPEN_LOG_W("Failed to convert layout string '" << layout
+                                                                 << "' to enum: " << e.what());
                 return std::nullopt;
             }
         }();
@@ -762,8 +763,8 @@ std::string TensorDescriptor::GetLayout(std::string storage_layout) const
     return result;
 }
 
-
-miopenTensorLayout_t TensorDescriptor::StringToLayoutType(std::string layout_str, bool vectorized, int vector_length)
+miopenTensorLayout_t
+TensorDescriptor::StringToLayoutType(std::string layout_str, bool vectorized, int vector_length)
 {
     if(vectorized)
     {
@@ -798,7 +799,7 @@ miopenTensorLayout_t TensorDescriptor::StringToLayoutType(std::string layout_str
         {
             return miopenTensorNCDHW;
         }
-        else if (layout_str == "CHWN")
+        else if(layout_str == "CHWN")
         {
             return miopenTensorCHWN;
         }

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -548,12 +548,16 @@ const std::optional<miopenTensorLayout_t>& TensorDescriptor::GetLayoutEnum() con
                 return tensorLayout;
 
             auto layout = GetLayout_str();
-            if(IsPossibleLayout4D5D(layout))
+            
+            try
             {
                 return StringToLayoutType(layout);
             }
-
-            return std::nullopt;
+            catch(const miopen::Exception& e)
+            {
+                MIOPEN_LOG_W("Failed to convert layout string '" << layout << "' to enum: " << e.what());
+                return std::nullopt;
+            }
         }();
 
         cached_layout_enum_calculated = true;
@@ -760,7 +764,6 @@ std::string TensorDescriptor::GetLayout(std::string storage_layout) const
 
 miopenTensorLayout_t TensorDescriptor::StringToLayoutType(const std::string& layout_str)
 {
-    miopenTensorLayout_t default_layout = miopenTensorNCHW;
     if(layout_str == "NCHWc4")
         return miopenTensorNCHWc4;
     else if(layout_str == "NCHWc8")
@@ -769,6 +772,10 @@ miopenTensorLayout_t TensorDescriptor::StringToLayoutType(const std::string& lay
         return miopenTensorCHWNc4;
     else if(layout_str == "CHWNc8")
         return miopenTensorCHWNc8;
+    else if (layout_str == "CHWN")
+    {
+        return miopenTensorCHWN;
+    }
     else if(layout_str == "NCHW")
     {
         return miopenTensorNCHW;
@@ -789,7 +796,6 @@ miopenTensorLayout_t TensorDescriptor::StringToLayoutType(const std::string& lay
     {
         MIOPEN_THROW("We only support NCHWc4, NCHWc8, CHWNc4, CHWNc8, NCHW, NHWC, NDHWC, NCDHW "
                     "vectorized tensor layout.");
-        return default_layout;
     }
 }
 

--- a/test/gtest/unit_conv_ProblemDescription.cpp
+++ b/test/gtest/unit_conv_ProblemDescription.cpp
@@ -226,6 +226,22 @@ public:
                 miopen::conv::Direction::Forward,
                 "NDHWC", "NDHWC", "NDHWC"
             },
+            TestCase{
+                {miopenHalf, {1, 1, 1, 1, 1}, {10000, 1, 1000, 100, 10}}, // NDHWC
+                {miopenHalf, {1, 1, 1, 1, 1}, {10000, 1, 1000, 100, 10}}, // NDHWC
+                {miopenHalf, miopenTensorNCDHW, {1, 1, 1, 1, 1}, {10000, 1, 1000, 100, 10}}, // NCDHW
+                {{0, 0, 0}, {1, 1, 1}, {1, 1, 1}},
+                miopen::conv::Direction::Forward,
+                "NCDHW", "NCDHW", "NCDHW"
+            },
+            TestCase{
+                {miopenHalf, {1, 10, 10, 10, 10}, {10000, 1, 1000, 100, 10}}, // NDHWC
+                {miopenHalf, {10, 10, 10, 10, 10}, {10000, 1, 1000, 100, 10}}, // NDHWC
+                {miopenHalf, miopenTensorNCDHW, {1, 1, 1, 1, 1}, {10000, 1, 1000, 100, 10}}, // NCDHW
+                {{0, 0, 0}, {1, 1, 1}, {1, 1, 1}},
+                miopen::conv::Direction::Forward,
+                "NDHWC", "NDHWC", "NDHWC"
+            },
 #if 1
             TestCase{
                 {miopenHalf, {1, 1, 1, 1, 1}, {1, 1, 1, 1, 1}}, // ?

--- a/test/gtest/unit_conv_ProblemDescription.cpp
+++ b/test/gtest/unit_conv_ProblemDescription.cpp
@@ -153,7 +153,7 @@ public:
             },
             TestCase{
                 {miopenHalf, miopenTensorNCHWc4, {1, 16, 4, 4}}, // NCHWc4
-                {miopenHalf, miopenTensorNCHWc4, {1, 16, 4, 4}}, // NCHWc4
+                {miopenHalf, miopenTensorNCHWc4, {4, 16, 4, 4}}, // NCHWc4
                 {miopenHalf, miopenTensorNCHWc4, {1, 16, 4, 4}}, // NCHWc4
                 {{0, 0}, {1, 1}, {1, 1}},
                 miopen::conv::Direction::Forward,
@@ -161,7 +161,7 @@ public:
             },
             TestCase{
                 {miopenHalf, miopenTensorNCHWc8, {1, 32, 4, 4}}, // NCHWc8
-                {miopenHalf, miopenTensorNCHWc8, {1, 32, 4, 4}}, // NCHWc8
+                {miopenHalf, miopenTensorNCHWc8, {8, 32, 4, 4}}, // NCHWc8
                 {miopenHalf, miopenTensorNCHWc8, {1, 32, 4, 4}}, // NCHWc8
                 {{0, 0}, {1, 1}, {1, 1}},
                 miopen::conv::Direction::Forward,
@@ -169,7 +169,7 @@ public:
             },
             TestCase{
                 {miopenHalf, miopenTensorCHWNc4, {1, 16, 4, 4}}, // CHWNc4
-                {miopenHalf, miopenTensorCHWNc4, {1, 16, 4, 4}}, // CHWNc4
+                {miopenHalf, miopenTensorCHWNc4, {4, 16, 4, 4}}, // CHWNc4
                 {miopenHalf, miopenTensorCHWNc4, {1, 16, 4, 4}}, // CHWNc4
                 {{0, 0}, {1, 1}, {1, 1}},
                 miopen::conv::Direction::Forward,
@@ -177,7 +177,7 @@ public:
             },
             TestCase{
                 {miopenHalf, miopenTensorCHWNc8, {1, 32, 4, 4}}, // CHWNc8
-                {miopenHalf, miopenTensorCHWNc8, {1, 32, 4, 4}}, // CHWNc8
+                {miopenHalf, miopenTensorCHWNc8, {8, 32, 4, 4}}, // CHWNc8
                 {miopenHalf, miopenTensorCHWNc8, {1, 32, 4, 4}}, // CHWNc8
                 {{0, 0}, {1, 1}, {1, 1}},
                 miopen::conv::Direction::Forward,
@@ -244,14 +244,29 @@ public:
     {
         const auto p = GetParam();
 
-        const auto pd = miopen::conv::ProblemDescription{p.in.GetTensorDescriptor(),
-                                                         p.weights.GetTensorDescriptor(),
-                                                         p.out.GetTensorDescriptor(),
-                                                         p.conv.GetConvolutionDescriptor(),
+        auto inLayoutDescriptor = p.in.GetTensorDescriptor();
+        auto weightsLayoutDescriptor = p.weights.GetTensorDescriptor();
+        auto outLayoutDescriptor =  p.out.GetTensorDescriptor();
+        auto convDescriptor = p.conv.GetConvolutionDescriptor();
+        const auto pd = miopen::conv::ProblemDescription{inLayoutDescriptor,
+                                                         weightsLayoutDescriptor,
+                                                         outLayoutDescriptor,
+                                                         convDescriptor,
                                                          p.direction};
         ASSERT_EQ(pd.GetInLayout(), p.layout_in);
         ASSERT_EQ(pd.GetWeightsLayout(), p.layout_weights);
         ASSERT_EQ(pd.GetOutLayout(), p.layout_out);
+
+        if(p.direction == miopen::conv::Direction::Forward)
+        {
+            auto output = convDescriptor.GetForwardOutputTensor(
+            inLayoutDescriptor, weightsLayoutDescriptor,
+            outLayoutDescriptor.GetType());
+        
+            ASSERT_EQ(inLayoutDescriptor.GetLayout_t(), output.GetLayout_t());
+            ASSERT_EQ(inLayoutDescriptor.GetLayout_str(), output.GetLayout_str());
+            ASSERT_EQ(inLayoutDescriptor.GetLayoutEnum(), output.GetLayoutEnum());
+        }      
     }
 };
 

--- a/test/gtest/unit_conv_ProblemDescription.cpp
+++ b/test/gtest/unit_conv_ProblemDescription.cpp
@@ -260,11 +260,11 @@ public:
     {
         const auto p = GetParam();
 
-        auto inLayoutDescriptor = p.in.GetTensorDescriptor();
+        auto inLayoutDescriptor      = p.in.GetTensorDescriptor();
         auto weightsLayoutDescriptor = p.weights.GetTensorDescriptor();
-        auto outLayoutDescriptor =  p.out.GetTensorDescriptor();
-        auto convDescriptor = p.conv.GetConvolutionDescriptor();
-        const auto pd = miopen::conv::ProblemDescription{inLayoutDescriptor,
+        auto outLayoutDescriptor     = p.out.GetTensorDescriptor();
+        auto convDescriptor          = p.conv.GetConvolutionDescriptor();
+        const auto pd                = miopen::conv::ProblemDescription{inLayoutDescriptor,
                                                          weightsLayoutDescriptor,
                                                          outLayoutDescriptor,
                                                          convDescriptor,
@@ -276,13 +276,12 @@ public:
         if(p.direction == miopen::conv::Direction::Forward)
         {
             auto output = convDescriptor.GetForwardOutputTensor(
-            inLayoutDescriptor, weightsLayoutDescriptor,
-            outLayoutDescriptor.GetType());
-        
+                inLayoutDescriptor, weightsLayoutDescriptor, outLayoutDescriptor.GetType());
+
             ASSERT_EQ(inLayoutDescriptor.GetLayout_t(), output.GetLayout_t());
             ASSERT_EQ(inLayoutDescriptor.GetLayout_str(), output.GetLayout_str());
             ASSERT_EQ(inLayoutDescriptor.GetLayoutEnum(), output.GetLayoutEnum());
-        }      
+        }
     }
 };
 

--- a/test/utils/gtest_formating_checks.py
+++ b/test/utils/gtest_formating_checks.py
@@ -40,8 +40,6 @@ IGNORE_LIST = {
     "../../test/gtest/layout_transpose.cpp",
     "../../test/gtest/reduce_custom_fp32.cpp",
     "../../test/gtest/unary_tensor_ops.cpp",
-    "../../test/gtest/cba_infer.cpp",
-    "../../test/gtest/conv_activ_infer.cpp",
     "CPU_MIOpenDriverRegressionBigTensorTest_FP32",
     "GPU_UnitTestConvSolverAsmBwdWrW3x3Wrw_FP32",
 }

--- a/test/utils/gtest_formating_checks.py
+++ b/test/utils/gtest_formating_checks.py
@@ -40,6 +40,8 @@ IGNORE_LIST = {
     "../../test/gtest/layout_transpose.cpp",
     "../../test/gtest/reduce_custom_fp32.cpp",
     "../../test/gtest/unary_tensor_ops.cpp",
+    "../../test/gtest/cba_infer.cpp",
+    "../../test/gtest/conv_activ_infer.cpp",
     "CPU_MIOpenDriverRegressionBigTensorTest_FP32",
     "GPU_UnitTestConvSolverAsmBwdWrW3x3Wrw_FP32",
 }


### PR DESCRIPTION
The convolution output logic was using the string layout from input to determine strides, and then was requesting the input enum when constructing the output tensor.

Since these are calculated differently you can get different results which will cause problems.

Unifying the two to instead use the string layout will resolve mismatches, and also allows us to use the provided y layout instead of relying on the x layout enum.

issue could be replicated with the following:

`./bin/MIOpenDriver convfp16 -n 8 -c 1 -H 5 -W 5 -k 32 -y 3 -x 3 -p 1 -q 1 -u 1 -v 1 -l 1 -j 1 --in_layout NHWC --fil_layout NHWC --out_layout NHWC -m conv -g 1 -F 1 -t 1`