### PR TITLE
Fix uint32 gridDim overflow in naive conv on large batch 

### DIFF
--- a/src/hipoc/hipoc_kernel.cpp
+++ b/src/hipoc/hipoc_kernel.cpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (c) 2017 Advanced Micro Devices, Inc.
+ * Copyright (c) 2017-2026 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -108,6 +108,24 @@ void HIPOCKernelInvoke::run(void* args, std::size_t size) const
     {
         MIOPEN_THROW("MIOPEN_DEVICE_ARCH used, escaping launching kernel");
     }
+
+    // hipExtModuleLaunchKernel() takes the global and local work sizes as uint32_t and
+    // derives the launch grid from them. Reject work sizes that do not fit: otherwise
+    // they are silently truncated, producing an illegal grid and an asynchronous HIP
+    // "invalid configuration argument". During Find (EvaluateInvokers) that error can
+    // corrupt the HIP context and make an unrelated later launch fail fatally. Throwing
+    // here lets Find drop the offending candidate cleanly. Mirrors the guard already
+    // present in run_cooperative() (WORKAROUND_SWDEV_448157).
+    if(gdims[0] >= (1ULL << 32) || gdims[1] >= (1ULL << 32) || gdims[2] >= (1ULL << 32))
+        MIOPEN_THROW("gridDim x blockDim >= 2^32");
+
+    if(ldims[0] == 0 || ldims[1] == 0 || ldims[2] == 0 || gdims[0] % ldims[0] != 0 ||
+       gdims[1] % ldims[1] != 0 || gdims[2] % ldims[2] != 0)
+        MIOPEN_THROW(miopenStatusInternalError);
+
+    // HIP caps gridDim.y and gridDim.z at 65535.
+    if((gdims[1] / ldims[1]) > 0xFFFF || (gdims[2] / ldims[2]) > 0xFFFF)
+        MIOPEN_THROW(miopenStatusInternalError, "gridDim.y/z exceeds 65535");
 
     MIOPEN_HANDLE_LOCK
 

--- a/src/solver/conv/conv_direct_naive_conv_fwd.cpp
+++ b/src/solver/conv/conv_direct_naive_conv_fwd.cpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (c) 2020 Advanced Micro Devices, Inc.
+ * Copyright (c) 2020-2026 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -27,6 +27,7 @@
 #include <miopen/solver/conv_direct_naive_conv.hpp>
 #include <miopen/conv/solvers.hpp>
 #include <miopen/conv/data_invoke_params.hpp>
+#include <miopen/solver/problem_description_interpreter.hpp>
 #include <miopen/env.hpp>
 
 MIOPEN_DECLARE_ENV_VAR_BOOL(MIOPEN_DEBUG_CONV_DIRECT_NAIVE_CONV_FWD)
@@ -63,6 +64,27 @@ bool ConvDirectNaiveConvFwd::IsApplicable(const ExecutionContext& ctx,
 
     if(!problem.AllTensorsLengthsFitIntoInt())
         return false;
+
+    // The naive convolution kernels are launched with a 1-D grid whose global work
+    // size is grid_size * block_size, where (forward direction)
+    //   grid_size = n * k   (default/NCHW layout)  or  n * ho  (NHWC layout),
+    // and block_size = 256 (see conv_internal::GetConv2DFWDSolution). This global work
+    // size is passed to hipExtModuleLaunchKernel() as a uint32_t; once it reaches 2^32
+    // it is silently truncated, producing an illegal grid (e.g. gridDim.x == 0) and a
+    // HIP "invalid configuration argument" at launch time. This is reachable with large
+    // batches, e.g. a ViT patch-embedding conv (3->1024, 14x14 kernel, stride 14) with
+    // n >= 16384 on gfx950. Declare the solver not applicable for such sizes so that a
+    // non-overflowing solver is selected instead.
+    if(problem.Is2d())
+    {
+        const auto n  = static_cast<std::size_t>(ProblemInterpreter::GetBatchN(problem));
+        const auto k  = static_cast<std::size_t>(ProblemInterpreter::GetOutputChannelK(problem));
+        const auto ho = static_cast<std::size_t>(ProblemInterpreter::GetOutputHeightHo(problem));
+        const std::size_t grid_size  = problem.IsLayoutDefault() ? (n * k) : (n * ho);
+        const std::size_t block_size = 256;
+        if(grid_size * block_size >= (static_cast<std::size_t>(1) << 32))
+            return false;
+    }
 
     if(problem.IsTensorsCasted())
     {


### PR DESCRIPTION
…figuration argument)

The naive forward convolution solver builds a 1-D launch grid with global work size grid_size * 256, where grid_size = n * k (default/NCHW layout) or n * ho (NHWC). This value is passed to hipExtModuleLaunchKernel() as a uint32_t. For large problems it reaches/exceeds 2^32 and is silently truncated, producing an illegal grid (e.g. gridDim.x == 0 when n*k*256 is a multiple of 2^32) and a HIP "invalid configuration argument" during Find (EvaluateInvokers). The asynchronous error then corrupts the HIP context and can make an unrelated later launch fail with miopenStatusUnknownError.

Reproduced on gfx950 (MI355X) with a ViT patch-embedding convolution:
  Conv2d(3, 1024, kernel_size=14, stride=14, bias=False), input [N,3,14,14] bf16.
A stream of large N triggers it (e.g. N=32768: grid_size = n*k = 2^25, global work size = 2^25 * 256 = 2^33, truncated to 0 -> gridDim.x = 0).

Fix (two layers):
- ConvDirectNaiveConvFwd::IsApplicable: declare the solver not applicable when the 1-D grid would overflow uint32 (grid_size * 256 >= 2^32), so a non-overflowing solver is selected instead.
- HIPOCKernelInvoke::run: validate the launch geometry before the HIP call and throw (mirroring run_cooperative()'s WORKAROUND_SWDEV_448157) so an oversized launch can no longer silently truncate and corrupt the HIP context; Find drops the offending candidate cleanly.

Validated in a production-config build (MLIR + AI heuristics on): the repro's miopenStatusUnknownError is gone, every batch size in the repro sequence is served by a valid solver (ConvHipImplicitGemmGroupFwdXdlops) with correct output, and the conv-followed-by-another-kernel path no longer fails fatally.

## Proposed changes

Please describe the motivation behind the pull request, whether it enables a new feature or fixes a bug. If there are associated pull requests or issues, please link them to the pull request.

## Checklist

Please put an `x` into the boxes that apply. You can also fill these out after creating the PR. If you're not sure, please don't hesitate to ask.

- [ ] I have added automated tests relevant to the introduced functionality
- [ ] I have sufficient test coverage for the changes, and code coverage hasn't decreased as a result of my PR
- [ ] I have ran the tests, and they are all passing locally
- [ ] I have added relevant documentation for the changes
- [ ] I have removed the stale documentation which is no longer relevant after this pull request
- [ ] I have ran `make format` & `make check_format` to ensure the changes have been formatted
