### PR TITLE
Fix error and silent failure in Git hooks install script

### DIFF
--- a/.githooks/install
+++ b/.githooks/install
@@ -3,5 +3,9 @@
 cd $(git rev-parse --git-dir)
 
 echo "Installing hooks..." 
-ln -s ../.githooks hooks
-echo "Done!"
+ln -sT ../.githooks hooks
+if [ $? -eq 0 ]; then
+    echo "Done!"
+else
+    echo "Hooks failed to install: .git/hooks already exists or cannot be created"
+fi


### PR DESCRIPTION
## Proposed changes

I discovered that the pre-commit hook installer fails in the common scenario that `.git/hooks` already exists. Instead of creating a symlink `.git/hooks` that points to `.githooks`, it will create a symlink `.git/hook/.githooks` that points to a non-existant `.git/.githooks`. I've added  the flag `-T` to the `ln` command that will enforce that `.git/hooks` does not already exist and I've added a check for the exit value of the `ln` command to communicate when it has failed.

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [ ] I have added automated tests relevant to the introduced functionality
- [ ] I have sufficient test coverage for the changes, and code coverage hasn't decreased as a result of my PR
- [ ] I have ran the tests, and they are all passing locally
- [ ] I have added relevant documentation for the changes
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] I have ran `make format` & `make check_format` to ensure the changes have been formatted
