### PR TITLE
[Jenkins] Never fail submodule update

### DIFF
--- a/vars/utils.groovy
+++ b/vars/utils.groovy
@@ -315,7 +315,7 @@ def getDockerImage(Map conf=[:])
 def buildHipClangJob(Map conf=[:]){
         show_node_info()
         miopenCheckout()
-        sh(script: "file ./fin/CMakeLists.txt || git submodule update --init --recursive")
+        sh(script: "git submodule update --init --recursive || true")
         checkout scm
         env.HSA_ENABLE_SDMA=0
         env.DOCKER_BUILDKIT=1

--- a/vars/utils.groovy
+++ b/vars/utils.groovy
@@ -316,6 +316,11 @@ def buildHipClangJob(Map conf=[:]){
         show_node_info()
         miopenCheckout()
         checkout scm
+        /*
+            The following is a workaround for git submodule updating for the fin module.  After Jenkins upgrade,
+            many plugins started misbehaving, and submodules wouldn't get pulled.  This ensures that we always pull
+            the fin submodule and fail silently when the submodule directory already has artifacts in it.
+        */
         sh(script: "git submodule update --init --recursive || true")
         env.HSA_ENABLE_SDMA=0
         env.DOCKER_BUILDKIT=1

--- a/vars/utils.groovy
+++ b/vars/utils.groovy
@@ -315,8 +315,8 @@ def getDockerImage(Map conf=[:])
 def buildHipClangJob(Map conf=[:]){
         show_node_info()
         miopenCheckout()
-        sh(script: "git submodule update --init --recursive || true")
         checkout scm
+        sh(script: "git submodule update --init --recursive || true")
         env.HSA_ENABLE_SDMA=0
         env.DOCKER_BUILDKIT=1
         def image


### PR DESCRIPTION
## Proposed changes

Need to be even more lenient when updating submodules.  This fix wasn't enough: https://github.com/ROCm/MIOpen/pull/3886

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [ ] I have added automated tests relevant to the introduced functionality
- [x] I have sufficient test coverage for the changes, and code coverage hasn't decreased as a result of my PR
- [x] I have ran the tests, and they are all passing locally
- [x] I have added relevant documentation for the changes
- [x] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] I have ran `make format` & `make check_format` to ensure the changes have been formatted
