### PR TITLE
Update MIOpen version and changelog for ROCm 7.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,24 +4,24 @@
 Full documentation for MIOpen is available [here](https://rocm.docs.amd.com/projects/MIOpen/en/latest/)
 ## MIOpen 3.5.0 for ROCm 7.0.0
 ### Added
-* [Conv] Add misa kernels for gfx950
-* [Conv] Enable split_k support for CK backward data solvers (2D)
-* Add grouped convolution + activation fusion
-* Add grouped convolution + bias + activation fusion
-* [BatchNorm] Enable NHWC in OpenCL
+* [Conv] Added misa kernels for gfx950
+* [Conv] Enabled split_k support for CK backward data solvers (2D)
+* Added grouped convolution + activation fusion
+* Added grouped convolution + bias + activation fusion
+* [BatchNorm] Enabled NHWC in OpenCL
 * Composable Kernel (CK) can now be built inline as part of MIOpen
-* Change to using median value with outliers removed when deciding on the best solution to run
+* Changed to using median value with outliers removed when deciding on the best solution to run
 
 ### Optimized
-* [BatchNorm] Optimize NHWC OpenCL kernels and improve heuristics
+* [BatchNorm] Optimized NHWC OpenCL kernels and improved heuristics
 * [RNN] Dynamic algorithm optimization
-* [Conv] Eliminate redundant clearing of output buffers
+* [Conv] Eliminated redundant clearing of output buffers
 * [RNN] Updated selection heuristics
 
 ### Resolved issues
-* Fix segmentation fault when user specifies workspace smaller than what is required
-* Fix memory access faults in misa kernels due to out-of-bounds memory usage
+* Fixed a segmentation fault when user specifies workspace smaller than what is required
 * Fixed a layout calculation logic error that returned incorrect results and enabled less restrictive layout selection
+* Fixed memory access faults in misa kernels due to out-of-bounds memory usage
 
 
 ## MIOpen 3.4.0 for ROCm 6.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Full documentation for MIOpen is available [here](https://rocm.docs.amd.com/proj
 * Add grouped convolution + activation fusion
 * Add grouped convolution + bias + activation fusion
 * [BatchNorm] Enable NHWC in OpenCL
-* CK can now be built inline as part of MIOpen
+* Composable Kernel (CK) can now be built inline as part of MIOpen
 * Swap to using median value with outliers removed for deciding on best solution to run
 
 ### Optimized

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,8 @@ Full documentation for MIOpen is available [here](https://rocm.docs.amd.com/proj
 
 ### Resolved issues
 * Fix segmentation fault when user specifies workspace smaller than what is required
-* Fix layout calculation logic and enable less restrictive layout selection
 * Fix memory access faults in misa kernels due to out-of-bounds memory usage
+* Fixed a layout calculation logic error that returned incorrect results and enabled less restrictive layout selection
 
 
 ## MIOpen 3.4.0 for ROCm 6.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Full documentation for MIOpen is available [here](https://rocm.docs.amd.com/proj
 ### Resolved issues
 * Fix segmentation fault when user specifies workspace smaller than what is required
 * Fix layout calculation logic and enable less restrictive layout selection
+* Fix memory access faults in misa kernels due to out-of-bounds memory usage
 
 
 ## MIOpen 3.4.0 for ROCm 6.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Full documentation for MIOpen is available [here](https://rocm.docs.amd.com/proj
 * Add grouped convolution + bias + activation fusion
 * [BatchNorm] Enable NHWC in OpenCL
 * Composable Kernel (CK) can now be built inline as part of MIOpen
-* Swap to using median value with outliers removed for deciding on best solution to run
+* Change to using median value with outliers removed when deciding on the best solution to run
 
 ### Optimized
 * [BatchNorm] Optimize NHWC OpenCL kernels and improve heuristics

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 # Change Log for MIOpen
 
 Full documentation for MIOpen is available [here](https://rocm.docs.amd.com/projects/MIOpen/en/latest/)
+## MIOpen 3.5.0 for ROCm 7.0.0
+### Added
+* [Conv] Add misa kernels for gfx950
+* [Conv] Enable split_k support for CK backward data solvers (2D)
+* Add grouped convolution + activation fusion
+* Add grouped convolution + bias + activation fusion
+* [BatchNorm] Enable NHWC in OpenCL
+* CK can now be built inline as part of MIOpen
+* Swap to using median value with outliers removed for deciding on best solution to run
+
+### Optimized
+* [BatchNorm] Optimize NHWC OpenCL kernels and improve heuristics
+* [RNN] Dynamic algorithm optimization
+* [Conv] Eliminate redundant clearing of output buffers
+* [RNN] Updated selection heuristics
+
+### Resolved issues
+* Fix segmentation fault when user specifies workspace smaller than what is required
+* Fix layout calculation logic and enable less restrictive layout selection
+
+
 ## MIOpen 3.4.0 for ROCm 6.4.0
 ### Added
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,7 +130,7 @@ if(MIOPEN_STRIP_SYMBOLS AND NOT WIN32 AND NOT APPLE)
     set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -s")
 endif()
 
-rocm_setup_version(VERSION 3.4.1)
+rocm_setup_version(VERSION 3.5.0)
 
 list( APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake )
 include(TargetFlags)


### PR DESCRIPTION
## Proposed changes

This PR updates the MIOpen version to 3.5.0 for ROCm 7.0.0, and also updates the changelog for MIOpen 3.5.0 / ROCm 7.0.0 to match what should be in ROCm 7.0 RC1.

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [ ] I have added automated tests relevant to the introduced functionality
- [ ] I have sufficient test coverage for the changes, and code coverage hasn't decreased as a result of my PR
- [ ] I have ran the tests, and they are all passing locally
- [x] I have added relevant documentation for the changes
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] I have ran `make format` & `make check_format` to ensure the changes have been formatted
