### PR TITLE
Cherry-pick to docs/6.4.2: Fix or remove Intersphinx links on API reference page (#3880)

### DIFF
--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -28,14 +28,12 @@ The MIOpen API library is structured as follows:
   * :doc:`Reduction <../doxygen/html/group___tensor_reduce>`
   * :doc:`Find <../doxygen/html/group__find2>`
   * :doc:`Layernorm <../doxygen/html/group__layernorm>` (experimental)
-  * :doc:`Sum <../doxygen/html/group__sum>` (experimental)
   * :doc:`GroupNorm <../doxygen/html/group__groupnorm>` (experimental)
   * :doc:`Cat <../doxygen/html/group__cat>` (experimental)
   * :doc:`SGD <../doxygen/html/group___s_g_d>` (experimental)
-  * :doc:`ReduceExtreme <../doxygen/html/group__ReduceExtreme>` (experimental)
+  * :doc:`ReduceExtreme <../doxygen/html/group___reduce_extreme>` (experimental)
   * :doc:`Getitem <../doxygen/html/group__getitem>` (experimental)
-  * :doc:`ReduceCalculation <../doxygen/html/group__ReduceCalculation>` (experimental)
-  * :doc:`RotaryPositionalEmbeddings <../doxygen/html/group__RotaryPositionalEmbeddings>` (experimental)
+  * :doc:`ReduceCalculation <../doxygen/html/group__reducecalculation>` (experimental)
+  * :doc:`RotaryPositionalEmbeddings <../doxygen/html/group___rotary_positional_embeddings>` (experimental)
   * :doc:`ReLU <../doxygen/html/group___re_l_u>` (experimental)
   * :doc:`Kthvalue <../doxygen/html/group__kthvalue>` (experimental)
-  * :doc:`GLU <../doxygen/html/group__glu>` (experimental)


### PR DESCRIPTION
(cherry picked from commit bf88cdcc3ba3110825d3a7a85b894f0bf201b19f)

## Proposed changes

Cherry-pick link fix

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [ ] I have added automated tests relevant to the introduced functionality
- [ ] I have sufficient test coverage for the changes, and code coverage hasn't decreased as a result of my PR
- [ ] I have ran the tests, and they are all passing locally
- [x ] I have added relevant documentation for the changes
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] I have ran `make format` & `make check_format` to ensure the changes have been formatted
