### PR TITLE
Users/jeonghyun/asan ck kernels hang mi open unit tests

### DIFF
--- a/src/fusion.cpp
+++ b/src/fusion.cpp
@@ -443,7 +443,6 @@ FusionPlanDescriptor::FusionPlanDescriptor(const miopenFusionDirection_t dir,
       kernel_source_type(OpenclText),
       fp_contains_bn(false),
       data_type(inDesc.GetType()),
-      compiled_invoker(std::nullopt),
       conv_fwd_algo(std::nullopt)
 {
 }

--- a/src/fusion.cpp
+++ b/src/fusion.cpp
@@ -442,7 +442,9 @@ FusionPlanDescriptor::FusionPlanDescriptor(const miopenFusionDirection_t dir,
       is_valid(false),
       kernel_source_type(OpenclText),
       fp_contains_bn(false),
-      data_type(inDesc.GetType())
+      data_type(inDesc.GetType()),
+      compiled_invoker(std::nullopt),
+      conv_fwd_algo(std::nullopt)
 {
 }
 

--- a/test/gtest/tensor_api.cpp
+++ b/test/gtest/tensor_api.cpp
@@ -396,8 +396,8 @@ protected:
 
     static void GenerateValidConfigs(std::vector<TestConfig>& configs)
     {
-        static int dims[]    = {4, 4, 16, 9, 16};
-        static int strides[] = {9216, 2304, 144, 16, 1};
+        static int dims[]    = {4, 4, 16, 9, 16, 1, 1, 1};
+        static int strides[] = {9216, 2304, 144, 16, 1, 1, 1, 1};
         static_assert(sizeof(dims) == sizeof(strides));
         const auto max_ndims = sizeof(dims) / sizeof(dims[0]);
 

--- a/test/gtest/tensor_api.cpp
+++ b/test/gtest/tensor_api.cpp
@@ -396,8 +396,8 @@ protected:
 
     static void GenerateValidConfigs(std::vector<TestConfig>& configs)
     {
-        static int dims[]    = {4, 4, 16, 9, 16, 1, 1, 1};
-        static int strides[] = {9216, 2304, 144, 16, 1, 1, 1, 1};
+        static int dims[]    = {4, 4, 16, 9, 16};
+        static int strides[] = {9216, 2304, 144, 16, 1};
         static_assert(sizeof(dims) == sizeof(strides));
         const auto max_ndims = sizeof(dims) / sizeof(dims[0]);
 


### PR DESCRIPTION
# ASAN Fixes for MIOpen

**Jira:** [ALMIOPEN-1146](https://amd-hub.atlassian.net/browse/ALMIOPEN-1146), [AICK-723](https://amd-hub.atlassian.net/browse/AICK-723)

## Bug 1: Uninitialized `std::optional` in FusionPlanDescriptor

**File:** `src/fusion.cpp`

**Issue:** The `FusionPlanDescriptor(dir, inDesc)` constructor does not list `conv_fwd_algo` in its member initializer list. Per C++20, `std::optional` should default-construct to empty, but under `amdclang++ -O2 -fsanitize=address` with ASAN fake-stack, the default initialization appears to be skipped. Stale stack bytes make the optional's discriminant non-zero, causing undefined behavior on destruction.

Previously, this struct also had an uninitialized `compiled_invoker` (`std::optional<std::pair<size_t, Invoker>>`), which caused a SEGFAULT at address `0x700` when ASAN fake-stack reuse left stale data in its `std::function` pointer. That member was refactored into `std::vector<Invoker>` (which self-initializes), resolving that crash. `conv_fwd_algo` still has the same underlying issue.

**Fix:** Explicitly initialize in the member initializer list:

```cpp
      data_type(inDesc.GetType()),
      conv_fwd_algo(std::nullopt)       // <-- ADDED
```

---
## Bug 2: Global Buffer Overflow in tensor_api.cpp (Dropped)
Already addressed by rocm-libraries#4323, which skips the wrong-ndims negative test when AddressSanitizer is enabled.
---

**File:** `test/gtest/tensor_api.cpp`

**Issue:** `dims[]` and `strides[]` arrays have 5 elements. `GetWrongNumDims()` generates `num_dims + 1` for negative testing -- for 5D layouts this gives `ndims = 6`. The test config keeps the original `dimsA` pointer but sets `nbDims = 6`, so the MIOpen C API reads 6 elements from a 5-element array. ASAN catches this as `global-buffer-overflow` at test registration, blocking all `miopen_gtest` tests.

**Fix:** Pad arrays to 8 elements:

```cpp
static int dims[]    = {4, 4, 16, 9, 16, 1, 1, 1};       // 8 elements
static int strides[] = {9216, 2304, 144, 16, 1, 1, 1, 1}; // 8 elements
```


[ALMIOPEN-1146]: https://amd-hub.atlassian.net/browse/ALMIOPEN-1146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AICK-723]: https://amd-hub.atlassian.net/browse/AICK-723?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ