### PR TITLE
Export directive  added for GetWorkspaceSize function for Windows build

### DIFF
--- a/driver/sys_info.hpp
+++ b/driver/sys_info.hpp
@@ -84,16 +84,21 @@ public:
                   << "CPU Model: " << cpuModel << "; "
                   << "RAM Size: " << ramSize << "; "
                   << "GPU Model: " << gpuInfo << std::endl;
+#else
+        miopMajor;
+        miopMinor;
+        miopPatch;
 #endif
     }
 
 private:
     std::string GetTimestamp()
     {
-        auto now   = std::chrono::system_clock::now();
-        auto now_c = std::chrono::system_clock::to_time_t(now);
         std::stringstream ss;
 #ifdef __linux__
+        auto now   = std::chrono::system_clock::now();
+        auto now_c = std::chrono::system_clock::to_time_t(now);
+
         ss << std::put_time(std::gmtime(&now_c), "%Y-%m-%d %H:%M:%S UTC");
 #endif
         return ss.str();

--- a/src/include/miopen/fusion/solvers.hpp
+++ b/src/include/miopen/fusion/solvers.hpp
@@ -250,7 +250,8 @@ struct ConvCKIgemmGrpFwdActivFused final
                 const FusionDescription& fdesc_problem,
                 const PerformanceConfigConvCKIgemmGrpFwdActivFused& config) const override;
     bool MayNeedWorkspace() const override { return true; }
-    size_t GetWorkspaceSize(const FusionContext&, const FusionDescription&) const override;
+    MIOPEN_INTERNALS_EXPORT size_t GetWorkspaceSize(const FusionContext&,
+                                                    const FusionDescription&) const override;
 
 private:
     template <typename DataType>
@@ -322,7 +323,8 @@ struct ConvCKIgemmGrpFwdBiasActivFused final
                 const FusionDescription& fdesc_problem,
                 const PerformanceConfigConvCKIgemmGrpFwdBiasActivFused& config) const override;
     bool MayNeedWorkspace() const override { return true; }
-    size_t GetWorkspaceSize(const FusionContext&, const FusionDescription&) const override;
+    MIOPEN_INTERNALS_EXPORT size_t GetWorkspaceSize(const FusionContext&,
+                                                    const FusionDescription&) const override;
 
 private:
     template <typename DataType>


### PR DESCRIPTION
Test PR for fixing Windows build related linker issues:

[2025-07-22T15:46:12.458Z] [ 67%] Linking CXX executable ..\..\bin\test_conv_activ_infer.exe
[2025-07-22T15:46:12.561Z] lld-link: error: undefined symbol: public: virtual unsigned __int64 __cdecl miopen::solver::fusion::ConvCKIgemmGrpFwdActivFused::GetWorkspaceSize(struct miopen::FusionContext const &, struct miopen::FusionDescription const &) const
[2025-07-22T15:46:12.561Z] >>> referenced by CMakeFiles/test_conv_activ_infer.dir/conv_activ_infer.cpp.obj:(const miopen::solver::fusion::ConvCKIgemmGrpFwdActivFused::`vftable')
[2025-07-22T15:46:12.561Z] clang++: error: linker command failed with exit code 1 (use -v to see invocation)


[2025-07-22T15:46:38.326Z] [ 67%] Linking CXX executable ..\..\bin\test_cba_infer.exe
[2025-07-22T15:46:38.528Z] lld-link: error: undefined symbol: public: virtual unsigned __int64 __cdecl miopen::solver::fusion::ConvCKIgemmGrpFwdBiasActivFused::GetWorkspaceSize(struct miopen::FusionContext const &, struct miopen::FusionDescription const &) const
[2025-07-22T15:46:38.528Z] >>> referenced by CMakeFiles/test_cba_infer.dir/cba_infer.cpp.obj:(const miopen::solver::fusion::ConvCKIgemmGrpFwdBiasActivFused::`vftable')
[2025-07-22T15:46:38.528Z] clang++: error: linker command failed with exit code 1 (use -v to see invocation)


Update: It also contains fixes for "Unused variables" check failures. I need these changes in this PR to be able to get to linking step.