### PR TITLE
[Jenkins] Add workaround to get submodule checkout working

### DIFF
--- a/vars/utils.groovy
+++ b/vars/utils.groovy
@@ -28,7 +28,7 @@ def miopenCheckout()
     checkout([
         $class: 'GitSCM',
         branches: scm.branches,
-        doGenerateSubmoduleConfigurations: true,
+        doGenerateSubmoduleConfigurations: false,
         extensions: scm.extensions + [
             [$class: 'SubmoduleOption', parentCredentials: true],
         ],

--- a/vars/utils.groovy
+++ b/vars/utils.groovy
@@ -315,6 +315,7 @@ def getDockerImage(Map conf=[:])
 def buildHipClangJob(Map conf=[:]){
         show_node_info()
         miopenCheckout()
+        sh(script: "file ./fin/CMakeLists.txt || git submodule update --init --recursive")
         checkout scm
         env.HSA_ENABLE_SDMA=0
         env.DOCKER_BUILDKIT=1


### PR DESCRIPTION
## Proposed changes

When Jenkins was updated, it broke our use of git scm to checkout subrepos.  This PR introduces a workaround to get CI working again.

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [ ] I have added automated tests relevant to the introduced functionality
- [x] I have sufficient test coverage for the changes, and code coverage hasn't decreased as a result of my PR
- [x] I have ran the tests, and they are all passing locally
- [x] I have added relevant documentation for the changes
- [x] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] I have ran `make format` & `make check_format` to ensure the changes have been formatted
