### PR TITLE
Re-enable clearing outputs for CK

### DIFF
--- a/src/solver/conv/conv_hip_implicit_gemm_3d_grouped_bwd_xdlops.cpp
+++ b/src/solver/conv/conv_hip_implicit_gemm_3d_grouped_bwd_xdlops.cpp
@@ -559,21 +559,21 @@ ConvSolution ConvHipImplicitGemm3DGroupBwdXdlops::GetSolution(
             {
             case BILINEAR:
                 return InitInvokerFactoryBwdNCHW<3,
-                                                 false,
+                                                 true,
                                                  DeviceOpGBwdBilinearPtrs<T>,
                                                  CKArgs<T>,
                                                  miopen::conv::DataInvokeParams>(
                     ctx, problem, config.kernel_id);
             case SCALE:
                 return InitInvokerFactoryBwdNCHW<3,
-                                                 false,
+                                                 true,
                                                  DeviceOpGBwdScalePtrs<T>,
                                                  CKArgs<T>,
                                                  miopen::conv::DataInvokeParams>(
                     ctx, problem, config.kernel_id);
             default:
                 return InitInvokerFactoryBwdNCHW<3,
-                                                 false,
+                                                 true,
                                                  DeviceOpGBwdDefaultPtrs<T>,
                                                  CKArgs<T>,
                                                  miopen::conv::DataInvokeParams>(
@@ -585,19 +585,19 @@ ConvSolution ConvHipImplicitGemm3DGroupBwdXdlops::GetSolution(
             switch(problem.GetAlphaBetaCase())
             {
             case BILINEAR:
-                return InitInvokerFactoryNHWC<false,
+                return InitInvokerFactoryNHWC<true,
                                               DeviceOpGBwdBilinearPtrs<T>,
                                               CKArgs<T>,
                                               miopen::conv::DataInvokeParams>(
                     ctx, problem, config.kernel_id);
             case SCALE:
-                return InitInvokerFactoryNHWC<false,
+                return InitInvokerFactoryNHWC<true,
                                               DeviceOpGBwdScalePtrs<T>,
                                               CKArgs<T>,
                                               miopen::conv::DataInvokeParams>(
                     ctx, problem, config.kernel_id);
             default:
-                return InitInvokerFactoryNHWC<false,
+                return InitInvokerFactoryNHWC<true,
                                               DeviceOpGBwdDefaultPtrs<T>,
                                               CKArgs<T>,
                                               miopen::conv::DataInvokeParams>(

--- a/src/solver/conv/conv_hip_implicit_gemm_3d_grouped_fwd_xdlops.cpp
+++ b/src/solver/conv/conv_hip_implicit_gemm_3d_grouped_fwd_xdlops.cpp
@@ -554,21 +554,21 @@ ConvSolution ConvHipImplicitGemm3DGroupFwdXdlops::GetSolution(
             {
             case BILINEAR:
                 return InitInvokerFactoryFwdNCHW<3,
-                                                 false,
+                                                 true,
                                                  DeviceOpGFwdBilinearPtrs<T>,
                                                  CKArgs<T>,
                                                  miopen::conv::DataInvokeParams>(
                     ctx, problem, config.kernel_id);
             case SCALE:
                 return InitInvokerFactoryFwdNCHW<3,
-                                                 false,
+                                                 true,
                                                  DeviceOpGFwdScalePtrs<T>,
                                                  CKArgs<T>,
                                                  miopen::conv::DataInvokeParams>(
                     ctx, problem, config.kernel_id);
             default:
                 return InitInvokerFactoryFwdNCHW<3,
-                                                 false,
+                                                 true,
                                                  DeviceOpGFwdDefaultPtrs<T>,
                                                  CKArgs<T>,
                                                  miopen::conv::DataInvokeParams>(
@@ -580,19 +580,19 @@ ConvSolution ConvHipImplicitGemm3DGroupFwdXdlops::GetSolution(
             switch(problem.GetAlphaBetaCase())
             {
             case BILINEAR:
-                return InitInvokerFactoryNHWC<false,
+                return InitInvokerFactoryNHWC<true,
                                               DeviceOpGFwdBilinearPtrs<T>,
                                               CKArgs<T>,
                                               miopen::conv::DataInvokeParams>(
                     ctx, problem, config.kernel_id);
             case SCALE:
-                return InitInvokerFactoryNHWC<false,
+                return InitInvokerFactoryNHWC<true,
                                               DeviceOpGFwdScalePtrs<T>,
                                               CKArgs<T>,
                                               miopen::conv::DataInvokeParams>(
                     ctx, problem, config.kernel_id);
             default:
-                return InitInvokerFactoryNHWC<false,
+                return InitInvokerFactoryNHWC<true,
                                               DeviceOpGFwdDefaultPtrs<T>,
                                               CKArgs<T>,
                                               miopen::conv::DataInvokeParams>(

--- a/src/solver/conv/conv_hip_implicit_gemm_3d_grouped_wrw_xdlops.cpp
+++ b/src/solver/conv/conv_hip_implicit_gemm_3d_grouped_wrw_xdlops.cpp
@@ -537,21 +537,21 @@ ConvSolution ConvHipImplicitGemm3DGroupWrwXdlops::GetSolution(
             {
             case BILINEAR:
                 return InitInvokerFactoryWrwNCHW<3,
-                                                 false,
+                                                 true,
                                                  DeviceOpGBwdWeightBilinearPtrs<T>,
                                                  CKArgs<T>,
                                                  miopen::conv::WrWInvokeParams>(
                     ctx, problem, config.kernel_id);
             case SCALE:
                 return InitInvokerFactoryWrwNCHW<3,
-                                                 false,
+                                                 true,
                                                  DeviceOpGBwdWeightScalePtrs<T>,
                                                  CKArgs<T>,
                                                  miopen::conv::WrWInvokeParams>(
                     ctx, problem, config.kernel_id);
             default:
                 return InitInvokerFactoryWrwNCHW<3,
-                                                 false,
+                                                 true,
                                                  DeviceOpGBwdWeightDefaultPtrs<T>,
                                                  CKArgs<T>,
                                                  miopen::conv::WrWInvokeParams>(
@@ -563,19 +563,19 @@ ConvSolution ConvHipImplicitGemm3DGroupWrwXdlops::GetSolution(
             switch(problem.GetAlphaBetaCase())
             {
             case BILINEAR:
-                return InitInvokerFactoryNHWC<false,
+                return InitInvokerFactoryNHWC<true,
                                               DeviceOpGBwdWeightBilinearPtrs<T>,
                                               CKArgs<T>,
                                               miopen::conv::WrWInvokeParams>(
                     ctx, problem, config.kernel_id);
             case SCALE:
-                return InitInvokerFactoryNHWC<false,
+                return InitInvokerFactoryNHWC<true,
                                               DeviceOpGBwdWeightScalePtrs<T>,
                                               CKArgs<T>,
                                               miopen::conv::WrWInvokeParams>(
                     ctx, problem, config.kernel_id);
             default:
-                return InitInvokerFactoryNHWC<false,
+                return InitInvokerFactoryNHWC<true,
                                               DeviceOpGBwdWeightDefaultPtrs<T>,
                                               CKArgs<T>,
                                               miopen::conv::WrWInvokeParams>(

--- a/src/solver/conv/conv_hip_implicit_gemm_grouped_bwd_xdlops.cpp
+++ b/src/solver/conv/conv_hip_implicit_gemm_grouped_bwd_xdlops.cpp
@@ -592,7 +592,7 @@ ConvSolution ConvHipImplicitGemmGroupBwdXdlops::GetSolution(
         [&](auto data_type_val) {
             using T = decltype(data_type_val);
             return InitInvokerFactoryBwdNCHW<2,
-                                             false,
+                                             true,
                                              DeviceOpGBwdPtrs<T>,
                                              CKArgs,
                                              miopen::conv::DataInvokeParams>(
@@ -600,7 +600,7 @@ ConvSolution ConvHipImplicitGemmGroupBwdXdlops::GetSolution(
         },
         [&](auto data_type_val) {
             using T = decltype(data_type_val);
-            return InitInvokerFactoryNHWC<false,
+            return InitInvokerFactoryNHWC<true,
                                           DeviceOpGBwdPtrs<T>,
                                           CKArgs,
                                           miopen::conv::DataInvokeParams>(

--- a/src/solver/conv/conv_hip_implicit_gemm_grouped_fwd_xdlops.cpp
+++ b/src/solver/conv/conv_hip_implicit_gemm_grouped_fwd_xdlops.cpp
@@ -557,7 +557,7 @@ ConvSolution ConvHipImplicitGemmGroupFwdXdlops::GetSolution(
         [&](auto data_type_val) {
             using T = decltype(data_type_val);
             return InitInvokerFactoryFwdNCHW<2,
-                                             false,
+                                             true,
                                              DeviceOpGFwdPtrs<T>,
                                              CKArgs,
                                              miopen::conv::DataInvokeParams>(
@@ -565,7 +565,7 @@ ConvSolution ConvHipImplicitGemmGroupFwdXdlops::GetSolution(
         },
         [&](auto data_type_val) {
             using T = decltype(data_type_val);
-            return InitInvokerFactoryNHWC<false,
+            return InitInvokerFactoryNHWC<true,
                                           DeviceOpGFwdPtrs<T>,
                                           CKArgs,
                                           miopen::conv::DataInvokeParams>(

--- a/src/solver/conv/conv_hip_implicit_gemm_grouped_wrw_xdlops.cpp
+++ b/src/solver/conv/conv_hip_implicit_gemm_grouped_wrw_xdlops.cpp
@@ -634,7 +634,7 @@ ConvSolution ConvHipImplicitGemmGroupWrwXdlops::GetSolution(
         [&](auto data_type_val) {
             using T = decltype(data_type_val);
             return InitInvokerFactoryWrwNCHW<2,
-                                             false,
+                                             true,
                                              DeviceOpGWrwPtrs<T>,
                                              CKArgs,
                                              miopen::conv::WrWInvokeParams>(
@@ -642,7 +642,7 @@ ConvSolution ConvHipImplicitGemmGroupWrwXdlops::GetSolution(
         },
         [&](auto data_type_val) {
             using T = decltype(data_type_val);
-            return InitInvokerFactoryNHWC<false,
+            return InitInvokerFactoryNHWC<true,
                                           DeviceOpGWrwPtrs<T>,
                                           CKArgs,
                                           miopen::conv::WrWInvokeParams>(

--- a/src/solver/conv_ck_igemm_grp_fwd_activ_fused.cpp
+++ b/src/solver/conv_ck_igemm_grp_fwd_activ_fused.cpp
@@ -666,7 +666,7 @@ GetSolutionForDimensionality(const FusionContext& ctx,
         [&](auto data_type_val) {
             (void)data_type_val;
             return InitInvokerFactoryFwdNCHW<NDimSpatial,
-                                             false,
+                                             true,
                                              DeviceOpGFwdActPtrs<NDimSpatial,
                                                                  DataType,
                                                                  typename Layouts::InLayout,
@@ -678,7 +678,7 @@ GetSolutionForDimensionality(const FusionContext& ctx,
         },
         [&](auto data_type_val) {
             (void)data_type_val;
-            return InitInvokerFactoryNHWC<false,
+            return InitInvokerFactoryNHWC<true,
                                           DeviceOpGFwdActPtrs<NDimSpatial,
                                                               DataType,
                                                               typename Layouts::InLayout,


### PR DESCRIPTION
Found some cases where removing clearing from MIOpen was causing output issues.
Re-enabling clearing in all cases for now.

Example:

 ./bin/MIOpenDriver conv --batchsize 64 --spatial_dim 2 --pad_h 0 --pad_w 0 --pad_d 0 --conv_stride_h 2 --conv_stride_w 2 --conv_stride_d 1 --dilation_h 1 --dilation_w 1 --dilation_d 1 --group_count 1 --mode conv --pad_mode default --trans_output_pad_h 0 --trans_output_pad_w 0 --trans_output_pad_d 0 --out_layout NCHW --in_d 1 --in_h 4 --in_w 4 --fil_d 1 --fil_h 3 --fil_w 3 --in_channels 3 --out_channels 4 --forw 2 -i 1 -t 1 --init_output_nan 1 -S 155
