### PR TITLE
[GTESTS] Fix violation of gtest formatting checks after #3829

### DIFF
--- a/test/gtest/cba_infer.cpp
+++ b/test/gtest/cba_infer.cpp
@@ -39,228 +39,191 @@
 #include "gtest_common.hpp"
 #include "cba.hpp"
 
-namespace cba_infer {
+namespace {
 
 using float16 = half_float::half;
 
-struct GPU_ConvBiasActivInfer_FP32 : ConvBiasActivInferTest<float>
+template <typename T, typename TestCaseType = ConvTestCaseBase>
+struct CBAInferBase : ConvBiasActivInferTest<T, TestCaseType>
 {
-};
-
-struct GPU_ConvBiasActivInferFusionCompileStep_FP32 : ConvBiasActivInferTest<float>
-{
-};
-
-struct GPU_ConvBiasActivInfer_FP16 : ConvBiasActivInferTest<half_float::half>
-{
-};
-
-template <typename T>
-struct GPU_ConvGrpBiasActivInfer : ConvBiasActivInferTest<T, GroupConvTestConfig<2u>>
-{
-};
-
-template <typename T>
-struct GPU_ConvGrpBiasActivInfer3D : ConvBiasActivInferTest<T, GroupConvTestConfig<3u>>
-{
-};
-
-using GPU_ConvGrpBiasActivInfer_BFP16 = GPU_ConvGrpBiasActivInfer<bfloat16>;
-using GPU_ConvGrpBiasActivInfer_FP16  = GPU_ConvGrpBiasActivInfer<float16>;
-using GPU_ConvGrpBiasActivInfer_FP32  = GPU_ConvGrpBiasActivInfer<float>;
-
-using GPU_ConvGrpBiasActivInfer3D_BFP16 = GPU_ConvGrpBiasActivInfer3D<bfloat16>;
-using GPU_ConvGrpBiasActivInfer3D_FP16  = GPU_ConvGrpBiasActivInfer3D<float16>;
-using GPU_ConvGrpBiasActivInfer3D_FP32  = GPU_ConvGrpBiasActivInfer3D<float>;
-
-template <typename Solver, typename TestCase>
-void RunSolver(miopen::FusionPlanDescriptor& fusePlanDesc,
-               const std::unique_ptr<miopen::fusion::FusionInvokeParams>& plan_params,
-               const TestCase& conv_config,
-               bool& test_skipped)
-{
-    auto& handle = get_handle();
-    Solver solv{};
-    const auto fusion_problem = miopen::FusionDescription{&fusePlanDesc};
-    auto fusion_ctx           = miopen::FusionContext{handle};
-    if(!solv.IsApplicable(fusion_ctx, fusion_problem))
+    void RunSolver(const miopen::solver::fusion::FusionSolverBase& solv)
     {
-        test_skipped = true;
-        GTEST_SKIP() << solv.SolverDbId() << " Not Applicable" << conv_config;
+        auto& handle              = get_handle();
+        const auto fusion_problem = miopen::FusionDescription{&this->fusePlanDesc};
+        auto fusion_ctx           = miopen::FusionContext{handle};
+        if(!solv.IsApplicable(fusion_ctx, fusion_problem))
+        {
+            this->test_skipped = true;
+            GTEST_SKIP() << solv.SolverDbId() << " Not Applicable" << this->conv_config;
+        }
+        ASSERT_TRUE(solv.IsApplicable(fusion_ctx, fusion_problem));
+        auto sol = solv.GetSolution(fusion_ctx, fusion_problem);
+        ASSERT_TRUE(sol.Succeeded());
+        ASSERT_TRUE(sol.invoker_factory);
+
+        const auto plan_params =
+            std::make_unique<miopen::fusion::FusionInvokeParams>(this->params,
+                                                                 this->input.desc,
+                                                                 this->in_dev.get(),
+                                                                 this->output.desc,
+                                                                 this->out_dev.get(),
+                                                                 false);
+
+        const auto invoker = handle.PrepareInvoker(*sol.invoker_factory, sol.construction_params);
+        (invoker)(handle, *(plan_params.get()));
+        handle.Finish();
     }
-    ASSERT_TRUE(solv.IsApplicable(fusion_ctx, fusion_problem));
-    auto sol = solv.GetSolution(fusion_ctx, fusion_problem);
-    ASSERT_TRUE(sol.Succeeded());
-    ASSERT_TRUE(sol.invoker_factory);
-    const auto invoker = handle.PrepareInvoker(*sol.invoker_factory, sol.construction_params);
-    (invoker)(handle, *(plan_params.get()));
-    handle.Finish();
+
+    std::unique_ptr<miopen::fusion::FusionInvokeParams> createFusionInvokeParams(
+        const miopen::FusionDescription& fusion_desc,
+        const miopen::FusionContext& fusion_ctx,
+        const miopen::solver::SolverInterfaceTunable<miopen::FusionContext,
+                                                     miopen::FusionDescription>& solv,
+        bool useWorkspace = false)
+    {
+        if(useWorkspace)
+        {
+            this->wspace.resize(solv.GetWorkspaceSize(fusion_ctx, fusion_desc));
+
+            return std::make_unique<miopen::fusion::FusionInvokeParams>(this->params,
+                                                                        this->input.desc,
+                                                                        this->in_dev.get(),
+                                                                        this->output.desc,
+                                                                        this->out_dev.get(),
+                                                                        false,
+                                                                        this->wspace.ptr(),
+                                                                        this->wspace.size());
+        }
+        else
+        {
+            return std::make_unique<miopen::fusion::FusionInvokeParams>(this->params,
+                                                                        this->input.desc,
+                                                                        this->in_dev.get(),
+                                                                        this->output.desc,
+                                                                        this->out_dev.get(),
+                                                                        false);
+        }
+    }
+
+    // Have to keep it a template besause of GetDefaultPerformanceConfig() call
+    template <typename Solver>
+    void RunTunableSolver()
+    {
+        auto& handle = get_handle();
+        Solver solv{};
+        const auto fusion_problem = miopen::FusionDescription{&this->fusePlanDesc};
+        auto fusion_ctx           = miopen::FusionContext{handle};
+        if(!solv.IsApplicable(fusion_ctx, fusion_problem))
+        {
+            this->test_skipped = true;
+            GTEST_SKIP() << solv.SolverDbId() << " Not Applicable" << this->conv_config;
+        }
+        ASSERT_TRUE(solv.IsApplicable(fusion_ctx, fusion_problem));
+        auto sol = solv.GetSolution(fusion_ctx,
+                                    fusion_problem,
+                                    solv.GetDefaultPerformanceConfig(fusion_ctx, fusion_problem));
+        ASSERT_TRUE(sol.Succeeded());
+        ASSERT_TRUE(sol.invoker_factory);
+
+        auto plan_params =
+            createFusionInvokeParams(fusion_problem, fusion_ctx, solv, solv.MayNeedWorkspace());
+
+        const auto invoker = handle.PrepareInvoker(*sol.invoker_factory, sol.construction_params);
+        (invoker)(handle, *(plan_params.get()));
+        handle.Finish();
+    }
+};
+
+using GPU_ConvBiasActivInfer_FP32                  = CBAInferBase<float>;
+using GPU_ConvBiasActivInferFusionCompileStep_FP32 = CBAInferBase<float>;
+using GPU_ConvBiasActivInfer_FP16                  = CBAInferBase<half_float::half>;
+
+using GPU_ConvGrpBiasActivInfer_BFP16 = CBAInferBase<bfloat16, GroupConvTestConfig<2u>>;
+using GPU_ConvGrpBiasActivInfer_FP16  = CBAInferBase<float16, GroupConvTestConfig<2u>>;
+using GPU_ConvGrpBiasActivInfer_FP32  = CBAInferBase<float, GroupConvTestConfig<2u>>;
+
+using GPU_ConvGrpBiasActivInfer3D_BFP16 = CBAInferBase<bfloat16, GroupConvTestConfig<3u>>;
+using GPU_ConvGrpBiasActivInfer3D_FP16  = CBAInferBase<float16, GroupConvTestConfig<3u>>;
+using GPU_ConvGrpBiasActivInfer3D_FP32  = CBAInferBase<float, GroupConvTestConfig<3u>>;
+
+template <typename Configs, typename TensorTypes>
+inline auto gcbaInferParamGenSmoke(Configs configs, TensorTypes tensorTypes)
+{
+    return ::testing::Combine(testing::Values(miopenActivationRELU, miopenActivationCLIPPEDRELU),
+                              testing::ValuesIn(configs),
+                              tensorTypes,
+                              testing::Values(0.5f),
+                              testing::Values(1.0f),
+                              testing::Values(0.5f));
 }
 
-template <typename Solver>
-std::unique_ptr<miopen::fusion::FusionInvokeParams>
-createFusionInvokeParams(const miopen::FusionDescription& fusion_desc,
-                         const miopen::FusionContext& fusion_ctx,
-                         const miopen::OperatorArgs& params,
-                         const Solver& solv,
-                         const miopen::TensorDescriptor& input_desc,
-                         ConstData_t in_dev_ptr,
-                         const miopen::TensorDescriptor& output_desc,
-                         Data_t out_dev_ptr,
-                         Workspace& wspace,
-                         bool useWorkspace = false)
+template <typename Configs, typename TensorTypes>
+inline auto gcbaInferParamGenFull(Configs configs, TensorTypes tensorTypes)
 {
-    if(useWorkspace)
-    {
-        wspace.resize(solv.GetWorkspaceSize(fusion_ctx, fusion_desc));
-
-        return std::make_unique<miopen::fusion::FusionInvokeParams>(params,
-                                                                    input_desc,
-                                                                    in_dev_ptr,
-                                                                    output_desc,
-                                                                    out_dev_ptr,
-                                                                    false,
-                                                                    wspace.ptr(),
-                                                                    wspace.size());
-    }
-    else
-    {
-        return std::make_unique<miopen::fusion::FusionInvokeParams>(
-            params, input_desc, in_dev_ptr, output_desc, out_dev_ptr, false);
-    }
+    return ::testing::Combine(testing::Values(miopenActivationCLAMP),
+                              testing::ValuesIn(configs),
+                              tensorTypes,
+                              testing::Values(0.5f),
+                              testing::Values(1.0f),
+                              testing::Values(0.5f));
 }
 
-template <typename Solver, typename TCase = ConvTestCaseBase>
-void RunTunableSolver(miopen::FusionPlanDescriptor& fusePlanDesc,
-                      const miopen::OperatorArgs& params,
-                      const TCase& conv_config,
-                      bool& test_skipped,
-                      const miopen::TensorDescriptor& input_desc,
-                      ConstData_t in_dev_ptr,
-                      const miopen::TensorDescriptor& output_desc,
-                      Data_t out_dev_ptr,
-                      Workspace& wspace)
-{
-    auto& handle = get_handle();
-    Solver solv{};
-    const auto fusion_problem = miopen::FusionDescription{&fusePlanDesc};
-    auto fusion_ctx           = miopen::FusionContext{handle};
-    if(!solv.IsApplicable(fusion_ctx, fusion_problem))
-    {
-        test_skipped = true;
-        GTEST_SKIP() << solv.SolverDbId() << " Not Applicable" << conv_config;
-    }
-    ASSERT_TRUE(solv.IsApplicable(fusion_ctx, fusion_problem));
-    auto sol = solv.GetSolution(
-        fusion_ctx, fusion_problem, solv.GetDefaultPerformanceConfig(fusion_ctx, fusion_problem));
-    ASSERT_TRUE(sol.Succeeded());
-    ASSERT_TRUE(sol.invoker_factory);
-
-    auto plan_params = createFusionInvokeParams<Solver>(fusion_problem,
-                                                        fusion_ctx,
-                                                        params,
-                                                        solv,
-                                                        input_desc,
-                                                        in_dev_ptr,
-                                                        output_desc,
-                                                        out_dev_ptr,
-                                                        wspace,
-                                                        solv.MayNeedWorkspace());
-
-    const auto invoker = handle.PrepareInvoker(*sol.invoker_factory, sol.construction_params);
-    (invoker)(handle, *(plan_params.get()));
-    handle.Finish();
-}
-
-} // namespace cba_infer
-using namespace cba_infer;
+} // namespace
 
 TEST_P(GPU_ConvBiasActivInfer_FP32, ConvBiasActivAsm1x1UFloat)
 {
-    RunTunableSolver<miopen::solver::fusion::ConvBiasActivAsm1x1U>(fusePlanDesc,
-                                                                   params,
-                                                                   conv_config,
-                                                                   test_skipped,
-                                                                   input.desc,
-                                                                   in_dev.get(),
-                                                                   output.desc,
-                                                                   out_dev.get(),
-                                                                   wspace);
+    RunTunableSolver<miopen::solver::fusion::ConvBiasActivAsm1x1U>();
 }
 TEST_P(GPU_ConvBiasActivInfer_FP32, ConvOclDirectFwdFused)
 {
-    RunTunableSolver<miopen::solver::fusion::ConvOclDirectFwdFused>(fusePlanDesc,
-                                                                    params,
-                                                                    conv_config,
-                                                                    test_skipped,
-                                                                    input.desc,
-                                                                    in_dev.get(),
-                                                                    output.desc,
-                                                                    out_dev.get(),
-                                                                    wspace);
+    RunTunableSolver<miopen::solver::fusion::ConvOclDirectFwdFused>();
 }
 TEST_P(GPU_ConvBiasActivInfer_FP32, ConvBinWinogradRxSFused)
 {
-    const auto plan_params = std::make_unique<miopen::fusion::FusionInvokeParams>(
-        params, input.desc, in_dev.get(), output.desc, out_dev.get(), false);
-    RunSolver<miopen::solver::fusion::ConvBinWinogradRxSFused>(
-        fusePlanDesc, plan_params, conv_config, test_skipped);
+    RunSolver(miopen::solver::fusion::ConvBinWinogradRxSFused{});
 }
 TEST_P(GPU_ConvBiasActivInfer_FP32, ConvBinWinogradRxSf2x3g1Fused)
 {
-    const auto plan_params = std::make_unique<miopen::fusion::FusionInvokeParams>(
-        params, input.desc, in_dev.get(), output.desc, out_dev.get(), false);
-    RunSolver<miopen::solver::fusion::ConvBinWinogradRxSf2x3g1Fused>(
-        fusePlanDesc, plan_params, conv_config, test_skipped);
+    RunSolver(miopen::solver::fusion::ConvBinWinogradRxSf2x3g1Fused{});
 }
 TEST_P(GPU_ConvBiasActivInfer_FP16, ConvWinoFuryRxSf2x3Fused)
 {
-    const auto plan_params = std::make_unique<miopen::fusion::FusionInvokeParams>(
-        params, input.desc, in_dev.get(), output.desc, out_dev.get(), false);
-    RunSolver<miopen::solver::fusion::ConvWinoFuryRxSFused<2, 3>>(
-        fusePlanDesc, plan_params, conv_config, test_skipped);
+    RunSolver(miopen::solver::fusion::ConvWinoFuryRxSFused<2, 3>{});
 }
 TEST_P(GPU_ConvBiasActivInfer_FP16, ConvWinoRageRxSf2x3Fused)
 {
-    const auto plan_params = std::make_unique<miopen::fusion::FusionInvokeParams>(
-        params, input.desc, in_dev.get(), output.desc, out_dev.get(), false);
-    RunSolver<miopen::solver::fusion::ConvWinoRageRxSFused<2, 3>>(
-        fusePlanDesc, plan_params, conv_config, test_skipped);
+    RunSolver(miopen::solver::fusion::ConvWinoRageRxSFused<2, 3>{});
 }
 
 TEST_P(GPU_ConvBiasActivInfer_FP16, ConvCKIgemmFwdBiasActivFused)
 {
-    RunTunableSolver<miopen::solver::fusion::ConvCKIgemmFwdBiasActivFused>(fusePlanDesc,
-                                                                           params,
-                                                                           conv_config,
-                                                                           test_skipped,
-                                                                           input.desc,
-                                                                           in_dev.get(),
-                                                                           output.desc,
-                                                                           out_dev.get(),
-                                                                           wspace);
+    RunTunableSolver<miopen::solver::fusion::ConvCKIgemmFwdBiasActivFused>();
 }
 
-#define DEFINE_GRP_CONV_BIAS_ACTIV_TEST(conv_bias_active_fixture)                                \
-    TEST_P(conv_bias_active_fixture, ConvCKIgemmGrpFwdBiasActivFused)                            \
-    {                                                                                            \
-        RunTunableSolver<miopen::solver::fusion::ConvCKIgemmGrpFwdBiasActivFused>(fusePlanDesc,  \
-                                                                                  params,        \
-                                                                                  conv_config,   \
-                                                                                  test_skipped,  \
-                                                                                  input.desc,    \
-                                                                                  in_dev.get(),  \
-                                                                                  output.desc,   \
-                                                                                  out_dev.get(), \
-                                                                                  wspace);       \
-    }
-
-DEFINE_GRP_CONV_BIAS_ACTIV_TEST(GPU_ConvGrpBiasActivInfer_BFP16)
-DEFINE_GRP_CONV_BIAS_ACTIV_TEST(GPU_ConvGrpBiasActivInfer3D_BFP16)
-DEFINE_GRP_CONV_BIAS_ACTIV_TEST(GPU_ConvGrpBiasActivInfer_FP16)
-DEFINE_GRP_CONV_BIAS_ACTIV_TEST(GPU_ConvGrpBiasActivInfer3D_FP16)
-DEFINE_GRP_CONV_BIAS_ACTIV_TEST(GPU_ConvGrpBiasActivInfer_FP32)
-DEFINE_GRP_CONV_BIAS_ACTIV_TEST(GPU_ConvGrpBiasActivInfer3D_FP32)
+TEST_P(GPU_ConvGrpBiasActivInfer_BFP16, ConvCKIgemmGrpFwdBiasActivFused)
+{
+    RunTunableSolver<miopen::solver::fusion::ConvCKIgemmGrpFwdBiasActivFused>();
+}
+TEST_P(GPU_ConvGrpBiasActivInfer3D_BFP16, ConvCKIgemmGrpFwdBiasActivFused)
+{
+    RunTunableSolver<miopen::solver::fusion::ConvCKIgemmGrpFwdBiasActivFused>();
+}
+TEST_P(GPU_ConvGrpBiasActivInfer_FP16, ConvCKIgemmGrpFwdBiasActivFused)
+{
+    RunTunableSolver<miopen::solver::fusion::ConvCKIgemmGrpFwdBiasActivFused>();
+}
+TEST_P(GPU_ConvGrpBiasActivInfer3D_FP16, ConvCKIgemmGrpFwdBiasActivFused)
+{
+    RunTunableSolver<miopen::solver::fusion::ConvCKIgemmGrpFwdBiasActivFused>();
+}
+TEST_P(GPU_ConvGrpBiasActivInfer_FP32, ConvCKIgemmGrpFwdBiasActivFused)
+{
+    RunTunableSolver<miopen::solver::fusion::ConvCKIgemmGrpFwdBiasActivFused>();
+}
+TEST_P(GPU_ConvGrpBiasActivInfer3D_FP32, ConvCKIgemmGrpFwdBiasActivFused)
+{
+    RunTunableSolver<miopen::solver::fusion::ConvCKIgemmGrpFwdBiasActivFused>();
+}
 
 #if MIOPEN_BACKEND_HIP
 
@@ -270,15 +233,7 @@ TEST_P(GPU_ConvBiasActivInferFusionCompileStep_FP32, ConvBiasActivAsm1x1UFloat_t
     ScopedEnvironment<int> find_enforce_tuning_iter_env(wa::MIOPEN_DEBUG_TUNING_ITERATIONS_MAX, 5);
 
     fusePlanDesc.Compile(get_handle());
-    RunTunableSolver<miopen::solver::fusion::ConvOclDirectFwdFused>(fusePlanDesc,
-                                                                    params,
-                                                                    conv_config,
-                                                                    test_skipped,
-                                                                    input.desc,
-                                                                    in_dev.get(),
-                                                                    output.desc,
-                                                                    out_dev.get(),
-                                                                    wspace);
+    RunTunableSolver<miopen::solver::fusion::ConvOclDirectFwdFused>();
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -311,80 +266,71 @@ INSTANTIATE_TEST_SUITE_P(Smoke,
                                           testing::Values(0.75f),
                                           testing::Values(0.5f)));
 
-#define INSTANTIATE_GRP_CONV_BIAS_ACTIV_SUITE_SMOKE(test_fixture, configs, tensor_types)     \
-    INSTANTIATE_TEST_SUITE_P(                                                                \
-        Smoke,                                                                               \
-        test_fixture,                                                                        \
-        testing::Combine(testing::Values(miopenActivationRELU, miopenActivationCLIPPEDRELU), \
-                         testing::ValuesIn(configs),                                         \
-                         tensor_types,                                                       \
-                         testing::Values(0.5f),                                              \
-                         testing::Values(1.0f),                                              \
-                         testing::Values(0.5f)));
-
-#define INSTANTIATE_GRP_CONV_BIAS_ACTIV_SUITE_FULL(test_fixture, configs, tensor_types) \
-    INSTANTIATE_TEST_SUITE_P(Full,                                                      \
-                             test_fixture,                                              \
-                             testing::Combine(testing::Values(miopenActivationCLAMP),   \
-                                              testing::ValuesIn(configs),               \
-                                              tensor_types,                             \
-                                              testing::Values(0.5f),                    \
-                                              testing::Values(1.0f),                    \
-                                              testing::Values(0.5f)));
-
 // BFP16 tests
-INSTANTIATE_GRP_CONV_BIAS_ACTIV_SUITE_SMOKE(
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
     GPU_ConvGrpBiasActivInfer_BFP16,
-    GroupConvTestConfig<2u>::GetSmokeConfigs<Direction::Forward>(),
-    testing::Values(miopenTensorNHWC /*, miopenTensorNCHW*/))
-INSTANTIATE_GRP_CONV_BIAS_ACTIV_SUITE_SMOKE(
+    gcbaInferParamGenSmoke(GroupConvTestConfig<2u>::GetSmokeConfigs<Direction::Forward>(),
+                           testing::Values(miopenTensorNHWC /*, miopenTensorNCHW*/)));
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
     GPU_ConvGrpBiasActivInfer3D_BFP16,
-    GroupConvTestConfig<3u>::GetSmokeConfigs<Direction::Forward>(),
-    testing::Values(miopenTensorNDHWC /*, miopenTensorNCDHW*/))
+    gcbaInferParamGenSmoke(GroupConvTestConfig<3u>::GetSmokeConfigs<Direction::Forward>(),
+                           testing::Values(miopenTensorNDHWC /*, miopenTensorNCDHW*/)));
 
-INSTANTIATE_GRP_CONV_BIAS_ACTIV_SUITE_FULL(
+INSTANTIATE_TEST_SUITE_P(
+    Full,
     GPU_ConvGrpBiasActivInfer_BFP16,
-    GroupConvTestConfig<2u>::GetConfigs<Direction::Forward>(),
-    testing::Values(miopenTensorNHWC /*, miopenTensorNCHW*/))
-INSTANTIATE_GRP_CONV_BIAS_ACTIV_SUITE_FULL(
+    gcbaInferParamGenFull(GroupConvTestConfig<2u>::GetConfigs<Direction::Forward>(),
+                          testing::Values(miopenTensorNHWC /*, miopenTensorNCHW*/)));
+INSTANTIATE_TEST_SUITE_P(
+    Full,
     GPU_ConvGrpBiasActivInfer3D_BFP16,
-    GroupConvTestConfig<3u>::GetConfigs<Direction::Forward>(),
-    testing::Values(miopenTensorNDHWC /*, miopenTensorNCDHW*/))
+    gcbaInferParamGenFull(GroupConvTestConfig<3u>::GetConfigs<Direction::Forward>(),
+                          testing::Values(miopenTensorNDHWC /*, miopenTensorNCDHW*/)));
 
 // FP16 tests
-INSTANTIATE_GRP_CONV_BIAS_ACTIV_SUITE_SMOKE(
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
     GPU_ConvGrpBiasActivInfer_FP16,
-    GroupConvTestConfig<2u>::GetSmokeConfigs<Direction::Forward>(),
-    testing::Values(miopenTensorNHWC /*, miopenTensorNCHW*/))
-INSTANTIATE_GRP_CONV_BIAS_ACTIV_SUITE_SMOKE(
+    gcbaInferParamGenSmoke(GroupConvTestConfig<2u>::GetSmokeConfigs<Direction::Forward>(),
+                           testing::Values(miopenTensorNHWC /*, miopenTensorNCHW*/)));
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
     GPU_ConvGrpBiasActivInfer3D_FP16,
-    GroupConvTestConfig<3u>::GetSmokeConfigs<Direction::Forward>(),
-    testing::Values(miopenTensorNDHWC /*, miopenTensorNCDHW*/))
+    gcbaInferParamGenSmoke(GroupConvTestConfig<3u>::GetSmokeConfigs<Direction::Forward>(),
+                           testing::Values(miopenTensorNDHWC /*, miopenTensorNCDHW*/)));
 
-INSTANTIATE_GRP_CONV_BIAS_ACTIV_SUITE_FULL(
+INSTANTIATE_TEST_SUITE_P(
+    Full,
     GPU_ConvGrpBiasActivInfer_FP16,
-    GroupConvTestConfig<2u>::GetConfigs<Direction::Forward>(),
-    testing::Values(miopenTensorNHWC /*, miopenTensorNCHW*/))
-INSTANTIATE_GRP_CONV_BIAS_ACTIV_SUITE_FULL(
+    gcbaInferParamGenFull(GroupConvTestConfig<2u>::GetConfigs<Direction::Forward>(),
+                          testing::Values(miopenTensorNHWC /*, miopenTensorNCHW*/)));
+INSTANTIATE_TEST_SUITE_P(
+    Full,
     GPU_ConvGrpBiasActivInfer3D_FP16,
-    GroupConvTestConfig<3u>::GetConfigs<Direction::Forward>(),
-    testing::Values(miopenTensorNDHWC /*, miopenTensorNCDHW*/))
+    gcbaInferParamGenFull(GroupConvTestConfig<3u>::GetConfigs<Direction::Forward>(),
+                          testing::Values(miopenTensorNDHWC /*, miopenTensorNCDHW*/)));
 
 // FP32 tests
-INSTANTIATE_GRP_CONV_BIAS_ACTIV_SUITE_SMOKE(
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
     GPU_ConvGrpBiasActivInfer_FP32,
-    GroupConvTestConfig<2u>::GetSmokeConfigs<Direction::Forward>(),
-    testing::Values(miopenTensorNHWC /*, miopenTensorNCHW*/))
-INSTANTIATE_GRP_CONV_BIAS_ACTIV_SUITE_SMOKE(
+    gcbaInferParamGenSmoke(GroupConvTestConfig<2u>::GetSmokeConfigs<Direction::Forward>(),
+                           testing::Values(miopenTensorNHWC /*, miopenTensorNCHW*/)));
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
     GPU_ConvGrpBiasActivInfer3D_FP32,
-    GroupConvTestConfig<3u>::GetSmokeConfigs<Direction::Forward>(),
-    testing::Values(miopenTensorNDHWC /*, miopenTensorNCDHW*/))
+    gcbaInferParamGenSmoke(GroupConvTestConfig<3u>::GetSmokeConfigs<Direction::Forward>(),
+                           testing::Values(miopenTensorNDHWC /*, miopenTensorNCDHW*/)));
 
-INSTANTIATE_GRP_CONV_BIAS_ACTIV_SUITE_FULL(
+INSTANTIATE_TEST_SUITE_P(
+    Full,
     GPU_ConvGrpBiasActivInfer_FP32,
-    GroupConvTestConfig<2u>::GetConfigs<Direction::Forward>(),
-    testing::Values(miopenTensorNHWC /*, miopenTensorNCHW*/))
-INSTANTIATE_GRP_CONV_BIAS_ACTIV_SUITE_FULL(
+    gcbaInferParamGenFull(GroupConvTestConfig<2u>::GetConfigs<Direction::Forward>(),
+                          testing::Values(miopenTensorNHWC /*, miopenTensorNCHW*/)));
+INSTANTIATE_TEST_SUITE_P(
+    Full,
     GPU_ConvGrpBiasActivInfer3D_FP32,
-    GroupConvTestConfig<3u>::GetConfigs<Direction::Forward>(),
-    testing::Values(miopenTensorNDHWC /*, miopenTensorNCDHW*/))
+    gcbaInferParamGenFull(GroupConvTestConfig<3u>::GetConfigs<Direction::Forward>(),
+                          testing::Values(miopenTensorNDHWC /*, miopenTensorNCDHW*/)));

--- a/test/gtest/conv_activ_infer.cpp
+++ b/test/gtest/conv_activ_infer.cpp
@@ -38,223 +38,223 @@
 #include "gtest_common.hpp"
 #include "conv_activ.hpp"
 
-namespace ca_infer {
+namespace {
 
 using float16 = half_float::half;
 
-template <typename T>
-struct GPU_ConvGrpActivInfer : ConvActivInferTest<T, GroupConvTestConfig<2u>>
+template <typename T, typename TestCaseType>
+struct CAInferBase : ConvActivInferTest<T, TestCaseType>
 {
+    void RunSolver(const miopen::solver::fusion::FusionSolverBase& solv)
+    {
+        auto& handle              = get_handle();
+        const auto fusion_problem = miopen::FusionDescription{&this->fusePlanDesc};
+        auto fusion_ctx           = miopen::FusionContext{handle};
+        if(!solv.IsApplicable(fusion_ctx, fusion_problem))
+        {
+            this->test_skipped = true;
+            GTEST_SKIP() << solv.SolverDbId() << " Not Applicable" << this->conv_config;
+        }
+        ASSERT_TRUE(solv.IsApplicable(fusion_ctx, fusion_problem));
+        auto sol = solv.GetSolution(fusion_ctx, fusion_problem);
+        ASSERT_TRUE(sol.Succeeded());
+        ASSERT_TRUE(sol.invoker_factory);
+
+        const auto plan_params =
+            std::make_unique<miopen::fusion::FusionInvokeParams>(this->params,
+                                                                 this->input.desc,
+                                                                 this->in_dev.get(),
+                                                                 this->output.desc,
+                                                                 this->out_dev.get(),
+                                                                 false);
+
+        const auto invoker = handle.PrepareInvoker(*sol.invoker_factory, sol.construction_params);
+        (invoker)(handle, *(plan_params.get()));
+        handle.Finish();
+    }
+
+    std::unique_ptr<miopen::fusion::FusionInvokeParams> createFusionInvokeParams(
+        const miopen::FusionDescription& fusion_desc,
+        const miopen::FusionContext& fusion_ctx,
+        const miopen::solver::SolverInterfaceTunable<miopen::FusionContext,
+                                                     miopen::FusionDescription>& solv,
+        bool useWorkspace = false)
+    {
+        if(useWorkspace)
+        {
+            this->wspace.resize(solv.GetWorkspaceSize(fusion_ctx, fusion_desc));
+
+            return std::make_unique<miopen::fusion::FusionInvokeParams>(this->params,
+                                                                        this->input.desc,
+                                                                        this->in_dev.get(),
+                                                                        this->output.desc,
+                                                                        this->out_dev.get(),
+                                                                        false,
+                                                                        this->wspace.ptr(),
+                                                                        this->wspace.size());
+        }
+        else
+        {
+            return std::make_unique<miopen::fusion::FusionInvokeParams>(this->params,
+                                                                        this->input.desc,
+                                                                        this->in_dev.get(),
+                                                                        this->output.desc,
+                                                                        this->out_dev.get(),
+                                                                        false);
+        }
+    }
+
+    // Have to keep it a template besause of GetDefaultPerformanceConfig() call
+    template <typename Solver>
+    void RunTunableSolver()
+    {
+        auto& handle = get_handle();
+        Solver solv{};
+        const auto fusion_problem = miopen::FusionDescription{&this->fusePlanDesc};
+        auto fusion_ctx           = miopen::FusionContext{handle};
+        if(!solv.IsApplicable(fusion_ctx, fusion_problem))
+        {
+            this->test_skipped = true;
+            GTEST_SKIP() << solv.SolverDbId() << " Not Applicable" << this->conv_config;
+        }
+        ASSERT_TRUE(solv.IsApplicable(fusion_ctx, fusion_problem));
+        auto sol = solv.GetSolution(fusion_ctx,
+                                    fusion_problem,
+                                    solv.GetDefaultPerformanceConfig(fusion_ctx, fusion_problem));
+        ASSERT_TRUE(sol.Succeeded());
+        ASSERT_TRUE(sol.invoker_factory);
+
+        auto plan_params =
+            createFusionInvokeParams(fusion_problem, fusion_ctx, solv, solv.MayNeedWorkspace());
+
+        const auto invoker = handle.PrepareInvoker(*sol.invoker_factory, sol.construction_params);
+        (invoker)(handle, *(plan_params.get()));
+        handle.Finish();
+    }
 };
 
-using GPU_ConvGrpActivInfer_BFP16 = GPU_ConvGrpActivInfer<bfloat16>;
-using GPU_ConvGrpActivInfer_FP16  = GPU_ConvGrpActivInfer<float16>;
-using GPU_ConvGrpActivInfer_FP32  = GPU_ConvGrpActivInfer<float>;
-
-template <typename T>
-struct GPU_ConvGrpActivInfer3D : ConvActivInferTest<T, GroupConvTestConfig<3u>>
+template <typename Configs, typename TensorTypes>
+inline auto gcaInferParamGenSmoke(Configs configs, TensorTypes tensorTypes)
 {
+    return ::testing::Combine(testing::Values(miopenActivationRELU, miopenActivationCLIPPEDRELU),
+                              testing::ValuesIn(configs),
+                              tensorTypes,
+                              testing::Values(0.5f),
+                              testing::Values(1.0f),
+                              testing::Values(0.5f));
+}
+
+template <typename Configs, typename TensorTypes>
+inline auto gcaInferParamGenFull(Configs configs, TensorTypes tensorTypes)
+{
+    return ::testing::Combine(testing::Values(miopenActivationCLAMP),
+                              testing::ValuesIn(configs),
+                              tensorTypes,
+                              testing::Values(0.5f),
+                              testing::Values(1.0f),
+                              testing::Values(0.5f));
+}
+
+using GPU_ConvGrpActivInfer_BFP16 = CAInferBase<bfloat16, GroupConvTestConfig<2u>>;
+using GPU_ConvGrpActivInfer_FP16  = CAInferBase<float16, GroupConvTestConfig<2u>>;
+using GPU_ConvGrpActivInfer_FP32  = CAInferBase<float, GroupConvTestConfig<2u>>;
+
+using GPU_ConvGrpActivInfer3D_BFP16 = CAInferBase<bfloat16, GroupConvTestConfig<3u>>;
+using GPU_ConvGrpActivInfer3D_FP16  = CAInferBase<float16, GroupConvTestConfig<3u>>;
+using GPU_ConvGrpActivInfer3D_FP32  = CAInferBase<float, GroupConvTestConfig<3u>>;
+
+} // namespace
+
+TEST_P(GPU_ConvGrpActivInfer_BFP16, ConvCKIgemmGrpFwdActivFused)
+{
+    RunTunableSolver<miopen::solver::fusion::ConvCKIgemmGrpFwdActivFused>();
 };
-
-using GPU_ConvGrpActivInfer3D_BFP16 = GPU_ConvGrpActivInfer3D<bfloat16>;
-using GPU_ConvGrpActivInfer3D_FP16  = GPU_ConvGrpActivInfer3D<float16>;
-using GPU_ConvGrpActivInfer3D_FP32  = GPU_ConvGrpActivInfer3D<float>;
-
-template <typename Solver, typename TestCase>
-void RunSolver(miopen::FusionPlanDescriptor& fusePlanDesc,
-               const std::unique_ptr<miopen::fusion::FusionInvokeParams>& plan_params,
-               const TestCase& conv_config,
-               bool& test_skipped)
+TEST_P(GPU_ConvGrpActivInfer3D_BFP16, ConvCKIgemmGrpFwdActivFused)
 {
-    auto& handle = get_handle();
-    Solver solv{};
-    const auto fusion_problem = miopen::FusionDescription{&fusePlanDesc};
-    auto fusion_ctx           = miopen::FusionContext{handle};
-    if(!solv.IsApplicable(fusion_ctx, fusion_problem))
-    {
-        test_skipped = true;
-        GTEST_SKIP() << solv.SolverDbId() << " Not Applicable" << conv_config;
-    }
-    ASSERT_TRUE(solv.IsApplicable(fusion_ctx, fusion_problem));
-    auto sol = solv.GetSolution(fusion_ctx, fusion_problem);
-    ASSERT_TRUE(sol.Succeeded());
-    ASSERT_TRUE(sol.invoker_factory);
-    const auto invoker = handle.PrepareInvoker(*sol.invoker_factory, sol.construction_params);
-    (invoker)(handle, *(plan_params.get()));
-    handle.Finish();
-}
-
-template <typename Solver>
-std::unique_ptr<miopen::fusion::FusionInvokeParams>
-createFusionInvokeParams(const miopen::FusionDescription& fusion_desc,
-                         const miopen::FusionContext& fusion_ctx,
-                         const miopen::OperatorArgs& params,
-                         const Solver& solv,
-                         const miopen::TensorDescriptor& input_desc,
-                         ConstData_t in_dev_ptr,
-                         const miopen::TensorDescriptor& output_desc,
-                         Data_t out_dev_ptr,
-                         Workspace& wspace,
-                         bool useWorkspace = false)
+    RunTunableSolver<miopen::solver::fusion::ConvCKIgemmGrpFwdActivFused>();
+};
+TEST_P(GPU_ConvGrpActivInfer_FP16, ConvCKIgemmGrpFwdActivFused)
 {
-    if(useWorkspace)
-    {
-        wspace.resize(solv.GetWorkspaceSize(fusion_ctx, fusion_desc));
-
-        return std::make_unique<miopen::fusion::FusionInvokeParams>(params,
-                                                                    input_desc,
-                                                                    in_dev_ptr,
-                                                                    output_desc,
-                                                                    out_dev_ptr,
-                                                                    false,
-                                                                    wspace.ptr(),
-                                                                    wspace.size());
-    }
-    else
-    {
-        return std::make_unique<miopen::fusion::FusionInvokeParams>(
-            params, input_desc, in_dev_ptr, output_desc, out_dev_ptr, false);
-    }
-}
-
-template <typename Solver, typename TCase = ConvTestCaseBase>
-void RunTunableSolver(miopen::FusionPlanDescriptor& fusePlanDesc,
-                      const miopen::OperatorArgs& params,
-                      const TCase& conv_config,
-                      bool& test_skipped,
-                      const miopen::TensorDescriptor& input_desc,
-                      ConstData_t in_dev_ptr,
-                      const miopen::TensorDescriptor& output_desc,
-                      Data_t out_dev_ptr,
-                      Workspace& wspace)
+    RunTunableSolver<miopen::solver::fusion::ConvCKIgemmGrpFwdActivFused>();
+};
+TEST_P(GPU_ConvGrpActivInfer3D_FP16, ConvCKIgemmGrpFwdActivFused)
 {
-    auto& handle = get_handle();
-    Solver solv{};
-    const auto fusion_problem = miopen::FusionDescription{&fusePlanDesc};
-    auto fusion_ctx           = miopen::FusionContext{handle};
-    if(!solv.IsApplicable(fusion_ctx, fusion_problem))
-    {
-        test_skipped = true;
-        GTEST_SKIP() << solv.SolverDbId() << " Not Applicable" << conv_config;
-    }
-    ASSERT_TRUE(solv.IsApplicable(fusion_ctx, fusion_problem));
-    auto sol = solv.GetSolution(
-        fusion_ctx, fusion_problem, solv.GetDefaultPerformanceConfig(fusion_ctx, fusion_problem));
-    ASSERT_TRUE(sol.Succeeded());
-    ASSERT_TRUE(sol.invoker_factory);
-
-    auto plan_params = createFusionInvokeParams<Solver>(fusion_problem,
-                                                        fusion_ctx,
-                                                        params,
-                                                        solv,
-                                                        input_desc,
-                                                        in_dev_ptr,
-                                                        output_desc,
-                                                        out_dev_ptr,
-                                                        wspace,
-                                                        solv.MayNeedWorkspace());
-
-    const auto invoker = handle.PrepareInvoker(*sol.invoker_factory, sol.construction_params);
-    (invoker)(handle, *(plan_params.get()));
-    handle.Finish();
-}
-
-} // namespace ca_infer
-
-using namespace ca_infer;
-
-#define DEFINE_GRP_CONV_ACTIV_TEST(conv_active_fixture)                                      \
-    TEST_P(conv_active_fixture, ConvCKIgemmGrpFwdActivFused)                                 \
-    {                                                                                        \
-        RunTunableSolver<miopen::solver::fusion::ConvCKIgemmGrpFwdActivFused>(fusePlanDesc,  \
-                                                                              params,        \
-                                                                              conv_config,   \
-                                                                              test_skipped,  \
-                                                                              input.desc,    \
-                                                                              in_dev.get(),  \
-                                                                              output.desc,   \
-                                                                              out_dev.get(), \
-                                                                              wspace);       \
-    }
-
-DEFINE_GRP_CONV_ACTIV_TEST(GPU_ConvGrpActivInfer_BFP16)
-DEFINE_GRP_CONV_ACTIV_TEST(GPU_ConvGrpActivInfer3D_BFP16)
-DEFINE_GRP_CONV_ACTIV_TEST(GPU_ConvGrpActivInfer_FP16)
-DEFINE_GRP_CONV_ACTIV_TEST(GPU_ConvGrpActivInfer3D_FP16)
-DEFINE_GRP_CONV_ACTIV_TEST(GPU_ConvGrpActivInfer_FP32)
-DEFINE_GRP_CONV_ACTIV_TEST(GPU_ConvGrpActivInfer3D_FP32)
-
-#define INSTANTIATE_GRP_CONV_ACTIV_SUITE_SMOKE(test_fixture, configs, tensor_types)          \
-    INSTANTIATE_TEST_SUITE_P(                                                                \
-        Smoke,                                                                               \
-        test_fixture,                                                                        \
-        testing::Combine(testing::Values(miopenActivationRELU, miopenActivationCLIPPEDRELU), \
-                         testing::ValuesIn(configs),                                         \
-                         tensor_types,                                                       \
-                         testing::Values(0.5f),                                              \
-                         testing::Values(1.0f),                                              \
-                         testing::Values(0.5f)));
-
-#define INSTANTIATE_GRP_CONV_ACTIV_SUITE_FULL(test_fixture, configs, tensor_types)    \
-    INSTANTIATE_TEST_SUITE_P(Full,                                                    \
-                             test_fixture,                                            \
-                             testing::Combine(testing::Values(miopenActivationCLAMP), \
-                                              testing::ValuesIn(configs),             \
-                                              tensor_types,                           \
-                                              testing::Values(0.5f),                  \
-                                              testing::Values(1.0f),                  \
-                                              testing::Values(0.5f)));
+    RunTunableSolver<miopen::solver::fusion::ConvCKIgemmGrpFwdActivFused>();
+};
+TEST_P(GPU_ConvGrpActivInfer_FP32, ConvCKIgemmGrpFwdActivFused)
+{
+    RunTunableSolver<miopen::solver::fusion::ConvCKIgemmGrpFwdActivFused>();
+};
+TEST_P(GPU_ConvGrpActivInfer3D_FP32, ConvCKIgemmGrpFwdActivFused)
+{
+    RunTunableSolver<miopen::solver::fusion::ConvCKIgemmGrpFwdActivFused>();
+};
 
 // Instantiate test suites for BFP16
-INSTANTIATE_GRP_CONV_ACTIV_SUITE_SMOKE(
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
     GPU_ConvGrpActivInfer_BFP16,
-    GroupConvTestConfig<2>::GetSmokeConfigs<Direction::Forward>(),
-    testing::Values(miopenTensorNHWC /*, miopenTensorNCHW*/))
-INSTANTIATE_GRP_CONV_ACTIV_SUITE_SMOKE(
+    gcaInferParamGenSmoke(GroupConvTestConfig<2>::GetSmokeConfigs<Direction::Forward>(),
+                          testing::Values(miopenTensorNHWC /*, miopenTensorNCHW*/)));
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
     GPU_ConvGrpActivInfer3D_BFP16,
-    GroupConvTestConfig<3>::GetSmokeConfigs<Direction::Forward>(),
-    testing::Values(miopenTensorNDHWC /*, miopenTensorNCDHW*/))
+    gcaInferParamGenSmoke(GroupConvTestConfig<3>::GetSmokeConfigs<Direction::Forward>(),
+                          testing::Values(miopenTensorNDHWC /*, miopenTensorNCDHW*/)));
 
-INSTANTIATE_GRP_CONV_ACTIV_SUITE_FULL(GPU_ConvGrpActivInfer_BFP16,
-                                      GroupConvTestConfig<2>::GetConfigs<Direction::Forward>(),
-                                      testing::Values(miopenTensorNHWC /*, miopenTensorNCHW*/))
-INSTANTIATE_GRP_CONV_ACTIV_SUITE_FULL(GPU_ConvGrpActivInfer3D_BFP16,
-                                      GroupConvTestConfig<3>::GetConfigs<Direction::Forward>(),
-                                      testing::Values(miopenTensorNDHWC /*, miopenTensorNCDHW*/))
+INSTANTIATE_TEST_SUITE_P(
+    Full,
+    GPU_ConvGrpActivInfer_BFP16,
+    gcaInferParamGenFull(GroupConvTestConfig<2>::GetConfigs<Direction::Forward>(),
+                         testing::Values(miopenTensorNHWC /*, miopenTensorNCHW*/)));
+INSTANTIATE_TEST_SUITE_P(
+    Full,
+    GPU_ConvGrpActivInfer3D_BFP16,
+    gcaInferParamGenFull(GroupConvTestConfig<3>::GetConfigs<Direction::Forward>(),
+                         testing::Values(miopenTensorNDHWC /*, miopenTensorNCDHW*/)));
 
 // Instantiate test suites for FP16
-INSTANTIATE_GRP_CONV_ACTIV_SUITE_SMOKE(
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
     GPU_ConvGrpActivInfer_FP16,
-    GroupConvTestConfig<2>::GetSmokeConfigs<Direction::Forward>(),
-    testing::Values(miopenTensorNHWC /*, miopenTensorNCHW*/))
-INSTANTIATE_GRP_CONV_ACTIV_SUITE_SMOKE(
+    gcaInferParamGenSmoke(GroupConvTestConfig<2>::GetSmokeConfigs<Direction::Forward>(),
+                          testing::Values(miopenTensorNHWC /*, miopenTensorNCHW*/)));
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
     GPU_ConvGrpActivInfer3D_FP16,
-    GroupConvTestConfig<3>::GetSmokeConfigs<Direction::Forward>(),
-    testing::Values(miopenTensorNDHWC /*, miopenTensorNCDHW*/))
+    gcaInferParamGenSmoke(GroupConvTestConfig<3>::GetSmokeConfigs<Direction::Forward>(),
+                          testing::Values(miopenTensorNDHWC /*, miopenTensorNCDHW*/)));
 
-INSTANTIATE_GRP_CONV_ACTIV_SUITE_FULL(GPU_ConvGrpActivInfer_FP16,
-                                      GroupConvTestConfig<2>::GetConfigs<Direction::Forward>(),
-                                      testing::Values(miopenTensorNHWC /*, miopenTensorNCHW*/))
-INSTANTIATE_GRP_CONV_ACTIV_SUITE_FULL(GPU_ConvGrpActivInfer3D_FP16,
-                                      GroupConvTestConfig<3>::GetConfigs<Direction::Forward>(),
-                                      testing::Values(miopenTensorNDHWC /*, miopenTensorNCDHW*/))
+INSTANTIATE_TEST_SUITE_P(
+    Full,
+    GPU_ConvGrpActivInfer_FP16,
+    gcaInferParamGenFull(GroupConvTestConfig<2>::GetConfigs<Direction::Forward>(),
+                         testing::Values(miopenTensorNHWC /*, miopenTensorNCHW*/)));
+INSTANTIATE_TEST_SUITE_P(
+    Full,
+    GPU_ConvGrpActivInfer3D_FP16,
+    gcaInferParamGenFull(GroupConvTestConfig<3>::GetConfigs<Direction::Forward>(),
+                         testing::Values(miopenTensorNDHWC /*, miopenTensorNCDHW*/)));
 
 // Instantiate test suites for FP32
-INSTANTIATE_GRP_CONV_ACTIV_SUITE_SMOKE(
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
     GPU_ConvGrpActivInfer_FP32,
-    GroupConvTestConfig<2>::GetSmokeConfigs<Direction::Forward>(),
-    testing::Values(miopenTensorNHWC /*, miopenTensorNCHW*/))
-INSTANTIATE_GRP_CONV_ACTIV_SUITE_SMOKE(
+    gcaInferParamGenSmoke(GroupConvTestConfig<2>::GetSmokeConfigs<Direction::Forward>(),
+                          testing::Values(miopenTensorNHWC /*, miopenTensorNCHW*/)));
+INSTANTIATE_TEST_SUITE_P(
+    Smoke,
     GPU_ConvGrpActivInfer3D_FP32,
-    GroupConvTestConfig<3>::GetSmokeConfigs<Direction::Forward>(),
-    testing::Values(miopenTensorNDHWC /*, miopenTensorNCDHW*/))
+    gcaInferParamGenSmoke(GroupConvTestConfig<3>::GetSmokeConfigs<Direction::Forward>(),
+                          testing::Values(miopenTensorNDHWC /*, miopenTensorNCDHW*/)));
 
-INSTANTIATE_GRP_CONV_ACTIV_SUITE_FULL(GPU_ConvGrpActivInfer_FP32,
-                                      GroupConvTestConfig<2>::GetConfigs<Direction::Forward>(),
-                                      testing::Values(miopenTensorNHWC /*, miopenTensorNCHW*/))
-INSTANTIATE_GRP_CONV_ACTIV_SUITE_FULL(GPU_ConvGrpActivInfer3D_FP32,
-                                      GroupConvTestConfig<3>::GetConfigs<Direction::Forward>(),
-                                      testing::Values(miopenTensorNDHWC /*, miopenTensorNCDHW*/))
-
-#undef DEFINE_GRP_CONV_ACTIV_TEST
-#undef INSTANTIATE_CONV_ACTIV_SUITE
+INSTANTIATE_TEST_SUITE_P(
+    Full,
+    GPU_ConvGrpActivInfer_FP32,
+    gcaInferParamGenFull(GroupConvTestConfig<2>::GetConfigs<Direction::Forward>(),
+                         testing::Values(miopenTensorNHWC /*, miopenTensorNCHW*/)));
+INSTANTIATE_TEST_SUITE_P(
+    Full,
+    GPU_ConvGrpActivInfer3D_FP32,
+    gcaInferParamGenFull(GroupConvTestConfig<3>::GetConfigs<Direction::Forward>(),
+                         testing::Values(miopenTensorNDHWC /*, miopenTensorNCDHW*/)));


### PR DESCRIPTION
#3829 introduced new tests breaking Gtest formatting checks because of using additional C macros. A function in a base class can replace the macros without adding an exception to the checks or complicating the checking script.

Further refactoring will be needed to remove code duplication in CA and CBA tests.

This PR introduces merge conflicts with #3833 and will be merged after it. Or before depending on the urgency.