### PR TITLE
[HotFix] Enable ck wrw solver on gfx950 for bf16 datatype

### DIFF
--- a/src/solver/conv/conv_hip_implicit_gemm_grouped_wrw_xdlops.cpp
+++ b/src/solver/conv/conv_hip_implicit_gemm_grouped_wrw_xdlops.cpp
@@ -611,7 +611,8 @@ bool ConvHipImplicitGemmGroupWrwXdlops::IsApplicable(
     case miopenFloat: return CheckCKApplicability<float>(problem);
     case miopenInt8: return CheckCKApplicability<int8_t>(problem);
     case miopenBFloat16:
-        return ctx.GetStream().GetDeviceName() == "gfx942" &&
+        return (ctx.GetStream().GetDeviceName() == "gfx942" ||
+                StartsWith(ctx.GetStream().GetDeviceName(), "gfx95")) &&
                CheckCKApplicability<ck::bhalf_t>(problem);
     case miopenInt64:
     case miopenInt32:


### PR DESCRIPTION
## Proposed changes

Enable ck wrw solver on gfx950 for bf16 datatype

## Checklist

- [ ] I have added automated tests relevant to the introduced functionality
- [ ] I have sufficient test coverage for the changes, and code coverage hasn't decreased as a result of my PR
- [ ] I have ran the tests, and they are all passing locally
- [x] I have added relevant documentation for the changes
- [x] I have removed the stale documentation which is no longer relevant after this pull request
- [x] I have ran `make format` & `make check_format` to ensure the changes have been formatted
