### PR TITLE
Remove fdelayed-template-parsing, as it's deprecated after C++20

### DIFF
--- a/cmake/EnableCompilerWarnings.cmake
+++ b/cmake/EnableCompilerWarnings.cmake
@@ -115,7 +115,6 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION
 endif()
 if(WIN32)
     list(APPEND __clang_cxx_compile_options
-        -fdelayed-template-parsing
         -fms-extensions
         -fms-compatibility)
 endif()

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,8 @@ boost@1.83 -DCMAKE_POSITION_INDEPENDENT_CODE=On --build -DCMAKE_CXX_FLAGS=" -std
 facebook/zstd@v1.4.5 -X subdir -DCMAKE_DIR=build/cmake
 # ROCm/half@10abd99e7815f0ca5d892f58dd7d15a23b7cf92c --build
 ROCm/rocMLIR@rocm-5.5.0 -H sha256:a5f62769d28a73e60bc8d61022820f050e97c977c8f6f6275488db31512e1f42 -DBUILD_FAT_LIBROCKCOMPILER=1 -DCMAKE_IGNORE_PATH="/opt/conda/envs/py_3.8;/opt/conda/envs/py_3.9;/opt/conda/envs/py_3.10" -DCMAKE_IGNORE_PREFIX_PATH=/opt/conda -DCMAKE_CXX_FLAGS=" -Wno-deprecated-declarations "
-nlohmann/json@v3.11.2 -DJSON_MultipleHeaders=ON -DJSON_BuildTests=Off
-ROCm/FunctionalPlus@v0.2.18-p0
+nlohmann/json@v3.11.3 -DJSON_MultipleHeaders=ON -DJSON_BuildTests=Off
+ROCm/FunctionalPlus@v0.2.22
 ROCm/eigen@3.4.0
 ROCm/frugally-deep@38c52448b1a4996b3e0e435a877d02441098b1dd
 ROCm/composable_kernel@84a7600bdc5cc06123a82e48348820e2dd6c3285 -DCMAKE_BUILD_TYPE=Release

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ ROCm/rocMLIR@rocm-5.5.0 -H sha256:a5f62769d28a73e60bc8d61022820f050e97c977c8f6f6
 nlohmann/json@v3.11.2 -DJSON_MultipleHeaders=ON -DJSON_BuildTests=Off
 ROCm/FunctionalPlus@v0.2.18-p0
 ROCm/eigen@3.4.0
-ROCm/frugally-deep@9683d557eb672ee2304f80f6682c51242d748a50
+ROCm/frugally-deep@38c52448b1a4996b3e0e435a877d02441098b1dd
 ROCm/composable_kernel@84a7600bdc5cc06123a82e48348820e2dd6c3285 -DCMAKE_BUILD_TYPE=Release
 google/googletest@v1.14.0


### PR DESCRIPTION
Removing this option to fix current Windows build breakage:

[2025-07-24T17:17:56.371Z] clang++[  5%] Building CXX object addkernels/CMakeFiles/addkernels.dir/addkernels.cpp.obj
[2025-07-24T17:17:56.371Z] : error: -fdelayed-template-parsing is deprecated after C++20 [-Werror,-Wdelayed-template-parsing-in-cxx20]
[2025-07-24T17:17:56.371Z] clang++: error: -fdelayed-template-parsing is deprecated after C++20 [-Werror,-Wdelayed-template-parsing-in-cxx20]
[2025-07-24T17:17:56.371Z] jom: C:\w\build\WinRelWithDebInfo\addkernels\CMakeFiles\addkernels.dir\build.make [addkernels\CMakeFiles\addkernels.dir\include_inliner.cpp.obj] Error 1
[2025-07-24T17:17:56.371Z] jom: C:\w\build\WinRelWithDebInfo\addkernels\CMakeFiles\addkernels.dir\build.make [addkernels\CMakeFiles\addkernels.dir\addkernels.cpp.obj] Error 1