### PR TITLE
Prefer using restrictive layout calcs and only fallback to less restrictive

### DIFF
--- a/src/conv/problem_description.cpp
+++ b/src/conv/problem_description.cpp
@@ -124,8 +124,8 @@ void ProblemDescription::HeuristicUpdateLayouts()
     // If we have preset layouts, and they are consistent with each other, we do not need to change
     // them.
     if(!in_layout.empty() && in_layout == out_layout && in_layout == weights_layout &&
-       in.IsPossibleLayout4D5D(in_layout) && out.IsPossibleLayout4D5D(out_layout) &&
-       weights.IsPossibleLayout4D5D(weights_layout))
+       in.IsPossibleLayout4D5D(in_layout, false) && out.IsPossibleLayout4D5D(out_layout, false) &&
+       weights.IsPossibleLayout4D5D(weights_layout, false))
     {
         return;
     }
@@ -135,8 +135,21 @@ void ProblemDescription::HeuristicUpdateLayouts()
 
     for(const std::string& layout : supported_layouts)
     {
-        if(in.IsPossibleLayout4D5D(layout) && out.IsPossibleLayout4D5D(layout) &&
-           weights.IsPossibleLayout4D5D(layout))
+        if(in.IsPossibleLayout4D5D(layout, false) && out.IsPossibleLayout4D5D(layout, false) &&
+           weights.IsPossibleLayout4D5D(layout, false))
+        {
+            in_layout      = layout;
+            weights_layout = layout;
+            out_layout     = layout;
+            return;
+        }
+    }
+
+    // fallback to less restrictive layout checks
+    for(const std::string& layout : supported_layouts)
+    {
+        if(in.IsPossibleLayout4D5D(layout, true) && out.IsPossibleLayout4D5D(layout, true) &&
+           weights.IsPossibleLayout4D5D(layout, true))
         {
             in_layout      = layout;
             weights_layout = layout;

--- a/src/include/miopen/tensor.hpp
+++ b/src/include/miopen/tensor.hpp
@@ -257,9 +257,11 @@ struct MIOPEN_INTERNALS_EXPORT TensorDescriptor : miopenTensorDescriptor
 
     // For vectorized layouts storage_layout must be without the ending 'c'
     // \todo make private
-    bool IsPossibleLayout(const std::string& storage_layout, const std::string& layout) const;
+    bool IsPossibleLayout(const std::string& storage_layout,
+                          const std::string& layout,
+                          bool allowLessRestrictive) const;
     // Layout could be NCHW, NHWC, NCDHW, NDHWC, NCHWc, ...
-    bool IsPossibleLayout4D5D(const std::string& layout) const;
+    bool IsPossibleLayout4D5D(const std::string& layout, bool allowLessRestrictive) const;
 
     static std::vector<int64_t> find_permutation(const std::vector<std::size_t>& lens,
                                                  const std::vector<std::size_t>& strides);

--- a/src/solver/pooling/backward2d.cpp
+++ b/src/solver/pooling/backward2d.cpp
@@ -176,8 +176,8 @@ bool PoolingBackward2d::IsApplicable(const ExecutionContext&,
             problem.GetPooling().GetMode() == miopenPoolingAverage ||
             problem.GetPooling().GetMode() == miopenPoolingAverageInclusive) &&
            problem.GetXDesc().GetNumDims() == 4 &&
-           problem.GetXDesc().IsPossibleLayout4D5D("NCHW") &&
-           problem.GetYDesc().IsPossibleLayout4D5D("NCHW") &&
+           problem.GetXDesc().IsPossibleLayout4D5D("NCHW", false) &&
+           problem.GetYDesc().IsPossibleLayout4D5D("NCHW", false) &&
            sizeof_local_memory(problem) <= TargetProperties::GetMaxLocalMemorySize();
 }
 

--- a/src/solver/pooling/backwardNd.cpp
+++ b/src/solver/pooling/backwardNd.cpp
@@ -52,12 +52,12 @@ bool PoolingBackwardNd::IsApplicable(const ExecutionContext&,
                || problem.GetPooling().GetMode() == miopenPoolingAverageInclusive) //
            && (                                                                    //
                   (problem.GetXDesc().GetNumDims() == 5                            //
-                   && problem.GetXDesc().IsPossibleLayout4D5D("NCDHW")             //
-                   && problem.GetYDesc().IsPossibleLayout4D5D("NCDHW"))            //
+                   && problem.GetXDesc().IsPossibleLayout4D5D("NCDHW", false)      //
+                   && problem.GetYDesc().IsPossibleLayout4D5D("NCDHW", false))     //
                   ||                                                               //
                   (problem.GetXDesc().GetNumDims() == 4                            //
-                   && problem.GetXDesc().IsPossibleLayout4D5D("NCHW")              //
-                   && problem.GetYDesc().IsPossibleLayout4D5D("NCHW"))             //
+                   && problem.GetXDesc().IsPossibleLayout4D5D("NCHW", false)       //
+                   && problem.GetYDesc().IsPossibleLayout4D5D("NCHW", false))      //
                   )                                                                //
            /// \todo This solver does not support workspace index mask mode yet.
            && !(problem.GetPooling().GetMode() == miopenPoolingMax //

--- a/src/solver/pooling/forward2d.cpp
+++ b/src/solver/pooling/forward2d.cpp
@@ -141,8 +141,8 @@ bool PoolingForward2d::IsApplicable(const ExecutionContext& context,
            problem.GetXDesc().GetType() == problem.GetYDesc().GetType() &&
            (problem.GetXDesc().GetType() == miopenFloat ||
             problem.GetXDesc().GetType() == miopenHalf) &&
-           problem.GetXDesc().IsPossibleLayout4D5D("NCHW") &&
-           problem.GetYDesc().IsPossibleLayout4D5D("NCHW") &&
+           problem.GetXDesc().IsPossibleLayout4D5D("NCHW", false) &&
+           problem.GetYDesc().IsPossibleLayout4D5D("NCHW", false) &&
            sizeof_private_memory(problem) <=
                TargetProperties::GetMaxWaveScratchSize() / context.GetStream().GetWavefrontWidth();
 }

--- a/src/solver/pooling/forwardNaive.cpp
+++ b/src/solver/pooling/forwardNaive.cpp
@@ -78,12 +78,12 @@ bool PoolingForwardNaive::IsApplicable(const ExecutionContext&,
                || problem.GetPooling().GetMode() == miopenPoolingAverageInclusive) //
            && (                                                                    //
                   (problem.GetXDesc().GetNumDims() == 5                            //
-                   && problem.GetXDesc().IsPossibleLayout4D5D("NCDHW")             //
-                   && problem.GetYDesc().IsPossibleLayout4D5D("NCDHW"))            //
+                   && problem.GetXDesc().IsPossibleLayout4D5D("NCDHW", false)      //
+                   && problem.GetYDesc().IsPossibleLayout4D5D("NCDHW", false))     //
                   ||                                                               //
                   (problem.GetXDesc().GetNumDims() == 4                            //
-                   && problem.GetXDesc().IsPossibleLayout4D5D("NCHW")              //
-                   && problem.GetYDesc().IsPossibleLayout4D5D("NCHW"))             //
+                   && problem.GetXDesc().IsPossibleLayout4D5D("NCHW", false)       //
+                   && problem.GetYDesc().IsPossibleLayout4D5D("NCHW", false))      //
               );
 }
 

--- a/src/solver/pooling/forwardNd.cpp
+++ b/src/solver/pooling/forwardNd.cpp
@@ -110,8 +110,8 @@ bool PoolingForwardNd::IsApplicable(const ExecutionContext& context,
 
     return problem.GetDirection() == miopen::pooling::Direction::Forward                      //
            && problem.GetXDesc().GetNumDims() == 5                                            //
-           && problem.GetXDesc().IsPossibleLayout4D5D("NCDHW")                                //
-           && problem.GetYDesc().IsPossibleLayout4D5D("NCDHW")                                //
+           && problem.GetXDesc().IsPossibleLayout4D5D("NCDHW", false)                         //
+           && problem.GetYDesc().IsPossibleLayout4D5D("NCDHW", false)                         //
            && problem.GetXDesc().GetType() == problem.GetYDesc().GetType()                    //
            && (problem.GetXDesc().GetType() == miopenFloat                                    //
                || problem.GetXDesc().GetType() == miopenHalf)                                 //

--- a/src/tensor.cpp
+++ b/src/tensor.cpp
@@ -423,7 +423,8 @@ void TensorDescriptor::CheckArgsAndInit(bool use_strides)
 
         if(tensorLayout)
         {
-            if(!this->IsPossibleLayout4D5D(TensorDescriptor::LayoutEnumToStr(tensorLayout.value())))
+            if(!this->IsPossibleLayout4D5D(TensorDescriptor::LayoutEnumToStr(tensorLayout.value()),
+                                           true))
                 MIOPEN_THROW(miopenStatusBadParm, "Mismatch of layout and strides");
         }
     }
@@ -647,7 +648,8 @@ std::size_t TensorDescriptor::GetElementSpace() const
 
 // For vectorized layouts storage_layout must be without the ending 'c'
 bool TensorDescriptor::IsPossibleLayout(const std::string& storage_layout,
-                                        const std::string& layout) const
+                                        const std::string& layout,
+                                        bool allowLessRestrictive) const
 {
     if(storage_layout.size() != this->GetNumDims())
     {
@@ -686,7 +688,7 @@ bool TensorDescriptor::IsPossibleLayout(const std::string& storage_layout,
         const auto pos = storage_layout.find(cur_char);
         if(pos == std::string::npos)
             MIOPEN_THROW(miopenStatusInternalError, "wrong layout format");
-        if(lens[pos] != 1)
+        if(lens[pos] != 1 || !allowLessRestrictive)
             layout_strides.push_back(strides[pos]);
     }
 
@@ -700,18 +702,22 @@ bool TensorDescriptor::IsPossibleLayout(const std::string& storage_layout,
 }
 
 // Layout could be NCHW, NHWC, NCDHW, NDHWC, NCHWc, ...
-bool TensorDescriptor::IsPossibleLayout4D5D(const std::string& layout) const
+bool TensorDescriptor::IsPossibleLayout4D5D(const std::string& layout,
+                                            bool allowLessRestrictive) const
 {
     if(tensorLayout)
     {
         if(this->tensorLayout == miopenTensorCHWNc4 || this->tensorLayout == miopenTensorCHWNc8)
-            return this->IsPossibleLayout(GetStorageLayout4D5D(4, true), layout);
+            return this->IsPossibleLayout(
+                GetStorageLayout4D5D(4, true), layout, allowLessRestrictive);
     }
 
     switch(this->GetNumDims())
     {
     case 4:
-    case 5: return this->IsPossibleLayout(GetStorageLayout4D5D(this->GetNumDims()), layout);
+    case 5:
+        return this->IsPossibleLayout(
+            GetStorageLayout4D5D(this->GetNumDims()), layout, allowLessRestrictive);
     default: return false;
     }
 }

--- a/test/gtest/unit_TensorDescriptor.cpp
+++ b/test/gtest/unit_TensorDescriptor.cpp
@@ -252,7 +252,7 @@ public:
 
         for(const auto& layout : this->GetAllLayouts())
         {
-            const auto is_possible_layout = td.IsPossibleLayout4D5D(layout);
+            const auto is_possible_layout = td.IsPossibleLayout4D5D(layout, false);
             const auto expected =
                 std::count(p.actual_layouts.cbegin(), p.actual_layouts.cend(), layout);
             ASSERT_EQ(is_possible_layout, expected) << "current layout: " << layout;


### PR DESCRIPTION
The previous less restrictive changes were causing some cases where C == 1, or H & W == 1 to have a changed layout selection choice. This layout choice could impact solutions in several ways, and lead to new solutions being selected. This change attempts to restore the previous layout choices, and extend to allowing additional support for cases where less restrictive checks are still valid.

Notes:
- Need to coordinate with #3858 (will need to revert the revert, and then land all the changes with this additional fix)
- Need to merge fin API changes as well when this is ready (https://github.com/ROCm/MIFin/pull/116).