### PR TITLE
Fix performance drop on gfx950 due to transpose kernel use

### DIFF
--- a/src/hip/batched_transpose_sol.cpp
+++ b/src/hip/batched_transpose_sol.cpp
@@ -25,6 +25,7 @@
  *******************************************************************************/
 
 #include <miopen/batched_transpose_sol.hpp>
+#include <miopen/env.hpp>
 #include <miopen/invoke_params.hpp>
 #include <miopen/tensor.hpp>
 #include <miopen/magic_div.hpp>
@@ -43,8 +44,9 @@
 #endif
 
 // Compiler has bug for some of the kernel instances, where pack/ediv is not 1.
-// Used to be only enabled for gfx942, but now we are enabling it for all gfx.
-#define WORKAROUND_SWDEV_530382 1
+// By default we'll use a smaller list for gfx942 right now but can also force
+// it by using this env var.
+MIOPEN_DECLARE_ENV_VAR_BOOL(MIOPEN_FORCE_HALF_TRANSPOSE_SHORTLIST)
 
 namespace miopen {
 namespace batched_transpose {
@@ -60,7 +62,8 @@ static inline std::string GetNameTrait(std::size_t type_size)
     MIOPEN_THROW("data type not supported");
 }
 
-static inline const std::vector<BatchedTransposeParam>& GetKernelList(std::size_t data_size)
+static inline const std::vector<BatchedTransposeParam>& GetKernelList(const ExecutionContext& ctx,
+                                                                      std::size_t data_size)
 {
     if(data_size == 1)
     {
@@ -83,8 +86,7 @@ static inline const std::vector<BatchedTransposeParam>& GetKernelList(std::size_
     }
     if(data_size == 2)
     {
-#if WORKAROUND_SWDEV_530382
-        static const std::vector<BatchedTransposeParam> half_kernel_list{
+        static const std::vector<BatchedTransposeParam> half_kernel_list_short{
             // clang-format off
             {16, 16, 1, 1, 1, 1},
             {32, 16, 1, 1, 1, 1},
@@ -99,8 +101,7 @@ static inline const std::vector<BatchedTransposeParam>& GetKernelList(std::size_
             {256, 4, 1, 1, 1, 1},
             // clang-format on
         };
-#else
-        static const std::vector<BatchedTransposeParam> half_kernel_list{
+        static const std::vector<BatchedTransposeParam> half_kernel_list_long{
             // clang-format off
             {16, 16, 1, 1, 1, 1},
             {32, 16, 1, 1, 1, 1},
@@ -134,9 +135,13 @@ static inline const std::vector<BatchedTransposeParam>& GetKernelList(std::size_
             {64, 64, 4, 4, 4, 4},
             // clang-format on
         };
-#endif
 
-        return half_kernel_list;
+        bool force_shortlist   = env::enabled(MIOPEN_FORCE_HALF_TRANSPOSE_SHORTLIST);
+        const auto device_name = ctx.GetStream().GetDeviceName();
+        if(device_name == "gfx942" || force_shortlist)
+            return half_kernel_list_short;
+
+        return half_kernel_list_long;
     }
     if(data_size == 4)
     {
@@ -214,8 +219,11 @@ static inline std::size_t GetExtraPaddingSize(uint32_t /* batch */,
     return static_cast<std::size_t>(padded_h) * padded_w - static_cast<std::size_t>(height) * width;
 }
 
-static inline BatchedTransposeParam
-HeuristicGet(std::size_t data_size, uint32_t batch, uint32_t height, uint32_t width)
+static inline BatchedTransposeParam HeuristicGet(const ExecutionContext& ctx,
+                                                 std::size_t data_size,
+                                                 uint32_t batch,
+                                                 uint32_t height,
+                                                 uint32_t width)
 {
     /*
      * Iterate from big tile size to small tile size, and try match ediv first
@@ -224,7 +232,7 @@ HeuristicGet(std::size_t data_size, uint32_t batch, uint32_t height, uint32_t wi
      * samllest.
      */
 
-    const auto& kernel_list = GetKernelList(data_size);
+    const auto& kernel_list = GetKernelList(ctx, data_size);
     BatchedTransposeParam best_kernel;
     std::size_t extra_padding_size = std::numeric_limits<std::size_t>::max();
     float hw_radio                 = GetNormalizedRadio(height, width);
@@ -332,7 +340,7 @@ BatchedTransposeSolution::BatchedTransposeSolution(const ExecutionContext& ctx,
         MIOPEN_THROW("These data type are not supported");
     num_cu                 = ctx.GetStream().GetMaxComputeUnits();
     std::size_t data_size  = miopen::GetTypeSize(data_type);
-    kernel_param_heuristic = batched_transpose::HeuristicGet(data_size, batch, height, width);
+    kernel_param_heuristic = batched_transpose::HeuristicGet(ctx, data_size, batch, height, width);
 }
 
 solver::KernelInfo BatchedTransposeSolution::GetKernelInfo() const


### PR DESCRIPTION
There was a fix to limit the number of transpose kernels used for 16 bit data created years ago.  It would only limit this on gfx942 systems which is where the problem was originally found.  Recently, we found on SR-IOV environments that other ASIC's were also hitting issues due to using the longer list of kernels so we changed it so all ASIC's used the short list.  Using the shorter list reduces possibilities though and we've just found that at least with one set of shapes on gfx950, this is slower by 13% which is very significant.

This PR restores it so that only gfx942 uses the restricted list of transpose kernels but also adds an environment var to force the use of the shorter list (MIOPEN_FORCE_HALF_TRANSPOSE_SHORTLIST=1).  This will restore the performance on gfx950 while also allowing control over limiting the transpose kernels if further issues are found.

We will be doing a deeper root cause analysis on this and once we know exactly why some of these transpose kernels don't work in some environments, we will consider next steps to resolve this fully.
