### PR TITLE
Fix BF16 intrinsic names

### DIFF
--- a/src/include/miopen/solver/static_ck_common.hpp
+++ b/src/include/miopen/solver/static_ck_common.hpp
@@ -46,9 +46,6 @@ MIOPEN_DECLARE_ENV_VAR_BOOL(MIOPEN_DEBUG_STATIC_CK_BLOCK_SYNC_LDS_WITHOUT_SYNC_V
 #define WORKAROUND_MIOPEN_ISSUE_557 1
 #define WORKAROUND_SWDEV_413051 1
 
-// LLVM buffer intrinsics llvm.amdgcn.buffer.* have been removed in HIP 6.4
-#define WORKAROUND_SWDEV_498660 (HIP_PACKAGE_VERSION_FLAT >= 6004000000)
-
 namespace miopen {
 namespace solver {
 namespace static_ck {

--- a/src/kernels/gfx908.kdb.bz2
+++ b/src/kernels/gfx908.kdb.bz2
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6d1426b88b4dffbc53d75f61eabdde30db9f46a79126bdbc299498de1843c39c
-size 110377283
+oid sha256:5b031689aec455f3b5f8d92e03b892e980d4eeacc7d92a7529726da866e13425
+size 109813941

--- a/src/kernels/gfx90a.kdb.bz2
+++ b/src/kernels/gfx90a.kdb.bz2
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3d03a8383d6ec454748d958d4569ebfbd87f23046b9e4a966ada4557aad1b5bf
-size 155231572
+oid sha256:4bf7742ceb14e1dbc376a9617a9ac918ca1a40891f7cca20de4ba75c172ffd57
+size 91903379

--- a/src/kernels/gfx942.kdb.bz2
+++ b/src/kernels/gfx942.kdb.bz2
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ada18f51c22610e5264f0b4077e23fb823dc78ec55d1c4002d38b53c3ad9dd5c
-size 3072563
+oid sha256:f9419e58682c642d87b8ba4a853047c665aa14db9d18eb5d80c00c411e0542d5
+size 3070101

--- a/src/kernels/static_composable_kernel/include/utility/amd_buffer_intrinsics.hpp
+++ b/src/kernels/static_composable_kernel/include/utility/amd_buffer_intrinsics.hpp
@@ -114,19 +114,19 @@ __device__ ushort
 llvm_amdgcn_raw_buffer_load_bf16(buffer_resourse_t srsrc,
                                  index_t voffset,
                                  index_t soffset,
-                                 index_t glc_slc) __asm(amd_buffer_intrinsic_name(load.bf16));
+                                 index_t glc_slc) __asm(amd_buffer_intrinsic_name(load.i16));
 
 __device__ ushort2_t
 llvm_amdgcn_raw_buffer_load_bf16x2(buffer_resourse_t srsrc,
                                    index_t voffset,
                                    index_t soffset,
-                                   index_t glc_slc) __asm(amd_buffer_intrinsic_name(load.v2bf16));
+                                   index_t glc_slc) __asm(amd_buffer_intrinsic_name(load.v2i16));
 
 __device__ ushort4_t
 llvm_amdgcn_raw_buffer_load_bf16x4(buffer_resourse_t srsrc,
                                    index_t voffset,
                                    index_t soffset,
-                                   index_t glc_slc) __asm(amd_buffer_intrinsic_name(load.v4bf16));
+                                   index_t glc_slc) __asm(amd_buffer_intrinsic_name(load.v4i16));
 
 // store
 __device__ void
@@ -227,21 +227,21 @@ llvm_amdgcn_raw_buffer_store_bf16(ushort vdata,
                                   buffer_resourse_t srsrc,
                                   index_t voffset,
                                   index_t soffset,
-                                  index_t glc_slc) __asm(amd_buffer_intrinsic_name(store.bf16));
+                                  index_t glc_slc) __asm(amd_buffer_intrinsic_name(store.i16));
 
 __device__ void
 llvm_amdgcn_raw_buffer_store_bf16x2(ushort2_t vdata,
                                     buffer_resourse_t srsrc,
                                     index_t voffset,
                                     index_t soffset,
-                                    index_t glc_slc) __asm(amd_buffer_intrinsic_name(store.v2bf16));
+                                    index_t glc_slc) __asm(amd_buffer_intrinsic_name(store.v2i16));
 
 __device__ void
 llvm_amdgcn_raw_buffer_store_bf16x4(ushort4_t vdata,
                                     buffer_resourse_t srsrc,
                                     index_t voffset,
                                     index_t soffset,
-                                    index_t glc_slc) __asm(amd_buffer_intrinsic_name(store.v4bf16));
+                                    index_t glc_slc) __asm(amd_buffer_intrinsic_name(store.v4i16));
 
 #if CK_USE_AMD_BUFFER_ATOMIC_FADD
 


### PR DESCRIPTION
`bf16` buffer intrinsics are missing in the current version of compiler and `i16` versions are to be used instead.

To reproduce the issue the latest staging-compiler docker image is needed.

Install requirements (inside MIOpen's source dir)
```bash
CXX=/opt/rocm/llvm/bin/clang++ cget install -f ./dev-requirements.txt --prefix /root/MIOpen/install_dir
```
Configure and build
```bash
rm -rf build
mkdir build
CXX=/opt/rocm/llvm/bin/clang++
cmake -DCMAKE_BUILD_TYPE=Release -DMIOPEN_BACKEND=HIP -DMIOPEN_TEST_DISCRETE=OFF -DCMAKE_PREFIX_PATH='/opt/rocm/;/opt/rocm/hip;/root/MIOpen/install_dir' -S . -B build
cmake --build build -j64 -t miopen_gtest
```
Run the tests
```bash
./build/bin/miopen_gtest --gtest_filter=*GPU_UnitTestConvSolverHipImplicitGemm*BFP16*
```
You should see the errors similar to the following:
```test/plain
Intrinsic name not mangled correctly for type arguments! Should be: llvm.amdgcn.raw.ptr.buffer.load.v2i16
ptr @llvm.amdgcn.raw.ptr.buffer.load.v2bf16
Intrinsic name not mangled correctly for type arguments! Should be: llvm.amdgcn.raw.ptr.buffer.load.v4i16
ptr @llvm.amdgcn.raw.ptr.buffer.load.v4bf16
Intrinsic name not mangled correctly for type arguments! Should be: llvm.amdgcn.raw.ptr.buffer.store.i16
ptr @llvm.amdgcn.raw.ptr.buffer.store.bf16
```

This PR fixes the described issue.